### PR TITLE
[7.17] [ML] Data Frame Analytics: Fix field name escaping for Vega based scatterplot matrix. (#193386)

### DIFF
--- a/x-pack/plugins/ml/public/application/components/scatterplot_matrix/scatterplot_matrix_vega_lite_spec.test.ts
+++ b/x-pack/plugins/ml/public/application/components/scatterplot_matrix/scatterplot_matrix_vega_lite_spec.test.ts
@@ -16,6 +16,7 @@ import { LEGEND_TYPES } from '../vega_chart/common';
 
 import {
   getColorSpec,
+  getEscapedVegaFieldName,
   getScatterplotMatrixVegaLiteSpec,
   COLOR_OUTLIER,
   COLOR_RANGE_NOMINAL,
@@ -53,6 +54,49 @@ describe('getColorSpec()', () => {
       },
       type: 'nominal',
     });
+  });
+});
+
+describe('getEscapedVegaFieldName()', () => {
+  it('should escape dots in field names', () => {
+    const fieldName = 'field.name';
+    const escapedFieldName = getEscapedVegaFieldName(fieldName);
+    expect(escapedFieldName).toBe('field\\.name');
+  });
+
+  it('should escape brackets in field names', () => {
+    const fieldName = 'field[name]';
+    const escapedFieldName = getEscapedVegaFieldName(fieldName);
+    expect(escapedFieldName).toBe('field\\[name\\]');
+  });
+
+  it('should escape both dots and brackets in field names', () => {
+    const fieldName = 'field.name[0]';
+    const escapedFieldName = getEscapedVegaFieldName(fieldName);
+    expect(escapedFieldName).toBe('field\\.name\\[0\\]');
+  });
+
+  it('should return the same string if there are no special characters', () => {
+    const fieldName = 'fieldname';
+    const escapedFieldName = getEscapedVegaFieldName(fieldName);
+    expect(escapedFieldName).toBe('fieldname');
+  });
+
+  it('should escape newlines in field names', () => {
+    // String quotes process backslashes, so we need to escape them for
+    // the test string to contain a backslash. For example, without the
+    // double backslash, this string would contain a newline character.
+    const fieldName = 'field\\name';
+    const escapedFieldName = getEscapedVegaFieldName(fieldName);
+    expect(escapedFieldName).toBe('field\\\\name');
+  });
+
+  it('should escape backslashes in field names', () => {
+    // String quotes process backslashes, so we need to escape them for
+    // the test string to contain a backslash.
+    const fieldName = 'fieldname\\withbackslash';
+    const escapedFieldName = getEscapedVegaFieldName(fieldName);
+    expect(escapedFieldName).toBe('fieldname\\\\withbackslash');
   });
 });
 

--- a/x-pack/plugins/ml/public/application/components/scatterplot_matrix/scatterplot_matrix_vega_lite_spec.ts
+++ b/x-pack/plugins/ml/public/application/components/scatterplot_matrix/scatterplot_matrix_vega_lite_spec.ts
@@ -59,11 +59,28 @@ export const getColorSpec = (
   return { value: DEFAULT_COLOR };
 };
 
-// Escapes the characters .[] in field names with double backslashes
+// Escapes the characters .[]\ in field names with double backslashes
 // since VEGA treats dots/brackets in field names as nested values.
 // See https://vega.github.io/vega-lite/docs/field.html for details.
