### PR TITLE
Updates file format details for Data Visualizer documentation

### DIFF
--- a/docs/user/ml/index.asciidoc
+++ b/docs/user/ml/index.asciidoc
@@ -19,10 +19,11 @@ if your data is stored in {es} and contains a time field, you can use the
 [role="screenshot"]
 image::user/ml/images/ml-data-visualizer-sample.png[{data-viz} for sample flight data]
 
-You can also upload a CSV, NDJSON, or log file. The *{data-viz}*
-identifies the file format and field mappings. You can then optionally import
-that data into an {es} index. To change the default file size limit, see
-<<kibana-general-settings, fileUpload:maxFileSize advanced settings>>.
+You can upload different file formats for analysis with the *{data-viz}*. The following file types are 
+supported up to 500 MB: CSV, TSV, NDJSON, and log files. 
+The following formats are supported up to 60 MB: PDF, Microsoft Office files (Word, Excel, PowerPoint), Plain Text (TXT), Rich Text (RTF), and Open Document Format (ODF).
+
+The *{data-viz}* identifies the file format and field mappings, and you can optionally import the data into an {es} index. To change the default file size limit, see <<kibana-general-settings, fileUpload:maxFileSize in advanced settings>>.
 
 If {stack-security-features} are enabled, users must have the necessary
 privileges to use {ml-features}. Refer to

--- a/docs/user/ml/index.asciidoc
+++ b/docs/user/ml/index.asciidoc
@@ -19,9 +19,20 @@ if your data is stored in {es} and contains a time field, you can use the
 [role="screenshot"]
 image::user/ml/images/ml-data-visualizer-sample.png[{data-viz} for sample flight data]
 
-You can upload different file formats for analysis with the *{data-viz}*. The following file types are 
-supported up to 500 MB: CSV, TSV, NDJSON, and log files. 
-The following formats are supported up to 60 MB: PDF, Microsoft Office files (Word, Excel, PowerPoint), Plain Text (TXT), Rich Text (RTF), and Open Document Format (ODF).
+You can upload different file formats for analysis with the *{data-viz}*.
+
+File formats supported up to 500 MB:
+* CSV
+* TSV
+* NDJSON
+* Log files
+
+File formats supported up to 60 MB:
+* PDF
+* Microsoft Office files (Word, Excel, PowerPoint)
+* Plain Text (TXT)
+* Rich Text (RTF)
+* Open Document Format (ODF)
 
 The *{data-viz}* identifies the file format and field mappings, and you can optionally import the data into an {es} index. To change the default file size limit, see <<kibana-general-settings, fileUpload:maxFileSize in advanced settings>>.
 

--- a/docs/user/ml/index.asciidoc
+++ b/docs/user/ml/index.asciidoc
@@ -34,7 +34,7 @@ File formats supported up to 60 MB:
 * Rich Text (RTF)
 * Open Document Format (ODF)
 
-The *{data-viz}* identifies the file format and field mappings, and you can optionally import the data into an {es} index. To change the default file size limit, see <<kibana-general-settings, fileUpload:maxFileSize in advanced settings>>.
+The *{data-viz}* identifies the file format and field mappings, and you can import the data into an {es} index. To change the default file size limit, see <<kibana-general-settings, `fileUpload:maxFileSize`>> in advanced settings.
 
 If {stack-security-features} are enabled, users must have the necessary
 privileges to use {ml-features}. Refer to


### PR DESCRIPTION
## Overview

This update adds details to the Data Visualizer documentation, specifying supported file formats and their size limits.
**Related issue:** [#189](https://github.com/elastic/search-docs-team/issues/189)

### Preview

[Machine Learning]()


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->