### PR TITLE
[OpenAPI][ResponseOps] Edit descriptions for alerting rule API examples

### DIFF
--- a/oas_docs/examples/create_es_query_esql_rule_request.yaml
+++ b/oas_docs/examples/create_es_query_esql_rule_request.yaml
@@ -1,4 +1,6 @@
-summary: Create an Elasticsearch query rule that uses Elasticsearch Query Language (ES|QL).
+summary: Elasticsearch query rule (ES|QL)
+description: >
+  Create an Elasticsearch query rule that uses Elasticsearch Query Language (ES|QL) to define its query and a server log connector to send notifications.
 value:
   name: my Elasticsearch query ESQL rule
   params:

--- a/oas_docs/examples/create_es_query_esql_rule_response.yaml
+++ b/oas_docs/examples/create_es_query_esql_rule_response.yaml
@@ -1,4 +1,5 @@
-summary: The create rule API returns a JSON object that contains details about the rule.
+summary: Elasticsearch query rule (ES|QL)
+description: The response for successfully creating an Elasticsearch query rule that uses Elasticsearch Query Language (ES|QL).
 value:
   id: e0d62360-78e8-11ee-9177-f7d404c8c945
   enabled: true

--- a/oas_docs/examples/create_es_query_kql_rule_request.yaml
+++ b/oas_docs/examples/create_es_query_kql_rule_request.yaml
@@ -1,4 +1,5 @@
-summary: Create an Elasticsearch query rule that uses Kibana query language (KQL).
+summary: Elasticsearch query rule (KQL)
+description: Create an Elasticsearch query rule that uses Kibana query language (KQL).
 value:
   consumer: alerts
   name: my Elasticsearch query KQL rule

--- a/oas_docs/examples/create_es_query_kql_rule_response.yaml
+++ b/oas_docs/examples/create_es_query_kql_rule_response.yaml
@@ -1,4 +1,5 @@
-summary: The create rule API returns a JSON object that contains details about the rule.
+summary: Elasticsearch query rule (KQL)
+description: The response for successfully creating an Elasticsearch query rule that uses Kibana query language (KQL).
 value:
   id: 7bd506d0-2284-11ee-8fad-6101956ced88
   enabled: true

--- a/oas_docs/examples/create_es_query_rule_request.yaml
+++ b/oas_docs/examples/create_es_query_rule_request.yaml
@@ -1,4 +1,6 @@
-summary: Create an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL) to define its query and a server log connector to send notifications.
+summary: Elasticsearch query rule (DSL)
+description: >
+  Create an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL) to define its query and a server log connector to send notifications.
 value:
   actions:
     - group: query matched

--- a/oas_docs/examples/create_es_query_rule_response.yaml
+++ b/oas_docs/examples/create_es_query_rule_response.yaml
@@ -1,4 +1,5 @@
-summary: The create rule API returns a JSON object that contains details about the rule.
+summary: Elasticsearch query rule (DSL)
+description: The response for successfully creating an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL).
 value:
   id: 58148c70-407f-11ee-850e-c71febc4ca7f
   enabled: true

--- a/oas_docs/examples/create_index_threshold_rule_request.yaml
+++ b/oas_docs/examples/create_index_threshold_rule_request.yaml
@@ -1,4 +1,6 @@
-summary: Create an index threshold rule.
+summary: Index threshold rule
+description: >
+  Create an index threshold rule that uses a server log connector to send notifications when the threshold is met.
 value:
   actions:
     - id: 48de3460-f401-11ed-9f8e-399c75a2deeb

--- a/oas_docs/examples/create_index_threshold_rule_response.yaml
+++ b/oas_docs/examples/create_index_threshold_rule_response.yaml
@@ -1,4 +1,5 @@
-summary: The create rule API returns a JSON object that contains details about the rule.
+summary: Index threshold rule
+description: The response for successfully creating an index threshold rule.
 value:
   actions:
     - group: threshold met

--- a/oas_docs/examples/create_tracking_containment_rule_request.yaml
+++ b/oas_docs/examples/create_tracking_containment_rule_request.yaml
@@ -1,4 +1,6 @@
-summary: Create a tracking containment rule.
+summary: Tracking containment rule
+description: >
+  Create a tracking containment rule that checks when an entity is contained or no longer contained within a boundary.
 value:
   consumer: alerts
   name: my tracking rule

--- a/oas_docs/examples/create_tracking_containment_rule_response.yaml
+++ b/oas_docs/examples/create_tracking_containment_rule_response.yaml
@@ -1,4 +1,5 @@
-summary: The create rule API returns a JSON object that contains details about the rule.
+summary: Tracking containment rule
+description: The response for successfully creating a tracking containment rule.
 value:
   id: b6883f9d-5f70-4758-a66e-369d7c26012f
   name: my tracking rule

--- a/oas_docs/examples/find_rules_response.yaml
+++ b/oas_docs/examples/find_rules_response.yaml
@@ -1,4 +1,5 @@
-summary: Retrieve information about a rule.
+summary: Index threshold rule
+description: A response that contains information about an index threshold rule.
 value:
   page: 1
   total: 1

--- a/oas_docs/examples/find_rules_response_conditional_action.yaml
+++ b/oas_docs/examples/find_rules_response_conditional_action.yaml
@@ -1,4 +1,5 @@
-summary: Retrieve information about a rule that has conditional actions.
+summary: Security rule
+description: A response that contains information about a security rule that has conditional actions.
 value:
   page: 1
   total: 1

--- a/oas_docs/examples/update_rule_request.yaml
+++ b/oas_docs/examples/update_rule_request.yaml
@@ -1,4 +1,5 @@
-summary: Update an index threshold rule.
+summary: Index threshold rule
+description: Update an index threshold rule that uses a server log connector to send notifications when the threshold is met.
 value:
   actions:
     - frequency:

--- a/oas_docs/examples/update_rule_response.yaml
+++ b/oas_docs/examples/update_rule_response.yaml
@@ -1,4 +1,5 @@
-summary: The update rule API returns a JSON object that contains details about the rule.
+summary: Index threshold rule
+description: The response for successfully updating an index threshold rule.
 value:
   id: ac4e6b90-6be7-11eb-ba0d-9b1c1f912d74
   consumer: alerts


### PR DESCRIPTION
## Summary

This PR edits the summaries and descriptions for the alerting API examples, since they will now be displayed when we publish the OpenAPI document.

### Preview

![image](https://github.com/user-attachments/assets/ea75cb8a-cc7d-41eb-b25b-d90dbdd9afd6)

The `summary` is the menu title when there are multiple examples. The `description` is displayed as commented out text within the body of the request or response example.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->