### PR TITLE
[data views] Remove regex for creating dot notation (#193795)

### DIFF
--- a/src/plugins/data_views/common/fields/utils.ts
+++ b/src/plugins/data_views/common/fields/utils.ts
@@ -25,16 +25,25 @@ export const isMultiField = isDataViewFieldSubtypeMulti;
 export const getFieldSubtypeMulti = getDataViewFieldSubtypeMulti;
 export const getFieldSubtypeNested = getDataViewFieldSubtypeNested;
 
-const DOT_PREFIX_RE = /(.).+?\./g;
-
 /**
  * Convert a dot.notated.string into a short
  * version (d.n.string)
  *
- * @return {any}
+ * @return {string}
  */
-export function shortenDottedString(input: any) {
-  return typeof input !== 'string' ? input : input.replace(DOT_PREFIX_RE, '$1.');
+
+export function shortenDottedString(input: string): string {
+  if (typeof input === 'string') {
+    const split = input.split('.');
+    return split.reduce((acc, part, i) => {
+      if (i === split.length - 1) {
+        return acc + part;
+      }
+      return acc + part[0] + '.';
+    }, '');
+  }
+
+  return input;
 }
 
 // Note - this code is duplicated from @kbn/es-query


### PR DESCRIPTION
## Summary

Use basic string and array functions instead of regex to create short dot field names.

(cherry picked from commit ab9459ca4358451614c3b4fb09380af9841e7a66)
