### PR TITLE
[8.15] [Unified Data Table] Prevent `undefined` errors when row accessed via `rows[rowIndex]` (#193791)

### DIFF
--- a/packages/kbn-unified-data-table/__mocks__/table_context.ts
+++ b/packages/kbn-unified-data-table/__mocks__/table_context.ts
@@ -14,17 +14,13 @@ import { servicesMock } from './services';
 import { DataTableContext } from '../src/table_context';
 import { convertValueToString } from '../src/utils/convert_value_to_string';
 import { buildDataTableRecord } from '@kbn/discover-utils';
-import type { EsHitRecord } from '@kbn/discover-utils/types';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
 
-const buildTableContext = (dataView: DataView, rows: EsHitRecord[]): DataTableContext => {
-  const usedRows = rows.map((row) => {
-    return buildDataTableRecord(row, dataView);
-  });
-
+const buildTableContext = (dataView: DataView, rows: DataTableRecord[]): DataTableContext => {
   return {
     expanded: undefined,
     setExpanded: jest.fn(),
-    rows: usedRows,
+    getRowByIndex: jest.fn((index) => rows[index]),
     onFilter: jest.fn(),
     dataView,
     isDarkMode: false,
@@ -35,13 +31,24 @@ const buildTableContext = (dataView: DataView, rows: EsHitRecord[]): DataTableCo
         rowIndex,
         columnId,
         fieldFormats: servicesMock.fieldFormats,
-        rows: usedRows,
+        rows,
         dataView,
         options,
       }),
   };
 };
 
-export const dataTableContextMock = buildTableContext(dataViewMock, esHitsMock);
+export const dataTableContextRowsMock = esHitsMock.map((row) =>
+  buildDataTableRecord(row, dataViewMock)
+);
 
-export const dataTableContextComplexMock = buildTableContext(dataViewComplexMock, esHitsComplex);
+export const dataTableContextMock = buildTableContext(dataViewMock, dataTableContextRowsMock);
+
+export const dataTableContextComplexRowsMock = esHitsComplex.map((row) =>
+  buildDataTableRecord(row, dataViewComplexMock)
+);
+
+export const dataTableContextComplexMock = buildTableContext(
+  dataViewComplexMock,
+  dataTableContextComplexRowsMock
+);

--- a/packages/kbn-unified-data-table/src/components/data_table.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.tsx
@@ -66,7 +66,7 @@ import {
   getVisibleColumns,
   canPrependTimeFieldColumn,
 } from './data_table_columns';
