### PR TITLE
[Discover] Support icon only buttons in Discover app menu

### DIFF
--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
@@ -46,7 +46,7 @@ export const getTopNavLinks = ({
   topNavCustomization: TopNavCustomization | undefined;
   shouldShowESQLToDataViewTransitionModal: boolean;
 }): TopNavMenuData[] => {
-  const alerts = {
+  const alerts: TopNavMenuData = {
     id: 'alerts',
     label: i18n.translate('discover.localMenu.localMenu.alertsTitle', {
       defaultMessage: 'Alerts',
@@ -69,7 +69,7 @@ export const getTopNavLinks = ({
   /**
    * Switches from ES|QL to classic mode and vice versa
    */
-  const esqLDataViewTransitionToggle = {
+  const esqLDataViewTransitionToggle: TopNavMenuData = {
     id: 'esql',
     label: isEsqlMode
       ? i18n.translate('discover.localMenu.switchToClassicTitle', {
@@ -114,7 +114,7 @@ export const getTopNavLinks = ({
     testId: isEsqlMode ? 'switch-to-dataviews' : 'select-text-based-language-btn',
   };
 
-  const newSearch = {
+  const newSearch: TopNavMenuData = {
     id: 'new',
     label: i18n.translate('discover.localMenu.localMenu.newSearchTitle', {
       defaultMessage: 'New',
@@ -122,11 +122,13 @@ export const getTopNavLinks = ({
     description: i18n.translate('discover.localMenu.newSearchDescription', {
       defaultMessage: 'New Search',
     }),
+    iconType: 'plus',
+    iconOnly: true,
     run: () => services.locator.navigate({}),
     testId: 'discoverNewButton',
   };
 
-  const saveSearch = {
+  const saveSearch: TopNavMenuData = {
     id: 'save',
     label: i18n.translate('discover.localMenu.saveTitle', {
       defaultMessage: 'Save',
@@ -149,7 +151,7 @@ export const getTopNavLinks = ({
     },
   };
 
-  const openSearch = {
+  const openSearch: TopNavMenuData = {
     id: 'open',
     label: i18n.translate('discover.localMenu.openTitle', {
       defaultMessage: 'Open',
@@ -157,6 +159,8 @@ export const getTopNavLinks = ({
     description: i18n.translate('discover.localMenu.openSavedSearchDescription', {
       defaultMessage: 'Open Saved Search',
     }),
+    iconType: 'folderOpen',
+    iconOnly: true,
     testId: 'discoverOpenButton',
     run: () =>
       showOpenSearchPanel({
@@ -165,7 +169,7 @@ export const getTopNavLinks = ({
       }),
   };
 
-  const shareSearch = {
+  const shareSearch: TopNavMenuData = {
     id: 'share',
     label: i18n.translate('discover.localMenu.shareTitle', {
       defaultMessage: 'Share',
@@ -173,6 +177,8 @@ export const getTopNavLinks = ({
     description: i18n.translate('discover.localMenu.shareSearchDescription', {
       defaultMessage: 'Share Search',
     }),
+    iconType: 'link',
+    iconOnly: true,
     testId: 'shareTopNavButton',
     run: async (anchorElement: HTMLElement) => {
       if (!services.share) return;
@@ -263,7 +269,7 @@ export const getTopNavLinks = ({
     },
   };
 
-  const inspectSearch = {
+  const inspectSearch: TopNavMenuData = {
     id: 'inspect',
     label: i18n.translate('discover.localMenu.inspectTitle', {
       defaultMessage: 'Inspect',
@@ -285,15 +291,15 @@ export const getTopNavLinks = ({
   }
 
   if (!defaultMenu?.newItem?.disabled) {
-    entries.push({ data: newSearch, order: defaultMenu?.newItem?.order ?? 100 });
+    entries.push({ data: newSearch, order: defaultMenu?.newItem?.order ?? 510 });
   }
 
   if (!defaultMenu?.openItem?.disabled) {
-    entries.push({ data: openSearch, order: defaultMenu?.openItem?.order ?? 200 });
+    entries.push({ data: openSearch, order: defaultMenu?.openItem?.order ?? 520 });
   }
 
   if (!defaultMenu?.shareItem?.disabled) {
-    entries.push({ data: shareSearch, order: defaultMenu?.shareItem?.order ?? 300 });
+    entries.push({ data: shareSearch, order: defaultMenu?.shareItem?.order ?? 530 });
   }
 
   if (

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
@@ -28,6 +28,7 @@ export interface TopNavMenuData {
   isLoading?: boolean;
   iconType?: string;
   iconSide?: EuiButtonProps['iconSide'];
+  iconOnly?: boolean;
   target?: string;
   href?: string;
   intl?: InjectedIntl;

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
@@ -9,10 +9,17 @@
 
 import { upperFirst, isFunction } from 'lodash';
 import React, { MouseEvent } from 'react';
-import { EuiToolTip, EuiButton, EuiHeaderLink, EuiBetaBadge, EuiButtonColor } from '@elastic/eui';
+import {
+  EuiToolTip,
+  EuiButton,
+  EuiHeaderLink,
+  EuiBetaBadge,
+  EuiButtonColor,
+  EuiButtonIcon,
+} from '@elastic/eui';
 import { TopNavMenuData } from './top_nav_menu_data';
 
-export function TopNavMenuItem(props: TopNavMenuData) {
+export function TopNavMenuItem(props: TopNavMenuData & { isMobileMenu?: boolean }) {
   function isDisabled(): boolean {
     const val = isFunction(props.disableButton) ? props.disableButton() : props.disableButton;
     return val!;
@@ -59,16 +66,28 @@ export function TopNavMenuItem(props: TopNavMenuData) {
       ? { onClick: undefined, href: props.href, target: props.target }
       : {};
 
-  // fill is not compatible with EuiHeaderLink
-  const btn = props.emphasize ? (
-    <EuiButton size="s" {...commonButtonProps} fill={props.fill ?? true}>
-      {getButtonContainer()}
-    </EuiButton>
-  ) : (
-    <EuiHeaderLink size="s" {...commonButtonProps} {...overrideProps}>
-      {getButtonContainer()}
-    </EuiHeaderLink>
-  );
+  const btn =
+    props.iconOnly && props.iconType && !props.isMobileMenu ? (
+      // icon only buttons are not supported by EuiHeaderLink
+      <EuiToolTip content={upperFirst(props.label || props.id!)} position="bottom">
+        <EuiButtonIcon
+          size="s"
+          {...commonButtonProps}
+          iconType={props.iconType}
+          display={props.emphasize && (props.fill ?? true) ? 'fill' : undefined}
+          aria-label={upperFirst(props.label || props.id!)}
+        />
+      </EuiToolTip>
+    ) : props.emphasize ? (
+      // fill is not compatible with EuiHeaderLink
+      <EuiButton size="s" {...commonButtonProps} fill={props.fill ?? true}>
+        {getButtonContainer()}
+      </EuiButton>
+    ) : (
+      <EuiHeaderLink size="s" {...commonButtonProps} {...overrideProps}>
+        {getButtonContainer()}
+      </EuiHeaderLink>
+    );
 
   const tooltip = getTooltip();
   if (tooltip) {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_items.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_items.tsx
@@ -7,10 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiHeaderLinks } from '@elastic/eui';
+import { EuiHeaderLinks, useIsWithinBreakpoints } from '@elastic/eui';
 import React from 'react';
 import type { TopNavMenuData } from './top_nav_menu_data';
 import { TopNavMenuItem } from './top_nav_menu_item';
+
+const POPOVER_BREAKPOINTS = ['xs', 's'];
 
 export const TopNavMenuItems = ({
   config,
@@ -19,11 +21,17 @@ export const TopNavMenuItems = ({
   config: TopNavMenuData[] | undefined;
   className?: string;
 }) => {
+  const isMobileMenu = useIsWithinBreakpoints(POPOVER_BREAKPOINTS);
   if (!config || config.length === 0) return null;
   return (
-    <EuiHeaderLinks data-test-subj="top-nav" gutterSize="xs" className={className}>
+    <EuiHeaderLinks
+      data-test-subj="top-nav"
+      gutterSize="xs"
+      className={className}
+      popoverBreakpoints={POPOVER_BREAKPOINTS}
+    >
       {config.map((menuItem: TopNavMenuData, i: number) => {
-        return <TopNavMenuItem key={`nav-menu-${i}`} {...menuItem} />;
+        return <TopNavMenuItem key={`nav-menu-${i}`} isMobileMenu={isMobileMenu} {...menuItem} />;
       })}
     </EuiHeaderLinks>
   );


### PR DESCRIPTION
## Summary

PoC for supporting icon only buttons in Discover app menu:
<img width="1996" alt="icon_only" src="https://github.com/user-attachments/assets/7b98c6c8-9460-4ed1-b08e-121c30e64383">

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)