### PR TITLE
[CI] Handle unlabeled events in on-merge workflow

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -3,6 +3,7 @@ on:
     types:
       - closed
       - labeled
+      - unlabeled
 
 jobs:
   on-merge:
@@ -21,6 +22,7 @@ jobs:
             || github.event.label.name == 'auto-backport'
           )
         )
+        || (github.event.action == 'unlabeled' && github.event.label.name == 'backport:skip')
         || (github.event.action == 'closed')
       )
     steps:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -22,7 +22,7 @@ jobs:
             || github.event.label.name == 'auto-backport'
           )
         )
-        || (github.event.action == 'unlabeled' && github.event.unlabel.name == 'backport:skip')
+        || (github.event.action == 'unlabeled' && github.event.label.name == 'backport:skip')
         || (github.event.action == 'closed')
       )
     steps:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -22,7 +22,7 @@ jobs:
             || github.event.label.name == 'auto-backport'
           )
         )
-        || (github.event.action == 'unlabeled' && github.event.label.name == 'backport:skip')
+        || (github.event.action == 'unlabeled' && github.event.unlabel.name == 'backport:skip')
         || (github.event.action == 'closed')
       )
     steps:


### PR DESCRIPTION
## Summary

Closes #194051

As far as I can tell from the docs the `unlabeled` event sends information about the removed label. I'm not sure the best way to test this aside from merging the PR and adjusting the labels on this PR afterwards. Reverting if needed.

Plan:
1. Merge PR
2. Add `backport:prev-minor`
3. Verify the workflow ran and _did not_ trigger a backport since `backport:skip` is still a label
4. Remove `backport:skip`
5. Verify the workflow ran and _did_ trigger a backport to `8.x`
6. Revert the labels and close the backport PR since it is not actually needed.


The plan was successful and the `unlabel` event triggered a backport, the corresponding workflow is at https://github.com/elastic/kibana/actions/runs/11042722929/job/30675618235
<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->