### PR TITLE
Allow elasticsearch.publicBaseUrl to be set using an environment variable

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -64,6 +64,7 @@ kibana_vars=(
     elasticsearch.logQueries
     elasticsearch.password
     elasticsearch.pingTimeout
+    elasticsearch.publicBaseUrl
     elasticsearch.requestHeadersWhitelist
     elasticsearch.requestTimeout
     elasticsearch.serviceAccountToken

--- a/x-pack/plugins/cloud/public/types.ts
+++ b/x-pack/plugins/cloud/public/types.ts
@@ -228,7 +228,7 @@ export interface CloudSetup {
 
 export interface PublicElasticsearchConfigType {
   /**
-   * The URL to the Elasticsearch cluster, derived from xpack.elasticsearch.publicBaseUrl if populated
+   * The URL to the Elasticsearch cluster, derived from elasticsearch.publicBaseUrl if populated
    * Otherwise this is based on the cloudId
    * If neither is populated, this will be undefined
    */


### PR DESCRIPTION
## Summary

Allows users to set `elasticsearch.publicBaseUrl` with a ELASTICSEARCH_PUBLICBASEURL environment variable.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->