### PR TITLE
Revert "[8.15] Bump maximum supported package spec version to 3.2 (#193574) (#193727)"

### DIFF
--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -25,7 +25,7 @@ import { BULK_CREATE_MAX_ARTIFACTS_BYTES } from './services/artifacts/artifacts'
 const DEFAULT_BUNDLED_PACKAGE_LOCATION = path.join(__dirname, '../target/bundled_packages');
 const DEFAULT_GPG_KEY_PATH = path.join(__dirname, '../target/keys/GPG-KEY-elasticsearch');
 
-const REGISTRY_SPEC_MAX_VERSION = '3.2';
+const REGISTRY_SPEC_MAX_VERSION = '3.0';
 
 export const config: PluginConfigDescriptor = {
   exposeToBrowser: {


### PR DESCRIPTION
This reverts commit 603b31b04eec5d1d89191593eaef8b9f4a9dbd2c (https://github.com/elastic/kibana/pull/193574). This was not expected to be changed in a patch version.