### PR TITLE
Fix code scanning alert no. 456: Incomplete string escaping or encoding

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.ts
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.ts
@@ -125,7 +125,7 @@ export const createFilterFromOptions = (
             if (!value) {
               return null;
             }
-            return `${field}: "${value.replace(/"/g, '\\"')}"`;
+            return `${field}: "${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
           })
           .join(' and ')
       : `${options.groupBy} : "${id}"`;


### PR DESCRIPTION
Fixes [https://github.com/elastic/kibana/security/code-scanning/456](https://github.com/elastic/kibana/security/code-scanning/456)

To fix the problem, we need to ensure that backslashes are also escaped in the `value` string. This can be done by first replacing backslashes with double backslashes and then replacing double quotes with escaped double quotes. This ensures that all occurrences of backslashes and double quotes are properly escaped.

- Modify the `value.replace` call to first escape backslashes and then escape double quotes.
- The changes will be made in the `createFilterFromOptions` function, specifically on line 128.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!--ONMERGE {"backportTargets":["7.17","8.15","8.x"]} ONMERGE-->