### PR TITLE
[Automatic Import] Replace import all

### DIFF
--- a/x-pack/plugins/integration_assistant/server/integration_builder/agent.test.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/agent.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import * as Utils from '../util';
+import { ensureDirSync, createSync } from '../util';
 import { createAgentInput } from './agent';
 import { InputType } from '../../common';
 
@@ -27,13 +27,13 @@ describe('createAgentInput', () => {
 
     createAgentInput(dataStreamPath, inputTypes);
 
-    expect(Utils.ensureDirSync).toHaveBeenCalledWith(`${dataStreamPath}/agent/stream`);
+    expect(ensureDirSync).toHaveBeenCalledWith(`${dataStreamPath}/agent/stream`);
 
-    expect(Utils.createSync).toHaveBeenCalledWith(
+    expect(createSync).toHaveBeenCalledWith(
       `${dataStreamPath}/agent/stream/aws-s3.yml.hbs`,
       expect.any(String)
     );
-    expect(Utils.createSync).toHaveBeenCalledWith(
+    expect(createSync).toHaveBeenCalledWith(
       `${dataStreamPath}/agent/stream/filestream.yml.hbs`,
       expect.any(String)
     );
@@ -42,7 +42,7 @@ describe('createAgentInput', () => {
   it('Should not create agent files if there are no input types', async () => {
     createAgentInput(dataStreamPath, []);
 
-    expect(Utils.ensureDirSync).toHaveBeenCalledWith(`${dataStreamPath}/agent/stream`);
-    expect(Utils.createSync).not.toHaveBeenCalled();
+    expect(ensureDirSync).toHaveBeenCalledWith(`${dataStreamPath}/agent/stream`);
+    expect(createSync).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.test.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.test.ts
@@ -5,15 +5,14 @@
  * 2.0.
  */
 
-import * as buildIntegrationModule from './build_integration';
+import { buildPackage, renderPackageManifestYAML } from './build_integration';
 import { testIntegration } from '../../__jest__/fixtures/build_integration';
-import * as Utils from '../util';
-import * as DataStreamModule from './data_stream';
-import * as FieldsModule from './fields';
-import * as AgentModule from './agent';
-import * as PipelineModule from './pipeline';
+import { generateUniqueId, ensureDirSync, createSync } from '../util';
+import { createDataStream } from './data_stream';
+import { createFieldMapping } from './fields';
+import { createAgentInput } from './agent';
+import { createPipeline } from './pipeline';
 import { DataStream, Docs, InputType, Pipeline, Integration } from '../../common';
-import { renderPackageManifestYAML } from './build_integration';
 import yaml from 'js-yaml';
 
 const mockedDataPath = 'path';
@@ -25,7 +24,7 @@ jest.mock('./fields');
 jest.mock('./agent');
 jest.mock('./pipeline');
 
-(Utils.generateUniqueId as jest.Mock).mockReturnValue(mockedId);
+(generateUniqueId as jest.Mock).mockReturnValue(mockedId);
 
 jest.mock('@kbn/utils', () => ({
   getDataPath: jest.fn(() => mockedDataPath),
@@ -97,77 +96,68 @@ describe('buildPackage', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    await buildIntegrationModule.buildPackage(testIntegration);
+    await buildPackage(testIntegration);
   });
 
   it('Should create expected directories and files', async () => {
     // Package & integration folders
-    expect(Utils.ensureDirSync).toHaveBeenCalledWith(packagePath);
-    expect(Utils.ensureDirSync).toHaveBeenCalledWith(integrationPath);
+    expect(ensureDirSync).toHaveBeenCalledWith(packagePath);
+    expect(ensureDirSync).toHaveBeenCalledWith(integrationPath);
 
     // _dev files
-    expect(Utils.ensureDirSync).toHaveBeenCalledWith(`${integrationPath}/_dev/build`);
-    expect(Utils.createSync).toHaveBeenCalledWith(
+    expect(ensureDirSync).toHaveBeenCalledWith(`${integrationPath}/_dev/build`);
+    expect(createSync).toHaveBeenCalledWith(
       `${integrationPath}/_dev/build/docs/README.md`,
       expect.any(String)
     );
-    expect(Utils.createSync).toHaveBeenCalledWith(
+    expect(createSync).toHaveBeenCalledWith(
       `${integrationPath}/_dev/build/build.yml`,
       expect.any(String)
     );
 
     // Docs files
-    expect(Utils.ensureDirSync).toHaveBeenCalledWith(`${integrationPath}/docs/`);
-    expect(Utils.createSync).toHaveBeenCalledWith(
+    expect(ensureDirSync).toHaveBeenCalledWith(`${integrationPath}/docs/`);
+    expect(createSync).toHaveBeenCalledWith(
       `${integrationPath}/docs/README.md`,
       expect.any(String)
     );
 
     // Changelog file
-    expect(Utils.createSync).toHaveBeenCalledWith(
-      `${integrationPath}/changelog.yml`,
-      expect.any(String)
-    );
+    expect(createSync).toHaveBeenCalledWith(`${integrationPath}/changelog.yml`, expect.any(String));
 
     // Manifest files
-    expect(Utils.createSync).toHaveBeenCalledWith(
-      `${integrationPath}/manifest.yml`,
-      expect.any(String)
-    );
+    expect(createSync).toHaveBeenCalledWith(`${integrationPath}/manifest.yml`, expect.any(String));
   });
 
   it('Should create logo files if info is present in the integration', async () => {
     testIntegration.logo = 'logo';
 
-    await buildIntegrationModule.buildPackage(testIntegration);
+    await buildPackage(testIntegration);
 
-    expect(Utils.ensureDirSync).toHaveBeenCalledWith(`${integrationPath}/img`);
-    expect(Utils.createSync).toHaveBeenCalledWith(
-      `${integrationPath}/img/logo.svg`,
-      expect.any(Buffer)
-    );
+    expect(ensureDirSync).toHaveBeenCalledWith(`${integrationPath}/img`);
+    expect(createSync).toHaveBeenCalledWith(`${integrationPath}/img/logo.svg`, expect.any(Buffer));
   });
 
   it('Should not create logo files if info is not present in the integration', async () => {
     jest.clearAllMocks();
     testIntegration.logo = undefined;
 
-    await buildIntegrationModule.buildPackage(testIntegration);
+    await buildPackage(testIntegration);
 
-    expect(Utils.ensureDirSync).not.toHaveBeenCalledWith(`${integrationPath}/img`);
-    expect(Utils.createSync).not.toHaveBeenCalledWith(
+    expect(ensureDirSync).not.toHaveBeenCalledWith(`${integrationPath}/img`);
+    expect(createSync).not.toHaveBeenCalledWith(
       `${integrationPath}/img/logo.svg`,
       expect.any(Buffer)
     );
   });
 
   it('Should call createDataStream for each datastream', async () => {
-    expect(DataStreamModule.createDataStream).toHaveBeenCalledWith(
+    expect(createDataStream).toHaveBeenCalledWith(
       'integration',
       firstDatastreamPath,
       firstDataStream
     );
-    expect(DataStreamModule.createDataStream).toHaveBeenCalledWith(
+    expect(createDataStream).toHaveBeenCalledWith(
       'integration',
       secondDatastreamPath,
       secondDataStream
@@ -175,35 +165,23 @@ describe('buildPackage', () => {
   });
 
   it('Should call createAgentInput for each datastream', async () => {
-    expect(AgentModule.createAgentInput).toHaveBeenCalledWith(
-      firstDatastreamPath,
-      firstDataStreamInputTypes
-    );
-    expect(AgentModule.createAgentInput).toHaveBeenCalledWith(
-      secondDatastreamPath,
-      secondDataStreamInputTypes
-    );
+    expect(createAgentInput).toHaveBeenCalledWith(firstDatastreamPath, firstDataStreamInputTypes);
+    expect(createAgentInput).toHaveBeenCalledWith(secondDatastreamPath, secondDataStreamInputTypes);
   });
 
   it('Should call createPipeline for each datastream', async () => {
-    expect(PipelineModule.createPipeline).toHaveBeenCalledWith(
-      firstDatastreamPath,
-      firstDataStreamPipeline
-    );
-    expect(PipelineModule.createPipeline).toHaveBeenCalledWith(
-      secondDatastreamPath,
-      secondDataStreamPipeline
-    );
+    expect(createPipeline).toHaveBeenCalledWith(firstDatastreamPath, firstDataStreamPipeline);
+    expect(createPipeline).toHaveBeenCalledWith(secondDatastreamPath, secondDataStreamPipeline);
   });
 
   it('Should call createFieldMapping for each datastream', async () => {
-    expect(FieldsModule.createFieldMapping).toHaveBeenCalledWith(
+    expect(createFieldMapping).toHaveBeenCalledWith(
       'integration',
       firstDatastreamName,
       firstDatastreamPath,
       firstDataStreamDocs
     );
-    expect(FieldsModule.createFieldMapping).toHaveBeenCalledWith(
+    expect(createFieldMapping).toHaveBeenCalledWith(
       'integration',
       secondDatastreamName,
       secondDatastreamPath,

--- a/x-pack/plugins/integration_assistant/server/integration_builder/data_stream.test.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/data_stream.test.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import * as Utils from '../util';
+import { ensureDirSync, createSync, copySync } from '../util';
 import { DataStream, Docs, InputType, Pipeline } from '../../common';
 import { createDataStream } from './data_stream';
-import * as nunjucks from 'nunjucks';
+import { render } from 'nunjucks';
 
 jest.mock('nunjucks');
 
@@ -59,31 +59,26 @@ describe('createDataStream', () => {
     createDataStream(packageName, dataStreamPath, firstDataStream);
 
     // pipeline
-    expect(Utils.ensureDirSync).toHaveBeenCalledWith(dataStreamPath);
-    expect(Utils.ensureDirSync).toHaveBeenCalledWith(
-      `${dataStreamPath}/elasticsearch/ingest_pipeline`
-    );
+    expect(ensureDirSync).toHaveBeenCalledWith(dataStreamPath);
+    expect(ensureDirSync).toHaveBeenCalledWith(`${dataStreamPath}/elasticsearch/ingest_pipeline`);
 
     // dataStream files
-    expect(Utils.copySync).toHaveBeenCalledWith(expect.any(String), `${dataStreamPath}/fields`);
+    expect(copySync).toHaveBeenCalledWith(expect.any(String), `${dataStreamPath}/fields`);
 
     // test files
-    expect(Utils.ensureDirSync).toHaveBeenCalledWith(`${dataStreamPath}/_dev/test/pipeline`);
-    expect(Utils.copySync).toHaveBeenCalledWith(
+    expect(ensureDirSync).toHaveBeenCalledWith(`${dataStreamPath}/_dev/test/pipeline`);
+    expect(copySync).toHaveBeenCalledWith(
       expect.any(String),
       `${dataStreamPath}/_dev/test/pipeline/test-common-config.yml`
     );
-    expect(Utils.createSync).toHaveBeenCalledWith(
+    expect(createSync).toHaveBeenCalledWith(
       `${dataStreamPath}/_dev/test/pipeline/test-${packageName}-datastream-1.log`,
       samples
     );
 
     // // Manifest files
-    expect(Utils.createSync).toHaveBeenCalledWith(`${dataStreamPath}/manifest.yml`, undefined);
-    expect(nunjucks.render).toHaveBeenCalledWith(`filestream_manifest.yml.njk`, expect.anything());
-    expect(nunjucks.render).toHaveBeenCalledWith(
-      `azure_eventhub_manifest.yml.njk`,
-      expect.anything()
-    );
+    expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/manifest.yml`, undefined);
+    expect(render).toHaveBeenCalledWith(`filestream_manifest.yml.njk`, expect.anything());
+    expect(render).toHaveBeenCalledWith(`azure_eventhub_manifest.yml.njk`, expect.anything());
   });
 });

--- a/x-pack/plugins/integration_assistant/server/integration_builder/fields.test.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/fields.test.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import * as Utils from '../util';
-import * as nunjucks from 'nunjucks';
+import { createSync } from '../util';
+import { render } from 'nunjucks';
 import { createFieldMapping } from './fields';
 import { Docs } from '../../common';
 
@@ -19,7 +19,7 @@ jest.mock('../util', () => ({
 
 const mockedTemplate = 'mocked template';
 
-(nunjucks.render as jest.Mock).mockReturnValue(mockedTemplate);
+(render as jest.Mock).mockReturnValue(mockedTemplate);
 
 describe('createFieldMapping', () => {
   const dataStreamPath = 'path';
@@ -46,14 +46,8 @@ describe('createFieldMapping', () => {
   type: keyword
 `;
 
-    expect(Utils.createSync).toHaveBeenCalledWith(
-      `${dataStreamPath}/base-fields.yml`,
-      mockedTemplate
-    );
-    expect(Utils.createSync).toHaveBeenCalledWith(
-      `${dataStreamPath}/fields/fields.yml`,
-      expectedFields
-    );
+    expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/base-fields.yml`, mockedTemplate);
+    expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/fields.yml`, expectedFields);
   });
 
   it('Should create fields files even if docs value is empty', async () => {
@@ -62,13 +56,7 @@ describe('createFieldMapping', () => {
     const expectedFields = `[]
 `;
 
-    expect(Utils.createSync).toHaveBeenCalledWith(
-      `${dataStreamPath}/base-fields.yml`,
-      mockedTemplate
-    );
-    expect(Utils.createSync).toHaveBeenCalledWith(
-      `${dataStreamPath}/fields/fields.yml`,
-      expectedFields
-    );
+    expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/base-fields.yml`, mockedTemplate);
+    expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/fields.yml`, expectedFields);
   });
 });

--- a/x-pack/plugins/integration_assistant/server/integration_builder/pipeline.test.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/pipeline.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { Pipeline } from '../../common';
-import * as Utils from '../util';
+import { createSync } from '../util';
 import { createPipeline } from './pipeline';
 
 jest.mock('../util');
@@ -50,7 +50,7 @@ processors:
       ignore_missing: true
       if: ctx.event?.original == null
 `;
-    expect(Utils.createSync).toHaveBeenCalledWith(
+    expect(createSync).toHaveBeenCalledWith(
       `${dataStreamPath}/elasticsearch/ingest_pipeline/default.yml`,
       expectYamlContent
     );
@@ -62,7 +62,7 @@ processors:
     const expectYamlContent = `---
 {}
 `;
-    expect(Utils.createSync).toHaveBeenCalledWith(
+    expect(createSync).toHaveBeenCalledWith(
       `${dataStreamPath}/elasticsearch/ingest_pipeline/default.yml`,
       expectYamlContent
     );

--- a/x-pack/plugins/integration_assistant/server/util/samples.ts
+++ b/x-pack/plugins/integration_assistant/server/util/samples.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as yaml from 'js-yaml';
+import { dump } from 'js-yaml';
 import type { CategorizationState, EcsMappingState, RelatedState } from '../types';
 
 interface SampleObj {
@@ -160,7 +160,7 @@ export function generateFields(mergedDocs: string): string {
     .filter((key) => !ecsTopKeysSet.has(key))
     .map((key) => recursiveParse(doc[key], [key]));
 
-  return yaml.dump(fieldsStructure, { sortKeys: false });
+  return dump(fieldsStructure, { sortKeys: false });
 }
 
 export function merge(


### PR DESCRIPTION
## Summary

Replace `import * from XXX` by `import { function_name } from XXX` across multiple files