-function getEscapedVegaFieldName(fieldName: string) {
-  return fieldName.replace(/([\.|\[|\]])/g, '\\$1');
+export function getEscapedVegaFieldName(fieldName: string) {
+  // Note the following isn't 100% ideal because there are cases when we may
+  // end up with an additional backslash being rendered for labels of the
+  // scatterplot. However, all other variations I tried caused rendering
+  // problems of the charts and rendering would fail completely.
+
+  // For example, just escaping \n in the first replace without the general
+  // backslash escaping causes the following Vega error:
+  // Duplicate scale or projection name: "child__row_my_numbercolumn_my_number_x"
+
+  // Escaping just the backslash without the additional \n escaping causes
+  // causes an "expression parse error" in Vega and the chart wouldn't render.
+
+  // Escape newline characters
+  fieldName = fieldName.replace(/\n/g, '\\n');
+  // Escape .[]\
+  fieldName = fieldName.replace(/([\.|\[|\]|\\])/g, '\\$1');
+
+  return fieldName;
 }
 
 type VegaValue = Record<string, string | number>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ML] Data Frame Analytics: Fix field name escaping for Vega based scatterplot matrix. (#193386)](https://github.com/elastic/kibana/pull/193386)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Walter Rafelsberger","email":"walter.rafelsberger@elastic.co"},"sourceCommit":{"committedDate":"2024-09-24T08:41:46Z","message":"[ML] Data Frame Analytics: Fix field name escaping for Vega based scatterplot matrix. (#193386)\n\n## Summary\r\n\r\nField names with `\\n` would fail to render the DFA scatterplot matrix:\r\n\r\n<img width=\"804\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/26e356b8-236d-4255-b556-2ebc2e5db4fc\">\r\n\r\nThis fixes the escaping and adds unit tests.\r\n\r\nThe fix isn't 100% ideal because there are cases when we may end up with\r\nan additional backslash being rendered for labels of the scatterplot.\r\nHowever, all other variations I tried caused rendering problems of the\r\ncharts and rendering would fail completely.\r\n\r\nFor example, just escaping `\\n` without the general backslash escaping\r\ncauses the following Vega error: `Duplicate scale or projection name:\r\n\"child__row_my_numbercolumn_my_number_x\"`\r\n\r\nOn the other hand escaping just the backslash without the additional\r\n`\\n` escaping causes an \"expression parse error\" in in Vega and the\r\nchart wouldn't render.\r\n\r\nNote this PR just focuses on escaping for the Vega spec for the\r\nscatterplot matrix. There are still other places in the UI (data grid\r\nheaders, fields selector).\r\n\r\n<img width=\"792\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/35532741-7a13-4707-b8da-c72dcc8c935b\">\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"194d6307dc41b6a4a295abc3e412de148e05386e","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug",":ml","release_note:skip","Feature:Data Frame Analytics","v9.0.0","backport:all-open","v8.16.0","v8.15.2","v7.17.25"],"number":193386,"url":"https://github.com/elastic/kibana/pull/193386","mergeCommit":{"message":"[ML] Data Frame Analytics: Fix field name escaping for Vega based scatterplot matrix. (#193386)\n\n## Summary\r\n\r\nField names with `\\n` would fail to render the DFA scatterplot matrix:\r\n\r\n<img width=\"804\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/26e356b8-236d-4255-b556-2ebc2e5db4fc\">\r\n\r\nThis fixes the escaping and adds unit tests.\r\n\r\nThe fix isn't 100% ideal because there are cases when we may end up with\r\nan additional backslash being rendered for labels of the scatterplot.\r\nHowever, all other variations I tried caused rendering problems of the\r\ncharts and rendering would fail completely.\r\n\r\nFor example, just escaping `\\n` without the general backslash escaping\r\ncauses the following Vega error: `Duplicate scale or projection name:\r\n\"child__row_my_numbercolumn_my_number_x\"`\r\n\r\nOn the other hand escaping just the backslash without the additional\r\n`\\n` escaping causes an \"expression parse error\" in in Vega and the\r\nchart wouldn't render.\r\n\r\nNote this PR just focuses on escaping for the Vega spec for the\r\nscatterplot matrix. There are still other places in the UI (data grid\r\nheaders, fields selector).\r\n\r\n<img width=\"792\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/35532741-7a13-4707-b8da-c72dcc8c935b\">\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"194d6307dc41b6a4a295abc3e412de148e05386e"}},"sourceBranch":"main","suggestedTargetBranches":["7.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/193386","number":193386,"mergeCommit":{"message":"[ML] Data Frame Analytics: Fix field name escaping for Vega based scatterplot matrix. (#193386)\n\n## Summary\r\n\r\nField names with `\\n` would fail to render the DFA scatterplot matrix:\r\n\r\n<img width=\"804\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/26e356b8-236d-4255-b556-2ebc2e5db4fc\">\r\n\r\nThis fixes the escaping and adds unit tests.\r\n\r\nThe fix isn't 100% ideal because there are cases when we may end up with\r\nan additional backslash being rendered for labels of the scatterplot.\r\nHowever, all other variations I tried caused rendering problems of the\r\ncharts and rendering would fail completely.\r\n\r\nFor example, just escaping `\\n` without the general backslash escaping\r\ncauses the following Vega error: `Duplicate scale or projection name:\r\n\"child__row_my_numbercolumn_my_number_x\"`\r\n\r\nOn the other hand escaping just the backslash without the additional\r\n`\\n` escaping causes an \"expression parse error\" in in Vega and the\r\nchart wouldn't render.\r\n\r\nNote this PR just focuses on escaping for the Vega spec for the\r\nscatterplot matrix. There are still other places in the UI (data grid\r\nheaders, fields selector).\r\n\r\n<img width=\"792\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/35532741-7a13-4707-b8da-c72dcc8c935b\">\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"194d6307dc41b6a4a295abc3e412de148e05386e"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/193832","number":193832,"state":"OPEN"},{"branch":"8.15","label":"v8.15.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/193830","number":193830,"state":"OPEN"},{"branch":"7.17","label":"v7.17.25","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->