### PR TITLE
[Security Solution] [8.16.0] Deprecate MD5 and SHA-1

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -1974,4 +1974,169 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       }
     ),
   },
+  {
+    key: 'windows.advanced.alerts.hash.md5',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.alerts.hash.md5',
+      {
+        defaultMessage:
+          'Compute and include MD5 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.alerts.hash.sha1',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.alerts.hash.sha1',
+      {
+        defaultMessage:
+          'Compute and include SHA-1 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.events.hash.md5',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.hash.md5',
+      {
+        defaultMessage:
+          'Compute and include MD5 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.events.hash.sha1',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.hash.sha1',
+      {
+        defaultMessage:
+          'Compute and include SHA-1 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.events.hash.sha256',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.hash.sha256',
+      {
+        defaultMessage:
+          'Compute and include SHA-256 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'linux.advanced.alerts.hash.md5',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.alerts.hash.md5',
+      {
+        defaultMessage:
+          'Compute and include MD5 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'linux.advanced.alerts.hash.sha1',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.alerts.hash.sha1',
+      {
+        defaultMessage:
+          'Compute and include SHA-1 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'linux.advanced.events.hash.md5',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.events.hash.md5',
+      {
+        defaultMessage:
+          'Compute and include MD5 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'linux.advanced.events.hash.sha1',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.events.hash.sha1',
+      {
+        defaultMessage:
+          'Compute and include SHA-1 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'linux.advanced.events.hash.sha256',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.events.hash.sha256',
+      {
+        defaultMessage:
+          'Compute and include SHA-256 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'mac.advanced.alerts.hash.md5',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.alerts.hash.md5',
+      {
+        defaultMessage:
+          'Compute and include MD5 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'mac.advanced.alerts.hash.sha1',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.alerts.hash.sha1',
+      {
+        defaultMessage:
+          'Compute and include SHA-1 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'mac.advanced.events.hash.md5',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.events.hash.md5',
+      {
+        defaultMessage:
+          'Compute and include MD5 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'mac.advanced.events.hash.sha1',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.events.hash.sha1',
+      {
+        defaultMessage:
+          'Compute and include SHA-1 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: false',
+      }
+    ),
+  },
+  {
+    key: 'mac.advanced.events.hash.sha256',
+    first_supported_version: '8.16',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.events.hash.sha256',
+      {
+        defaultMessage:
+          'Compute and include SHA-256 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: false',
+      }
+    ),
+  },
 ];


### PR DESCRIPTION
## Summary

Defend spends a non-trivial amount of CPU time computing MD5 and SHA-1 hashes of potentially-large files in both events and alerts.  NIST [declared](https://csrc.nist.gov/csrc/media/events/ispab-december-2005-meeting/documents/b_burr-dec2005-ispab.pdf) MD5 "fully broken" in 2004, and SHA-1 "broken" in 2005.  Let's move past 2005 and deprecate these broken hash algorithms by default.  

Users can use the advanced policy options in this PR to restore the legacy behavior, if desired.  Also, Defend will scan user trust-, exception-, or blocklists for `.hash.md5` and `.hash.sha1`.  If present, it will force-enable the identified hash regardless of advanced policy.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
