### PR TITLE
[Links Panel] [Docs] Remove "technical preview" label from links panel documentation

### DIFF
--- a/docs/user/dashboard/links-panel.asciidoc
+++ b/docs/user/dashboard/links-panel.asciidoc
@@ -1,8 +1,6 @@
 [[dashboard-links]]
 === Link panels
 
-preview::["This functionality is in technical preview, and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
-
 You can use *Links* panels to create links to other dashboards or external websites. When creating links to other dashboards, you have the option to carry the time range and query and filters to apply to the linked dashboard. Links to external websites follow the <<external-URL-policy,`externalUrl.policy`>> settings. *Links* panels support vertical and horizontal layouts and may be saved to the *Library* for use on other dashboards.
 
 [role="screenshot"]


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/193742

## Summary

The links panel was [GAed in 8.14](https://github.com/elastic/kibana/pull/178999), but the [docs](https://www.elastic.co/guide/en/kibana/current/dashboard-links.html) were not updated to reflect this. This PR removes the "technical preview" label from the links panel docs to keep them up-to-date with the current status of the links panel.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/a110861a-a78b-49ce-81cd-ddb64b15749b) | ![image](https://github.com/user-attachments/assets/e5ddcb39-db5c-4d5d-b107-8877a5e61d15) | 

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->