### PR TITLE
[EDR Workflows][Fleet] Accurate endpoint count across multiple agent policies

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.ts
@@ -328,7 +328,8 @@ export const getAgentStatusForAgentPolicyHandler: FleetRequestHandler<
       soClient,
       request.query.policyId,
       request.query.kuery,
-      coreContext.savedObjects.client.getCurrentNamespace()
+      coreContext.savedObjects.client.getCurrentNamespace(),
+      request.query.policyIds
     );
 
     const body: GetAgentStatusResponse = { results };

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -241,6 +241,7 @@ export const PostBulkUpdateAgentTagsRequestSchema = {
 export const GetAgentStatusRequestSchema = {
   query: schema.object({
     policyId: schema.maybe(schema.string()),
+    policyIds: schema.maybe(schema.arrayOf(schema.string())),
     kuery: schema.maybe(
       schema.string({
         validate: (value: string) => {

--- a/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/middleware/policy_settings_middleware.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/middleware/policy_settings_middleware.ts
@@ -97,7 +97,7 @@ export const policySettingsMiddlewareRunner: MiddlewareRunner = async (
     // Agent summary is secondary data, so its ok for it to come after the details
     // page is populated with the main content
     if (policyItem.policy_id) {
-      const { results } = await sendGetFleetAgentStatusForPolicy(http, policyItem.policy_id);
+      const { results } = await sendGetFleetAgentStatusForPolicy(http, policyItem.policy_ids);
       dispatch({
         type: 'serverReturnedPolicyDetailsAgentSummaryData',
         payload: {

--- a/x-pack/plugins/security_solution/public/management/services/policies/ingest.ts
+++ b/x-pack/plugins/security_solution/public/management/services/policies/ingest.ts
@@ -86,20 +86,20 @@ export const sendPutPackagePolicy = (
  * Get a status summary for all Agents that are currently assigned to a given agent policy
  *
  * @param http
- * @param policyId
+ * @param policyIds
  * @param options
  */
 export const sendGetFleetAgentStatusForPolicy = (
   http: HttpStart,
   /** the Agent (fleet) policy id */
-  policyId: string,
+  policyIds: string[],
   options: Exclude<HttpFetchOptions, 'query'> = {}
 ): Promise<GetAgentStatusResponse> => {
   return http.get(INGEST_API_FLEET_AGENT_STATUS, {
     ...options,
     version: API_VERSIONS.public.v1,
     query: {
-      policyId,
+      policyIds,
     },
   });
 };


### PR DESCRIPTION
This PR updates the method for counting endpoint statuses. Previously, we fetched agent status using a single agent policy ID. With this change, we now pass an array of policy IDs, allowing us to include the returned stats for endpoints that share the same integration policy assigned to multiple agent policies.

![Screenshot 2024-09-23 at 13 53 57](https://github.com/user-attachments/assets/570027b7-79d7-4c9a-aa64-c0ecfe76cb7f)
![Screenshot 2024-09-23 at 13 53 24](https://github.com/user-attachments/assets/17d62c24-9d46-4133-a817-ea5849930435)
![Screenshot 2024-09-23 at 13 53 45](https://github.com/user-attachments/assets/c9fb5ed7-e4a0-4faa-a24d-253def10f163)





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->