### PR TITLE
[#192624] Fix archive for `incompatible_cluster_routing_allocation`

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/incompatible_cluster_routing_allocation.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/incompatible_cluster_routing_allocation.test.ts
@@ -97,8 +97,7 @@ async function updateRoutingAllocations(
   });
 }
 
-// Failing 9.0 version update: https://github.com/elastic/kibana/issues/192624
-describe.skip('incompatible_cluster_routing_allocation', () => {
+describe('incompatible_cluster_routing_allocation', () => {
   let client: ElasticsearchClient;
   let root: Root;
 


### PR DESCRIPTION
## Summary

Related #192624.

ES complained because the archive was created with `8.0.0`, but ES 9.0.0 requires the datastore to be _upgraded_ to 8.16.0. The following steps have been followed:

```shell
# 1. Start ES 8.16 with the affected data-archive
yarn es snapshot --version=8.16.0 --data-archive src/core/server/integration_tests/saved_objects/migrations/archives/8.0.0_v1_migrations_sample_data_saved_objects.zip
# ... after ES has completely started up, stop it.

# 2. Compress the archive
cd .es/8.16.0
zip -r ../../src/core/server/integration_tests/saved_objects/migrations/archives/8.0.0_v1_migrations_sample_data_saved_objects.zip data  -x "*/\.*"
cd ../../

# 3. Run the tests to confirm that the issue is fixed.
yarn test:jest_integration src/core/server/integration_tests/saved_objects/migrations/group3/incompatible_cluster_routing_allocation.test.ts
```


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->