### PR TITLE
[8.15] [Automatic Import] move base-fields into fields folder (#193960)

### DIFF
--- a/x-pack/plugins/integration_assistant/server/integration_builder/fields.test.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/fields.test.ts
@@ -50,7 +50,10 @@ describe('createFieldMapping', () => {
       `${dataStreamPath}/fields/base-fields.yml`,
       mockedTemplate
     );
-    expect(Utils.createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/fields.yml`, expectedFields);
+    expect(Utils.createSync).toHaveBeenCalledWith(
+      `${dataStreamPath}/fields/fields.yml`,
+      expectedFields
+    );
   });
 
   it('Should create fields files even if docs value is empty', async () => {
@@ -63,6 +66,9 @@ describe('createFieldMapping', () => {
       `${dataStreamPath}/fields/base-fields.yml`,
       mockedTemplate
     );
-    expect(Utils.createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/fields.yml`, expectedFields);
+    expect(Utils.createSync).toHaveBeenCalledWith(
+      `${dataStreamPath}/fields/fields.yml`,
+      expectedFields
+    );
   });
 });

--- a/x-pack/plugins/integration_assistant/server/integration_builder/fields.test.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/fields.test.ts
@@ -47,13 +47,10 @@ describe('createFieldMapping', () => {
 `;
 
     expect(Utils.createSync).toHaveBeenCalledWith(
-      `${dataStreamPath}/base-fields.yml`,
+      `${dataStreamPath}/fields/base-fields.yml`,
       mockedTemplate
     );
-    expect(Utils.createSync).toHaveBeenCalledWith(
-      `${dataStreamPath}/fields/fields.yml`,
-      expectedFields
-    );
+    expect(Utils.createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/fields.yml`, expectedFields);
   });
 
   it('Should create fields files even if docs value is empty', async () => {
@@ -63,12 +60,9 @@ describe('createFieldMapping', () => {
 `;
 
     expect(Utils.createSync).toHaveBeenCalledWith(
-      `${dataStreamPath}/base-fields.yml`,
+      `${dataStreamPath}/fields/base-fields.yml`,
       mockedTemplate
     );
-    expect(Utils.createSync).toHaveBeenCalledWith(
-      `${dataStreamPath}/fields/fields.yml`,
-      expectedFields
-    );
+    expect(Utils.createSync).toHaveBeenCalledWith(`${dataStreamPath}/fields/fields.yml`, expectedFields);
   });
 });

--- a/x-pack/plugins/integration_assistant/server/integration_builder/fields.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/fields.ts
@@ -15,12 +15,13 @@ export function createFieldMapping(
   specificDataStreamDir: string,
   docs: object[]
 ): void {
-  createBaseFields(specificDataStreamDir, packageName, dataStreamName);
-  createCustomFields(specificDataStreamDir, docs);
+  const dataStreamFieldsDir = `${specificDataStreamDir}/fields`;
+  createBaseFields(dataStreamFieldsDir, packageName, dataStreamName);
+  createCustomFields(dataStreamFieldsDir, docs);
 }
 
 function createBaseFields(
-  specificDataStreamDir: string,
+  dataStreamFieldsDir: string,
   packageName: string,
   dataStreamName: string
 ): void {
@@ -30,11 +31,11 @@ function createBaseFields(
     dataset: datasetName,
   });
 
-  createSync(`${specificDataStreamDir}/base-fields.yml`, baseFields);
+  createSync(`${dataStreamFieldsDir}/base-fields.yml`, baseFields);
 }
 
-function createCustomFields(specificDataStreamDir: string, pipelineResults: object[]): void {
+function createCustomFields(dataStreamFieldsDir: string, pipelineResults: object[]): void {
   const mergedResults = mergeSamples(pipelineResults);
   const fieldKeys = generateFields(mergedResults);
-  createSync(`${specificDataStreamDir}/fields/fields.yml`, fieldKeys);
+  createSync(`${dataStreamFieldsDir}/fields.yml`, fieldKeys);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Automatic Import] move base-fields into fields folder (#193960)](https://github.com/elastic/kibana/pull/193960)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Hanna Tamoudi","email":"hanna.tamoudi@elastic.co"},"sourceCommit":{"committedDate":"2024-09-25T12:47:16Z","message":"[Automatic Import] move base-fields into fields folder (#193960)","sha":"0ee92df29b88b882557b9b74e1807642484cccd7","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","v9.0.0","backport:prev-major","Team:Security-Scalability","Feature:AutomaticImport"],"number":193960,"url":"https://github.com/elastic/kibana/pull/193960","mergeCommit":{"message":"[Automatic Import] move base-fields into fields folder (#193960)","sha":"0ee92df29b88b882557b9b74e1807642484cccd7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/193960","number":193960,"mergeCommit":{"message":"[Automatic Import] move base-fields into fields folder (#193960)","sha":"0ee92df29b88b882557b9b74e1807642484cccd7"}}]}] BACKPORT-->