### PR TITLE
[8.x] [ftr] enable mock-idp-plugin for stateful (deployment-agnostic) tests (#192279)

### DIFF
--- a/packages/kbn-mock-idp-plugin/server/index.ts
+++ b/packages/kbn-mock-idp-plugin/server/index.ts
@@ -17,6 +17,7 @@ export const config = {
     // The plugin should only be enabled in Serverless.
     enabled: offeringBasedSchema({
       serverless: schema.boolean({ defaultValue: true }),
+      traditional: schema.boolean({ defaultValue: false }),
       options: { defaultValue: false },
     }),
   }),

--- a/packages/kbn-mock-idp-plugin/server/plugin.ts
+++ b/packages/kbn-mock-idp-plugin/server/plugin.ts
@@ -11,7 +11,11 @@ import type { PluginInitializer, Plugin } from '@kbn/core-plugins-server';
 import { schema } from '@kbn/config-schema';
 import type { TypeOf } from '@kbn/config-schema';
 import { MOCK_IDP_LOGIN_PATH, MOCK_IDP_LOGOUT_PATH, createSAMLResponse } from '@kbn/mock-idp-utils';
-import { SERVERLESS_ROLES_ROOT_PATH, readRolesFromResource } from '@kbn/es';
+import {
+  SERVERLESS_ROLES_ROOT_PATH,
+  STATEFUL_ROLES_ROOT_PATH,
+  readRolesFromResource,
+} from '@kbn/es';
 import { resolve } from 'path';
 import { CloudSetup } from '@kbn/cloud-plugin/server';
 
@@ -40,6 +44,11 @@ const readServerlessRoles = (projectType: string) => {
   } else {
     throw new Error(`Unsupported projectType: ${projectType}`);
   }
+};
+
+const readStatefulRoles = () => {
+  const rolesResourcePath = resolve(STATEFUL_ROLES_ROOT_PATH, 'roles.yml');
+  return readRolesFromResource(rolesResourcePath);
 };
 
 export type CreateSAMLResponseParams = TypeOf<typeof createSAMLResponseSchema>;
@@ -73,22 +82,18 @@ export const plugin: PluginInitializer<
         options: { authRequired: false },
       },
       (context, request, response) => {
-        const projectType = plugins.cloud.serverless?.projectType;
-        if (!projectType) {
-          return response.customError({ statusCode: 500, body: 'projectType is not defined' });
-        } else {
-          try {
-            if (roles.length === 0) {
-              roles.push(...readServerlessRoles(projectType));
-            }
-            return response.ok({
-              body: {
-                roles,
-              },
-            });
-          } catch (err) {
-            return response.customError({ statusCode: 500, body: err.message });
+        try {
+          if (roles.length === 0) {
+            const projectType = plugins.cloud?.serverless?.projectType;
+            roles.push(...(projectType ? readServerlessRoles(projectType) : readStatefulRoles()));
           }
+          return response.ok({
+            body: {
+              roles,
+            },
+          });
+        } catch (err) {
+          return response.customError({ statusCode: 500, body: err.message });
         }
       }
     );

--- a/x-pack/test/api_integration/deployment_agnostic/default_configs/stateful.config.base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/default_configs/stateful.config.base.ts
@@ -43,11 +43,18 @@ export function createStatefulTestConfig<T extends DeploymentAgnosticCommonServi
       );
     }
 
