### PR TITLE
[Security Solution][Notes] - change order for new flyout notes tab from descending to ascending (oldest notes to the top) to be consistent with timeline notes and cases

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_list.tsx
@@ -93,7 +93,7 @@ export const NotesList = memo(({ eventId }: NotesListProps) => {
   const notes: Note[] = useSelector((state: State) =>
     selectSortedNotesByDocumentId(state, {
       documentId: eventId,
-      sort: { field: 'created', direction: 'desc' },
+      sort: { field: 'created', direction: 'asc' },
     })
   );
 


### PR DESCRIPTION
## Summary

This PR makes the tiniest change to the expandable flyout notes tab to render the notes from the oldest ones at the top to the newest one at the bottom (opposite to what we have today).
The reason is we want to follow the notes tab in timeline and the way cases comments are ordered in the case details page.

| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2024-09-24 at 10 49 08 AM](https://github.com/user-attachments/assets/d9f26c3e-83a1-4518-a0cd-da7151f76a08) | ![Screenshot 2024-09-24 at 10 46 03 AM](https://github.com/user-attachments/assets/2bbd858a-d13c-4b1b-a708-9d7259761d48) |


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->