### PR TITLE
[Automatic Import] move base-fields into fields folder

### DIFF
--- a/x-pack/plugins/integration_assistant/server/integration_builder/fields.test.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/fields.test.ts
@@ -46,7 +46,10 @@ describe('createFieldMapping', () => {
   type: keyword
 `;
 
-    expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/base-fields.yml`, mockedTemplate);
+    expect(createSync).toHaveBeenCalledWith(
+      `${dataStreamPath}/fields/base-fields.yml`,
+      mockedTemplate
+    );
     expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/fields.yml`, expectedFields);
   });
 
@@ -56,7 +59,10 @@ describe('createFieldMapping', () => {
     const expectedFields = `[]
 `;
 
-    expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/base-fields.yml`, mockedTemplate);
+    expect(createSync).toHaveBeenCalledWith(
+      `${dataStreamPath}/fields/base-fields.yml`,
+      mockedTemplate
+    );
     expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/fields.yml`, expectedFields);
   });
 });

--- a/x-pack/plugins/integration_assistant/server/integration_builder/fields.test.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/fields.test.ts
@@ -46,7 +46,7 @@ describe('createFieldMapping', () => {
   type: keyword
 `;
 
-    expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/base-fields.yml`, mockedTemplate);
+    expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/base-fields.yml`, mockedTemplate);
     expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/fields.yml`, expectedFields);
   });
 
@@ -56,7 +56,7 @@ describe('createFieldMapping', () => {
     const expectedFields = `[]
 `;
 
-    expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/base-fields.yml`, mockedTemplate);
+    expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/base-fields.yml`, mockedTemplate);
     expect(createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/fields.yml`, expectedFields);
   });
 });

--- a/x-pack/plugins/integration_assistant/server/integration_builder/fields.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/fields.ts
@@ -15,7 +15,7 @@ export function createFieldMapping(
   specificDataStreamDir: string,
   docs: object[]
 ): void {
-  const dataStreamFieldsDir = `${specificDataStreamDir}/fields`
+  const dataStreamFieldsDir = `${specificDataStreamDir}/fields`;
   createBaseFields(dataStreamFieldsDir, packageName, dataStreamName);
   createCustomFields(dataStreamFieldsDir, docs);
 }

--- a/x-pack/plugins/integration_assistant/server/integration_builder/fields.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/fields.ts
@@ -15,12 +15,13 @@ export function createFieldMapping(
   specificDataStreamDir: string,
   docs: object[]
 ): void {
-  createBaseFields(specificDataStreamDir, packageName, dataStreamName);
-  createCustomFields(specificDataStreamDir, docs);
+  const dataStreamFieldsDir = `${specificDataStreamDir}/fields`
+  createBaseFields(dataStreamFieldsDir, packageName, dataStreamName);
+  createCustomFields(dataStreamFieldsDir, docs);
 }
 
 function createBaseFields(
-  specificDataStreamDir: string,
+  dataStreamFieldsDir: string,
   packageName: string,
   dataStreamName: string
 ): void {
@@ -30,11 +31,11 @@ function createBaseFields(
     dataset: datasetName,
   });
 
-  createSync(`${specificDataStreamDir}/base-fields.yml`, baseFields);
+  createSync(`${dataStreamFieldsDir}/base-fields.yml`, baseFields);
 }
 
-function createCustomFields(specificDataStreamDir: string, pipelineResults: object[]): void {
+function createCustomFields(dataStreamFieldsDir: string, pipelineResults: object[]): void {
   const mergedResults = mergeSamples(pipelineResults);
   const fieldKeys = generateFields(mergedResults);
-  createSync(`${specificDataStreamDir}/fields/fields.yml`, fieldKeys);
+  createSync(`${dataStreamFieldsDir}/fields.yml`, fieldKeys);
 }


### PR DESCRIPTION
## Summary

Currently when using Automatic import, `base-fields.yml` is created outside the `fields` folder.
When running `elastic-package build` on a generated integration, we get the following warnings:
```
Error: building package failed: invalid content found in built zip package: found 8 validation errors:
   1. item [base-fields.yml] is not allowed in folder [/Projects/abc-1.0.0/build/packages/abc-1.0.0.zip/data_stream/abc]
   5. expected field "data_stream.type" with type "constant_keyword" not found in datastream "abc"
   6. expected field "data_stream.dataset" with type "constant_keyword" not found in datastream "abc"
   7. expected field "data_stream.namespace" with type "constant_keyword" not found in datastream "abc"
   8. expected field "@timestamp" with type "date" not found in datastream "abc"
```

This is fixed by moving the file inside the correct `fields` folder.



<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->