+    // if config is executed on CI or locally
+    const isRunOnCI = process.env.CI;
+
     const xPackAPITestsConfig = await readConfigFile(require.resolve('../../config.ts'));
 
     // TODO: move to kbn-es because currently metadata file has hardcoded entityID and Location
     const idpPath = require.resolve(
       '@kbn/security-api-integration-helpers/saml/idp_metadata_mock_idp.xml'
+    );
+    const samlIdPPlugin = path.resolve(
+      __dirname,
+      '../../../security_api_integration/plugins/saml_provider'
     );
 
     const servers = {
@@ -98,6 +105,17 @@ export function createStatefulTestConfig<T extends DeploymentAgnosticCommonServi
         ...xPackAPITestsConfig.get('kbnTestServer'),
         serverArgs: [
           ...xPackAPITestsConfig.get('kbnTestServer.serverArgs'),
+          // if the config is run locally, explicitly enable mock-idp-plugin for UI role selector
+          ...(isRunOnCI ? [] : ['--mock_idp_plugin.enabled=true']),
+          // This ensures that we register the Security SAML API endpoints.
+          // In the real world the SAML config is injected by control plane.
+          `--plugin-path=${samlIdPPlugin}`,
+          '--xpack.cloud.id=ftr_fake_cloud_id',
+          // Ensure that SAML is used as the default authentication method whenever a user navigates to Kibana. In other
+          // words, Kibana should attempt to authenticate the user using the provider with the lowest order if the Login
+          // Selector is disabled (replicating Serverless configuration). By declaring `cloud-basic` with a higher
+          // order, we indicate that basic authentication can still be used, but only if explicitly requested when the
+          // user navigates to `/login` page directly and enters username and password in the login form.
           '--xpack.security.authc.selector.enabled=false',
           `--xpack.security.authc.providers=${JSON.stringify({
             saml: { 'cloud-saml-kibana': { order: 0, realm: MOCK_IDP_REALM_NAME } },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ftr] enable mock-idp-plugin for stateful (deployment-agnostic) tests (#192279)](https://github.com/elastic/kibana/pull/192279)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2024-09-13T10:24:08Z","message":"[ftr] enable mock-idp-plugin for stateful (deployment-agnostic) tests (#192279)\n\n## Summary\r\n\r\ncloses #190221\r\n\r\nThis PR enables `mock-idp-plugin` when Kibana is started with stateful\r\nFTR config for deployment-agnostic tests:\r\n\r\n```\r\n node scripts/functional_tests_server --config=x-pack/test/api_integration/deployment_agnostic/configs/stateful/platform.stateful.config.ts\r\n```\r\n\r\n<img width=\"1574\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/494e89ee-cd65-4dde-86da-a5e2c28ec40d\">\r\n\r\nYou can pick up one of the the role defined for stateful SAML\r\nauthentication in\r\nhttps://github.com/elastic/kibana/blob/main/packages/kbn-es/src/stateful_resources/roles.yml\r\n\r\nNote: this plugin is only enabled locally for a better manual testing\r\nexperience, it is **not loaded on CI**\r\n\r\nIt is done to unify DevEx when folks work on deployment-agnostic tests\r\nand would like to confirm the functionality under the same role for both\r\nstateful and serverless deployments.\r\n\r\nThanks @azasypkin for the help, again :)\r\n\r\nHow to test: \r\n- start the servers using\r\n`x-pack/test/api_integration/deployment_agnostic/configs/stateful/platform.stateful.config.ts`\r\nconfig and go to `http://localhost:5620`\r\n- try to login with different roles, make sure valid role is applied in\r\ntop right profile menu","sha":"a94a4db8bc9e9d923273beb5c31b2253172a8568","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","FTR","v8.16.0"],"number":192279,"url":"https://github.com/elastic/kibana/pull/192279","mergeCommit":{"message":"[ftr] enable mock-idp-plugin for stateful (deployment-agnostic) tests (#192279)\n\n## Summary\r\n\r\ncloses #190221\r\n\r\nThis PR enables `mock-idp-plugin` when Kibana is started with stateful\r\nFTR config for deployment-agnostic tests:\r\n\r\n```\r\n node scripts/functional_tests_server --config=x-pack/test/api_integration/deployment_agnostic/configs/stateful/platform.stateful.config.ts\r\n```\r\n\r\n<img width=\"1574\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/494e89ee-cd65-4dde-86da-a5e2c28ec40d\">\r\n\r\nYou can pick up one of the the role defined for stateful SAML\r\nauthentication in\r\nhttps://github.com/elastic/kibana/blob/main/packages/kbn-es/src/stateful_resources/roles.yml\r\n\r\nNote: this plugin is only enabled locally for a better manual testing\r\nexperience, it is **not loaded on CI**\r\n\r\nIt is done to unify DevEx when folks work on deployment-agnostic tests\r\nand would like to confirm the functionality under the same role for both\r\nstateful and serverless deployments.\r\n\r\nThanks @azasypkin for the help, again :)\r\n\r\nHow to test: \r\n- start the servers using\r\n`x-pack/test/api_integration/deployment_agnostic/configs/stateful/platform.stateful.config.ts`\r\nconfig and go to `http://localhost:5620`\r\n- try to login with different roles, make sure valid role is applied in\r\ntop right profile menu","sha":"a94a4db8bc9e9d923273beb5c31b2253172a8568"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/192279","number":192279,"mergeCommit":{"message":"[ftr] enable mock-idp-plugin for stateful (deployment-agnostic) tests (#192279)\n\n## Summary\r\n\r\ncloses #190221\r\n\r\nThis PR enables `mock-idp-plugin` when Kibana is started with stateful\r\nFTR config for deployment-agnostic tests:\r\n\r\n```\r\n node scripts/functional_tests_server --config=x-pack/test/api_integration/deployment_agnostic/configs/stateful/platform.stateful.config.ts\r\n```\r\n\r\n<img width=\"1574\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/494e89ee-cd65-4dde-86da-a5e2c28ec40d\">\r\n\r\nYou can pick up one of the the role defined for stateful SAML\r\nauthentication in\r\nhttps://github.com/elastic/kibana/blob/main/packages/kbn-es/src/stateful_resources/roles.yml\r\n\r\nNote: this plugin is only enabled locally for a better manual testing\r\nexperience, it is **not loaded on CI**\r\n\r\nIt is done to unify DevEx when folks work on deployment-agnostic tests\r\nand would like to confirm the functionality under the same role for both\r\nstateful and serverless deployments.\r\n\r\nThanks @azasypkin for the help, again :)\r\n\r\nHow to test: \r\n- start the servers using\r\n`x-pack/test/api_integration/deployment_agnostic/configs/stateful/platform.stateful.config.ts`\r\nconfig and go to `http://localhost:5620`\r\n- try to login with different roles, make sure valid role is applied in\r\ntop right profile menu","sha":"a94a4db8bc9e9d923273beb5c31b2253172a8568"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->