### PR TITLE
Fix the required permission for elasticsearch.username user

### DIFF
--- a/docs/maps/connect-to-ems.asciidoc
+++ b/docs/maps/connect-to-ems.asciidoc
@@ -148,7 +148,7 @@ endif::[]
  | URL of the {es} instance to use for license validation.
 
 | `elasticsearch.username` and `elasticsearch.password`
-  | Credentials of a user with at least the `monitor` role.
+  | Credentials of a user with at least the {stack-ref}/security-privileges.html[`monitor`] permission.
 
 | `elasticsearch.ssl.certificateAuthorities`
  | Paths to one or more PEM-encoded X.509 certificate authority (CA) certificates that make up a trusted certificate chain for {hosted-ems}. This chain is used by {hosted-ems} to establish trust when connecting to your {es} cluster. <<elasticsearch-ssl-certificateAuthorities,Equivalent {kib} setting>>.


### PR DESCRIPTION


## Summary

Fix the documentation of Elastic Maps Service hosted locally.
In the description of `elasticsearch.username`, fix the required permission. `monitor` is not a role, it is a permission.


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
