### PR TITLE
Delete imports/references to EUI's distributed `.css` files

### DIFF
--- a/packages/kbn-ui-shared-deps-npm/webpack.config.js
+++ b/packages/kbn-ui-shared-deps-npm/webpack.config.js
@@ -101,8 +101,6 @@ module.exports = (_, argv) => {
         'tslib',
         'uuid',
       ],
-      'kbn-ui-shared-deps-npm.v8.dark': ['@elastic/eui/dist/eui_theme_dark.css'],
-      'kbn-ui-shared-deps-npm.v8.light': ['@elastic/eui/dist/eui_theme_light.css'],
     },
     context: __dirname,
     devtool: 'cheap-source-map',

--- a/x-pack/plugins/canvas/shareable_runtime/index.ts
+++ b/x-pack/plugins/canvas/shareable_runtime/index.ts
@@ -8,4 +8,3 @@
 export * from './api';
 import '@kbn/core-apps-server-internal/assets/legacy_light_theme.css';
 import '../public/style/index.scss';
-import '@elastic/eui/dist/eui_theme_light.css';

--- a/x-pack/plugins/canvas/storybook/addon/panel.tsx
+++ b/x-pack/plugins/canvas/storybook/addon/panel.tsx
@@ -9,7 +9,6 @@ import React, { useState } from 'react';
 import { EuiResizableContainer } from '@elastic/eui';
 import { StateChange } from './components/state_change';
 
-import '@elastic/eui/dist/eui_theme_light.css';
 import './panel.css';
 
 import { RecordedAction } from './types';


### PR DESCRIPTION
## Summary

These files no longer contain any meaningful CSS used within Kibana as of EUI's completed Emotion migration, and can be safely removed. EUI will shortly no longer distribute these static `.css` files (although `.scss` src files will still remain exported for the near future).

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->