### PR TITLE
[8.15] [Links Panel] [Docs] Remove "technical preview" label from links panel documentation

### DIFF
--- a/docs/user/dashboard/make-dashboards-interactive.asciidoc
+++ b/docs/user/dashboard/make-dashboards-interactive.asciidoc
@@ -214,8 +214,6 @@ To use saved search interactions, open the panel menu, then click *More > View s
 [[dashboard-links]]
 === Create links to other dashboards
 
-preview::["This functionality is in technical preview, and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
-
 You can use *Links* panels to create links to other dashboards or external websites. When creating links to other dashboards, you have the option to carry the time range and query and filters to apply to the linked dashboard. Links to external websites follow the <<external-URL-policy,`externalUrl.policy`>> settings. *Links* panels support vertical and horizontal layouts and may be saved to the *Library* for use on other dashboards.
 
 [role="screenshot"]


### PR DESCRIPTION
## Summary

Manual backport of https://github.com/elastic/kibana/pull/194055 to target the docs **before** the [docs refresh](https://github.com/elastic/kibana/pull/192305)


### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
