### PR TITLE
[EEM] Add index pattern and filter overrides for history

### DIFF
--- a/x-pack/packages/kbn-entities-schema/src/schema/entity_definition.ts
+++ b/x-pack/packages/kbn-entities-schema/src/schema/entity_definition.ts
@@ -33,6 +33,12 @@ export const entityDefinitionSchema = z.object({
   staticFields: z.optional(z.record(z.string(), z.string())),
   managed: z.optional(z.boolean()).default(false),
   history: z.object({
+    overrides: z.optional(
+      z.object({
+        indexPatterns: z.optional(arrayOfStringsSchema),
+        filter: filterSchema,
+      })
+    ),
     timestampField: z.string(),
     interval: durationSchemaWithMinimum(1),
     settings: historySettingsSchema,

--- a/x-pack/plugins/entity_manager/server/lib/entities/transform/__snapshots__/generate_history_transform.test.ts.snap
+++ b/x-pack/plugins/entity_manager/server/lib/entities/transform/__snapshots__/generate_history_transform.test.ts.snap
@@ -152,6 +152,170 @@ Object {
 }
 `;
 
+exports[`generateHistoryTransform(definition) should generate a valid history backfill transform with overrides 1`] = `
+Object {
+  "_meta": Object {
+    "definitionVersion": "999.999.999",
+    "managed": false,
+  },
+  "defer_validation": true,
+  "dest": Object {
+    "index": ".entities.v1.history.noop",
+    "pipeline": "entities-v1-history-admin-console-services-backfill",
+  },
+  "frequency": "2m",
+  "pivot": Object {
+    "aggs": Object {
+      "_errorRate_A": Object {
+        "filter": Object {
+          "bool": Object {
+            "minimum_should_match": 1,
+            "should": Array [
+              Object {
+                "match_phrase": Object {
+                  "log.level": "ERROR",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "_logRate_A": Object {
+        "filter": Object {
+          "bool": Object {
+            "minimum_should_match": 1,
+            "should": Array [
+              Object {
+                "exists": Object {
+                  "field": "log.level",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "entity.lastSeenTimestamp": Object {
+        "max": Object {
+          "field": "@timestamp",
+        },
+      },
+      "entity.metadata.host.name": Object {
+        "terms": Object {
+          "field": "host.name",
+          "size": 1000,
+        },
+      },
+      "entity.metadata.host.os.name": Object {
+        "terms": Object {
+          "field": "host.os.name",
+          "size": 1000,
+        },
+      },
+      "entity.metadata.sourceIndex": Object {
+        "terms": Object {
+          "field": "_index",
+          "size": 1000,
+        },
+      },
+      "entity.metadata.tags": Object {
+        "terms": Object {
+          "field": "tags",
+          "size": 1000,
+        },
+      },
+      "entity.metrics.errorRate": Object {
+        "bucket_script": Object {
+          "buckets_path": Object {
+            "A": "_errorRate_A>_count",
+          },
+          "script": Object {
+            "lang": "painless",
+            "source": "params.A",
+          },
+        },
+      },
+      "entity.metrics.logRate": Object {
+        "bucket_script": Object {
+          "buckets_path": Object {
+            "A": "_logRate_A>_count",
+          },
+          "script": Object {
+            "lang": "painless",
+            "source": "params.A",
+          },
+        },
+      },
+    },
+    "group_by": Object {
+      "@timestamp": Object {
+        "date_histogram": Object {
+          "field": "@timestamp",
+          "fixed_interval": "1m",
+        },
+      },
+      "entity.identity.event.category": Object {
+        "terms": Object {
+          "field": "event.category",
+          "missing_bucket": true,
+        },
+      },
+      "entity.identity.log.logger": Object {
+        "terms": Object {
+          "field": "log.logger",
+          "missing_bucket": false,
+        },
+      },
+    },
+  },
+  "settings": Object {
+    "deduce_mappings": false,
+    "unattended": true,
+  },
+  "source": Object {
+    "index": Array [
+      "some-summary-index",
+    ],
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "bool": Object {
+              "minimum_should_match": 1,
+              "should": Array [
+                Object {
+                  "match": Object {
+                    "includes_metrics": true,
+                  },
+                },
+              ],
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "log.logger",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "gte": "now-10m",
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+  "sync": Object {
+    "time": Object {
+      "delay": "2m",
+      "field": "@timestamp",
+    },
+  },
+  "transform_id": "entities-v1-history-admin-console-services-backfill",
+}
+`;
+
 exports[`generateHistoryTransform(definition) should generate a valid history transform 1`] = `
 Object {
   "_meta": Object {
@@ -278,6 +442,170 @@ Object {
     "query": Object {
       "bool": Object {
         "filter": Array [
+          Object {
+            "exists": Object {
+              "field": "log.logger",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "gte": "now-10m",
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+  "sync": Object {
+    "time": Object {
+      "delay": "2m",
+      "field": "@timestamp",
+    },
+  },
+  "transform_id": "entities-v1-history-admin-console-services",
+}
+`;
+
+exports[`generateHistoryTransform(definition) should generate a valid history transform with overrides 1`] = `
+Object {
+  "_meta": Object {
+    "definitionVersion": "1.0.0",
+    "managed": false,
+  },
+  "defer_validation": true,
+  "dest": Object {
+    "index": ".entities.v1.history.noop",
+    "pipeline": "entities-v1-history-admin-console-services",
+  },
+  "frequency": "2m",
+  "pivot": Object {
+    "aggs": Object {
+      "_errorRate_A": Object {
+        "filter": Object {
+          "bool": Object {
+            "minimum_should_match": 1,
+            "should": Array [
+              Object {
+                "match_phrase": Object {
+                  "log.level": "ERROR",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "_logRate_A": Object {
+        "filter": Object {
+          "bool": Object {
+            "minimum_should_match": 1,
+            "should": Array [
+              Object {
+                "exists": Object {
+                  "field": "log.level",
+                },
+              },
+            ],
+          },
+        },
+      },
+      "entity.lastSeenTimestamp": Object {
+        "max": Object {
+          "field": "@timestamp",
+        },
+      },
+      "entity.metadata.host.name": Object {
+        "terms": Object {
+          "field": "host.name",
+          "size": 1000,
+        },
+      },
+      "entity.metadata.host.os.name": Object {
+        "terms": Object {
+          "field": "host.os.name",
+          "size": 1000,
+        },
+      },
+      "entity.metadata.sourceIndex": Object {
+        "terms": Object {
+          "field": "_index",
+          "size": 1000,
+        },
+      },
+      "entity.metadata.tags": Object {
+        "terms": Object {
+          "field": "tags",
+          "size": 1000,
+        },
+      },
+      "entity.metrics.errorRate": Object {
+        "bucket_script": Object {
+          "buckets_path": Object {
+            "A": "_errorRate_A>_count",
+          },
+          "script": Object {
+            "lang": "painless",
+            "source": "params.A",
+          },
+        },
+      },
+      "entity.metrics.logRate": Object {
+        "bucket_script": Object {
+          "buckets_path": Object {
+            "A": "_logRate_A>_count",
+          },
+          "script": Object {
+            "lang": "painless",
+            "source": "params.A",
+          },
+        },
+      },
+    },
+    "group_by": Object {
+      "@timestamp": Object {
+        "date_histogram": Object {
+          "field": "@timestamp",
+          "fixed_interval": "1m",
+        },
+      },
+      "entity.identity.event.category": Object {
+        "terms": Object {
+          "field": "event.category",
+          "missing_bucket": true,
+        },
+      },
+      "entity.identity.log.logger": Object {
+        "terms": Object {
+          "field": "log.logger",
+          "missing_bucket": false,
+        },
+      },
+    },
+  },
+  "settings": Object {
+    "deduce_mappings": false,
+    "unattended": true,
+  },
+  "source": Object {
+    "index": Array [
+      "some-summary-index",
+    ],
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "bool": Object {
+              "minimum_should_match": 1,
+              "should": Array [
+                Object {
+                  "match": Object {
+                    "includes_metrics": true,
+                  },
+                },
+              ],
+            },
+          },
           Object {
             "exists": Object {
               "field": "log.logger",

--- a/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_history_transform.test.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_history_transform.test.ts
@@ -21,4 +21,26 @@ describe('generateHistoryTransform(definition)', () => {
     const transform = generateBackfillHistoryTransform(entityDefinitionWithBackfill);
     expect(transform).toMatchSnapshot();
   });
+  it('should generate a valid history transform with overrides', () => {
+    const definitionWithOverrides = {
+      ...entityDefinition,
+      history: {
+        ...entityDefinition.history,
+        overrides: { indexPatterns: ['some-summary-index'], filter: 'includes_metrics: true' },
+      },
+    };
+    const transform = generateHistoryTransform(definitionWithOverrides);
+    expect(transform).toMatchSnapshot();
+  });
+  it('should generate a valid history backfill transform with overrides', () => {
+    const definitionWithOverrides = {
+      ...entityDefinitionWithBackfill,
+      history: {
+        ...entityDefinition.history,
+        overrides: { indexPatterns: ['some-summary-index'], filter: 'includes_metrics: true' },
+      },
+    };
+    const transform = generateHistoryTransform(definitionWithOverrides);
+    expect(transform).toMatchSnapshot();
+  });
 });

--- a/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_history_transform.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_history_transform.ts
@@ -30,7 +30,9 @@ export function generateHistoryTransform(
 ): TransformPutTransformRequest {
   const filter: QueryDslQueryContainer[] = [];
 
-  if (definition.filter) {
+  if (definition.history.overrides?.filter) {
+    filter.push(getElasticsearchQueryOrThrow(definition.history.overrides.filter));
+  } else if (definition.filter) {
     filter.push(getElasticsearchQueryOrThrow(definition.filter));
   }
 
@@ -70,7 +72,9 @@ export function generateBackfillHistoryTransform(
 
   const filter: QueryDslQueryContainer[] = [];
 
-  if (definition.filter) {
+  if (definition.history.overrides?.filter) {
+    filter.push(getElasticsearchQueryOrThrow(definition.history.overrides.filter));
+  } else if (definition.filter) {
     filter.push(getElasticsearchQueryOrThrow(definition.filter));
   }
 
@@ -114,6 +118,10 @@ const generateTransformPutRequest = ({
   frequency?: string;
   syncDelay?: string;
 }) => {
+  const indexPatterns =
+    definition.history.overrides?.indexPatterns != null
+      ? definition.history.overrides.indexPatterns
+      : definition.indexPatterns;
   return {
     transform_id: transformId,
     _meta: {
@@ -122,7 +130,7 @@ const generateTransformPutRequest = ({
     },
     defer_validation: true,
     source: {
-      index: definition.indexPatterns,
+      index: indexPatterns,
       ...(filter.length > 0 && {
         query: {
           bool: {


### PR DESCRIPTION
## Summary

This PR adds an `overrides` section to the `history` configuration in the `EntityDefinition`.  With this change, we can support a use case where there might already be summarized data (like APM)  but still retain the original source indices for when we fallback to the `source` for filtering that's not available from the entities index. 

CC @dgieselaar 