### PR TITLE
[Search][ES3] fix: link to dev_tools instead of dev_tools:console

### DIFF
--- a/x-pack/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/plugins/serverless_search/public/navigation_tree.ts
@@ -33,7 +33,7 @@ export const navigationTree = (useSearchHomepage: boolean = false): NavigationTr
           title: i18n.translate('xpack.serverlessSearch.nav.devTools', {
             defaultMessage: 'Dev Tools',
           }),
-          link: 'dev_tools:console',
+          link: 'dev_tools',
           getIsActive: ({ pathNameSerialized, prepend }) => {
             return pathNameSerialized.startsWith(prepend('/app/dev_tools'));
           },


### PR DESCRIPTION
## Summary

Updating the search "Dev Tools" link from using dev_tools:console to just dev_tools. The console deeplink is missing from the deeplinks definition sometimes and causing the side nav item to be removed.

