### PR TITLE
[8.x] Allow elasticsearch.publicBaseUrl to be set using an environment variable (#193716)

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -64,6 +64,7 @@ kibana_vars=(
     elasticsearch.logQueries
     elasticsearch.password
     elasticsearch.pingTimeout
+    elasticsearch.publicBaseUrl
     elasticsearch.requestHeadersWhitelist
     elasticsearch.requestTimeout
     elasticsearch.serviceAccountToken

--- a/x-pack/plugins/cloud/public/types.ts
+++ b/x-pack/plugins/cloud/public/types.ts
@@ -228,7 +228,7 @@ export interface CloudSetup {
 
 export interface PublicElasticsearchConfigType {
   /**
-   * The URL to the Elasticsearch cluster, derived from xpack.elasticsearch.publicBaseUrl if populated
+   * The URL to the Elasticsearch cluster, derived from elasticsearch.publicBaseUrl if populated
    * Otherwise this is based on the cloudId
    * If neither is populated, this will be undefined
    */


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Allow elasticsearch.publicBaseUrl to be set using an environment variable (#193716)](https://github.com/elastic/kibana/pull/193716)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sander Philipse","email":"94373878+sphilipse@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-09-23T16:43:45Z","message":"Allow elasticsearch.publicBaseUrl to be set using an environment variable (#193716)\n\n## Summary\r\n\r\nAllows users to set `elasticsearch.publicBaseUrl` with a\r\nELASTICSEARCH_PUBLICBASEURL environment variable.","sha":"be8002215411633cfe913d3110ae74d64092c580","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","v8.16.0","backport:version"],"number":193716,"url":"https://github.com/elastic/kibana/pull/193716","mergeCommit":{"message":"Allow elasticsearch.publicBaseUrl to be set using an environment variable (#193716)\n\n## Summary\r\n\r\nAllows users to set `elasticsearch.publicBaseUrl` with a\r\nELASTICSEARCH_PUBLICBASEURL environment variable.","sha":"be8002215411633cfe913d3110ae74d64092c580"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/193716","number":193716,"mergeCommit":{"message":"Allow elasticsearch.publicBaseUrl to be set using an environment variable (#193716)\n\n## Summary\r\n\r\nAllows users to set `elasticsearch.publicBaseUrl` with a\r\nELASTICSEARCH_PUBLICBASEURL environment variable.","sha":"be8002215411633cfe913d3110ae74d64092c580"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->