-import { UnifiedDataTableContext } from '../table_context';
+import { DataTableContext, UnifiedDataTableContext } from '../table_context';
 import { getSchemaDetectors } from './data_table_schema';
 import {
   DataTableCompareToolbarBtn,
@@ -510,11 +510,11 @@ export const UnifiedDataTable = ({
     [displayedRows, dataView, fieldFormats]
   );
 
-  const unifiedDataTableContextValue = useMemo(
+  const unifiedDataTableContextValue = useMemo<DataTableContext>(
     () => ({
       expanded: expandedDoc,
       setExpanded: setExpandedDoc,
-      rows: displayedRows,
+      getRowByIndex: (index: number) => displayedRows[index],
       onFilter,
       dataView,
       isDarkMode: darkMode,

--- a/packages/kbn-unified-data-table/src/components/data_table_document_selection.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_document_selection.test.tsx
@@ -13,7 +13,7 @@ import {
   DataTableDocumentToolbarBtn,
   SelectButton,
 } from './data_table_document_selection';
-import { dataTableContextMock } from '../../__mocks__/table_context';
+import { dataTableContextMock, dataTableContextRowsMock } from '../../__mocks__/table_context';
 import { UnifiedDataTableContext } from '../table_context';
 import { getDocId } from '@kbn/discover-utils';
 import { render, screen } from '@testing-library/react';
@@ -142,7 +142,7 @@ describe('document selection', () => {
       const props = {
         isPlainRecord: false,
         isFilterActive: false,
-        rows: dataTableContextMock.rows,
+        rows: dataTableContextRowsMock,
         selectedDocs: ['i::1::'],
         setIsFilterActive: jest.fn(),
         setSelectedDocs: jest.fn(),

--- a/packages/kbn-unified-data-table/src/components/data_table_document_selection.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_document_selection.tsx
@@ -26,10 +26,10 @@ import { UnifiedDataTableContext } from '../table_context';
 
 export const SelectButton = ({ rowIndex, setCellProps }: EuiDataGridCellValueElementProps) => {
   const { euiTheme } = useEuiTheme();
-  const { selectedDocs, expanded, rows, isDarkMode, setSelectedDocs } =
+  const { selectedDocs, expanded, getRowByIndex, isDarkMode, setSelectedDocs } =
     useContext(UnifiedDataTableContext);
-  const doc = useMemo(() => rows[rowIndex], [rows, rowIndex]);
-  const checked = useMemo(() => selectedDocs.includes(doc.id), [selectedDocs, doc.id]);
+  const doc = useMemo(() => getRowByIndex(rowIndex), [getRowByIndex, rowIndex]);
+  const checked = useMemo(() => (doc ? selectedDocs.includes(doc.id) : false), [doc, selectedDocs]);
 
   const toggleDocumentSelectionLabel = i18n.translate('unifiedDataTable.grid.selectDoc', {
     defaultMessage: `Select document ''{rowNumber}''`,
@@ -45,6 +45,10 @@ export const SelectButton = ({ rowIndex, setCellProps }: EuiDataGridCellValueEle
       setCellProps({ style: undefined });
     }
   }, [expanded, doc, setCellProps, isDarkMode]);
+
+  if (!doc) {
+    return null;
+  }
 
   return (
     <EuiFlexGroup

--- a/packages/kbn-unified-data-table/src/components/data_table_expand_button.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_expand_button.test.tsx
@@ -34,12 +34,12 @@ describe('Data table view button ', function () {
     );
     const button = findTestSubject(component, 'docTableExpandToggleColumn');
     await button.simulate('click');
-    expect(contextMock.setExpanded).toHaveBeenCalledWith(dataTableContextMock.rows[0]);
+    expect(contextMock.setExpanded).toHaveBeenCalledWith(dataTableContextMock.getRowByIndex(0));
   });
   it('when the current document is expanded, setExpanded is called with undefined', async () => {
     const contextMock = {
       ...dataTableContextMock,
-      expanded: dataTableContextMock.rows[0],
+      expanded: dataTableContextMock.getRowByIndex(0),
     };
 
     const component = mountWithIntl(
@@ -62,7 +62,7 @@ describe('Data table view button ', function () {
   it('when another document is expanded, setExpanded is called with the current document', async () => {
     const contextMock = {
       ...dataTableContextMock,
-      expanded: dataTableContextMock.rows[0],
+      expanded: dataTableContextMock.getRowByIndex(0),
     };
 
     const component = mountWithIntl(
@@ -80,6 +80,6 @@ describe('Data table view button ', function () {
     );
     const button = findTestSubject(component, 'docTableExpandToggleColumn');
     await button.simulate('click');
-    expect(contextMock.setExpanded).toHaveBeenCalledWith(dataTableContextMock.rows[1]);
+    expect(contextMock.setExpanded).toHaveBeenCalledWith(dataTableContextMock.getRowByIndex(1));
   });
 });

--- a/packages/kbn-unified-data-table/src/components/data_table_expand_button.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_expand_button.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { EuiButtonIcon, EuiDataGridCellValueElementProps, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { UnifiedDataTableContext } from '../table_context';
@@ -18,13 +18,13 @@ import { DataTableRowControl } from './data_table_row_control';
 export const ExpandButton = ({ rowIndex, setCellProps }: EuiDataGridCellValueElementProps) => {
   const toolTipRef = useRef<EuiToolTip>(null);
   const [pressed, setPressed] = useState<boolean>(false);
-  const { expanded, setExpanded, rows, isDarkMode, componentsTourSteps } =
+  const { expanded, setExpanded, getRowByIndex, isDarkMode, componentsTourSteps } =
     useContext(UnifiedDataTableContext);
-  const current = rows[rowIndex];
+  const current = useMemo(() => getRowByIndex(rowIndex), [getRowByIndex, rowIndex]);
 
   const tourStep = componentsTourSteps ? componentsTourSteps.expandButton : undefined;
   useEffect(() => {
-    if (current.isAnchor) {
+    if (current?.isAnchor) {
       setCellProps({
         className: 'unifiedDataTable__cell--highlight',
       });
@@ -42,7 +42,7 @@ export const ExpandButton = ({ rowIndex, setCellProps }: EuiDataGridCellValueEle
     defaultMessage: 'Toggle dialog with details',
   });
 
-  const testSubj = current.isAnchor
+  const testSubj = current?.isAnchor
     ? 'docTableExpandToggleColumnAnchor'
     : 'docTableExpandToggleColumn';
 
@@ -55,7 +55,7 @@ export const ExpandButton = ({ rowIndex, setCellProps }: EuiDataGridCellValueEle
     }
   }, [isCurrentRowExpanded, setPressed, pressed]);
 
-  if (!setExpanded) {
+  if (!setExpanded || !current) {
     return null;
   }
 

--- a/packages/kbn-unified-data-table/src/components/default_cell_actions.tsx
+++ b/packages/kbn-unified-data-table/src/components/default_cell_actions.tsx
@@ -23,10 +23,10 @@ function onFilterCell(
   mode: '+' | '-',
   field: DataViewField
 ) {
-  const row = context.rows[rowIndex];
-  const value = row.flattened[columnId];
+  const row = context.getRowByIndex(rowIndex);
 
-  if (field && context.onFilter) {
+  if (row && field && context.onFilter) {
+    const value = row.flattened[columnId];
     context.onFilter(field, value, mode);
   }
 }

--- a/packages/kbn-unified-data-table/src/table_context.tsx
+++ b/packages/kbn-unified-data-table/src/table_context.tsx
@@ -15,7 +15,7 @@ import type { ValueToStringConverter } from './types';
 export interface DataTableContext {
   expanded?: DataTableRecord | undefined;
   setExpanded?: (hit?: DataTableRecord) => void;
-  rows: DataTableRecord[];
+  getRowByIndex: (index: number) => DataTableRecord | undefined;
   onFilter?: DocViewFilterFn;
   dataView: DataView;
   isDarkMode: boolean;

--- a/packages/kbn-unified-data-table/src/utils/convert_value_to_string.test.tsx
+++ b/packages/kbn-unified-data-table/src/utils/convert_value_to_string.test.tsx
@@ -6,14 +6,19 @@
  * Side Public License, v 1.
  */
 
-import { dataTableContextComplexMock, dataTableContextMock } from '../../__mocks__/table_context';
+import {
+  dataTableContextComplexMock,
+  dataTableContextComplexRowsMock,
+  dataTableContextMock,
+  dataTableContextRowsMock,
+} from '../../__mocks__/table_context';
 import { servicesMock } from '../../__mocks__/services';
 import { convertValueToString, convertNameToString } from './convert_value_to_string';
 
 describe('convertValueToString', () => {
   it('should convert a keyword value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'keyword_key',
@@ -28,7 +33,7 @@ describe('convertValueToString', () => {
 
   it('should convert a text value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'text_message',
@@ -43,7 +48,7 @@ describe('convertValueToString', () => {
 
   it('should convert a text value to text (not for CSV)', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'text_message',
@@ -58,7 +63,7 @@ describe('convertValueToString', () => {
 
   it('should convert a multiline text value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'text_message',
@@ -74,7 +79,7 @@ describe('convertValueToString', () => {
 
   it('should convert a number value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'number_price',
@@ -89,7 +94,7 @@ describe('convertValueToString', () => {
 
   it('should convert a date value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'date',
@@ -104,7 +109,7 @@ describe('convertValueToString', () => {
 
   it('should convert a date nanos value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'date_nanos',
@@ -119,7 +124,7 @@ describe('convertValueToString', () => {
 
   it('should convert a date nanos value to text (not for CSV)', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'date_nanos',
@@ -134,7 +139,7 @@ describe('convertValueToString', () => {
 
   it('should convert a boolean value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'bool_enabled',
@@ -149,7 +154,7 @@ describe('convertValueToString', () => {
 
   it('should convert a binary value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'binary_blob',
@@ -164,7 +169,7 @@ describe('convertValueToString', () => {
 
   it('should convert a binary value to text (not for CSV)', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'binary_blob',
@@ -179,7 +184,7 @@ describe('convertValueToString', () => {
 
   it('should convert an object value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'object_user.first',
@@ -194,7 +199,7 @@ describe('convertValueToString', () => {
 
   it('should convert a nested value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'nested_user',
@@ -211,7 +216,7 @@ describe('convertValueToString', () => {
 
   it('should convert a flattened value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'flattened_labels',
@@ -226,7 +231,7 @@ describe('convertValueToString', () => {
 
   it('should convert a range value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'range_time_frame',
@@ -243,7 +248,7 @@ describe('convertValueToString', () => {
 
   it('should convert a rank features value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'rank_features',
@@ -258,7 +263,7 @@ describe('convertValueToString', () => {
 
   it('should convert a histogram value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'histogram',
@@ -273,7 +278,7 @@ describe('convertValueToString', () => {
 
   it('should convert a IP value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'ip_addr',
@@ -288,7 +293,7 @@ describe('convertValueToString', () => {
 
   it('should convert a IP value to text (not for CSV)', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'ip_addr',
@@ -303,7 +308,7 @@ describe('convertValueToString', () => {
 
   it('should convert a version value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'version',
@@ -318,7 +323,7 @@ describe('convertValueToString', () => {
 
   it('should convert a version value to text (not for CSV)', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'version',
@@ -333,7 +338,7 @@ describe('convertValueToString', () => {
 
   it('should convert a vector value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'vector',
@@ -348,7 +353,7 @@ describe('convertValueToString', () => {
 
   it('should convert a geo point value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'geo_point',
@@ -363,7 +368,7 @@ describe('convertValueToString', () => {
 
   it('should convert a geo point object value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'geo_point',
@@ -378,7 +383,7 @@ describe('convertValueToString', () => {
 
   it('should convert an array value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'array_tags',
@@ -393,7 +398,7 @@ describe('convertValueToString', () => {
 
   it('should convert a shape value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'geometry',
@@ -410,7 +415,7 @@ describe('convertValueToString', () => {
 
   it('should convert a runtime value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'runtime_number',
@@ -425,7 +430,7 @@ describe('convertValueToString', () => {
 
   it('should convert a scripted value to text', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'scripted_string',
@@ -440,7 +445,7 @@ describe('convertValueToString', () => {
 
   it('should convert a scripted value to text (not for CSV)', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'scripted_string',
@@ -455,7 +460,7 @@ describe('convertValueToString', () => {
 
   it('should return an empty string and not fail', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'unknown',
@@ -470,7 +475,7 @@ describe('convertValueToString', () => {
 
   it('should return an empty string when rowIndex is out of range', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'unknown',
@@ -485,7 +490,7 @@ describe('convertValueToString', () => {
 
   it('should return _source value', () => {
     const result = convertValueToString({
-      rows: dataTableContextMock.rows,
+      rows: dataTableContextRowsMock,
       dataView: dataTableContextMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: '_source',
@@ -508,7 +513,7 @@ describe('convertValueToString', () => {
 
   it('should return a formatted _source value', () => {
     const result = convertValueToString({
-      rows: dataTableContextMock.rows,
+      rows: dataTableContextRowsMock,
       dataView: dataTableContextMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: '_source',
@@ -525,7 +530,7 @@ describe('convertValueToString', () => {
 
   it('should escape formula', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'array_tags',
@@ -539,7 +544,7 @@ describe('convertValueToString', () => {
     expect(result.withFormula).toBe(true);
 
     const result2 = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'scripted_string',
@@ -555,7 +560,7 @@ describe('convertValueToString', () => {
 
   it('should not escape formulas when not for CSV', () => {
     const result = convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       columnId: 'array_tags',

--- a/packages/kbn-unified-data-table/src/utils/copy_value_to_clipboard.test.tsx
+++ b/packages/kbn-unified-data-table/src/utils/copy_value_to_clipboard.test.tsx
@@ -6,7 +6,10 @@
  * Side Public License, v 1.
  */
 
-import { dataTableContextComplexMock } from '../../__mocks__/table_context';
+import {
+  dataTableContextComplexMock,
+  dataTableContextComplexRowsMock,
+} from '../../__mocks__/table_context';
 import { servicesMock } from '../../__mocks__/services';
 import {
   copyValueToClipboard,
@@ -22,7 +25,7 @@ const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 describe('copyValueToClipboard', () => {
   const valueToStringConverter: ValueToStringConverter = (rowIndex, columnId, options) =>
     convertValueToString({
-      rows: dataTableContextComplexMock.rows,
+      rows: dataTableContextComplexRowsMock,
       dataView: dataTableContextComplexMock.dataView,
       fieldFormats: servicesMock.fieldFormats,
       rowIndex,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Unified Data Table] Prevent `undefined` errors when row accessed via `rows[rowIndex]` (#193791)](https://github.com/elastic/kibana/pull/193791)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2024-09-24T18:36:11Z","message":"[Unified Data Table] Prevent `undefined` errors when row accessed via `rows[rowIndex]` (#193791)\n\n## Summary\r\n\r\nThis PR fixes an issue present in 8.15, but which no longer exists after\r\nlater refactoring, where saved search panels (possibly only ES|QL\r\npanels? It was hard to nail down since involved a race condition) could\r\nfail in dashboards when adding Unified Search filters that reduce the\r\nnumber of results in the grid.\r\n\r\nI'm still not 100% sure what the source of the issue was since it\r\ninvolved a race condition (didn't fail consistently for me locally) and\r\ninternal EUI data grid code, but I have a hunch. The `undefined` errors\r\noccurred when trying to access a row by index from `DataTableContext` in\r\ncertain cell renderers during the first render after search results had\r\nchanged. I believe what was happening was the change to\r\n`DataTableContext` triggered a re-render of the cells before EUI data\r\ngrid internally updated its state, resulting in attempts to access rows\r\nfrom within the cell renderers that no longer existed in the updated\r\n`DataTableContext`, and causing `undefined` reference errors.\r\n\r\nI'm making these changes in `main` instead of `8.15` directly because\r\nthe updated approach is generally a safer way to retrieve rows and\r\nprevent similar issues in the future. Previously we added `rows` to\r\n`DataTableContext` and retrieved a single row by index using bracket\r\nnotation, which can potentially return `undefined`, but TypeScript does\r\nnot protect against it for us. Instead I've updated `DataTableContext`\r\nwith a `getRowByIndex` method that correctly returns `DataTableRecord |\r\nundefined` and forces consumers to explicitly handle the `undefined`\r\nscenario.\r\n\r\nThe PR will require some manual backporting to 8.15 since some things\r\nhave changed since then, but it shouldn't be difficult.\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6ff07918b0490fa7d66202376073a337da55c73e","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:fix","v9.0.0","Team:DataDiscovery","backport:prev-minor","backport:prev-major","Feature:UnifiedDataTable"],"number":193791,"url":"https://github.com/elastic/kibana/pull/193791","mergeCommit":{"message":"[Unified Data Table] Prevent `undefined` errors when row accessed via `rows[rowIndex]` (#193791)\n\n## Summary\r\n\r\nThis PR fixes an issue present in 8.15, but which no longer exists after\r\nlater refactoring, where saved search panels (possibly only ES|QL\r\npanels? It was hard to nail down since involved a race condition) could\r\nfail in dashboards when adding Unified Search filters that reduce the\r\nnumber of results in the grid.\r\n\r\nI'm still not 100% sure what the source of the issue was since it\r\ninvolved a race condition (didn't fail consistently for me locally) and\r\ninternal EUI data grid code, but I have a hunch. The `undefined` errors\r\noccurred when trying to access a row by index from `DataTableContext` in\r\ncertain cell renderers during the first render after search results had\r\nchanged. I believe what was happening was the change to\r\n`DataTableContext` triggered a re-render of the cells before EUI data\r\ngrid internally updated its state, resulting in attempts to access rows\r\nfrom within the cell renderers that no longer existed in the updated\r\n`DataTableContext`, and causing `undefined` reference errors.\r\n\r\nI'm making these changes in `main` instead of `8.15` directly because\r\nthe updated approach is generally a safer way to retrieve rows and\r\nprevent similar issues in the future. Previously we added `rows` to\r\n`DataTableContext` and retrieved a single row by index using bracket\r\nnotation, which can potentially return `undefined`, but TypeScript does\r\nnot protect against it for us. Instead I've updated `DataTableContext`\r\nwith a `getRowByIndex` method that correctly returns `DataTableRecord |\r\nundefined` and forces consumers to explicitly handle the `undefined`\r\nscenario.\r\n\r\nThe PR will require some manual backporting to 8.15 since some things\r\nhave changed since then, but it shouldn't be difficult.\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6ff07918b0490fa7d66202376073a337da55c73e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/193791","number":193791,"mergeCommit":{"message":"[Unified Data Table] Prevent `undefined` errors when row accessed via `rows[rowIndex]` (#193791)\n\n## Summary\r\n\r\nThis PR fixes an issue present in 8.15, but which no longer exists after\r\nlater refactoring, where saved search panels (possibly only ES|QL\r\npanels? It was hard to nail down since involved a race condition) could\r\nfail in dashboards when adding Unified Search filters that reduce the\r\nnumber of results in the grid.\r\n\r\nI'm still not 100% sure what the source of the issue was since it\r\ninvolved a race condition (didn't fail consistently for me locally) and\r\ninternal EUI data grid code, but I have a hunch. The `undefined` errors\r\noccurred when trying to access a row by index from `DataTableContext` in\r\ncertain cell renderers during the first render after search results had\r\nchanged. I believe what was happening was the change to\r\n`DataTableContext` triggered a re-render of the cells before EUI data\r\ngrid internally updated its state, resulting in attempts to access rows\r\nfrom within the cell renderers that no longer existed in the updated\r\n`DataTableContext`, and causing `undefined` reference errors.\r\n\r\nI'm making these changes in `main` instead of `8.15` directly because\r\nthe updated approach is generally a safer way to retrieve rows and\r\nprevent similar issues in the future. Previously we added `rows` to\r\n`DataTableContext` and retrieved a single row by index using bracket\r\nnotation, which can potentially return `undefined`, but TypeScript does\r\nnot protect against it for us. Instead I've updated `DataTableContext`\r\nwith a `getRowByIndex` method that correctly returns `DataTableRecord |\r\nundefined` and forces consumers to explicitly handle the `undefined`\r\nscenario.\r\n\r\nThe PR will require some manual backporting to 8.15 since some things\r\nhave changed since then, but it shouldn't be difficult.\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6ff07918b0490fa7d66202376073a337da55c73e"}},{"url":"https://github.com/elastic/kibana/pull/193908","number":193908,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->