### PR TITLE
[ResponseOps][Alerts] Add fallback value for alert filter controls panels

### DIFF
--- a/packages/kbn-alerts-ui-shared/src/alert_filter_controls/utils.ts
+++ b/packages/kbn-alerts-ui-shared/src/alert_filter_controls/utils.ts
@@ -17,7 +17,7 @@ import { isEmpty, isEqual, pick } from 'lodash';
 import type { FilterControlConfig } from './types';
 
 export const getPanelsInOrderFromControlsState = (controlState: ControlGroupRuntimeState) => {
-  const panels = controlState.initialChildControlState;
+  const panels = controlState.initialChildControlState ?? {};
   return Object.values(panels).sort((a, b) => a.order - b.order);
 };
 


### PR DESCRIPTION
## Summary

Adds a fallback value for the alert filter controls bar's `panels` configuration when it's undefined.

Fixes #193565