### PR TITLE
[Onboarding] Fix failed Firehose tests

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/observability/onboarding/firehose.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/onboarding/firehose.ts
@@ -20,8 +20,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const synthtrace = getService('svlLogsSynthtraceClient');
 
-  // Failing: See https://github.com/elastic/kibana/issues/193294
-  describe.skip('Onboarding Firehose Quickstart Flow', () => {
+  describe('Onboarding Firehose Quickstart Flow', () => {
     before(async () => {
       await PageObjects.svlCommonPage.loginAsAdmin(); // Onboarding requires admin role
       await PageObjects.common.navigateToUrlWithBrowserHistory(
@@ -39,7 +38,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     beforeEach(async () => {
-      await (await testSubjects.find('createCloudFormationOptionAWSCLI')).click();
+      await (await testSubjects.find('createCloudFormationOptionAWSCLI', 20000)).click();
       await testSubjects.existOrFail('observabilityOnboardingFirehoseCreateStackCommand');
     });
 


### PR DESCRIPTION
Closes [193294](https://github.com/elastic/kibana/issues/193294)

When the Firehose flow initialized it installs firehose integration and assets for all supported AWS services in the background that might take a while. This change increases the wait time until the loader in the UI is hidden and the test can proceed.

[Successful flaky test runner job](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6998#_)

<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->