### PR TITLE
[Security Solution] Omit `Solution` from tags and titles in Security Solution's OpenAPI bundles

### DIFF
--- a/oas_docs/output/kibana.serverless.staging.yaml
+++ b/oas_docs/output/kibana.serverless.staging.yaml
@@ -5419,8 +5419,7 @@ paths:
           name: id_field
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_IdField
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_IdField'
         - description: If 'wait_for' the request will wait for the index refresh.
           in: query
           name: refresh
@@ -5443,7 +5442,7 @@ paths:
                     type: boolean
                   record:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityRecord
+                      #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityRecord
                     description: The deleted record if it existed.
                 required:
                   - deleted
@@ -5452,7 +5451,7 @@ paths:
           description: Invalid request
       summary: Delete an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     get:
       description: Get the asset criticality record for a specific entity.
       operationId: GetAssetCriticalityRecord
@@ -5469,15 +5468,14 @@ paths:
           name: id_field
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_IdField
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_IdField'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityRecord
+                  #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityRecord
           description: Successful response
         '400':
           description: Invalid request
@@ -5485,7 +5483,7 @@ paths:
           description: Criticality record not found
       summary: Get an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     post:
       description: >
         Create or update an asset criticality record for a specific entity.
@@ -5501,7 +5499,7 @@ paths:
             schema:
               allOf:
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Entity_Analytics_API_CreateAssetCriticalityRecord
+                    #/components/schemas/Security_Entity_Analytics_API_CreateAssetCriticalityRecord
                 - type: object
                   properties:
                     refresh:
@@ -5518,13 +5516,13 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityRecord
+                  #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityRecord
           description: Successful response
         '400':
           description: Invalid request
       summary: Upsert an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/asset_criticality/bulk:
     post:
       description: >
@@ -5553,7 +5551,7 @@ paths:
                 records:
                   items:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_CreateAssetCriticalityRecord
+                      #/components/schemas/Security_Entity_Analytics_API_CreateAssetCriticalityRecord
                   maxItems: 1000
                   minItems: 1
                   type: array
@@ -5577,11 +5575,11 @@ paths:
                   errors:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityBulkUploadErrorItem
+                        #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityBulkUploadErrorItem
                     type: array
                   stats:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityBulkUploadStats
+                      #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityBulkUploadStats
                 required:
                   - errors
                   - stats
@@ -5590,7 +5588,7 @@ paths:
           description: File too large
       summary: Bulk upsert asset criticality records
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/asset_criticality/list:
     get:
       description: List asset criticality records, paging, sorting and filtering as needed.
@@ -5654,7 +5652,7 @@ paths:
                   records:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityRecord
+                        #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityRecord
                     type: array
                   total:
                     minimum: 0
@@ -5667,7 +5665,7 @@ paths:
           description: Bulk upload successful
       summary: List asset criticality records
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/data_views:
     get:
       operationId: getAllDataViewsDefault
@@ -6224,18 +6222,17 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Returns user privileges for the Kibana space
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Privileges API
   /api/detection_engine/rules:
     delete:
@@ -6247,25 +6244,23 @@ paths:
           name: id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RuleObjectId'
+            $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
         - description: The rule's `rule_id` value.
           in: query
           name: rule_id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+            $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
       summary: Delete a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     get:
       description: Retrieve a detection rule using the `rule_id` or `id` field.
@@ -6276,25 +6271,23 @@ paths:
           name: id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RuleObjectId'
+            $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
         - description: The rule's `rule_id` value.
           in: query
           name: rule_id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+            $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
       summary: Retrieve a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     patch:
       description: >-
@@ -6305,20 +6298,18 @@ paths:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RulePatchProps
+              $ref: '#/components/schemas/Security_Detections_API_RulePatchProps'
         required: true
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
       summary: Patch a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     post:
       description: Create a new detection rule.
@@ -6327,20 +6318,18 @@ paths:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleCreateProps
+              $ref: '#/components/schemas/Security_Detections_API_RuleCreateProps'
         required: true
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
       summary: Create a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     put:
       description: >
@@ -6355,20 +6344,18 @@ paths:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleUpdateProps
+              $ref: '#/components/schemas/Security_Detections_API_RuleUpdateProps'
         required: true
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
       summary: Update a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
   /api/detection_engine/rules/_bulk_action:
     post:
@@ -6389,20 +6376,16 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               oneOf:
+                - $ref: '#/components/schemas/Security_Detections_API_BulkDeleteRules'
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkDeleteRules
+                    #/components/schemas/Security_Detections_API_BulkDisableRules
+                - $ref: '#/components/schemas/Security_Detections_API_BulkEnableRules'
+                - $ref: '#/components/schemas/Security_Detections_API_BulkExportRules'
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkDisableRules
+                    #/components/schemas/Security_Detections_API_BulkDuplicateRules
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkEnableRules
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkExportRules
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkDuplicateRules
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkManualRuleRun
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkEditRules
+                    #/components/schemas/Security_Detections_API_BulkManualRuleRun
+                - $ref: '#/components/schemas/Security_Detections_API_BulkEditRules'
       responses:
         '200':
           content:
@@ -6410,13 +6393,13 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_BulkEditActionResponse
+                      #/components/schemas/Security_Detections_API_BulkEditActionResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_BulkExportActionResponse
+                      #/components/schemas/Security_Detections_API_BulkExportActionResponse
           description: OK
       summary: Apply a bulk action to detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
   /api/detection_engine/rules/_export:
     post:
@@ -6463,7 +6446,7 @@ paths:
                     properties:
                       rule_id:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+                          #/components/schemas/Security_Detections_API_RuleSignatureId
                     required:
                       - rule_id
                   type: array
@@ -6481,7 +6464,7 @@ paths:
           description: Indicates a successful call.
       summary: Export detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Import/Export API
   /api/detection_engine/rules/_find:
     get:
@@ -6508,14 +6491,13 @@ paths:
           name: sort_field
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_FindRulesSortField
+            $ref: '#/components/schemas/Security_Detections_API_FindRulesSortField'
         - description: Sort order
           in: query
           name: sort_order
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_SortOrder'
+            $ref: '#/components/schemas/Security_Detections_API_SortOrder'
         - description: Page number
           in: query
           name: page
@@ -6542,7 +6524,7 @@ paths:
                   data:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                        #/components/schemas/Security_Detections_API_RuleResponse
                     type: array
                   page:
                     type: integer
@@ -6558,7 +6540,7 @@ paths:
           description: Successful response
       summary: List all detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
   /api/detection_engine/rules/_import:
     post:
@@ -6626,8 +6608,7 @@ paths:
                 properties:
                   action_connectors_errors:
                     items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_ErrorSchema
+                      $ref: '#/components/schemas/Security_Detections_API_ErrorSchema'
                     type: array
                   action_connectors_success:
                     type: boolean
@@ -6637,17 +6618,15 @@ paths:
                   action_connectors_warnings:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_WarningSchema
+                        #/components/schemas/Security_Detections_API_WarningSchema
                     type: array
                   errors:
                     items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_ErrorSchema
+                      $ref: '#/components/schemas/Security_Detections_API_ErrorSchema'
                     type: array
                   exceptions_errors:
                     items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_ErrorSchema
+                      $ref: '#/components/schemas/Security_Detections_API_ErrorSchema'
                     type: array
                   exceptions_success:
                     type: boolean
@@ -6677,7 +6656,7 @@ paths:
           description: Indicates a successful call.
       summary: Import detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Import/Export API
   /api/detection_engine/rules/{id}/exceptions:
     post:
@@ -6689,7 +6668,7 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Exceptions_API_RuleId'
+            $ref: '#/components/schemas/Security_Exceptions_API_RuleId'
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
@@ -6699,7 +6678,7 @@ paths:
                 items:
                   items:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_CreateRuleExceptionListItemProps
+                      #/components/schemas/Security_Exceptions_API_CreateRuleExceptionListItemProps
                   type: array
               required:
                 - items
@@ -6712,7 +6691,7 @@ paths:
               schema:
                 items:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItem
                 type: array
           description: Successful response
         '400':
@@ -6721,34 +6700,33 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create rule exception list items
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/detection_engine/rules/preview:
     post:
       operationId: RulePreview
@@ -6768,44 +6746,44 @@ paths:
               anyOf:
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_EqlRuleCreateProps
+                        #/components/schemas/Security_Detections_API_EqlRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_QueryRuleCreateProps
+                        #/components/schemas/Security_Detections_API_QueryRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleCreateProps
+                        #/components/schemas/Security_Detections_API_SavedQueryRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_ThresholdRuleCreateProps
+                        #/components/schemas/Security_Detections_API_ThresholdRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleCreateProps
+                        #/components/schemas/Security_Detections_API_ThreatMatchRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleCreateProps
+                        #/components/schemas/Security_Detections_API_MachineLearningRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_NewTermsRuleCreateProps
+                        #/components/schemas/Security_Detections_API_NewTermsRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_EsqlRuleCreateProps
+                        #/components/schemas/Security_Detections_API_EsqlRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
               discriminator:
                 propertyName: type
         description: >-
@@ -6824,11 +6802,11 @@ paths:
                   logs:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewLogs
+                        #/components/schemas/Security_Detections_API_RulePreviewLogs
                     type: array
                   previewId:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+                      #/components/schemas/Security_Detections_API_NonEmptyString
                 required:
                   - logs
           description: Successful response
@@ -6838,27 +6816,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Preview rule alerts generated on specified time range
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rule preview API
   /api/detection_engine/signals/assignees:
     post:
@@ -6874,12 +6851,10 @@ paths:
               type: object
               properties:
                 assignees:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_AlertAssignees
+                  $ref: '#/components/schemas/Security_Detections_API_AlertAssignees'
                   description: Details about the assignees to assign and unassign.
                 ids:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_AlertIds
+                  $ref: '#/components/schemas/Security_Detections_API_AlertIds'
                   description: List of alerts ids to assign and unassign passed assignees.
               required:
                 - assignees
@@ -6892,7 +6867,7 @@ paths:
           description: Invalid request.
       summary: Assign and unassign users from detection alerts
       tags:
-        - Security Solution Detections API
+        - Security Detections API
   /api/detection_engine/signals/search:
     post:
       description: Find and/or aggregate detection alerts that match the given query.
@@ -6928,8 +6903,7 @@ paths:
                   minimum: 0
                   type: integer
                 sort:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_AlertsSort
+                  $ref: '#/components/schemas/Security_Detections_API_AlertsSort'
                 track_total_hits:
                   type: boolean
         description: Search and/or aggregation query
@@ -6949,27 +6923,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Find and/or aggregate detection alerts
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/signals/status:
     post:
@@ -6981,9 +6954,9 @@ paths:
             schema:
               oneOf:
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_SetAlertsStatusByIds
+                    #/components/schemas/Security_Detections_API_SetAlertsStatusByIds
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_SetAlertsStatusByQuery
+                    #/components/schemas/Security_Detections_API_SetAlertsStatusByQuery
         description: >-
           An object containing desired status and explicit alert ids or a query
           to select alerts
@@ -7003,27 +6976,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Set a detection alert status
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/signals/tags:
     post:
@@ -7039,11 +7011,9 @@ paths:
               type: object
               properties:
                 ids:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_AlertIds
+                  $ref: '#/components/schemas/Security_Detections_API_AlertIds'
                 tags:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_SetAlertTags
+                  $ref: '#/components/schemas/Security_Detections_API_SetAlertTags'
               required:
                 - ids
                 - tags
@@ -7066,27 +7036,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Add and remove detection alert tags
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/tags:
     get:
@@ -7097,12 +7066,11 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+                $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
           description: Indicates a successful call
       summary: List all detection rule tags
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Tags API
   /api/endpoint_list:
     post:
@@ -7117,7 +7085,7 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointList
+                  #/components/schemas/Security_Endpoint_Exceptions_API_EndpointList
           description: Successful response
         '400':
           content:
@@ -7125,34 +7093,34 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Create an endpoint exception list
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
   /api/endpoint_list/items:
     delete:
       description: >-
@@ -7166,21 +7134,21 @@ paths:
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemId
+              #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemId
         - description: Either `id` or `item_id` must be specified
           in: query
           name: item_id
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId
+              #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemHumanId
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointListItem
+                  #/components/schemas/Security_Endpoint_Exceptions_API_EndpointListItem
           description: Successful response
         '400':
           content:
@@ -7188,41 +7156,41 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Endpoint list item not found
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Delete an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     get:
       description: >-
         Get the details of an endpoint exception list item using the `id` or
@@ -7235,14 +7203,14 @@ paths:
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemId
+              #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemId
         - description: Either `id` or `item_id` must be specified
           in: query
           name: item_id
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId
+              #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemHumanId
       responses:
         '200':
           content:
@@ -7250,7 +7218,7 @@ paths:
               schema:
                 items:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointListItem
+                    #/components/schemas/Security_Endpoint_Exceptions_API_EndpointListItem
                 type: array
           description: Successful response
         '400':
@@ -7259,41 +7227,41 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Endpoint list item not found
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Get an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     post:
       description: >-
         Create an endpoint exception list item, and associate it with the
@@ -7307,34 +7275,34 @@ paths:
               properties:
                 comments:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemCommentArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemCommentArray
                   default: []
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemDescription
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemDescription
                 entries:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryArray
                 item_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemHumanId
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemMeta
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemName
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemName
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
                   default: []
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemTags
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemTags
                   default: []
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemType
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemType
               required:
                 - type
                 - name
@@ -7348,7 +7316,7 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointListItem
+                  #/components/schemas/Security_Endpoint_Exceptions_API_EndpointListItem
           description: Successful response
         '400':
           content:
@@ -7356,41 +7324,41 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Endpoint list item already exists
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Create an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     put:
       description: >-
         Update an endpoint exception list item using the `id` or `item_id`
@@ -7406,38 +7374,38 @@ paths:
                   type: string
                 comments:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemCommentArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemCommentArray
                   default: []
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemDescription
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemDescription
                 entries:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryArray
                 id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemId
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemId
                   description: Either `id` or `item_id` must be specified
                 item_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemHumanId
                   description: Either `id` or `item_id` must be specified
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemMeta
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemName
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemName
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
                   default: []
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemTags
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemTags
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemType
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemType
               required:
                 - type
                 - name
@@ -7451,7 +7419,7 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointListItem
+                  #/components/schemas/Security_Endpoint_Exceptions_API_EndpointListItem
           description: Successful response
         '400':
           content:
@@ -7459,41 +7427,41 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Endpoint list item not found
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Update an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
   /api/endpoint_list/items/_find:
     get:
       description: Get a list of all endpoint exception list items.
@@ -7509,7 +7477,7 @@ paths:
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_FindEndpointListItemsFilter
+              #/components/schemas/Security_Endpoint_Exceptions_API_FindEndpointListItemsFilter
         - description: The page number to return
           in: query
           name: page
@@ -7530,7 +7498,7 @@ paths:
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+              #/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString
         - description: Determines the sort order, which can be `desc` or `asc`
           in: query
           name: sort_order
@@ -7550,7 +7518,7 @@ paths:
                   data:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointListItem
+                        #/components/schemas/Security_Endpoint_Exceptions_API_EndpointListItem
                     type: array
                   page:
                     minimum: 0
@@ -7575,41 +7543,41 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Endpoint list not found
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Get endpoint exception list items
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
   /api/endpoint/action:
     get:
       description: Get a list of all response actions.
@@ -7620,18 +7588,18 @@ paths:
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Management_API_GetEndpointActionListRouteQuery
+              #/components/schemas/Security_Endpoint_Management_API_GetEndpointActionListRouteQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get response actions
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action_log/{agent_id}:
     get:
       deprecated: true
@@ -7642,25 +7610,24 @@ paths:
           name: agent_id
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Management_API_AgentId
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentId'
         - in: query
           name: query
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Management_API_ActionLogRequestQuery
+              #/components/schemas/Security_Endpoint_Management_API_ActionLogRequestQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get an action request log
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action_status:
     get:
       description: Get the status of response actions for the specified agent IDs.
@@ -7673,19 +7640,18 @@ paths:
             type: object
             properties:
               agent_ids:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_AgentIds
+                $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentIds'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_ActionStatusSuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_ActionStatusSuccessResponse
           description: OK
       summary: Get response actions status
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}:
     get:
       description: Get the details of a response action using the action ID.
@@ -7702,11 +7668,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get action details
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}/file/{file_id}:
     get:
       description: Get information for the specified file using the file ID.
@@ -7728,11 +7694,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get file information
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}/file/{file_id}/download:
     get:
       description: Download a file from an endpoint.
@@ -7754,11 +7720,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Download a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/execute:
     post:
       description: Run a shell command on an endpoint.
@@ -7768,7 +7734,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_ExecuteRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_ExecuteRouteRequestBody
         required: true
       responses:
         '200':
@@ -7776,11 +7742,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Run a command
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/get_file:
     post:
       description: Get a file from an endpoint.
@@ -7790,7 +7756,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_GetFileRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_GetFileRouteRequestBody
         required: true
       responses:
         '200':
@@ -7798,11 +7764,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/isolate:
     post:
       description: >-
@@ -7814,7 +7780,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_IsolateRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_IsolateRouteRequestBody
         required: true
       responses:
         '200':
@@ -7822,11 +7788,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Isolate an endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/kill_process:
     post:
       description: Terminate a running process on an endpoint.
@@ -7836,7 +7802,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_KillProcessRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_KillProcessRouteRequestBody
         required: true
       responses:
         '200':
@@ -7844,11 +7810,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Terminate a process
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/running_procs:
     post:
       description: Get a list of all processes running on an endpoint.
@@ -7858,7 +7824,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_GetProcessesRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_GetProcessesRouteRequestBody
         required: true
       responses:
         '200':
@@ -7866,11 +7832,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get running processes
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/scan:
     post:
       description: Scan a specific file or directory on an endpoint for malware.
@@ -7880,7 +7846,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_ScanRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_ScanRouteRequestBody
         required: true
       responses:
         '200':
@@ -7888,11 +7854,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Scan a file or directory
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/state:
     get:
       description: >-
@@ -7905,11 +7871,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_ActionStateSuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_ActionStateSuccessResponse
           description: OK
       summary: Get actions state
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/suspend_process:
     post:
       description: Suspend a running process on an endpoint.
@@ -7919,7 +7885,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_SuspendProcessRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_SuspendProcessRouteRequestBody
         required: true
       responses:
         '200':
@@ -7927,11 +7893,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Suspend a process
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/unisolate:
     post:
       description: Release an isolated endpoint, allowing it to rejoin a network.
@@ -7941,7 +7907,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_UnisolateRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_UnisolateRouteRequestBody
         required: true
       responses:
         '200':
@@ -7949,11 +7915,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Release an isolated endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/upload:
     post:
       description: Upload a file to an endpoint.
@@ -7963,7 +7929,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_UploadRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_UploadRouteRequestBody
         required: true
       responses:
         '200':
@@ -7971,11 +7937,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Upload a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata:
     get:
       operationId: GetEndpointMetadataList
@@ -7985,18 +7951,18 @@ paths:
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Management_API_ListRequestQuery
+              #/components/schemas/Security_Endpoint_Management_API_ListRequestQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get a metadata list
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata/{id}:
     get:
       operationId: GetEndpointMetadata
@@ -8012,11 +7978,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get metadata
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata/transforms:
     get:
       operationId: GetEndpointMetadataTransform
@@ -8026,11 +7992,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get metadata transforms
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/policy_response:
     get:
       operationId: GetPolicyResponse
@@ -8042,19 +8008,18 @@ paths:
             type: object
             properties:
               agentId:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_AgentId
+                $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get a policy response
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/policy/summaries:
     get:
       deprecated: true
@@ -8077,11 +8042,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get an agent policy summary
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/protection_updates_note/{package_policy_id}:
     get:
       operationId: GetProtectionUpdatesNote
@@ -8097,11 +8062,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_ProtectionUpdatesNoteResponse
+                  #/components/schemas/Security_Endpoint_Management_API_ProtectionUpdatesNoteResponse
           description: OK
       summary: Get a protection updates note
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
     post:
       operationId: CreateUpdateProtectionUpdatesNote
       parameters:
@@ -8125,11 +8090,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_ProtectionUpdatesNoteResponse
+                  #/components/schemas/Security_Endpoint_Management_API_ProtectionUpdatesNoteResponse
           description: OK
       summary: Create or update a protection updates note
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/suggestions/{suggestion_type}:
     post:
       operationId: GetEndpointSuggestions
@@ -8162,11 +8127,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get suggestions
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/entity_store/engines:
     get:
       operationId: ListEntityEngines
@@ -8182,12 +8147,12 @@ paths:
                   engines:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Entity_Analytics_API_EngineDescriptor
+                        #/components/schemas/Security_Entity_Analytics_API_EngineDescriptor
                     type: array
           description: Successful response
       summary: List the Entity Engines
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}:
     delete:
       operationId: DeleteEntityEngine
@@ -8197,8 +8162,7 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
         - description: Control flag to also delete the entity data.
           in: query
           name: data
@@ -8217,7 +8181,7 @@ paths:
           description: Successful response
       summary: Delete the Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     get:
       operationId: GetEntityEngine
       parameters:
@@ -8226,19 +8190,18 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_EngineDescriptor
+                  #/components/schemas/Security_Entity_Analytics_API_EngineDescriptor
           description: Successful response
       summary: Get an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/init:
     post:
       operationId: InitEntityEngine
@@ -8248,8 +8211,7 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
@@ -8260,7 +8222,7 @@ paths:
                   type: string
                 indexPattern:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Entity_Analytics_API_IndexPattern
+                    #/components/schemas/Security_Entity_Analytics_API_IndexPattern
         description: Schema for the engine initialization
         required: true
       responses:
@@ -8269,11 +8231,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_EngineDescriptor
+                  #/components/schemas/Security_Entity_Analytics_API_EngineDescriptor
           description: Successful response
       summary: Initialize an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/start:
     post:
       operationId: StartEntityEngine
@@ -8283,8 +8245,7 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
       responses:
         '200':
           content:
@@ -8297,7 +8258,7 @@ paths:
           description: Successful response
       summary: Start an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/stats:
     post:
       operationId: GetEntityEngineStats
@@ -8307,8 +8268,7 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
       responses:
         '200':
           content:
@@ -8318,25 +8278,25 @@ paths:
                 properties:
                   indexPattern:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_IndexPattern
+                      #/components/schemas/Security_Entity_Analytics_API_IndexPattern
                   indices:
                     items:
                       type: object
                     type: array
                   status:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_EngineStatus
+                      #/components/schemas/Security_Entity_Analytics_API_EngineStatus
                   transforms:
                     items:
                       type: object
                     type: array
                   type:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+                      #/components/schemas/Security_Entity_Analytics_API_EntityType
           description: Successful response
       summary: Get Entity Engine stats
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/stop:
     post:
       operationId: StopEntityEngine
@@ -8346,8 +8306,7 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
       responses:
         '200':
           content:
@@ -8360,7 +8319,7 @@ paths:
           description: Successful response
       summary: Stop an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/entities/list:
     get:
       description: List entities records, paging, sorting and filtering as needed.
@@ -8403,8 +8362,7 @@ paths:
           required: true
           schema:
             items:
-              $ref: >-
-                #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+              $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
             type: array
       responses:
         '200':
@@ -8415,7 +8373,7 @@ paths:
                 properties:
                   inspect:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_InspectQuery
+                      #/components/schemas/Security_Entity_Analytics_API_InspectQuery
                   page:
                     minimum: 1
                     type: integer
@@ -8426,7 +8384,7 @@ paths:
                   records:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Entity_Analytics_API_Entity
+                        #/components/schemas/Security_Entity_Analytics_API_Entity
                     type: array
                   total:
                     minimum: 0
@@ -8439,7 +8397,7 @@ paths:
           description: Entities returned successfully
       summary: List Entity Store Entities
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/exception_lists:
     delete:
       description: Delete an exception list using the `id` or `list_id` field.
@@ -8450,29 +8408,26 @@ paths:
           name: id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         - description: Either `id` or `list_id` must be specified
           in: query
           name: list_id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         - in: query
           name: namespace_type
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             default: single
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -8480,41 +8435,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     get:
       description: Get the details of an exception list using the `id` or `list_id` field.
       operationId: ReadExceptionList
@@ -8524,29 +8477,26 @@ paths:
           name: id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         - description: Either `id` or `list_id` must be specified
           in: query
           name: list_id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         - in: query
           name: namespace_type
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             default: single
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -8554,41 +8504,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get exception list details
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     post:
       description: >
         An exception list groups exception items and can be associated with
@@ -8612,33 +8560,33 @@ paths:
               properties:
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListDescription
+                    #/components/schemas/Security_Exceptions_API_ExceptionListDescription
                 list_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListHumanId
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListMeta
+                    #/components/schemas/Security_Exceptions_API_ExceptionListMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListName
+                    #/components/schemas/Security_Exceptions_API_ExceptionListName
                 namespace_type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                    #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
                   default: single
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListOsTypeArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListOsTypeArray
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListTags
+                    #/components/schemas/Security_Exceptions_API_ExceptionListTags
                   default: []
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListType
+                    #/components/schemas/Security_Exceptions_API_ExceptionListType
                 version:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListVersion
+                    #/components/schemas/Security_Exceptions_API_ExceptionListVersion
                   default: 1
               required:
                 - name
@@ -8651,8 +8599,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -8660,41 +8607,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list already exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     put:
       description: Update an exception list using the `id` or `list_id` field.
       operationId: UpdateExceptionList
@@ -8708,36 +8653,35 @@ paths:
                   type: string
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListDescription
+                    #/components/schemas/Security_Exceptions_API_ExceptionListDescription
                 id:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+                  $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
                 list_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListHumanId
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListMeta
+                    #/components/schemas/Security_Exceptions_API_ExceptionListMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListName
+                    #/components/schemas/Security_Exceptions_API_ExceptionListName
                 namespace_type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                    #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
                   default: single
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListOsTypeArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListOsTypeArray
                   default: []
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListTags
+                    #/components/schemas/Security_Exceptions_API_ExceptionListTags
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListType
+                    #/components/schemas/Security_Exceptions_API_ExceptionListType
                 version:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListVersion
+                    #/components/schemas/Security_Exceptions_API_ExceptionListVersion
               required:
                 - name
                 - description
@@ -8749,8 +8693,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -8758,41 +8701,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Update an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_duplicate:
     post:
       description: Duplicate an existing exception list.
@@ -8803,14 +8744,13 @@ paths:
           name: list_id
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         - in: query
           name: namespace_type
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
         - description: >-
             Determines whether to include expired exceptions in the exported
             list
@@ -8828,8 +8768,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -8837,41 +8776,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '405':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list to duplicate not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Duplicate an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_export:
     post:
       description: Export an exception list and its associated items to an NDJSON file.
@@ -8882,21 +8819,19 @@ paths:
           name: id
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         - description: Exception list's human identifier
           in: query
           name: list_id
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         - in: query
           name: namespace_type
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
         - description: >-
             Determines whether to include expired exceptions in the exported
             list
@@ -8926,41 +8861,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Export an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_find:
     get:
       description: Get a list of all exception lists.
@@ -8984,7 +8917,7 @@ paths:
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_FindExceptionListsFilter
+              #/components/schemas/Security_Exceptions_API_FindExceptionListsFilter
         - description: >
             Determines whether the returned containers are Kibana associated
             with a Kibana space
@@ -8998,7 +8931,7 @@ paths:
               - single
             items:
               $ref: >-
-                #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             type: array
         - description: The page number to return
           in: query
@@ -9039,7 +8972,7 @@ paths:
                   data:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                        #/components/schemas/Security_Exceptions_API_ExceptionList
                     type: array
                   page:
                     minimum: 1
@@ -9062,34 +8995,33 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get exception lists
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_import:
     post:
       description: Import an exception list and its associated items from an NDJSON file.
@@ -9153,7 +9085,7 @@ paths:
                 properties:
                   errors:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_ExceptionListsImportBulkErrorArray
+                      #/components/schemas/Security_Exceptions_API_ExceptionListsImportBulkErrorArray
                   success:
                     type: boolean
                   success_count:
@@ -9184,34 +9116,33 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Import an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/items:
     delete:
       description: Delete an exception list item using the `id` or `item_id` field.
@@ -9222,29 +9153,27 @@ paths:
           name: id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemId'
         - description: Either `id` or `item_id` must be specified
           in: query
           name: item_id
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+              #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
         - in: query
           name: namespace_type
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             default: single
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItem'
           description: Successful response
         '400':
           content:
@@ -9252,41 +9181,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     get:
       description: >-
         Get the details of an exception list item using the `id` or `item_id`
@@ -9298,29 +9225,27 @@ paths:
           name: id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemId'
         - description: Either `id` or `item_id` must be specified
           in: query
           name: item_id
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+              #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
         - in: query
           name: namespace_type
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             default: single
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItem'
           description: Successful response
         '400':
           content:
@@ -9328,41 +9253,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     post:
       description: >
         Create an exception item and associate it with the specified exception
@@ -9380,44 +9303,44 @@ paths:
               properties:
                 comments:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_CreateExceptionListItemCommentArray
+                    #/components/schemas/Security_Exceptions_API_CreateExceptionListItemCommentArray
                   default: []
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemDescription
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemDescription
                 entries:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryArray
                 expire_time:
                   format: date-time
                   type: string
                 item_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
                 list_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListHumanId
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemMeta
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemName
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemName
                 namespace_type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                    #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
                   default: single
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemOsTypeArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemOsTypeArray
                   default: []
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemTags
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemTags
                   default: []
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemType
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemType
               required:
                 - list_id
                 - type
@@ -9431,8 +9354,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItem'
           description: Successful response
         '400':
           content:
@@ -9440,41 +9362,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list item already exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     put:
       description: Update an exception list item using the `id` or `item_id` field.
       operationId: UpdateExceptionListItem
@@ -9488,48 +9408,48 @@ paths:
                   type: string
                 comments:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_UpdateExceptionListItemCommentArray
+                    #/components/schemas/Security_Exceptions_API_UpdateExceptionListItemCommentArray
                   default: []
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemDescription
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemDescription
                 entries:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryArray
                 expire_time:
                   format: date-time
                   type: string
                 id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemId
                   description: Either `id` or `item_id` must be specified
                 item_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
                   description: Either `id` or `item_id` must be specified
                 list_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListHumanId
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemMeta
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemName
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemName
                 namespace_type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                    #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
                   default: single
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemOsTypeArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemOsTypeArray
                   default: []
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemTags
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemTags
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemType
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemType
               required:
                 - type
                 - name
@@ -9542,8 +9462,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItem'
           description: Successful response
         '400':
           content:
@@ -9551,41 +9470,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Update an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/items/_find:
     get:
       description: Get a list of all exception list items in the specified list.
@@ -9598,7 +9515,7 @@ paths:
           schema:
             items:
               $ref: >-
-                #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+                #/components/schemas/Security_Exceptions_API_ExceptionListHumanId
             type: array
         - description: >
             Filters the returned results according to the value of the specified
@@ -9612,7 +9529,7 @@ paths:
             default: []
             items:
               $ref: >-
-                #/components/schemas/Security_Solution_Exceptions_API_FindExceptionListItemsFilter
+                #/components/schemas/Security_Exceptions_API_FindExceptionListItemsFilter
             type: array
         - description: >
             Determines whether the returned containers are Kibana associated
@@ -9627,7 +9544,7 @@ paths:
               - single
             items:
               $ref: >-
-                #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             type: array
         - in: query
           name: search
@@ -9653,8 +9570,7 @@ paths:
           name: sort_field
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         - description: Determines the sort order, which can be `desc` or `asc`
           in: query
           name: sort_order
@@ -9674,7 +9590,7 @@ paths:
                   data:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                        #/components/schemas/Security_Exceptions_API_ExceptionListItem
                     type: array
                   page:
                     minimum: 1
@@ -9699,41 +9615,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get exception list items
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/summary:
     get:
       description: Get a summary of the specified exception list.
@@ -9744,21 +9658,19 @@ paths:
           name: id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         - description: Exception list's human readable identifier
           in: query
           name: list_id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         - in: query
           name: namespace_type
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             default: single
         - description: Search filter clause
           in: query
@@ -9792,41 +9704,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get an exception list summary
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exceptions/shared:
     post:
       description: >
@@ -9851,10 +9761,10 @@ paths:
               properties:
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListDescription
+                    #/components/schemas/Security_Exceptions_API_ExceptionListDescription
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListName
+                    #/components/schemas/Security_Exceptions_API_ExceptionListName
               required:
                 - name
                 - description
@@ -9864,8 +9774,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -9873,41 +9782,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list already exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create a shared exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/fleet/agent_download_sources:
     get:
       operationId: get-download-sources
@@ -13618,7 +13525,7 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - in: query
           name: deleteReferences
           required: false
@@ -13636,7 +13543,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -13644,41 +13551,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Get the details of a list using the list ID.
       operationId: ReadList
@@ -13688,13 +13590,13 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -13702,41 +13604,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get list details
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     patch:
       description: Update specific fields of an existing list using the list ID.
       operationId: PatchList
@@ -13749,15 +13646,13 @@ paths:
                 _version:
                   type: string
                 description:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListDescription
+                  $ref: '#/components/schemas/Security_Lists_API_ListDescription'
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListMetadata'
                 name:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListName'
+                  $ref: '#/components/schemas/Security_Lists_API_ListName'
                 version:
                   minimum: 1
                   type: integer
@@ -13770,7 +13665,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -13778,41 +13673,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Patch a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: Create a new list.
       operationId: CreateList
@@ -13823,21 +13713,19 @@ paths:
               type: object
               properties:
                 description:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListDescription
+                  $ref: '#/components/schemas/Security_Lists_API_ListDescription'
                 deserializer:
                   type: string
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListMetadata'
                 name:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListName'
+                  $ref: '#/components/schemas/Security_Lists_API_ListName'
                 serializer:
                   type: string
                 type:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListType'
+                  $ref: '#/components/schemas/Security_Lists_API_ListType'
                 version:
                   default: 1
                   minimum: 1
@@ -13853,7 +13741,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -13861,41 +13749,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List already exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     put:
       description: >
         Update a list using the list ID. The original list is replaced, and all
@@ -13914,15 +13797,13 @@ paths:
                 _version:
                   type: string
                 description:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListDescription
+                  $ref: '#/components/schemas/Security_Lists_API_ListDescription'
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListMetadata'
                 name:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListName'
+                  $ref: '#/components/schemas/Security_Lists_API_ListName'
                 version:
                   minimum: 1
                   type: integer
@@ -13937,7 +13818,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -13945,41 +13826,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Update a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/_find:
     get:
       description: >-
@@ -14004,7 +13880,7 @@ paths:
           name: sort_field
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
+            $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
         - description: Determines the sort order, which can be `desc` or `asc`
           in: query
           name: sort_order
@@ -14027,7 +13903,7 @@ paths:
           name: cursor
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_FindListsCursor'
+            $ref: '#/components/schemas/Security_Lists_API_FindListsCursor'
         - description: >
             Filters the returned results according to the value of the specified
             field,
@@ -14037,7 +13913,7 @@ paths:
           name: filter
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_FindListsFilter'
+            $ref: '#/components/schemas/Security_Lists_API_FindListsFilter'
       responses:
         '200':
           content:
@@ -14046,11 +13922,10 @@ paths:
                 type: object
                 properties:
                   cursor:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_FindListsCursor
+                    $ref: '#/components/schemas/Security_Lists_API_FindListsCursor'
                   data:
                     items:
-                      $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                      $ref: '#/components/schemas/Security_Lists_API_List'
                     type: array
                   page:
                     minimum: 0
@@ -14074,34 +13949,30 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get lists
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/index:
     delete:
       description: Delete the `.lists` and `.items` data streams.
@@ -14124,41 +13995,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List data stream not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Verify that `.lists` and `.items` data streams exist.
       operationId: ReadListIndex
@@ -14183,41 +14049,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List data stream(s) not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get status of list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: Create `.lists` and `.items` data streams in the relevant space.
       operationId: CreateListIndex
@@ -14239,41 +14100,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List data stream exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items:
     delete:
       description: Delete a list item using its `id`, or its `list_id` and `value` fields.
@@ -14284,13 +14140,13 @@ paths:
           name: id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: Required if `id` is not specified
           in: query
           name: list_id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: Required if `id` is not specified
           in: query
           name: value
@@ -14316,10 +14172,9 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/Security_Solution_Lists_API_ListItem'
+                  - $ref: '#/components/schemas/Security_Lists_API_ListItem'
                   - items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Lists_API_ListItem
+                      $ref: '#/components/schemas/Security_Lists_API_ListItem'
                     type: array
           description: Successful response
         '400':
@@ -14328,41 +14183,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Get the details of a list item.
       operationId: ReadListItem
@@ -14372,13 +14222,13 @@ paths:
           name: id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: Required if `id` is not specified
           in: query
           name: list_id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: Required if `id` is not specified
           in: query
           name: value
@@ -14391,10 +14241,9 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/Security_Solution_Lists_API_ListItem'
+                  - $ref: '#/components/schemas/Security_Lists_API_ListItem'
                   - items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Lists_API_ListItem
+                      $ref: '#/components/schemas/Security_Lists_API_ListItem'
                     type: array
           description: Successful response
         '400':
@@ -14403,41 +14252,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     patch:
       description: Update specific fields of an existing list item using the list item ID.
       operationId: PatchListItem
@@ -14450,10 +14294,9 @@ paths:
                 _version:
                   type: string
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemMetadata'
                 refresh:
                   description: >-
                     Determines when changes made by the request are made visible
@@ -14464,8 +14307,7 @@ paths:
                     - wait_for
                   type: string
                 value:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemValue
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemValue'
               required:
                 - id
         description: List item's properties
@@ -14475,7 +14317,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_ListItem'
+                $ref: '#/components/schemas/Security_Lists_API_ListItem'
           description: Successful response
         '400':
           content:
@@ -14483,41 +14325,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Patch a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: >
         Create a list item and associate it with the specified list.
@@ -14537,12 +14374,11 @@ paths:
               type: object
               properties:
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemId'
                 list_id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemMetadata'
                 refresh:
                   description: >-
                     Determines when changes made by the request are made visible
@@ -14553,8 +14389,7 @@ paths:
                     - wait_for
                   type: string
                 value:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemValue
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemValue'
               required:
                 - list_id
                 - value
@@ -14565,7 +14400,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_ListItem'
+                $ref: '#/components/schemas/Security_Lists_API_ListItem'
           description: Successful response
         '400':
           content:
@@ -14573,41 +14408,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List item already exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     put:
       description: >
         Update a list item using the list item ID. The original list item is
@@ -14626,13 +14456,11 @@ paths:
                 _version:
                   type: string
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemMetadata'
                 value:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemValue
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemValue'
               required:
                 - id
                 - value
@@ -14643,7 +14471,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_ListItem'
+                $ref: '#/components/schemas/Security_Lists_API_ListItem'
           description: Successful response
         '400':
           content:
@@ -14651,41 +14479,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Update a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_export:
     post:
       description: Export list item values from the specified list.
@@ -14696,7 +14519,7 @@ paths:
           name: list_id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
       responses:
         '200':
           content:
@@ -14712,41 +14535,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Export list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_find:
     get:
       description: Get all list items in the specified list.
@@ -14757,7 +14575,7 @@ paths:
           name: list_id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: The page number to return
           in: query
           name: page
@@ -14775,7 +14593,7 @@ paths:
           name: sort_field
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
+            $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
         - description: Determines the sort order, which can be `desc` or `asc`
           in: query
           name: sort_order
@@ -14798,8 +14616,7 @@ paths:
           name: cursor
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Lists_API_FindListItemsCursor
+            $ref: '#/components/schemas/Security_Lists_API_FindListItemsCursor'
         - description: >
             Filters the returned results according to the value of the specified
             field,
@@ -14809,8 +14626,7 @@ paths:
           name: filter
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Lists_API_FindListItemsFilter
+            $ref: '#/components/schemas/Security_Lists_API_FindListItemsFilter'
       responses:
         '200':
           content:
@@ -14820,11 +14636,10 @@ paths:
                 properties:
                   cursor:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_FindListItemsCursor
+                      #/components/schemas/Security_Lists_API_FindListItemsCursor
                   data:
                     items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Lists_API_ListItem
+                      $ref: '#/components/schemas/Security_Lists_API_ListItem'
                     type: array
                   page:
                     minimum: 0
@@ -14848,34 +14663,30 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_import:
     post:
       description: >
@@ -14894,7 +14705,7 @@ paths:
           name: list_id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: >
             Type of the importing list.
 
@@ -14905,7 +14716,7 @@ paths:
           name: type
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListType'
+            $ref: '#/components/schemas/Security_Lists_API_ListType'
         - in: query
           name: serializer
           required: false
@@ -14946,7 +14757,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -14954,41 +14765,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List with specified list_id does not exist response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Import list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/privileges:
     get:
       operationId: ReadListPrivileges
@@ -15002,11 +14808,9 @@ paths:
                   is_authenticated:
                     type: boolean
                   listItems:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_ListItemPrivileges
+                    $ref: '#/components/schemas/Security_Lists_API_ListItemPrivileges'
                   lists:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_ListPrivileges
+                    $ref: '#/components/schemas/Security_Lists_API_ListPrivileges'
                 required:
                   - lists
                   - listItems
@@ -15018,34 +14822,30 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get list privileges
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/ml/saved_objects/sync:
     get:
       description: >
@@ -15114,7 +14914,7 @@ paths:
           description: Indicates the note was successfully deleted.
       summary: Delete a note
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     get:
       description: Get all notes for a given document.
@@ -15123,7 +14923,7 @@ paths:
         - in: query
           name: documentIds
           schema:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_DocumentIds'
+            $ref: '#/components/schemas/Security_Timeline_API_DocumentIds'
         - in: query
           name: page
           schema:
@@ -15160,13 +14960,12 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 oneOf:
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_GetNotesResult
+                  - $ref: '#/components/schemas/Security_Timeline_API_GetNotesResult'
                   - type: object
           description: Indicates the requested notes were returned.
       summary: Get notes
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     patch:
       description: Add a note to a Timeline or update an existing note.
@@ -15187,7 +14986,7 @@ paths:
                   nullable: true
                   type: string
                 note:
-                  $ref: '#/components/schemas/Security_Solution_Timeline_API_BareNote'
+                  $ref: '#/components/schemas/Security_Timeline_API_BareNote'
                 noteId:
                   nullable: true
                   type: string
@@ -15213,7 +15012,7 @@ paths:
                     properties:
                       persistNote:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Timeline_API_ResponseNote
+                          #/components/schemas/Security_Timeline_API_ResponseNote
                     required:
                       - persistNote
                 required:
@@ -15221,7 +15020,7 @@ paths:
           description: Indicates the note was successfully created.
       summary: Add or update a note
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/osquery/live_queries:
     get:
@@ -15233,18 +15032,18 @@ paths:
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Osquery_API_FindLiveQueryRequestQuery
+              #/components/schemas/Security_Osquery_API_FindLiveQueryRequestQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get live queries
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create and run a live query.
       operationId: OsqueryCreateLiveQuery
@@ -15253,7 +15052,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Osquery_API_CreateLiveQueryRequestBody
+                #/components/schemas/Security_Osquery_API_CreateLiveQueryRequestBody
         required: true
       responses:
         '200':
@@ -15261,11 +15060,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Create a live query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/live_queries/{id}:
     get:
       description: Get the details of a live query using the query ID.
@@ -15275,7 +15074,7 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_Id'
+            $ref: '#/components/schemas/Security_Osquery_API_Id'
         - in: query
           name: query
           schema:
@@ -15287,11 +15086,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get live query details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/live_queries/{id}/results/{actionId}:
     get:
       description: Get the results of a live query using the query action ID.
@@ -15301,29 +15100,29 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_Id'
+            $ref: '#/components/schemas/Security_Osquery_API_Id'
         - in: path
           name: actionId
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_Id'
+            $ref: '#/components/schemas/Security_Osquery_API_Id'
         - in: query
           name: query
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Osquery_API_GetLiveQueryResultsRequestQuery
+              #/components/schemas/Security_Osquery_API_GetLiveQueryResultsRequestQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get live query results
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/packs:
     get:
       description: Get a list of all query packs.
@@ -15333,19 +15132,18 @@ paths:
           name: query
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Osquery_API_FindPacksRequestQuery
+            $ref: '#/components/schemas/Security_Osquery_API_FindPacksRequestQuery'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get packs
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create a query pack.
       operationId: OsqueryCreatePacks
@@ -15353,8 +15151,7 @@ paths:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
-              $ref: >-
-                #/components/schemas/Security_Solution_Osquery_API_CreatePacksRequestBody
+              $ref: '#/components/schemas/Security_Osquery_API_CreatePacksRequestBody'
         required: true
       responses:
         '200':
@@ -15362,11 +15159,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Create a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/packs/{id}:
     delete:
       description: Delete a query pack using the pack ID.
@@ -15376,18 +15173,18 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_PackId'
+            $ref: '#/components/schemas/Security_Osquery_API_PackId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Delete a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     get:
       description: Get the details of a query pack using the pack ID.
       operationId: OsqueryGetPacksDetails
@@ -15396,18 +15193,18 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_PackId'
+            $ref: '#/components/schemas/Security_Osquery_API_PackId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get pack details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     put:
       description: |
         Update a query pack using the pack ID.
@@ -15419,13 +15216,12 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_PackId'
+            $ref: '#/components/schemas/Security_Osquery_API_PackId'
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
-              $ref: >-
-                #/components/schemas/Security_Solution_Osquery_API_UpdatePacksRequestBody
+              $ref: '#/components/schemas/Security_Osquery_API_UpdatePacksRequestBody'
         required: true
       responses:
         '200':
@@ -15433,11 +15229,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Update a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/saved_queries:
     get:
       description: Get a list of all saved queries.
@@ -15448,18 +15244,18 @@ paths:
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Osquery_API_FindSavedQueryRequestQuery
+              #/components/schemas/Security_Osquery_API_FindSavedQueryRequestQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get saved queries
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create and run a saved query.
       operationId: OsqueryCreateSavedQuery
@@ -15468,7 +15264,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Osquery_API_CreateSavedQueryRequestBody
+                #/components/schemas/Security_Osquery_API_CreateSavedQueryRequestBody
         required: true
       responses:
         '200':
@@ -15476,11 +15272,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Create a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/saved_queries/{id}:
     delete:
       description: Delete a saved query using the query ID.
@@ -15490,18 +15286,18 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+            $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Delete a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     get:
       description: Get the details of a saved query using the query ID.
       operationId: OsqueryGetSavedQueryDetails
@@ -15510,18 +15306,18 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+            $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get saved query details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     put:
       description: |
         Update a saved query using the query ID.
@@ -15533,13 +15329,13 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+            $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Osquery_API_UpdateSavedQueryRequestBody
+                #/components/schemas/Security_Osquery_API_UpdateSavedQueryRequestBody
         required: true
       responses:
         '200':
@@ -15547,11 +15343,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Update a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/pinned_event:
     patch:
       description: Pin an event to an existing Timeline.
@@ -15586,7 +15382,7 @@ paths:
                     properties:
                       persistPinnedEventOnTimeline:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Timeline_API_PersistPinnedEventResponse
+                          #/components/schemas/Security_Timeline_API_PersistPinnedEventResponse
                     required:
                       - persistPinnedEventOnTimeline
                 required:
@@ -15594,7 +15390,7 @@ paths:
           description: Indicates the event was successfully pinned to the Timeline.
       summary: Pin an event
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/risk_score/engine/schedule_now:
     post:
@@ -15612,25 +15408,25 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_RiskEngineScheduleNowResponse
+                  #/components/schemas/Security_Entity_Analytics_API_RiskEngineScheduleNowResponse
           description: Successful response
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_TaskManagerUnavailableResponse
+                  #/components/schemas/Security_Entity_Analytics_API_TaskManagerUnavailableResponse
           description: Task manager is unavailable
         default:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_RiskEngineScheduleNowErrorResponse
+                  #/components/schemas/Security_Entity_Analytics_API_RiskEngineScheduleNowErrorResponse
           description: Unexpected error
       summary: Run the risk scoring engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/saved_objects/_export:
     post:
       description: >
@@ -16509,7 +16305,7 @@ paths:
           description: Indicates the Timeline was successfully deleted.
       summary: Delete Timelines or Timeline templates
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     get:
       description: Get the details of an existing saved Timeline or Timeline template.
@@ -16537,7 +16333,7 @@ paths:
                     properties:
                       getOneTimeline:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                          #/components/schemas/Security_Timeline_API_TimelineResponse
                         nullable: true
                     required:
                       - getOneTimeline
@@ -16546,7 +16342,7 @@ paths:
           description: Indicates that the (template) Timeline was found and returned.
       summary: Get Timeline or Timeline template details
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     patch:
       description: >-
@@ -16561,8 +16357,7 @@ paths:
               type: object
               properties:
                 timeline:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_SavedTimeline
+                  $ref: '#/components/schemas/Security_Timeline_API_SavedTimeline'
                 timelineId:
                   nullable: true
                   type: string
@@ -16590,7 +16385,7 @@ paths:
                         properties:
                           timeline:
                             $ref: >-
-                              #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                              #/components/schemas/Security_Timeline_API_TimelineResponse
                         required:
                           - timeline
                     required:
@@ -16616,7 +16411,7 @@ paths:
             a draft Timeline.
       summary: Update a Timeline
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     post:
       description: Create a new Timeline or Timeline template.
@@ -16628,8 +16423,7 @@ paths:
               type: object
               properties:
                 status:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_TimelineStatus
+                  $ref: '#/components/schemas/Security_Timeline_API_TimelineStatus'
                   nullable: true
                 templateTimelineId:
                   nullable: true
@@ -16638,14 +16432,12 @@ paths:
                   nullable: true
                   type: number
                 timeline:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_SavedTimeline
+                  $ref: '#/components/schemas/Security_Timeline_API_SavedTimeline'
                 timelineId:
                   nullable: true
                   type: string
                 timelineType:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_TimelineType
+                  $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
                   nullable: true
                 version:
                   nullable: true
@@ -16671,7 +16463,7 @@ paths:
                         properties:
                           timeline:
                             $ref: >-
-                              #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                              #/components/schemas/Security_Timeline_API_TimelineResponse
                     required:
                       - persistTimeline
                 required:
@@ -16690,7 +16482,7 @@ paths:
           description: Indicates that there was an error in the Timeline creation.
       summary: Create a Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_draft:
     get:
@@ -16704,7 +16496,7 @@ paths:
           name: timelineType
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_TimelineType'
+            $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
       responses:
         '200':
           content:
@@ -16720,7 +16512,7 @@ paths:
                         properties:
                           timeline:
                             $ref: >-
-                              #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                              #/components/schemas/Security_Timeline_API_TimelineResponse
                         required:
                           - timeline
                     required:
@@ -16758,7 +16550,7 @@ paths:
             draft Timeline with the given `timelineId`.
       summary: Get draft Timeline or Timeline template details
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     post:
       description: >
@@ -16776,8 +16568,7 @@ paths:
               type: object
               properties:
                 timelineType:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_TimelineType
+                  $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
               required:
                 - timelineType
         description: >-
@@ -16799,7 +16590,7 @@ paths:
                         properties:
                           timeline:
                             $ref: >-
-                              #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                              #/components/schemas/Security_Timeline_API_TimelineResponse
                         required:
                           - timeline
                     required:
@@ -16838,7 +16629,7 @@ paths:
             `timelineId`.
       summary: Create a clean draft Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_export:
     post:
@@ -16885,7 +16676,7 @@ paths:
           description: Indicates that the export size limit was exceeded.
       summary: Export Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_favorite:
     patch:
@@ -16907,8 +16698,7 @@ paths:
                   nullable: true
                   type: string
                 timelineType:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_TimelineType
+                  $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
                   nullable: true
               required:
                 - timelineId
@@ -16929,7 +16719,7 @@ paths:
                     properties:
                       persistFavorite:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Timeline_API_FavoriteTimelineResponse
+                          #/components/schemas/Security_Timeline_API_FavoriteTimelineResponse
                     required:
                       - persistFavorite
                 required:
@@ -16950,7 +16740,7 @@ paths:
             the favorite status.
       summary: Favorite a Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_import:
     post:
@@ -16964,8 +16754,7 @@ paths:
               properties:
                 file:
                   allOf:
-                    - $ref: >-
-                        #/components/schemas/Security_Solution_Timeline_API_Readable
+                    - $ref: '#/components/schemas/Security_Timeline_API_Readable'
                     - type: object
                       properties:
                         hapi:
@@ -16996,7 +16785,7 @@ paths:
                 properties:
                   data:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_ImportTimelineResult
+                      #/components/schemas/Security_Timeline_API_ImportTimelineResult
                 required:
                   - data
           description: Indicates the import of Timelines was successful.
@@ -17043,7 +16832,7 @@ paths:
           description: Indicates the import of Timelines was unsuccessful.
       summary: Import Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_prepackaged:
     post:
@@ -17057,19 +16846,16 @@ paths:
               properties:
                 prepackagedTimelines:
                   items:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_SavedTimeline
+                    $ref: '#/components/schemas/Security_Timeline_API_SavedTimeline'
                   type: array
                 timelinesToInstall:
                   items:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_ImportTimelines
+                    $ref: '#/components/schemas/Security_Timeline_API_ImportTimelines'
                     nullable: true
                   type: array
                 timelinesToUpdate:
                   items:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_ImportTimelines
+                    $ref: '#/components/schemas/Security_Timeline_API_ImportTimelines'
                     nullable: true
                   type: array
               required:
@@ -17087,7 +16873,7 @@ paths:
                 properties:
                   data:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_ImportTimelineResult
+                      #/components/schemas/Security_Timeline_API_ImportTimelineResult
                 required:
                   - data
           description: Indicates the installation of prepackaged Timelines was successful.
@@ -17106,7 +16892,7 @@ paths:
             unsuccessful.
       summary: Install prepackaged Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/resolve:
     get:
@@ -17134,7 +16920,7 @@ paths:
                     properties:
                       getOneTimeline:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                          #/components/schemas/Security_Timeline_API_TimelineResponse
                         nullable: true
                     required:
                       - getOneTimeline
@@ -17147,7 +16933,7 @@ paths:
           description: The (template) Timeline was not found
       summary: Get an existing saved Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timelines:
     get:
@@ -17168,13 +16954,12 @@ paths:
         - in: query
           name: timeline_type
           schema:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_TimelineType'
+            $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
             nullable: true
         - in: query
           name: sort_field
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_SortFieldTimeline
+            $ref: '#/components/schemas/Security_Timeline_API_SortFieldTimeline'
         - in: query
           name: sort_order
           schema:
@@ -17200,7 +16985,7 @@ paths:
         - in: query
           name: status
           schema:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_TimelineStatus'
+            $ref: '#/components/schemas/Security_Timeline_API_TimelineStatus'
             nullable: true
       responses:
         '200':
@@ -17225,7 +17010,7 @@ paths:
                       timelines:
                         items:
                           $ref: >-
-                            #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                            #/components/schemas/Security_Timeline_API_TimelineResponse
                         type: array
                       totalCount:
                         type: number
@@ -17253,7 +17038,7 @@ paths:
           description: Bad request. The user supplied invalid data.
       summary: Get Timelines or Timeline templates
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /s/{spaceId}/api/observability/slos:
     get:
@@ -23203,72 +22988,68 @@ components:
         name:
           description: User name
           type: string
-    Security_Solution_Detections_API_AlertAssignees:
+    Security_Detections_API_AlertAssignees:
       type: object
       properties:
         add:
           description: A list of users ids to assign.
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           type: array
         remove:
           description: A list of users ids to unassign.
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           type: array
       required:
         - add
         - remove
-    Security_Solution_Detections_API_AlertIds:
+    Security_Detections_API_AlertIds:
       description: A list of alerts ids.
       items:
-        $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+        $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
       minItems: 1
       type: array
-    Security_Solution_Detections_API_AlertsIndex:
+    Security_Detections_API_AlertsIndex:
       deprecated: true
       description: (deprecated) Has no effect.
       type: string
-    Security_Solution_Detections_API_AlertsIndexNamespace:
+    Security_Detections_API_AlertsIndexNamespace:
       description: Has no effect.
       type: string
-    Security_Solution_Detections_API_AlertsSort:
+    Security_Detections_API_AlertsSort:
       oneOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertsSortCombinations
+        - $ref: '#/components/schemas/Security_Detections_API_AlertsSortCombinations'
         - items:
             $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_AlertsSortCombinations
+              #/components/schemas/Security_Detections_API_AlertsSortCombinations
           type: array
-    Security_Solution_Detections_API_AlertsSortCombinations:
+    Security_Detections_API_AlertsSortCombinations:
       anyOf:
         - type: string
         - additionalProperties: true
           type: object
-    Security_Solution_Detections_API_AlertStatus:
+    Security_Detections_API_AlertStatus:
       enum:
         - open
         - closed
         - acknowledged
         - in-progress
       type: string
-    Security_Solution_Detections_API_AlertSuppression:
+    Security_Detections_API_AlertSuppression:
       type: object
       properties:
         duration:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppressionDuration
+            #/components/schemas/Security_Detections_API_AlertSuppressionDuration
         group_by:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppressionGroupBy
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppressionGroupBy'
         missing_fields_strategy:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppressionMissingFieldsStrategy
+            #/components/schemas/Security_Detections_API_AlertSuppressionMissingFieldsStrategy
       required:
         - group_by
-    Security_Solution_Detections_API_AlertSuppressionDuration:
+    Security_Detections_API_AlertSuppressionDuration:
       type: object
       properties:
         unit:
@@ -23283,13 +23064,13 @@ components:
       required:
         - value
         - unit
-    Security_Solution_Detections_API_AlertSuppressionGroupBy:
+    Security_Detections_API_AlertSuppressionGroupBy:
       items:
         type: string
       maxItems: 3
       minItems: 1
       type: array
-    Security_Solution_Detections_API_AlertSuppressionMissingFieldsStrategy:
+    Security_Detections_API_AlertSuppressionMissingFieldsStrategy:
       description: >-
         Describes how alerts will be generated for documents with missing
         suppress by fields:
@@ -23301,38 +23082,38 @@ components:
         - doNotSuppress
         - suppress
       type: string
-    Security_Solution_Detections_API_AlertTag:
-      $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
-    Security_Solution_Detections_API_AlertTags:
+    Security_Detections_API_AlertTag:
+      $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
+    Security_Detections_API_AlertTags:
       items:
-        $ref: '#/components/schemas/Security_Solution_Detections_API_AlertTag'
+        $ref: '#/components/schemas/Security_Detections_API_AlertTag'
       type: array
-    Security_Solution_Detections_API_AnomalyThreshold:
+    Security_Detections_API_AnomalyThreshold:
       description: Anomaly threshold
       minimum: 0
       type: integer
-    Security_Solution_Detections_API_BuildingBlockType:
+    Security_Detections_API_BuildingBlockType:
       description: >-
         Determines if the rule acts as a building block. By default,
         building-block alerts are not displayed in the UI. These rules are used
         as a foundation for other rules that do generate alerts. Its value must
         be default.
       type: string
-    Security_Solution_Detections_API_BulkActionEditPayload:
+    Security_Detections_API_BulkActionEditPayload:
       anyOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadTags
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadTags
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadIndexPatterns
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadIndexPatterns
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadInvestigationFields
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadInvestigationFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadTimeline
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadTimeline
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadRuleActions
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadRuleActions
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadSchedule
-    Security_Solution_Detections_API_BulkActionEditPayloadIndexPatterns:
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadSchedule
+    Security_Detections_API_BulkActionEditPayloadIndexPatterns:
       type: object
       properties:
         overwrite_data_views:
@@ -23344,12 +23125,11 @@ components:
             - set_index_patterns
           type: string
         value:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionEditPayloadInvestigationFields:
+    Security_Detections_API_BulkActionEditPayloadInvestigationFields:
       type: object
       properties:
         type:
@@ -23359,12 +23139,11 @@ components:
             - set_investigation_fields
           type: string
         value:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+          $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionEditPayloadRuleActions:
+    Security_Detections_API_BulkActionEditPayloadRuleActions:
       type: object
       properties:
         type:
@@ -23378,17 +23157,17 @@ components:
             actions:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_NormalizedRuleAction
+                  #/components/schemas/Security_Detections_API_NormalizedRuleAction
               type: array
             throttle:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThrottleForBulkActions
+                #/components/schemas/Security_Detections_API_ThrottleForBulkActions
           required:
             - actions
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionEditPayloadSchedule:
+    Security_Detections_API_BulkActionEditPayloadSchedule:
       type: object
       properties:
         type:
@@ -23416,7 +23195,7 @@ components:
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionEditPayloadTags:
+    Security_Detections_API_BulkActionEditPayloadTags:
       type: object
       properties:
         type:
@@ -23426,11 +23205,11 @@ components:
             - set_tags
           type: string
         value:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleTagArray'
+          $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionEditPayloadTimeline:
+    Security_Detections_API_BulkActionEditPayloadTimeline:
       type: object
       properties:
         type:
@@ -23441,18 +23220,17 @@ components:
           type: object
           properties:
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
           required:
             - timeline_id
             - timeline_title
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionsDryRunErrCode:
+    Security_Detections_API_BulkActionsDryRunErrCode:
       enum:
         - IMMUTABLE
         - MACHINE_LEARNING_AUTH
@@ -23461,7 +23239,7 @@ components:
         - MANUAL_RULE_RUN_FEATURE
         - MANUAL_RULE_RUN_DISABLED_RULE
       type: string
-    Security_Solution_Detections_API_BulkActionSkipResult:
+    Security_Detections_API_BulkActionSkipResult:
       type: object
       properties:
         id:
@@ -23469,12 +23247,11 @@ components:
         name:
           type: string
         skip_reason:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkEditSkipReason
+          $ref: '#/components/schemas/Security_Detections_API_BulkEditSkipReason'
       required:
         - id
         - skip_reason
-    Security_Solution_Detections_API_BulkDeleteRules:
+    Security_Detections_API_BulkDeleteRules:
       type: object
       properties:
         action:
@@ -23492,7 +23269,7 @@ components:
           type: string
       required:
         - action
-    Security_Solution_Detections_API_BulkDisableRules:
+    Security_Detections_API_BulkDisableRules:
       type: object
       properties:
         action:
@@ -23510,7 +23287,7 @@ components:
           type: string
       required:
         - action
-    Security_Solution_Detections_API_BulkDuplicateRules:
+    Security_Detections_API_BulkDuplicateRules:
       type: object
       properties:
         action:
@@ -23540,7 +23317,7 @@ components:
           type: string
       required:
         - action
-    Security_Solution_Detections_API_BulkEditActionResponse:
+    Security_Detections_API_BulkEditActionResponse:
       type: object
       properties:
         attributes:
@@ -23549,14 +23326,14 @@ components:
             errors:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_NormalizedRuleError
+                  #/components/schemas/Security_Detections_API_NormalizedRuleError
               type: array
             results:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BulkEditActionResults
+                #/components/schemas/Security_Detections_API_BulkEditActionResults
             summary:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BulkEditActionSummary
+                #/components/schemas/Security_Detections_API_BulkEditActionSummary
           required:
             - results
             - summary
@@ -23570,32 +23347,31 @@ components:
           type: boolean
       required:
         - attributes
-    Security_Solution_Detections_API_BulkEditActionResults:
+    Security_Detections_API_BulkEditActionResults:
       type: object
       properties:
         created:
           items:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RuleResponse'
+            $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           type: array
         deleted:
           items:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RuleResponse'
+            $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           type: array
         skipped:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_BulkActionSkipResult
+            $ref: '#/components/schemas/Security_Detections_API_BulkActionSkipResult'
           type: array
         updated:
           items:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RuleResponse'
+            $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           type: array
       required:
         - updated
         - created
         - deleted
         - skipped
-    Security_Solution_Detections_API_BulkEditActionSummary:
+    Security_Detections_API_BulkEditActionSummary:
       type: object
       properties:
         failed:
@@ -23611,7 +23387,7 @@ components:
         - skipped
         - succeeded
         - total
-    Security_Solution_Detections_API_BulkEditRules:
+    Security_Detections_API_BulkEditRules:
       type: object
       properties:
         action:
@@ -23621,8 +23397,7 @@ components:
         edit:
           description: Array of objects containing the edit operations
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayload
+            $ref: '#/components/schemas/Security_Detections_API_BulkActionEditPayload'
           minItems: 1
           type: array
         ids:
@@ -23637,11 +23412,11 @@ components:
       required:
         - action
         - edit
-    Security_Solution_Detections_API_BulkEditSkipReason:
+    Security_Detections_API_BulkEditSkipReason:
       enum:
         - RULE_NOT_MODIFIED
       type: string
-    Security_Solution_Detections_API_BulkEnableRules:
+    Security_Detections_API_BulkEnableRules:
       type: object
       properties:
         action:
@@ -23659,9 +23434,9 @@ components:
           type: string
       required:
         - action
-    Security_Solution_Detections_API_BulkExportActionResponse:
+    Security_Detections_API_BulkExportActionResponse:
       type: string
-    Security_Solution_Detections_API_BulkExportRules:
+    Security_Detections_API_BulkExportRules:
       type: object
       properties:
         action:
@@ -23679,7 +23454,7 @@ components:
           type: string
       required:
         - action
-    Security_Solution_Detections_API_BulkManualRuleRun:
+    Security_Detections_API_BulkManualRuleRun:
       type: object
       properties:
         action:
@@ -23709,12 +23484,12 @@ components:
       required:
         - action
         - run
-    Security_Solution_Detections_API_ConcurrentSearches:
+    Security_Detections_API_ConcurrentSearches:
       minimum: 1
       type: integer
-    Security_Solution_Detections_API_DataViewId:
+    Security_Detections_API_DataViewId:
       type: string
-    Security_Solution_Detections_API_DefaultParams:
+    Security_Detections_API_DefaultParams:
       type: object
       properties:
         command:
@@ -23725,7 +23500,7 @@ components:
           type: string
       required:
         - command
-    Security_Solution_Detections_API_EcsMapping:
+    Security_Detections_API_EcsMapping:
       additionalProperties:
         type: object
         properties:
@@ -23738,7 +23513,7 @@ components:
                   type: string
                 type: array
       type: object
-    Security_Solution_Detections_API_EndpointResponseAction:
+    Security_Detections_API_EndpointResponseAction:
       type: object
       properties:
         action_type_id:
@@ -23747,53 +23522,44 @@ components:
           type: string
         params:
           oneOf:
-            - $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_DefaultParams
-            - $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ProcessesParams
+            - $ref: '#/components/schemas/Security_Detections_API_DefaultParams'
+            - $ref: '#/components/schemas/Security_Detections_API_ProcessesParams'
       required:
         - action_type_id
         - params
-    Security_Solution_Detections_API_EqlOptionalFields:
+    Security_Detections_API_EqlOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         event_category_override:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EventCategoryOverride
+          $ref: '#/components/schemas/Security_Detections_API_EventCategoryOverride'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         response_actions:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ResponseAction
+            $ref: '#/components/schemas/Security_Detections_API_ResponseAction'
           type: array
         tiebreaker_field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_TiebreakerField
+          $ref: '#/components/schemas/Security_Detections_API_TiebreakerField'
         timestamp_field:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_TimestampField'
-    Security_Solution_Detections_API_EqlQueryLanguage:
+          $ref: '#/components/schemas/Security_Detections_API_TimestampField'
+    Security_Detections_API_EqlQueryLanguage:
       enum:
         - eql
       type: string
-    Security_Solution_Detections_API_EqlRequiredFields:
+    Security_Detections_API_EqlRequiredFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlQueryLanguage
+          $ref: '#/components/schemas/Security_Detections_API_EqlQueryLanguage'
           description: Query language to use
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
           description: EQL query to execute
         type:
           description: Rule type
@@ -23804,125 +23570,101 @@ components:
         - type
         - query
         - language
-    Security_Solution_Detections_API_EqlRule:
+    Security_Detections_API_EqlRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -23946,428 +23688,341 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRuleResponseFields
-    Security_Solution_Detections_API_EqlRuleCreateFields:
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRuleResponseFields'
+    Security_Detections_API_EqlRuleCreateFields:
       allOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRequiredFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlOptionalFields
-    Security_Solution_Detections_API_EqlRuleCreateProps:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRequiredFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EqlOptionalFields'
+    Security_Detections_API_EqlRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRuleCreateFields
-    Security_Solution_Detections_API_EqlRulePatchFields:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRuleCreateFields'
+    Security_Detections_API_EqlRulePatchFields:
       allOf:
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_EqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_EqlQueryLanguage'
               description: Query language to use
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
               description: EQL query to execute
             type:
               description: Rule type
               enum:
                 - eql
               type: string
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlOptionalFields
-    Security_Solution_Detections_API_EqlRulePatchProps:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlOptionalFields'
+    Security_Detections_API_EqlRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRulePatchFields
-    Security_Solution_Detections_API_EqlRuleResponseFields:
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRulePatchFields'
+    Security_Detections_API_EqlRuleResponseFields:
       allOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRequiredFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlOptionalFields
-    Security_Solution_Detections_API_EqlRuleUpdateProps:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRequiredFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EqlOptionalFields'
+    Security_Detections_API_EqlRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRuleCreateFields
-    Security_Solution_Detections_API_ErrorSchema:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRuleCreateFields'
+    Security_Detections_API_ErrorSchema:
       additionalProperties: false
       type: object
       properties:
@@ -24391,133 +24046,108 @@ components:
           minLength: 1
           type: string
         rule_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+          $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
       required:
         - error
-    Security_Solution_Detections_API_EsqlQueryLanguage:
+    Security_Detections_API_EsqlQueryLanguage:
       enum:
         - esql
       type: string
-    Security_Solution_Detections_API_EsqlRule:
+    Security_Detections_API_EsqlRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -24541,301 +24171,241 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleResponseFields
-    Security_Solution_Detections_API_EsqlRuleCreateFields:
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleResponseFields'
+    Security_Detections_API_EsqlRuleCreateFields:
       allOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleOptionalFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleRequiredFields
-    Security_Solution_Detections_API_EsqlRuleCreateProps:
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleOptionalFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleRequiredFields'
+    Security_Detections_API_EsqlRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleCreateFields
-    Security_Solution_Detections_API_EsqlRuleOptionalFields:
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleCreateFields'
+    Security_Detections_API_EsqlRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         response_actions:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ResponseAction
+            $ref: '#/components/schemas/Security_Detections_API_ResponseAction'
           type: array
-    Security_Solution_Detections_API_EsqlRulePatchProps:
+    Security_Detections_API_EsqlRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_EsqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_EsqlQueryLanguage'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
               description: ESQL query to execute
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             type:
               description: Rule type
               enum:
                 - esql
               type: string
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleOptionalFields
-    Security_Solution_Detections_API_EsqlRuleRequiredFields:
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleOptionalFields'
+    Security_Detections_API_EsqlRuleRequiredFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlQueryLanguage
+          $ref: '#/components/schemas/Security_Detections_API_EsqlQueryLanguage'
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
           description: ESQL query to execute
         type:
           description: Rule type
@@ -24846,147 +24416,118 @@ components:
         - type
         - language
         - query
-    Security_Solution_Detections_API_EsqlRuleResponseFields:
+    Security_Detections_API_EsqlRuleResponseFields:
       allOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleOptionalFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleRequiredFields
-    Security_Solution_Detections_API_EsqlRuleUpdateProps:
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleOptionalFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleRequiredFields'
+    Security_Detections_API_EsqlRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleCreateFields
-    Security_Solution_Detections_API_EventCategoryOverride:
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleCreateFields'
+    Security_Detections_API_EventCategoryOverride:
       type: string
-    Security_Solution_Detections_API_ExceptionListType:
+    Security_Detections_API_ExceptionListType:
       description: The exception type
       enum:
         - detection
@@ -24997,7 +24538,7 @@ components:
         - endpoint_host_isolation_exceptions
         - endpoint_blocklists
       type: string
-    Security_Solution_Detections_API_ExternalRuleSource:
+    Security_Detections_API_ExternalRuleSource:
       description: >-
         Type of rule source for externally sourced rules, i.e. rules that have
         an external source, such as the Elastic Prebuilt rules repo.
@@ -25005,7 +24546,7 @@ components:
       properties:
         is_customized:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IsExternalRuleCustomized
+            #/components/schemas/Security_Detections_API_IsExternalRuleCustomized
         type:
           enum:
             - external
@@ -25013,7 +24554,7 @@ components:
       required:
         - type
         - is_customized
-    Security_Solution_Detections_API_FindRulesSortField:
+    Security_Detections_API_FindRulesSortField:
       enum:
         - created_at
         - createdAt
@@ -25030,13 +24571,13 @@ components:
         - updated_at
         - updatedAt
       type: string
-    Security_Solution_Detections_API_HistoryWindowStart:
-      $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
-    Security_Solution_Detections_API_IndexPatternArray:
+    Security_Detections_API_HistoryWindowStart:
+      $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
+    Security_Detections_API_IndexPatternArray:
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_InternalRuleSource:
+    Security_Detections_API_InternalRuleSource:
       description: >-
         Type of rule source for internally sourced rules, i.e. created within
         the Kibana apps.
@@ -25048,7 +24589,7 @@ components:
           type: string
       required:
         - type
-    Security_Solution_Detections_API_InvestigationFields:
+    Security_Detections_API_InvestigationFields:
       description: >
         Schema for fields relating to investigation fields. These are user
         defined fields we use to highlight
@@ -25081,39 +24622,38 @@ components:
       properties:
         field_names:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           minItems: 1
           type: array
       required:
         - field_names
-    Security_Solution_Detections_API_InvestigationGuide:
+    Security_Detections_API_InvestigationGuide:
       description: Notes to help investigate alerts produced by the rule.
       type: string
-    Security_Solution_Detections_API_IsExternalRuleCustomized:
+    Security_Detections_API_IsExternalRuleCustomized:
       description: >-
         Determines whether an external/prebuilt rule has been customized by the
         user (i.e. any of its fields have been modified and diverged from the
         base value).
       type: boolean
-    Security_Solution_Detections_API_IsRuleEnabled:
+    Security_Detections_API_IsRuleEnabled:
       description: Determines whether the rule is enabled.
       type: boolean
-    Security_Solution_Detections_API_IsRuleImmutable:
+    Security_Detections_API_IsRuleImmutable:
       deprecated: true
       description: >-
         This field determines whether the rule is a prebuilt Elastic rule. It
         will be replaced with the `rule_source` field.
       type: boolean
-    Security_Solution_Detections_API_ItemsPerSearch:
+    Security_Detections_API_ItemsPerSearch:
       minimum: 1
       type: integer
-    Security_Solution_Detections_API_KqlQueryLanguage:
+    Security_Detections_API_KqlQueryLanguage:
       enum:
         - kuery
         - lucene
       type: string
-    Security_Solution_Detections_API_MachineLearningJobId:
+    Security_Detections_API_MachineLearningJobId:
       description: Machine learning job ID
       oneOf:
         - type: string
@@ -25121,125 +24661,101 @@ components:
             type: string
           minItems: 1
           type: array
-    Security_Solution_Detections_API_MachineLearningRule:
+    Security_Detections_API_MachineLearningRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -25263,303 +24779,248 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleResponseFields
-    Security_Solution_Detections_API_MachineLearningRuleCreateFields:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleResponseFields
+    Security_Detections_API_MachineLearningRuleCreateFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleRequiredFields
+            #/components/schemas/Security_Detections_API_MachineLearningRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleOptionalFields
-    Security_Solution_Detections_API_MachineLearningRuleCreateProps:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleOptionalFields
+    Security_Detections_API_MachineLearningRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleCreateFields
-    Security_Solution_Detections_API_MachineLearningRuleOptionalFields:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleCreateFields
+    Security_Detections_API_MachineLearningRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
-    Security_Solution_Detections_API_MachineLearningRulePatchFields:
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
+    Security_Detections_API_MachineLearningRulePatchFields:
       allOf:
         - type: object
           properties:
             anomaly_threshold:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AnomalyThreshold
+              $ref: '#/components/schemas/Security_Detections_API_AnomalyThreshold'
             machine_learning_job_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_MachineLearningJobId
+                #/components/schemas/Security_Detections_API_MachineLearningJobId
             type:
               description: Rule type
               enum:
                 - machine_learning
               type: string
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleOptionalFields
-    Security_Solution_Detections_API_MachineLearningRulePatchProps:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleOptionalFields
+    Security_Detections_API_MachineLearningRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRulePatchFields
-    Security_Solution_Detections_API_MachineLearningRuleRequiredFields:
+            #/components/schemas/Security_Detections_API_MachineLearningRulePatchFields
+    Security_Detections_API_MachineLearningRuleRequiredFields:
       type: object
       properties:
         anomaly_threshold:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AnomalyThreshold
+          $ref: '#/components/schemas/Security_Detections_API_AnomalyThreshold'
         machine_learning_job_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningJobId
+          $ref: '#/components/schemas/Security_Detections_API_MachineLearningJobId'
         type:
           description: Rule type
           enum:
@@ -25569,272 +25030,222 @@ components:
         - type
         - machine_learning_job_id
         - anomaly_threshold
-    Security_Solution_Detections_API_MachineLearningRuleResponseFields:
+    Security_Detections_API_MachineLearningRuleResponseFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleRequiredFields
+            #/components/schemas/Security_Detections_API_MachineLearningRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleOptionalFields
-    Security_Solution_Detections_API_MachineLearningRuleUpdateProps:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleOptionalFields
+    Security_Detections_API_MachineLearningRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleCreateFields
-    Security_Solution_Detections_API_MaxSignals:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleCreateFields
+    Security_Detections_API_MaxSignals:
       minimum: 1
       type: integer
-    Security_Solution_Detections_API_NewTermsFields:
+    Security_Detections_API_NewTermsFields:
       items:
         type: string
       maxItems: 3
       minItems: 1
       type: array
-    Security_Solution_Detections_API_NewTermsRule:
+    Security_Detections_API_NewTermsRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -25858,329 +25269,269 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleResponseFields
-    Security_Solution_Detections_API_NewTermsRuleCreateFields:
+            #/components/schemas/Security_Detections_API_NewTermsRuleResponseFields
+    Security_Detections_API_NewTermsRuleCreateFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleRequiredFields
+            #/components/schemas/Security_Detections_API_NewTermsRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleOptionalFields
+            #/components/schemas/Security_Detections_API_NewTermsRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleDefaultableFields
-    Security_Solution_Detections_API_NewTermsRuleCreateProps:
+            #/components/schemas/Security_Detections_API_NewTermsRuleDefaultableFields
+    Security_Detections_API_NewTermsRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleCreateFields
-    Security_Solution_Detections_API_NewTermsRuleDefaultableFields:
+            #/components/schemas/Security_Detections_API_NewTermsRuleCreateFields
+    Security_Detections_API_NewTermsRuleDefaultableFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
-    Security_Solution_Detections_API_NewTermsRuleOptionalFields:
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
+    Security_Detections_API_NewTermsRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         response_actions:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ResponseAction
+            $ref: '#/components/schemas/Security_Detections_API_ResponseAction'
           type: array
-    Security_Solution_Detections_API_NewTermsRulePatchFields:
+    Security_Detections_API_NewTermsRulePatchFields:
       allOf:
         - type: object
           properties:
             history_window_start:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_HistoryWindowStart
+              $ref: '#/components/schemas/Security_Detections_API_HistoryWindowStart'
             new_terms_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_NewTermsFields
+              $ref: '#/components/schemas/Security_Detections_API_NewTermsFields'
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
             type:
               description: Rule type
               enum:
                 - new_terms
               type: string
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleOptionalFields
+            #/components/schemas/Security_Detections_API_NewTermsRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleDefaultableFields
-    Security_Solution_Detections_API_NewTermsRulePatchProps:
+            #/components/schemas/Security_Detections_API_NewTermsRuleDefaultableFields
+    Security_Detections_API_NewTermsRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRulePatchFields
-    Security_Solution_Detections_API_NewTermsRuleRequiredFields:
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
+        - $ref: '#/components/schemas/Security_Detections_API_NewTermsRulePatchFields'
+    Security_Detections_API_NewTermsRuleRequiredFields:
       type: object
       properties:
         history_window_start:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_HistoryWindowStart
+          $ref: '#/components/schemas/Security_Detections_API_HistoryWindowStart'
         new_terms_fields:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NewTermsFields'
+          $ref: '#/components/schemas/Security_Detections_API_NewTermsFields'
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
         type:
           description: Rule type
           enum:
@@ -26191,189 +25542,157 @@ components:
         - query
         - new_terms_fields
         - history_window_start
-    Security_Solution_Detections_API_NewTermsRuleResponseFields:
+    Security_Detections_API_NewTermsRuleResponseFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleRequiredFields
+            #/components/schemas/Security_Detections_API_NewTermsRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleOptionalFields
+            #/components/schemas/Security_Detections_API_NewTermsRuleOptionalFields
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
           required:
             - language
-    Security_Solution_Detections_API_NewTermsRuleUpdateProps:
+    Security_Detections_API_NewTermsRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleCreateFields
-    Security_Solution_Detections_API_NonEmptyString:
+            #/components/schemas/Security_Detections_API_NewTermsRuleCreateFields
+    Security_Detections_API_NonEmptyString:
       description: A string that is not empty and does not contain only whitespace
       minLength: 1
       pattern: ^(?! *$).+$
       type: string
-    Security_Solution_Detections_API_NormalizedRuleAction:
+    Security_Detections_API_NormalizedRuleAction:
       additionalProperties: false
       type: object
       properties:
         alerts_filter:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionAlertsFilter
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionAlertsFilter'
         frequency:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionFrequency
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionFrequency'
         group:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionGroup
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionGroup'
         id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleActionId'
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionId'
         params:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionParams
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionParams'
       required:
         - id
         - params
-    Security_Solution_Detections_API_NormalizedRuleError:
+    Security_Detections_API_NormalizedRuleError:
       type: object
       properties:
         err_code:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionsDryRunErrCode
+            #/components/schemas/Security_Detections_API_BulkActionsDryRunErrCode
         message:
           type: string
         rules:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_RuleDetailsInError
+            $ref: '#/components/schemas/Security_Detections_API_RuleDetailsInError'
           type: array
         status_code:
           type: integer
@@ -26381,16 +25700,16 @@ components:
         - message
         - status_code
         - rules
-    Security_Solution_Detections_API_OsqueryParams:
+    Security_Detections_API_OsqueryParams:
       type: object
       properties:
         ecs_mapping:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_EcsMapping'
+          $ref: '#/components/schemas/Security_Detections_API_EcsMapping'
         pack_id:
           type: string
         queries:
           items:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_OsqueryQuery'
+            $ref: '#/components/schemas/Security_Detections_API_OsqueryQuery'
           type: array
         query:
           type: string
@@ -26398,11 +25717,11 @@ components:
           type: string
         timeout:
           type: number
-    Security_Solution_Detections_API_OsqueryQuery:
+    Security_Detections_API_OsqueryQuery:
       type: object
       properties:
         ecs_mapping:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_EcsMapping'
+          $ref: '#/components/schemas/Security_Detections_API_EcsMapping'
         id:
           description: Query ID
           type: string
@@ -26421,7 +25740,7 @@ components:
       required:
         - id
         - query
-    Security_Solution_Detections_API_OsqueryResponseAction:
+    Security_Detections_API_OsqueryResponseAction:
       type: object
       properties:
         action_type_id:
@@ -26429,11 +25748,11 @@ components:
             - .osquery
           type: string
         params:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_OsqueryParams'
+          $ref: '#/components/schemas/Security_Detections_API_OsqueryParams'
       required:
         - action_type_id
         - params
-    Security_Solution_Detections_API_PlatformErrorResponse:
+    Security_Detections_API_PlatformErrorResponse:
       type: object
       properties:
         error:
@@ -26446,7 +25765,7 @@ components:
         - statusCode
         - error
         - message
-    Security_Solution_Detections_API_ProcessesParams:
+    Security_Detections_API_ProcessesParams:
       type: object
       properties:
         command:
@@ -26471,125 +25790,101 @@ components:
       required:
         - command
         - config
-    Security_Solution_Detections_API_QueryRule:
+    Security_Detections_API_QueryRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -26613,176 +25908,142 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleResponseFields
-    Security_Solution_Detections_API_QueryRuleCreateFields:
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleResponseFields'
+    Security_Detections_API_QueryRuleCreateFields:
       allOf:
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleRequiredFields'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleOptionalFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleRequiredFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleOptionalFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleDefaultableFields
-    Security_Solution_Detections_API_QueryRuleCreateProps:
+            #/components/schemas/Security_Detections_API_QueryRuleDefaultableFields
+    Security_Detections_API_QueryRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleCreateFields
-    Security_Solution_Detections_API_QueryRuleDefaultableFields:
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleCreateFields'
+    Security_Detections_API_QueryRuleDefaultableFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
-    Security_Solution_Detections_API_QueryRuleOptionalFields:
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
+    Security_Detections_API_QueryRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         response_actions:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ResponseAction
+            $ref: '#/components/schemas/Security_Detections_API_ResponseAction'
           type: array
         saved_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_SavedQueryId'
-    Security_Solution_Detections_API_QueryRulePatchFields:
+          $ref: '#/components/schemas/Security_Detections_API_SavedQueryId'
+    Security_Detections_API_QueryRulePatchFields:
       allOf:
         - type: object
           properties:
@@ -26791,138 +26052,110 @@ components:
               enum:
                 - query
               type: string
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleOptionalFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleOptionalFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleDefaultableFields
-    Security_Solution_Detections_API_QueryRulePatchProps:
+            #/components/schemas/Security_Detections_API_QueryRuleDefaultableFields
+    Security_Detections_API_QueryRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRulePatchFields
-    Security_Solution_Detections_API_QueryRuleRequiredFields:
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRulePatchFields'
+    Security_Detections_API_QueryRuleRequiredFields:
       type: object
       properties:
         type:
@@ -26932,155 +26165,125 @@ components:
           type: string
       required:
         - type
-    Security_Solution_Detections_API_QueryRuleResponseFields:
+    Security_Detections_API_QueryRuleResponseFields:
       allOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleRequiredFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleOptionalFields
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleRequiredFields'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleOptionalFields'
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
           required:
             - query
             - language
-    Security_Solution_Detections_API_QueryRuleUpdateProps:
+    Security_Detections_API_QueryRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleCreateFields
-    Security_Solution_Detections_API_RelatedIntegration:
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleCreateFields'
+    Security_Detections_API_RelatedIntegration:
       description: >
         Related integration is a potential dependency of a rule. It's assumed
         that if the user installs
@@ -27141,20 +26344,19 @@ components:
       type: object
       properties:
         integration:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
         package:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
         version:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
       required:
         - package
         - version
-    Security_Solution_Detections_API_RelatedIntegrationArray:
+    Security_Detections_API_RelatedIntegrationArray:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Detections_API_RelatedIntegration
+        $ref: '#/components/schemas/Security_Detections_API_RelatedIntegration'
       type: array
-    Security_Solution_Detections_API_RequiredField:
+    Security_Detections_API_RequiredField:
       description: >
         Describes an Elasticsearch field that is needed for the rule to
         function.
@@ -27195,20 +26397,20 @@ components:
           description: Whether the field is an ECS field
           type: boolean
         name:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Name of an Elasticsearch field
         type:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Type of the Elasticsearch field
       required:
         - name
         - type
         - ecs
-    Security_Solution_Detections_API_RequiredFieldArray:
+    Security_Detections_API_RequiredFieldArray:
       items:
-        $ref: '#/components/schemas/Security_Solution_Detections_API_RequiredField'
+        $ref: '#/components/schemas/Security_Detections_API_RequiredField'
       type: array
-    Security_Solution_Detections_API_RequiredFieldInput:
+    Security_Detections_API_RequiredFieldInput:
       description: >-
         Input parameters to create a RequiredField. Does not include the `ecs`
         field, because `ecs` is calculated on the backend based on the field
@@ -27216,21 +26418,19 @@ components:
       type: object
       properties:
         name:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Name of an Elasticsearch field
         type:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Type of an Elasticsearch field
       required:
         - name
         - type
-    Security_Solution_Detections_API_ResponseAction:
+    Security_Detections_API_ResponseAction:
       oneOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_OsqueryResponseAction
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EndpointResponseAction
-    Security_Solution_Detections_API_ResponseFields:
+        - $ref: '#/components/schemas/Security_Detections_API_OsqueryResponseAction'
+        - $ref: '#/components/schemas/Security_Detections_API_EndpointResponseAction'
+    Security_Detections_API_ResponseFields:
       type: object
       properties:
         created_at:
@@ -27239,24 +26439,20 @@ components:
         created_by:
           type: string
         execution_summary:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleExecutionSummary
+          $ref: '#/components/schemas/Security_Detections_API_RuleExecutionSummary'
         id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleObjectId'
+          $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
         immutable:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IsRuleImmutable
+          $ref: '#/components/schemas/Security_Detections_API_IsRuleImmutable'
         required_fields:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RequiredFieldArray
+          $ref: '#/components/schemas/Security_Detections_API_RequiredFieldArray'
         revision:
           minimum: 0
           type: integer
         rule_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+          $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
         rule_source:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleSource'
+          $ref: '#/components/schemas/Security_Detections_API_RuleSource'
         updated_at:
           format: date-time
           type: string
@@ -27273,12 +26469,12 @@ components:
         - revision
         - related_integrations
         - required_fields
-    Security_Solution_Detections_API_RiskScore:
+    Security_Detections_API_RiskScore:
       description: Risk score (0 to 100)
       maximum: 100
       minimum: 0
       type: integer
-    Security_Solution_Detections_API_RiskScoreMapping:
+    Security_Detections_API_RiskScoreMapping:
       description: >-
         Overrides generated alerts' risk_score with a value from the source
         event
@@ -27292,7 +26488,7 @@ components:
               - equals
             type: string
           risk_score:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+            $ref: '#/components/schemas/Security_Detections_API_RiskScore'
           value:
             type: string
         required:
@@ -27300,66 +26496,60 @@ components:
           - operator
           - value
       type: array
-    Security_Solution_Detections_API_RuleAction:
+    Security_Detections_API_RuleAction:
       type: object
       properties:
         action_type_id:
           description: The action type used for sending notifications.
           type: string
         alerts_filter:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionAlertsFilter
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionAlertsFilter'
         frequency:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionFrequency
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionFrequency'
         group:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionGroup
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionGroup'
         id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleActionId'
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionId'
         params:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionParams
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionParams'
         uuid:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
       required:
         - action_type_id
         - id
         - params
-    Security_Solution_Detections_API_RuleActionAlertsFilter:
+    Security_Detections_API_RuleActionAlertsFilter:
       additionalProperties: true
       type: object
-    Security_Solution_Detections_API_RuleActionFrequency:
+    Security_Detections_API_RuleActionFrequency:
       description: >-
         The action frequency defines when the action runs (for example, only on
         rule execution or at specific time intervals).
       type: object
       properties:
         notifyWhen:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionNotifyWhen
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionNotifyWhen'
         summary:
           description: >-
             Action summary indicates whether we will send a summary notification
             about all the generate alerts or notification per individual alert
           type: boolean
         throttle:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
           nullable: true
       required:
         - summary
         - notifyWhen
         - throttle
-    Security_Solution_Detections_API_RuleActionGroup:
+    Security_Detections_API_RuleActionGroup:
       description: >-
         Optionally groups actions by use cases. Use `default` for alert
         notifications.
       type: string
-    Security_Solution_Detections_API_RuleActionId:
+    Security_Detections_API_RuleActionId:
       description: The connector ID.
       type: string
-    Security_Solution_Detections_API_RuleActionNotifyWhen:
+    Security_Detections_API_RuleActionNotifyWhen:
       description: >-
         The condition for throttling the notification: `onActionGroupChange`,
         `onActiveAlert`,  or `onThrottleInterval`
@@ -27368,13 +26558,13 @@ components:
         - onThrottleInterval
         - onActionGroupChange
       type: string
-    Security_Solution_Detections_API_RuleActionParams:
+    Security_Detections_API_RuleActionParams:
       additionalProperties: true
       description: >-
         Object containing the allowed connector fields, which varies according
         to the connector type.
       type: object
-    Security_Solution_Detections_API_RuleActionThrottle:
+    Security_Detections_API_RuleActionThrottle:
       description: Defines how often rule actions are taken.
       oneOf:
         - enum:
@@ -27385,34 +26575,30 @@ components:
           example: 1h
           pattern: ^[1-9]\d*[smhd]$
           type: string
-    Security_Solution_Detections_API_RuleAuthorArray:
+    Security_Detections_API_RuleAuthorArray:
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_RuleCreateProps:
+    Security_Detections_API_RuleCreateProps:
       anyOf:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRuleCreateProps'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleCreateProps'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRuleCreateProps
+            #/components/schemas/Security_Detections_API_SavedQueryRuleCreateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleCreateProps
+            #/components/schemas/Security_Detections_API_ThresholdRuleCreateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleCreateProps
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleCreateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleCreateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleCreateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleCreateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleCreateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleCreateProps
+            #/components/schemas/Security_Detections_API_MachineLearningRuleCreateProps
+        - $ref: '#/components/schemas/Security_Detections_API_NewTermsRuleCreateProps'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleCreateProps'
       discriminator:
         propertyName: type
-    Security_Solution_Detections_API_RuleDescription:
+    Security_Detections_API_RuleDescription:
       minLength: 1
       type: string
-    Security_Solution_Detections_API_RuleDetailsInError:
+    Security_Detections_API_RuleDetailsInError:
       type: object
       properties:
         id:
@@ -27421,14 +26607,14 @@ components:
           type: string
       required:
         - id
-    Security_Solution_Detections_API_RuleExceptionList:
+    Security_Detections_API_RuleExceptionList:
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: ID of the exception container
         list_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: List ID of the exception container
         namespace_type:
           description: Determines the exceptions validity in rule's Kibana space
@@ -27437,14 +26623,13 @@ components:
             - single
           type: string
         type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ExceptionListType
+          $ref: '#/components/schemas/Security_Detections_API_ExceptionListType'
       required:
         - id
         - list_id
         - type
         - namespace_type
-    Security_Solution_Detections_API_RuleExecutionMetrics:
+    Security_Detections_API_RuleExecutionMetrics:
       type: object
       properties:
         execution_gap_duration_s:
@@ -27470,7 +26655,7 @@ components:
             request/response
           minimum: 0
           type: integer
-    Security_Solution_Detections_API_RuleExecutionStatus:
+    Security_Detections_API_RuleExecutionStatus:
       description: >-
         Custom execution status of Security rules that is different from the
         status used in the Alerting Framework. We merge our custom status with
@@ -27503,9 +26688,9 @@ components:
         - failed
         - succeeded
       type: string
-    Security_Solution_Detections_API_RuleExecutionStatusOrder:
+    Security_Detections_API_RuleExecutionStatusOrder:
       type: integer
-    Security_Solution_Detections_API_RuleExecutionSummary:
+    Security_Detections_API_RuleExecutionSummary:
       type: object
       properties:
         last_execution:
@@ -27519,14 +26704,13 @@ components:
               type: string
             metrics:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleExecutionMetrics
+                #/components/schemas/Security_Detections_API_RuleExecutionMetrics
             status:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleExecutionStatus
+              $ref: '#/components/schemas/Security_Detections_API_RuleExecutionStatus'
               description: Status of the last execution
             status_order:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleExecutionStatusOrder
+                #/components/schemas/Security_Detections_API_RuleExecutionStatusOrder
           required:
             - date
             - status
@@ -27535,19 +26719,19 @@ components:
             - metrics
       required:
         - last_execution
-    Security_Solution_Detections_API_RuleFalsePositiveArray:
+    Security_Detections_API_RuleFalsePositiveArray:
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_RuleFilterArray:
+    Security_Detections_API_RuleFilterArray:
       items: {}
       type: array
-    Security_Solution_Detections_API_RuleInterval:
+    Security_Detections_API_RuleInterval:
       description: >-
         Frequency of rule execution, using a date math range. For example, "1h"
         means the rule runs every hour. Defaults to 5m (5 minutes).
       type: string
-    Security_Solution_Detections_API_RuleIntervalFrom:
+    Security_Detections_API_RuleIntervalFrom:
       description: >-
         Time from which data is analyzed each time the rule runs, using a date
         math range. For example, now-4200s means the rule analyzes data from 70
@@ -27555,52 +26739,47 @@ components:
         minutes before the start time).
       format: date-math
       type: string
-    Security_Solution_Detections_API_RuleIntervalTo:
+    Security_Detections_API_RuleIntervalTo:
       type: string
-    Security_Solution_Detections_API_RuleLicense:
+    Security_Detections_API_RuleLicense:
       description: The rule's license.
       type: string
-    Security_Solution_Detections_API_RuleMetadata:
+    Security_Detections_API_RuleMetadata:
       additionalProperties: true
       type: object
-    Security_Solution_Detections_API_RuleName:
+    Security_Detections_API_RuleName:
       minLength: 1
       type: string
-    Security_Solution_Detections_API_RuleNameOverride:
+    Security_Detections_API_RuleNameOverride:
       description: Sets the source field for the alert's signal.rule.name value
       type: string
-    Security_Solution_Detections_API_RuleObjectId:
-      $ref: '#/components/schemas/Security_Solution_Detections_API_UUID'
-    Security_Solution_Detections_API_RulePatchProps:
+    Security_Detections_API_RuleObjectId:
+      $ref: '#/components/schemas/Security_Detections_API_UUID'
+    Security_Detections_API_RulePatchProps:
       anyOf:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRulePatchProps'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRulePatchProps'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRulePatchProps
+            #/components/schemas/Security_Detections_API_SavedQueryRulePatchProps
+        - $ref: '#/components/schemas/Security_Detections_API_ThresholdRulePatchProps'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRulePatchProps
+            #/components/schemas/Security_Detections_API_ThreatMatchRulePatchProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRulePatchProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRulePatchProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRulePatchProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRulePatchProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRulePatchProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRulePatchProps
-    Security_Solution_Detections_API_RulePreviewLoggedRequest:
+            #/components/schemas/Security_Detections_API_MachineLearningRulePatchProps
+        - $ref: '#/components/schemas/Security_Detections_API_NewTermsRulePatchProps'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRulePatchProps'
+    Security_Detections_API_RulePreviewLoggedRequest:
       type: object
       properties:
         description:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
         duration:
           type: integer
         request:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
       required:
         - request
-    Security_Solution_Detections_API_RulePreviewLogs:
+    Security_Detections_API_RulePreviewLogs:
       type: object
       properties:
         duration:
@@ -27608,26 +26787,24 @@ components:
           type: integer
         errors:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           type: array
         requests:
           items:
             $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_RulePreviewLoggedRequest
+              #/components/schemas/Security_Detections_API_RulePreviewLoggedRequest
           type: array
         startedAt:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
         warnings:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           type: array
       required:
         - errors
         - warnings
         - duration
-    Security_Solution_Detections_API_RulePreviewParams:
+    Security_Detections_API_RulePreviewParams:
       type: object
       properties:
         invocationCount:
@@ -27638,30 +26815,28 @@ components:
       required:
         - invocationCount
         - timeframeEnd
-    Security_Solution_Detections_API_RuleQuery:
+    Security_Detections_API_RuleQuery:
       type: string
-    Security_Solution_Detections_API_RuleReferenceArray:
+    Security_Detections_API_RuleReferenceArray:
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_RuleResponse:
+    Security_Detections_API_RuleResponse:
       anyOf:
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_EqlRule'
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_QueryRule'
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_SavedQueryRule'
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ThresholdRule'
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRule
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRule
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_NewTermsRule'
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_EsqlRule'
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRule'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRule'
+        - $ref: '#/components/schemas/Security_Detections_API_SavedQueryRule'
+        - $ref: '#/components/schemas/Security_Detections_API_ThresholdRule'
+        - $ref: '#/components/schemas/Security_Detections_API_ThreatMatchRule'
+        - $ref: '#/components/schemas/Security_Detections_API_MachineLearningRule'
+        - $ref: '#/components/schemas/Security_Detections_API_NewTermsRule'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRule'
       discriminator:
         propertyName: type
-    Security_Solution_Detections_API_RuleSignatureId:
+    Security_Detections_API_RuleSignatureId:
       description: Could be any string, not necessarily a UUID
       type: string
-    Security_Solution_Detections_API_RuleSource:
+    Security_Detections_API_RuleSource:
       description: >-
         Discriminated union that determines whether the rule is internally
         sourced (created within the Kibana app) or has an external source, such
@@ -27669,175 +26844,145 @@ components:
       discriminator:
         propertyName: type
       oneOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ExternalRuleSource
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_InternalRuleSource
-    Security_Solution_Detections_API_RuleTagArray:
+        - $ref: '#/components/schemas/Security_Detections_API_ExternalRuleSource'
+        - $ref: '#/components/schemas/Security_Detections_API_InternalRuleSource'
+    Security_Detections_API_RuleTagArray:
       description: >-
         String array containing words and phrases to help categorize, filter,
         and search rules. Defaults to an empty array.
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_RuleUpdateProps:
+    Security_Detections_API_RuleUpdateProps:
       anyOf:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRuleUpdateProps'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleUpdateProps'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRuleUpdateProps
+            #/components/schemas/Security_Detections_API_SavedQueryRuleUpdateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleUpdateProps
+            #/components/schemas/Security_Detections_API_ThresholdRuleUpdateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleUpdateProps
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleUpdateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleUpdateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleUpdateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleUpdateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleUpdateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleUpdateProps
+            #/components/schemas/Security_Detections_API_MachineLearningRuleUpdateProps
+        - $ref: '#/components/schemas/Security_Detections_API_NewTermsRuleUpdateProps'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleUpdateProps'
       discriminator:
         propertyName: type
-    Security_Solution_Detections_API_RuleVersion:
+    Security_Detections_API_RuleVersion:
       description: The rule's version number.
       minimum: 1
       type: integer
-    Security_Solution_Detections_API_SavedObjectResolveAliasPurpose:
+    Security_Detections_API_SavedObjectResolveAliasPurpose:
       enum:
         - savedObjectConversion
         - savedObjectImport
       type: string
-    Security_Solution_Detections_API_SavedObjectResolveAliasTargetId:
+    Security_Detections_API_SavedObjectResolveAliasTargetId:
       type: string
-    Security_Solution_Detections_API_SavedObjectResolveOutcome:
+    Security_Detections_API_SavedObjectResolveOutcome:
       enum:
         - exactMatch
         - aliasMatch
         - conflict
       type: string
-    Security_Solution_Detections_API_SavedQueryId:
+    Security_Detections_API_SavedQueryId:
       type: string
-    Security_Solution_Detections_API_SavedQueryRule:
+    Security_Detections_API_SavedQueryRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -27861,321 +27006,264 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleResponseFields
-    Security_Solution_Detections_API_SavedQueryRuleCreateFields:
+            #/components/schemas/Security_Detections_API_SavedQueryRuleResponseFields
+    Security_Detections_API_SavedQueryRuleCreateFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleRequiredFields
+            #/components/schemas/Security_Detections_API_SavedQueryRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleOptionalFields
+            #/components/schemas/Security_Detections_API_SavedQueryRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleDefaultableFields
-    Security_Solution_Detections_API_SavedQueryRuleCreateProps:
+            #/components/schemas/Security_Detections_API_SavedQueryRuleDefaultableFields
+    Security_Detections_API_SavedQueryRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleCreateFields
-    Security_Solution_Detections_API_SavedQueryRuleDefaultableFields:
+            #/components/schemas/Security_Detections_API_SavedQueryRuleCreateFields
+    Security_Detections_API_SavedQueryRuleDefaultableFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
-    Security_Solution_Detections_API_SavedQueryRuleOptionalFields:
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
+    Security_Detections_API_SavedQueryRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
         response_actions:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ResponseAction
+            $ref: '#/components/schemas/Security_Detections_API_ResponseAction'
           type: array
-    Security_Solution_Detections_API_SavedQueryRulePatchFields:
+    Security_Detections_API_SavedQueryRulePatchFields:
       allOf:
         - type: object
           properties:
             saved_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedQueryId
+              $ref: '#/components/schemas/Security_Detections_API_SavedQueryId'
             type:
               description: Rule type
               enum:
                 - saved_query
               type: string
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleOptionalFields
+            #/components/schemas/Security_Detections_API_SavedQueryRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleDefaultableFields
-    Security_Solution_Detections_API_SavedQueryRulePatchProps:
+            #/components/schemas/Security_Detections_API_SavedQueryRuleDefaultableFields
+    Security_Detections_API_SavedQueryRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRulePatchFields
-    Security_Solution_Detections_API_SavedQueryRuleRequiredFields:
+            #/components/schemas/Security_Detections_API_SavedQueryRulePatchFields
+    Security_Detections_API_SavedQueryRuleRequiredFields:
       type: object
       properties:
         saved_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_SavedQueryId'
+          $ref: '#/components/schemas/Security_Detections_API_SavedQueryId'
         type:
           description: Rule type
           enum:
@@ -28184,166 +27272,138 @@ components:
       required:
         - type
         - saved_id
-    Security_Solution_Detections_API_SavedQueryRuleResponseFields:
+    Security_Detections_API_SavedQueryRuleResponseFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleRequiredFields
+            #/components/schemas/Security_Detections_API_SavedQueryRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleOptionalFields
+            #/components/schemas/Security_Detections_API_SavedQueryRuleOptionalFields
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
           required:
             - language
-    Security_Solution_Detections_API_SavedQueryRuleUpdateProps:
+    Security_Detections_API_SavedQueryRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleCreateFields
-    Security_Solution_Detections_API_SetAlertsStatusByIds:
+            #/components/schemas/Security_Detections_API_SavedQueryRuleCreateFields
+    Security_Detections_API_SetAlertsStatusByIds:
       type: object
       properties:
         signal_ids:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           minItems: 1
           type: array
         status:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_AlertStatus'
+          $ref: '#/components/schemas/Security_Detections_API_AlertStatus'
       required:
         - signal_ids
         - status
-    Security_Solution_Detections_API_SetAlertsStatusByQuery:
+    Security_Detections_API_SetAlertsStatusByQuery:
       type: object
       properties:
         conflicts:
@@ -28356,23 +27416,23 @@ components:
           additionalProperties: true
           type: object
         status:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_AlertStatus'
+          $ref: '#/components/schemas/Security_Detections_API_AlertStatus'
       required:
         - query
         - status
-    Security_Solution_Detections_API_SetAlertTags:
+    Security_Detections_API_SetAlertTags:
       type: object
       properties:
         tags_to_add:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_AlertTags'
+          $ref: '#/components/schemas/Security_Detections_API_AlertTags'
         tags_to_remove:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_AlertTags'
+          $ref: '#/components/schemas/Security_Detections_API_AlertTags'
       required:
         - tags_to_add
         - tags_to_remove
-    Security_Solution_Detections_API_SetupGuide:
+    Security_Detections_API_SetupGuide:
       type: string
-    Security_Solution_Detections_API_Severity:
+    Security_Detections_API_Severity:
       description: Severity of the rule
       enum:
         - low
@@ -28380,7 +27440,7 @@ components:
         - high
         - critical
       type: string
-    Security_Solution_Detections_API_SeverityMapping:
+    Security_Detections_API_SeverityMapping:
       description: Overrides generated alerts' severity with values from the source event
       items:
         type: object
@@ -28392,7 +27452,7 @@ components:
               - equals
             type: string
           severity:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+            $ref: '#/components/schemas/Security_Detections_API_Severity'
           value:
             type: string
         required:
@@ -28401,7 +27461,7 @@ components:
           - severity
           - value
       type: array
-    Security_Solution_Detections_API_SiemErrorResponse:
+    Security_Detections_API_SiemErrorResponse:
       type: object
       properties:
         message:
@@ -28411,48 +27471,47 @@ components:
       required:
         - status_code
         - message
-    Security_Solution_Detections_API_SortOrder:
+    Security_Detections_API_SortOrder:
       enum:
         - asc
         - desc
       type: string
-    Security_Solution_Detections_API_Threat:
+    Security_Detections_API_Threat:
       type: object
       properties:
         framework:
           description: Relevant attack framework
           type: string
         tactic:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThreatTactic'
+          $ref: '#/components/schemas/Security_Detections_API_ThreatTactic'
         technique:
           description: Array containing information on the attack techniques (optional)
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ThreatTechnique
+            $ref: '#/components/schemas/Security_Detections_API_ThreatTechnique'
           type: array
       required:
         - framework
         - tactic
-    Security_Solution_Detections_API_ThreatArray:
+    Security_Detections_API_ThreatArray:
       items:
-        $ref: '#/components/schemas/Security_Solution_Detections_API_Threat'
+        $ref: '#/components/schemas/Security_Detections_API_Threat'
       type: array
-    Security_Solution_Detections_API_ThreatFilters:
+    Security_Detections_API_ThreatFilters:
       items:
         description: >-
           Query and filter context array used to filter documents from the
           Elasticsearch index containing the threat values
       type: array
-    Security_Solution_Detections_API_ThreatIndex:
+    Security_Detections_API_ThreatIndex:
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_ThreatIndicatorPath:
+    Security_Detections_API_ThreatIndicatorPath:
       description: >-
         Defines the path to the threat indicator in the indicator documents
         (optional)
       type: string
-    Security_Solution_Detections_API_ThreatMapping:
+    Security_Detections_API_ThreatMapping:
       items:
         type: object
         properties:
@@ -28461,15 +27520,13 @@ components:
               type: object
               properties:
                 field:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+                  $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
                 type:
                   enum:
                     - mapping
                   type: string
                 value:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+                  $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
               required:
                 - field
                 - type
@@ -28479,125 +27536,101 @@ components:
           - entries
       minItems: 1
       type: array
-    Security_Solution_Detections_API_ThreatMatchRule:
+    Security_Detections_API_ThreatMatchRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -28621,343 +27654,282 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleResponseFields
-    Security_Solution_Detections_API_ThreatMatchRuleCreateFields:
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleResponseFields
+    Security_Detections_API_ThreatMatchRuleCreateFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleRequiredFields
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleDefaultableFields
-    Security_Solution_Detections_API_ThreatMatchRuleCreateProps:
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleDefaultableFields
+    Security_Detections_API_ThreatMatchRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleCreateFields
-    Security_Solution_Detections_API_ThreatMatchRuleDefaultableFields:
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleCreateFields
+    Security_Detections_API_ThreatMatchRuleDefaultableFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
-    Security_Solution_Detections_API_ThreatMatchRuleOptionalFields:
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
+    Security_Detections_API_ThreatMatchRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         concurrent_searches:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ConcurrentSearches
+          $ref: '#/components/schemas/Security_Detections_API_ConcurrentSearches'
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         items_per_search:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ItemsPerSearch'
+          $ref: '#/components/schemas/Security_Detections_API_ItemsPerSearch'
         saved_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_SavedQueryId'
+          $ref: '#/components/schemas/Security_Detections_API_SavedQueryId'
         threat_filters:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThreatFilters'
+          $ref: '#/components/schemas/Security_Detections_API_ThreatFilters'
         threat_indicator_path:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatIndicatorPath
+          $ref: '#/components/schemas/Security_Detections_API_ThreatIndicatorPath'
         threat_language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
-    Security_Solution_Detections_API_ThreatMatchRulePatchFields:
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
+    Security_Detections_API_ThreatMatchRulePatchFields:
       allOf:
         - type: object
           properties:
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
             threat_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatIndex
+              $ref: '#/components/schemas/Security_Detections_API_ThreatIndex'
             threat_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatMapping
+              $ref: '#/components/schemas/Security_Detections_API_ThreatMapping'
             threat_query:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatQuery
+              $ref: '#/components/schemas/Security_Detections_API_ThreatQuery'
             type:
               description: Rule type
               enum:
                 - threat_match
               type: string
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleDefaultableFields
-    Security_Solution_Detections_API_ThreatMatchRulePatchProps:
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleDefaultableFields
+    Security_Detections_API_ThreatMatchRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRulePatchFields
-    Security_Solution_Detections_API_ThreatMatchRuleRequiredFields:
+            #/components/schemas/Security_Detections_API_ThreatMatchRulePatchFields
+    Security_Detections_API_ThreatMatchRuleRequiredFields:
       type: object
       properties:
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
         threat_index:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThreatIndex'
+          $ref: '#/components/schemas/Security_Detections_API_ThreatIndex'
         threat_mapping:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThreatMapping'
+          $ref: '#/components/schemas/Security_Detections_API_ThreatMapping'
         threat_query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThreatQuery'
+          $ref: '#/components/schemas/Security_Detections_API_ThreatQuery'
         type:
           description: Rule type
           enum:
@@ -28969,155 +27941,128 @@ components:
         - threat_query
         - threat_mapping
         - threat_index
-    Security_Solution_Detections_API_ThreatMatchRuleResponseFields:
+    Security_Detections_API_ThreatMatchRuleResponseFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleRequiredFields
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleOptionalFields
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
           required:
             - language
-    Security_Solution_Detections_API_ThreatMatchRuleUpdateProps:
+    Security_Detections_API_ThreatMatchRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleCreateFields
-    Security_Solution_Detections_API_ThreatQuery:
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleCreateFields
+    Security_Detections_API_ThreatQuery:
       description: Query to run
       type: string
-    Security_Solution_Detections_API_ThreatSubtechnique:
+    Security_Detections_API_ThreatSubtechnique:
       type: object
       properties:
         id:
@@ -29133,7 +28078,7 @@ components:
         - id
         - name
         - reference
-    Security_Solution_Detections_API_ThreatTactic:
+    Security_Detections_API_ThreatTactic:
       type: object
       properties:
         id:
@@ -29149,7 +28094,7 @@ components:
         - id
         - name
         - reference
-    Security_Solution_Detections_API_ThreatTechnique:
+    Security_Detections_API_ThreatTechnique:
       type: object
       properties:
         id:
@@ -29164,35 +28109,33 @@ components:
         subtechnique:
           description: Array containing more specific information on the attack technique
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ThreatSubtechnique
+            $ref: '#/components/schemas/Security_Detections_API_ThreatSubtechnique'
           type: array
       required:
         - id
         - name
         - reference
-    Security_Solution_Detections_API_Threshold:
+    Security_Detections_API_Threshold:
       type: object
       properties:
         cardinality:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdCardinality
+          $ref: '#/components/schemas/Security_Detections_API_ThresholdCardinality'
         field:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThresholdField'
+          $ref: '#/components/schemas/Security_Detections_API_ThresholdField'
         value:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThresholdValue'
+          $ref: '#/components/schemas/Security_Detections_API_ThresholdValue'
       required:
         - field
         - value
-    Security_Solution_Detections_API_ThresholdAlertSuppression:
+    Security_Detections_API_ThresholdAlertSuppression:
       type: object
       properties:
         duration:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppressionDuration
+            #/components/schemas/Security_Detections_API_AlertSuppressionDuration
       required:
         - duration
-    Security_Solution_Detections_API_ThresholdCardinality:
+    Security_Detections_API_ThresholdCardinality:
       items:
         type: object
         properties:
@@ -29205,132 +28148,108 @@ components:
           - field
           - value
       type: array
-    Security_Solution_Detections_API_ThresholdField:
+    Security_Detections_API_ThresholdField:
       description: Field to aggregate on
       oneOf:
         - type: string
         - items:
             type: string
           type: array
-    Security_Solution_Detections_API_ThresholdRule:
+    Security_Detections_API_ThresholdRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -29354,319 +28273,265 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleResponseFields
-    Security_Solution_Detections_API_ThresholdRuleCreateFields:
+            #/components/schemas/Security_Detections_API_ThresholdRuleResponseFields
+    Security_Detections_API_ThresholdRuleCreateFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleRequiredFields
+            #/components/schemas/Security_Detections_API_ThresholdRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThresholdRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleDefaultableFields
-    Security_Solution_Detections_API_ThresholdRuleCreateProps:
+            #/components/schemas/Security_Detections_API_ThresholdRuleDefaultableFields
+    Security_Detections_API_ThresholdRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleCreateFields
-    Security_Solution_Detections_API_ThresholdRuleDefaultableFields:
+            #/components/schemas/Security_Detections_API_ThresholdRuleCreateFields
+    Security_Detections_API_ThresholdRuleDefaultableFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
-    Security_Solution_Detections_API_ThresholdRuleOptionalFields:
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
+    Security_Detections_API_ThresholdRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdAlertSuppression
+            #/components/schemas/Security_Detections_API_ThresholdAlertSuppression
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         saved_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_SavedQueryId'
-    Security_Solution_Detections_API_ThresholdRulePatchFields:
+          $ref: '#/components/schemas/Security_Detections_API_SavedQueryId'
+    Security_Detections_API_ThresholdRulePatchFields:
       allOf:
         - type: object
           properties:
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
             threshold:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Threshold'
+              $ref: '#/components/schemas/Security_Detections_API_Threshold'
             type:
               description: Rule type
               enum:
                 - threshold
               type: string
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThresholdRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleDefaultableFields
-    Security_Solution_Detections_API_ThresholdRulePatchProps:
+            #/components/schemas/Security_Detections_API_ThresholdRuleDefaultableFields
+    Security_Detections_API_ThresholdRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRulePatchFields
-    Security_Solution_Detections_API_ThresholdRuleRequiredFields:
+            #/components/schemas/Security_Detections_API_ThresholdRulePatchFields
+    Security_Detections_API_ThresholdRuleRequiredFields:
       type: object
       properties:
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
         threshold:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_Threshold'
+          $ref: '#/components/schemas/Security_Detections_API_Threshold'
         type:
           description: Rule type
           enum:
@@ -29676,156 +28541,129 @@ components:
         - type
         - query
         - threshold
-    Security_Solution_Detections_API_ThresholdRuleResponseFields:
+    Security_Detections_API_ThresholdRuleResponseFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleRequiredFields
+            #/components/schemas/Security_Detections_API_ThresholdRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThresholdRuleOptionalFields
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
           required:
             - language
-    Security_Solution_Detections_API_ThresholdRuleUpdateProps:
+    Security_Detections_API_ThresholdRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleCreateFields
-    Security_Solution_Detections_API_ThresholdValue:
+            #/components/schemas/Security_Detections_API_ThresholdRuleCreateFields
+    Security_Detections_API_ThresholdValue:
       description: Threshold value
       minimum: 1
       type: integer
-    Security_Solution_Detections_API_ThrottleForBulkActions:
+    Security_Detections_API_ThrottleForBulkActions:
       description: >-
         The condition for throttling the notification: 'rule', 'no_actions', or
         time duration
@@ -29835,29 +28673,29 @@ components:
         - 1d
         - 7d
       type: string
-    Security_Solution_Detections_API_TiebreakerField:
+    Security_Detections_API_TiebreakerField:
       description: Sets a secondary field for sorting events
       type: string
-    Security_Solution_Detections_API_TimelineTemplateId:
+    Security_Detections_API_TimelineTemplateId:
       description: Timeline template ID
       type: string
-    Security_Solution_Detections_API_TimelineTemplateTitle:
+    Security_Detections_API_TimelineTemplateTitle:
       description: Timeline template title
       type: string
-    Security_Solution_Detections_API_TimestampField:
+    Security_Detections_API_TimestampField:
       description: Contains the event timestamp used for sorting a sequence of events
       type: string
-    Security_Solution_Detections_API_TimestampOverride:
+    Security_Detections_API_TimestampOverride:
       description: Sets the time field used to query indices
       type: string
-    Security_Solution_Detections_API_TimestampOverrideFallbackDisabled:
+    Security_Detections_API_TimestampOverrideFallbackDisabled:
       description: Disables the fallback to the event's @timestamp field
       type: boolean
-    Security_Solution_Detections_API_UUID:
+    Security_Detections_API_UUID:
       description: A universally unique identifier
       format: uuid
       type: string
-    Security_Solution_Detections_API_WarningSchema:
+    Security_Detections_API_WarningSchema:
       type: object
       properties:
         actionPath:
@@ -29872,16 +28710,14 @@ components:
         - type
         - message
         - actionPath
-    Security_Solution_Endpoint_Exceptions_API_EndpointList:
+    Security_Endpoint_Exceptions_API_EndpointList:
       oneOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionList
+        - $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_ExceptionList'
         - additionalProperties: false
           type: object
-    Security_Solution_Endpoint_Exceptions_API_EndpointListItem:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItem
-    Security_Solution_Endpoint_Exceptions_API_ExceptionList:
+    Security_Endpoint_Exceptions_API_EndpointListItem:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItem'
+    Security_Endpoint_Exceptions_API_ExceptionList:
       type: object
       properties:
         _version:
@@ -29893,35 +28729,35 @@ components:
           type: string
         description:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListDescription
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListDescription
         id:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListId
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListId
         immutable:
           type: boolean
         list_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListHumanId
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListHumanId
         meta:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListMeta
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListMeta
         name:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListName
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListName
         namespace_type:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionNamespaceType
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionNamespaceType
         os_types:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListOsTypeArray
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListOsTypeArray
         tags:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListTags
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListTags
         tie_breaker_id:
           type: string
         type:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListType
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListType
         updated_at:
           format: date-time
           type: string
@@ -29929,7 +28765,7 @@ components:
           type: string
         version:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListVersion
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListVersion
       required:
         - id
         - list_id
@@ -29944,23 +28780,21 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListDescription:
+    Security_Endpoint_Exceptions_API_ExceptionListDescription:
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListHumanId:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+    Security_Endpoint_Exceptions_API_ExceptionListHumanId:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
       description: Human readable string identifier, e.g. `trusted-linux-processes`
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListId:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItem:
+    Security_Endpoint_Exceptions_API_ExceptionListId:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ExceptionListItem:
       type: object
       properties:
         _version:
           type: string
         comments:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemCommentArray
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemCommentArray
         created_at:
           format: date-time
           type: string
@@ -29968,42 +28802,42 @@ components:
           type: string
         description:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemDescription
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemDescription
         entries:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryArray
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryArray
         expire_time:
           format: date-time
           type: string
         id:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemId
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemId
         item_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemHumanId
         list_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListHumanId
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListHumanId
         meta:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemMeta
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemMeta
         name:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemName
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemName
         namespace_type:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionNamespaceType
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionNamespaceType
         os_types:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
         tags:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemTags
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemTags
         tie_breaker_id:
           type: string
         type:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemType
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemType
         updated_at:
           format: date-time
           type: string
@@ -30024,69 +28858,64 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemComment:
+    Security_Endpoint_Exceptions_API_ExceptionListItemComment:
       type: object
       properties:
         comment:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         created_at:
           format: date-time
           type: string
         created_by:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         updated_at:
           format: date-time
           type: string
         updated_by:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
       required:
         - id
         - comment
         - created_at
         - created_by
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemCommentArray:
+    Security_Endpoint_Exceptions_API_ExceptionListItemCommentArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemComment
+          #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemComment
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemDescription:
+    Security_Endpoint_Exceptions_API_ExceptionListItemDescription:
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntry:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntry:
       anyOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatch
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatch
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryList
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryList
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryExists
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryExists
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryNested
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryNested
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatchWildcard
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatchWildcard
       discriminator:
         propertyName: type
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryArray:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntry
+          #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntry
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryExists:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryExists:
       type: object
       properties:
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - exists
@@ -30095,27 +28924,24 @@ components:
         - type
         - field
         - operator
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryList:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryList:
       type: object
       properties:
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         list:
           type: object
           properties:
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ListId
+              $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_ListId'
             type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ListType
+              $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_ListType'
           required:
             - id
             - type
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - list
@@ -30125,36 +28951,33 @@ components:
         - field
         - list
         - operator
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatch:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatch:
       type: object
       properties:
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - match
           type: string
         value:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
       required:
         - type
         - field
         - value
         - operator
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny:
       type: object
       properties:
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - match_any
@@ -30162,7 +28985,7 @@ components:
         value:
           items:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+              #/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString
           minItems: 1
           type: array
       required:
@@ -30170,39 +28993,36 @@ components:
         - field
         - value
         - operator
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatchWildcard:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatchWildcard:
       type: object
       properties:
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - wildcard
           type: string
         value:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
       required:
         - type
         - field
         - value
         - operator
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryNested:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryNested:
       type: object
       properties:
         entries:
           items:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryNestedEntryItem
+              #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryNestedEntryItem
           minItems: 1
           type: array
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         type:
           enum:
             - nested
@@ -30211,66 +29031,62 @@ components:
         - type
         - field
         - entries
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryNestedEntryItem:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryNestedEntryItem:
       oneOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatch
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatch
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryExists
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator:
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryExists
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator:
       enum:
         - excluded
         - included
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemId:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemMeta:
+    Security_Endpoint_Exceptions_API_ExceptionListItemHumanId:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ExceptionListItemId:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ExceptionListItemMeta:
       additionalProperties: true
       type: object
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemName:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray:
+    Security_Endpoint_Exceptions_API_ExceptionListItemName:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListOsType
+          #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListOsType
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemTags:
+    Security_Endpoint_Exceptions_API_ExceptionListItemTags:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+        $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemType:
+    Security_Endpoint_Exceptions_API_ExceptionListItemType:
       enum:
         - simple
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListMeta:
+    Security_Endpoint_Exceptions_API_ExceptionListMeta:
       additionalProperties: true
       type: object
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListName:
+    Security_Endpoint_Exceptions_API_ExceptionListName:
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListOsType:
+    Security_Endpoint_Exceptions_API_ExceptionListOsType:
       enum:
         - linux
         - macos
         - windows
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListOsTypeArray:
+    Security_Endpoint_Exceptions_API_ExceptionListOsTypeArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListOsType
+          #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListOsType
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListTags:
+    Security_Endpoint_Exceptions_API_ExceptionListTags:
       items:
         type: string
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListType:
+    Security_Endpoint_Exceptions_API_ExceptionListType:
       enum:
         - detection
         - rule_default
@@ -30280,10 +29096,10 @@ components:
         - endpoint_host_isolation_exceptions
         - endpoint_blocklists
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListVersion:
+    Security_Endpoint_Exceptions_API_ExceptionListVersion:
       minimum: 1
       type: integer
-    Security_Solution_Endpoint_Exceptions_API_ExceptionNamespaceType:
+    Security_Endpoint_Exceptions_API_ExceptionNamespaceType:
       description: >
         Determines whether the exception container is available in all Kibana
         spaces or just the space
@@ -30298,13 +29114,11 @@ components:
         - agnostic
         - single
       type: string
-    Security_Solution_Endpoint_Exceptions_API_FindEndpointListItemsFilter:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ListId:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ListType:
+    Security_Endpoint_Exceptions_API_FindEndpointListItemsFilter:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ListId:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ListType:
       enum:
         - binary
         - boolean
@@ -30330,12 +29144,12 @@ components:
         - short
         - text
       type: string
-    Security_Solution_Endpoint_Exceptions_API_NonEmptyString:
+    Security_Endpoint_Exceptions_API_NonEmptyString:
       description: A string that is not empty and does not contain only whitespace
       minLength: 1
       pattern: ^(?! *$).+$
       type: string
-    Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse:
+    Security_Endpoint_Exceptions_API_PlatformErrorResponse:
       type: object
       properties:
         error:
@@ -30348,7 +29162,7 @@ components:
         - statusCode
         - error
         - message
-    Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse:
+    Security_Endpoint_Exceptions_API_SiemErrorResponse:
       type: object
       properties:
         message:
@@ -30358,21 +29172,18 @@ components:
       required:
         - status_code
         - message
-    Security_Solution_Endpoint_Management_API_ActionLogRequestQuery:
+    Security_Endpoint_Management_API_ActionLogRequestQuery:
       type: object
       properties:
         end_date:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_EndDate
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_EndDate'
         page:
-          $ref: '#/components/schemas/Security_Solution_Endpoint_Management_API_Page'
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_Page'
         page_size:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_PageSize
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_PageSize'
         start_date:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_StartDate
-    Security_Solution_Endpoint_Management_API_ActionStateSuccessResponse:
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_StartDate'
+    Security_Endpoint_Management_API_ActionStateSuccessResponse:
       type: object
       properties:
         body:
@@ -30387,7 +29198,7 @@ components:
             - data
       required:
         - body
-    Security_Solution_Endpoint_Management_API_ActionStatusSuccessResponse:
+    Security_Endpoint_Management_API_ActionStatusSuccessResponse:
       type: object
       properties:
         body:
@@ -30398,10 +29209,10 @@ components:
               properties:
                 agent_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_AgentId
+                    #/components/schemas/Security_Endpoint_Management_API_AgentId
                 pending_actions:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionsSchema
+                    #/components/schemas/Security_Endpoint_Management_API_PendingActionsSchema
               required:
                 - agent_id
                 - pending_actions
@@ -30409,10 +29220,10 @@ components:
             - data
       required:
         - body
-    Security_Solution_Endpoint_Management_API_AgentId:
+    Security_Endpoint_Management_API_AgentId:
       description: Agent ID
       type: string
-    Security_Solution_Endpoint_Management_API_AgentIds:
+    Security_Endpoint_Management_API_AgentIds:
       minLength: 1
       oneOf:
         - items:
@@ -30423,27 +29234,26 @@ components:
           type: array
         - minLength: 1
           type: string
-    Security_Solution_Endpoint_Management_API_AgentTypes:
+    Security_Endpoint_Management_API_AgentTypes:
       enum:
         - endpoint
         - sentinel_one
         - crowdstrike
       type: string
-    Security_Solution_Endpoint_Management_API_AlertIds:
+    Security_Endpoint_Management_API_AlertIds:
       description: A list of alerts ids.
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Management_API_NonEmptyString
+        $ref: '#/components/schemas/Security_Endpoint_Management_API_NonEmptyString'
       minItems: 1
       type: array
-    Security_Solution_Endpoint_Management_API_CaseIds:
+    Security_Endpoint_Management_API_CaseIds:
       description: Case IDs to be updated (cannot contain empty strings)
       items:
         minLength: 1
         type: string
       minItems: 1
       type: array
-    Security_Solution_Endpoint_Management_API_Command:
+    Security_Endpoint_Management_API_Command:
       description: The command to be executed (cannot be an empty string)
       enum:
         - isolate
@@ -30457,51 +29267,46 @@ components:
         - scan
       minLength: 1
       type: string
-    Security_Solution_Endpoint_Management_API_Commands:
+    Security_Endpoint_Management_API_Commands:
       items:
-        $ref: '#/components/schemas/Security_Solution_Endpoint_Management_API_Command'
+        $ref: '#/components/schemas/Security_Endpoint_Management_API_Command'
       type: array
-    Security_Solution_Endpoint_Management_API_Comment:
+    Security_Endpoint_Management_API_Comment:
       description: Optional comment
       type: string
-    Security_Solution_Endpoint_Management_API_EndDate:
+    Security_Endpoint_Management_API_EndDate:
       description: End date
       type: string
-    Security_Solution_Endpoint_Management_API_EndpointIds:
+    Security_Endpoint_Management_API_EndpointIds:
       description: List of endpoint IDs (cannot contain empty strings)
       items:
         minLength: 1
         type: string
       minItems: 1
       type: array
-    Security_Solution_Endpoint_Management_API_EntityId:
+    Security_Endpoint_Management_API_EntityId:
       type: object
       properties:
         entity_id:
           minLength: 1
           type: string
-    Security_Solution_Endpoint_Management_API_ExecuteRouteRequestBody:
+    Security_Endpoint_Management_API_ExecuteRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
@@ -30511,31 +29316,27 @@ components:
               properties:
                 command:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Command
+                    #/components/schemas/Security_Endpoint_Management_API_Command
                 timeout:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Timeout
+                    #/components/schemas/Security_Endpoint_Management_API_Timeout
               required:
                 - command
           required:
             - parameters
-    Security_Solution_Endpoint_Management_API_GetEndpointActionListRouteQuery:
+    Security_Endpoint_Management_API_GetEndpointActionListRouteQuery:
       type: object
       properties:
         agentIds:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_AgentIds
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentIds'
         agentTypes:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
         commands:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_Commands
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_Commands'
         endDate:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_EndDate
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_EndDate'
         page:
-          $ref: '#/components/schemas/Security_Solution_Endpoint_Management_API_Page'
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_Page'
         pageSize:
           default: 10
           description: Number of items per page
@@ -30543,38 +29344,30 @@ components:
           minimum: 1
           type: integer
         startDate:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_StartDate
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_StartDate'
         types:
-          $ref: '#/components/schemas/Security_Solution_Endpoint_Management_API_Types'
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_Types'
         userIds:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_UserIds
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_UserIds'
         withOutputs:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_WithOutputs
-    Security_Solution_Endpoint_Management_API_GetFileRouteRequestBody:
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_WithOutputs'
+    Security_Endpoint_Management_API_GetFileRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
@@ -30588,44 +29381,38 @@ components:
                 - path
           required:
             - parameters
-    Security_Solution_Endpoint_Management_API_GetProcessesRouteRequestBody:
+    Security_Endpoint_Management_API_GetProcessesRouteRequestBody:
       $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Management_API_NoParametersRequestSchema
-    Security_Solution_Endpoint_Management_API_IsolateRouteRequestBody:
+        #/components/schemas/Security_Endpoint_Management_API_NoParametersRequestSchema
+    Security_Endpoint_Management_API_IsolateRouteRequestBody:
       $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Management_API_NoParametersRequestSchema
-    Security_Solution_Endpoint_Management_API_KillProcessRouteRequestBody:
+        #/components/schemas/Security_Endpoint_Management_API_NoParametersRequestSchema
+    Security_Endpoint_Management_API_KillProcessRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
           properties:
             parameters:
               oneOf:
+                - $ref: '#/components/schemas/Security_Endpoint_Management_API_Pid'
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Pid
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_EntityId
+                    #/components/schemas/Security_Endpoint_Management_API_EntityId
                 - type: object
                   properties:
                     process_name:
@@ -30634,7 +29421,7 @@ components:
                       type: string
           required:
             - parameters
-    Security_Solution_Endpoint_Management_API_ListRequestQuery:
+    Security_Endpoint_Management_API_ListRequestQuery:
       type: object
       properties:
         hostStatuses:
@@ -30681,121 +29468,111 @@ components:
           type: string
       required:
         - hostStatuses
-    Security_Solution_Endpoint_Management_API_NonEmptyString:
+    Security_Endpoint_Management_API_NonEmptyString:
       description: A string that is not empty and does not contain only whitespace
       minLength: 1
       pattern: ^(?! *$).+$
       type: string
-    Security_Solution_Endpoint_Management_API_NoParametersRequestSchema:
+    Security_Endpoint_Management_API_NoParametersRequestSchema:
       type: object
       properties:
         body:
           type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
       required:
         - body
-    Security_Solution_Endpoint_Management_API_Page:
+    Security_Endpoint_Management_API_Page:
       default: 1
       description: Page number
       minimum: 1
       type: integer
-    Security_Solution_Endpoint_Management_API_PageSize:
+    Security_Endpoint_Management_API_PageSize:
       default: 10
       description: Number of items per page
       maximum: 100
       minimum: 1
       type: integer
-    Security_Solution_Endpoint_Management_API_Parameters:
+    Security_Endpoint_Management_API_Parameters:
       description: Optional parameters object
       type: object
-    Security_Solution_Endpoint_Management_API_PendingActionDataType:
+    Security_Endpoint_Management_API_PendingActionDataType:
       type: integer
-    Security_Solution_Endpoint_Management_API_PendingActionsSchema:
+    Security_Endpoint_Management_API_PendingActionsSchema:
       oneOf:
         - type: object
           properties:
             execute:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             get-file:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             isolate:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             kill-process:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             running-processes:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             scan:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             suspend-process:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             unisolate:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             upload:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
         - additionalProperties: true
           type: object
-    Security_Solution_Endpoint_Management_API_Pid:
+    Security_Endpoint_Management_API_Pid:
       type: object
       properties:
         pid:
           minimum: 1
           type: integer
-    Security_Solution_Endpoint_Management_API_ProtectionUpdatesNoteResponse:
+    Security_Endpoint_Management_API_ProtectionUpdatesNoteResponse:
       type: object
       properties:
         note:
           type: string
-    Security_Solution_Endpoint_Management_API_ScanRouteRequestBody:
+    Security_Endpoint_Management_API_ScanRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
@@ -30809,88 +29586,77 @@ components:
                 - path
           required:
             - parameters
-    Security_Solution_Endpoint_Management_API_StartDate:
+    Security_Endpoint_Management_API_StartDate:
       description: Start date
       type: string
-    Security_Solution_Endpoint_Management_API_SuccessResponse:
+    Security_Endpoint_Management_API_SuccessResponse:
       type: object
       properties: {}
-    Security_Solution_Endpoint_Management_API_SuspendProcessRouteRequestBody:
+    Security_Endpoint_Management_API_SuspendProcessRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
           properties:
             parameters:
               oneOf:
+                - $ref: '#/components/schemas/Security_Endpoint_Management_API_Pid'
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Pid
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_EntityId
+                    #/components/schemas/Security_Endpoint_Management_API_EntityId
           required:
             - parameters
-    Security_Solution_Endpoint_Management_API_Timeout:
+    Security_Endpoint_Management_API_Timeout:
       description: The maximum timeout value in milliseconds (optional)
       minimum: 1
       type: integer
-    Security_Solution_Endpoint_Management_API_Type:
+    Security_Endpoint_Management_API_Type:
       description: Type of response action
       enum:
         - automated
         - manual
       type: string
-    Security_Solution_Endpoint_Management_API_Types:
+    Security_Endpoint_Management_API_Types:
       description: List of types of response actions
       items:
-        $ref: '#/components/schemas/Security_Solution_Endpoint_Management_API_Type'
+        $ref: '#/components/schemas/Security_Endpoint_Management_API_Type'
       maxLength: 2
       minLength: 1
       type: array
-    Security_Solution_Endpoint_Management_API_UnisolateRouteRequestBody:
+    Security_Endpoint_Management_API_UnisolateRouteRequestBody:
       $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Management_API_NoParametersRequestSchema
-    Security_Solution_Endpoint_Management_API_UploadRouteRequestBody:
+        #/components/schemas/Security_Endpoint_Management_API_NoParametersRequestSchema
+    Security_Endpoint_Management_API_UploadRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
@@ -30907,7 +29673,7 @@ components:
           required:
             - parameters
             - file
-    Security_Solution_Endpoint_Management_API_UserIds:
+    Security_Endpoint_Management_API_UserIds:
       description: User IDs
       oneOf:
         - items:
@@ -30917,7 +29683,7 @@ components:
           type: array
         - minLength: 1
           type: string
-    Security_Solution_Endpoint_Management_API_WithOutputs:
+    Security_Endpoint_Management_API_WithOutputs:
       description: Shows detailed outputs for an action response
       oneOf:
         - items:
@@ -30927,7 +29693,7 @@ components:
           type: array
         - minLength: 1
           type: string
-    Security_Solution_Entity_Analytics_API_AssetCriticalityBulkUploadErrorItem:
+    Security_Entity_Analytics_API_AssetCriticalityBulkUploadErrorItem:
       type: object
       properties:
         index:
@@ -30937,7 +29703,7 @@ components:
       required:
         - message
         - index
-    Security_Solution_Entity_Analytics_API_AssetCriticalityBulkUploadStats:
+    Security_Entity_Analytics_API_AssetCriticalityBulkUploadStats:
       type: object
       properties:
         failed:
@@ -30950,7 +29716,7 @@ components:
         - successful
         - failed
         - total
-    Security_Solution_Entity_Analytics_API_AssetCriticalityLevel:
+    Security_Entity_Analytics_API_AssetCriticalityLevel:
       description: The criticality level of the asset.
       enum:
         - low_impact
@@ -30958,10 +29724,10 @@ components:
         - high_impact
         - extreme_impact
       type: string
-    Security_Solution_Entity_Analytics_API_AssetCriticalityRecord:
+    Security_Entity_Analytics_API_AssetCriticalityRecord:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_CreateAssetCriticalityRecord
+            #/components/schemas/Security_Entity_Analytics_API_CreateAssetCriticalityRecord
         - type: object
           properties:
             '@timestamp':
@@ -30971,11 +29737,11 @@ components:
               type: string
           required:
             - '@timestamp'
-    Security_Solution_Entity_Analytics_API_AssetCriticalityRecordIdParts:
+    Security_Entity_Analytics_API_AssetCriticalityRecordIdParts:
       type: object
       properties:
         id_field:
-          $ref: '#/components/schemas/Security_Solution_Entity_Analytics_API_IdField'
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_IdField'
           description: The field representing the ID.
           example: host.name
         id_value:
@@ -30984,49 +29750,44 @@ components:
       required:
         - id_value
         - id_field
-    Security_Solution_Entity_Analytics_API_CreateAssetCriticalityRecord:
+    Security_Entity_Analytics_API_CreateAssetCriticalityRecord:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityRecordIdParts
+            #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityRecordIdParts
         - type: object
           properties:
             criticality_level:
               $ref: >-
-                #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityLevel
+                #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel
           required:
             - criticality_level
-    Security_Solution_Entity_Analytics_API_EngineDescriptor:
+    Security_Entity_Analytics_API_EngineDescriptor:
       type: object
       properties:
         filter:
           type: string
         indexPattern:
-          $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_IndexPattern
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_IndexPattern'
         status:
-          $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_EngineStatus
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_EngineStatus'
         type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
-    Security_Solution_Entity_Analytics_API_EngineStatus:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
+    Security_Entity_Analytics_API_EngineStatus:
       enum:
         - installing
         - started
         - stopped
       type: string
-    Security_Solution_Entity_Analytics_API_Entity:
+    Security_Entity_Analytics_API_Entity:
       oneOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_UserEntity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_HostEntity
-    Security_Solution_Entity_Analytics_API_EntityType:
+        - $ref: '#/components/schemas/Security_Entity_Analytics_API_UserEntity'
+        - $ref: '#/components/schemas/Security_Entity_Analytics_API_HostEntity'
+    Security_Entity_Analytics_API_EntityType:
       enum:
         - user
         - host
       type: string
-    Security_Solution_Entity_Analytics_API_HostEntity:
+    Security_Entity_Analytics_API_HostEntity:
       type: object
       properties:
         entity:
@@ -31101,14 +29862,14 @@ components:
               type: array
           required:
             - name
-    Security_Solution_Entity_Analytics_API_IdField:
+    Security_Entity_Analytics_API_IdField:
       enum:
         - host.name
         - user.name
       type: string
-    Security_Solution_Entity_Analytics_API_IndexPattern:
+    Security_Entity_Analytics_API_IndexPattern:
       type: string
-    Security_Solution_Entity_Analytics_API_InspectQuery:
+    Security_Entity_Analytics_API_InspectQuery:
       type: object
       properties:
         dsl:
@@ -31122,7 +29883,7 @@ components:
       required:
         - dsl
         - response
-    Security_Solution_Entity_Analytics_API_RiskEngineScheduleNowErrorResponse:
+    Security_Entity_Analytics_API_RiskEngineScheduleNowErrorResponse:
       type: object
       properties:
         full_error:
@@ -31132,12 +29893,12 @@ components:
       required:
         - message
         - full_error
-    Security_Solution_Entity_Analytics_API_RiskEngineScheduleNowResponse:
+    Security_Entity_Analytics_API_RiskEngineScheduleNowResponse:
       type: object
       properties:
         success:
           type: boolean
-    Security_Solution_Entity_Analytics_API_TaskManagerUnavailableResponse:
+    Security_Entity_Analytics_API_TaskManagerUnavailableResponse:
       description: Task manager is unavailable
       type: object
       properties:
@@ -31149,7 +29910,7 @@ components:
       required:
         - status_code
         - message
-    Security_Solution_Entity_Analytics_API_UserEntity:
+    Security_Entity_Analytics_API_UserEntity:
       type: object
       properties:
         entity:
@@ -31220,76 +29981,71 @@ components:
               type: array
           required:
             - name
-    Security_Solution_Exceptions_API_CreateExceptionListItemComment:
+    Security_Exceptions_API_CreateExceptionListItemComment:
       type: object
       properties:
         comment:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - comment
-    Security_Solution_Exceptions_API_CreateExceptionListItemCommentArray:
+    Security_Exceptions_API_CreateExceptionListItemCommentArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_CreateExceptionListItemComment
+          #/components/schemas/Security_Exceptions_API_CreateExceptionListItemComment
       type: array
-    Security_Solution_Exceptions_API_CreateRuleExceptionListItemComment:
+    Security_Exceptions_API_CreateRuleExceptionListItemComment:
       type: object
       properties:
         comment:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - comment
-    Security_Solution_Exceptions_API_CreateRuleExceptionListItemCommentArray:
+    Security_Exceptions_API_CreateRuleExceptionListItemCommentArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_CreateRuleExceptionListItemComment
+          #/components/schemas/Security_Exceptions_API_CreateRuleExceptionListItemComment
       type: array
-    Security_Solution_Exceptions_API_CreateRuleExceptionListItemProps:
+    Security_Exceptions_API_CreateRuleExceptionListItemProps:
       type: object
       properties:
         comments:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_CreateRuleExceptionListItemCommentArray
+            #/components/schemas/Security_Exceptions_API_CreateRuleExceptionListItemCommentArray
           default: []
         description:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemDescription
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemDescription
         entries:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryArray
         expire_time:
           format: date-time
           type: string
         item_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
         meta:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemMeta
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemMeta'
         name:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemName
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemName'
         namespace_type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionNamespaceType'
           default: single
         os_types:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemOsTypeArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemOsTypeArray
           default: []
         tags:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemTags
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemTags'
           default: []
         type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemType'
       required:
         - type
         - name
         - description
         - entries
-    Security_Solution_Exceptions_API_ExceptionList:
+    Security_Exceptions_API_ExceptionList:
       type: object
       properties:
         _version:
@@ -31301,43 +30057,35 @@ components:
           type: string
         description:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListDescription
+            #/components/schemas/Security_Exceptions_API_ExceptionListDescription
         id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         immutable:
           type: boolean
         list_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         meta:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListMeta
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListMeta'
         name:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListName
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListName'
         namespace_type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionNamespaceType'
         os_types:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListOsTypeArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListOsTypeArray
         tags:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListTags
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListTags'
         tie_breaker_id:
           type: string
         type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListType'
         updated_at:
           format: date-time
           type: string
         updated_by:
           type: string
         version:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListVersion
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListVersion'
       required:
         - id
         - list_id
@@ -31352,21 +30100,21 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Exceptions_API_ExceptionListDescription:
+    Security_Exceptions_API_ExceptionListDescription:
       type: string
-    Security_Solution_Exceptions_API_ExceptionListHumanId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ExceptionListHumanId:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       description: Human readable string identifier, e.g. `trusted-linux-processes`
-    Security_Solution_Exceptions_API_ExceptionListId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_ExceptionListItem:
+    Security_Exceptions_API_ExceptionListId:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ExceptionListItem:
       type: object
       properties:
         _version:
           type: string
         comments:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemCommentArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemCommentArray
         created_at:
           format: date-time
           type: string
@@ -31374,42 +30122,35 @@ components:
           type: string
         description:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemDescription
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemDescription
         entries:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryArray
         expire_time:
           format: date-time
           type: string
         id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemId'
         item_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
         list_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         meta:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemMeta
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemMeta'
         name:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemName
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemName'
         namespace_type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionNamespaceType'
         os_types:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemOsTypeArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemOsTypeArray
         tags:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemTags
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemTags'
         tie_breaker_id:
           type: string
         type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemType'
         updated_at:
           format: date-time
           type: string
@@ -31430,64 +30171,62 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Exceptions_API_ExceptionListItemComment:
+    Security_Exceptions_API_ExceptionListItemComment:
       type: object
       properties:
         comment:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         created_at:
           format: date-time
           type: string
         created_by:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         id:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         updated_at:
           format: date-time
           type: string
         updated_by:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - id
         - comment
         - created_at
         - created_by
-    Security_Solution_Exceptions_API_ExceptionListItemCommentArray:
+    Security_Exceptions_API_ExceptionListItemCommentArray:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemComment
+        $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemComment'
       type: array
-    Security_Solution_Exceptions_API_ExceptionListItemDescription:
+    Security_Exceptions_API_ExceptionListItemDescription:
       type: string
-    Security_Solution_Exceptions_API_ExceptionListItemEntry:
+    Security_Exceptions_API_ExceptionListItemEntry:
       anyOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryMatch
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryMatch
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryMatchAny
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryMatchAny
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryList
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryList
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryExists
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryExists
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryNested
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryNested
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryMatchWildcard
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryMatchWildcard
       discriminator:
         propertyName: type
-    Security_Solution_Exceptions_API_ExceptionListItemEntryArray:
+    Security_Exceptions_API_ExceptionListItemEntryArray:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntry
+        $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemEntry'
       type: array
-    Security_Solution_Exceptions_API_ExceptionListItemEntryExists:
+    Security_Exceptions_API_ExceptionListItemEntryExists:
       type: object
       properties:
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - exists
@@ -31496,24 +30235,24 @@ components:
         - type
         - field
         - operator
-    Security_Solution_Exceptions_API_ExceptionListItemEntryList:
+    Security_Exceptions_API_ExceptionListItemEntryList:
       type: object
       properties:
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         list:
           type: object
           properties:
             id:
-              $ref: '#/components/schemas/Security_Solution_Exceptions_API_ListId'
+              $ref: '#/components/schemas/Security_Exceptions_API_ListId'
             type:
-              $ref: '#/components/schemas/Security_Solution_Exceptions_API_ListType'
+              $ref: '#/components/schemas/Security_Exceptions_API_ListType'
           required:
             - id
             - type
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - list
@@ -31523,41 +30262,40 @@ components:
         - field
         - list
         - operator
-    Security_Solution_Exceptions_API_ExceptionListItemEntryMatch:
+    Security_Exceptions_API_ExceptionListItemEntryMatch:
       type: object
       properties:
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - match
           type: string
         value:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - type
         - field
         - value
         - operator
-    Security_Solution_Exceptions_API_ExceptionListItemEntryMatchAny:
+    Security_Exceptions_API_ExceptionListItemEntryMatchAny:
       type: object
       properties:
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - match_any
           type: string
         value:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
           minItems: 1
           type: array
       required:
@@ -31565,36 +30303,36 @@ components:
         - field
         - value
         - operator
-    Security_Solution_Exceptions_API_ExceptionListItemEntryMatchWildcard:
+    Security_Exceptions_API_ExceptionListItemEntryMatchWildcard:
       type: object
       properties:
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - wildcard
           type: string
         value:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - type
         - field
         - value
         - operator
-    Security_Solution_Exceptions_API_ExceptionListItemEntryNested:
+    Security_Exceptions_API_ExceptionListItemEntryNested:
       type: object
       properties:
         entries:
           items:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryNestedEntryItem
+              #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryNestedEntryItem
           minItems: 1
           type: array
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         type:
           enum:
             - nested
@@ -31603,58 +30341,56 @@ components:
         - type
         - field
         - entries
-    Security_Solution_Exceptions_API_ExceptionListItemEntryNestedEntryItem:
+    Security_Exceptions_API_ExceptionListItemEntryNestedEntryItem:
       oneOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryMatch
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryMatch
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryMatchAny
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryMatchAny
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryExists
-    Security_Solution_Exceptions_API_ExceptionListItemEntryOperator:
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryExists
+    Security_Exceptions_API_ExceptionListItemEntryOperator:
       enum:
         - excluded
         - included
       type: string
-    Security_Solution_Exceptions_API_ExceptionListItemHumanId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_ExceptionListItemId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_ExceptionListItemMeta:
+    Security_Exceptions_API_ExceptionListItemHumanId:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ExceptionListItemId:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ExceptionListItemMeta:
       additionalProperties: true
       type: object
-    Security_Solution_Exceptions_API_ExceptionListItemName:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_ExceptionListItemOsTypeArray:
+    Security_Exceptions_API_ExceptionListItemName:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ExceptionListItemOsTypeArray:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_ExceptionListOsType
+        $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListOsType'
       type: array
-    Security_Solution_Exceptions_API_ExceptionListItemTags:
+    Security_Exceptions_API_ExceptionListItemTags:
       items:
-        $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+        $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       type: array
-    Security_Solution_Exceptions_API_ExceptionListItemType:
+    Security_Exceptions_API_ExceptionListItemType:
       enum:
         - simple
       type: string
-    Security_Solution_Exceptions_API_ExceptionListMeta:
+    Security_Exceptions_API_ExceptionListMeta:
       additionalProperties: true
       type: object
-    Security_Solution_Exceptions_API_ExceptionListName:
+    Security_Exceptions_API_ExceptionListName:
       type: string
-    Security_Solution_Exceptions_API_ExceptionListOsType:
+    Security_Exceptions_API_ExceptionListOsType:
       enum:
         - linux
         - macos
         - windows
       type: string
-    Security_Solution_Exceptions_API_ExceptionListOsTypeArray:
+    Security_Exceptions_API_ExceptionListOsTypeArray:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_ExceptionListOsType
+        $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListOsType'
       type: array
-    Security_Solution_Exceptions_API_ExceptionListsImportBulkError:
+    Security_Exceptions_API_ExceptionListsImportBulkError:
       type: object
       properties:
         error:
@@ -31668,26 +30404,24 @@ components:
             - status_code
             - message
         id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         item_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
         list_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
       required:
         - error
-    Security_Solution_Exceptions_API_ExceptionListsImportBulkErrorArray:
+    Security_Exceptions_API_ExceptionListsImportBulkErrorArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_ExceptionListsImportBulkError
+          #/components/schemas/Security_Exceptions_API_ExceptionListsImportBulkError
       type: array
-    Security_Solution_Exceptions_API_ExceptionListTags:
+    Security_Exceptions_API_ExceptionListTags:
       items:
         type: string
       type: array
-    Security_Solution_Exceptions_API_ExceptionListType:
+    Security_Exceptions_API_ExceptionListType:
       enum:
         - detection
         - rule_default
@@ -31697,10 +30431,10 @@ components:
         - endpoint_host_isolation_exceptions
         - endpoint_blocklists
       type: string
-    Security_Solution_Exceptions_API_ExceptionListVersion:
+    Security_Exceptions_API_ExceptionListVersion:
       minimum: 1
       type: integer
-    Security_Solution_Exceptions_API_ExceptionNamespaceType:
+    Security_Exceptions_API_ExceptionNamespaceType:
       description: >
         Determines whether the exception container is available in all Kibana
         spaces or just the space
@@ -31715,13 +30449,13 @@ components:
         - agnostic
         - single
       type: string
-    Security_Solution_Exceptions_API_FindExceptionListItemsFilter:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_FindExceptionListsFilter:
+    Security_Exceptions_API_FindExceptionListItemsFilter:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_FindExceptionListsFilter:
       type: string
-    Security_Solution_Exceptions_API_ListId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_ListType:
+    Security_Exceptions_API_ListId:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ListType:
       enum:
         - binary
         - boolean
@@ -31747,12 +30481,12 @@ components:
         - short
         - text
       type: string
-    Security_Solution_Exceptions_API_NonEmptyString:
+    Security_Exceptions_API_NonEmptyString:
       description: A string that is not empty and does not contain only whitespace
       minLength: 1
       pattern: ^(?! *$).+$
       type: string
-    Security_Solution_Exceptions_API_PlatformErrorResponse:
+    Security_Exceptions_API_PlatformErrorResponse:
       type: object
       properties:
         error:
@@ -31765,9 +30499,9 @@ components:
         - statusCode
         - error
         - message
-    Security_Solution_Exceptions_API_RuleId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_UUID'
-    Security_Solution_Exceptions_API_SiemErrorResponse:
+    Security_Exceptions_API_RuleId:
+      $ref: '#/components/schemas/Security_Exceptions_API_UUID'
+    Security_Exceptions_API_SiemErrorResponse:
       type: object
       properties:
         message:
@@ -31777,33 +30511,33 @@ components:
       required:
         - status_code
         - message
-    Security_Solution_Exceptions_API_UpdateExceptionListItemComment:
+    Security_Exceptions_API_UpdateExceptionListItemComment:
       type: object
       properties:
         comment:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         id:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - comment
-    Security_Solution_Exceptions_API_UpdateExceptionListItemCommentArray:
+    Security_Exceptions_API_UpdateExceptionListItemCommentArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_UpdateExceptionListItemComment
+          #/components/schemas/Security_Exceptions_API_UpdateExceptionListItemComment
       type: array
-    Security_Solution_Exceptions_API_UUID:
+    Security_Exceptions_API_UUID:
       description: A universally unique identifier
       format: uuid
       type: string
-    Security_Solution_Lists_API_FindListItemsCursor:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_FindListItemsFilter:
+    Security_Lists_API_FindListItemsCursor:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_FindListItemsFilter:
       type: string
-    Security_Solution_Lists_API_FindListsCursor:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_FindListsFilter:
+    Security_Lists_API_FindListsCursor:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_FindListsFilter:
       type: string
-    Security_Solution_Lists_API_List:
+    Security_Lists_API_List:
       type: object
       properties:
         _version:
@@ -31817,23 +30551,23 @@ components:
         created_by:
           type: string
         description:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListDescription'
+          $ref: '#/components/schemas/Security_Lists_API_ListDescription'
         deserializer:
           type: string
         id:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+          $ref: '#/components/schemas/Security_Lists_API_ListId'
         immutable:
           type: boolean
         meta:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListMetadata'
+          $ref: '#/components/schemas/Security_Lists_API_ListMetadata'
         name:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListName'
+          $ref: '#/components/schemas/Security_Lists_API_ListName'
         serializer:
           type: string
         tie_breaker_id:
           type: string
         type:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListType'
+          $ref: '#/components/schemas/Security_Lists_API_ListType'
         updated_at:
           format: date-time
           type: string
@@ -31854,11 +30588,11 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Lists_API_ListDescription:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_ListId:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_ListItem:
+    Security_Lists_API_ListDescription:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_ListId:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_ListItem:
       type: object
       properties:
         _version:
@@ -31874,24 +30608,24 @@ components:
         deserializer:
           type: string
         id:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemId'
+          $ref: '#/components/schemas/Security_Lists_API_ListItemId'
         list_id:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+          $ref: '#/components/schemas/Security_Lists_API_ListId'
         meta:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemMetadata'
+          $ref: '#/components/schemas/Security_Lists_API_ListItemMetadata'
         serializer:
           type: string
         tie_breaker_id:
           type: string
         type:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListType'
+          $ref: '#/components/schemas/Security_Lists_API_ListType'
         updated_at:
           format: date-time
           type: string
         updated_by:
           type: string
         value:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemValue'
+          $ref: '#/components/schemas/Security_Lists_API_ListItemValue'
       required:
         - id
         - type
@@ -31902,12 +30636,12 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Lists_API_ListItemId:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_ListItemMetadata:
+    Security_Lists_API_ListItemId:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_ListItemMetadata:
       additionalProperties: true
       type: object
-    Security_Solution_Lists_API_ListItemPrivileges:
+    Security_Lists_API_ListItemPrivileges:
       type: object
       properties:
         application:
@@ -31934,14 +30668,14 @@ components:
         - cluster
         - index
         - application
-    Security_Solution_Lists_API_ListItemValue:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_ListMetadata:
+    Security_Lists_API_ListItemValue:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_ListMetadata:
       additionalProperties: true
       type: object
-    Security_Solution_Lists_API_ListName:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_ListPrivileges:
+    Security_Lists_API_ListName:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_ListPrivileges:
       type: object
       properties:
         application:
@@ -31968,7 +30702,7 @@ components:
         - cluster
         - index
         - application
-    Security_Solution_Lists_API_ListType:
+    Security_Lists_API_ListType:
       enum:
         - binary
         - boolean
@@ -31994,12 +30728,12 @@ components:
         - short
         - text
       type: string
-    Security_Solution_Lists_API_NonEmptyString:
+    Security_Lists_API_NonEmptyString:
       description: A string that is not empty and does not contain only whitespace
       minLength: 1
       pattern: ^(?! *$).+$
       type: string
-    Security_Solution_Lists_API_PlatformErrorResponse:
+    Security_Lists_API_PlatformErrorResponse:
       type: object
       properties:
         error:
@@ -32012,7 +30746,7 @@ components:
         - statusCode
         - error
         - message
-    Security_Solution_Lists_API_SiemErrorResponse:
+    Security_Lists_API_SiemErrorResponse:
       type: object
       properties:
         message:
@@ -32022,33 +30756,28 @@ components:
       required:
         - status_code
         - message
-    Security_Solution_Osquery_API_ArrayQueries:
+    Security_Osquery_API_ArrayQueries:
       items:
-        $ref: '#/components/schemas/Security_Solution_Osquery_API_ArrayQueriesItem'
+        $ref: '#/components/schemas/Security_Osquery_API_ArrayQueriesItem'
       type: array
-    Security_Solution_Osquery_API_ArrayQueriesItem:
+    Security_Osquery_API_ArrayQueriesItem:
       type: object
       properties:
         ecs_mapping:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_ECSMappingOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_ECSMappingOrUndefined'
         id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Id'
+          $ref: '#/components/schemas/Security_Osquery_API_Id'
         platform:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PlatformOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PlatformOrUndefined'
         query:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Query'
+          $ref: '#/components/schemas/Security_Osquery_API_Query'
         removed:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_RemovedOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_RemovedOrUndefined'
         snapshot:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SnapshotOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_SnapshotOrUndefined'
         version:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_VersionOrUndefined
-    Security_Solution_Osquery_API_CreateLiveQueryRequestBody:
+          $ref: '#/components/schemas/Security_Osquery_API_VersionOrUndefined'
+    Security_Osquery_API_CreateLiveQueryRequestBody:
       type: object
       properties:
         agent_all:
@@ -32074,8 +30803,7 @@ components:
             type: string
           type: array
         ecs_mapping:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_ECSMappingOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_ECSMappingOrUndefined'
         event_ids:
           items:
             type: string
@@ -32084,72 +30812,62 @@ components:
           nullable: true
           type: object
         pack_id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PackIdOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_PackIdOrUndefined'
         queries:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_ArrayQueries'
+          $ref: '#/components/schemas/Security_Osquery_API_ArrayQueries'
         query:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_QueryOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_QueryOrUndefined'
         saved_query_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SavedQueryIdOrUndefined
-    Security_Solution_Osquery_API_CreatePacksRequestBody:
+          $ref: '#/components/schemas/Security_Osquery_API_SavedQueryIdOrUndefined'
+    Security_Osquery_API_CreatePacksRequestBody:
       type: object
       properties:
         description:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         enabled:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_EnabledOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_EnabledOrUndefined'
         name:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PackName'
+          $ref: '#/components/schemas/Security_Osquery_API_PackName'
         policy_ids:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PolicyIdsOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PolicyIdsOrUndefined'
         queries:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_ObjectQueries'
+          $ref: '#/components/schemas/Security_Osquery_API_ObjectQueries'
         shards:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Shards'
-    Security_Solution_Osquery_API_CreateSavedQueryRequestBody:
+          $ref: '#/components/schemas/Security_Osquery_API_Shards'
+    Security_Osquery_API_CreateSavedQueryRequestBody:
       type: object
       properties:
         description:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         ecs_mapping:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_ECSMappingOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_ECSMappingOrUndefined'
         id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+          $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
         interval:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Interval'
+          $ref: '#/components/schemas/Security_Osquery_API_Interval'
         platform:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         query:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_QueryOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_QueryOrUndefined'
         removed:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_RemovedOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_RemovedOrUndefined'
         snapshot:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SnapshotOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_SnapshotOrUndefined'
         version:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_VersionOrUndefined
-    Security_Solution_Osquery_API_DefaultSuccessResponse:
+          $ref: '#/components/schemas/Security_Osquery_API_VersionOrUndefined'
+    Security_Osquery_API_DefaultSuccessResponse:
       type: object
       properties: {}
-    Security_Solution_Osquery_API_Description:
+    Security_Osquery_API_Description:
       type: string
-    Security_Solution_Osquery_API_DescriptionOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Description'
+    Security_Osquery_API_DescriptionOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Description'
       nullable: true
-    Security_Solution_Osquery_API_ECSMapping:
+    Security_Osquery_API_ECSMapping:
       additionalProperties:
-        $ref: '#/components/schemas/Security_Solution_Osquery_API_ECSMappingItem'
+        $ref: '#/components/schemas/Security_Osquery_API_ECSMappingItem'
       type: object
-    Security_Solution_Osquery_API_ECSMappingItem:
+    Security_Osquery_API_ECSMappingItem:
       type: object
       properties:
         field:
@@ -32160,220 +30878,196 @@ components:
             - items:
                 type: string
               type: array
-    Security_Solution_Osquery_API_ECSMappingOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_ECSMapping'
+    Security_Osquery_API_ECSMappingOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_ECSMapping'
       nullable: true
-    Security_Solution_Osquery_API_Enabled:
+    Security_Osquery_API_Enabled:
       type: boolean
-    Security_Solution_Osquery_API_EnabledOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Enabled'
+    Security_Osquery_API_EnabledOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Enabled'
       nullable: true
-    Security_Solution_Osquery_API_FindLiveQueryRequestQuery:
+    Security_Osquery_API_FindLiveQueryRequestQuery:
       type: object
       properties:
         kuery:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_KueryOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_KueryOrUndefined'
         page:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PageOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_PageOrUndefined'
         pageSize:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PageSizeOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PageSizeOrUndefined'
         sort:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SortOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrUndefined'
         sortOrder:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SortOrderOrUndefined
-    Security_Solution_Osquery_API_FindPacksRequestQuery:
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrderOrUndefined'
+    Security_Osquery_API_FindPacksRequestQuery:
       type: object
       properties:
         page:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PageOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_PageOrUndefined'
         pageSize:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PageSizeOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PageSizeOrUndefined'
         sort:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SortOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrUndefined'
         sortOrder:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SortOrderOrUndefined
-    Security_Solution_Osquery_API_FindSavedQueryRequestQuery:
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrderOrUndefined'
+    Security_Osquery_API_FindSavedQueryRequestQuery:
       type: object
       properties:
         page:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PageOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_PageOrUndefined'
         pageSize:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PageSizeOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PageSizeOrUndefined'
         sort:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SortOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrUndefined'
         sortOrder:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SortOrderOrUndefined
-    Security_Solution_Osquery_API_GetLiveQueryResultsRequestQuery:
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrderOrUndefined'
+    Security_Osquery_API_GetLiveQueryResultsRequestQuery:
       type: object
       properties:
         kuery:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_KueryOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_KueryOrUndefined'
         page:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PageOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_PageOrUndefined'
         pageSize:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PageSizeOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PageSizeOrUndefined'
         sort:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SortOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrUndefined'
         sortOrder:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SortOrderOrUndefined
-    Security_Solution_Osquery_API_Id:
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrderOrUndefined'
+    Security_Osquery_API_Id:
       type: string
-    Security_Solution_Osquery_API_Interval:
+    Security_Osquery_API_Interval:
       type: string
-    Security_Solution_Osquery_API_IntervalOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Interval'
+    Security_Osquery_API_IntervalOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Interval'
       nullable: true
-    Security_Solution_Osquery_API_KueryOrUndefined:
+    Security_Osquery_API_KueryOrUndefined:
       nullable: true
       type: string
-    Security_Solution_Osquery_API_ObjectQueries:
+    Security_Osquery_API_ObjectQueries:
       additionalProperties:
-        $ref: '#/components/schemas/Security_Solution_Osquery_API_ObjectQueriesItem'
+        $ref: '#/components/schemas/Security_Osquery_API_ObjectQueriesItem'
       type: object
-    Security_Solution_Osquery_API_ObjectQueriesItem:
+    Security_Osquery_API_ObjectQueriesItem:
       type: object
       properties:
         ecs_mapping:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_ECSMappingOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_ECSMappingOrUndefined'
         id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Id'
+          $ref: '#/components/schemas/Security_Osquery_API_Id'
         platform:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PlatformOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PlatformOrUndefined'
         query:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Query'
+          $ref: '#/components/schemas/Security_Osquery_API_Query'
         removed:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_RemovedOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_RemovedOrUndefined'
         saved_query_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SavedQueryIdOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_SavedQueryIdOrUndefined'
         snapshot:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SnapshotOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_SnapshotOrUndefined'
         version:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_VersionOrUndefined
-    Security_Solution_Osquery_API_PackId:
+          $ref: '#/components/schemas/Security_Osquery_API_VersionOrUndefined'
+    Security_Osquery_API_PackId:
       type: string
-    Security_Solution_Osquery_API_PackIdOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_PackId'
+    Security_Osquery_API_PackIdOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_PackId'
       nullable: true
-    Security_Solution_Osquery_API_PackName:
+    Security_Osquery_API_PackName:
       type: string
-    Security_Solution_Osquery_API_PageOrUndefined:
+    Security_Osquery_API_PageOrUndefined:
       nullable: true
       type: integer
-    Security_Solution_Osquery_API_PageSizeOrUndefined:
+    Security_Osquery_API_PageSizeOrUndefined:
       nullable: true
       type: integer
-    Security_Solution_Osquery_API_Platform:
+    Security_Osquery_API_Platform:
       type: string
-    Security_Solution_Osquery_API_PlatformOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Platform'
+    Security_Osquery_API_PlatformOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Platform'
       nullable: true
-    Security_Solution_Osquery_API_PolicyIds:
+    Security_Osquery_API_PolicyIds:
       items:
         type: string
       type: array
-    Security_Solution_Osquery_API_PolicyIdsOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_PolicyIds'
+    Security_Osquery_API_PolicyIdsOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_PolicyIds'
       nullable: true
-    Security_Solution_Osquery_API_Query:
+    Security_Osquery_API_Query:
       type: string
-    Security_Solution_Osquery_API_QueryOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Query'
+    Security_Osquery_API_QueryOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Query'
       nullable: true
-    Security_Solution_Osquery_API_Removed:
+    Security_Osquery_API_Removed:
       type: boolean
-    Security_Solution_Osquery_API_RemovedOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Removed'
+    Security_Osquery_API_RemovedOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Removed'
       nullable: true
-    Security_Solution_Osquery_API_SavedQueryId:
+    Security_Osquery_API_SavedQueryId:
       type: string
-    Security_Solution_Osquery_API_SavedQueryIdOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+    Security_Osquery_API_SavedQueryIdOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
       nullable: true
-    Security_Solution_Osquery_API_Shards:
+    Security_Osquery_API_Shards:
       additionalProperties:
         type: number
       type: object
-    Security_Solution_Osquery_API_Snapshot:
+    Security_Osquery_API_Snapshot:
       type: boolean
-    Security_Solution_Osquery_API_SnapshotOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Snapshot'
+    Security_Osquery_API_SnapshotOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Snapshot'
       nullable: true
-    Security_Solution_Osquery_API_SortOrderOrUndefined:
+    Security_Osquery_API_SortOrderOrUndefined:
       oneOf:
         - nullable: true
           type: string
         - enum:
             - asc
             - desc
-    Security_Solution_Osquery_API_SortOrUndefined:
+    Security_Osquery_API_SortOrUndefined:
       nullable: true
       type: string
-    Security_Solution_Osquery_API_UpdatePacksRequestBody:
+    Security_Osquery_API_UpdatePacksRequestBody:
       type: object
       properties:
         description:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         enabled:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_EnabledOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_EnabledOrUndefined'
         id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PackId'
+          $ref: '#/components/schemas/Security_Osquery_API_PackId'
         policy_ids:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PolicyIdsOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PolicyIdsOrUndefined'
         queries:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_ObjectQueries'
+          $ref: '#/components/schemas/Security_Osquery_API_ObjectQueries'
         shards:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Shards'
-    Security_Solution_Osquery_API_UpdateSavedQueryRequestBody:
+          $ref: '#/components/schemas/Security_Osquery_API_Shards'
+    Security_Osquery_API_UpdateSavedQueryRequestBody:
       type: object
       properties:
         description:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         ecs_mapping:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_ECSMappingOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_ECSMappingOrUndefined'
         id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+          $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
         interval:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_IntervalOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_IntervalOrUndefined'
         platform:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         query:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_QueryOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_QueryOrUndefined'
         removed:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_RemovedOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_RemovedOrUndefined'
         snapshot:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SnapshotOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_SnapshotOrUndefined'
         version:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_VersionOrUndefined
-    Security_Solution_Osquery_API_Version:
+          $ref: '#/components/schemas/Security_Osquery_API_VersionOrUndefined'
+    Security_Osquery_API_Version:
       type: string
-    Security_Solution_Osquery_API_VersionOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Version'
+    Security_Osquery_API_VersionOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Version'
       nullable: true
-    Security_Solution_Timeline_API_BareNote:
+    Security_Timeline_API_BareNote:
       type: object
       properties:
         created:
@@ -32398,7 +31092,7 @@ components:
           type: string
       required:
         - timelineId
-    Security_Solution_Timeline_API_BarePinnedEvent:
+    Security_Timeline_API_BarePinnedEvent:
       type: object
       properties:
         created:
@@ -32420,7 +31114,7 @@ components:
       required:
         - eventId
         - timelineId
-    Security_Solution_Timeline_API_ColumnHeaderResult:
+    Security_Timeline_API_ColumnHeaderResult:
       type: object
       properties:
         aggregatable:
@@ -32449,7 +31143,7 @@ components:
           type: boolean
         type:
           type: string
-    Security_Solution_Timeline_API_DataProviderQueryMatch:
+    Security_Timeline_API_DataProviderQueryMatch:
       type: object
       properties:
         enabled:
@@ -32468,14 +31162,13 @@ components:
           nullable: true
           type: string
         queryMatch:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_QueryMatchResult'
-    Security_Solution_Timeline_API_DataProviderResult:
+          $ref: '#/components/schemas/Security_Timeline_API_QueryMatchResult'
+    Security_Timeline_API_DataProviderResult:
       type: object
       properties:
         and:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_DataProviderQueryMatch
+            $ref: '#/components/schemas/Security_Timeline_API_DataProviderQueryMatch'
           nullable: true
           type: array
         enabled:
@@ -32494,12 +31187,12 @@ components:
           nullable: true
           type: string
         queryMatch:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_QueryMatchResult'
+          $ref: '#/components/schemas/Security_Timeline_API_QueryMatchResult'
           nullable: true
         type:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_DataProviderType'
+          $ref: '#/components/schemas/Security_Timeline_API_DataProviderType'
           nullable: true
-    Security_Solution_Timeline_API_DataProviderType:
+    Security_Timeline_API_DataProviderType:
       description: >-
         The type of data provider to create. Valid values are `default` and
         `template`.
@@ -32507,13 +31200,13 @@ components:
         - default
         - template
       type: string
-    Security_Solution_Timeline_API_DocumentIds:
+    Security_Timeline_API_DocumentIds:
       oneOf:
         - items:
             type: string
           type: array
         - type: string
-    Security_Solution_Timeline_API_FavoriteTimelineResponse:
+    Security_Timeline_API_FavoriteTimelineResponse:
       type: object
       properties:
         code:
@@ -32521,8 +31214,7 @@ components:
           type: number
         favorite:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_FavoriteTimelineResult
+            $ref: '#/components/schemas/Security_Timeline_API_FavoriteTimelineResult'
           type: array
         message:
           nullable: true
@@ -32536,13 +31228,13 @@ components:
           nullable: true
           type: number
         timelineType:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_TimelineType'
+          $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
         version:
           type: string
       required:
         - savedObjectId
         - version
-    Security_Solution_Timeline_API_FavoriteTimelineResult:
+    Security_Timeline_API_FavoriteTimelineResult:
       type: object
       properties:
         favoriteDate:
@@ -32554,7 +31246,7 @@ components:
         userName:
           nullable: true
           type: string
-    Security_Solution_Timeline_API_FilterTimelineResult:
+    Security_Timeline_API_FilterTimelineResult:
       type: object
       properties:
         exists:
@@ -32594,19 +31286,19 @@ components:
           type: string
         script:
           type: string
-    Security_Solution_Timeline_API_GetNotesResult:
+    Security_Timeline_API_GetNotesResult:
       type: object
       properties:
         notes:
           items:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_Note'
+            $ref: '#/components/schemas/Security_Timeline_API_Note'
           type: array
         totalCount:
           type: number
       required:
         - totalCount
         - notes
-    Security_Solution_Timeline_API_ImportTimelineResult:
+    Security_Timeline_API_ImportTimelineResult:
       type: object
       properties:
         errors:
@@ -32631,19 +31323,19 @@ components:
           type: number
         timelines_updated:
           type: number
-    Security_Solution_Timeline_API_ImportTimelines:
+    Security_Timeline_API_ImportTimelines:
       allOf:
-        - $ref: '#/components/schemas/Security_Solution_Timeline_API_SavedTimeline'
+        - $ref: '#/components/schemas/Security_Timeline_API_SavedTimeline'
         - type: object
           properties:
             eventNotes:
               items:
-                $ref: '#/components/schemas/Security_Solution_Timeline_API_BareNote'
+                $ref: '#/components/schemas/Security_Timeline_API_BareNote'
               nullable: true
               type: array
             globalNotes:
               items:
-                $ref: '#/components/schemas/Security_Solution_Timeline_API_BareNote'
+                $ref: '#/components/schemas/Security_Timeline_API_BareNote'
               nullable: true
               type: array
             pinnedEventIds:
@@ -32657,9 +31349,9 @@ components:
             version:
               nullable: true
               type: string
-    Security_Solution_Timeline_API_Note:
+    Security_Timeline_API_Note:
       allOf:
-        - $ref: '#/components/schemas/Security_Solution_Timeline_API_BareNote'
+        - $ref: '#/components/schemas/Security_Timeline_API_BareNote'
         - type: object
           properties:
             noteId:
@@ -32669,17 +31361,17 @@ components:
           required:
             - noteId
             - version
-    Security_Solution_Timeline_API_PersistPinnedEventResponse:
+    Security_Timeline_API_PersistPinnedEventResponse:
       oneOf:
         - allOf:
-            - $ref: '#/components/schemas/Security_Solution_Timeline_API_PinnedEvent'
+            - $ref: '#/components/schemas/Security_Timeline_API_PinnedEvent'
             - $ref: >-
-                #/components/schemas/Security_Solution_Timeline_API_PinnedEventBaseResponseBody
+                #/components/schemas/Security_Timeline_API_PinnedEventBaseResponseBody
         - nullable: true
           type: object
-    Security_Solution_Timeline_API_PinnedEvent:
+    Security_Timeline_API_PinnedEvent:
       allOf:
-        - $ref: '#/components/schemas/Security_Solution_Timeline_API_BarePinnedEvent'
+        - $ref: '#/components/schemas/Security_Timeline_API_BarePinnedEvent'
         - type: object
           properties:
             pinnedEventId:
@@ -32689,7 +31381,7 @@ components:
           required:
             - pinnedEventId
             - version
-    Security_Solution_Timeline_API_PinnedEventBaseResponseBody:
+    Security_Timeline_API_PinnedEventBaseResponseBody:
       type: object
       properties:
         code:
@@ -32698,7 +31390,7 @@ components:
           type: string
       required:
         - code
-    Security_Solution_Timeline_API_QueryMatchResult:
+    Security_Timeline_API_QueryMatchResult:
       type: object
       properties:
         displayField:
@@ -32716,7 +31408,7 @@ components:
         value:
           nullable: true
           type: string
-    Security_Solution_Timeline_API_Readable:
+    Security_Timeline_API_Readable:
       type: object
       properties:
         _data:
@@ -32742,7 +31434,7 @@ components:
           type: object
         readable:
           type: boolean
-    Security_Solution_Timeline_API_ResponseNote:
+    Security_Timeline_API_ResponseNote:
       type: object
       properties:
         code:
@@ -32750,12 +31442,12 @@ components:
         message:
           type: string
         note:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_Note'
+          $ref: '#/components/schemas/Security_Timeline_API_Note'
       required:
         - code
         - message
         - note
-    Security_Solution_Timeline_API_RowRendererId:
+    Security_Timeline_API_RowRendererId:
       enum:
         - alert
         - alerts
@@ -32776,13 +31468,12 @@ components:
         - threat_match
         - zeek
       type: string
-    Security_Solution_Timeline_API_SavedTimeline:
+    Security_Timeline_API_SavedTimeline:
       type: object
       properties:
         columns:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_ColumnHeaderResult
+            $ref: '#/components/schemas/Security_Timeline_API_ColumnHeaderResult'
           nullable: true
           type: array
         created:
@@ -32793,8 +31484,7 @@ components:
           type: string
         dataProviders:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_DataProviderResult
+            $ref: '#/components/schemas/Security_Timeline_API_DataProviderResult'
           nullable: true
           type: array
         dataViewId:
@@ -32842,19 +31532,17 @@ components:
           type: string
         excludedRowRendererIds:
           items:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_RowRendererId'
+            $ref: '#/components/schemas/Security_Timeline_API_RowRendererId'
           nullable: true
           type: array
         favorite:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_FavoriteTimelineResult
+            $ref: '#/components/schemas/Security_Timeline_API_FavoriteTimelineResult'
           nullable: true
           type: array
         filters:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_FilterTimelineResult
+            $ref: '#/components/schemas/Security_Timeline_API_FilterTimelineResult'
           nullable: true
           type: array
         indexNames:
@@ -32867,7 +31555,7 @@ components:
           type: string
         kqlQuery:
           $ref: >-
-            #/components/schemas/Security_Solution_Timeline_API_SerializedFilterQueryResult
+            #/components/schemas/Security_Timeline_API_SerializedFilterQueryResult
           nullable: true
         savedQueryId:
           nullable: true
@@ -32876,7 +31564,7 @@ components:
           nullable: true
           type: string
         sort:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_Sort'
+          $ref: '#/components/schemas/Security_Timeline_API_Sort'
           nullable: true
         status:
           enum:
@@ -32892,7 +31580,7 @@ components:
           nullable: true
           type: number
         timelineType:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_TimelineType'
+          $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
           nullable: true
         title:
           nullable: true
@@ -32903,7 +31591,7 @@ components:
         updatedBy:
           nullable: true
           type: string
-    Security_Solution_Timeline_API_SerializedFilterQueryResult:
+    Security_Timeline_API_SerializedFilterQueryResult:
       type: object
       properties:
         filterQuery:
@@ -32923,13 +31611,13 @@ components:
             serializedQuery:
               nullable: true
               type: string
-    Security_Solution_Timeline_API_Sort:
+    Security_Timeline_API_Sort:
       oneOf:
-        - $ref: '#/components/schemas/Security_Solution_Timeline_API_SortObject'
+        - $ref: '#/components/schemas/Security_Timeline_API_SortObject'
         - items:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_SortObject'
+            $ref: '#/components/schemas/Security_Timeline_API_SortObject'
           type: array
-    Security_Solution_Timeline_API_SortFieldTimeline:
+    Security_Timeline_API_SortFieldTimeline:
       description: The field to sort the timelines by.
       enum:
         - title
@@ -32937,7 +31625,7 @@ components:
         - updated
         - created
       type: string
-    Security_Solution_Timeline_API_SortObject:
+    Security_Timeline_API_SortObject:
       type: object
       properties:
         columnId:
@@ -32949,14 +31637,14 @@ components:
         sortDirection:
           nullable: true
           type: string
-    Security_Solution_Timeline_API_TimelineResponse:
+    Security_Timeline_API_TimelineResponse:
       allOf:
-        - $ref: '#/components/schemas/Security_Solution_Timeline_API_SavedTimeline'
+        - $ref: '#/components/schemas/Security_Timeline_API_SavedTimeline'
         - type: object
           properties:
             eventIdToNoteIds:
               items:
-                $ref: '#/components/schemas/Security_Solution_Timeline_API_Note'
+                $ref: '#/components/schemas/Security_Timeline_API_Note'
               type: array
             noteIds:
               items:
@@ -32964,7 +31652,7 @@ components:
               type: array
             notes:
               items:
-                $ref: '#/components/schemas/Security_Solution_Timeline_API_Note'
+                $ref: '#/components/schemas/Security_Timeline_API_Note'
               type: array
             pinnedEventIds:
               items:
@@ -32972,8 +31660,7 @@ components:
               type: array
             pinnedEventsSaveObject:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Timeline_API_PinnedEvent
+                $ref: '#/components/schemas/Security_Timeline_API_PinnedEvent'
               type: array
             savedObjectId:
               type: string
@@ -32982,7 +31669,7 @@ components:
           required:
             - savedObjectId
             - version
-    Security_Solution_Timeline_API_TimelineStatus:
+    Security_Timeline_API_TimelineStatus:
       description: >-
         The status of the timeline. Valid values are `active`, `draft`, and
         `immutable`.
@@ -32991,7 +31678,7 @@ components:
         - draft
         - immutable
       type: string
-    Security_Solution_Timeline_API_TimelineType:
+    Security_Timeline_API_TimelineType:
       description: >-
         The type of timeline to create. Valid values are `default` and
         `template`.
@@ -34275,29 +32962,29 @@ tags:
       You can create rules that automatically turn events and external alerts
       sent to Elastic Security into detection alerts. These alerts are displayed
       on the Detections page.
-    name: Security Solution Detections API
+    name: Security Detections API
   - description: >-
       Endpoint Exceptions API allows you to manage detection rule endpoint
       exceptions to prevent a rule from generating an alert from incoming events
       even when the rule's other criteria are met.
-    name: Security Solution Endpoint Exceptions API
+    name: Security Endpoint Exceptions API
   - description: Interact with and manage endpoints running the Elastic Defend integration.
-    name: Security Solution Endpoint Management API
+    name: Security Endpoint Management API
   - description: ''
-    name: Security Solution Entity Analytics API
+    name: Security Entity Analytics API
   - description: >-
       Exceptions API allows you to manage detection rule exceptions to prevent a
       rule from generating an alert from incoming events even when the rule's
       other criteria are met.
-    name: Security Solution Exceptions API
+    name: Security Exceptions API
   - description: Lists API allows you to manage lists of keywords, IPs or IP ranges items.
-    name: Security Solution Lists API
+    name: Security Lists API
   - description: Run live queries, manage packs and saved queries.
-    name: Security Solution Osquery API
+    name: Security Osquery API
   - description: >-
       You can create Timelines and Timeline templates via the API, as well as
       import new Timelines from an ndjson file.
-    name: Security Solution Timeline API
+    name: Security Timeline API
   - description: SLO APIs enable you to define, manage and track service-level objectives
     name: slo
   - name: system

--- a/oas_docs/output/kibana.staging.yaml
+++ b/oas_docs/output/kibana.staging.yaml
@@ -6595,8 +6595,7 @@ paths:
           name: id_field
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_IdField
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_IdField'
         - description: If 'wait_for' the request will wait for the index refresh.
           in: query
           name: refresh
@@ -6619,7 +6618,7 @@ paths:
                     type: boolean
                   record:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityRecord
+                      #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityRecord
                     description: The deleted record if it existed.
                 required:
                   - deleted
@@ -6628,7 +6627,7 @@ paths:
           description: Invalid request
       summary: Delete an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     get:
       description: Get the asset criticality record for a specific entity.
       operationId: GetAssetCriticalityRecord
@@ -6645,15 +6644,14 @@ paths:
           name: id_field
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_IdField
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_IdField'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityRecord
+                  #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityRecord
           description: Successful response
         '400':
           description: Invalid request
@@ -6661,7 +6659,7 @@ paths:
           description: Criticality record not found
       summary: Get an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     post:
       description: >
         Create or update an asset criticality record for a specific entity.
@@ -6677,7 +6675,7 @@ paths:
             schema:
               allOf:
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Entity_Analytics_API_CreateAssetCriticalityRecord
+                    #/components/schemas/Security_Entity_Analytics_API_CreateAssetCriticalityRecord
                 - type: object
                   properties:
                     refresh:
@@ -6694,13 +6692,13 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityRecord
+                  #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityRecord
           description: Successful response
         '400':
           description: Invalid request
       summary: Upsert an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/asset_criticality/bulk:
     post:
       description: >
@@ -6729,7 +6727,7 @@ paths:
                 records:
                   items:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_CreateAssetCriticalityRecord
+                      #/components/schemas/Security_Entity_Analytics_API_CreateAssetCriticalityRecord
                   maxItems: 1000
                   minItems: 1
                   type: array
@@ -6753,11 +6751,11 @@ paths:
                   errors:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityBulkUploadErrorItem
+                        #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityBulkUploadErrorItem
                     type: array
                   stats:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityBulkUploadStats
+                      #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityBulkUploadStats
                 required:
                   - errors
                   - stats
@@ -6766,7 +6764,7 @@ paths:
           description: File too large
       summary: Bulk upsert asset criticality records
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/asset_criticality/list:
     get:
       description: List asset criticality records, paging, sorting and filtering as needed.
@@ -6830,7 +6828,7 @@ paths:
                   records:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityRecord
+                        #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityRecord
                     type: array
                   total:
                     minimum: 0
@@ -6843,7 +6841,7 @@ paths:
           description: Bulk upload successful
       summary: List asset criticality records
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/cases:
     delete:
       description: >
@@ -8730,14 +8728,13 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Not enough permissions response
         '404':
           content:
@@ -8749,12 +8746,11 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete an alerts index
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alert index API
     get:
       operationId: ReadAlertsIndex
@@ -8779,32 +8775,29 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Not enough permissions response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Not found
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Reads the alert index name if it exists
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alert index API
     post:
       operationId: CreateAlertsIndex
@@ -8825,32 +8818,29 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Not enough permissions response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Not found
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create an alerts index
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alert index API
   /api/detection_engine/privileges:
     get:
@@ -8884,18 +8874,17 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Returns user privileges for the Kibana space
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Privileges API
   /api/detection_engine/rules:
     delete:
@@ -8907,25 +8896,23 @@ paths:
           name: id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RuleObjectId'
+            $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
         - description: The rule's `rule_id` value.
           in: query
           name: rule_id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+            $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
       summary: Delete a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     get:
       description: Retrieve a detection rule using the `rule_id` or `id` field.
@@ -8936,25 +8923,23 @@ paths:
           name: id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RuleObjectId'
+            $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
         - description: The rule's `rule_id` value.
           in: query
           name: rule_id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+            $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
       summary: Retrieve a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     patch:
       description: >-
@@ -8965,20 +8950,18 @@ paths:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RulePatchProps
+              $ref: '#/components/schemas/Security_Detections_API_RulePatchProps'
         required: true
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
       summary: Patch a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     post:
       description: Create a new detection rule.
@@ -8987,20 +8970,18 @@ paths:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleCreateProps
+              $ref: '#/components/schemas/Security_Detections_API_RuleCreateProps'
         required: true
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
       summary: Create a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     put:
       description: >
@@ -9015,20 +8996,18 @@ paths:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleUpdateProps
+              $ref: '#/components/schemas/Security_Detections_API_RuleUpdateProps'
         required: true
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
       summary: Update a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
   /api/detection_engine/rules/_bulk_action:
     post:
@@ -9049,20 +9028,16 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               oneOf:
+                - $ref: '#/components/schemas/Security_Detections_API_BulkDeleteRules'
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkDeleteRules
+                    #/components/schemas/Security_Detections_API_BulkDisableRules
+                - $ref: '#/components/schemas/Security_Detections_API_BulkEnableRules'
+                - $ref: '#/components/schemas/Security_Detections_API_BulkExportRules'
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkDisableRules
+                    #/components/schemas/Security_Detections_API_BulkDuplicateRules
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkEnableRules
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkExportRules
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkDuplicateRules
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkManualRuleRun
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_BulkEditRules
+                    #/components/schemas/Security_Detections_API_BulkManualRuleRun
+                - $ref: '#/components/schemas/Security_Detections_API_BulkEditRules'
       responses:
         '200':
           content:
@@ -9070,13 +9045,13 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_BulkEditActionResponse
+                      #/components/schemas/Security_Detections_API_BulkEditActionResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_BulkExportActionResponse
+                      #/components/schemas/Security_Detections_API_BulkExportActionResponse
           description: OK
       summary: Apply a bulk action to detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
   /api/detection_engine/rules/_bulk_create:
     post:
@@ -9088,8 +9063,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleCreateProps
+                $ref: '#/components/schemas/Security_Detections_API_RuleCreateProps'
               type: array
         description: A JSON array of rules, where each rule contains the required fields.
         required: true
@@ -9099,11 +9073,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_BulkCrudRulesResponse
+                  #/components/schemas/Security_Detections_API_BulkCrudRulesResponse
           description: Indicates a successful call.
       summary: Create multiple detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
   /api/detection_engine/rules/_bulk_delete:
     delete:
@@ -9118,11 +9092,10 @@ paths:
                 type: object
                 properties:
                   id:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+                    $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
                   rule_id:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+                      #/components/schemas/Security_Detections_API_RuleSignatureId
               type: array
         description: >-
           A JSON array of `id` or `rule_id` fields of the rules you want to
@@ -9134,7 +9107,7 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_BulkCrudRulesResponse
+                  #/components/schemas/Security_Detections_API_BulkCrudRulesResponse
           description: Indicates a successful call.
         '400':
           content:
@@ -9142,27 +9115,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete multiple detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
     post:
       deprecated: true
@@ -9176,11 +9148,10 @@ paths:
                 type: object
                 properties:
                   id:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+                    $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
                   rule_id:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+                      #/components/schemas/Security_Detections_API_RuleSignatureId
               type: array
         description: >-
           A JSON array of `id` or `rule_id` fields of the rules you want to
@@ -9192,7 +9163,7 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_BulkCrudRulesResponse
+                  #/components/schemas/Security_Detections_API_BulkCrudRulesResponse
           description: Indicates a successful call.
         '400':
           content:
@@ -9200,27 +9171,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete multiple detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
   /api/detection_engine/rules/_bulk_update:
     patch:
@@ -9234,8 +9204,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RulePatchProps
+                $ref: '#/components/schemas/Security_Detections_API_RulePatchProps'
               type: array
         description: A JSON array of rules, where each rule contains the required fields.
         required: true
@@ -9245,11 +9214,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_BulkCrudRulesResponse
+                  #/components/schemas/Security_Detections_API_BulkCrudRulesResponse
           description: Indicates a successful call.
       summary: Patch multiple detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
     put:
       deprecated: true
@@ -9266,8 +9235,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleUpdateProps
+                $ref: '#/components/schemas/Security_Detections_API_RuleUpdateProps'
               type: array
         description: >-
           A JSON array where each element includes the `id` or `rule_id` field
@@ -9279,11 +9247,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_BulkCrudRulesResponse
+                  #/components/schemas/Security_Detections_API_BulkCrudRulesResponse
           description: Indicates a successful call.
       summary: Update multiple detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
   /api/detection_engine/rules/_export:
     post:
@@ -9330,7 +9298,7 @@ paths:
                     properties:
                       rule_id:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+                          #/components/schemas/Security_Detections_API_RuleSignatureId
                     required:
                       - rule_id
                   type: array
@@ -9348,7 +9316,7 @@ paths:
           description: Indicates a successful call.
       summary: Export detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Import/Export API
   /api/detection_engine/rules/_find:
     get:
@@ -9375,14 +9343,13 @@ paths:
           name: sort_field
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_FindRulesSortField
+            $ref: '#/components/schemas/Security_Detections_API_FindRulesSortField'
         - description: Sort order
           in: query
           name: sort_order
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_SortOrder'
+            $ref: '#/components/schemas/Security_Detections_API_SortOrder'
         - description: Page number
           in: query
           name: page
@@ -9409,7 +9376,7 @@ paths:
                   data:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RuleResponse
+                        #/components/schemas/Security_Detections_API_RuleResponse
                     type: array
                   page:
                     type: integer
@@ -9425,7 +9392,7 @@ paths:
           description: Successful response
       summary: List all detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
   /api/detection_engine/rules/_import:
     post:
@@ -9493,8 +9460,7 @@ paths:
                 properties:
                   action_connectors_errors:
                     items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_ErrorSchema
+                      $ref: '#/components/schemas/Security_Detections_API_ErrorSchema'
                     type: array
                   action_connectors_success:
                     type: boolean
@@ -9504,17 +9470,15 @@ paths:
                   action_connectors_warnings:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_WarningSchema
+                        #/components/schemas/Security_Detections_API_WarningSchema
                     type: array
                   errors:
                     items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_ErrorSchema
+                      $ref: '#/components/schemas/Security_Detections_API_ErrorSchema'
                     type: array
                   exceptions_errors:
                     items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_ErrorSchema
+                      $ref: '#/components/schemas/Security_Detections_API_ErrorSchema'
                     type: array
                   exceptions_success:
                     type: boolean
@@ -9544,7 +9508,7 @@ paths:
           description: Indicates a successful call.
       summary: Import detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Import/Export API
   /api/detection_engine/rules/{id}/exceptions:
     post:
@@ -9556,7 +9520,7 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Exceptions_API_RuleId'
+            $ref: '#/components/schemas/Security_Exceptions_API_RuleId'
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
@@ -9566,7 +9530,7 @@ paths:
                 items:
                   items:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_CreateRuleExceptionListItemProps
+                      #/components/schemas/Security_Exceptions_API_CreateRuleExceptionListItemProps
                   type: array
               required:
                 - items
@@ -9579,7 +9543,7 @@ paths:
               schema:
                 items:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItem
                 type: array
           description: Successful response
         '400':
@@ -9588,34 +9552,33 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create rule exception list items
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/detection_engine/rules/prepackaged:
     put:
       description: Install and update all Elastic prebuilt detection rules and Timelines.
@@ -9652,7 +9615,7 @@ paths:
           description: Indicates a successful call
       summary: Install prebuilt detection rules and Timelines
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Prebuilt Rules API
   /api/detection_engine/rules/prepackaged/_status:
     get:
@@ -9711,7 +9674,7 @@ paths:
           description: Indicates a successful call
       summary: Retrieve the status of prebuilt detection rules and Timelines
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Prebuilt Rules API
   /api/detection_engine/rules/preview:
     post:
@@ -9732,44 +9695,44 @@ paths:
               anyOf:
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_EqlRuleCreateProps
+                        #/components/schemas/Security_Detections_API_EqlRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_QueryRuleCreateProps
+                        #/components/schemas/Security_Detections_API_QueryRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleCreateProps
+                        #/components/schemas/Security_Detections_API_SavedQueryRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_ThresholdRuleCreateProps
+                        #/components/schemas/Security_Detections_API_ThresholdRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleCreateProps
+                        #/components/schemas/Security_Detections_API_ThreatMatchRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleCreateProps
+                        #/components/schemas/Security_Detections_API_MachineLearningRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_NewTermsRuleCreateProps
+                        #/components/schemas/Security_Detections_API_NewTermsRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
                 - allOf:
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_EsqlRuleCreateProps
+                        #/components/schemas/Security_Detections_API_EsqlRuleCreateProps
                     - $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewParams
+                        #/components/schemas/Security_Detections_API_RulePreviewParams
               discriminator:
                 propertyName: type
         description: >-
@@ -9788,11 +9751,11 @@ paths:
                   logs:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_RulePreviewLogs
+                        #/components/schemas/Security_Detections_API_RulePreviewLogs
                     type: array
                   previewId:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+                      #/components/schemas/Security_Detections_API_NonEmptyString
                 required:
                   - logs
           description: Successful response
@@ -9802,27 +9765,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Preview rule alerts generated on specified time range
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rule preview API
   /api/detection_engine/signals/assignees:
     post:
@@ -9838,12 +9800,10 @@ paths:
               type: object
               properties:
                 assignees:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_AlertAssignees
+                  $ref: '#/components/schemas/Security_Detections_API_AlertAssignees'
                   description: Details about the assignees to assign and unassign.
                 ids:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_AlertIds
+                  $ref: '#/components/schemas/Security_Detections_API_AlertIds'
                   description: List of alerts ids to assign and unassign passed assignees.
               required:
                 - assignees
@@ -9856,7 +9816,7 @@ paths:
           description: Invalid request.
       summary: Assign and unassign users from detection alerts
       tags:
-        - Security Solution Detections API
+        - Security Detections API
   /api/detection_engine/signals/finalize_migration:
     post:
       description: >
@@ -9890,7 +9850,7 @@ paths:
               schema:
                 items:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_MigrationFinalizationResult
+                    #/components/schemas/Security_Detections_API_MigrationFinalizationResult
                 type: array
           description: Successful response
         '400':
@@ -9899,27 +9859,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Finalize detection alert migrations
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts migration API
   /api/detection_engine/signals/migration:
     delete:
@@ -9963,7 +9922,7 @@ paths:
               schema:
                 items:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_MigrationCleanupResult
+                    #/components/schemas/Security_Detections_API_MigrationCleanupResult
                 type: array
           description: Successful response
         '400':
@@ -9972,27 +9931,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Clean up detection alert migrations
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts migration API
     post:
       description: >
@@ -10013,13 +9971,13 @@ paths:
                     index:
                       items:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+                          #/components/schemas/Security_Detections_API_NonEmptyString
                       minItems: 1
                       type: array
                   required:
                     - index
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_AlertsReindexOptions
+                    #/components/schemas/Security_Detections_API_AlertsReindexOptions
         description: Alerts migration parameters
         required: true
       responses:
@@ -10033,11 +9991,11 @@ paths:
                     items:
                       oneOf:
                         - $ref: >-
-                            #/components/schemas/Security_Solution_Detections_API_AlertsIndexMigrationSuccess
+                            #/components/schemas/Security_Detections_API_AlertsIndexMigrationSuccess
                         - $ref: >-
-                            #/components/schemas/Security_Solution_Detections_API_AlertsIndexMigrationError
+                            #/components/schemas/Security_Detections_API_AlertsIndexMigrationError
                         - $ref: >-
-                            #/components/schemas/Security_Solution_Detections_API_SkippedAlertsIndexMigration
+                            #/components/schemas/Security_Detections_API_SkippedAlertsIndexMigration
                     type: array
                 required:
                   - indices
@@ -10048,27 +10006,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Initiate a detection alert migration
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts migration API
   /api/detection_engine/signals/migration_status:
     post:
@@ -10100,7 +10057,7 @@ paths:
                   indices:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Detections_API_IndexMigrationStatus
+                        #/components/schemas/Security_Detections_API_IndexMigrationStatus
                     type: array
                 required:
                   - indices
@@ -10111,27 +10068,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Retrieve the status of detection alert migrations
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts migration API
   /api/detection_engine/signals/search:
     post:
@@ -10168,8 +10124,7 @@ paths:
                   minimum: 0
                   type: integer
                 sort:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_AlertsSort
+                  $ref: '#/components/schemas/Security_Detections_API_AlertsSort'
                 track_total_hits:
                   type: boolean
         description: Search and/or aggregation query
@@ -10189,27 +10144,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Find and/or aggregate detection alerts
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/signals/status:
     post:
@@ -10221,9 +10175,9 @@ paths:
             schema:
               oneOf:
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_SetAlertsStatusByIds
+                    #/components/schemas/Security_Detections_API_SetAlertsStatusByIds
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_SetAlertsStatusByQuery
+                    #/components/schemas/Security_Detections_API_SetAlertsStatusByQuery
         description: >-
           An object containing desired status and explicit alert ids or a query
           to select alerts
@@ -10243,27 +10197,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Set a detection alert status
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/signals/tags:
     post:
@@ -10279,11 +10232,9 @@ paths:
               type: object
               properties:
                 ids:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_AlertIds
+                  $ref: '#/components/schemas/Security_Detections_API_AlertIds'
                 tags:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_SetAlertTags
+                  $ref: '#/components/schemas/Security_Detections_API_SetAlertTags'
               required:
                 - ids
                 - tags
@@ -10306,27 +10257,26 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                      #/components/schemas/Security_Detections_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                      #/components/schemas/Security_Detections_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_PlatformErrorResponse
+                  #/components/schemas/Security_Detections_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Detections_API_SiemErrorResponse'
           description: Internal server error response
       summary: Add and remove detection alert tags
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/tags:
     get:
@@ -10337,12 +10287,11 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+                $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
           description: Indicates a successful call
       summary: List all detection rule tags
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Tags API
   /api/encrypted_saved_objects/_rotate_key:
     post:
@@ -10450,7 +10399,7 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointList
+                  #/components/schemas/Security_Endpoint_Exceptions_API_EndpointList
           description: Successful response
         '400':
           content:
@@ -10458,34 +10407,34 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Create an endpoint exception list
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
   /api/endpoint_list/items:
     delete:
       description: >-
@@ -10499,21 +10448,21 @@ paths:
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemId
+              #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemId
         - description: Either `id` or `item_id` must be specified
           in: query
           name: item_id
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId
+              #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemHumanId
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointListItem
+                  #/components/schemas/Security_Endpoint_Exceptions_API_EndpointListItem
           description: Successful response
         '400':
           content:
@@ -10521,41 +10470,41 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Endpoint list item not found
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Delete an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     get:
       description: >-
         Get the details of an endpoint exception list item using the `id` or
@@ -10568,14 +10517,14 @@ paths:
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemId
+              #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemId
         - description: Either `id` or `item_id` must be specified
           in: query
           name: item_id
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId
+              #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemHumanId
       responses:
         '200':
           content:
@@ -10583,7 +10532,7 @@ paths:
               schema:
                 items:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointListItem
+                    #/components/schemas/Security_Endpoint_Exceptions_API_EndpointListItem
                 type: array
           description: Successful response
         '400':
@@ -10592,41 +10541,41 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Endpoint list item not found
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Get an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     post:
       description: >-
         Create an endpoint exception list item, and associate it with the
@@ -10640,34 +10589,34 @@ paths:
               properties:
                 comments:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemCommentArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemCommentArray
                   default: []
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemDescription
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemDescription
                 entries:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryArray
                 item_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemHumanId
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemMeta
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemName
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemName
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
                   default: []
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemTags
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemTags
                   default: []
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemType
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemType
               required:
                 - type
                 - name
@@ -10681,7 +10630,7 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointListItem
+                  #/components/schemas/Security_Endpoint_Exceptions_API_EndpointListItem
           description: Successful response
         '400':
           content:
@@ -10689,41 +10638,41 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Endpoint list item already exists
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Create an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     put:
       description: >-
         Update an endpoint exception list item using the `id` or `item_id`
@@ -10739,38 +10688,38 @@ paths:
                   type: string
                 comments:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemCommentArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemCommentArray
                   default: []
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemDescription
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemDescription
                 entries:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryArray
                 id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemId
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemId
                   description: Either `id` or `item_id` must be specified
                 item_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemHumanId
                   description: Either `id` or `item_id` must be specified
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemMeta
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemName
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemName
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
                   default: []
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemTags
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemTags
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemType
+                    #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemType
               required:
                 - type
                 - name
@@ -10784,7 +10733,7 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointListItem
+                  #/components/schemas/Security_Endpoint_Exceptions_API_EndpointListItem
           description: Successful response
         '400':
           content:
@@ -10792,41 +10741,41 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Endpoint list item not found
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Update an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
   /api/endpoint_list/items/_find:
     get:
       description: Get a list of all endpoint exception list items.
@@ -10842,7 +10791,7 @@ paths:
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_FindEndpointListItemsFilter
+              #/components/schemas/Security_Endpoint_Exceptions_API_FindEndpointListItemsFilter
         - description: The page number to return
           in: query
           name: page
@@ -10863,7 +10812,7 @@ paths:
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+              #/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString
         - description: Determines the sort order, which can be `desc` or `asc`
           in: query
           name: sort_order
@@ -10883,7 +10832,7 @@ paths:
                   data:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_EndpointListItem
+                        #/components/schemas/Security_Endpoint_Exceptions_API_EndpointListItem
                     type: array
                   page:
                     minimum: 0
@@ -10908,41 +10857,41 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Invalid input data
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_PlatformErrorResponse
           description: Insufficient privileges
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Endpoint list not found
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse
+                  #/components/schemas/Security_Endpoint_Exceptions_API_SiemErrorResponse
           description: Internal server error
       summary: Get endpoint exception list items
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
   /api/endpoint/action:
     get:
       description: Get a list of all response actions.
@@ -10953,18 +10902,18 @@ paths:
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Management_API_GetEndpointActionListRouteQuery
+              #/components/schemas/Security_Endpoint_Management_API_GetEndpointActionListRouteQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get response actions
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action_log/{agent_id}:
     get:
       deprecated: true
@@ -10975,25 +10924,24 @@ paths:
           name: agent_id
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Management_API_AgentId
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentId'
         - in: query
           name: query
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Management_API_ActionLogRequestQuery
+              #/components/schemas/Security_Endpoint_Management_API_ActionLogRequestQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get an action request log
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action_status:
     get:
       description: Get the status of response actions for the specified agent IDs.
@@ -11006,19 +10954,18 @@ paths:
             type: object
             properties:
               agent_ids:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_AgentIds
+                $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentIds'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_ActionStatusSuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_ActionStatusSuccessResponse
           description: OK
       summary: Get response actions status
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}:
     get:
       description: Get the details of a response action using the action ID.
@@ -11035,11 +10982,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get action details
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}/file/{file_id}:
     get:
       description: Get information for the specified file using the file ID.
@@ -11061,11 +11008,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get file information
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}/file/{file_id}/download:
     get:
       description: Download a file from an endpoint.
@@ -11087,11 +11034,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Download a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/execute:
     post:
       description: Run a shell command on an endpoint.
@@ -11101,7 +11048,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_ExecuteRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_ExecuteRouteRequestBody
         required: true
       responses:
         '200':
@@ -11109,11 +11056,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Run a command
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/get_file:
     post:
       description: Get a file from an endpoint.
@@ -11123,7 +11070,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_GetFileRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_GetFileRouteRequestBody
         required: true
       responses:
         '200':
@@ -11131,11 +11078,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/isolate:
     post:
       description: >-
@@ -11147,7 +11094,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_IsolateRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_IsolateRouteRequestBody
         required: true
       responses:
         '200':
@@ -11155,11 +11102,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Isolate an endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/kill_process:
     post:
       description: Terminate a running process on an endpoint.
@@ -11169,7 +11116,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_KillProcessRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_KillProcessRouteRequestBody
         required: true
       responses:
         '200':
@@ -11177,11 +11124,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Terminate a process
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/running_procs:
     post:
       description: Get a list of all processes running on an endpoint.
@@ -11191,7 +11138,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_GetProcessesRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_GetProcessesRouteRequestBody
         required: true
       responses:
         '200':
@@ -11199,11 +11146,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get running processes
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/scan:
     post:
       description: Scan a specific file or directory on an endpoint for malware.
@@ -11213,7 +11160,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_ScanRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_ScanRouteRequestBody
         required: true
       responses:
         '200':
@@ -11221,11 +11168,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Scan a file or directory
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/state:
     get:
       description: >-
@@ -11238,11 +11185,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_ActionStateSuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_ActionStateSuccessResponse
           description: OK
       summary: Get actions state
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/suspend_process:
     post:
       description: Suspend a running process on an endpoint.
@@ -11252,7 +11199,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_SuspendProcessRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_SuspendProcessRouteRequestBody
         required: true
       responses:
         '200':
@@ -11260,11 +11207,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Suspend a process
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/unisolate:
     post:
       description: Release an isolated endpoint, allowing it to rejoin a network.
@@ -11274,7 +11221,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_UnisolateRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_UnisolateRouteRequestBody
         required: true
       responses:
         '200':
@@ -11282,11 +11229,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Release an isolated endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/upload:
     post:
       description: Upload a file to an endpoint.
@@ -11296,7 +11243,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_UploadRouteRequestBody
+                #/components/schemas/Security_Endpoint_Management_API_UploadRouteRequestBody
         required: true
       responses:
         '200':
@@ -11304,11 +11251,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Upload a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/isolate:
     post:
       deprecated: true
@@ -11328,22 +11275,22 @@ paths:
               properties:
                 agent_type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+                    #/components/schemas/Security_Endpoint_Management_API_AgentTypes
                 alert_ids:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+                    #/components/schemas/Security_Endpoint_Management_API_AlertIds
                 case_ids:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+                    #/components/schemas/Security_Endpoint_Management_API_CaseIds
                 comment:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+                    #/components/schemas/Security_Endpoint_Management_API_Comment
                 endpoint_ids:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                    #/components/schemas/Security_Endpoint_Management_API_EndpointIds
                 parameters:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+                    #/components/schemas/Security_Endpoint_Management_API_Parameters
               required:
                 - endpoint_ids
         required: true
@@ -11353,7 +11300,7 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
         '308':
           description: Permanent Redirect
@@ -11365,7 +11312,7 @@ paths:
                 type: string
       summary: Isolate an endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata:
     get:
       operationId: GetEndpointMetadataList
@@ -11375,18 +11322,18 @@ paths:
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Management_API_ListRequestQuery
+              #/components/schemas/Security_Endpoint_Management_API_ListRequestQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get a metadata list
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata/{id}:
     get:
       operationId: GetEndpointMetadata
@@ -11402,11 +11349,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get metadata
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata/transforms:
     get:
       operationId: GetEndpointMetadataTransform
@@ -11416,11 +11363,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get metadata transforms
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/policy_response:
     get:
       operationId: GetPolicyResponse
@@ -11432,19 +11379,18 @@ paths:
             type: object
             properties:
               agentId:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_AgentId
+                $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get a policy response
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/policy/summaries:
     get:
       deprecated: true
@@ -11467,11 +11413,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get an agent policy summary
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/protection_updates_note/{package_policy_id}:
     get:
       operationId: GetProtectionUpdatesNote
@@ -11487,11 +11433,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_ProtectionUpdatesNoteResponse
+                  #/components/schemas/Security_Endpoint_Management_API_ProtectionUpdatesNoteResponse
           description: OK
       summary: Get a protection updates note
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
     post:
       operationId: CreateUpdateProtectionUpdatesNote
       parameters:
@@ -11515,11 +11461,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_ProtectionUpdatesNoteResponse
+                  #/components/schemas/Security_Endpoint_Management_API_ProtectionUpdatesNoteResponse
           description: OK
       summary: Create or update a protection updates note
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/suggestions/{suggestion_type}:
     post:
       operationId: GetEndpointSuggestions
@@ -11552,11 +11498,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
       summary: Get suggestions
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/unisolate:
     post:
       deprecated: true
@@ -11576,22 +11522,22 @@ paths:
               properties:
                 agent_type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+                    #/components/schemas/Security_Endpoint_Management_API_AgentTypes
                 alert_ids:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+                    #/components/schemas/Security_Endpoint_Management_API_AlertIds
                 case_ids:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+                    #/components/schemas/Security_Endpoint_Management_API_CaseIds
                 comment:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+                    #/components/schemas/Security_Endpoint_Management_API_Comment
                 endpoint_ids:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                    #/components/schemas/Security_Endpoint_Management_API_EndpointIds
                 parameters:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+                    #/components/schemas/Security_Endpoint_Management_API_Parameters
               required:
                 - endpoint_ids
         required: true
@@ -11601,7 +11547,7 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Endpoint_Management_API_SuccessResponse
+                  #/components/schemas/Security_Endpoint_Management_API_SuccessResponse
           description: OK
         '308':
           description: Permanent Redirect
@@ -11613,7 +11559,7 @@ paths:
                 type: string
       summary: Release an isolated endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/entity_store/engines:
     get:
       operationId: ListEntityEngines
@@ -11629,12 +11575,12 @@ paths:
                   engines:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Entity_Analytics_API_EngineDescriptor
+                        #/components/schemas/Security_Entity_Analytics_API_EngineDescriptor
                     type: array
           description: Successful response
       summary: List the Entity Engines
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}:
     delete:
       operationId: DeleteEntityEngine
@@ -11644,8 +11590,7 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
         - description: Control flag to also delete the entity data.
           in: query
           name: data
@@ -11664,7 +11609,7 @@ paths:
           description: Successful response
       summary: Delete the Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     get:
       operationId: GetEntityEngine
       parameters:
@@ -11673,19 +11618,18 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_EngineDescriptor
+                  #/components/schemas/Security_Entity_Analytics_API_EngineDescriptor
           description: Successful response
       summary: Get an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/init:
     post:
       operationId: InitEntityEngine
@@ -11695,8 +11639,7 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
@@ -11707,7 +11650,7 @@ paths:
                   type: string
                 indexPattern:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Entity_Analytics_API_IndexPattern
+                    #/components/schemas/Security_Entity_Analytics_API_IndexPattern
         description: Schema for the engine initialization
         required: true
       responses:
@@ -11716,11 +11659,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_EngineDescriptor
+                  #/components/schemas/Security_Entity_Analytics_API_EngineDescriptor
           description: Successful response
       summary: Initialize an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/start:
     post:
       operationId: StartEntityEngine
@@ -11730,8 +11673,7 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
       responses:
         '200':
           content:
@@ -11744,7 +11686,7 @@ paths:
           description: Successful response
       summary: Start an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/stats:
     post:
       operationId: GetEntityEngineStats
@@ -11754,8 +11696,7 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
       responses:
         '200':
           content:
@@ -11765,25 +11706,25 @@ paths:
                 properties:
                   indexPattern:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_IndexPattern
+                      #/components/schemas/Security_Entity_Analytics_API_IndexPattern
                   indices:
                     items:
                       type: object
                     type: array
                   status:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_EngineStatus
+                      #/components/schemas/Security_Entity_Analytics_API_EngineStatus
                   transforms:
                     items:
                       type: object
                     type: array
                   type:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+                      #/components/schemas/Security_Entity_Analytics_API_EntityType
           description: Successful response
       summary: Get Entity Engine stats
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/stop:
     post:
       operationId: StopEntityEngine
@@ -11793,8 +11734,7 @@ paths:
           name: entityType
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+            $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
       responses:
         '200':
           content:
@@ -11807,7 +11747,7 @@ paths:
           description: Successful response
       summary: Stop an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/entities/list:
     get:
       description: List entities records, paging, sorting and filtering as needed.
@@ -11850,8 +11790,7 @@ paths:
           required: true
           schema:
             items:
-              $ref: >-
-                #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
+              $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
             type: array
       responses:
         '200':
@@ -11862,7 +11801,7 @@ paths:
                 properties:
                   inspect:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Entity_Analytics_API_InspectQuery
+                      #/components/schemas/Security_Entity_Analytics_API_InspectQuery
                   page:
                     minimum: 1
                     type: integer
@@ -11873,7 +11812,7 @@ paths:
                   records:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Entity_Analytics_API_Entity
+                        #/components/schemas/Security_Entity_Analytics_API_Entity
                     type: array
                   total:
                     minimum: 0
@@ -11886,7 +11825,7 @@ paths:
           description: Entities returned successfully
       summary: List Entity Store Entities
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/exception_lists:
     delete:
       description: Delete an exception list using the `id` or `list_id` field.
@@ -11897,29 +11836,26 @@ paths:
           name: id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         - description: Either `id` or `list_id` must be specified
           in: query
           name: list_id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         - in: query
           name: namespace_type
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             default: single
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -11927,41 +11863,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     get:
       description: Get the details of an exception list using the `id` or `list_id` field.
       operationId: ReadExceptionList
@@ -11971,29 +11905,26 @@ paths:
           name: id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         - description: Either `id` or `list_id` must be specified
           in: query
           name: list_id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         - in: query
           name: namespace_type
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             default: single
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -12001,41 +11932,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get exception list details
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     post:
       description: >
         An exception list groups exception items and can be associated with
@@ -12059,33 +11988,33 @@ paths:
               properties:
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListDescription
+                    #/components/schemas/Security_Exceptions_API_ExceptionListDescription
                 list_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListHumanId
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListMeta
+                    #/components/schemas/Security_Exceptions_API_ExceptionListMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListName
+                    #/components/schemas/Security_Exceptions_API_ExceptionListName
                 namespace_type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                    #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
                   default: single
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListOsTypeArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListOsTypeArray
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListTags
+                    #/components/schemas/Security_Exceptions_API_ExceptionListTags
                   default: []
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListType
+                    #/components/schemas/Security_Exceptions_API_ExceptionListType
                 version:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListVersion
+                    #/components/schemas/Security_Exceptions_API_ExceptionListVersion
                   default: 1
               required:
                 - name
@@ -12098,8 +12027,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -12107,41 +12035,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list already exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     put:
       description: Update an exception list using the `id` or `list_id` field.
       operationId: UpdateExceptionList
@@ -12155,36 +12081,35 @@ paths:
                   type: string
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListDescription
+                    #/components/schemas/Security_Exceptions_API_ExceptionListDescription
                 id:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+                  $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
                 list_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListHumanId
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListMeta
+                    #/components/schemas/Security_Exceptions_API_ExceptionListMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListName
+                    #/components/schemas/Security_Exceptions_API_ExceptionListName
                 namespace_type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                    #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
                   default: single
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListOsTypeArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListOsTypeArray
                   default: []
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListTags
+                    #/components/schemas/Security_Exceptions_API_ExceptionListTags
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListType
+                    #/components/schemas/Security_Exceptions_API_ExceptionListType
                 version:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListVersion
+                    #/components/schemas/Security_Exceptions_API_ExceptionListVersion
               required:
                 - name
                 - description
@@ -12196,8 +12121,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -12205,41 +12129,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Update an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_duplicate:
     post:
       description: Duplicate an existing exception list.
@@ -12250,14 +12172,13 @@ paths:
           name: list_id
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         - in: query
           name: namespace_type
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
         - description: >-
             Determines whether to include expired exceptions in the exported
             list
@@ -12275,8 +12196,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -12284,41 +12204,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '405':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list to duplicate not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Duplicate an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_export:
     post:
       description: Export an exception list and its associated items to an NDJSON file.
@@ -12329,21 +12247,19 @@ paths:
           name: id
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         - description: Exception list's human identifier
           in: query
           name: list_id
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         - in: query
           name: namespace_type
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
         - description: >-
             Determines whether to include expired exceptions in the exported
             list
@@ -12373,41 +12289,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Export an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_find:
     get:
       description: Get a list of all exception lists.
@@ -12431,7 +12345,7 @@ paths:
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_FindExceptionListsFilter
+              #/components/schemas/Security_Exceptions_API_FindExceptionListsFilter
         - description: >
             Determines whether the returned containers are Kibana associated
             with a Kibana space
@@ -12445,7 +12359,7 @@ paths:
               - single
             items:
               $ref: >-
-                #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             type: array
         - description: The page number to return
           in: query
@@ -12486,7 +12400,7 @@ paths:
                   data:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                        #/components/schemas/Security_Exceptions_API_ExceptionList
                     type: array
                   page:
                     minimum: 1
@@ -12509,34 +12423,33 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get exception lists
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_import:
     post:
       description: Import an exception list and its associated items from an NDJSON file.
@@ -12600,7 +12513,7 @@ paths:
                 properties:
                   errors:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_ExceptionListsImportBulkErrorArray
+                      #/components/schemas/Security_Exceptions_API_ExceptionListsImportBulkErrorArray
                   success:
                     type: boolean
                   success_count:
@@ -12631,34 +12544,33 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Import an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/items:
     delete:
       description: Delete an exception list item using the `id` or `item_id` field.
@@ -12669,29 +12581,27 @@ paths:
           name: id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemId'
         - description: Either `id` or `item_id` must be specified
           in: query
           name: item_id
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+              #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
         - in: query
           name: namespace_type
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             default: single
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItem'
           description: Successful response
         '400':
           content:
@@ -12699,41 +12609,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     get:
       description: >-
         Get the details of an exception list item using the `id` or `item_id`
@@ -12745,29 +12653,27 @@ paths:
           name: id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemId'
         - description: Either `id` or `item_id` must be specified
           in: query
           name: item_id
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+              #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
         - in: query
           name: namespace_type
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             default: single
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItem'
           description: Successful response
         '400':
           content:
@@ -12775,41 +12681,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     post:
       description: >
         Create an exception item and associate it with the specified exception
@@ -12827,44 +12731,44 @@ paths:
               properties:
                 comments:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_CreateExceptionListItemCommentArray
+                    #/components/schemas/Security_Exceptions_API_CreateExceptionListItemCommentArray
                   default: []
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemDescription
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemDescription
                 entries:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryArray
                 expire_time:
                   format: date-time
                   type: string
                 item_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
                 list_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListHumanId
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemMeta
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemName
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemName
                 namespace_type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                    #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
                   default: single
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemOsTypeArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemOsTypeArray
                   default: []
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemTags
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemTags
                   default: []
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemType
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemType
               required:
                 - list_id
                 - type
@@ -12878,8 +12782,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItem'
           description: Successful response
         '400':
           content:
@@ -12887,41 +12790,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list item already exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     put:
       description: Update an exception list item using the `id` or `item_id` field.
       operationId: UpdateExceptionListItem
@@ -12935,48 +12836,48 @@ paths:
                   type: string
                 comments:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_UpdateExceptionListItemCommentArray
+                    #/components/schemas/Security_Exceptions_API_UpdateExceptionListItemCommentArray
                   default: []
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemDescription
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemDescription
                 entries:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryArray
                 expire_time:
                   format: date-time
                   type: string
                 id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemId
                   description: Either `id` or `item_id` must be specified
                 item_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
                   description: Either `id` or `item_id` must be specified
                 list_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+                    #/components/schemas/Security_Exceptions_API_ExceptionListHumanId
                 meta:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemMeta
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemMeta
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemName
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemName
                 namespace_type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                    #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
                   default: single
                 os_types:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemOsTypeArray
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemOsTypeArray
                   default: []
                 tags:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemTags
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemTags
                 type:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemType
+                    #/components/schemas/Security_Exceptions_API_ExceptionListItemType
               required:
                 - type
                 - name
@@ -12989,8 +12890,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItem'
           description: Successful response
         '400':
           content:
@@ -12998,41 +12898,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Update an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/items/_find:
     get:
       description: Get a list of all exception list items in the specified list.
@@ -13045,7 +12943,7 @@ paths:
           schema:
             items:
               $ref: >-
-                #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+                #/components/schemas/Security_Exceptions_API_ExceptionListHumanId
             type: array
         - description: >
             Filters the returned results according to the value of the specified
@@ -13059,7 +12957,7 @@ paths:
             default: []
             items:
               $ref: >-
-                #/components/schemas/Security_Solution_Exceptions_API_FindExceptionListItemsFilter
+                #/components/schemas/Security_Exceptions_API_FindExceptionListItemsFilter
             type: array
         - description: >
             Determines whether the returned containers are Kibana associated
@@ -13074,7 +12972,7 @@ paths:
               - single
             items:
               $ref: >-
-                #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+                #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             type: array
         - in: query
           name: search
@@ -13100,8 +12998,7 @@ paths:
           name: sort_field
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         - description: Determines the sort order, which can be `desc` or `asc`
           in: query
           name: sort_order
@@ -13121,7 +13018,7 @@ paths:
                   data:
                     items:
                       $ref: >-
-                        #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItem
+                        #/components/schemas/Security_Exceptions_API_ExceptionListItem
                     type: array
                   page:
                     minimum: 1
@@ -13146,41 +13043,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get exception list items
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/summary:
     get:
       description: Get a summary of the specified exception list.
@@ -13191,21 +13086,19 @@ paths:
           name: id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         - description: Exception list's human readable identifier
           in: query
           name: list_id
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+            $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         - in: query
           name: namespace_type
           required: false
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+              #/components/schemas/Security_Exceptions_API_ExceptionNamespaceType
             default: single
         - description: Search filter clause
           in: query
@@ -13239,41 +13132,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get an exception list summary
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exceptions/shared:
     post:
       description: >
@@ -13298,10 +13189,10 @@ paths:
               properties:
                 description:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListDescription
+                    #/components/schemas/Security_Exceptions_API_ExceptionListDescription
                 name:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Exceptions_API_ExceptionListName
+                    #/components/schemas/Security_Exceptions_API_ExceptionListName
               required:
                 - name
                 - description
@@ -13311,8 +13202,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_ExceptionList
+                $ref: '#/components/schemas/Security_Exceptions_API_ExceptionList'
           description: Successful response
         '400':
           content:
@@ -13320,41 +13210,39 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                      #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                      #/components/schemas/Security_Exceptions_API_SiemErrorResponse
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_PlatformErrorResponse
+                  #/components/schemas/Security_Exceptions_API_PlatformErrorResponse
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Exception list already exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Exceptions_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Exceptions_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create a shared exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/fleet/agent_download_sources:
     get:
       operationId: get-download-sources
@@ -17065,7 +16953,7 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - in: query
           name: deleteReferences
           required: false
@@ -17083,7 +16971,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -17091,41 +16979,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Get the details of a list using the list ID.
       operationId: ReadList
@@ -17135,13 +17018,13 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -17149,41 +17032,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get list details
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     patch:
       description: Update specific fields of an existing list using the list ID.
       operationId: PatchList
@@ -17196,15 +17074,13 @@ paths:
                 _version:
                   type: string
                 description:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListDescription
+                  $ref: '#/components/schemas/Security_Lists_API_ListDescription'
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListMetadata'
                 name:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListName'
+                  $ref: '#/components/schemas/Security_Lists_API_ListName'
                 version:
                   minimum: 1
                   type: integer
@@ -17217,7 +17093,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -17225,41 +17101,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Patch a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: Create a new list.
       operationId: CreateList
@@ -17270,21 +17141,19 @@ paths:
               type: object
               properties:
                 description:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListDescription
+                  $ref: '#/components/schemas/Security_Lists_API_ListDescription'
                 deserializer:
                   type: string
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListMetadata'
                 name:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListName'
+                  $ref: '#/components/schemas/Security_Lists_API_ListName'
                 serializer:
                   type: string
                 type:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListType'
+                  $ref: '#/components/schemas/Security_Lists_API_ListType'
                 version:
                   default: 1
                   minimum: 1
@@ -17300,7 +17169,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -17308,41 +17177,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List already exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     put:
       description: >
         Update a list using the list ID. The original list is replaced, and all
@@ -17361,15 +17225,13 @@ paths:
                 _version:
                   type: string
                 description:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListDescription
+                  $ref: '#/components/schemas/Security_Lists_API_ListDescription'
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListMetadata'
                 name:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListName'
+                  $ref: '#/components/schemas/Security_Lists_API_ListName'
                 version:
                   minimum: 1
                   type: integer
@@ -17384,7 +17246,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -17392,41 +17254,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Update a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/_find:
     get:
       description: >-
@@ -17451,7 +17308,7 @@ paths:
           name: sort_field
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
+            $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
         - description: Determines the sort order, which can be `desc` or `asc`
           in: query
           name: sort_order
@@ -17474,7 +17331,7 @@ paths:
           name: cursor
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_FindListsCursor'
+            $ref: '#/components/schemas/Security_Lists_API_FindListsCursor'
         - description: >
             Filters the returned results according to the value of the specified
             field,
@@ -17484,7 +17341,7 @@ paths:
           name: filter
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_FindListsFilter'
+            $ref: '#/components/schemas/Security_Lists_API_FindListsFilter'
       responses:
         '200':
           content:
@@ -17493,11 +17350,10 @@ paths:
                 type: object
                 properties:
                   cursor:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_FindListsCursor
+                    $ref: '#/components/schemas/Security_Lists_API_FindListsCursor'
                   data:
                     items:
-                      $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                      $ref: '#/components/schemas/Security_Lists_API_List'
                     type: array
                   page:
                     minimum: 0
@@ -17521,34 +17377,30 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get lists
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/index:
     delete:
       description: Delete the `.lists` and `.items` data streams.
@@ -17571,41 +17423,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List data stream not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Verify that `.lists` and `.items` data streams exist.
       operationId: ReadListIndex
@@ -17630,41 +17477,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List data stream(s) not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get status of list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: Create `.lists` and `.items` data streams in the relevant space.
       operationId: CreateListIndex
@@ -17686,41 +17528,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List data stream exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items:
     delete:
       description: Delete a list item using its `id`, or its `list_id` and `value` fields.
@@ -17731,13 +17568,13 @@ paths:
           name: id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: Required if `id` is not specified
           in: query
           name: list_id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: Required if `id` is not specified
           in: query
           name: value
@@ -17763,10 +17600,9 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/Security_Solution_Lists_API_ListItem'
+                  - $ref: '#/components/schemas/Security_Lists_API_ListItem'
                   - items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Lists_API_ListItem
+                      $ref: '#/components/schemas/Security_Lists_API_ListItem'
                     type: array
           description: Successful response
         '400':
@@ -17775,41 +17611,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Delete a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Get the details of a list item.
       operationId: ReadListItem
@@ -17819,13 +17650,13 @@ paths:
           name: id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: Required if `id` is not specified
           in: query
           name: list_id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: Required if `id` is not specified
           in: query
           name: value
@@ -17838,10 +17669,9 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/Security_Solution_Lists_API_ListItem'
+                  - $ref: '#/components/schemas/Security_Lists_API_ListItem'
                   - items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Lists_API_ListItem
+                      $ref: '#/components/schemas/Security_Lists_API_ListItem'
                     type: array
           description: Successful response
         '400':
@@ -17850,41 +17680,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     patch:
       description: Update specific fields of an existing list item using the list item ID.
       operationId: PatchListItem
@@ -17897,10 +17722,9 @@ paths:
                 _version:
                   type: string
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemMetadata'
                 refresh:
                   description: >-
                     Determines when changes made by the request are made visible
@@ -17911,8 +17735,7 @@ paths:
                     - wait_for
                   type: string
                 value:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemValue
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemValue'
               required:
                 - id
         description: List item's properties
@@ -17922,7 +17745,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_ListItem'
+                $ref: '#/components/schemas/Security_Lists_API_ListItem'
           description: Successful response
         '400':
           content:
@@ -17930,41 +17753,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Patch a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: >
         Create a list item and associate it with the specified list.
@@ -17984,12 +17802,11 @@ paths:
               type: object
               properties:
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemId'
                 list_id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemMetadata'
                 refresh:
                   description: >-
                     Determines when changes made by the request are made visible
@@ -18000,8 +17817,7 @@ paths:
                     - wait_for
                   type: string
                 value:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemValue
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemValue'
               required:
                 - list_id
                 - value
@@ -18012,7 +17828,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_ListItem'
+                $ref: '#/components/schemas/Security_Lists_API_ListItem'
           description: Successful response
         '400':
           content:
@@ -18020,41 +17836,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List item already exists response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Create a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     put:
       description: >
         Update a list item using the list item ID. The original list item is
@@ -18073,13 +17884,11 @@ paths:
                 _version:
                   type: string
                 id:
-                  $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemId'
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemId'
                 meta:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemMetadata
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemMetadata'
                 value:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Lists_API_ListItemValue
+                  $ref: '#/components/schemas/Security_Lists_API_ListItemValue'
               required:
                 - id
                 - value
@@ -18090,7 +17899,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_ListItem'
+                $ref: '#/components/schemas/Security_Lists_API_ListItem'
           description: Successful response
         '400':
           content:
@@ -18098,41 +17907,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List item not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Update a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_export:
     post:
       description: Export list item values from the specified list.
@@ -18143,7 +17947,7 @@ paths:
           name: list_id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
       responses:
         '200':
           content:
@@ -18159,41 +17963,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '404':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List not found response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Export list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_find:
     get:
       description: Get all list items in the specified list.
@@ -18204,7 +18003,7 @@ paths:
           name: list_id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: The page number to return
           in: query
           name: page
@@ -18222,7 +18021,7 @@ paths:
           name: sort_field
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
+            $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
         - description: Determines the sort order, which can be `desc` or `asc`
           in: query
           name: sort_order
@@ -18245,8 +18044,7 @@ paths:
           name: cursor
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Lists_API_FindListItemsCursor
+            $ref: '#/components/schemas/Security_Lists_API_FindListItemsCursor'
         - description: >
             Filters the returned results according to the value of the specified
             field,
@@ -18256,8 +18054,7 @@ paths:
           name: filter
           required: false
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Lists_API_FindListItemsFilter
+            $ref: '#/components/schemas/Security_Lists_API_FindListItemsFilter'
       responses:
         '200':
           content:
@@ -18267,11 +18064,10 @@ paths:
                 properties:
                   cursor:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_FindListItemsCursor
+                      #/components/schemas/Security_Lists_API_FindListItemsCursor
                   data:
                     items:
-                      $ref: >-
-                        #/components/schemas/Security_Solution_Lists_API_ListItem
+                      $ref: '#/components/schemas/Security_Lists_API_ListItem'
                     type: array
                   page:
                     minimum: 0
@@ -18295,34 +18091,30 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_import:
     post:
       description: >
@@ -18341,7 +18133,7 @@ paths:
           name: list_id
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+            $ref: '#/components/schemas/Security_Lists_API_ListId'
         - description: >
             Type of the importing list.
 
@@ -18352,7 +18144,7 @@ paths:
           name: type
           required: false
           schema:
-            $ref: '#/components/schemas/Security_Solution_Lists_API_ListType'
+            $ref: '#/components/schemas/Security_Lists_API_ListType'
         - in: query
           name: serializer
           required: false
@@ -18393,7 +18185,7 @@ paths:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: '#/components/schemas/Security_Solution_Lists_API_List'
+                $ref: '#/components/schemas/Security_Lists_API_List'
           description: Successful response
         '400':
           content:
@@ -18401,41 +18193,36 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '409':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: List with specified list_id does not exist response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Import list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/privileges:
     get:
       operationId: ReadListPrivileges
@@ -18449,11 +18236,9 @@ paths:
                   is_authenticated:
                     type: boolean
                   listItems:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_ListItemPrivileges
+                    $ref: '#/components/schemas/Security_Lists_API_ListItemPrivileges'
                   lists:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_ListPrivileges
+                    $ref: '#/components/schemas/Security_Lists_API_ListPrivileges'
                 required:
                   - lists
                   - listItems
@@ -18465,34 +18250,30 @@ paths:
               schema:
                 oneOf:
                   - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                      #/components/schemas/Security_Lists_API_PlatformErrorResponse
+                  - $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Invalid input data response
         '401':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Unsuccessful authentication response
         '403':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_PlatformErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_PlatformErrorResponse'
           description: Not enough privileges response
         '500':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Lists_API_SiemErrorResponse
+                $ref: '#/components/schemas/Security_Lists_API_SiemErrorResponse'
           description: Internal server error response
       summary: Get list privileges
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/ml/saved_objects/sync:
     get:
       description: >
@@ -18563,7 +18344,7 @@ paths:
           description: Indicates the note was successfully deleted.
       summary: Delete a note
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     get:
       description: Get all notes for a given document.
@@ -18572,7 +18353,7 @@ paths:
         - in: query
           name: documentIds
           schema:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_DocumentIds'
+            $ref: '#/components/schemas/Security_Timeline_API_DocumentIds'
         - in: query
           name: page
           schema:
@@ -18609,13 +18390,12 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 oneOf:
-                  - $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_GetNotesResult
+                  - $ref: '#/components/schemas/Security_Timeline_API_GetNotesResult'
                   - type: object
           description: Indicates the requested notes were returned.
       summary: Get notes
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     patch:
       description: Add a note to a Timeline or update an existing note.
@@ -18636,7 +18416,7 @@ paths:
                   nullable: true
                   type: string
                 note:
-                  $ref: '#/components/schemas/Security_Solution_Timeline_API_BareNote'
+                  $ref: '#/components/schemas/Security_Timeline_API_BareNote'
                 noteId:
                   nullable: true
                   type: string
@@ -18662,7 +18442,7 @@ paths:
                     properties:
                       persistNote:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Timeline_API_ResponseNote
+                          #/components/schemas/Security_Timeline_API_ResponseNote
                     required:
                       - persistNote
                 required:
@@ -18670,7 +18450,7 @@ paths:
           description: Indicates the note was successfully created.
       summary: Add or update a note
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/osquery/live_queries:
     get:
@@ -18682,18 +18462,18 @@ paths:
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Osquery_API_FindLiveQueryRequestQuery
+              #/components/schemas/Security_Osquery_API_FindLiveQueryRequestQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get live queries
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create and run a live query.
       operationId: OsqueryCreateLiveQuery
@@ -18702,7 +18482,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Osquery_API_CreateLiveQueryRequestBody
+                #/components/schemas/Security_Osquery_API_CreateLiveQueryRequestBody
         required: true
       responses:
         '200':
@@ -18710,11 +18490,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Create a live query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/live_queries/{id}:
     get:
       description: Get the details of a live query using the query ID.
@@ -18724,7 +18504,7 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_Id'
+            $ref: '#/components/schemas/Security_Osquery_API_Id'
         - in: query
           name: query
           schema:
@@ -18736,11 +18516,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get live query details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/live_queries/{id}/results/{actionId}:
     get:
       description: Get the results of a live query using the query action ID.
@@ -18750,29 +18530,29 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_Id'
+            $ref: '#/components/schemas/Security_Osquery_API_Id'
         - in: path
           name: actionId
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_Id'
+            $ref: '#/components/schemas/Security_Osquery_API_Id'
         - in: query
           name: query
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Osquery_API_GetLiveQueryResultsRequestQuery
+              #/components/schemas/Security_Osquery_API_GetLiveQueryResultsRequestQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get live query results
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/packs:
     get:
       description: Get a list of all query packs.
@@ -18782,19 +18562,18 @@ paths:
           name: query
           required: true
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Osquery_API_FindPacksRequestQuery
+            $ref: '#/components/schemas/Security_Osquery_API_FindPacksRequestQuery'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get packs
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create a query pack.
       operationId: OsqueryCreatePacks
@@ -18802,8 +18581,7 @@ paths:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
-              $ref: >-
-                #/components/schemas/Security_Solution_Osquery_API_CreatePacksRequestBody
+              $ref: '#/components/schemas/Security_Osquery_API_CreatePacksRequestBody'
         required: true
       responses:
         '200':
@@ -18811,11 +18589,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Create a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/packs/{id}:
     delete:
       description: Delete a query pack using the pack ID.
@@ -18825,18 +18603,18 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_PackId'
+            $ref: '#/components/schemas/Security_Osquery_API_PackId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Delete a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     get:
       description: Get the details of a query pack using the pack ID.
       operationId: OsqueryGetPacksDetails
@@ -18845,18 +18623,18 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_PackId'
+            $ref: '#/components/schemas/Security_Osquery_API_PackId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get pack details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     put:
       description: |
         Update a query pack using the pack ID.
@@ -18868,13 +18646,12 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_PackId'
+            $ref: '#/components/schemas/Security_Osquery_API_PackId'
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
-              $ref: >-
-                #/components/schemas/Security_Solution_Osquery_API_UpdatePacksRequestBody
+              $ref: '#/components/schemas/Security_Osquery_API_UpdatePacksRequestBody'
         required: true
       responses:
         '200':
@@ -18882,11 +18659,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Update a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/saved_queries:
     get:
       description: Get a list of all saved queries.
@@ -18897,18 +18674,18 @@ paths:
           required: true
           schema:
             $ref: >-
-              #/components/schemas/Security_Solution_Osquery_API_FindSavedQueryRequestQuery
+              #/components/schemas/Security_Osquery_API_FindSavedQueryRequestQuery
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get saved queries
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create and run a saved query.
       operationId: OsqueryCreateSavedQuery
@@ -18917,7 +18694,7 @@ paths:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Osquery_API_CreateSavedQueryRequestBody
+                #/components/schemas/Security_Osquery_API_CreateSavedQueryRequestBody
         required: true
       responses:
         '200':
@@ -18925,11 +18702,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Create a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/saved_queries/{id}:
     delete:
       description: Delete a saved query using the query ID.
@@ -18939,18 +18716,18 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+            $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Delete a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     get:
       description: Get the details of a saved query using the query ID.
       operationId: OsqueryGetSavedQueryDetails
@@ -18959,18 +18736,18 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+            $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Get saved query details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     put:
       description: |
         Update a saved query using the query ID.
@@ -18982,13 +18759,13 @@ paths:
           name: id
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+            $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
             schema:
               $ref: >-
-                #/components/schemas/Security_Solution_Osquery_API_UpdateSavedQueryRequestBody
+                #/components/schemas/Security_Osquery_API_UpdateSavedQueryRequestBody
         required: true
       responses:
         '200':
@@ -18996,11 +18773,11 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Osquery_API_DefaultSuccessResponse
+                  #/components/schemas/Security_Osquery_API_DefaultSuccessResponse
           description: OK
       summary: Update a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/pinned_event:
     patch:
       description: Pin an event to an existing Timeline.
@@ -19035,7 +18812,7 @@ paths:
                     properties:
                       persistPinnedEventOnTimeline:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Timeline_API_PersistPinnedEventResponse
+                          #/components/schemas/Security_Timeline_API_PersistPinnedEventResponse
                     required:
                       - persistPinnedEventOnTimeline
                 required:
@@ -19043,7 +18820,7 @@ paths:
           description: Indicates the event was successfully pinned to the Timeline.
       summary: Pin an event
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/risk_score/engine/schedule_now:
     post:
@@ -19061,25 +18838,25 @@ paths:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_RiskEngineScheduleNowResponse
+                  #/components/schemas/Security_Entity_Analytics_API_RiskEngineScheduleNowResponse
           description: Successful response
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_TaskManagerUnavailableResponse
+                  #/components/schemas/Security_Entity_Analytics_API_TaskManagerUnavailableResponse
           description: Task manager is unavailable
         default:
           content:
             application/json; Elastic-Api-Version=2023-10-31:
               schema:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Entity_Analytics_API_RiskEngineScheduleNowErrorResponse
+                  #/components/schemas/Security_Entity_Analytics_API_RiskEngineScheduleNowErrorResponse
           description: Unexpected error
       summary: Run the risk scoring engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/saved_objects/_bulk_create:
     post:
       deprecated: true
@@ -20617,7 +20394,7 @@ paths:
           description: Indicates the Timeline was successfully deleted.
       summary: Delete Timelines or Timeline templates
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     get:
       description: Get the details of an existing saved Timeline or Timeline template.
@@ -20645,7 +20422,7 @@ paths:
                     properties:
                       getOneTimeline:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                          #/components/schemas/Security_Timeline_API_TimelineResponse
                         nullable: true
                     required:
                       - getOneTimeline
@@ -20654,7 +20431,7 @@ paths:
           description: Indicates that the (template) Timeline was found and returned.
       summary: Get Timeline or Timeline template details
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     patch:
       description: >-
@@ -20669,8 +20446,7 @@ paths:
               type: object
               properties:
                 timeline:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_SavedTimeline
+                  $ref: '#/components/schemas/Security_Timeline_API_SavedTimeline'
                 timelineId:
                   nullable: true
                   type: string
@@ -20698,7 +20474,7 @@ paths:
                         properties:
                           timeline:
                             $ref: >-
-                              #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                              #/components/schemas/Security_Timeline_API_TimelineResponse
                         required:
                           - timeline
                     required:
@@ -20724,7 +20500,7 @@ paths:
             a draft Timeline.
       summary: Update a Timeline
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     post:
       description: Create a new Timeline or Timeline template.
@@ -20736,8 +20512,7 @@ paths:
               type: object
               properties:
                 status:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_TimelineStatus
+                  $ref: '#/components/schemas/Security_Timeline_API_TimelineStatus'
                   nullable: true
                 templateTimelineId:
                   nullable: true
@@ -20746,14 +20521,12 @@ paths:
                   nullable: true
                   type: number
                 timeline:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_SavedTimeline
+                  $ref: '#/components/schemas/Security_Timeline_API_SavedTimeline'
                 timelineId:
                   nullable: true
                   type: string
                 timelineType:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_TimelineType
+                  $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
                   nullable: true
                 version:
                   nullable: true
@@ -20779,7 +20552,7 @@ paths:
                         properties:
                           timeline:
                             $ref: >-
-                              #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                              #/components/schemas/Security_Timeline_API_TimelineResponse
                     required:
                       - persistTimeline
                 required:
@@ -20798,7 +20571,7 @@ paths:
           description: Indicates that there was an error in the Timeline creation.
       summary: Create a Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_draft:
     get:
@@ -20812,7 +20585,7 @@ paths:
           name: timelineType
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_TimelineType'
+            $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
       responses:
         '200':
           content:
@@ -20828,7 +20601,7 @@ paths:
                         properties:
                           timeline:
                             $ref: >-
-                              #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                              #/components/schemas/Security_Timeline_API_TimelineResponse
                         required:
                           - timeline
                     required:
@@ -20866,7 +20639,7 @@ paths:
             draft Timeline with the given `timelineId`.
       summary: Get draft Timeline or Timeline template details
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     post:
       description: >
@@ -20884,8 +20657,7 @@ paths:
               type: object
               properties:
                 timelineType:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_TimelineType
+                  $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
               required:
                 - timelineType
         description: >-
@@ -20907,7 +20679,7 @@ paths:
                         properties:
                           timeline:
                             $ref: >-
-                              #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                              #/components/schemas/Security_Timeline_API_TimelineResponse
                         required:
                           - timeline
                     required:
@@ -20946,7 +20718,7 @@ paths:
             `timelineId`.
       summary: Create a clean draft Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_export:
     post:
@@ -20993,7 +20765,7 @@ paths:
           description: Indicates that the export size limit was exceeded.
       summary: Export Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_favorite:
     patch:
@@ -21015,8 +20787,7 @@ paths:
                   nullable: true
                   type: string
                 timelineType:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Timeline_API_TimelineType
+                  $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
                   nullable: true
               required:
                 - timelineId
@@ -21037,7 +20808,7 @@ paths:
                     properties:
                       persistFavorite:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Timeline_API_FavoriteTimelineResponse
+                          #/components/schemas/Security_Timeline_API_FavoriteTimelineResponse
                     required:
                       - persistFavorite
                 required:
@@ -21058,7 +20829,7 @@ paths:
             the favorite status.
       summary: Favorite a Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_import:
     post:
@@ -21072,8 +20843,7 @@ paths:
               properties:
                 file:
                   allOf:
-                    - $ref: >-
-                        #/components/schemas/Security_Solution_Timeline_API_Readable
+                    - $ref: '#/components/schemas/Security_Timeline_API_Readable'
                     - type: object
                       properties:
                         hapi:
@@ -21104,7 +20874,7 @@ paths:
                 properties:
                   data:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_ImportTimelineResult
+                      #/components/schemas/Security_Timeline_API_ImportTimelineResult
                 required:
                   - data
           description: Indicates the import of Timelines was successful.
@@ -21151,7 +20921,7 @@ paths:
           description: Indicates the import of Timelines was unsuccessful.
       summary: Import Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_prepackaged:
     post:
@@ -21165,19 +20935,16 @@ paths:
               properties:
                 prepackagedTimelines:
                   items:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_SavedTimeline
+                    $ref: '#/components/schemas/Security_Timeline_API_SavedTimeline'
                   type: array
                 timelinesToInstall:
                   items:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_ImportTimelines
+                    $ref: '#/components/schemas/Security_Timeline_API_ImportTimelines'
                     nullable: true
                   type: array
                 timelinesToUpdate:
                   items:
-                    $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_ImportTimelines
+                    $ref: '#/components/schemas/Security_Timeline_API_ImportTimelines'
                     nullable: true
                   type: array
               required:
@@ -21195,7 +20962,7 @@ paths:
                 properties:
                   data:
                     $ref: >-
-                      #/components/schemas/Security_Solution_Timeline_API_ImportTimelineResult
+                      #/components/schemas/Security_Timeline_API_ImportTimelineResult
                 required:
                   - data
           description: Indicates the installation of prepackaged Timelines was successful.
@@ -21214,7 +20981,7 @@ paths:
             unsuccessful.
       summary: Install prepackaged Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/resolve:
     get:
@@ -21242,7 +21009,7 @@ paths:
                     properties:
                       getOneTimeline:
                         $ref: >-
-                          #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                          #/components/schemas/Security_Timeline_API_TimelineResponse
                         nullable: true
                     required:
                       - getOneTimeline
@@ -21255,7 +21022,7 @@ paths:
           description: The (template) Timeline was not found
       summary: Get an existing saved Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timelines:
     get:
@@ -21276,13 +21043,12 @@ paths:
         - in: query
           name: timeline_type
           schema:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_TimelineType'
+            $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
             nullable: true
         - in: query
           name: sort_field
           schema:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_SortFieldTimeline
+            $ref: '#/components/schemas/Security_Timeline_API_SortFieldTimeline'
         - in: query
           name: sort_order
           schema:
@@ -21308,7 +21074,7 @@ paths:
         - in: query
           name: status
           schema:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_TimelineStatus'
+            $ref: '#/components/schemas/Security_Timeline_API_TimelineStatus'
             nullable: true
       responses:
         '200':
@@ -21333,7 +21099,7 @@ paths:
                       timelines:
                         items:
                           $ref: >-
-                            #/components/schemas/Security_Solution_Timeline_API_TimelineResponse
+                            #/components/schemas/Security_Timeline_API_TimelineResponse
                         type: array
                       totalCount:
                         type: number
@@ -21361,7 +21127,7 @@ paths:
           description: Bad request. The user supplied invalid data.
       summary: Get Timelines or Timeline templates
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /s/{spaceId}/api/observability/slos:
     get:
@@ -31044,35 +30810,33 @@ components:
         name:
           description: User name
           type: string
-    Security_Solution_Detections_API_AlertAssignees:
+    Security_Detections_API_AlertAssignees:
       type: object
       properties:
         add:
           description: A list of users ids to assign.
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           type: array
         remove:
           description: A list of users ids to unassign.
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           type: array
       required:
         - add
         - remove
-    Security_Solution_Detections_API_AlertIds:
+    Security_Detections_API_AlertIds:
       description: A list of alerts ids.
       items:
-        $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+        $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
       minItems: 1
       type: array
-    Security_Solution_Detections_API_AlertsIndex:
+    Security_Detections_API_AlertsIndex:
       deprecated: true
       description: (deprecated) Has no effect.
       type: string
-    Security_Solution_Detections_API_AlertsIndexMigrationError:
+    Security_Detections_API_AlertsIndexMigrationError:
       type: object
       properties:
         error:
@@ -31090,7 +30854,7 @@ components:
       required:
         - index
         - error
-    Security_Solution_Detections_API_AlertsIndexMigrationSuccess:
+    Security_Detections_API_AlertsIndexMigrationSuccess:
       type: object
       properties:
         index:
@@ -31103,10 +30867,10 @@ components:
         - index
         - migration_id
         - migration_index
-    Security_Solution_Detections_API_AlertsIndexNamespace:
+    Security_Detections_API_AlertsIndexNamespace:
       description: Has no effect.
       type: string
-    Security_Solution_Detections_API_AlertsReindexOptions:
+    Security_Detections_API_AlertsReindexOptions:
       type: object
       properties:
         requests_per_second:
@@ -31118,41 +30882,39 @@ components:
         slices:
           minimum: 1
           type: integer
-    Security_Solution_Detections_API_AlertsSort:
+    Security_Detections_API_AlertsSort:
       oneOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertsSortCombinations
+        - $ref: '#/components/schemas/Security_Detections_API_AlertsSortCombinations'
         - items:
             $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_AlertsSortCombinations
+              #/components/schemas/Security_Detections_API_AlertsSortCombinations
           type: array
-    Security_Solution_Detections_API_AlertsSortCombinations:
+    Security_Detections_API_AlertsSortCombinations:
       anyOf:
         - type: string
         - additionalProperties: true
           type: object
-    Security_Solution_Detections_API_AlertStatus:
+    Security_Detections_API_AlertStatus:
       enum:
         - open
         - closed
         - acknowledged
         - in-progress
       type: string
-    Security_Solution_Detections_API_AlertSuppression:
+    Security_Detections_API_AlertSuppression:
       type: object
       properties:
         duration:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppressionDuration
+            #/components/schemas/Security_Detections_API_AlertSuppressionDuration
         group_by:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppressionGroupBy
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppressionGroupBy'
         missing_fields_strategy:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppressionMissingFieldsStrategy
+            #/components/schemas/Security_Detections_API_AlertSuppressionMissingFieldsStrategy
       required:
         - group_by
-    Security_Solution_Detections_API_AlertSuppressionDuration:
+    Security_Detections_API_AlertSuppressionDuration:
       type: object
       properties:
         unit:
@@ -31167,13 +30929,13 @@ components:
       required:
         - value
         - unit
-    Security_Solution_Detections_API_AlertSuppressionGroupBy:
+    Security_Detections_API_AlertSuppressionGroupBy:
       items:
         type: string
       maxItems: 3
       minItems: 1
       type: array
-    Security_Solution_Detections_API_AlertSuppressionMissingFieldsStrategy:
+    Security_Detections_API_AlertSuppressionMissingFieldsStrategy:
       description: >-
         Describes how alerts will be generated for documents with missing
         suppress by fields:
@@ -31185,13 +30947,13 @@ components:
         - doNotSuppress
         - suppress
       type: string
-    Security_Solution_Detections_API_AlertTag:
-      $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
-    Security_Solution_Detections_API_AlertTags:
+    Security_Detections_API_AlertTag:
+      $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
+    Security_Detections_API_AlertTags:
       items:
-        $ref: '#/components/schemas/Security_Solution_Detections_API_AlertTag'
+        $ref: '#/components/schemas/Security_Detections_API_AlertTag'
       type: array
-    Security_Solution_Detections_API_AlertVersion:
+    Security_Detections_API_AlertVersion:
       type: object
       properties:
         count:
@@ -31201,32 +30963,32 @@ components:
       required:
         - version
         - count
-    Security_Solution_Detections_API_AnomalyThreshold:
+    Security_Detections_API_AnomalyThreshold:
       description: Anomaly threshold
       minimum: 0
       type: integer
-    Security_Solution_Detections_API_BuildingBlockType:
+    Security_Detections_API_BuildingBlockType:
       description: >-
         Determines if the rule acts as a building block. By default,
         building-block alerts are not displayed in the UI. These rules are used
         as a foundation for other rules that do generate alerts. Its value must
         be default.
       type: string
-    Security_Solution_Detections_API_BulkActionEditPayload:
+    Security_Detections_API_BulkActionEditPayload:
       anyOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadTags
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadTags
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadIndexPatterns
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadIndexPatterns
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadInvestigationFields
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadInvestigationFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadTimeline
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadTimeline
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadRuleActions
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadRuleActions
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayloadSchedule
-    Security_Solution_Detections_API_BulkActionEditPayloadIndexPatterns:
+            #/components/schemas/Security_Detections_API_BulkActionEditPayloadSchedule
+    Security_Detections_API_BulkActionEditPayloadIndexPatterns:
       type: object
       properties:
         overwrite_data_views:
@@ -31238,12 +31000,11 @@ components:
             - set_index_patterns
           type: string
         value:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionEditPayloadInvestigationFields:
+    Security_Detections_API_BulkActionEditPayloadInvestigationFields:
       type: object
       properties:
         type:
@@ -31253,12 +31014,11 @@ components:
             - set_investigation_fields
           type: string
         value:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+          $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionEditPayloadRuleActions:
+    Security_Detections_API_BulkActionEditPayloadRuleActions:
       type: object
       properties:
         type:
@@ -31272,17 +31032,17 @@ components:
             actions:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_NormalizedRuleAction
+                  #/components/schemas/Security_Detections_API_NormalizedRuleAction
               type: array
             throttle:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThrottleForBulkActions
+                #/components/schemas/Security_Detections_API_ThrottleForBulkActions
           required:
             - actions
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionEditPayloadSchedule:
+    Security_Detections_API_BulkActionEditPayloadSchedule:
       type: object
       properties:
         type:
@@ -31310,7 +31070,7 @@ components:
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionEditPayloadTags:
+    Security_Detections_API_BulkActionEditPayloadTags:
       type: object
       properties:
         type:
@@ -31320,11 +31080,11 @@ components:
             - set_tags
           type: string
         value:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleTagArray'
+          $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionEditPayloadTimeline:
+    Security_Detections_API_BulkActionEditPayloadTimeline:
       type: object
       properties:
         type:
@@ -31335,18 +31095,17 @@ components:
           type: object
           properties:
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
           required:
             - timeline_id
             - timeline_title
       required:
         - type
         - value
-    Security_Solution_Detections_API_BulkActionsDryRunErrCode:
+    Security_Detections_API_BulkActionsDryRunErrCode:
       enum:
         - IMMUTABLE
         - MACHINE_LEARNING_AUTH
@@ -31355,7 +31114,7 @@ components:
         - MANUAL_RULE_RUN_FEATURE
         - MANUAL_RULE_RUN_DISABLED_RULE
       type: string
-    Security_Solution_Detections_API_BulkActionSkipResult:
+    Security_Detections_API_BulkActionSkipResult:
       type: object
       properties:
         id:
@@ -31363,18 +31122,17 @@ components:
         name:
           type: string
         skip_reason:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkEditSkipReason
+          $ref: '#/components/schemas/Security_Detections_API_BulkEditSkipReason'
       required:
         - id
         - skip_reason
-    Security_Solution_Detections_API_BulkCrudRulesResponse:
+    Security_Detections_API_BulkCrudRulesResponse:
       items:
         oneOf:
-          - $ref: '#/components/schemas/Security_Solution_Detections_API_RuleResponse'
-          - $ref: '#/components/schemas/Security_Solution_Detections_API_ErrorSchema'
+          - $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
+          - $ref: '#/components/schemas/Security_Detections_API_ErrorSchema'
       type: array
-    Security_Solution_Detections_API_BulkDeleteRules:
+    Security_Detections_API_BulkDeleteRules:
       type: object
       properties:
         action:
@@ -31392,7 +31150,7 @@ components:
           type: string
       required:
         - action
-    Security_Solution_Detections_API_BulkDisableRules:
+    Security_Detections_API_BulkDisableRules:
       type: object
       properties:
         action:
@@ -31410,7 +31168,7 @@ components:
           type: string
       required:
         - action
-    Security_Solution_Detections_API_BulkDuplicateRules:
+    Security_Detections_API_BulkDuplicateRules:
       type: object
       properties:
         action:
@@ -31440,7 +31198,7 @@ components:
           type: string
       required:
         - action
-    Security_Solution_Detections_API_BulkEditActionResponse:
+    Security_Detections_API_BulkEditActionResponse:
       type: object
       properties:
         attributes:
@@ -31449,14 +31207,14 @@ components:
             errors:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_NormalizedRuleError
+                  #/components/schemas/Security_Detections_API_NormalizedRuleError
               type: array
             results:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BulkEditActionResults
+                #/components/schemas/Security_Detections_API_BulkEditActionResults
             summary:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BulkEditActionSummary
+                #/components/schemas/Security_Detections_API_BulkEditActionSummary
           required:
             - results
             - summary
@@ -31470,32 +31228,31 @@ components:
           type: boolean
       required:
         - attributes
-    Security_Solution_Detections_API_BulkEditActionResults:
+    Security_Detections_API_BulkEditActionResults:
       type: object
       properties:
         created:
           items:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RuleResponse'
+            $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           type: array
         deleted:
           items:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RuleResponse'
+            $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           type: array
         skipped:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_BulkActionSkipResult
+            $ref: '#/components/schemas/Security_Detections_API_BulkActionSkipResult'
           type: array
         updated:
           items:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RuleResponse'
+            $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           type: array
       required:
         - updated
         - created
         - deleted
         - skipped
-    Security_Solution_Detections_API_BulkEditActionSummary:
+    Security_Detections_API_BulkEditActionSummary:
       type: object
       properties:
         failed:
@@ -31511,7 +31268,7 @@ components:
         - skipped
         - succeeded
         - total
-    Security_Solution_Detections_API_BulkEditRules:
+    Security_Detections_API_BulkEditRules:
       type: object
       properties:
         action:
@@ -31521,8 +31278,7 @@ components:
         edit:
           description: Array of objects containing the edit operations
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_BulkActionEditPayload
+            $ref: '#/components/schemas/Security_Detections_API_BulkActionEditPayload'
           minItems: 1
           type: array
         ids:
@@ -31537,11 +31293,11 @@ components:
       required:
         - action
         - edit
-    Security_Solution_Detections_API_BulkEditSkipReason:
+    Security_Detections_API_BulkEditSkipReason:
       enum:
         - RULE_NOT_MODIFIED
       type: string
-    Security_Solution_Detections_API_BulkEnableRules:
+    Security_Detections_API_BulkEnableRules:
       type: object
       properties:
         action:
@@ -31559,9 +31315,9 @@ components:
           type: string
       required:
         - action
-    Security_Solution_Detections_API_BulkExportActionResponse:
+    Security_Detections_API_BulkExportActionResponse:
       type: string
-    Security_Solution_Detections_API_BulkExportRules:
+    Security_Detections_API_BulkExportRules:
       type: object
       properties:
         action:
@@ -31579,7 +31335,7 @@ components:
           type: string
       required:
         - action
-    Security_Solution_Detections_API_BulkManualRuleRun:
+    Security_Detections_API_BulkManualRuleRun:
       type: object
       properties:
         action:
@@ -31609,12 +31365,12 @@ components:
       required:
         - action
         - run
-    Security_Solution_Detections_API_ConcurrentSearches:
+    Security_Detections_API_ConcurrentSearches:
       minimum: 1
       type: integer
-    Security_Solution_Detections_API_DataViewId:
+    Security_Detections_API_DataViewId:
       type: string
-    Security_Solution_Detections_API_DefaultParams:
+    Security_Detections_API_DefaultParams:
       type: object
       properties:
         command:
@@ -31625,7 +31381,7 @@ components:
           type: string
       required:
         - command
-    Security_Solution_Detections_API_EcsMapping:
+    Security_Detections_API_EcsMapping:
       additionalProperties:
         type: object
         properties:
@@ -31638,7 +31394,7 @@ components:
                   type: string
                 type: array
       type: object
-    Security_Solution_Detections_API_EndpointResponseAction:
+    Security_Detections_API_EndpointResponseAction:
       type: object
       properties:
         action_type_id:
@@ -31647,53 +31403,44 @@ components:
           type: string
         params:
           oneOf:
-            - $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_DefaultParams
-            - $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ProcessesParams
+            - $ref: '#/components/schemas/Security_Detections_API_DefaultParams'
+            - $ref: '#/components/schemas/Security_Detections_API_ProcessesParams'
       required:
         - action_type_id
         - params
-    Security_Solution_Detections_API_EqlOptionalFields:
+    Security_Detections_API_EqlOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         event_category_override:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EventCategoryOverride
+          $ref: '#/components/schemas/Security_Detections_API_EventCategoryOverride'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         response_actions:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ResponseAction
+            $ref: '#/components/schemas/Security_Detections_API_ResponseAction'
           type: array
         tiebreaker_field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_TiebreakerField
+          $ref: '#/components/schemas/Security_Detections_API_TiebreakerField'
         timestamp_field:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_TimestampField'
-    Security_Solution_Detections_API_EqlQueryLanguage:
+          $ref: '#/components/schemas/Security_Detections_API_TimestampField'
+    Security_Detections_API_EqlQueryLanguage:
       enum:
         - eql
       type: string
-    Security_Solution_Detections_API_EqlRequiredFields:
+    Security_Detections_API_EqlRequiredFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlQueryLanguage
+          $ref: '#/components/schemas/Security_Detections_API_EqlQueryLanguage'
           description: Query language to use
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
           description: EQL query to execute
         type:
           description: Rule type
@@ -31704,125 +31451,101 @@ components:
         - type
         - query
         - language
-    Security_Solution_Detections_API_EqlRule:
+    Security_Detections_API_EqlRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -31846,428 +31569,341 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRuleResponseFields
-    Security_Solution_Detections_API_EqlRuleCreateFields:
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRuleResponseFields'
+    Security_Detections_API_EqlRuleCreateFields:
       allOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRequiredFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlOptionalFields
-    Security_Solution_Detections_API_EqlRuleCreateProps:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRequiredFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EqlOptionalFields'
+    Security_Detections_API_EqlRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRuleCreateFields
-    Security_Solution_Detections_API_EqlRulePatchFields:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRuleCreateFields'
+    Security_Detections_API_EqlRulePatchFields:
       allOf:
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_EqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_EqlQueryLanguage'
               description: Query language to use
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
               description: EQL query to execute
             type:
               description: Rule type
               enum:
                 - eql
               type: string
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlOptionalFields
-    Security_Solution_Detections_API_EqlRulePatchProps:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlOptionalFields'
+    Security_Detections_API_EqlRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRulePatchFields
-    Security_Solution_Detections_API_EqlRuleResponseFields:
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRulePatchFields'
+    Security_Detections_API_EqlRuleResponseFields:
       allOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRequiredFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlOptionalFields
-    Security_Solution_Detections_API_EqlRuleUpdateProps:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRequiredFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EqlOptionalFields'
+    Security_Detections_API_EqlRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRuleCreateFields
-    Security_Solution_Detections_API_ErrorSchema:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRuleCreateFields'
+    Security_Detections_API_ErrorSchema:
       additionalProperties: false
       type: object
       properties:
@@ -32291,133 +31927,108 @@ components:
           minLength: 1
           type: string
         rule_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+          $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
       required:
         - error
-    Security_Solution_Detections_API_EsqlQueryLanguage:
+    Security_Detections_API_EsqlQueryLanguage:
       enum:
         - esql
       type: string
-    Security_Solution_Detections_API_EsqlRule:
+    Security_Detections_API_EsqlRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -32441,301 +32052,241 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleResponseFields
-    Security_Solution_Detections_API_EsqlRuleCreateFields:
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleResponseFields'
+    Security_Detections_API_EsqlRuleCreateFields:
       allOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleOptionalFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleRequiredFields
-    Security_Solution_Detections_API_EsqlRuleCreateProps:
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleOptionalFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleRequiredFields'
+    Security_Detections_API_EsqlRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleCreateFields
-    Security_Solution_Detections_API_EsqlRuleOptionalFields:
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleCreateFields'
+    Security_Detections_API_EsqlRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         response_actions:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ResponseAction
+            $ref: '#/components/schemas/Security_Detections_API_ResponseAction'
           type: array
-    Security_Solution_Detections_API_EsqlRulePatchProps:
+    Security_Detections_API_EsqlRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_EsqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_EsqlQueryLanguage'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
               description: ESQL query to execute
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             type:
               description: Rule type
               enum:
                 - esql
               type: string
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleOptionalFields
-    Security_Solution_Detections_API_EsqlRuleRequiredFields:
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleOptionalFields'
+    Security_Detections_API_EsqlRuleRequiredFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlQueryLanguage
+          $ref: '#/components/schemas/Security_Detections_API_EsqlQueryLanguage'
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
           description: ESQL query to execute
         type:
           description: Rule type
@@ -32746,147 +32297,118 @@ components:
         - type
         - language
         - query
-    Security_Solution_Detections_API_EsqlRuleResponseFields:
+    Security_Detections_API_EsqlRuleResponseFields:
       allOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleOptionalFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleRequiredFields
-    Security_Solution_Detections_API_EsqlRuleUpdateProps:
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleOptionalFields'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleRequiredFields'
+    Security_Detections_API_EsqlRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleCreateFields
-    Security_Solution_Detections_API_EventCategoryOverride:
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleCreateFields'
+    Security_Detections_API_EventCategoryOverride:
       type: string
-    Security_Solution_Detections_API_ExceptionListType:
+    Security_Detections_API_ExceptionListType:
       description: The exception type
       enum:
         - detection
@@ -32897,7 +32419,7 @@ components:
         - endpoint_host_isolation_exceptions
         - endpoint_blocklists
       type: string
-    Security_Solution_Detections_API_ExternalRuleSource:
+    Security_Detections_API_ExternalRuleSource:
       description: >-
         Type of rule source for externally sourced rules, i.e. rules that have
         an external source, such as the Elastic Prebuilt rules repo.
@@ -32905,7 +32427,7 @@ components:
       properties:
         is_customized:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IsExternalRuleCustomized
+            #/components/schemas/Security_Detections_API_IsExternalRuleCustomized
         type:
           enum:
             - external
@@ -32913,7 +32435,7 @@ components:
       required:
         - type
         - is_customized
-    Security_Solution_Detections_API_FindRulesSortField:
+    Security_Detections_API_FindRulesSortField:
       enum:
         - created_at
         - createdAt
@@ -32930,23 +32452,22 @@ components:
         - updated_at
         - updatedAt
       type: string
-    Security_Solution_Detections_API_HistoryWindowStart:
-      $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
-    Security_Solution_Detections_API_IndexMigrationStatus:
+    Security_Detections_API_HistoryWindowStart:
+      $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
+    Security_Detections_API_IndexMigrationStatus:
       type: object
       properties:
         index:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
         is_outdated:
           type: boolean
         migrations:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_MigrationStatus
+            $ref: '#/components/schemas/Security_Detections_API_MigrationStatus'
           type: array
         signal_versions:
           items:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_AlertVersion'
+            $ref: '#/components/schemas/Security_Detections_API_AlertVersion'
           type: array
         version:
           type: integer
@@ -32956,11 +32477,11 @@ components:
         - signal_versions
         - migrations
         - is_outdated
-    Security_Solution_Detections_API_IndexPatternArray:
+    Security_Detections_API_IndexPatternArray:
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_InternalRuleSource:
+    Security_Detections_API_InternalRuleSource:
       description: >-
         Type of rule source for internally sourced rules, i.e. created within
         the Kibana apps.
@@ -32972,7 +32493,7 @@ components:
           type: string
       required:
         - type
-    Security_Solution_Detections_API_InvestigationFields:
+    Security_Detections_API_InvestigationFields:
       description: >
         Schema for fields relating to investigation fields. These are user
         defined fields we use to highlight
@@ -33005,39 +32526,38 @@ components:
       properties:
         field_names:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           minItems: 1
           type: array
       required:
         - field_names
-    Security_Solution_Detections_API_InvestigationGuide:
+    Security_Detections_API_InvestigationGuide:
       description: Notes to help investigate alerts produced by the rule.
       type: string
-    Security_Solution_Detections_API_IsExternalRuleCustomized:
+    Security_Detections_API_IsExternalRuleCustomized:
       description: >-
         Determines whether an external/prebuilt rule has been customized by the
         user (i.e. any of its fields have been modified and diverged from the
         base value).
       type: boolean
-    Security_Solution_Detections_API_IsRuleEnabled:
+    Security_Detections_API_IsRuleEnabled:
       description: Determines whether the rule is enabled.
       type: boolean
-    Security_Solution_Detections_API_IsRuleImmutable:
+    Security_Detections_API_IsRuleImmutable:
       deprecated: true
       description: >-
         This field determines whether the rule is a prebuilt Elastic rule. It
         will be replaced with the `rule_source` field.
       type: boolean
-    Security_Solution_Detections_API_ItemsPerSearch:
+    Security_Detections_API_ItemsPerSearch:
       minimum: 1
       type: integer
-    Security_Solution_Detections_API_KqlQueryLanguage:
+    Security_Detections_API_KqlQueryLanguage:
       enum:
         - kuery
         - lucene
       type: string
-    Security_Solution_Detections_API_MachineLearningJobId:
+    Security_Detections_API_MachineLearningJobId:
       description: Machine learning job ID
       oneOf:
         - type: string
@@ -33045,125 +32565,101 @@ components:
             type: string
           minItems: 1
           type: array
-    Security_Solution_Detections_API_MachineLearningRule:
+    Security_Detections_API_MachineLearningRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -33187,303 +32683,248 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleResponseFields
-    Security_Solution_Detections_API_MachineLearningRuleCreateFields:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleResponseFields
+    Security_Detections_API_MachineLearningRuleCreateFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleRequiredFields
+            #/components/schemas/Security_Detections_API_MachineLearningRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleOptionalFields
-    Security_Solution_Detections_API_MachineLearningRuleCreateProps:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleOptionalFields
+    Security_Detections_API_MachineLearningRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleCreateFields
-    Security_Solution_Detections_API_MachineLearningRuleOptionalFields:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleCreateFields
+    Security_Detections_API_MachineLearningRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
-    Security_Solution_Detections_API_MachineLearningRulePatchFields:
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
+    Security_Detections_API_MachineLearningRulePatchFields:
       allOf:
         - type: object
           properties:
             anomaly_threshold:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AnomalyThreshold
+              $ref: '#/components/schemas/Security_Detections_API_AnomalyThreshold'
             machine_learning_job_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_MachineLearningJobId
+                #/components/schemas/Security_Detections_API_MachineLearningJobId
             type:
               description: Rule type
               enum:
                 - machine_learning
               type: string
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleOptionalFields
-    Security_Solution_Detections_API_MachineLearningRulePatchProps:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleOptionalFields
+    Security_Detections_API_MachineLearningRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRulePatchFields
-    Security_Solution_Detections_API_MachineLearningRuleRequiredFields:
+            #/components/schemas/Security_Detections_API_MachineLearningRulePatchFields
+    Security_Detections_API_MachineLearningRuleRequiredFields:
       type: object
       properties:
         anomaly_threshold:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AnomalyThreshold
+          $ref: '#/components/schemas/Security_Detections_API_AnomalyThreshold'
         machine_learning_job_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningJobId
+          $ref: '#/components/schemas/Security_Detections_API_MachineLearningJobId'
         type:
           description: Rule type
           enum:
@@ -33493,148 +32934,122 @@ components:
         - type
         - machine_learning_job_id
         - anomaly_threshold
-    Security_Solution_Detections_API_MachineLearningRuleResponseFields:
+    Security_Detections_API_MachineLearningRuleResponseFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleRequiredFields
+            #/components/schemas/Security_Detections_API_MachineLearningRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleOptionalFields
-    Security_Solution_Detections_API_MachineLearningRuleUpdateProps:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleOptionalFields
+    Security_Detections_API_MachineLearningRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleCreateFields
-    Security_Solution_Detections_API_MaxSignals:
+            #/components/schemas/Security_Detections_API_MachineLearningRuleCreateFields
+    Security_Detections_API_MaxSignals:
       minimum: 1
       type: integer
-    Security_Solution_Detections_API_MigrationCleanupResult:
+    Security_Detections_API_MigrationCleanupResult:
       type: object
       properties:
         destinationIndex:
@@ -33671,7 +33086,7 @@ components:
         - sourceIndex
         - version
         - updated
-    Security_Solution_Detections_API_MigrationFinalizationResult:
+    Security_Detections_API_MigrationFinalizationResult:
       type: object
       properties:
         completed:
@@ -33711,11 +33126,11 @@ components:
         - sourceIndex
         - version
         - updated
-    Security_Solution_Detections_API_MigrationStatus:
+    Security_Detections_API_MigrationStatus:
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
         status:
           enum:
             - success
@@ -33732,131 +33147,107 @@ components:
         - status
         - version
         - updated
-    Security_Solution_Detections_API_NewTermsFields:
+    Security_Detections_API_NewTermsFields:
       items:
         type: string
       maxItems: 3
       minItems: 1
       type: array
-    Security_Solution_Detections_API_NewTermsRule:
+    Security_Detections_API_NewTermsRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -33880,329 +33271,269 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleResponseFields
-    Security_Solution_Detections_API_NewTermsRuleCreateFields:
+            #/components/schemas/Security_Detections_API_NewTermsRuleResponseFields
+    Security_Detections_API_NewTermsRuleCreateFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleRequiredFields
+            #/components/schemas/Security_Detections_API_NewTermsRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleOptionalFields
+            #/components/schemas/Security_Detections_API_NewTermsRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleDefaultableFields
-    Security_Solution_Detections_API_NewTermsRuleCreateProps:
+            #/components/schemas/Security_Detections_API_NewTermsRuleDefaultableFields
+    Security_Detections_API_NewTermsRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleCreateFields
-    Security_Solution_Detections_API_NewTermsRuleDefaultableFields:
+            #/components/schemas/Security_Detections_API_NewTermsRuleCreateFields
+    Security_Detections_API_NewTermsRuleDefaultableFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
-    Security_Solution_Detections_API_NewTermsRuleOptionalFields:
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
+    Security_Detections_API_NewTermsRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         response_actions:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ResponseAction
+            $ref: '#/components/schemas/Security_Detections_API_ResponseAction'
           type: array
-    Security_Solution_Detections_API_NewTermsRulePatchFields:
+    Security_Detections_API_NewTermsRulePatchFields:
       allOf:
         - type: object
           properties:
             history_window_start:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_HistoryWindowStart
+              $ref: '#/components/schemas/Security_Detections_API_HistoryWindowStart'
             new_terms_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_NewTermsFields
+              $ref: '#/components/schemas/Security_Detections_API_NewTermsFields'
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
             type:
               description: Rule type
               enum:
                 - new_terms
               type: string
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleOptionalFields
+            #/components/schemas/Security_Detections_API_NewTermsRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleDefaultableFields
-    Security_Solution_Detections_API_NewTermsRulePatchProps:
+            #/components/schemas/Security_Detections_API_NewTermsRuleDefaultableFields
+    Security_Detections_API_NewTermsRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRulePatchFields
-    Security_Solution_Detections_API_NewTermsRuleRequiredFields:
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
+        - $ref: '#/components/schemas/Security_Detections_API_NewTermsRulePatchFields'
+    Security_Detections_API_NewTermsRuleRequiredFields:
       type: object
       properties:
         history_window_start:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_HistoryWindowStart
+          $ref: '#/components/schemas/Security_Detections_API_HistoryWindowStart'
         new_terms_fields:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NewTermsFields'
+          $ref: '#/components/schemas/Security_Detections_API_NewTermsFields'
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
         type:
           description: Rule type
           enum:
@@ -34213,189 +33544,157 @@ components:
         - query
         - new_terms_fields
         - history_window_start
-    Security_Solution_Detections_API_NewTermsRuleResponseFields:
+    Security_Detections_API_NewTermsRuleResponseFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleRequiredFields
+            #/components/schemas/Security_Detections_API_NewTermsRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleOptionalFields
+            #/components/schemas/Security_Detections_API_NewTermsRuleOptionalFields
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
           required:
             - language
-    Security_Solution_Detections_API_NewTermsRuleUpdateProps:
+    Security_Detections_API_NewTermsRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleCreateFields
-    Security_Solution_Detections_API_NonEmptyString:
+            #/components/schemas/Security_Detections_API_NewTermsRuleCreateFields
+    Security_Detections_API_NonEmptyString:
       description: A string that is not empty and does not contain only whitespace
       minLength: 1
       pattern: ^(?! *$).+$
       type: string
-    Security_Solution_Detections_API_NormalizedRuleAction:
+    Security_Detections_API_NormalizedRuleAction:
       additionalProperties: false
       type: object
       properties:
         alerts_filter:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionAlertsFilter
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionAlertsFilter'
         frequency:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionFrequency
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionFrequency'
         group:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionGroup
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionGroup'
         id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleActionId'
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionId'
         params:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionParams
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionParams'
       required:
         - id
         - params
-    Security_Solution_Detections_API_NormalizedRuleError:
+    Security_Detections_API_NormalizedRuleError:
       type: object
       properties:
         err_code:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_BulkActionsDryRunErrCode
+            #/components/schemas/Security_Detections_API_BulkActionsDryRunErrCode
         message:
           type: string
         rules:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_RuleDetailsInError
+            $ref: '#/components/schemas/Security_Detections_API_RuleDetailsInError'
           type: array
         status_code:
           type: integer
@@ -34403,16 +33702,16 @@ components:
         - message
         - status_code
         - rules
-    Security_Solution_Detections_API_OsqueryParams:
+    Security_Detections_API_OsqueryParams:
       type: object
       properties:
         ecs_mapping:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_EcsMapping'
+          $ref: '#/components/schemas/Security_Detections_API_EcsMapping'
         pack_id:
           type: string
         queries:
           items:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_OsqueryQuery'
+            $ref: '#/components/schemas/Security_Detections_API_OsqueryQuery'
           type: array
         query:
           type: string
@@ -34420,11 +33719,11 @@ components:
           type: string
         timeout:
           type: number
-    Security_Solution_Detections_API_OsqueryQuery:
+    Security_Detections_API_OsqueryQuery:
       type: object
       properties:
         ecs_mapping:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_EcsMapping'
+          $ref: '#/components/schemas/Security_Detections_API_EcsMapping'
         id:
           description: Query ID
           type: string
@@ -34443,7 +33742,7 @@ components:
       required:
         - id
         - query
-    Security_Solution_Detections_API_OsqueryResponseAction:
+    Security_Detections_API_OsqueryResponseAction:
       type: object
       properties:
         action_type_id:
@@ -34451,11 +33750,11 @@ components:
             - .osquery
           type: string
         params:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_OsqueryParams'
+          $ref: '#/components/schemas/Security_Detections_API_OsqueryParams'
       required:
         - action_type_id
         - params
-    Security_Solution_Detections_API_PlatformErrorResponse:
+    Security_Detections_API_PlatformErrorResponse:
       type: object
       properties:
         error:
@@ -34468,7 +33767,7 @@ components:
         - statusCode
         - error
         - message
-    Security_Solution_Detections_API_ProcessesParams:
+    Security_Detections_API_ProcessesParams:
       type: object
       properties:
         command:
@@ -34493,125 +33792,101 @@ components:
       required:
         - command
         - config
-    Security_Solution_Detections_API_QueryRule:
+    Security_Detections_API_QueryRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -34635,176 +33910,142 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleResponseFields
-    Security_Solution_Detections_API_QueryRuleCreateFields:
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleResponseFields'
+    Security_Detections_API_QueryRuleCreateFields:
       allOf:
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleRequiredFields'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleOptionalFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleRequiredFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleOptionalFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleDefaultableFields
-    Security_Solution_Detections_API_QueryRuleCreateProps:
+            #/components/schemas/Security_Detections_API_QueryRuleDefaultableFields
+    Security_Detections_API_QueryRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleCreateFields
-    Security_Solution_Detections_API_QueryRuleDefaultableFields:
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleCreateFields'
+    Security_Detections_API_QueryRuleDefaultableFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
-    Security_Solution_Detections_API_QueryRuleOptionalFields:
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
+    Security_Detections_API_QueryRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         response_actions:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ResponseAction
+            $ref: '#/components/schemas/Security_Detections_API_ResponseAction'
           type: array
         saved_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_SavedQueryId'
-    Security_Solution_Detections_API_QueryRulePatchFields:
+          $ref: '#/components/schemas/Security_Detections_API_SavedQueryId'
+    Security_Detections_API_QueryRulePatchFields:
       allOf:
         - type: object
           properties:
@@ -34813,138 +34054,110 @@ components:
               enum:
                 - query
               type: string
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleOptionalFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleOptionalFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleDefaultableFields
-    Security_Solution_Detections_API_QueryRulePatchProps:
+            #/components/schemas/Security_Detections_API_QueryRuleDefaultableFields
+    Security_Detections_API_QueryRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRulePatchFields
-    Security_Solution_Detections_API_QueryRuleRequiredFields:
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRulePatchFields'
+    Security_Detections_API_QueryRuleRequiredFields:
       type: object
       properties:
         type:
@@ -34954,155 +34167,125 @@ components:
           type: string
       required:
         - type
-    Security_Solution_Detections_API_QueryRuleResponseFields:
+    Security_Detections_API_QueryRuleResponseFields:
       allOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleRequiredFields
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleOptionalFields
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleRequiredFields'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleOptionalFields'
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
           required:
             - query
             - language
-    Security_Solution_Detections_API_QueryRuleUpdateProps:
+    Security_Detections_API_QueryRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleCreateFields
-    Security_Solution_Detections_API_RelatedIntegration:
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleCreateFields'
+    Security_Detections_API_RelatedIntegration:
       description: >
         Related integration is a potential dependency of a rule. It's assumed
         that if the user installs
@@ -35163,20 +34346,19 @@ components:
       type: object
       properties:
         integration:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
         package:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
         version:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
       required:
         - package
         - version
-    Security_Solution_Detections_API_RelatedIntegrationArray:
+    Security_Detections_API_RelatedIntegrationArray:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Detections_API_RelatedIntegration
+        $ref: '#/components/schemas/Security_Detections_API_RelatedIntegration'
       type: array
-    Security_Solution_Detections_API_RequiredField:
+    Security_Detections_API_RequiredField:
       description: >
         Describes an Elasticsearch field that is needed for the rule to
         function.
@@ -35217,20 +34399,20 @@ components:
           description: Whether the field is an ECS field
           type: boolean
         name:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Name of an Elasticsearch field
         type:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Type of the Elasticsearch field
       required:
         - name
         - type
         - ecs
-    Security_Solution_Detections_API_RequiredFieldArray:
+    Security_Detections_API_RequiredFieldArray:
       items:
-        $ref: '#/components/schemas/Security_Solution_Detections_API_RequiredField'
+        $ref: '#/components/schemas/Security_Detections_API_RequiredField'
       type: array
-    Security_Solution_Detections_API_RequiredFieldInput:
+    Security_Detections_API_RequiredFieldInput:
       description: >-
         Input parameters to create a RequiredField. Does not include the `ecs`
         field, because `ecs` is calculated on the backend based on the field
@@ -35238,21 +34420,19 @@ components:
       type: object
       properties:
         name:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Name of an Elasticsearch field
         type:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Type of an Elasticsearch field
       required:
         - name
         - type
-    Security_Solution_Detections_API_ResponseAction:
+    Security_Detections_API_ResponseAction:
       oneOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_OsqueryResponseAction
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EndpointResponseAction
-    Security_Solution_Detections_API_ResponseFields:
+        - $ref: '#/components/schemas/Security_Detections_API_OsqueryResponseAction'
+        - $ref: '#/components/schemas/Security_Detections_API_EndpointResponseAction'
+    Security_Detections_API_ResponseFields:
       type: object
       properties:
         created_at:
@@ -35261,24 +34441,20 @@ components:
         created_by:
           type: string
         execution_summary:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleExecutionSummary
+          $ref: '#/components/schemas/Security_Detections_API_RuleExecutionSummary'
         id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleObjectId'
+          $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
         immutable:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IsRuleImmutable
+          $ref: '#/components/schemas/Security_Detections_API_IsRuleImmutable'
         required_fields:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RequiredFieldArray
+          $ref: '#/components/schemas/Security_Detections_API_RequiredFieldArray'
         revision:
           minimum: 0
           type: integer
         rule_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+          $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
         rule_source:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleSource'
+          $ref: '#/components/schemas/Security_Detections_API_RuleSource'
         updated_at:
           format: date-time
           type: string
@@ -35295,12 +34471,12 @@ components:
         - revision
         - related_integrations
         - required_fields
-    Security_Solution_Detections_API_RiskScore:
+    Security_Detections_API_RiskScore:
       description: Risk score (0 to 100)
       maximum: 100
       minimum: 0
       type: integer
-    Security_Solution_Detections_API_RiskScoreMapping:
+    Security_Detections_API_RiskScoreMapping:
       description: >-
         Overrides generated alerts' risk_score with a value from the source
         event
@@ -35314,7 +34490,7 @@ components:
               - equals
             type: string
           risk_score:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+            $ref: '#/components/schemas/Security_Detections_API_RiskScore'
           value:
             type: string
         required:
@@ -35322,66 +34498,60 @@ components:
           - operator
           - value
       type: array
-    Security_Solution_Detections_API_RuleAction:
+    Security_Detections_API_RuleAction:
       type: object
       properties:
         action_type_id:
           description: The action type used for sending notifications.
           type: string
         alerts_filter:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionAlertsFilter
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionAlertsFilter'
         frequency:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionFrequency
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionFrequency'
         group:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionGroup
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionGroup'
         id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleActionId'
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionId'
         params:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionParams
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionParams'
         uuid:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
       required:
         - action_type_id
         - id
         - params
-    Security_Solution_Detections_API_RuleActionAlertsFilter:
+    Security_Detections_API_RuleActionAlertsFilter:
       additionalProperties: true
       type: object
-    Security_Solution_Detections_API_RuleActionFrequency:
+    Security_Detections_API_RuleActionFrequency:
       description: >-
         The action frequency defines when the action runs (for example, only on
         rule execution or at specific time intervals).
       type: object
       properties:
         notifyWhen:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionNotifyWhen
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionNotifyWhen'
         summary:
           description: >-
             Action summary indicates whether we will send a summary notification
             about all the generate alerts or notification per individual alert
           type: boolean
         throttle:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+          $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
           nullable: true
       required:
         - summary
         - notifyWhen
         - throttle
-    Security_Solution_Detections_API_RuleActionGroup:
+    Security_Detections_API_RuleActionGroup:
       description: >-
         Optionally groups actions by use cases. Use `default` for alert
         notifications.
       type: string
-    Security_Solution_Detections_API_RuleActionId:
+    Security_Detections_API_RuleActionId:
       description: The connector ID.
       type: string
-    Security_Solution_Detections_API_RuleActionNotifyWhen:
+    Security_Detections_API_RuleActionNotifyWhen:
       description: >-
         The condition for throttling the notification: `onActionGroupChange`,
         `onActiveAlert`,  or `onThrottleInterval`
@@ -35390,13 +34560,13 @@ components:
         - onThrottleInterval
         - onActionGroupChange
       type: string
-    Security_Solution_Detections_API_RuleActionParams:
+    Security_Detections_API_RuleActionParams:
       additionalProperties: true
       description: >-
         Object containing the allowed connector fields, which varies according
         to the connector type.
       type: object
-    Security_Solution_Detections_API_RuleActionThrottle:
+    Security_Detections_API_RuleActionThrottle:
       description: Defines how often rule actions are taken.
       oneOf:
         - enum:
@@ -35407,34 +34577,30 @@ components:
           example: 1h
           pattern: ^[1-9]\d*[smhd]$
           type: string
-    Security_Solution_Detections_API_RuleAuthorArray:
+    Security_Detections_API_RuleAuthorArray:
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_RuleCreateProps:
+    Security_Detections_API_RuleCreateProps:
       anyOf:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRuleCreateProps'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleCreateProps'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRuleCreateProps
+            #/components/schemas/Security_Detections_API_SavedQueryRuleCreateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleCreateProps
+            #/components/schemas/Security_Detections_API_ThresholdRuleCreateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleCreateProps
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleCreateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleCreateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleCreateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleCreateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleCreateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleCreateProps
+            #/components/schemas/Security_Detections_API_MachineLearningRuleCreateProps
+        - $ref: '#/components/schemas/Security_Detections_API_NewTermsRuleCreateProps'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleCreateProps'
       discriminator:
         propertyName: type
-    Security_Solution_Detections_API_RuleDescription:
+    Security_Detections_API_RuleDescription:
       minLength: 1
       type: string
-    Security_Solution_Detections_API_RuleDetailsInError:
+    Security_Detections_API_RuleDetailsInError:
       type: object
       properties:
         id:
@@ -35443,14 +34609,14 @@ components:
           type: string
       required:
         - id
-    Security_Solution_Detections_API_RuleExceptionList:
+    Security_Detections_API_RuleExceptionList:
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: ID of the exception container
         list_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: List ID of the exception container
         namespace_type:
           description: Determines the exceptions validity in rule's Kibana space
@@ -35459,14 +34625,13 @@ components:
             - single
           type: string
         type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ExceptionListType
+          $ref: '#/components/schemas/Security_Detections_API_ExceptionListType'
       required:
         - id
         - list_id
         - type
         - namespace_type
-    Security_Solution_Detections_API_RuleExecutionMetrics:
+    Security_Detections_API_RuleExecutionMetrics:
       type: object
       properties:
         execution_gap_duration_s:
@@ -35492,7 +34657,7 @@ components:
             request/response
           minimum: 0
           type: integer
-    Security_Solution_Detections_API_RuleExecutionStatus:
+    Security_Detections_API_RuleExecutionStatus:
       description: >-
         Custom execution status of Security rules that is different from the
         status used in the Alerting Framework. We merge our custom status with
@@ -35525,9 +34690,9 @@ components:
         - failed
         - succeeded
       type: string
-    Security_Solution_Detections_API_RuleExecutionStatusOrder:
+    Security_Detections_API_RuleExecutionStatusOrder:
       type: integer
-    Security_Solution_Detections_API_RuleExecutionSummary:
+    Security_Detections_API_RuleExecutionSummary:
       type: object
       properties:
         last_execution:
@@ -35541,14 +34706,13 @@ components:
               type: string
             metrics:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleExecutionMetrics
+                #/components/schemas/Security_Detections_API_RuleExecutionMetrics
             status:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleExecutionStatus
+              $ref: '#/components/schemas/Security_Detections_API_RuleExecutionStatus'
               description: Status of the last execution
             status_order:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleExecutionStatusOrder
+                #/components/schemas/Security_Detections_API_RuleExecutionStatusOrder
           required:
             - date
             - status
@@ -35557,19 +34721,19 @@ components:
             - metrics
       required:
         - last_execution
-    Security_Solution_Detections_API_RuleFalsePositiveArray:
+    Security_Detections_API_RuleFalsePositiveArray:
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_RuleFilterArray:
+    Security_Detections_API_RuleFilterArray:
       items: {}
       type: array
-    Security_Solution_Detections_API_RuleInterval:
+    Security_Detections_API_RuleInterval:
       description: >-
         Frequency of rule execution, using a date math range. For example, "1h"
         means the rule runs every hour. Defaults to 5m (5 minutes).
       type: string
-    Security_Solution_Detections_API_RuleIntervalFrom:
+    Security_Detections_API_RuleIntervalFrom:
       description: >-
         Time from which data is analyzed each time the rule runs, using a date
         math range. For example, now-4200s means the rule analyzes data from 70
@@ -35577,52 +34741,47 @@ components:
         minutes before the start time).
       format: date-math
       type: string
-    Security_Solution_Detections_API_RuleIntervalTo:
+    Security_Detections_API_RuleIntervalTo:
       type: string
-    Security_Solution_Detections_API_RuleLicense:
+    Security_Detections_API_RuleLicense:
       description: The rule's license.
       type: string
-    Security_Solution_Detections_API_RuleMetadata:
+    Security_Detections_API_RuleMetadata:
       additionalProperties: true
       type: object
-    Security_Solution_Detections_API_RuleName:
+    Security_Detections_API_RuleName:
       minLength: 1
       type: string
-    Security_Solution_Detections_API_RuleNameOverride:
+    Security_Detections_API_RuleNameOverride:
       description: Sets the source field for the alert's signal.rule.name value
       type: string
-    Security_Solution_Detections_API_RuleObjectId:
-      $ref: '#/components/schemas/Security_Solution_Detections_API_UUID'
-    Security_Solution_Detections_API_RulePatchProps:
+    Security_Detections_API_RuleObjectId:
+      $ref: '#/components/schemas/Security_Detections_API_UUID'
+    Security_Detections_API_RulePatchProps:
       anyOf:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRulePatchProps'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRulePatchProps'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRulePatchProps
+            #/components/schemas/Security_Detections_API_SavedQueryRulePatchProps
+        - $ref: '#/components/schemas/Security_Detections_API_ThresholdRulePatchProps'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRulePatchProps
+            #/components/schemas/Security_Detections_API_ThreatMatchRulePatchProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRulePatchProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRulePatchProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRulePatchProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRulePatchProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRulePatchProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRulePatchProps
-    Security_Solution_Detections_API_RulePreviewLoggedRequest:
+            #/components/schemas/Security_Detections_API_MachineLearningRulePatchProps
+        - $ref: '#/components/schemas/Security_Detections_API_NewTermsRulePatchProps'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRulePatchProps'
+    Security_Detections_API_RulePreviewLoggedRequest:
       type: object
       properties:
         description:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
         duration:
           type: integer
         request:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
       required:
         - request
-    Security_Solution_Detections_API_RulePreviewLogs:
+    Security_Detections_API_RulePreviewLogs:
       type: object
       properties:
         duration:
@@ -35630,26 +34789,24 @@ components:
           type: integer
         errors:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           type: array
         requests:
           items:
             $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_RulePreviewLoggedRequest
+              #/components/schemas/Security_Detections_API_RulePreviewLoggedRequest
           type: array
         startedAt:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
         warnings:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           type: array
       required:
         - errors
         - warnings
         - duration
-    Security_Solution_Detections_API_RulePreviewParams:
+    Security_Detections_API_RulePreviewParams:
       type: object
       properties:
         invocationCount:
@@ -35660,30 +34817,28 @@ components:
       required:
         - invocationCount
         - timeframeEnd
-    Security_Solution_Detections_API_RuleQuery:
+    Security_Detections_API_RuleQuery:
       type: string
-    Security_Solution_Detections_API_RuleReferenceArray:
+    Security_Detections_API_RuleReferenceArray:
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_RuleResponse:
+    Security_Detections_API_RuleResponse:
       anyOf:
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_EqlRule'
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_QueryRule'
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_SavedQueryRule'
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ThresholdRule'
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRule
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRule
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_NewTermsRule'
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_EsqlRule'
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRule'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRule'
+        - $ref: '#/components/schemas/Security_Detections_API_SavedQueryRule'
+        - $ref: '#/components/schemas/Security_Detections_API_ThresholdRule'
+        - $ref: '#/components/schemas/Security_Detections_API_ThreatMatchRule'
+        - $ref: '#/components/schemas/Security_Detections_API_MachineLearningRule'
+        - $ref: '#/components/schemas/Security_Detections_API_NewTermsRule'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRule'
       discriminator:
         propertyName: type
-    Security_Solution_Detections_API_RuleSignatureId:
+    Security_Detections_API_RuleSignatureId:
       description: Could be any string, not necessarily a UUID
       type: string
-    Security_Solution_Detections_API_RuleSource:
+    Security_Detections_API_RuleSource:
       description: >-
         Discriminated union that determines whether the rule is internally
         sourced (created within the Kibana app) or has an external source, such
@@ -35691,175 +34846,145 @@ components:
       discriminator:
         propertyName: type
       oneOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ExternalRuleSource
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_InternalRuleSource
-    Security_Solution_Detections_API_RuleTagArray:
+        - $ref: '#/components/schemas/Security_Detections_API_ExternalRuleSource'
+        - $ref: '#/components/schemas/Security_Detections_API_InternalRuleSource'
+    Security_Detections_API_RuleTagArray:
       description: >-
         String array containing words and phrases to help categorize, filter,
         and search rules. Defaults to an empty array.
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_RuleUpdateProps:
+    Security_Detections_API_RuleUpdateProps:
       anyOf:
+        - $ref: '#/components/schemas/Security_Detections_API_EqlRuleUpdateProps'
+        - $ref: '#/components/schemas/Security_Detections_API_QueryRuleUpdateProps'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EqlRuleUpdateProps
+            #/components/schemas/Security_Detections_API_SavedQueryRuleUpdateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_QueryRuleUpdateProps
+            #/components/schemas/Security_Detections_API_ThresholdRuleUpdateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleUpdateProps
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleUpdateProps
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleUpdateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleUpdateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_MachineLearningRuleUpdateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_NewTermsRuleUpdateProps
-        - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_EsqlRuleUpdateProps
+            #/components/schemas/Security_Detections_API_MachineLearningRuleUpdateProps
+        - $ref: '#/components/schemas/Security_Detections_API_NewTermsRuleUpdateProps'
+        - $ref: '#/components/schemas/Security_Detections_API_EsqlRuleUpdateProps'
       discriminator:
         propertyName: type
-    Security_Solution_Detections_API_RuleVersion:
+    Security_Detections_API_RuleVersion:
       description: The rule's version number.
       minimum: 1
       type: integer
-    Security_Solution_Detections_API_SavedObjectResolveAliasPurpose:
+    Security_Detections_API_SavedObjectResolveAliasPurpose:
       enum:
         - savedObjectConversion
         - savedObjectImport
       type: string
-    Security_Solution_Detections_API_SavedObjectResolveAliasTargetId:
+    Security_Detections_API_SavedObjectResolveAliasTargetId:
       type: string
-    Security_Solution_Detections_API_SavedObjectResolveOutcome:
+    Security_Detections_API_SavedObjectResolveOutcome:
       enum:
         - exactMatch
         - aliasMatch
         - conflict
       type: string
-    Security_Solution_Detections_API_SavedQueryId:
+    Security_Detections_API_SavedQueryId:
       type: string
-    Security_Solution_Detections_API_SavedQueryRule:
+    Security_Detections_API_SavedQueryRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -35883,321 +35008,264 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleResponseFields
-    Security_Solution_Detections_API_SavedQueryRuleCreateFields:
+            #/components/schemas/Security_Detections_API_SavedQueryRuleResponseFields
+    Security_Detections_API_SavedQueryRuleCreateFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleRequiredFields
+            #/components/schemas/Security_Detections_API_SavedQueryRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleOptionalFields
+            #/components/schemas/Security_Detections_API_SavedQueryRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleDefaultableFields
-    Security_Solution_Detections_API_SavedQueryRuleCreateProps:
+            #/components/schemas/Security_Detections_API_SavedQueryRuleDefaultableFields
+    Security_Detections_API_SavedQueryRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleCreateFields
-    Security_Solution_Detections_API_SavedQueryRuleDefaultableFields:
+            #/components/schemas/Security_Detections_API_SavedQueryRuleCreateFields
+    Security_Detections_API_SavedQueryRuleDefaultableFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
-    Security_Solution_Detections_API_SavedQueryRuleOptionalFields:
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
+    Security_Detections_API_SavedQueryRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
         response_actions:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ResponseAction
+            $ref: '#/components/schemas/Security_Detections_API_ResponseAction'
           type: array
-    Security_Solution_Detections_API_SavedQueryRulePatchFields:
+    Security_Detections_API_SavedQueryRulePatchFields:
       allOf:
         - type: object
           properties:
             saved_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedQueryId
+              $ref: '#/components/schemas/Security_Detections_API_SavedQueryId'
             type:
               description: Rule type
               enum:
                 - saved_query
               type: string
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleOptionalFields
+            #/components/schemas/Security_Detections_API_SavedQueryRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleDefaultableFields
-    Security_Solution_Detections_API_SavedQueryRulePatchProps:
+            #/components/schemas/Security_Detections_API_SavedQueryRuleDefaultableFields
+    Security_Detections_API_SavedQueryRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRulePatchFields
-    Security_Solution_Detections_API_SavedQueryRuleRequiredFields:
+            #/components/schemas/Security_Detections_API_SavedQueryRulePatchFields
+    Security_Detections_API_SavedQueryRuleRequiredFields:
       type: object
       properties:
         saved_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_SavedQueryId'
+          $ref: '#/components/schemas/Security_Detections_API_SavedQueryId'
         type:
           description: Rule type
           enum:
@@ -36206,166 +35274,138 @@ components:
       required:
         - type
         - saved_id
-    Security_Solution_Detections_API_SavedQueryRuleResponseFields:
+    Security_Detections_API_SavedQueryRuleResponseFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleRequiredFields
+            #/components/schemas/Security_Detections_API_SavedQueryRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleOptionalFields
+            #/components/schemas/Security_Detections_API_SavedQueryRuleOptionalFields
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
           required:
             - language
-    Security_Solution_Detections_API_SavedQueryRuleUpdateProps:
+    Security_Detections_API_SavedQueryRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_SavedQueryRuleCreateFields
-    Security_Solution_Detections_API_SetAlertsStatusByIds:
+            #/components/schemas/Security_Detections_API_SavedQueryRuleCreateFields
+    Security_Detections_API_SetAlertsStatusByIds:
       type: object
       properties:
         signal_ids:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           minItems: 1
           type: array
         status:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_AlertStatus'
+          $ref: '#/components/schemas/Security_Detections_API_AlertStatus'
       required:
         - signal_ids
         - status
-    Security_Solution_Detections_API_SetAlertsStatusByQuery:
+    Security_Detections_API_SetAlertsStatusByQuery:
       type: object
       properties:
         conflicts:
@@ -36378,23 +35418,23 @@ components:
           additionalProperties: true
           type: object
         status:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_AlertStatus'
+          $ref: '#/components/schemas/Security_Detections_API_AlertStatus'
       required:
         - query
         - status
-    Security_Solution_Detections_API_SetAlertTags:
+    Security_Detections_API_SetAlertTags:
       type: object
       properties:
         tags_to_add:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_AlertTags'
+          $ref: '#/components/schemas/Security_Detections_API_AlertTags'
         tags_to_remove:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_AlertTags'
+          $ref: '#/components/schemas/Security_Detections_API_AlertTags'
       required:
         - tags_to_add
         - tags_to_remove
-    Security_Solution_Detections_API_SetupGuide:
+    Security_Detections_API_SetupGuide:
       type: string
-    Security_Solution_Detections_API_Severity:
+    Security_Detections_API_Severity:
       description: Severity of the rule
       enum:
         - low
@@ -36402,7 +35442,7 @@ components:
         - high
         - critical
       type: string
-    Security_Solution_Detections_API_SeverityMapping:
+    Security_Detections_API_SeverityMapping:
       description: Overrides generated alerts' severity with values from the source event
       items:
         type: object
@@ -36414,7 +35454,7 @@ components:
               - equals
             type: string
           severity:
-            $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+            $ref: '#/components/schemas/Security_Detections_API_Severity'
           value:
             type: string
         required:
@@ -36423,7 +35463,7 @@ components:
           - severity
           - value
       type: array
-    Security_Solution_Detections_API_SiemErrorResponse:
+    Security_Detections_API_SiemErrorResponse:
       type: object
       properties:
         message:
@@ -36433,55 +35473,54 @@ components:
       required:
         - status_code
         - message
-    Security_Solution_Detections_API_SkippedAlertsIndexMigration:
+    Security_Detections_API_SkippedAlertsIndexMigration:
       type: object
       properties:
         index:
           type: string
       required:
         - index
-    Security_Solution_Detections_API_SortOrder:
+    Security_Detections_API_SortOrder:
       enum:
         - asc
         - desc
       type: string
-    Security_Solution_Detections_API_Threat:
+    Security_Detections_API_Threat:
       type: object
       properties:
         framework:
           description: Relevant attack framework
           type: string
         tactic:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThreatTactic'
+          $ref: '#/components/schemas/Security_Detections_API_ThreatTactic'
         technique:
           description: Array containing information on the attack techniques (optional)
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ThreatTechnique
+            $ref: '#/components/schemas/Security_Detections_API_ThreatTechnique'
           type: array
       required:
         - framework
         - tactic
-    Security_Solution_Detections_API_ThreatArray:
+    Security_Detections_API_ThreatArray:
       items:
-        $ref: '#/components/schemas/Security_Solution_Detections_API_Threat'
+        $ref: '#/components/schemas/Security_Detections_API_Threat'
       type: array
-    Security_Solution_Detections_API_ThreatFilters:
+    Security_Detections_API_ThreatFilters:
       items:
         description: >-
           Query and filter context array used to filter documents from the
           Elasticsearch index containing the threat values
       type: array
-    Security_Solution_Detections_API_ThreatIndex:
+    Security_Detections_API_ThreatIndex:
       items:
         type: string
       type: array
-    Security_Solution_Detections_API_ThreatIndicatorPath:
+    Security_Detections_API_ThreatIndicatorPath:
       description: >-
         Defines the path to the threat indicator in the indicator documents
         (optional)
       type: string
-    Security_Solution_Detections_API_ThreatMapping:
+    Security_Detections_API_ThreatMapping:
       items:
         type: object
         properties:
@@ -36490,15 +35529,13 @@ components:
               type: object
               properties:
                 field:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+                  $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
                 type:
                   enum:
                     - mapping
                   type: string
                 value:
-                  $ref: >-
-                    #/components/schemas/Security_Solution_Detections_API_NonEmptyString
+                  $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
               required:
                 - field
                 - type
@@ -36508,125 +35545,101 @@ components:
           - entries
       minItems: 1
       type: array
-    Security_Solution_Detections_API_ThreatMatchRule:
+    Security_Detections_API_ThreatMatchRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -36650,343 +35663,282 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleResponseFields
-    Security_Solution_Detections_API_ThreatMatchRuleCreateFields:
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleResponseFields
+    Security_Detections_API_ThreatMatchRuleCreateFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleRequiredFields
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleDefaultableFields
-    Security_Solution_Detections_API_ThreatMatchRuleCreateProps:
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleDefaultableFields
+    Security_Detections_API_ThreatMatchRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleCreateFields
-    Security_Solution_Detections_API_ThreatMatchRuleDefaultableFields:
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleCreateFields
+    Security_Detections_API_ThreatMatchRuleDefaultableFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
-    Security_Solution_Detections_API_ThreatMatchRuleOptionalFields:
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
+    Security_Detections_API_ThreatMatchRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppression
+          $ref: '#/components/schemas/Security_Detections_API_AlertSuppression'
         concurrent_searches:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ConcurrentSearches
+          $ref: '#/components/schemas/Security_Detections_API_ConcurrentSearches'
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         items_per_search:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ItemsPerSearch'
+          $ref: '#/components/schemas/Security_Detections_API_ItemsPerSearch'
         saved_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_SavedQueryId'
+          $ref: '#/components/schemas/Security_Detections_API_SavedQueryId'
         threat_filters:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThreatFilters'
+          $ref: '#/components/schemas/Security_Detections_API_ThreatFilters'
         threat_indicator_path:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatIndicatorPath
+          $ref: '#/components/schemas/Security_Detections_API_ThreatIndicatorPath'
         threat_language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
-    Security_Solution_Detections_API_ThreatMatchRulePatchFields:
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
+    Security_Detections_API_ThreatMatchRulePatchFields:
       allOf:
         - type: object
           properties:
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
             threat_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatIndex
+              $ref: '#/components/schemas/Security_Detections_API_ThreatIndex'
             threat_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatMapping
+              $ref: '#/components/schemas/Security_Detections_API_ThreatMapping'
             threat_query:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatQuery
+              $ref: '#/components/schemas/Security_Detections_API_ThreatQuery'
             type:
               description: Rule type
               enum:
                 - threat_match
               type: string
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleDefaultableFields
-    Security_Solution_Detections_API_ThreatMatchRulePatchProps:
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleDefaultableFields
+    Security_Detections_API_ThreatMatchRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRulePatchFields
-    Security_Solution_Detections_API_ThreatMatchRuleRequiredFields:
+            #/components/schemas/Security_Detections_API_ThreatMatchRulePatchFields
+    Security_Detections_API_ThreatMatchRuleRequiredFields:
       type: object
       properties:
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
         threat_index:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThreatIndex'
+          $ref: '#/components/schemas/Security_Detections_API_ThreatIndex'
         threat_mapping:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThreatMapping'
+          $ref: '#/components/schemas/Security_Detections_API_ThreatMapping'
         threat_query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThreatQuery'
+          $ref: '#/components/schemas/Security_Detections_API_ThreatQuery'
         type:
           description: Rule type
           enum:
@@ -36998,155 +35950,128 @@ components:
         - threat_query
         - threat_mapping
         - threat_index
-    Security_Solution_Detections_API_ThreatMatchRuleResponseFields:
+    Security_Detections_API_ThreatMatchRuleResponseFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleRequiredFields
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleOptionalFields
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
           required:
             - language
-    Security_Solution_Detections_API_ThreatMatchRuleUpdateProps:
+    Security_Detections_API_ThreatMatchRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThreatMatchRuleCreateFields
-    Security_Solution_Detections_API_ThreatQuery:
+            #/components/schemas/Security_Detections_API_ThreatMatchRuleCreateFields
+    Security_Detections_API_ThreatQuery:
       description: Query to run
       type: string
-    Security_Solution_Detections_API_ThreatSubtechnique:
+    Security_Detections_API_ThreatSubtechnique:
       type: object
       properties:
         id:
@@ -37162,7 +36087,7 @@ components:
         - id
         - name
         - reference
-    Security_Solution_Detections_API_ThreatTactic:
+    Security_Detections_API_ThreatTactic:
       type: object
       properties:
         id:
@@ -37178,7 +36103,7 @@ components:
         - id
         - name
         - reference
-    Security_Solution_Detections_API_ThreatTechnique:
+    Security_Detections_API_ThreatTechnique:
       type: object
       properties:
         id:
@@ -37193,35 +36118,33 @@ components:
         subtechnique:
           description: Array containing more specific information on the attack technique
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Detections_API_ThreatSubtechnique
+            $ref: '#/components/schemas/Security_Detections_API_ThreatSubtechnique'
           type: array
       required:
         - id
         - name
         - reference
-    Security_Solution_Detections_API_Threshold:
+    Security_Detections_API_Threshold:
       type: object
       properties:
         cardinality:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdCardinality
+          $ref: '#/components/schemas/Security_Detections_API_ThresholdCardinality'
         field:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThresholdField'
+          $ref: '#/components/schemas/Security_Detections_API_ThresholdField'
         value:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_ThresholdValue'
+          $ref: '#/components/schemas/Security_Detections_API_ThresholdValue'
       required:
         - field
         - value
-    Security_Solution_Detections_API_ThresholdAlertSuppression:
+    Security_Detections_API_ThresholdAlertSuppression:
       type: object
       properties:
         duration:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_AlertSuppressionDuration
+            #/components/schemas/Security_Detections_API_AlertSuppressionDuration
       required:
         - duration
-    Security_Solution_Detections_API_ThresholdCardinality:
+    Security_Detections_API_ThresholdCardinality:
       items:
         type: object
         properties:
@@ -37234,132 +36157,108 @@ components:
           - field
           - value
       type: array
-    Security_Solution_Detections_API_ThresholdField:
+    Security_Detections_API_ThresholdField:
       description: Field to aggregate on
       oneOf:
         - type: string
         - items:
             type: string
           type: array
-    Security_Solution_Detections_API_ThresholdRule:
+    Security_Detections_API_ThresholdRule:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
@@ -37383,319 +36282,265 @@ components:
             - setup
             - related_integrations
             - required_fields
-        - $ref: '#/components/schemas/Security_Solution_Detections_API_ResponseFields'
+        - $ref: '#/components/schemas/Security_Detections_API_ResponseFields'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleResponseFields
-    Security_Solution_Detections_API_ThresholdRuleCreateFields:
+            #/components/schemas/Security_Detections_API_ThresholdRuleResponseFields
+    Security_Detections_API_ThresholdRuleCreateFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleRequiredFields
+            #/components/schemas/Security_Detections_API_ThresholdRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThresholdRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleDefaultableFields
-    Security_Solution_Detections_API_ThresholdRuleCreateProps:
+            #/components/schemas/Security_Detections_API_ThresholdRuleDefaultableFields
+    Security_Detections_API_ThresholdRuleCreateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleCreateFields
-    Security_Solution_Detections_API_ThresholdRuleDefaultableFields:
+            #/components/schemas/Security_Detections_API_ThresholdRuleCreateFields
+    Security_Detections_API_ThresholdRuleDefaultableFields:
       type: object
       properties:
         language:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
-    Security_Solution_Detections_API_ThresholdRuleOptionalFields:
+          $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
+    Security_Detections_API_ThresholdRuleOptionalFields:
       type: object
       properties:
         alert_suppression:
           $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdAlertSuppression
+            #/components/schemas/Security_Detections_API_ThresholdAlertSuppression
         data_view_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_DataViewId'
+          $ref: '#/components/schemas/Security_Detections_API_DataViewId'
         filters:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_RuleFilterArray
+          $ref: '#/components/schemas/Security_Detections_API_RuleFilterArray'
         index:
-          $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_IndexPatternArray
+          $ref: '#/components/schemas/Security_Detections_API_IndexPatternArray'
         saved_id:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_SavedQueryId'
-    Security_Solution_Detections_API_ThresholdRulePatchFields:
+          $ref: '#/components/schemas/Security_Detections_API_SavedQueryId'
+    Security_Detections_API_ThresholdRulePatchFields:
       allOf:
         - type: object
           properties:
             query:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+              $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
             threshold:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Threshold'
+              $ref: '#/components/schemas/Security_Detections_API_Threshold'
             type:
               description: Rule type
               enum:
                 - threshold
               type: string
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThresholdRuleOptionalFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleDefaultableFields
-    Security_Solution_Detections_API_ThresholdRulePatchProps:
+            #/components/schemas/Security_Detections_API_ThresholdRuleDefaultableFields
+    Security_Detections_API_ThresholdRulePatchProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRulePatchFields
-    Security_Solution_Detections_API_ThresholdRuleRequiredFields:
+            #/components/schemas/Security_Detections_API_ThresholdRulePatchFields
+    Security_Detections_API_ThresholdRuleRequiredFields:
       type: object
       properties:
         query:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_RuleQuery'
+          $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
         threshold:
-          $ref: '#/components/schemas/Security_Solution_Detections_API_Threshold'
+          $ref: '#/components/schemas/Security_Detections_API_Threshold'
         type:
           description: Rule type
           enum:
@@ -37705,156 +36550,129 @@ components:
         - type
         - query
         - threshold
-    Security_Solution_Detections_API_ThresholdRuleResponseFields:
+    Security_Detections_API_ThresholdRuleResponseFields:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleRequiredFields
+            #/components/schemas/Security_Detections_API_ThresholdRuleRequiredFields
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleOptionalFields
+            #/components/schemas/Security_Detections_API_ThresholdRuleOptionalFields
         - type: object
           properties:
             language:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_KqlQueryLanguage
+              $ref: '#/components/schemas/Security_Detections_API_KqlQueryLanguage'
           required:
             - language
-    Security_Solution_Detections_API_ThresholdRuleUpdateProps:
+    Security_Detections_API_ThresholdRuleUpdateProps:
       allOf:
         - type: object
           properties:
             actions:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleAction
+                $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
             alias_purpose:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasPurpose
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasPurpose
             alias_target_id:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveAliasTargetId
+                #/components/schemas/Security_Detections_API_SavedObjectResolveAliasTargetId
             author:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleAuthorArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleAuthorArray'
             building_block_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_BuildingBlockType
+              $ref: '#/components/schemas/Security_Detections_API_BuildingBlockType'
             description:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleDescription
+              $ref: '#/components/schemas/Security_Detections_API_RuleDescription'
             enabled:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_IsRuleEnabled
+              $ref: '#/components/schemas/Security_Detections_API_IsRuleEnabled'
             exceptions_list:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RuleExceptionList
+                $ref: '#/components/schemas/Security_Detections_API_RuleExceptionList'
               type: array
             false_positives:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleFalsePositiveArray
+                #/components/schemas/Security_Detections_API_RuleFalsePositiveArray
             from:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalFrom
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalFrom'
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleObjectId
+              $ref: '#/components/schemas/Security_Detections_API_RuleObjectId'
             interval:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleInterval
+              $ref: '#/components/schemas/Security_Detections_API_RuleInterval'
             investigation_fields:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationFields
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationFields'
             license:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleLicense
+              $ref: '#/components/schemas/Security_Detections_API_RuleLicense'
             max_signals:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_MaxSignals'
+              $ref: '#/components/schemas/Security_Detections_API_MaxSignals'
             meta:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleMetadata
+              $ref: '#/components/schemas/Security_Detections_API_RuleMetadata'
             name:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RuleName'
+              $ref: '#/components/schemas/Security_Detections_API_RuleName'
             namespace:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndexNamespace
+                #/components/schemas/Security_Detections_API_AlertsIndexNamespace
             note:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_InvestigationGuide
+              $ref: '#/components/schemas/Security_Detections_API_InvestigationGuide'
             outcome:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SavedObjectResolveOutcome
+                #/components/schemas/Security_Detections_API_SavedObjectResolveOutcome
             output_index:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_AlertsIndex
+              $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             references:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleReferenceArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RelatedIntegrationArray
+                #/components/schemas/Security_Detections_API_RelatedIntegrationArray
             required_fields:
               items:
                 $ref: >-
-                  #/components/schemas/Security_Solution_Detections_API_RequiredFieldInput
+                  #/components/schemas/Security_Detections_API_RequiredFieldInput
               type: array
             risk_score:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_RiskScore'
+              $ref: '#/components/schemas/Security_Detections_API_RiskScore'
             risk_score_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RiskScoreMapping
+              $ref: '#/components/schemas/Security_Detections_API_RiskScoreMapping'
             rule_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleSignatureId
+              $ref: '#/components/schemas/Security_Detections_API_RuleSignatureId'
             rule_name_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleNameOverride
+              $ref: '#/components/schemas/Security_Detections_API_RuleNameOverride'
             setup:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_SetupGuide'
+              $ref: '#/components/schemas/Security_Detections_API_SetupGuide'
             severity:
-              $ref: '#/components/schemas/Security_Solution_Detections_API_Severity'
+              $ref: '#/components/schemas/Security_Detections_API_Severity'
             severity_mapping:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_SeverityMapping
+              $ref: '#/components/schemas/Security_Detections_API_SeverityMapping'
             tags:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleTagArray
+              $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
             threat:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_ThreatArray
+              $ref: '#/components/schemas/Security_Detections_API_ThreatArray'
             throttle:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleActionThrottle
+              $ref: '#/components/schemas/Security_Detections_API_RuleActionThrottle'
             timeline_id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateId
+              $ref: '#/components/schemas/Security_Detections_API_TimelineTemplateId'
             timeline_title:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimelineTemplateTitle
+                #/components/schemas/Security_Detections_API_TimelineTemplateTitle
             timestamp_override:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverride
+              $ref: '#/components/schemas/Security_Detections_API_TimestampOverride'
             timestamp_override_fallback_disabled:
               $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_TimestampOverrideFallbackDisabled
+                #/components/schemas/Security_Detections_API_TimestampOverrideFallbackDisabled
             to:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleIntervalTo
+              $ref: '#/components/schemas/Security_Detections_API_RuleIntervalTo'
             version:
-              $ref: >-
-                #/components/schemas/Security_Solution_Detections_API_RuleVersion
+              $ref: '#/components/schemas/Security_Detections_API_RuleVersion'
           required:
             - name
             - description
             - risk_score
             - severity
         - $ref: >-
-            #/components/schemas/Security_Solution_Detections_API_ThresholdRuleCreateFields
-    Security_Solution_Detections_API_ThresholdValue:
+            #/components/schemas/Security_Detections_API_ThresholdRuleCreateFields
+    Security_Detections_API_ThresholdValue:
       description: Threshold value
       minimum: 1
       type: integer
-    Security_Solution_Detections_API_ThrottleForBulkActions:
+    Security_Detections_API_ThrottleForBulkActions:
       description: >-
         The condition for throttling the notification: 'rule', 'no_actions', or
         time duration
@@ -37864,29 +36682,29 @@ components:
         - 1d
         - 7d
       type: string
-    Security_Solution_Detections_API_TiebreakerField:
+    Security_Detections_API_TiebreakerField:
       description: Sets a secondary field for sorting events
       type: string
-    Security_Solution_Detections_API_TimelineTemplateId:
+    Security_Detections_API_TimelineTemplateId:
       description: Timeline template ID
       type: string
-    Security_Solution_Detections_API_TimelineTemplateTitle:
+    Security_Detections_API_TimelineTemplateTitle:
       description: Timeline template title
       type: string
-    Security_Solution_Detections_API_TimestampField:
+    Security_Detections_API_TimestampField:
       description: Contains the event timestamp used for sorting a sequence of events
       type: string
-    Security_Solution_Detections_API_TimestampOverride:
+    Security_Detections_API_TimestampOverride:
       description: Sets the time field used to query indices
       type: string
-    Security_Solution_Detections_API_TimestampOverrideFallbackDisabled:
+    Security_Detections_API_TimestampOverrideFallbackDisabled:
       description: Disables the fallback to the event's @timestamp field
       type: boolean
-    Security_Solution_Detections_API_UUID:
+    Security_Detections_API_UUID:
       description: A universally unique identifier
       format: uuid
       type: string
-    Security_Solution_Detections_API_WarningSchema:
+    Security_Detections_API_WarningSchema:
       type: object
       properties:
         actionPath:
@@ -37901,16 +36719,14 @@ components:
         - type
         - message
         - actionPath
-    Security_Solution_Endpoint_Exceptions_API_EndpointList:
+    Security_Endpoint_Exceptions_API_EndpointList:
       oneOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionList
+        - $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_ExceptionList'
         - additionalProperties: false
           type: object
-    Security_Solution_Endpoint_Exceptions_API_EndpointListItem:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItem
-    Security_Solution_Endpoint_Exceptions_API_ExceptionList:
+    Security_Endpoint_Exceptions_API_EndpointListItem:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItem'
+    Security_Endpoint_Exceptions_API_ExceptionList:
       type: object
       properties:
         _version:
@@ -37922,35 +36738,35 @@ components:
           type: string
         description:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListDescription
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListDescription
         id:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListId
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListId
         immutable:
           type: boolean
         list_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListHumanId
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListHumanId
         meta:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListMeta
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListMeta
         name:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListName
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListName
         namespace_type:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionNamespaceType
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionNamespaceType
         os_types:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListOsTypeArray
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListOsTypeArray
         tags:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListTags
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListTags
         tie_breaker_id:
           type: string
         type:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListType
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListType
         updated_at:
           format: date-time
           type: string
@@ -37958,7 +36774,7 @@ components:
           type: string
         version:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListVersion
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListVersion
       required:
         - id
         - list_id
@@ -37973,23 +36789,21 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListDescription:
+    Security_Endpoint_Exceptions_API_ExceptionListDescription:
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListHumanId:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+    Security_Endpoint_Exceptions_API_ExceptionListHumanId:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
       description: Human readable string identifier, e.g. `trusted-linux-processes`
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListId:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItem:
+    Security_Endpoint_Exceptions_API_ExceptionListId:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ExceptionListItem:
       type: object
       properties:
         _version:
           type: string
         comments:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemCommentArray
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemCommentArray
         created_at:
           format: date-time
           type: string
@@ -37997,42 +36811,42 @@ components:
           type: string
         description:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemDescription
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemDescription
         entries:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryArray
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryArray
         expire_time:
           format: date-time
           type: string
         id:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemId
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemId
         item_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemHumanId
         list_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListHumanId
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListHumanId
         meta:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemMeta
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemMeta
         name:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemName
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemName
         namespace_type:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionNamespaceType
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionNamespaceType
         os_types:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray
         tags:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemTags
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemTags
         tie_breaker_id:
           type: string
         type:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemType
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemType
         updated_at:
           format: date-time
           type: string
@@ -38053,69 +36867,64 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemComment:
+    Security_Endpoint_Exceptions_API_ExceptionListItemComment:
       type: object
       properties:
         comment:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         created_at:
           format: date-time
           type: string
         created_by:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         updated_at:
           format: date-time
           type: string
         updated_by:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
       required:
         - id
         - comment
         - created_at
         - created_by
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemCommentArray:
+    Security_Endpoint_Exceptions_API_ExceptionListItemCommentArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemComment
+          #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemComment
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemDescription:
+    Security_Endpoint_Exceptions_API_ExceptionListItemDescription:
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntry:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntry:
       anyOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatch
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatch
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryList
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryList
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryExists
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryExists
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryNested
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryNested
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatchWildcard
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatchWildcard
       discriminator:
         propertyName: type
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryArray:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntry
+          #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntry
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryExists:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryExists:
       type: object
       properties:
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - exists
@@ -38124,27 +36933,24 @@ components:
         - type
         - field
         - operator
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryList:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryList:
       type: object
       properties:
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         list:
           type: object
           properties:
             id:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ListId
+              $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_ListId'
             type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ListType
+              $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_ListType'
           required:
             - id
             - type
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - list
@@ -38154,36 +36960,33 @@ components:
         - field
         - list
         - operator
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatch:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatch:
       type: object
       properties:
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - match
           type: string
         value:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
       required:
         - type
         - field
         - value
         - operator
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny:
       type: object
       properties:
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - match_any
@@ -38191,7 +36994,7 @@ components:
         value:
           items:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+              #/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString
           minItems: 1
           type: array
       required:
@@ -38199,39 +37002,36 @@ components:
         - field
         - value
         - operator
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatchWildcard:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatchWildcard:
       type: object
       properties:
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - wildcard
           type: string
         value:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
       required:
         - type
         - field
         - value
         - operator
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryNested:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryNested:
       type: object
       properties:
         entries:
           items:
             $ref: >-
-              #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryNestedEntryItem
+              #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryNestedEntryItem
           minItems: 1
           type: array
         field:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+          $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
         type:
           enum:
             - nested
@@ -38240,66 +37040,62 @@ components:
         - type
         - field
         - entries
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryNestedEntryItem:
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryNestedEntryItem:
       oneOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatch
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatch
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryMatchAny
         - $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryExists
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemEntryOperator:
+            #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListItemEntryExists
+    Security_Endpoint_Exceptions_API_ExceptionListItemEntryOperator:
       enum:
         - excluded
         - included
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemHumanId:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemId:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemMeta:
+    Security_Endpoint_Exceptions_API_ExceptionListItemHumanId:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ExceptionListItemId:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ExceptionListItemMeta:
       additionalProperties: true
       type: object
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemName:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray:
+    Security_Endpoint_Exceptions_API_ExceptionListItemName:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ExceptionListItemOsTypeArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListOsType
+          #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListOsType
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemTags:
+    Security_Endpoint_Exceptions_API_ExceptionListItemTags:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
+        $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListItemType:
+    Security_Endpoint_Exceptions_API_ExceptionListItemType:
       enum:
         - simple
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListMeta:
+    Security_Endpoint_Exceptions_API_ExceptionListMeta:
       additionalProperties: true
       type: object
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListName:
+    Security_Endpoint_Exceptions_API_ExceptionListName:
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListOsType:
+    Security_Endpoint_Exceptions_API_ExceptionListOsType:
       enum:
         - linux
         - macos
         - windows
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListOsTypeArray:
+    Security_Endpoint_Exceptions_API_ExceptionListOsTypeArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Exceptions_API_ExceptionListOsType
+          #/components/schemas/Security_Endpoint_Exceptions_API_ExceptionListOsType
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListTags:
+    Security_Endpoint_Exceptions_API_ExceptionListTags:
       items:
         type: string
       type: array
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListType:
+    Security_Endpoint_Exceptions_API_ExceptionListType:
       enum:
         - detection
         - rule_default
@@ -38309,10 +37105,10 @@ components:
         - endpoint_host_isolation_exceptions
         - endpoint_blocklists
       type: string
-    Security_Solution_Endpoint_Exceptions_API_ExceptionListVersion:
+    Security_Endpoint_Exceptions_API_ExceptionListVersion:
       minimum: 1
       type: integer
-    Security_Solution_Endpoint_Exceptions_API_ExceptionNamespaceType:
+    Security_Endpoint_Exceptions_API_ExceptionNamespaceType:
       description: >
         Determines whether the exception container is available in all Kibana
         spaces or just the space
@@ -38327,13 +37123,11 @@ components:
         - agnostic
         - single
       type: string
-    Security_Solution_Endpoint_Exceptions_API_FindEndpointListItemsFilter:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ListId:
-      $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Exceptions_API_NonEmptyString
-    Security_Solution_Endpoint_Exceptions_API_ListType:
+    Security_Endpoint_Exceptions_API_FindEndpointListItemsFilter:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ListId:
+      $ref: '#/components/schemas/Security_Endpoint_Exceptions_API_NonEmptyString'
+    Security_Endpoint_Exceptions_API_ListType:
       enum:
         - binary
         - boolean
@@ -38359,12 +37153,12 @@ components:
         - short
         - text
       type: string
-    Security_Solution_Endpoint_Exceptions_API_NonEmptyString:
+    Security_Endpoint_Exceptions_API_NonEmptyString:
       description: A string that is not empty and does not contain only whitespace
       minLength: 1
       pattern: ^(?! *$).+$
       type: string
-    Security_Solution_Endpoint_Exceptions_API_PlatformErrorResponse:
+    Security_Endpoint_Exceptions_API_PlatformErrorResponse:
       type: object
       properties:
         error:
@@ -38377,7 +37171,7 @@ components:
         - statusCode
         - error
         - message
-    Security_Solution_Endpoint_Exceptions_API_SiemErrorResponse:
+    Security_Endpoint_Exceptions_API_SiemErrorResponse:
       type: object
       properties:
         message:
@@ -38387,21 +37181,18 @@ components:
       required:
         - status_code
         - message
-    Security_Solution_Endpoint_Management_API_ActionLogRequestQuery:
+    Security_Endpoint_Management_API_ActionLogRequestQuery:
       type: object
       properties:
         end_date:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_EndDate
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_EndDate'
         page:
-          $ref: '#/components/schemas/Security_Solution_Endpoint_Management_API_Page'
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_Page'
         page_size:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_PageSize
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_PageSize'
         start_date:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_StartDate
-    Security_Solution_Endpoint_Management_API_ActionStateSuccessResponse:
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_StartDate'
+    Security_Endpoint_Management_API_ActionStateSuccessResponse:
       type: object
       properties:
         body:
@@ -38416,7 +37207,7 @@ components:
             - data
       required:
         - body
-    Security_Solution_Endpoint_Management_API_ActionStatusSuccessResponse:
+    Security_Endpoint_Management_API_ActionStatusSuccessResponse:
       type: object
       properties:
         body:
@@ -38427,10 +37218,10 @@ components:
               properties:
                 agent_id:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_AgentId
+                    #/components/schemas/Security_Endpoint_Management_API_AgentId
                 pending_actions:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionsSchema
+                    #/components/schemas/Security_Endpoint_Management_API_PendingActionsSchema
               required:
                 - agent_id
                 - pending_actions
@@ -38438,10 +37229,10 @@ components:
             - data
       required:
         - body
-    Security_Solution_Endpoint_Management_API_AgentId:
+    Security_Endpoint_Management_API_AgentId:
       description: Agent ID
       type: string
-    Security_Solution_Endpoint_Management_API_AgentIds:
+    Security_Endpoint_Management_API_AgentIds:
       minLength: 1
       oneOf:
         - items:
@@ -38452,27 +37243,26 @@ components:
           type: array
         - minLength: 1
           type: string
-    Security_Solution_Endpoint_Management_API_AgentTypes:
+    Security_Endpoint_Management_API_AgentTypes:
       enum:
         - endpoint
         - sentinel_one
         - crowdstrike
       type: string
-    Security_Solution_Endpoint_Management_API_AlertIds:
+    Security_Endpoint_Management_API_AlertIds:
       description: A list of alerts ids.
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Endpoint_Management_API_NonEmptyString
+        $ref: '#/components/schemas/Security_Endpoint_Management_API_NonEmptyString'
       minItems: 1
       type: array
-    Security_Solution_Endpoint_Management_API_CaseIds:
+    Security_Endpoint_Management_API_CaseIds:
       description: Case IDs to be updated (cannot contain empty strings)
       items:
         minLength: 1
         type: string
       minItems: 1
       type: array
-    Security_Solution_Endpoint_Management_API_Command:
+    Security_Endpoint_Management_API_Command:
       description: The command to be executed (cannot be an empty string)
       enum:
         - isolate
@@ -38486,51 +37276,46 @@ components:
         - scan
       minLength: 1
       type: string
-    Security_Solution_Endpoint_Management_API_Commands:
+    Security_Endpoint_Management_API_Commands:
       items:
-        $ref: '#/components/schemas/Security_Solution_Endpoint_Management_API_Command'
+        $ref: '#/components/schemas/Security_Endpoint_Management_API_Command'
       type: array
-    Security_Solution_Endpoint_Management_API_Comment:
+    Security_Endpoint_Management_API_Comment:
       description: Optional comment
       type: string
-    Security_Solution_Endpoint_Management_API_EndDate:
+    Security_Endpoint_Management_API_EndDate:
       description: End date
       type: string
-    Security_Solution_Endpoint_Management_API_EndpointIds:
+    Security_Endpoint_Management_API_EndpointIds:
       description: List of endpoint IDs (cannot contain empty strings)
       items:
         minLength: 1
         type: string
       minItems: 1
       type: array
-    Security_Solution_Endpoint_Management_API_EntityId:
+    Security_Endpoint_Management_API_EntityId:
       type: object
       properties:
         entity_id:
           minLength: 1
           type: string
-    Security_Solution_Endpoint_Management_API_ExecuteRouteRequestBody:
+    Security_Endpoint_Management_API_ExecuteRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
@@ -38540,31 +37325,27 @@ components:
               properties:
                 command:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Command
+                    #/components/schemas/Security_Endpoint_Management_API_Command
                 timeout:
                   $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Timeout
+                    #/components/schemas/Security_Endpoint_Management_API_Timeout
               required:
                 - command
           required:
             - parameters
-    Security_Solution_Endpoint_Management_API_GetEndpointActionListRouteQuery:
+    Security_Endpoint_Management_API_GetEndpointActionListRouteQuery:
       type: object
       properties:
         agentIds:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_AgentIds
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentIds'
         agentTypes:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
         commands:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_Commands
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_Commands'
         endDate:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_EndDate
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_EndDate'
         page:
-          $ref: '#/components/schemas/Security_Solution_Endpoint_Management_API_Page'
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_Page'
         pageSize:
           default: 10
           description: Number of items per page
@@ -38572,38 +37353,30 @@ components:
           minimum: 1
           type: integer
         startDate:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_StartDate
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_StartDate'
         types:
-          $ref: '#/components/schemas/Security_Solution_Endpoint_Management_API_Types'
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_Types'
         userIds:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_UserIds
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_UserIds'
         withOutputs:
-          $ref: >-
-            #/components/schemas/Security_Solution_Endpoint_Management_API_WithOutputs
-    Security_Solution_Endpoint_Management_API_GetFileRouteRequestBody:
+          $ref: '#/components/schemas/Security_Endpoint_Management_API_WithOutputs'
+    Security_Endpoint_Management_API_GetFileRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
@@ -38617,44 +37390,38 @@ components:
                 - path
           required:
             - parameters
-    Security_Solution_Endpoint_Management_API_GetProcessesRouteRequestBody:
+    Security_Endpoint_Management_API_GetProcessesRouteRequestBody:
       $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Management_API_NoParametersRequestSchema
-    Security_Solution_Endpoint_Management_API_IsolateRouteRequestBody:
+        #/components/schemas/Security_Endpoint_Management_API_NoParametersRequestSchema
+    Security_Endpoint_Management_API_IsolateRouteRequestBody:
       $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Management_API_NoParametersRequestSchema
-    Security_Solution_Endpoint_Management_API_KillProcessRouteRequestBody:
+        #/components/schemas/Security_Endpoint_Management_API_NoParametersRequestSchema
+    Security_Endpoint_Management_API_KillProcessRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
           properties:
             parameters:
               oneOf:
+                - $ref: '#/components/schemas/Security_Endpoint_Management_API_Pid'
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Pid
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_EntityId
+                    #/components/schemas/Security_Endpoint_Management_API_EntityId
                 - type: object
                   properties:
                     process_name:
@@ -38663,7 +37430,7 @@ components:
                       type: string
           required:
             - parameters
-    Security_Solution_Endpoint_Management_API_ListRequestQuery:
+    Security_Endpoint_Management_API_ListRequestQuery:
       type: object
       properties:
         hostStatuses:
@@ -38710,121 +37477,111 @@ components:
           type: string
       required:
         - hostStatuses
-    Security_Solution_Endpoint_Management_API_NonEmptyString:
+    Security_Endpoint_Management_API_NonEmptyString:
       description: A string that is not empty and does not contain only whitespace
       minLength: 1
       pattern: ^(?! *$).+$
       type: string
-    Security_Solution_Endpoint_Management_API_NoParametersRequestSchema:
+    Security_Endpoint_Management_API_NoParametersRequestSchema:
       type: object
       properties:
         body:
           type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
       required:
         - body
-    Security_Solution_Endpoint_Management_API_Page:
+    Security_Endpoint_Management_API_Page:
       default: 1
       description: Page number
       minimum: 1
       type: integer
-    Security_Solution_Endpoint_Management_API_PageSize:
+    Security_Endpoint_Management_API_PageSize:
       default: 10
       description: Number of items per page
       maximum: 100
       minimum: 1
       type: integer
-    Security_Solution_Endpoint_Management_API_Parameters:
+    Security_Endpoint_Management_API_Parameters:
       description: Optional parameters object
       type: object
-    Security_Solution_Endpoint_Management_API_PendingActionDataType:
+    Security_Endpoint_Management_API_PendingActionDataType:
       type: integer
-    Security_Solution_Endpoint_Management_API_PendingActionsSchema:
+    Security_Endpoint_Management_API_PendingActionsSchema:
       oneOf:
         - type: object
           properties:
             execute:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             get-file:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             isolate:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             kill-process:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             running-processes:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             scan:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             suspend-process:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             unisolate:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
             upload:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_PendingActionDataType
+                #/components/schemas/Security_Endpoint_Management_API_PendingActionDataType
         - additionalProperties: true
           type: object
-    Security_Solution_Endpoint_Management_API_Pid:
+    Security_Endpoint_Management_API_Pid:
       type: object
       properties:
         pid:
           minimum: 1
           type: integer
-    Security_Solution_Endpoint_Management_API_ProtectionUpdatesNoteResponse:
+    Security_Endpoint_Management_API_ProtectionUpdatesNoteResponse:
       type: object
       properties:
         note:
           type: string
-    Security_Solution_Endpoint_Management_API_ScanRouteRequestBody:
+    Security_Endpoint_Management_API_ScanRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
@@ -38838,88 +37595,77 @@ components:
                 - path
           required:
             - parameters
-    Security_Solution_Endpoint_Management_API_StartDate:
+    Security_Endpoint_Management_API_StartDate:
       description: Start date
       type: string
-    Security_Solution_Endpoint_Management_API_SuccessResponse:
+    Security_Endpoint_Management_API_SuccessResponse:
       type: object
       properties: {}
-    Security_Solution_Endpoint_Management_API_SuspendProcessRouteRequestBody:
+    Security_Endpoint_Management_API_SuspendProcessRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
           properties:
             parameters:
               oneOf:
+                - $ref: '#/components/schemas/Security_Endpoint_Management_API_Pid'
                 - $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_Pid
-                - $ref: >-
-                    #/components/schemas/Security_Solution_Endpoint_Management_API_EntityId
+                    #/components/schemas/Security_Endpoint_Management_API_EntityId
           required:
             - parameters
-    Security_Solution_Endpoint_Management_API_Timeout:
+    Security_Endpoint_Management_API_Timeout:
       description: The maximum timeout value in milliseconds (optional)
       minimum: 1
       type: integer
-    Security_Solution_Endpoint_Management_API_Type:
+    Security_Endpoint_Management_API_Type:
       description: Type of response action
       enum:
         - automated
         - manual
       type: string
-    Security_Solution_Endpoint_Management_API_Types:
+    Security_Endpoint_Management_API_Types:
       description: List of types of response actions
       items:
-        $ref: '#/components/schemas/Security_Solution_Endpoint_Management_API_Type'
+        $ref: '#/components/schemas/Security_Endpoint_Management_API_Type'
       maxLength: 2
       minLength: 1
       type: array
-    Security_Solution_Endpoint_Management_API_UnisolateRouteRequestBody:
+    Security_Endpoint_Management_API_UnisolateRouteRequestBody:
       $ref: >-
-        #/components/schemas/Security_Solution_Endpoint_Management_API_NoParametersRequestSchema
-    Security_Solution_Endpoint_Management_API_UploadRouteRequestBody:
+        #/components/schemas/Security_Endpoint_Management_API_NoParametersRequestSchema
+    Security_Endpoint_Management_API_UploadRouteRequestBody:
       allOf:
         - type: object
           properties:
             agent_type:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AgentTypes
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AgentTypes'
             alert_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_AlertIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_AlertIds'
             case_ids:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_CaseIds
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_CaseIds'
             comment:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Comment
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Comment'
             endpoint_ids:
               $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_EndpointIds
+                #/components/schemas/Security_Endpoint_Management_API_EndpointIds
             parameters:
-              $ref: >-
-                #/components/schemas/Security_Solution_Endpoint_Management_API_Parameters
+              $ref: '#/components/schemas/Security_Endpoint_Management_API_Parameters'
           required:
             - endpoint_ids
         - type: object
@@ -38936,7 +37682,7 @@ components:
           required:
             - parameters
             - file
-    Security_Solution_Endpoint_Management_API_UserIds:
+    Security_Endpoint_Management_API_UserIds:
       description: User IDs
       oneOf:
         - items:
@@ -38946,7 +37692,7 @@ components:
           type: array
         - minLength: 1
           type: string
-    Security_Solution_Endpoint_Management_API_WithOutputs:
+    Security_Endpoint_Management_API_WithOutputs:
       description: Shows detailed outputs for an action response
       oneOf:
         - items:
@@ -38956,7 +37702,7 @@ components:
           type: array
         - minLength: 1
           type: string
-    Security_Solution_Entity_Analytics_API_AssetCriticalityBulkUploadErrorItem:
+    Security_Entity_Analytics_API_AssetCriticalityBulkUploadErrorItem:
       type: object
       properties:
         index:
@@ -38966,7 +37712,7 @@ components:
       required:
         - message
         - index
-    Security_Solution_Entity_Analytics_API_AssetCriticalityBulkUploadStats:
+    Security_Entity_Analytics_API_AssetCriticalityBulkUploadStats:
       type: object
       properties:
         failed:
@@ -38979,7 +37725,7 @@ components:
         - successful
         - failed
         - total
-    Security_Solution_Entity_Analytics_API_AssetCriticalityLevel:
+    Security_Entity_Analytics_API_AssetCriticalityLevel:
       description: The criticality level of the asset.
       enum:
         - low_impact
@@ -38987,10 +37733,10 @@ components:
         - high_impact
         - extreme_impact
       type: string
-    Security_Solution_Entity_Analytics_API_AssetCriticalityRecord:
+    Security_Entity_Analytics_API_AssetCriticalityRecord:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_CreateAssetCriticalityRecord
+            #/components/schemas/Security_Entity_Analytics_API_CreateAssetCriticalityRecord
         - type: object
           properties:
             '@timestamp':
@@ -39000,11 +37746,11 @@ components:
               type: string
           required:
             - '@timestamp'
-    Security_Solution_Entity_Analytics_API_AssetCriticalityRecordIdParts:
+    Security_Entity_Analytics_API_AssetCriticalityRecordIdParts:
       type: object
       properties:
         id_field:
-          $ref: '#/components/schemas/Security_Solution_Entity_Analytics_API_IdField'
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_IdField'
           description: The field representing the ID.
           example: host.name
         id_value:
@@ -39013,49 +37759,44 @@ components:
       required:
         - id_value
         - id_field
-    Security_Solution_Entity_Analytics_API_CreateAssetCriticalityRecord:
+    Security_Entity_Analytics_API_CreateAssetCriticalityRecord:
       allOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityRecordIdParts
+            #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityRecordIdParts
         - type: object
           properties:
             criticality_level:
               $ref: >-
-                #/components/schemas/Security_Solution_Entity_Analytics_API_AssetCriticalityLevel
+                #/components/schemas/Security_Entity_Analytics_API_AssetCriticalityLevel
           required:
             - criticality_level
-    Security_Solution_Entity_Analytics_API_EngineDescriptor:
+    Security_Entity_Analytics_API_EngineDescriptor:
       type: object
       properties:
         filter:
           type: string
         indexPattern:
-          $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_IndexPattern
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_IndexPattern'
         status:
-          $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_EngineStatus
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_EngineStatus'
         type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_EntityType
-    Security_Solution_Entity_Analytics_API_EngineStatus:
+          $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
+    Security_Entity_Analytics_API_EngineStatus:
       enum:
         - installing
         - started
         - stopped
       type: string
-    Security_Solution_Entity_Analytics_API_Entity:
+    Security_Entity_Analytics_API_Entity:
       oneOf:
-        - $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_UserEntity
-        - $ref: >-
-            #/components/schemas/Security_Solution_Entity_Analytics_API_HostEntity
-    Security_Solution_Entity_Analytics_API_EntityType:
+        - $ref: '#/components/schemas/Security_Entity_Analytics_API_UserEntity'
+        - $ref: '#/components/schemas/Security_Entity_Analytics_API_HostEntity'
+    Security_Entity_Analytics_API_EntityType:
       enum:
         - user
         - host
       type: string
-    Security_Solution_Entity_Analytics_API_HostEntity:
+    Security_Entity_Analytics_API_HostEntity:
       type: object
       properties:
         entity:
@@ -39130,14 +37871,14 @@ components:
               type: array
           required:
             - name
-    Security_Solution_Entity_Analytics_API_IdField:
+    Security_Entity_Analytics_API_IdField:
       enum:
         - host.name
         - user.name
       type: string
-    Security_Solution_Entity_Analytics_API_IndexPattern:
+    Security_Entity_Analytics_API_IndexPattern:
       type: string
-    Security_Solution_Entity_Analytics_API_InspectQuery:
+    Security_Entity_Analytics_API_InspectQuery:
       type: object
       properties:
         dsl:
@@ -39151,7 +37892,7 @@ components:
       required:
         - dsl
         - response
-    Security_Solution_Entity_Analytics_API_RiskEngineScheduleNowErrorResponse:
+    Security_Entity_Analytics_API_RiskEngineScheduleNowErrorResponse:
       type: object
       properties:
         full_error:
@@ -39161,12 +37902,12 @@ components:
       required:
         - message
         - full_error
-    Security_Solution_Entity_Analytics_API_RiskEngineScheduleNowResponse:
+    Security_Entity_Analytics_API_RiskEngineScheduleNowResponse:
       type: object
       properties:
         success:
           type: boolean
-    Security_Solution_Entity_Analytics_API_TaskManagerUnavailableResponse:
+    Security_Entity_Analytics_API_TaskManagerUnavailableResponse:
       description: Task manager is unavailable
       type: object
       properties:
@@ -39178,7 +37919,7 @@ components:
       required:
         - status_code
         - message
-    Security_Solution_Entity_Analytics_API_UserEntity:
+    Security_Entity_Analytics_API_UserEntity:
       type: object
       properties:
         entity:
@@ -39249,76 +37990,71 @@ components:
               type: array
           required:
             - name
-    Security_Solution_Exceptions_API_CreateExceptionListItemComment:
+    Security_Exceptions_API_CreateExceptionListItemComment:
       type: object
       properties:
         comment:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - comment
-    Security_Solution_Exceptions_API_CreateExceptionListItemCommentArray:
+    Security_Exceptions_API_CreateExceptionListItemCommentArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_CreateExceptionListItemComment
+          #/components/schemas/Security_Exceptions_API_CreateExceptionListItemComment
       type: array
-    Security_Solution_Exceptions_API_CreateRuleExceptionListItemComment:
+    Security_Exceptions_API_CreateRuleExceptionListItemComment:
       type: object
       properties:
         comment:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - comment
-    Security_Solution_Exceptions_API_CreateRuleExceptionListItemCommentArray:
+    Security_Exceptions_API_CreateRuleExceptionListItemCommentArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_CreateRuleExceptionListItemComment
+          #/components/schemas/Security_Exceptions_API_CreateRuleExceptionListItemComment
       type: array
-    Security_Solution_Exceptions_API_CreateRuleExceptionListItemProps:
+    Security_Exceptions_API_CreateRuleExceptionListItemProps:
       type: object
       properties:
         comments:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_CreateRuleExceptionListItemCommentArray
+            #/components/schemas/Security_Exceptions_API_CreateRuleExceptionListItemCommentArray
           default: []
         description:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemDescription
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemDescription
         entries:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryArray
         expire_time:
           format: date-time
           type: string
         item_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
         meta:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemMeta
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemMeta'
         name:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemName
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemName'
         namespace_type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionNamespaceType'
           default: single
         os_types:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemOsTypeArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemOsTypeArray
           default: []
         tags:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemTags
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemTags'
           default: []
         type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemType'
       required:
         - type
         - name
         - description
         - entries
-    Security_Solution_Exceptions_API_ExceptionList:
+    Security_Exceptions_API_ExceptionList:
       type: object
       properties:
         _version:
@@ -39330,43 +38066,35 @@ components:
           type: string
         description:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListDescription
+            #/components/schemas/Security_Exceptions_API_ExceptionListDescription
         id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         immutable:
           type: boolean
         list_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         meta:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListMeta
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListMeta'
         name:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListName
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListName'
         namespace_type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionNamespaceType'
         os_types:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListOsTypeArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListOsTypeArray
         tags:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListTags
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListTags'
         tie_breaker_id:
           type: string
         type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListType'
         updated_at:
           format: date-time
           type: string
         updated_by:
           type: string
         version:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListVersion
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListVersion'
       required:
         - id
         - list_id
@@ -39381,21 +38109,21 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Exceptions_API_ExceptionListDescription:
+    Security_Exceptions_API_ExceptionListDescription:
       type: string
-    Security_Solution_Exceptions_API_ExceptionListHumanId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ExceptionListHumanId:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       description: Human readable string identifier, e.g. `trusted-linux-processes`
-    Security_Solution_Exceptions_API_ExceptionListId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_ExceptionListItem:
+    Security_Exceptions_API_ExceptionListId:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ExceptionListItem:
       type: object
       properties:
         _version:
           type: string
         comments:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemCommentArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemCommentArray
         created_at:
           format: date-time
           type: string
@@ -39403,42 +38131,35 @@ components:
           type: string
         description:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemDescription
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemDescription
         entries:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryArray
         expire_time:
           format: date-time
           type: string
         id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemId'
         item_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
         list_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
         meta:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemMeta
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemMeta'
         name:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemName
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemName'
         namespace_type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionNamespaceType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionNamespaceType'
         os_types:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemOsTypeArray
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemOsTypeArray
         tags:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemTags
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemTags'
         tie_breaker_id:
           type: string
         type:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemType
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemType'
         updated_at:
           format: date-time
           type: string
@@ -39459,64 +38180,62 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Exceptions_API_ExceptionListItemComment:
+    Security_Exceptions_API_ExceptionListItemComment:
       type: object
       properties:
         comment:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         created_at:
           format: date-time
           type: string
         created_by:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         id:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         updated_at:
           format: date-time
           type: string
         updated_by:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - id
         - comment
         - created_at
         - created_by
-    Security_Solution_Exceptions_API_ExceptionListItemCommentArray:
+    Security_Exceptions_API_ExceptionListItemCommentArray:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemComment
+        $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemComment'
       type: array
-    Security_Solution_Exceptions_API_ExceptionListItemDescription:
+    Security_Exceptions_API_ExceptionListItemDescription:
       type: string
-    Security_Solution_Exceptions_API_ExceptionListItemEntry:
+    Security_Exceptions_API_ExceptionListItemEntry:
       anyOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryMatch
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryMatch
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryMatchAny
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryMatchAny
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryList
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryList
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryExists
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryExists
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryNested
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryNested
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryMatchWildcard
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryMatchWildcard
       discriminator:
         propertyName: type
-    Security_Solution_Exceptions_API_ExceptionListItemEntryArray:
+    Security_Exceptions_API_ExceptionListItemEntryArray:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntry
+        $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListItemEntry'
       type: array
-    Security_Solution_Exceptions_API_ExceptionListItemEntryExists:
+    Security_Exceptions_API_ExceptionListItemEntryExists:
       type: object
       properties:
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - exists
@@ -39525,24 +38244,24 @@ components:
         - type
         - field
         - operator
-    Security_Solution_Exceptions_API_ExceptionListItemEntryList:
+    Security_Exceptions_API_ExceptionListItemEntryList:
       type: object
       properties:
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         list:
           type: object
           properties:
             id:
-              $ref: '#/components/schemas/Security_Solution_Exceptions_API_ListId'
+              $ref: '#/components/schemas/Security_Exceptions_API_ListId'
             type:
-              $ref: '#/components/schemas/Security_Solution_Exceptions_API_ListType'
+              $ref: '#/components/schemas/Security_Exceptions_API_ListType'
           required:
             - id
             - type
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - list
@@ -39552,41 +38271,40 @@ components:
         - field
         - list
         - operator
-    Security_Solution_Exceptions_API_ExceptionListItemEntryMatch:
+    Security_Exceptions_API_ExceptionListItemEntryMatch:
       type: object
       properties:
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - match
           type: string
         value:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - type
         - field
         - value
         - operator
-    Security_Solution_Exceptions_API_ExceptionListItemEntryMatchAny:
+    Security_Exceptions_API_ExceptionListItemEntryMatchAny:
       type: object
       properties:
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - match_any
           type: string
         value:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_NonEmptyString
+            $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
           minItems: 1
           type: array
       required:
@@ -39594,36 +38312,36 @@ components:
         - field
         - value
         - operator
-    Security_Solution_Exceptions_API_ExceptionListItemEntryMatchWildcard:
+    Security_Exceptions_API_ExceptionListItemEntryMatchWildcard:
       type: object
       properties:
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         operator:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryOperator
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryOperator
         type:
           enum:
             - wildcard
           type: string
         value:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - type
         - field
         - value
         - operator
-    Security_Solution_Exceptions_API_ExceptionListItemEntryNested:
+    Security_Exceptions_API_ExceptionListItemEntryNested:
       type: object
       properties:
         entries:
           items:
             $ref: >-
-              #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryNestedEntryItem
+              #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryNestedEntryItem
           minItems: 1
           type: array
         field:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         type:
           enum:
             - nested
@@ -39632,58 +38350,56 @@ components:
         - type
         - field
         - entries
-    Security_Solution_Exceptions_API_ExceptionListItemEntryNestedEntryItem:
+    Security_Exceptions_API_ExceptionListItemEntryNestedEntryItem:
       oneOf:
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryMatch
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryMatch
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryMatchAny
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryMatchAny
         - $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemEntryExists
-    Security_Solution_Exceptions_API_ExceptionListItemEntryOperator:
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemEntryExists
+    Security_Exceptions_API_ExceptionListItemEntryOperator:
       enum:
         - excluded
         - included
       type: string
-    Security_Solution_Exceptions_API_ExceptionListItemHumanId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_ExceptionListItemId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_ExceptionListItemMeta:
+    Security_Exceptions_API_ExceptionListItemHumanId:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ExceptionListItemId:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ExceptionListItemMeta:
       additionalProperties: true
       type: object
-    Security_Solution_Exceptions_API_ExceptionListItemName:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_ExceptionListItemOsTypeArray:
+    Security_Exceptions_API_ExceptionListItemName:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ExceptionListItemOsTypeArray:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_ExceptionListOsType
+        $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListOsType'
       type: array
-    Security_Solution_Exceptions_API_ExceptionListItemTags:
+    Security_Exceptions_API_ExceptionListItemTags:
       items:
-        $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+        $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       type: array
-    Security_Solution_Exceptions_API_ExceptionListItemType:
+    Security_Exceptions_API_ExceptionListItemType:
       enum:
         - simple
       type: string
-    Security_Solution_Exceptions_API_ExceptionListMeta:
+    Security_Exceptions_API_ExceptionListMeta:
       additionalProperties: true
       type: object
-    Security_Solution_Exceptions_API_ExceptionListName:
+    Security_Exceptions_API_ExceptionListName:
       type: string
-    Security_Solution_Exceptions_API_ExceptionListOsType:
+    Security_Exceptions_API_ExceptionListOsType:
       enum:
         - linux
         - macos
         - windows
       type: string
-    Security_Solution_Exceptions_API_ExceptionListOsTypeArray:
+    Security_Exceptions_API_ExceptionListOsTypeArray:
       items:
-        $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_ExceptionListOsType
+        $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListOsType'
       type: array
-    Security_Solution_Exceptions_API_ExceptionListsImportBulkError:
+    Security_Exceptions_API_ExceptionListsImportBulkError:
       type: object
       properties:
         error:
@@ -39697,26 +38413,24 @@ components:
             - status_code
             - message
         id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListId'
         item_id:
           $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListItemHumanId
+            #/components/schemas/Security_Exceptions_API_ExceptionListItemHumanId
         list_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Exceptions_API_ExceptionListHumanId
+          $ref: '#/components/schemas/Security_Exceptions_API_ExceptionListHumanId'
       required:
         - error
-    Security_Solution_Exceptions_API_ExceptionListsImportBulkErrorArray:
+    Security_Exceptions_API_ExceptionListsImportBulkErrorArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_ExceptionListsImportBulkError
+          #/components/schemas/Security_Exceptions_API_ExceptionListsImportBulkError
       type: array
-    Security_Solution_Exceptions_API_ExceptionListTags:
+    Security_Exceptions_API_ExceptionListTags:
       items:
         type: string
       type: array
-    Security_Solution_Exceptions_API_ExceptionListType:
+    Security_Exceptions_API_ExceptionListType:
       enum:
         - detection
         - rule_default
@@ -39726,10 +38440,10 @@ components:
         - endpoint_host_isolation_exceptions
         - endpoint_blocklists
       type: string
-    Security_Solution_Exceptions_API_ExceptionListVersion:
+    Security_Exceptions_API_ExceptionListVersion:
       minimum: 1
       type: integer
-    Security_Solution_Exceptions_API_ExceptionNamespaceType:
+    Security_Exceptions_API_ExceptionNamespaceType:
       description: >
         Determines whether the exception container is available in all Kibana
         spaces or just the space
@@ -39744,13 +38458,13 @@ components:
         - agnostic
         - single
       type: string
-    Security_Solution_Exceptions_API_FindExceptionListItemsFilter:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_FindExceptionListsFilter:
+    Security_Exceptions_API_FindExceptionListItemsFilter:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_FindExceptionListsFilter:
       type: string
-    Security_Solution_Exceptions_API_ListId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
-    Security_Solution_Exceptions_API_ListType:
+    Security_Exceptions_API_ListId:
+      $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
+    Security_Exceptions_API_ListType:
       enum:
         - binary
         - boolean
@@ -39776,12 +38490,12 @@ components:
         - short
         - text
       type: string
-    Security_Solution_Exceptions_API_NonEmptyString:
+    Security_Exceptions_API_NonEmptyString:
       description: A string that is not empty and does not contain only whitespace
       minLength: 1
       pattern: ^(?! *$).+$
       type: string
-    Security_Solution_Exceptions_API_PlatformErrorResponse:
+    Security_Exceptions_API_PlatformErrorResponse:
       type: object
       properties:
         error:
@@ -39794,9 +38508,9 @@ components:
         - statusCode
         - error
         - message
-    Security_Solution_Exceptions_API_RuleId:
-      $ref: '#/components/schemas/Security_Solution_Exceptions_API_UUID'
-    Security_Solution_Exceptions_API_SiemErrorResponse:
+    Security_Exceptions_API_RuleId:
+      $ref: '#/components/schemas/Security_Exceptions_API_UUID'
+    Security_Exceptions_API_SiemErrorResponse:
       type: object
       properties:
         message:
@@ -39806,33 +38520,33 @@ components:
       required:
         - status_code
         - message
-    Security_Solution_Exceptions_API_UpdateExceptionListItemComment:
+    Security_Exceptions_API_UpdateExceptionListItemComment:
       type: object
       properties:
         comment:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
         id:
-          $ref: '#/components/schemas/Security_Solution_Exceptions_API_NonEmptyString'
+          $ref: '#/components/schemas/Security_Exceptions_API_NonEmptyString'
       required:
         - comment
-    Security_Solution_Exceptions_API_UpdateExceptionListItemCommentArray:
+    Security_Exceptions_API_UpdateExceptionListItemCommentArray:
       items:
         $ref: >-
-          #/components/schemas/Security_Solution_Exceptions_API_UpdateExceptionListItemComment
+          #/components/schemas/Security_Exceptions_API_UpdateExceptionListItemComment
       type: array
-    Security_Solution_Exceptions_API_UUID:
+    Security_Exceptions_API_UUID:
       description: A universally unique identifier
       format: uuid
       type: string
-    Security_Solution_Lists_API_FindListItemsCursor:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_FindListItemsFilter:
+    Security_Lists_API_FindListItemsCursor:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_FindListItemsFilter:
       type: string
-    Security_Solution_Lists_API_FindListsCursor:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_FindListsFilter:
+    Security_Lists_API_FindListsCursor:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_FindListsFilter:
       type: string
-    Security_Solution_Lists_API_List:
+    Security_Lists_API_List:
       type: object
       properties:
         _version:
@@ -39846,23 +38560,23 @@ components:
         created_by:
           type: string
         description:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListDescription'
+          $ref: '#/components/schemas/Security_Lists_API_ListDescription'
         deserializer:
           type: string
         id:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+          $ref: '#/components/schemas/Security_Lists_API_ListId'
         immutable:
           type: boolean
         meta:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListMetadata'
+          $ref: '#/components/schemas/Security_Lists_API_ListMetadata'
         name:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListName'
+          $ref: '#/components/schemas/Security_Lists_API_ListName'
         serializer:
           type: string
         tie_breaker_id:
           type: string
         type:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListType'
+          $ref: '#/components/schemas/Security_Lists_API_ListType'
         updated_at:
           format: date-time
           type: string
@@ -39883,11 +38597,11 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Lists_API_ListDescription:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_ListId:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_ListItem:
+    Security_Lists_API_ListDescription:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_ListId:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_ListItem:
       type: object
       properties:
         _version:
@@ -39903,24 +38617,24 @@ components:
         deserializer:
           type: string
         id:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemId'
+          $ref: '#/components/schemas/Security_Lists_API_ListItemId'
         list_id:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListId'
+          $ref: '#/components/schemas/Security_Lists_API_ListId'
         meta:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemMetadata'
+          $ref: '#/components/schemas/Security_Lists_API_ListItemMetadata'
         serializer:
           type: string
         tie_breaker_id:
           type: string
         type:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListType'
+          $ref: '#/components/schemas/Security_Lists_API_ListType'
         updated_at:
           format: date-time
           type: string
         updated_by:
           type: string
         value:
-          $ref: '#/components/schemas/Security_Solution_Lists_API_ListItemValue'
+          $ref: '#/components/schemas/Security_Lists_API_ListItemValue'
       required:
         - id
         - type
@@ -39931,12 +38645,12 @@ components:
         - created_by
         - updated_at
         - updated_by
-    Security_Solution_Lists_API_ListItemId:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_ListItemMetadata:
+    Security_Lists_API_ListItemId:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_ListItemMetadata:
       additionalProperties: true
       type: object
-    Security_Solution_Lists_API_ListItemPrivileges:
+    Security_Lists_API_ListItemPrivileges:
       type: object
       properties:
         application:
@@ -39963,14 +38677,14 @@ components:
         - cluster
         - index
         - application
-    Security_Solution_Lists_API_ListItemValue:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_ListMetadata:
+    Security_Lists_API_ListItemValue:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_ListMetadata:
       additionalProperties: true
       type: object
-    Security_Solution_Lists_API_ListName:
-      $ref: '#/components/schemas/Security_Solution_Lists_API_NonEmptyString'
-    Security_Solution_Lists_API_ListPrivileges:
+    Security_Lists_API_ListName:
+      $ref: '#/components/schemas/Security_Lists_API_NonEmptyString'
+    Security_Lists_API_ListPrivileges:
       type: object
       properties:
         application:
@@ -39997,7 +38711,7 @@ components:
         - cluster
         - index
         - application
-    Security_Solution_Lists_API_ListType:
+    Security_Lists_API_ListType:
       enum:
         - binary
         - boolean
@@ -40023,12 +38737,12 @@ components:
         - short
         - text
       type: string
-    Security_Solution_Lists_API_NonEmptyString:
+    Security_Lists_API_NonEmptyString:
       description: A string that is not empty and does not contain only whitespace
       minLength: 1
       pattern: ^(?! *$).+$
       type: string
-    Security_Solution_Lists_API_PlatformErrorResponse:
+    Security_Lists_API_PlatformErrorResponse:
       type: object
       properties:
         error:
@@ -40041,7 +38755,7 @@ components:
         - statusCode
         - error
         - message
-    Security_Solution_Lists_API_SiemErrorResponse:
+    Security_Lists_API_SiemErrorResponse:
       type: object
       properties:
         message:
@@ -40051,33 +38765,28 @@ components:
       required:
         - status_code
         - message
-    Security_Solution_Osquery_API_ArrayQueries:
+    Security_Osquery_API_ArrayQueries:
       items:
-        $ref: '#/components/schemas/Security_Solution_Osquery_API_ArrayQueriesItem'
+        $ref: '#/components/schemas/Security_Osquery_API_ArrayQueriesItem'
       type: array
-    Security_Solution_Osquery_API_ArrayQueriesItem:
+    Security_Osquery_API_ArrayQueriesItem:
       type: object
       properties:
         ecs_mapping:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_ECSMappingOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_ECSMappingOrUndefined'
         id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Id'
+          $ref: '#/components/schemas/Security_Osquery_API_Id'
         platform:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PlatformOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PlatformOrUndefined'
         query:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Query'
+          $ref: '#/components/schemas/Security_Osquery_API_Query'
         removed:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_RemovedOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_RemovedOrUndefined'
         snapshot:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SnapshotOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_SnapshotOrUndefined'
         version:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_VersionOrUndefined
-    Security_Solution_Osquery_API_CreateLiveQueryRequestBody:
+          $ref: '#/components/schemas/Security_Osquery_API_VersionOrUndefined'
+    Security_Osquery_API_CreateLiveQueryRequestBody:
       type: object
       properties:
         agent_all:
@@ -40103,8 +38812,7 @@ components:
             type: string
           type: array
         ecs_mapping:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_ECSMappingOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_ECSMappingOrUndefined'
         event_ids:
           items:
             type: string
@@ -40113,72 +38821,62 @@ components:
           nullable: true
           type: object
         pack_id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PackIdOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_PackIdOrUndefined'
         queries:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_ArrayQueries'
+          $ref: '#/components/schemas/Security_Osquery_API_ArrayQueries'
         query:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_QueryOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_QueryOrUndefined'
         saved_query_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SavedQueryIdOrUndefined
-    Security_Solution_Osquery_API_CreatePacksRequestBody:
+          $ref: '#/components/schemas/Security_Osquery_API_SavedQueryIdOrUndefined'
+    Security_Osquery_API_CreatePacksRequestBody:
       type: object
       properties:
         description:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         enabled:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_EnabledOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_EnabledOrUndefined'
         name:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PackName'
+          $ref: '#/components/schemas/Security_Osquery_API_PackName'
         policy_ids:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PolicyIdsOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PolicyIdsOrUndefined'
         queries:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_ObjectQueries'
+          $ref: '#/components/schemas/Security_Osquery_API_ObjectQueries'
         shards:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Shards'
-    Security_Solution_Osquery_API_CreateSavedQueryRequestBody:
+          $ref: '#/components/schemas/Security_Osquery_API_Shards'
+    Security_Osquery_API_CreateSavedQueryRequestBody:
       type: object
       properties:
         description:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         ecs_mapping:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_ECSMappingOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_ECSMappingOrUndefined'
         id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+          $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
         interval:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Interval'
+          $ref: '#/components/schemas/Security_Osquery_API_Interval'
         platform:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         query:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_QueryOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_QueryOrUndefined'
         removed:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_RemovedOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_RemovedOrUndefined'
         snapshot:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SnapshotOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_SnapshotOrUndefined'
         version:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_VersionOrUndefined
-    Security_Solution_Osquery_API_DefaultSuccessResponse:
+          $ref: '#/components/schemas/Security_Osquery_API_VersionOrUndefined'
+    Security_Osquery_API_DefaultSuccessResponse:
       type: object
       properties: {}
-    Security_Solution_Osquery_API_Description:
+    Security_Osquery_API_Description:
       type: string
-    Security_Solution_Osquery_API_DescriptionOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Description'
+    Security_Osquery_API_DescriptionOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Description'
       nullable: true
-    Security_Solution_Osquery_API_ECSMapping:
+    Security_Osquery_API_ECSMapping:
       additionalProperties:
-        $ref: '#/components/schemas/Security_Solution_Osquery_API_ECSMappingItem'
+        $ref: '#/components/schemas/Security_Osquery_API_ECSMappingItem'
       type: object
-    Security_Solution_Osquery_API_ECSMappingItem:
+    Security_Osquery_API_ECSMappingItem:
       type: object
       properties:
         field:
@@ -40189,220 +38887,196 @@ components:
             - items:
                 type: string
               type: array
-    Security_Solution_Osquery_API_ECSMappingOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_ECSMapping'
+    Security_Osquery_API_ECSMappingOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_ECSMapping'
       nullable: true
-    Security_Solution_Osquery_API_Enabled:
+    Security_Osquery_API_Enabled:
       type: boolean
-    Security_Solution_Osquery_API_EnabledOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Enabled'
+    Security_Osquery_API_EnabledOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Enabled'
       nullable: true
-    Security_Solution_Osquery_API_FindLiveQueryRequestQuery:
+    Security_Osquery_API_FindLiveQueryRequestQuery:
       type: object
       properties:
         kuery:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_KueryOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_KueryOrUndefined'
         page:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PageOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_PageOrUndefined'
         pageSize:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PageSizeOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PageSizeOrUndefined'
         sort:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SortOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrUndefined'
         sortOrder:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SortOrderOrUndefined
-    Security_Solution_Osquery_API_FindPacksRequestQuery:
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrderOrUndefined'
+    Security_Osquery_API_FindPacksRequestQuery:
       type: object
       properties:
         page:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PageOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_PageOrUndefined'
         pageSize:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PageSizeOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PageSizeOrUndefined'
         sort:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SortOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrUndefined'
         sortOrder:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SortOrderOrUndefined
-    Security_Solution_Osquery_API_FindSavedQueryRequestQuery:
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrderOrUndefined'
+    Security_Osquery_API_FindSavedQueryRequestQuery:
       type: object
       properties:
         page:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PageOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_PageOrUndefined'
         pageSize:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PageSizeOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PageSizeOrUndefined'
         sort:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SortOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrUndefined'
         sortOrder:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SortOrderOrUndefined
-    Security_Solution_Osquery_API_GetLiveQueryResultsRequestQuery:
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrderOrUndefined'
+    Security_Osquery_API_GetLiveQueryResultsRequestQuery:
       type: object
       properties:
         kuery:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_KueryOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_KueryOrUndefined'
         page:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PageOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_PageOrUndefined'
         pageSize:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PageSizeOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PageSizeOrUndefined'
         sort:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SortOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrUndefined'
         sortOrder:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SortOrderOrUndefined
-    Security_Solution_Osquery_API_Id:
+          $ref: '#/components/schemas/Security_Osquery_API_SortOrderOrUndefined'
+    Security_Osquery_API_Id:
       type: string
-    Security_Solution_Osquery_API_Interval:
+    Security_Osquery_API_Interval:
       type: string
-    Security_Solution_Osquery_API_IntervalOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Interval'
+    Security_Osquery_API_IntervalOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Interval'
       nullable: true
-    Security_Solution_Osquery_API_KueryOrUndefined:
+    Security_Osquery_API_KueryOrUndefined:
       nullable: true
       type: string
-    Security_Solution_Osquery_API_ObjectQueries:
+    Security_Osquery_API_ObjectQueries:
       additionalProperties:
-        $ref: '#/components/schemas/Security_Solution_Osquery_API_ObjectQueriesItem'
+        $ref: '#/components/schemas/Security_Osquery_API_ObjectQueriesItem'
       type: object
-    Security_Solution_Osquery_API_ObjectQueriesItem:
+    Security_Osquery_API_ObjectQueriesItem:
       type: object
       properties:
         ecs_mapping:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_ECSMappingOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_ECSMappingOrUndefined'
         id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Id'
+          $ref: '#/components/schemas/Security_Osquery_API_Id'
         platform:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PlatformOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PlatformOrUndefined'
         query:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Query'
+          $ref: '#/components/schemas/Security_Osquery_API_Query'
         removed:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_RemovedOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_RemovedOrUndefined'
         saved_query_id:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SavedQueryIdOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_SavedQueryIdOrUndefined'
         snapshot:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SnapshotOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_SnapshotOrUndefined'
         version:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_VersionOrUndefined
-    Security_Solution_Osquery_API_PackId:
+          $ref: '#/components/schemas/Security_Osquery_API_VersionOrUndefined'
+    Security_Osquery_API_PackId:
       type: string
-    Security_Solution_Osquery_API_PackIdOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_PackId'
+    Security_Osquery_API_PackIdOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_PackId'
       nullable: true
-    Security_Solution_Osquery_API_PackName:
+    Security_Osquery_API_PackName:
       type: string
-    Security_Solution_Osquery_API_PageOrUndefined:
+    Security_Osquery_API_PageOrUndefined:
       nullable: true
       type: integer
-    Security_Solution_Osquery_API_PageSizeOrUndefined:
+    Security_Osquery_API_PageSizeOrUndefined:
       nullable: true
       type: integer
-    Security_Solution_Osquery_API_Platform:
+    Security_Osquery_API_Platform:
       type: string
-    Security_Solution_Osquery_API_PlatformOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Platform'
+    Security_Osquery_API_PlatformOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Platform'
       nullable: true
-    Security_Solution_Osquery_API_PolicyIds:
+    Security_Osquery_API_PolicyIds:
       items:
         type: string
       type: array
-    Security_Solution_Osquery_API_PolicyIdsOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_PolicyIds'
+    Security_Osquery_API_PolicyIdsOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_PolicyIds'
       nullable: true
-    Security_Solution_Osquery_API_Query:
+    Security_Osquery_API_Query:
       type: string
-    Security_Solution_Osquery_API_QueryOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Query'
+    Security_Osquery_API_QueryOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Query'
       nullable: true
-    Security_Solution_Osquery_API_Removed:
+    Security_Osquery_API_Removed:
       type: boolean
-    Security_Solution_Osquery_API_RemovedOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Removed'
+    Security_Osquery_API_RemovedOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Removed'
       nullable: true
-    Security_Solution_Osquery_API_SavedQueryId:
+    Security_Osquery_API_SavedQueryId:
       type: string
-    Security_Solution_Osquery_API_SavedQueryIdOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+    Security_Osquery_API_SavedQueryIdOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
       nullable: true
-    Security_Solution_Osquery_API_Shards:
+    Security_Osquery_API_Shards:
       additionalProperties:
         type: number
       type: object
-    Security_Solution_Osquery_API_Snapshot:
+    Security_Osquery_API_Snapshot:
       type: boolean
-    Security_Solution_Osquery_API_SnapshotOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Snapshot'
+    Security_Osquery_API_SnapshotOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Snapshot'
       nullable: true
-    Security_Solution_Osquery_API_SortOrderOrUndefined:
+    Security_Osquery_API_SortOrderOrUndefined:
       oneOf:
         - nullable: true
           type: string
         - enum:
             - asc
             - desc
-    Security_Solution_Osquery_API_SortOrUndefined:
+    Security_Osquery_API_SortOrUndefined:
       nullable: true
       type: string
-    Security_Solution_Osquery_API_UpdatePacksRequestBody:
+    Security_Osquery_API_UpdatePacksRequestBody:
       type: object
       properties:
         description:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         enabled:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_EnabledOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_EnabledOrUndefined'
         id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_PackId'
+          $ref: '#/components/schemas/Security_Osquery_API_PackId'
         policy_ids:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_PolicyIdsOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_PolicyIdsOrUndefined'
         queries:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_ObjectQueries'
+          $ref: '#/components/schemas/Security_Osquery_API_ObjectQueries'
         shards:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_Shards'
-    Security_Solution_Osquery_API_UpdateSavedQueryRequestBody:
+          $ref: '#/components/schemas/Security_Osquery_API_Shards'
+    Security_Osquery_API_UpdateSavedQueryRequestBody:
       type: object
       properties:
         description:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         ecs_mapping:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_ECSMappingOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_ECSMappingOrUndefined'
         id:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_SavedQueryId'
+          $ref: '#/components/schemas/Security_Osquery_API_SavedQueryId'
         interval:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_IntervalOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_IntervalOrUndefined'
         platform:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_DescriptionOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_DescriptionOrUndefined'
         query:
-          $ref: '#/components/schemas/Security_Solution_Osquery_API_QueryOrUndefined'
+          $ref: '#/components/schemas/Security_Osquery_API_QueryOrUndefined'
         removed:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_RemovedOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_RemovedOrUndefined'
         snapshot:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_SnapshotOrUndefined
+          $ref: '#/components/schemas/Security_Osquery_API_SnapshotOrUndefined'
         version:
-          $ref: >-
-            #/components/schemas/Security_Solution_Osquery_API_VersionOrUndefined
-    Security_Solution_Osquery_API_Version:
+          $ref: '#/components/schemas/Security_Osquery_API_VersionOrUndefined'
+    Security_Osquery_API_Version:
       type: string
-    Security_Solution_Osquery_API_VersionOrUndefined:
-      $ref: '#/components/schemas/Security_Solution_Osquery_API_Version'
+    Security_Osquery_API_VersionOrUndefined:
+      $ref: '#/components/schemas/Security_Osquery_API_Version'
       nullable: true
-    Security_Solution_Timeline_API_BareNote:
+    Security_Timeline_API_BareNote:
       type: object
       properties:
         created:
@@ -40427,7 +39101,7 @@ components:
           type: string
       required:
         - timelineId
-    Security_Solution_Timeline_API_BarePinnedEvent:
+    Security_Timeline_API_BarePinnedEvent:
       type: object
       properties:
         created:
@@ -40449,7 +39123,7 @@ components:
       required:
         - eventId
         - timelineId
-    Security_Solution_Timeline_API_ColumnHeaderResult:
+    Security_Timeline_API_ColumnHeaderResult:
       type: object
       properties:
         aggregatable:
@@ -40478,7 +39152,7 @@ components:
           type: boolean
         type:
           type: string
-    Security_Solution_Timeline_API_DataProviderQueryMatch:
+    Security_Timeline_API_DataProviderQueryMatch:
       type: object
       properties:
         enabled:
@@ -40497,14 +39171,13 @@ components:
           nullable: true
           type: string
         queryMatch:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_QueryMatchResult'
-    Security_Solution_Timeline_API_DataProviderResult:
+          $ref: '#/components/schemas/Security_Timeline_API_QueryMatchResult'
+    Security_Timeline_API_DataProviderResult:
       type: object
       properties:
         and:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_DataProviderQueryMatch
+            $ref: '#/components/schemas/Security_Timeline_API_DataProviderQueryMatch'
           nullable: true
           type: array
         enabled:
@@ -40523,12 +39196,12 @@ components:
           nullable: true
           type: string
         queryMatch:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_QueryMatchResult'
+          $ref: '#/components/schemas/Security_Timeline_API_QueryMatchResult'
           nullable: true
         type:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_DataProviderType'
+          $ref: '#/components/schemas/Security_Timeline_API_DataProviderType'
           nullable: true
-    Security_Solution_Timeline_API_DataProviderType:
+    Security_Timeline_API_DataProviderType:
       description: >-
         The type of data provider to create. Valid values are `default` and
         `template`.
@@ -40536,13 +39209,13 @@ components:
         - default
         - template
       type: string
-    Security_Solution_Timeline_API_DocumentIds:
+    Security_Timeline_API_DocumentIds:
       oneOf:
         - items:
             type: string
           type: array
         - type: string
-    Security_Solution_Timeline_API_FavoriteTimelineResponse:
+    Security_Timeline_API_FavoriteTimelineResponse:
       type: object
       properties:
         code:
@@ -40550,8 +39223,7 @@ components:
           type: number
         favorite:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_FavoriteTimelineResult
+            $ref: '#/components/schemas/Security_Timeline_API_FavoriteTimelineResult'
           type: array
         message:
           nullable: true
@@ -40565,13 +39237,13 @@ components:
           nullable: true
           type: number
         timelineType:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_TimelineType'
+          $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
         version:
           type: string
       required:
         - savedObjectId
         - version
-    Security_Solution_Timeline_API_FavoriteTimelineResult:
+    Security_Timeline_API_FavoriteTimelineResult:
       type: object
       properties:
         favoriteDate:
@@ -40583,7 +39255,7 @@ components:
         userName:
           nullable: true
           type: string
-    Security_Solution_Timeline_API_FilterTimelineResult:
+    Security_Timeline_API_FilterTimelineResult:
       type: object
       properties:
         exists:
@@ -40623,19 +39295,19 @@ components:
           type: string
         script:
           type: string
-    Security_Solution_Timeline_API_GetNotesResult:
+    Security_Timeline_API_GetNotesResult:
       type: object
       properties:
         notes:
           items:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_Note'
+            $ref: '#/components/schemas/Security_Timeline_API_Note'
           type: array
         totalCount:
           type: number
       required:
         - totalCount
         - notes
-    Security_Solution_Timeline_API_ImportTimelineResult:
+    Security_Timeline_API_ImportTimelineResult:
       type: object
       properties:
         errors:
@@ -40660,19 +39332,19 @@ components:
           type: number
         timelines_updated:
           type: number
-    Security_Solution_Timeline_API_ImportTimelines:
+    Security_Timeline_API_ImportTimelines:
       allOf:
-        - $ref: '#/components/schemas/Security_Solution_Timeline_API_SavedTimeline'
+        - $ref: '#/components/schemas/Security_Timeline_API_SavedTimeline'
         - type: object
           properties:
             eventNotes:
               items:
-                $ref: '#/components/schemas/Security_Solution_Timeline_API_BareNote'
+                $ref: '#/components/schemas/Security_Timeline_API_BareNote'
               nullable: true
               type: array
             globalNotes:
               items:
-                $ref: '#/components/schemas/Security_Solution_Timeline_API_BareNote'
+                $ref: '#/components/schemas/Security_Timeline_API_BareNote'
               nullable: true
               type: array
             pinnedEventIds:
@@ -40686,9 +39358,9 @@ components:
             version:
               nullable: true
               type: string
-    Security_Solution_Timeline_API_Note:
+    Security_Timeline_API_Note:
       allOf:
-        - $ref: '#/components/schemas/Security_Solution_Timeline_API_BareNote'
+        - $ref: '#/components/schemas/Security_Timeline_API_BareNote'
         - type: object
           properties:
             noteId:
@@ -40698,17 +39370,17 @@ components:
           required:
             - noteId
             - version
-    Security_Solution_Timeline_API_PersistPinnedEventResponse:
+    Security_Timeline_API_PersistPinnedEventResponse:
       oneOf:
         - allOf:
-            - $ref: '#/components/schemas/Security_Solution_Timeline_API_PinnedEvent'
+            - $ref: '#/components/schemas/Security_Timeline_API_PinnedEvent'
             - $ref: >-
-                #/components/schemas/Security_Solution_Timeline_API_PinnedEventBaseResponseBody
+                #/components/schemas/Security_Timeline_API_PinnedEventBaseResponseBody
         - nullable: true
           type: object
-    Security_Solution_Timeline_API_PinnedEvent:
+    Security_Timeline_API_PinnedEvent:
       allOf:
-        - $ref: '#/components/schemas/Security_Solution_Timeline_API_BarePinnedEvent'
+        - $ref: '#/components/schemas/Security_Timeline_API_BarePinnedEvent'
         - type: object
           properties:
             pinnedEventId:
@@ -40718,7 +39390,7 @@ components:
           required:
             - pinnedEventId
             - version
-    Security_Solution_Timeline_API_PinnedEventBaseResponseBody:
+    Security_Timeline_API_PinnedEventBaseResponseBody:
       type: object
       properties:
         code:
@@ -40727,7 +39399,7 @@ components:
           type: string
       required:
         - code
-    Security_Solution_Timeline_API_QueryMatchResult:
+    Security_Timeline_API_QueryMatchResult:
       type: object
       properties:
         displayField:
@@ -40745,7 +39417,7 @@ components:
         value:
           nullable: true
           type: string
-    Security_Solution_Timeline_API_Readable:
+    Security_Timeline_API_Readable:
       type: object
       properties:
         _data:
@@ -40771,7 +39443,7 @@ components:
           type: object
         readable:
           type: boolean
-    Security_Solution_Timeline_API_ResponseNote:
+    Security_Timeline_API_ResponseNote:
       type: object
       properties:
         code:
@@ -40779,12 +39451,12 @@ components:
         message:
           type: string
         note:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_Note'
+          $ref: '#/components/schemas/Security_Timeline_API_Note'
       required:
         - code
         - message
         - note
-    Security_Solution_Timeline_API_RowRendererId:
+    Security_Timeline_API_RowRendererId:
       enum:
         - alert
         - alerts
@@ -40805,13 +39477,12 @@ components:
         - threat_match
         - zeek
       type: string
-    Security_Solution_Timeline_API_SavedTimeline:
+    Security_Timeline_API_SavedTimeline:
       type: object
       properties:
         columns:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_ColumnHeaderResult
+            $ref: '#/components/schemas/Security_Timeline_API_ColumnHeaderResult'
           nullable: true
           type: array
         created:
@@ -40822,8 +39493,7 @@ components:
           type: string
         dataProviders:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_DataProviderResult
+            $ref: '#/components/schemas/Security_Timeline_API_DataProviderResult'
           nullable: true
           type: array
         dataViewId:
@@ -40871,19 +39541,17 @@ components:
           type: string
         excludedRowRendererIds:
           items:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_RowRendererId'
+            $ref: '#/components/schemas/Security_Timeline_API_RowRendererId'
           nullable: true
           type: array
         favorite:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_FavoriteTimelineResult
+            $ref: '#/components/schemas/Security_Timeline_API_FavoriteTimelineResult'
           nullable: true
           type: array
         filters:
           items:
-            $ref: >-
-              #/components/schemas/Security_Solution_Timeline_API_FilterTimelineResult
+            $ref: '#/components/schemas/Security_Timeline_API_FilterTimelineResult'
           nullable: true
           type: array
         indexNames:
@@ -40896,7 +39564,7 @@ components:
           type: string
         kqlQuery:
           $ref: >-
-            #/components/schemas/Security_Solution_Timeline_API_SerializedFilterQueryResult
+            #/components/schemas/Security_Timeline_API_SerializedFilterQueryResult
           nullable: true
         savedQueryId:
           nullable: true
@@ -40905,7 +39573,7 @@ components:
           nullable: true
           type: string
         sort:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_Sort'
+          $ref: '#/components/schemas/Security_Timeline_API_Sort'
           nullable: true
         status:
           enum:
@@ -40921,7 +39589,7 @@ components:
           nullable: true
           type: number
         timelineType:
-          $ref: '#/components/schemas/Security_Solution_Timeline_API_TimelineType'
+          $ref: '#/components/schemas/Security_Timeline_API_TimelineType'
           nullable: true
         title:
           nullable: true
@@ -40932,7 +39600,7 @@ components:
         updatedBy:
           nullable: true
           type: string
-    Security_Solution_Timeline_API_SerializedFilterQueryResult:
+    Security_Timeline_API_SerializedFilterQueryResult:
       type: object
       properties:
         filterQuery:
@@ -40952,13 +39620,13 @@ components:
             serializedQuery:
               nullable: true
               type: string
-    Security_Solution_Timeline_API_Sort:
+    Security_Timeline_API_Sort:
       oneOf:
-        - $ref: '#/components/schemas/Security_Solution_Timeline_API_SortObject'
+        - $ref: '#/components/schemas/Security_Timeline_API_SortObject'
         - items:
-            $ref: '#/components/schemas/Security_Solution_Timeline_API_SortObject'
+            $ref: '#/components/schemas/Security_Timeline_API_SortObject'
           type: array
-    Security_Solution_Timeline_API_SortFieldTimeline:
+    Security_Timeline_API_SortFieldTimeline:
       description: The field to sort the timelines by.
       enum:
         - title
@@ -40966,7 +39634,7 @@ components:
         - updated
         - created
       type: string
-    Security_Solution_Timeline_API_SortObject:
+    Security_Timeline_API_SortObject:
       type: object
       properties:
         columnId:
@@ -40978,14 +39646,14 @@ components:
         sortDirection:
           nullable: true
           type: string
-    Security_Solution_Timeline_API_TimelineResponse:
+    Security_Timeline_API_TimelineResponse:
       allOf:
-        - $ref: '#/components/schemas/Security_Solution_Timeline_API_SavedTimeline'
+        - $ref: '#/components/schemas/Security_Timeline_API_SavedTimeline'
         - type: object
           properties:
             eventIdToNoteIds:
               items:
-                $ref: '#/components/schemas/Security_Solution_Timeline_API_Note'
+                $ref: '#/components/schemas/Security_Timeline_API_Note'
               type: array
             noteIds:
               items:
@@ -40993,7 +39661,7 @@ components:
               type: array
             notes:
               items:
-                $ref: '#/components/schemas/Security_Solution_Timeline_API_Note'
+                $ref: '#/components/schemas/Security_Timeline_API_Note'
               type: array
             pinnedEventIds:
               items:
@@ -41001,8 +39669,7 @@ components:
               type: array
             pinnedEventsSaveObject:
               items:
-                $ref: >-
-                  #/components/schemas/Security_Solution_Timeline_API_PinnedEvent
+                $ref: '#/components/schemas/Security_Timeline_API_PinnedEvent'
               type: array
             savedObjectId:
               type: string
@@ -41011,7 +39678,7 @@ components:
           required:
             - savedObjectId
             - version
-    Security_Solution_Timeline_API_TimelineStatus:
+    Security_Timeline_API_TimelineStatus:
       description: >-
         The status of the timeline. Valid values are `active`, `draft`, and
         `immutable`.
@@ -41020,7 +39687,7 @@ components:
         - draft
         - immutable
       type: string
-    Security_Solution_Timeline_API_TimelineType:
+    Security_Timeline_API_TimelineType:
       description: >-
         The type of timeline to create. Valid values are `default` and
         `template`.
@@ -42297,29 +40964,29 @@ tags:
       You can create rules that automatically turn events and external alerts
       sent to Elastic Security into detection alerts. These alerts are displayed
       on the Detections page.
-    name: Security Solution Detections API
+    name: Security Detections API
   - description: >-
       Endpoint Exceptions API allows you to manage detection rule endpoint
       exceptions to prevent a rule from generating an alert from incoming events
       even when the rule's other criteria are met.
-    name: Security Solution Endpoint Exceptions API
+    name: Security Endpoint Exceptions API
   - description: Interact with and manage endpoints running the Elastic Defend integration.
-    name: Security Solution Endpoint Management API
+    name: Security Endpoint Management API
   - description: ''
-    name: Security Solution Entity Analytics API
+    name: Security Entity Analytics API
   - description: >-
       Exceptions API allows you to manage detection rule exceptions to prevent a
       rule from generating an alert from incoming events even when the rule's
       other criteria are met.
-    name: Security Solution Exceptions API
+    name: Security Exceptions API
   - description: Lists API allows you to manage lists of keywords, IPs or IP ranges items.
-    name: Security Solution Lists API
+    name: Security Lists API
   - description: Run live queries, manage packs and saved queries.
-    name: Security Solution Osquery API
+    name: Security Osquery API
   - description: >-
       You can create Timelines and Timeline templates via the API, as well as
       import new Timelines from an ndjson file.
-    name: Security Solution Timeline API
+    name: Security Timeline API
   - description: SLO APIs enable you to define, manage and track service-level objectives
     name: slo
   - name: system

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/ess/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/ess/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: Endpoint Exceptions API allow you to manage Endpoint lists.
-  title: Security Solution Endpoint Exceptions API (Elastic Cloud and self-hosted)
+  title: Security Endpoint Exceptions API (Elastic Cloud and self-hosted)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -53,7 +53,7 @@ paths:
           description: Internal server error
       summary: Create an endpoint exception list
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
   /api/endpoint_list/items:
     delete:
       description: >-
@@ -114,7 +114,7 @@ paths:
           description: Internal server error
       summary: Delete an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     get:
       description: >-
         Get the details of an endpoint exception list item using the `id` or
@@ -176,7 +176,7 @@ paths:
           description: Internal server error
       summary: Get an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     post:
       description: >-
         Create an endpoint exception list item, and associate it with the
@@ -257,7 +257,7 @@ paths:
           description: Internal server error
       summary: Create an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     put:
       description: >-
         Update an endpoint exception list item using the `id` or `item_id`
@@ -343,7 +343,7 @@ paths:
           description: Internal server error
       summary: Update an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
   /api/endpoint_list/items/_find:
     get:
       description: Get a list of all endpoint exception list items.
@@ -450,7 +450,7 @@ paths:
           description: Internal server error
       summary: Get endpoint exception list items
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
 components:
   schemas:
     EndpointList:
@@ -884,4 +884,4 @@ tags:
       Endpoint Exceptions API allows you to manage detection rule endpoint
       exceptions to prevent a rule from generating an alert from incoming events
       even when the rule's other criteria are met.
-    name: Security Solution Endpoint Exceptions API
+    name: Security Endpoint Exceptions API

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/serverless/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/docs/openapi/serverless/security_solution_endpoint_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: Endpoint Exceptions API allow you to manage Endpoint lists.
-  title: Security Solution Endpoint Exceptions API (Elastic Cloud Serverless)
+  title: Security Endpoint Exceptions API (Elastic Cloud Serverless)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -53,7 +53,7 @@ paths:
           description: Internal server error
       summary: Create an endpoint exception list
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
   /api/endpoint_list/items:
     delete:
       description: >-
@@ -114,7 +114,7 @@ paths:
           description: Internal server error
       summary: Delete an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     get:
       description: >-
         Get the details of an endpoint exception list item using the `id` or
@@ -176,7 +176,7 @@ paths:
           description: Internal server error
       summary: Get an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     post:
       description: >-
         Create an endpoint exception list item, and associate it with the
@@ -257,7 +257,7 @@ paths:
           description: Internal server error
       summary: Create an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
     put:
       description: >-
         Update an endpoint exception list item using the `id` or `item_id`
@@ -343,7 +343,7 @@ paths:
           description: Internal server error
       summary: Update an endpoint exception list item
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
   /api/endpoint_list/items/_find:
     get:
       description: Get a list of all endpoint exception list items.
@@ -450,7 +450,7 @@ paths:
           description: Internal server error
       summary: Get endpoint exception list items
       tags:
-        - Security Solution Endpoint Exceptions API
+        - Security Endpoint Exceptions API
 components:
   schemas:
     EndpointList:
@@ -884,4 +884,4 @@ tags:
       Endpoint Exceptions API allows you to manage detection rule endpoint
       exceptions to prevent a rule from generating an alert from incoming events
       even when the rule's other criteria are met.
-    name: Security Solution Endpoint Exceptions API
+    name: Security Endpoint Exceptions API

--- a/packages/kbn-securitysolution-endpoint-exceptions-common/scripts/openapi_bundle.js
+++ b/packages/kbn-securitysolution-endpoint-exceptions-common/scripts/openapi_bundle.js
@@ -24,12 +24,12 @@ const ROOT = resolve(__dirname, '..');
       includeLabels: ['serverless'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Endpoint Exceptions API (Elastic Cloud Serverless)',
+          title: 'Security Endpoint Exceptions API (Elastic Cloud Serverless)',
           description: 'Endpoint Exceptions API allow you to manage Endpoint lists.',
         },
         tags: [
           {
-            name: 'Security Solution Endpoint Exceptions API',
+            name: 'Security Endpoint Exceptions API',
             description:
               "Endpoint Exceptions API allows you to manage detection rule endpoint exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.",
           },
@@ -48,12 +48,12 @@ const ROOT = resolve(__dirname, '..');
       includeLabels: ['ess'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Endpoint Exceptions API (Elastic Cloud and self-hosted)',
+          title: 'Security Endpoint Exceptions API (Elastic Cloud and self-hosted)',
           description: 'Endpoint Exceptions API allow you to manage Endpoint lists.',
         },
         tags: [
           {
-            name: 'Security Solution Endpoint Exceptions API',
+            name: 'Security Endpoint Exceptions API',
             description:
               "Endpoint Exceptions API allows you to manage detection rule endpoint exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.",
           },

--- a/packages/kbn-securitysolution-exceptions-common/docs/openapi/ess/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/docs/openapi/ess/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -4,7 +4,7 @@ info:
     Exceptions API allows you to manage detection rule exceptions to prevent a
     rule from generating an alert from incoming events even when the rule's
     other criteria are met.
-  title: Security Solution Exceptions API (Elastic Cloud and self-hosted)
+  title: Security Exceptions API (Elastic Cloud and self-hosted)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -76,7 +76,7 @@ paths:
           description: Internal server error response
       summary: Create rule exception list items
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists:
     delete:
       description: Delete an exception list using the `id` or `list_id` field.
@@ -141,7 +141,7 @@ paths:
           description: Internal server error response
       summary: Delete an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     get:
       description: Get the details of an exception list using the `id` or `list_id` field.
       operationId: ReadExceptionList
@@ -205,7 +205,7 @@ paths:
           description: Internal server error response
       summary: Get exception list details
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     post:
       description: >
         An exception list groups exception items and can be associated with
@@ -295,7 +295,7 @@ paths:
           description: Internal server error response
       summary: Create an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     put:
       description: Update an exception list using the `id` or `list_id` field.
       operationId: UpdateExceptionList
@@ -376,7 +376,7 @@ paths:
           description: Internal server error response
       summary: Update an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_duplicate:
     post:
       description: Duplicate an existing exception list.
@@ -446,7 +446,7 @@ paths:
           description: Internal server error response
       summary: Duplicate an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_export:
     post:
       description: Export an exception list and its associated items to an NDJSON file.
@@ -526,7 +526,7 @@ paths:
           description: Internal server error response
       summary: Export an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_find:
     get:
       description: Get a list of all exception lists.
@@ -647,7 +647,7 @@ paths:
           description: Internal server error response
       summary: Get exception lists
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_import:
     post:
       description: Import an exception list and its associated items from an NDJSON file.
@@ -763,7 +763,7 @@ paths:
           description: Internal server error response
       summary: Import an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/items:
     delete:
       description: Delete an exception list item using the `id` or `item_id` field.
@@ -828,7 +828,7 @@ paths:
           description: Internal server error response
       summary: Delete an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     get:
       description: >-
         Get the details of an exception list item using the `id` or `item_id`
@@ -894,7 +894,7 @@ paths:
           description: Internal server error response
       summary: Get an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     post:
       description: >
         Create an exception item and associate it with the specified exception
@@ -988,7 +988,7 @@ paths:
           description: Internal server error response
       summary: Create an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     put:
       description: Update an exception list item using the `id` or `item_id` field.
       operationId: UpdateExceptionListItem
@@ -1080,7 +1080,7 @@ paths:
           description: Internal server error response
       summary: Update an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/items/_find:
     get:
       description: Get a list of all exception list items in the specified list.
@@ -1217,7 +1217,7 @@ paths:
           description: Internal server error response
       summary: Get exception list items
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/summary:
     get:
       description: Get a summary of the specified exception list.
@@ -1301,7 +1301,7 @@ paths:
           description: Internal server error response
       summary: Get an exception list summary
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exceptions/shared:
     post:
       description: >
@@ -1373,7 +1373,7 @@ paths:
           description: Internal server error response
       summary: Create a shared exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
 components:
   schemas:
     CreateExceptionListItemComment:
@@ -1903,4 +1903,4 @@ tags:
       Exceptions API allows you to manage detection rule exceptions to prevent a
       rule from generating an alert from incoming events even when the rule's
       other criteria are met.
-    name: Security Solution Exceptions API
+    name: Security Exceptions API

--- a/packages/kbn-securitysolution-exceptions-common/docs/openapi/serverless/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-exceptions-common/docs/openapi/serverless/security_solution_exceptions_api_2023_10_31.bundled.schema.yaml
@@ -4,7 +4,7 @@ info:
     Exceptions API allows you to manage detection rule exceptions to prevent a
     rule from generating an alert from incoming events even when the rule's
     other criteria are met.
-  title: Security Solution Exceptions API (Elastic Cloud Serverless)
+  title: Security Exceptions API (Elastic Cloud Serverless)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -76,7 +76,7 @@ paths:
           description: Internal server error response
       summary: Create rule exception list items
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists:
     delete:
       description: Delete an exception list using the `id` or `list_id` field.
@@ -141,7 +141,7 @@ paths:
           description: Internal server error response
       summary: Delete an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     get:
       description: Get the details of an exception list using the `id` or `list_id` field.
       operationId: ReadExceptionList
@@ -205,7 +205,7 @@ paths:
           description: Internal server error response
       summary: Get exception list details
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     post:
       description: >
         An exception list groups exception items and can be associated with
@@ -295,7 +295,7 @@ paths:
           description: Internal server error response
       summary: Create an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     put:
       description: Update an exception list using the `id` or `list_id` field.
       operationId: UpdateExceptionList
@@ -376,7 +376,7 @@ paths:
           description: Internal server error response
       summary: Update an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_duplicate:
     post:
       description: Duplicate an existing exception list.
@@ -446,7 +446,7 @@ paths:
           description: Internal server error response
       summary: Duplicate an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_export:
     post:
       description: Export an exception list and its associated items to an NDJSON file.
@@ -526,7 +526,7 @@ paths:
           description: Internal server error response
       summary: Export an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_find:
     get:
       description: Get a list of all exception lists.
@@ -647,7 +647,7 @@ paths:
           description: Internal server error response
       summary: Get exception lists
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/_import:
     post:
       description: Import an exception list and its associated items from an NDJSON file.
@@ -763,7 +763,7 @@ paths:
           description: Internal server error response
       summary: Import an exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/items:
     delete:
       description: Delete an exception list item using the `id` or `item_id` field.
@@ -828,7 +828,7 @@ paths:
           description: Internal server error response
       summary: Delete an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     get:
       description: >-
         Get the details of an exception list item using the `id` or `item_id`
@@ -894,7 +894,7 @@ paths:
           description: Internal server error response
       summary: Get an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     post:
       description: >
         Create an exception item and associate it with the specified exception
@@ -988,7 +988,7 @@ paths:
           description: Internal server error response
       summary: Create an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
     put:
       description: Update an exception list item using the `id` or `item_id` field.
       operationId: UpdateExceptionListItem
@@ -1080,7 +1080,7 @@ paths:
           description: Internal server error response
       summary: Update an exception list item
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/items/_find:
     get:
       description: Get a list of all exception list items in the specified list.
@@ -1217,7 +1217,7 @@ paths:
           description: Internal server error response
       summary: Get exception list items
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exception_lists/summary:
     get:
       description: Get a summary of the specified exception list.
@@ -1301,7 +1301,7 @@ paths:
           description: Internal server error response
       summary: Get an exception list summary
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
   /api/exceptions/shared:
     post:
       description: >
@@ -1373,7 +1373,7 @@ paths:
           description: Internal server error response
       summary: Create a shared exception list
       tags:
-        - Security Solution Exceptions API
+        - Security Exceptions API
 components:
   schemas:
     CreateExceptionListItemComment:
@@ -1903,4 +1903,4 @@ tags:
       Exceptions API allows you to manage detection rule exceptions to prevent a
       rule from generating an alert from incoming events even when the rule's
       other criteria are met.
-    name: Security Solution Exceptions API
+    name: Security Exceptions API

--- a/packages/kbn-securitysolution-exceptions-common/scripts/openapi_bundle.js
+++ b/packages/kbn-securitysolution-exceptions-common/scripts/openapi_bundle.js
@@ -24,13 +24,13 @@ const ROOT = resolve(__dirname, '..');
       includeLabels: ['serverless'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Exceptions API (Elastic Cloud Serverless)',
+          title: 'Security Exceptions API (Elastic Cloud Serverless)',
           description:
             "Exceptions API allows you to manage detection rule exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.",
         },
         tags: [
           {
-            name: 'Security Solution Exceptions API',
+            name: 'Security Exceptions API',
             description:
               "Exceptions API allows you to manage detection rule exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.",
           },
@@ -49,13 +49,13 @@ const ROOT = resolve(__dirname, '..');
       includeLabels: ['ess'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Exceptions API (Elastic Cloud and self-hosted)',
+          title: 'Security Exceptions API (Elastic Cloud and self-hosted)',
           description:
             "Exceptions API allows you to manage detection rule exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.",
         },
         tags: [
           {
-            name: 'Security Solution Exceptions API',
+            name: 'Security Exceptions API',
             description:
               "Exceptions API allows you to manage detection rule exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.",
           },

--- a/packages/kbn-securitysolution-lists-common/docs/openapi/ess/security_solution_lists_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/docs/openapi/ess/security_solution_lists_api_2023_10_31.bundled.schema.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: Lists API allows you to manage lists of keywords, IPs or IP ranges items.
-  title: Security Solution Lists API (Elastic Cloud and self-hosted)
+  title: Security Lists API (Elastic Cloud and self-hosted)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -78,7 +78,7 @@ paths:
           description: Internal server error response
       summary: Delete a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Get the details of a list using the list ID.
       operationId: ReadList
@@ -130,7 +130,7 @@ paths:
           description: Internal server error response
       summary: Get list details
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     patch:
       description: Update specific fields of an existing list using the list ID.
       operationId: PatchList
@@ -198,7 +198,7 @@ paths:
           description: Internal server error response
       summary: Patch a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: Create a new list.
       operationId: CreateList
@@ -273,7 +273,7 @@ paths:
           description: Internal server error response
       summary: Create a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     put:
       description: >
         Update a list using the list ID. The original list is replaced, and all
@@ -349,7 +349,7 @@ paths:
           description: Internal server error response
       summary: Update a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/_find:
     get:
       description: >-
@@ -465,7 +465,7 @@ paths:
           description: Internal server error response
       summary: Get lists
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/index:
     delete:
       description: Delete the `.lists` and `.items` data streams.
@@ -516,7 +516,7 @@ paths:
           description: Internal server error response
       summary: Delete list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Verify that `.lists` and `.items` data streams exist.
       operationId: ReadListIndex
@@ -569,7 +569,7 @@ paths:
           description: Internal server error response
       summary: Get status of list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: Create `.lists` and `.items` data streams in the relevant space.
       operationId: CreateListIndex
@@ -619,7 +619,7 @@ paths:
           description: Internal server error response
       summary: Create list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items:
     delete:
       description: Delete a list item using its `id`, or its `list_id` and `value` fields.
@@ -701,7 +701,7 @@ paths:
           description: Internal server error response
       summary: Delete a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Get the details of a list item.
       operationId: ReadListItem
@@ -769,7 +769,7 @@ paths:
           description: Internal server error response
       summary: Get a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     patch:
       description: Update specific fields of an existing list item using the list item ID.
       operationId: PatchListItem
@@ -841,7 +841,7 @@ paths:
           description: Internal server error response
       summary: Patch a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: >
         Create a list item and associate it with the specified list.
@@ -923,7 +923,7 @@ paths:
           description: Internal server error response
       summary: Create a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     put:
       description: >
         Update a list item using the list item ID. The original list item is
@@ -993,7 +993,7 @@ paths:
           description: Internal server error response
       summary: Update a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_export:
     post:
       description: Export list item values from the specified list.
@@ -1048,7 +1048,7 @@ paths:
           description: Internal server error response
       summary: Export list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_find:
     get:
       description: Get all list items in the specified list.
@@ -1168,7 +1168,7 @@ paths:
           description: Internal server error response
       summary: Get list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_import:
     post:
       description: >
@@ -1275,7 +1275,7 @@ paths:
           description: Internal server error response
       summary: Import list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/privileges:
     get:
       operationId: ReadListPrivileges
@@ -1325,7 +1325,7 @@ paths:
           description: Internal server error response
       summary: Get list privileges
       tags:
-        - Security Solution Lists API
+        - Security Lists API
 components:
   schemas:
     FindListItemsCursor:
@@ -1563,4 +1563,4 @@ security:
   - BasicAuth: []
 tags:
   - description: Lists API allows you to manage lists of keywords, IPs or IP ranges items.
-    name: Security Solution Lists API
+    name: Security Lists API

--- a/packages/kbn-securitysolution-lists-common/docs/openapi/serverless/security_solution_lists_api_2023_10_31.bundled.schema.yaml
+++ b/packages/kbn-securitysolution-lists-common/docs/openapi/serverless/security_solution_lists_api_2023_10_31.bundled.schema.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: Lists API allows you to manage lists of keywords, IPs or IP ranges items.
-  title: Security Solution Lists API (Elastic Cloud Serverless)
+  title: Security Lists API (Elastic Cloud Serverless)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -78,7 +78,7 @@ paths:
           description: Internal server error response
       summary: Delete a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Get the details of a list using the list ID.
       operationId: ReadList
@@ -130,7 +130,7 @@ paths:
           description: Internal server error response
       summary: Get list details
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     patch:
       description: Update specific fields of an existing list using the list ID.
       operationId: PatchList
@@ -198,7 +198,7 @@ paths:
           description: Internal server error response
       summary: Patch a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: Create a new list.
       operationId: CreateList
@@ -273,7 +273,7 @@ paths:
           description: Internal server error response
       summary: Create a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     put:
       description: >
         Update a list using the list ID. The original list is replaced, and all
@@ -349,7 +349,7 @@ paths:
           description: Internal server error response
       summary: Update a list
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/_find:
     get:
       description: >-
@@ -465,7 +465,7 @@ paths:
           description: Internal server error response
       summary: Get lists
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/index:
     delete:
       description: Delete the `.lists` and `.items` data streams.
@@ -516,7 +516,7 @@ paths:
           description: Internal server error response
       summary: Delete list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Verify that `.lists` and `.items` data streams exist.
       operationId: ReadListIndex
@@ -569,7 +569,7 @@ paths:
           description: Internal server error response
       summary: Get status of list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: Create `.lists` and `.items` data streams in the relevant space.
       operationId: CreateListIndex
@@ -619,7 +619,7 @@ paths:
           description: Internal server error response
       summary: Create list data streams
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items:
     delete:
       description: Delete a list item using its `id`, or its `list_id` and `value` fields.
@@ -701,7 +701,7 @@ paths:
           description: Internal server error response
       summary: Delete a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     get:
       description: Get the details of a list item.
       operationId: ReadListItem
@@ -769,7 +769,7 @@ paths:
           description: Internal server error response
       summary: Get a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     patch:
       description: Update specific fields of an existing list item using the list item ID.
       operationId: PatchListItem
@@ -841,7 +841,7 @@ paths:
           description: Internal server error response
       summary: Patch a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     post:
       description: >
         Create a list item and associate it with the specified list.
@@ -923,7 +923,7 @@ paths:
           description: Internal server error response
       summary: Create a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
     put:
       description: >
         Update a list item using the list item ID. The original list item is
@@ -993,7 +993,7 @@ paths:
           description: Internal server error response
       summary: Update a list item
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_export:
     post:
       description: Export list item values from the specified list.
@@ -1048,7 +1048,7 @@ paths:
           description: Internal server error response
       summary: Export list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_find:
     get:
       description: Get all list items in the specified list.
@@ -1168,7 +1168,7 @@ paths:
           description: Internal server error response
       summary: Get list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/items/_import:
     post:
       description: >
@@ -1275,7 +1275,7 @@ paths:
           description: Internal server error response
       summary: Import list items
       tags:
-        - Security Solution Lists API
+        - Security Lists API
   /api/lists/privileges:
     get:
       operationId: ReadListPrivileges
@@ -1325,7 +1325,7 @@ paths:
           description: Internal server error response
       summary: Get list privileges
       tags:
-        - Security Solution Lists API
+        - Security Lists API
 components:
   schemas:
     FindListItemsCursor:
@@ -1563,4 +1563,4 @@ security:
   - BasicAuth: []
 tags:
   - description: Lists API allows you to manage lists of keywords, IPs or IP ranges items.
-    name: Security Solution Lists API
+    name: Security Lists API

--- a/packages/kbn-securitysolution-lists-common/scripts/openapi_bundle.js
+++ b/packages/kbn-securitysolution-lists-common/scripts/openapi_bundle.js
@@ -24,12 +24,12 @@ const ROOT = resolve(__dirname, '..');
       includeLabels: ['serverless'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Lists API (Elastic Cloud Serverless)',
+          title: 'Security Lists API (Elastic Cloud Serverless)',
           description: 'Lists API allows you to manage lists of keywords, IPs or IP ranges items.',
         },
         tags: [
           {
-            name: 'Security Solution Lists API',
+            name: 'Security Lists API',
             description:
               'Lists API allows you to manage lists of keywords, IPs or IP ranges items.',
           },
@@ -48,12 +48,12 @@ const ROOT = resolve(__dirname, '..');
       includeLabels: ['ess'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Lists API (Elastic Cloud and self-hosted)',
+          title: 'Security Lists API (Elastic Cloud and self-hosted)',
           description: 'Lists API allows you to manage lists of keywords, IPs or IP ranges items.',
         },
         tags: [
           {
-            name: 'Security Solution Lists API',
+            name: 'Security Lists API',
             description:
               'Lists API allows you to manage lists of keywords, IPs or IP ranges items.',
           },

--- a/x-pack/plugins/osquery/docs/openapi/ess/osquery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/osquery/docs/openapi/ess/osquery_api_2023_10_31.bundled.schema.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: Run live queries, manage packs and saved queries.
-  title: Security Solution Osquery API (Elastic Cloud and self-hosted)
+  title: Security Osquery API (Elastic Cloud and self-hosted)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -30,7 +30,7 @@ paths:
           description: OK
       summary: Get live queries
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create and run a live query.
       operationId: OsqueryCreateLiveQuery
@@ -49,7 +49,7 @@ paths:
           description: OK
       summary: Create a live query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/live_queries/{id}:
     get:
       description: Get the details of a live query using the query ID.
@@ -74,7 +74,7 @@ paths:
           description: OK
       summary: Get live query details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/live_queries/{id}/results/{actionId}:
     get:
       description: Get the results of a live query using the query action ID.
@@ -104,7 +104,7 @@ paths:
           description: OK
       summary: Get live query results
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/packs:
     get:
       description: Get a list of all query packs.
@@ -124,7 +124,7 @@ paths:
           description: OK
       summary: Get packs
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create a query pack.
       operationId: OsqueryCreatePacks
@@ -143,7 +143,7 @@ paths:
           description: OK
       summary: Create a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/packs/{id}:
     delete:
       description: Delete a query pack using the pack ID.
@@ -163,7 +163,7 @@ paths:
           description: OK
       summary: Delete a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     get:
       description: Get the details of a query pack using the pack ID.
       operationId: OsqueryGetPacksDetails
@@ -182,7 +182,7 @@ paths:
           description: OK
       summary: Get pack details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     put:
       description: |
         Update a query pack using the pack ID.
@@ -210,7 +210,7 @@ paths:
           description: OK
       summary: Update a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/saved_queries:
     get:
       description: Get a list of all saved queries.
@@ -230,7 +230,7 @@ paths:
           description: OK
       summary: Get saved queries
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create and run a saved query.
       operationId: OsqueryCreateSavedQuery
@@ -249,7 +249,7 @@ paths:
           description: OK
       summary: Create a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/saved_queries/{id}:
     delete:
       description: Delete a saved query using the query ID.
@@ -269,7 +269,7 @@ paths:
           description: OK
       summary: Delete a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     get:
       description: Get the details of a saved query using the query ID.
       operationId: OsqueryGetSavedQueryDetails
@@ -288,7 +288,7 @@ paths:
           description: OK
       summary: Get saved query details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     put:
       description: |
         Update a saved query using the query ID.
@@ -316,7 +316,7 @@ paths:
           description: OK
       summary: Update a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
 components:
   schemas:
     ArrayQueries:
@@ -638,4 +638,4 @@ security:
   - BasicAuth: []
 tags:
   - description: Run live queries, manage packs and saved queries.
-    name: Security Solution Osquery API
+    name: Security Osquery API

--- a/x-pack/plugins/osquery/docs/openapi/serverless/osquery_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/osquery/docs/openapi/serverless/osquery_api_2023_10_31.bundled.schema.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: Run live queries, manage packs and saved queries.
-  title: Security Solution Osquery API (Elastic Cloud Serverless)
+  title: Security Osquery API (Elastic Cloud Serverless)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -30,7 +30,7 @@ paths:
           description: OK
       summary: Get live queries
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create and run a live query.
       operationId: OsqueryCreateLiveQuery
@@ -49,7 +49,7 @@ paths:
           description: OK
       summary: Create a live query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/live_queries/{id}:
     get:
       description: Get the details of a live query using the query ID.
@@ -74,7 +74,7 @@ paths:
           description: OK
       summary: Get live query details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/live_queries/{id}/results/{actionId}:
     get:
       description: Get the results of a live query using the query action ID.
@@ -104,7 +104,7 @@ paths:
           description: OK
       summary: Get live query results
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/packs:
     get:
       description: Get a list of all query packs.
@@ -124,7 +124,7 @@ paths:
           description: OK
       summary: Get packs
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create a query pack.
       operationId: OsqueryCreatePacks
@@ -143,7 +143,7 @@ paths:
           description: OK
       summary: Create a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/packs/{id}:
     delete:
       description: Delete a query pack using the pack ID.
@@ -163,7 +163,7 @@ paths:
           description: OK
       summary: Delete a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     get:
       description: Get the details of a query pack using the pack ID.
       operationId: OsqueryGetPacksDetails
@@ -182,7 +182,7 @@ paths:
           description: OK
       summary: Get pack details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     put:
       description: |
         Update a query pack using the pack ID.
@@ -210,7 +210,7 @@ paths:
           description: OK
       summary: Update a pack
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/saved_queries:
     get:
       description: Get a list of all saved queries.
@@ -230,7 +230,7 @@ paths:
           description: OK
       summary: Get saved queries
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     post:
       description: Create and run a saved query.
       operationId: OsqueryCreateSavedQuery
@@ -249,7 +249,7 @@ paths:
           description: OK
       summary: Create a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
   /api/osquery/saved_queries/{id}:
     delete:
       description: Delete a saved query using the query ID.
@@ -269,7 +269,7 @@ paths:
           description: OK
       summary: Delete a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     get:
       description: Get the details of a saved query using the query ID.
       operationId: OsqueryGetSavedQueryDetails
@@ -288,7 +288,7 @@ paths:
           description: OK
       summary: Get saved query details
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
     put:
       description: |
         Update a saved query using the query ID.
@@ -316,7 +316,7 @@ paths:
           description: OK
       summary: Update a saved query
       tags:
-        - Security Solution Osquery API
+        - Security Osquery API
 components:
   schemas:
     ArrayQueries:
@@ -638,4 +638,4 @@ security:
   - BasicAuth: []
 tags:
   - description: Run live queries, manage packs and saved queries.
-    name: Security Solution Osquery API
+    name: Security Osquery API

--- a/x-pack/plugins/osquery/scripts/openapi/bundle.js
+++ b/x-pack/plugins/osquery/scripts/openapi/bundle.js
@@ -22,12 +22,12 @@ const ELASTIC_ASSISTANT_ROOT = resolve(__dirname, '../..');
       includeLabels: ['serverless'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Osquery API (Elastic Cloud Serverless)',
+          title: 'Security Osquery API (Elastic Cloud Serverless)',
           description: 'Run live queries, manage packs and saved queries.',
         },
         tags: [
           {
-            name: 'Security Solution Osquery API',
+            name: 'Security Osquery API',
             description: 'Run live queries, manage packs and saved queries.',
           },
         ],
@@ -43,12 +43,12 @@ const ELASTIC_ASSISTANT_ROOT = resolve(__dirname, '../..');
       includeLabels: ['ess'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Osquery API (Elastic Cloud and self-hosted)',
+          title: 'Security Osquery API (Elastic Cloud and self-hosted)',
           description: 'Run live queries, manage packs and saved queries.',
         },
         tags: [
           {
-            name: 'Security Solution Osquery API',
+            name: 'Security Osquery API',
             description: 'Run live queries, manage packs and saved queries.',
           },
         ],

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -4,7 +4,7 @@ info:
     You can create rules that automatically turn events and external alerts sent
     to Elastic Security into detection alerts. These alerts are displayed on the
     Detections page.
-  title: Security Solution Detections API (Elastic Cloud and self-hosted)
+  title: Security Detections API (Elastic Cloud and self-hosted)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -55,7 +55,7 @@ paths:
           description: Internal server error response
       summary: Delete an alerts index
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alert index API
     get:
       operationId: ReadAlertsIndex
@@ -101,7 +101,7 @@ paths:
           description: Internal server error response
       summary: Reads the alert index name if it exists
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alert index API
     post:
       operationId: CreateAlertsIndex
@@ -143,7 +143,7 @@ paths:
           description: Internal server error response
       summary: Create an alerts index
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alert index API
   /api/detection_engine/privileges:
     get:
@@ -186,7 +186,7 @@ paths:
           description: Internal server error response
       summary: Returns user privileges for the Kibana space
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Privileges API
   /api/detection_engine/rules:
     delete:
@@ -214,7 +214,7 @@ paths:
           description: Indicates a successful call.
       summary: Delete a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     get:
       description: Retrieve a detection rule using the `rule_id` or `id` field.
@@ -241,7 +241,7 @@ paths:
           description: Indicates a successful call.
       summary: Retrieve a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     patch:
       description: >-
@@ -263,7 +263,7 @@ paths:
           description: Indicates a successful call.
       summary: Patch a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     post:
       description: Create a new detection rule.
@@ -283,7 +283,7 @@ paths:
           description: Indicates a successful call.
       summary: Create a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     put:
       description: >
@@ -309,7 +309,7 @@ paths:
           description: Indicates a successful call.
       summary: Update a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
   /api/detection_engine/rules/_bulk_action:
     post:
@@ -348,7 +348,7 @@ paths:
           description: OK
       summary: Apply a bulk action to detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
   /api/detection_engine/rules/_bulk_create:
     post:
@@ -373,7 +373,7 @@ paths:
           description: Indicates a successful call.
       summary: Create multiple detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
   /api/detection_engine/rules/_bulk_delete:
     delete:
@@ -425,7 +425,7 @@ paths:
           description: Internal server error response
       summary: Delete multiple detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
     post:
       deprecated: true
@@ -476,7 +476,7 @@ paths:
           description: Internal server error response
       summary: Delete multiple detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
   /api/detection_engine/rules/_bulk_update:
     patch:
@@ -503,7 +503,7 @@ paths:
           description: Indicates a successful call.
       summary: Patch multiple detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
     put:
       deprecated: true
@@ -535,7 +535,7 @@ paths:
           description: Indicates a successful call.
       summary: Update multiple detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
   /api/detection_engine/rules/_export:
     post:
@@ -599,7 +599,7 @@ paths:
           description: Indicates a successful call.
       summary: Export detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Import/Export API
   /api/detection_engine/rules/_find:
     get:
@@ -674,7 +674,7 @@ paths:
           description: Successful response
       summary: List all detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
   /api/detection_engine/rules/_import:
     post:
@@ -789,7 +789,7 @@ paths:
           description: Indicates a successful call.
       summary: Import detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Import/Export API
   /api/detection_engine/rules/prepackaged:
     put:
@@ -827,7 +827,7 @@ paths:
           description: Indicates a successful call
       summary: Install prebuilt detection rules and Timelines
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Prebuilt Rules API
   /api/detection_engine/rules/prepackaged/_status:
     get:
@@ -886,7 +886,7 @@ paths:
           description: Indicates a successful call
       summary: Retrieve the status of prebuilt detection rules and Timelines
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Prebuilt Rules API
   /api/detection_engine/rules/preview:
     post:
@@ -975,7 +975,7 @@ paths:
           description: Internal server error response
       summary: Preview rule alerts generated on specified time range
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rule preview API
   /api/detection_engine/signals/assignees:
     post:
@@ -1007,7 +1007,7 @@ paths:
           description: Invalid request.
       summary: Assign and unassign users from detection alerts
       tags:
-        - Security Solution Detections API
+        - Security Detections API
   /api/detection_engine/signals/finalize_migration:
     post:
       description: >
@@ -1065,7 +1065,7 @@ paths:
           description: Internal server error response
       summary: Finalize detection alert migrations
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts migration API
   /api/detection_engine/signals/migration:
     delete:
@@ -1133,7 +1133,7 @@ paths:
           description: Internal server error response
       summary: Clean up detection alert migrations
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts migration API
     post:
       description: >
@@ -1200,7 +1200,7 @@ paths:
           description: Internal server error response
       summary: Initiate a detection alert migration
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts migration API
   /api/detection_engine/signals/migration_status:
     post:
@@ -1258,7 +1258,7 @@ paths:
           description: Internal server error response
       summary: Retrieve the status of detection alert migrations
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts migration API
   /api/detection_engine/signals/search:
     post:
@@ -1331,7 +1331,7 @@ paths:
           description: Internal server error response
       summary: Find and/or aggregate detection alerts
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/signals/status:
     post:
@@ -1379,7 +1379,7 @@ paths:
           description: Internal server error response
       summary: Set a detection alert status
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/signals/tags:
     post:
@@ -1436,7 +1436,7 @@ paths:
           description: Internal server error response
       summary: Add and remove detection alert tags
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/tags:
     get:
@@ -1451,7 +1451,7 @@ paths:
           description: Indicates a successful call
       summary: List all detection rule tags
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Tags API
 components:
   schemas:
@@ -6999,4 +6999,4 @@ tags:
       You can create rules that automatically turn events and external alerts
       sent to Elastic Security into detection alerts. These alerts are displayed
       on the Detections page.
-    name: Security Solution Detections API
+    name: Security Detections API

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: Interact with and manage endpoints running the Elastic Defend integration.
-  title: Security Solution Endpoint Management API (Elastic Cloud and self-hosted)
+  title: Security Endpoint Management API (Elastic Cloud and self-hosted)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -30,7 +30,7 @@ paths:
           description: OK
       summary: Get response actions
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action_log/{agent_id}:
     get:
       deprecated: true
@@ -56,7 +56,7 @@ paths:
           description: OK
       summary: Get an action request log
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action_status:
     get:
       description: Get the status of response actions for the specified agent IDs.
@@ -79,7 +79,7 @@ paths:
           description: OK
       summary: Get response actions status
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}:
     get:
       description: Get the details of a response action using the action ID.
@@ -99,7 +99,7 @@ paths:
           description: OK
       summary: Get action details
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}/file/{file_id}:
     get:
       description: Get information for the specified file using the file ID.
@@ -124,7 +124,7 @@ paths:
           description: OK
       summary: Get file information
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}/file/{file_id}/download:
     get:
       description: Download a file from an endpoint.
@@ -149,7 +149,7 @@ paths:
           description: OK
       summary: Download a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/execute:
     post:
       description: Run a shell command on an endpoint.
@@ -169,7 +169,7 @@ paths:
           description: OK
       summary: Run a command
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/get_file:
     post:
       description: Get a file from an endpoint.
@@ -189,7 +189,7 @@ paths:
           description: OK
       summary: Get a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/isolate:
     post:
       description: >-
@@ -211,7 +211,7 @@ paths:
           description: OK
       summary: Isolate an endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/kill_process:
     post:
       description: Terminate a running process on an endpoint.
@@ -231,7 +231,7 @@ paths:
           description: OK
       summary: Terminate a process
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/running_procs:
     post:
       description: Get a list of all processes running on an endpoint.
@@ -251,7 +251,7 @@ paths:
           description: OK
       summary: Get running processes
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/scan:
     post:
       description: Scan a specific file or directory on an endpoint for malware.
@@ -271,7 +271,7 @@ paths:
           description: OK
       summary: Scan a file or directory
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/state:
     get:
       description: >-
@@ -287,7 +287,7 @@ paths:
           description: OK
       summary: Get actions state
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/suspend_process:
     post:
       description: Suspend a running process on an endpoint.
@@ -307,7 +307,7 @@ paths:
           description: OK
       summary: Suspend a process
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/unisolate:
     post:
       description: Release an isolated endpoint, allowing it to rejoin a network.
@@ -327,7 +327,7 @@ paths:
           description: OK
       summary: Release an isolated endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/upload:
     post:
       description: Upload a file to an endpoint.
@@ -347,7 +347,7 @@ paths:
           description: OK
       summary: Upload a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/isolate:
     post:
       deprecated: true
@@ -397,7 +397,7 @@ paths:
                 type: string
       summary: Isolate an endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata:
     get:
       operationId: GetEndpointMetadataList
@@ -416,7 +416,7 @@ paths:
           description: OK
       summary: Get a metadata list
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata/{id}:
     get:
       operationId: GetEndpointMetadata
@@ -435,7 +435,7 @@ paths:
           description: OK
       summary: Get metadata
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata/transforms:
     get:
       operationId: GetEndpointMetadataTransform
@@ -448,7 +448,7 @@ paths:
           description: OK
       summary: Get metadata transforms
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/policy_response:
     get:
       operationId: GetPolicyResponse
@@ -470,7 +470,7 @@ paths:
           description: OK
       summary: Get a policy response
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/policy/summaries:
     get:
       deprecated: true
@@ -496,7 +496,7 @@ paths:
           description: OK
       summary: Get an agent policy summary
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/protection_updates_note/{package_policy_id}:
     get:
       operationId: GetProtectionUpdatesNote
@@ -515,7 +515,7 @@ paths:
           description: OK
       summary: Get a protection updates note
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
     post:
       operationId: CreateUpdateProtectionUpdatesNote
       parameters:
@@ -542,7 +542,7 @@ paths:
           description: OK
       summary: Create or update a protection updates note
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/suggestions/{suggestion_type}:
     post:
       operationId: GetEndpointSuggestions
@@ -578,7 +578,7 @@ paths:
           description: OK
       summary: Get suggestions
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/unisolate:
     post:
       deprecated: true
@@ -628,7 +628,7 @@ paths:
                 type: string
       summary: Release an isolated endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
 components:
   schemas:
     ActionLogRequestQuery:
@@ -1135,4 +1135,4 @@ security:
   - BasicAuth: []
 tags:
   - description: Interact with and manage endpoints running the Elastic Defend integration.
-    name: Security Solution Endpoint Management API
+    name: Security Endpoint Management API

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: ''
-  title: Security Solution Entity Analytics API (Elastic Cloud and self-hosted)
+  title: Security Entity Analytics API (Elastic Cloud and self-hosted)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -59,7 +59,7 @@ paths:
           description: Invalid request
       summary: Delete an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     get:
       description: Get the asset criticality record for a specific entity.
       operationId: GetAssetCriticalityRecord
@@ -90,7 +90,7 @@ paths:
           description: Criticality record not found
       summary: Get an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     post:
       description: >
         Create or update an asset criticality record for a specific entity.
@@ -127,7 +127,7 @@ paths:
           description: Invalid request
       summary: Upsert an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/asset_criticality/bulk:
     post:
       description: >
@@ -190,7 +190,7 @@ paths:
           description: File too large
       summary: Bulk upsert asset criticality records
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/asset_criticality/list:
     get:
       description: List asset criticality records, paging, sorting and filtering as needed.
@@ -266,7 +266,7 @@ paths:
           description: Bulk upload successful
       summary: List asset criticality records
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines:
     get:
       operationId: ListEntityEngines
@@ -286,7 +286,7 @@ paths:
           description: Successful response
       summary: List the Entity Engines
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}:
     delete:
       operationId: DeleteEntityEngine
@@ -315,7 +315,7 @@ paths:
           description: Successful response
       summary: Delete the Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     get:
       operationId: GetEntityEngine
       parameters:
@@ -334,7 +334,7 @@ paths:
           description: Successful response
       summary: Get an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/init:
     post:
       operationId: InitEntityEngine
@@ -366,7 +366,7 @@ paths:
           description: Successful response
       summary: Initialize an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/start:
     post:
       operationId: StartEntityEngine
@@ -389,7 +389,7 @@ paths:
           description: Successful response
       summary: Start an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/stats:
     post:
       operationId: GetEntityEngineStats
@@ -424,7 +424,7 @@ paths:
           description: Successful response
       summary: Get Entity Engine stats
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/stop:
     post:
       operationId: StopEntityEngine
@@ -447,7 +447,7 @@ paths:
           description: Successful response
       summary: Stop an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/entities/list:
     get:
       description: List entities records, paging, sorting and filtering as needed.
@@ -523,7 +523,7 @@ paths:
           description: Entities returned successfully
       summary: List Entity Store Entities
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/risk_score/engine/schedule_now:
     post:
       description: >-
@@ -555,7 +555,7 @@ paths:
           description: Unexpected error
       summary: Run the risk scoring engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
 components:
   schemas:
     AssetCriticalityBulkUploadErrorItem:
@@ -851,4 +851,4 @@ security:
   - BasicAuth: []
 tags:
   - description: ''
-    name: Security Solution Entity Analytics API
+    name: Security Entity Analytics API

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
@@ -3,7 +3,7 @@ info:
   description: >-
     You can create Timelines and Timeline templates via the API, as well as
     import new Timelines from an ndjson file.
-  title: Security Solution Timeline API (Elastic Cloud and self-hosted)
+  title: Security Timeline API (Elastic Cloud and self-hosted)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -53,7 +53,7 @@ paths:
           description: Indicates the note was successfully deleted.
       summary: Delete a note
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     get:
       description: Get all notes for a given document.
@@ -104,7 +104,7 @@ paths:
           description: Indicates the requested notes were returned.
       summary: Get notes
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     patch:
       description: Add a note to a Timeline or update an existing note.
@@ -158,7 +158,7 @@ paths:
           description: Indicates the note was successfully created.
       summary: Add or update a note
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/pinned_event:
     patch:
@@ -201,7 +201,7 @@ paths:
           description: Indicates the event was successfully pinned to the Timeline.
       summary: Pin an event
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline:
     delete:
@@ -247,7 +247,7 @@ paths:
           description: Indicates the Timeline was successfully deleted.
       summary: Delete Timelines or Timeline templates
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     get:
       description: Get the details of an existing saved Timeline or Timeline template.
@@ -283,7 +283,7 @@ paths:
           description: Indicates that the (template) Timeline was found and returned.
       summary: Get Timeline or Timeline template details
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     patch:
       description: >-
@@ -351,7 +351,7 @@ paths:
             a draft Timeline.
       summary: Update a Timeline
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     post:
       description: Create a new Timeline or Timeline template.
@@ -421,7 +421,7 @@ paths:
           description: Indicates that there was an error in the Timeline creation.
       summary: Create a Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_draft:
     get:
@@ -488,7 +488,7 @@ paths:
             draft Timeline with the given `timelineId`.
       summary: Get draft Timeline or Timeline template details
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     post:
       description: >
@@ -566,7 +566,7 @@ paths:
             `timelineId`.
       summary: Create a clean draft Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_export:
     post:
@@ -613,7 +613,7 @@ paths:
           description: Indicates that the export size limit was exceeded.
       summary: Export Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_favorite:
     patch:
@@ -676,7 +676,7 @@ paths:
             the favorite status.
       summary: Favorite a Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_import:
     post:
@@ -767,7 +767,7 @@ paths:
           description: Indicates the import of Timelines was unsuccessful.
       summary: Import Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_prepackaged:
     post:
@@ -826,7 +826,7 @@ paths:
             unsuccessful.
       summary: Install prepackaged Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/resolve:
     get:
@@ -866,7 +866,7 @@ paths:
           description: The (template) Timeline was not found
       summary: Get an existing saved Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timelines:
     get:
@@ -970,7 +970,7 @@ paths:
           description: Bad request. The user supplied invalid data.
       summary: Get Timelines or Timeline templates
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
 components:
   schemas:
@@ -1601,4 +1601,4 @@ tags:
   - description: >-
       You can create Timelines and Timeline templates via the API, as well as
       import new Timelines from an ndjson file.
-    name: Security Solution Timeline API
+    name: Security Timeline API

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -4,7 +4,7 @@ info:
     You can create rules that automatically turn events and external alerts sent
     to Elastic Security into detection alerts. These alerts are displayed on the
     Detections page.
-  title: Security Solution Detections API (Elastic Cloud Serverless)
+  title: Security Detections API (Elastic Cloud Serverless)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -55,7 +55,7 @@ paths:
           description: Internal server error response
       summary: Returns user privileges for the Kibana space
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Privileges API
   /api/detection_engine/rules:
     delete:
@@ -83,7 +83,7 @@ paths:
           description: Indicates a successful call.
       summary: Delete a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     get:
       description: Retrieve a detection rule using the `rule_id` or `id` field.
@@ -110,7 +110,7 @@ paths:
           description: Indicates a successful call.
       summary: Retrieve a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     patch:
       description: >-
@@ -132,7 +132,7 @@ paths:
           description: Indicates a successful call.
       summary: Patch a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     post:
       description: Create a new detection rule.
@@ -152,7 +152,7 @@ paths:
           description: Indicates a successful call.
       summary: Create a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
     put:
       description: >
@@ -178,7 +178,7 @@ paths:
           description: Indicates a successful call.
       summary: Update a detection rule
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
   /api/detection_engine/rules/_bulk_action:
     post:
@@ -217,7 +217,7 @@ paths:
           description: OK
       summary: Apply a bulk action to detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Bulk API
   /api/detection_engine/rules/_export:
     post:
@@ -281,7 +281,7 @@ paths:
           description: Indicates a successful call.
       summary: Export detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Import/Export API
   /api/detection_engine/rules/_find:
     get:
@@ -356,7 +356,7 @@ paths:
           description: Successful response
       summary: List all detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rules API
   /api/detection_engine/rules/_import:
     post:
@@ -471,7 +471,7 @@ paths:
           description: Indicates a successful call.
       summary: Import detection rules
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Import/Export API
   /api/detection_engine/rules/preview:
     post:
@@ -560,7 +560,7 @@ paths:
           description: Internal server error response
       summary: Preview rule alerts generated on specified time range
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Rule preview API
   /api/detection_engine/signals/assignees:
     post:
@@ -592,7 +592,7 @@ paths:
           description: Invalid request.
       summary: Assign and unassign users from detection alerts
       tags:
-        - Security Solution Detections API
+        - Security Detections API
   /api/detection_engine/signals/search:
     post:
       description: Find and/or aggregate detection alerts that match the given query.
@@ -664,7 +664,7 @@ paths:
           description: Internal server error response
       summary: Find and/or aggregate detection alerts
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/signals/status:
     post:
@@ -712,7 +712,7 @@ paths:
           description: Internal server error response
       summary: Set a detection alert status
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/signals/tags:
     post:
@@ -769,7 +769,7 @@ paths:
           description: Internal server error response
       summary: Add and remove detection alert tags
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Alerts API
   /api/detection_engine/tags:
     get:
@@ -784,7 +784,7 @@ paths:
           description: Indicates a successful call
       summary: List all detection rule tags
       tags:
-        - Security Solution Detections API
+        - Security Detections API
         - Tags API
 components:
   schemas:
@@ -6145,4 +6145,4 @@ tags:
       You can create rules that automatically turn events and external alerts
       sent to Elastic Security into detection alerts. These alerts are displayed
       on the Detections page.
-    name: Security Solution Detections API
+    name: Security Detections API

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: Interact with and manage endpoints running the Elastic Defend integration.
-  title: Security Solution Endpoint Management API (Elastic Cloud Serverless)
+  title: Security Endpoint Management API (Elastic Cloud Serverless)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -30,7 +30,7 @@ paths:
           description: OK
       summary: Get response actions
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action_log/{agent_id}:
     get:
       deprecated: true
@@ -56,7 +56,7 @@ paths:
           description: OK
       summary: Get an action request log
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action_status:
     get:
       description: Get the status of response actions for the specified agent IDs.
@@ -79,7 +79,7 @@ paths:
           description: OK
       summary: Get response actions status
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}:
     get:
       description: Get the details of a response action using the action ID.
@@ -99,7 +99,7 @@ paths:
           description: OK
       summary: Get action details
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}/file/{file_id}:
     get:
       description: Get information for the specified file using the file ID.
@@ -124,7 +124,7 @@ paths:
           description: OK
       summary: Get file information
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/{action_id}/file/{file_id}/download:
     get:
       description: Download a file from an endpoint.
@@ -149,7 +149,7 @@ paths:
           description: OK
       summary: Download a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/execute:
     post:
       description: Run a shell command on an endpoint.
@@ -169,7 +169,7 @@ paths:
           description: OK
       summary: Run a command
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/get_file:
     post:
       description: Get a file from an endpoint.
@@ -189,7 +189,7 @@ paths:
           description: OK
       summary: Get a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/isolate:
     post:
       description: >-
@@ -211,7 +211,7 @@ paths:
           description: OK
       summary: Isolate an endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/kill_process:
     post:
       description: Terminate a running process on an endpoint.
@@ -231,7 +231,7 @@ paths:
           description: OK
       summary: Terminate a process
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/running_procs:
     post:
       description: Get a list of all processes running on an endpoint.
@@ -251,7 +251,7 @@ paths:
           description: OK
       summary: Get running processes
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/scan:
     post:
       description: Scan a specific file or directory on an endpoint for malware.
@@ -271,7 +271,7 @@ paths:
           description: OK
       summary: Scan a file or directory
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/state:
     get:
       description: >-
@@ -287,7 +287,7 @@ paths:
           description: OK
       summary: Get actions state
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/suspend_process:
     post:
       description: Suspend a running process on an endpoint.
@@ -307,7 +307,7 @@ paths:
           description: OK
       summary: Suspend a process
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/unisolate:
     post:
       description: Release an isolated endpoint, allowing it to rejoin a network.
@@ -327,7 +327,7 @@ paths:
           description: OK
       summary: Release an isolated endpoint
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/action/upload:
     post:
       description: Upload a file to an endpoint.
@@ -347,7 +347,7 @@ paths:
           description: OK
       summary: Upload a file
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata:
     get:
       operationId: GetEndpointMetadataList
@@ -366,7 +366,7 @@ paths:
           description: OK
       summary: Get a metadata list
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata/{id}:
     get:
       operationId: GetEndpointMetadata
@@ -385,7 +385,7 @@ paths:
           description: OK
       summary: Get metadata
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/metadata/transforms:
     get:
       operationId: GetEndpointMetadataTransform
@@ -398,7 +398,7 @@ paths:
           description: OK
       summary: Get metadata transforms
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/policy_response:
     get:
       operationId: GetPolicyResponse
@@ -420,7 +420,7 @@ paths:
           description: OK
       summary: Get a policy response
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/policy/summaries:
     get:
       deprecated: true
@@ -446,7 +446,7 @@ paths:
           description: OK
       summary: Get an agent policy summary
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/protection_updates_note/{package_policy_id}:
     get:
       operationId: GetProtectionUpdatesNote
@@ -465,7 +465,7 @@ paths:
           description: OK
       summary: Get a protection updates note
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
     post:
       operationId: CreateUpdateProtectionUpdatesNote
       parameters:
@@ -492,7 +492,7 @@ paths:
           description: OK
       summary: Create or update a protection updates note
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
   /api/endpoint/suggestions/{suggestion_type}:
     post:
       operationId: GetEndpointSuggestions
@@ -528,7 +528,7 @@ paths:
           description: OK
       summary: Get suggestions
       tags:
-        - Security Solution Endpoint Management API
+        - Security Endpoint Management API
 components:
   schemas:
     ActionLogRequestQuery:
@@ -1035,4 +1035,4 @@ security:
   - BasicAuth: []
 tags:
   - description: Interact with and manage endpoints running the Elastic Defend integration.
-    name: Security Solution Endpoint Management API
+    name: Security Endpoint Management API

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: ''
-  title: Security Solution Entity Analytics API (Elastic Cloud Serverless)
+  title: Security Entity Analytics API (Elastic Cloud Serverless)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -59,7 +59,7 @@ paths:
           description: Invalid request
       summary: Delete an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     get:
       description: Get the asset criticality record for a specific entity.
       operationId: GetAssetCriticalityRecord
@@ -90,7 +90,7 @@ paths:
           description: Criticality record not found
       summary: Get an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     post:
       description: >
         Create or update an asset criticality record for a specific entity.
@@ -127,7 +127,7 @@ paths:
           description: Invalid request
       summary: Upsert an asset criticality record
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/asset_criticality/bulk:
     post:
       description: >
@@ -190,7 +190,7 @@ paths:
           description: File too large
       summary: Bulk upsert asset criticality records
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/asset_criticality/list:
     get:
       description: List asset criticality records, paging, sorting and filtering as needed.
@@ -266,7 +266,7 @@ paths:
           description: Bulk upload successful
       summary: List asset criticality records
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines:
     get:
       operationId: ListEntityEngines
@@ -286,7 +286,7 @@ paths:
           description: Successful response
       summary: List the Entity Engines
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}:
     delete:
       operationId: DeleteEntityEngine
@@ -315,7 +315,7 @@ paths:
           description: Successful response
       summary: Delete the Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
     get:
       operationId: GetEntityEngine
       parameters:
@@ -334,7 +334,7 @@ paths:
           description: Successful response
       summary: Get an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/init:
     post:
       operationId: InitEntityEngine
@@ -366,7 +366,7 @@ paths:
           description: Successful response
       summary: Initialize an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/start:
     post:
       operationId: StartEntityEngine
@@ -389,7 +389,7 @@ paths:
           description: Successful response
       summary: Start an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/stats:
     post:
       operationId: GetEntityEngineStats
@@ -424,7 +424,7 @@ paths:
           description: Successful response
       summary: Get Entity Engine stats
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/engines/{entityType}/stop:
     post:
       operationId: StopEntityEngine
@@ -447,7 +447,7 @@ paths:
           description: Successful response
       summary: Stop an Entity Engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/entity_store/entities/list:
     get:
       description: List entities records, paging, sorting and filtering as needed.
@@ -523,7 +523,7 @@ paths:
           description: Entities returned successfully
       summary: List Entity Store Entities
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
   /api/risk_score/engine/schedule_now:
     post:
       description: >-
@@ -555,7 +555,7 @@ paths:
           description: Unexpected error
       summary: Run the risk scoring engine
       tags:
-        - Security Solution Entity Analytics API
+        - Security Entity Analytics API
 components:
   schemas:
     AssetCriticalityBulkUploadErrorItem:
@@ -851,4 +851,4 @@ security:
   - BasicAuth: []
 tags:
   - description: ''
-    name: Security Solution Entity Analytics API
+    name: Security Entity Analytics API

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
@@ -3,7 +3,7 @@ info:
   description: >-
     You can create Timelines and Timeline templates via the API, as well as
     import new Timelines from an ndjson file.
-  title: Security Solution Timeline API (Elastic Cloud Serverless)
+  title: Security Timeline API (Elastic Cloud Serverless)
   version: '2023-10-31'
 servers:
   - url: http://{kibana_host}:{port}
@@ -53,7 +53,7 @@ paths:
           description: Indicates the note was successfully deleted.
       summary: Delete a note
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     get:
       description: Get all notes for a given document.
@@ -104,7 +104,7 @@ paths:
           description: Indicates the requested notes were returned.
       summary: Get notes
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     patch:
       description: Add a note to a Timeline or update an existing note.
@@ -158,7 +158,7 @@ paths:
           description: Indicates the note was successfully created.
       summary: Add or update a note
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/pinned_event:
     patch:
@@ -201,7 +201,7 @@ paths:
           description: Indicates the event was successfully pinned to the Timeline.
       summary: Pin an event
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline:
     delete:
@@ -247,7 +247,7 @@ paths:
           description: Indicates the Timeline was successfully deleted.
       summary: Delete Timelines or Timeline templates
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     get:
       description: Get the details of an existing saved Timeline or Timeline template.
@@ -283,7 +283,7 @@ paths:
           description: Indicates that the (template) Timeline was found and returned.
       summary: Get Timeline or Timeline template details
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     patch:
       description: >-
@@ -351,7 +351,7 @@ paths:
             a draft Timeline.
       summary: Update a Timeline
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     post:
       description: Create a new Timeline or Timeline template.
@@ -421,7 +421,7 @@ paths:
           description: Indicates that there was an error in the Timeline creation.
       summary: Create a Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_draft:
     get:
@@ -488,7 +488,7 @@ paths:
             draft Timeline with the given `timelineId`.
       summary: Get draft Timeline or Timeline template details
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
     post:
       description: >
@@ -566,7 +566,7 @@ paths:
             `timelineId`.
       summary: Create a clean draft Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_export:
     post:
@@ -613,7 +613,7 @@ paths:
           description: Indicates that the export size limit was exceeded.
       summary: Export Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_favorite:
     patch:
@@ -676,7 +676,7 @@ paths:
             the favorite status.
       summary: Favorite a Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_import:
     post:
@@ -767,7 +767,7 @@ paths:
           description: Indicates the import of Timelines was unsuccessful.
       summary: Import Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/_prepackaged:
     post:
@@ -826,7 +826,7 @@ paths:
             unsuccessful.
       summary: Install prepackaged Timelines
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timeline/resolve:
     get:
@@ -866,7 +866,7 @@ paths:
           description: The (template) Timeline was not found
       summary: Get an existing saved Timeline or Timeline template
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
   /api/timelines:
     get:
@@ -970,7 +970,7 @@ paths:
           description: Bad request. The user supplied invalid data.
       summary: Get Timelines or Timeline templates
       tags:
-        - Security Solution Timeline API
+        - Security Timeline API
         - access:securitySolution
 components:
   schemas:
@@ -1601,4 +1601,4 @@ tags:
   - description: >-
       You can create Timelines and Timeline templates via the API, as well as
       import new Timelines from an ndjson file.
-    name: Security Solution Timeline API
+    name: Security Timeline API

--- a/x-pack/plugins/security_solution/scripts/openapi/bundle_detections.js
+++ b/x-pack/plugins/security_solution/scripts/openapi/bundle_detections.js
@@ -22,13 +22,13 @@ const ROOT = resolve(__dirname, '../..');
       includeLabels: ['serverless'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Detections API (Elastic Cloud Serverless)',
+          title: 'Security Detections API (Elastic Cloud Serverless)',
           description:
             'You can create rules that automatically turn events and external alerts sent to Elastic Security into detection alerts. These alerts are displayed on the Detections page.',
         },
         tags: [
           {
-            name: 'Security Solution Detections API',
+            name: 'Security Detections API',
             description:
               'You can create rules that automatically turn events and external alerts sent to Elastic Security into detection alerts. These alerts are displayed on the Detections page.',
           },
@@ -47,13 +47,13 @@ const ROOT = resolve(__dirname, '../..');
       includeLabels: ['ess'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Detections API (Elastic Cloud and self-hosted)',
+          title: 'Security Detections API (Elastic Cloud and self-hosted)',
           description:
             'You can create rules that automatically turn events and external alerts sent to Elastic Security into detection alerts. These alerts are displayed on the Detections page.',
         },
         tags: [
           {
-            name: 'Security Solution Detections API',
+            name: 'Security Detections API',
             description:
               'You can create rules that automatically turn events and external alerts sent to Elastic Security into detection alerts. These alerts are displayed on the Detections page.',
           },

--- a/x-pack/plugins/security_solution/scripts/openapi/bundle_endpoint_management.js
+++ b/x-pack/plugins/security_solution/scripts/openapi/bundle_endpoint_management.js
@@ -22,12 +22,12 @@ const ROOT = resolve(__dirname, '../..');
       includeLabels: ['serverless'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Endpoint Management API (Elastic Cloud Serverless)',
+          title: 'Security Endpoint Management API (Elastic Cloud Serverless)',
           description: 'Interact with and manage endpoints running the Elastic Defend integration.',
         },
         tags: [
           {
-            name: 'Security Solution Endpoint Management API',
+            name: 'Security Endpoint Management API',
             description:
               'Interact with and manage endpoints running the Elastic Defend integration.',
           },
@@ -46,12 +46,12 @@ const ROOT = resolve(__dirname, '../..');
       includeLabels: ['ess'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Endpoint Management API (Elastic Cloud and self-hosted)',
+          title: 'Security Endpoint Management API (Elastic Cloud and self-hosted)',
           description: 'Interact with and manage endpoints running the Elastic Defend integration.',
         },
         tags: [
           {
-            name: 'Security Solution Endpoint Management API',
+            name: 'Security Endpoint Management API',
             description:
               'Interact with and manage endpoints running the Elastic Defend integration.',
           },

--- a/x-pack/plugins/security_solution/scripts/openapi/bundle_entity_analytics.js
+++ b/x-pack/plugins/security_solution/scripts/openapi/bundle_entity_analytics.js
@@ -22,12 +22,12 @@ const ROOT = resolve(__dirname, '../..');
       includeLabels: ['serverless'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Entity Analytics API (Elastic Cloud Serverless)',
+          title: 'Security Entity Analytics API (Elastic Cloud Serverless)',
           description: '',
         },
         tags: [
           {
-            name: 'Security Solution Entity Analytics API',
+            name: 'Security Entity Analytics API',
             description: '',
           },
         ],
@@ -45,12 +45,12 @@ const ROOT = resolve(__dirname, '../..');
       includeLabels: ['ess'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Entity Analytics API (Elastic Cloud and self-hosted)',
+          title: 'Security Entity Analytics API (Elastic Cloud and self-hosted)',
           description: '',
         },
         tags: [
           {
-            name: 'Security Solution Entity Analytics API',
+            name: 'Security Entity Analytics API',
             description: '',
           },
         ],

--- a/x-pack/plugins/security_solution/scripts/openapi/bundle_timeline.js
+++ b/x-pack/plugins/security_solution/scripts/openapi/bundle_timeline.js
@@ -22,13 +22,13 @@ const ROOT = resolve(__dirname, '../..');
       includeLabels: ['serverless'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Timeline API (Elastic Cloud Serverless)',
+          title: 'Security Timeline API (Elastic Cloud Serverless)',
           description:
             'You can create Timelines and Timeline templates via the API, as well as import new Timelines from an ndjson file.',
         },
         tags: [
           {
-            name: 'Security Solution Timeline API',
+            name: 'Security Timeline API',
             description:
               'You can create Timelines and Timeline templates via the API, as well as import new Timelines from an ndjson file.',
           },
@@ -47,13 +47,13 @@ const ROOT = resolve(__dirname, '../..');
       includeLabels: ['ess'],
       prototypeDocument: {
         info: {
-          title: 'Security Solution Timeline API (Elastic Cloud and self-hosted)',
+          title: 'Security Timeline API (Elastic Cloud and self-hosted)',
           description:
             'You can create Timelines and Timeline templates via the API, as well as import new Timelines from an ndjson file.',
         },
         tags: [
           {
-            name: 'Security Solution Timeline API',
+            name: 'Security Timeline API',
             description:
               'You can create Timelines and Timeline templates via the API, as well as import new Timelines from an ndjson file.',
           },


### PR DESCRIPTION
**Relates to:** https://github.com/elastic/kibana/issues/184428

## Summary

This PR omit `Solution` from from tag names and titles in Security Solution's OpenAPI bundles based on Security Docs team recommendation.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->