### PR TITLE
[map embeddable] fix panel disappears from dashboard when canceling edit after dashboard save

### DIFF
--- a/x-pack/plugins/maps/public/react_embeddable/initialize_edit_api.ts
+++ b/x-pack/plugins/maps/public/react_embeddable/initialize_edit_api.ts
@@ -20,13 +20,12 @@ export function initializeEditApi(
     return {};
   }
 
-  const parentApiContext = parentApi.getAppContext();
-
   return {
     getTypeDisplayName: () => {
       return MAP_EMBEDDABLE_NAME;
     },
     onEdit: async () => {
+      const parentApiContext = parentApi.getAppContext();
       const stateTransfer = getEmbeddableService().getStateTransfer();
       await stateTransfer.navigateToEditor(APP_ID, {
         path: getEditPath(savedObjectId),

--- a/x-pack/plugins/maps/public/react_embeddable/initialize_edit_api.ts
+++ b/x-pack/plugins/maps/public/react_embeddable/initialize_edit_api.ts
@@ -16,32 +16,30 @@ export function initializeEditApi(
   parentApi?: unknown,
   savedObjectId?: string
 ) {
-  if (!parentApi || !apiHasAppContext(parentApi)) {
-    return {};
-  }
-
-  return {
-    getTypeDisplayName: () => {
-      return MAP_EMBEDDABLE_NAME;
-    },
-    onEdit: async () => {
-      const parentApiContext = parentApi.getAppContext();
-      const stateTransfer = getEmbeddableService().getStateTransfer();
-      await stateTransfer.navigateToEditor(APP_ID, {
-        path: getEditPath(savedObjectId),
-        state: {
-          embeddableId: uuid,
-          valueInput: getState(),
-          originatingApp: parentApiContext.currentAppId,
-          originatingPath: parentApiContext.getCurrentPath?.(),
+  return !parentApi || !apiHasAppContext(parentApi)
+    ? {}
+    : {
+        getTypeDisplayName: () => {
+          return MAP_EMBEDDABLE_NAME;
         },
-      });
-    },
-    isEditingEnabled: () => {
-      return getMapsCapabilities().save as boolean;
-    },
-    getEditHref: async () => {
-      return getHttp().basePath.prepend(getFullPath(savedObjectId));
-    },
-  };
+        onEdit: async () => {
+          const parentApiContext = parentApi.getAppContext();
+          const stateTransfer = getEmbeddableService().getStateTransfer();
+          await stateTransfer.navigateToEditor(APP_ID, {
+            path: getEditPath(savedObjectId),
+            state: {
+              embeddableId: uuid,
+              valueInput: getState(),
+              originatingApp: parentApiContext.currentAppId,
+              originatingPath: parentApiContext.getCurrentPath?.(),
+            },
+          });
+        },
+        isEditingEnabled: () => {
+          return getMapsCapabilities().save as boolean;
+        },
+        getEditHref: async () => {
+          return getHttp().basePath.prepend(getFullPath(savedObjectId));
+        },
+      };
 }


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/193905. Broke work into separate PRs to backport map embeddable changes to 8.15.

Resolves issue for Map embeddable. The problem is that Map embeddable is using a stale result from `parentApi.getAppContext`. Dashboard's  `getAppContext` changes the `getCurrentPath` when the dashboard has a saved object id. By using the stale results, `getCurrentPath` returned `#/create` instead of `#/view/`.

### Test steps
1. create new dashboard
2. Click "Add panel" (problem also exists when using "Add from library")
3. Select "Maps"
4.  In editor, click "Save and return"
5. Save dashboard
6. Click "Edit" in panel context menu
7. In editor, click "Cancel"
8. Ensure map panel is still displayed in dashboard

<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->