### PR TITLE
[ML] Async import ENABLE_ESQL to avoid adding full package to page load bundle.

### DIFF
--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -10,7 +10,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { type DataView, DataViewType } from '@kbn/data-views-plugin/public';
 import { DataViewPickerProps } from '@kbn/unified-search-plugin/public';
-import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { TextBasedLanguages } from '@kbn/esql-utils';
 import { useSavedSearchInitial } from '../../state_management/discover_state_provider';
 import { ESQL_TRANSITION_MODAL_KEY } from '../../../../../common/constants';

--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -10,7 +10,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { type DataView, DataViewType } from '@kbn/data-views-plugin/public';
 import { DataViewPickerProps } from '@kbn/unified-search-plugin/public';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
 import { TextBasedLanguages } from '@kbn/esql-utils';
 import { useSavedSearchInitial } from '../../state_management/discover_state_provider';
 import { ESQL_TRANSITION_MODAL_KEY } from '../../../../../common/constants';

--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
@@ -13,7 +13,7 @@ import type { TopNavMenuData } from '@kbn/navigation-plugin/public';
 import { setStateToKbnUrl } from '@kbn/kibana-utils-plugin/public';
 import { omit } from 'lodash';
 import { METRIC_TYPE } from '@kbn/analytics';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
 import type { DiscoverAppLocatorParams } from '../../../../../common';
 import { ESQL_TRANSITION_MODAL_KEY } from '../../../../../common/constants';
 import { showOpenSearchPanel } from './show_open_search_panel';

--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
@@ -13,7 +13,7 @@ import type { TopNavMenuData } from '@kbn/navigation-plugin/public';
 import { setStateToKbnUrl } from '@kbn/kibana-utils-plugin/public';
 import { omit } from 'lodash';
 import { METRIC_TYPE } from '@kbn/analytics';
-import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import type { DiscoverAppLocatorParams } from '../../../../../common';
 import { ESQL_TRANSITION_MODAL_KEY } from '../../../../../common/constants';
 import { showOpenSearchPanel } from './show_open_search_panel';

--- a/src/plugins/discover/public/plugin.tsx
+++ b/src/plugins/discover/public/plugin.tsx
@@ -19,7 +19,7 @@ import {
   ScopedHistory,
 } from '@kbn/core/public';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
 import { setStateToKbnUrl } from '@kbn/kibana-utils-plugin/public';
 import { SEARCH_EMBEDDABLE_TYPE, TRUNCATE_MAX_HEIGHT } from '@kbn/discover-utils';
 import { SavedSearchAttributes, SavedSearchType } from '@kbn/saved-search-plugin/common';

--- a/src/plugins/discover/public/plugin.tsx
+++ b/src/plugins/discover/public/plugin.tsx
@@ -19,7 +19,7 @@ import {
   ScopedHistory,
 } from '@kbn/core/public';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
-import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { setStateToKbnUrl } from '@kbn/kibana-utils-plugin/public';
 import { SEARCH_EMBEDDABLE_TYPE, TRUNCATE_MAX_HEIGHT } from '@kbn/discover-utils';
 import { SavedSearchAttributes, SavedSearchType } from '@kbn/saved-search-plugin/common';

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/initialize_field_stats_controls.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/initialize_field_stats_controls.ts
@@ -16,7 +16,7 @@ import type { StateComparators } from '@kbn/presentation-publishing';
 import { BehaviorSubject } from 'rxjs';
 import fastIsEqual from 'fast-deep-equal';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
 import { FieldStatsInitializerViewType } from '../grid_embeddable/types';
 import type { FieldStatsInitialState } from '../grid_embeddable/types';
 import type { FieldStatsControlsApi } from './types';

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/initialize_field_stats_controls.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/embeddables/field_stats/initialize_field_stats_controls.ts
@@ -16,7 +16,7 @@ import type { StateComparators } from '@kbn/presentation-publishing';
 import { BehaviorSubject } from 'rxjs';
 import fastIsEqual from 'fast-deep-equal';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
-import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { FieldStatsInitializerViewType } from '../grid_embeddable/types';
 import type { FieldStatsInitialState } from '../grid_embeddable/types';
 import type { FieldStatsControlsApi } from './types';

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/index_data_visualizer.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/index_data_visualizer.tsx
@@ -32,7 +32,7 @@ import {
   UrlStateProvider,
 } from '@kbn/ml-url-state';
 import type { SavedSearch } from '@kbn/saved-search-plugin/public';
-import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { EuiCallOut } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { getCoreStart, getPluginsStart } from '../../kibana_services';

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/index_data_visualizer.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/index_data_visualizer.tsx
@@ -32,7 +32,7 @@ import {
   UrlStateProvider,
 } from '@kbn/ml-url-state';
 import type { SavedSearch } from '@kbn/saved-search-plugin/public';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
 import { EuiCallOut } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { getCoreStart, getPluginsStart } from '../../kibana_services';

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/ui_actions/create_field_stats_table.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/ui_actions/create_field_stats_table.tsx
@@ -17,7 +17,7 @@ import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import React from 'react';
 import { isDefined } from '@kbn/ml-is-defined';
 import { COMMON_VISUALIZATION_GROUPING } from '@kbn/visualizations-plugin/public';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
 import { FIELD_STATS_EMBEDDABLE_TYPE } from '../embeddables/field_stats/constants';
 import type { DataVisualizerStartDependencies } from '../../common/types/data_visualizer_plugin';
 import type {

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/ui_actions/create_field_stats_table.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/ui_actions/create_field_stats_table.tsx
@@ -17,7 +17,7 @@ import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import React from 'react';
 import { isDefined } from '@kbn/ml-is-defined';
 import { COMMON_VISUALIZATION_GROUPING } from '@kbn/visualizations-plugin/public';
-import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { FIELD_STATS_EMBEDDABLE_TYPE } from '../embeddables/field_stats/constants';
 import type { DataVisualizerStartDependencies } from '../../common/types/data_visualizer_plugin';
 import type {

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -11,7 +11,7 @@ import type { Observable } from 'rxjs';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { render, unmountComponentAtNode } from 'react-dom';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
 import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
 import {
   DataViewBase,

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -11,7 +11,7 @@ import type { Observable } from 'rxjs';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { render, unmountComponentAtNode } from 'react-dom';
-import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
 import {
   DataViewBase,

--- a/x-pack/plugins/lens/public/trigger_actions/open_lens_config/in_app_embeddable_edit/in_app_embeddable_edit_action_helpers.tsx
+++ b/x-pack/plugins/lens/public/trigger_actions/open_lens_config/in_app_embeddable_edit/in_app_embeddable_edit_action_helpers.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import type { CoreStart } from '@kbn/core/public';
 import { isOfAggregateQueryType } from '@kbn/es-query';
-import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { IncompatibleActionError } from '@kbn/ui-actions-plugin/public';
 import type { LensPluginStartDependencies } from '../../../plugin';

--- a/x-pack/plugins/lens/public/trigger_actions/open_lens_config/in_app_embeddable_edit/in_app_embeddable_edit_action_helpers.tsx
+++ b/x-pack/plugins/lens/public/trigger_actions/open_lens_config/in_app_embeddable_edit/in_app_embeddable_edit_action_helpers.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import type { CoreStart } from '@kbn/core/public';
 import { isOfAggregateQueryType } from '@kbn/es-query';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { IncompatibleActionError } from '@kbn/ui-actions-plugin/public';
 import type { LensPluginStartDependencies } from '../../../plugin';

--- a/x-pack/plugins/ml/public/application/datavisualizer/datavisualizer_selector.tsx
+++ b/x-pack/plugins/ml/public/application/datavisualizer/datavisualizer_selector.tsx
@@ -23,7 +23,7 @@ import {
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useTimefilter } from '@kbn/ml-date-picker';
-import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { isFullLicense } from '../license';
 import { useMlKibana, useNavigateToPath } from '../contexts/kibana';
 import { HelpMenu } from '../components/help_menu';

--- a/x-pack/plugins/ml/public/application/datavisualizer/datavisualizer_selector.tsx
+++ b/x-pack/plugins/ml/public/application/datavisualizer/datavisualizer_selector.tsx
@@ -23,7 +23,7 @@ import {
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useTimefilter } from '@kbn/ml-date-picker';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
 import { isFullLicense } from '../license';
 import { useMlKibana, useNavigateToPath } from '../contexts/kibana';
 import { HelpMenu } from '../components/help_menu';

--- a/x-pack/plugins/ml/public/plugin.ts
+++ b/x-pack/plugins/ml/public/plugin.ts
@@ -51,7 +51,6 @@ import type { SavedSearchPublicPluginStart } from '@kbn/saved-search-plugin/publ
 import type { PresentationUtilPluginStart } from '@kbn/presentation-util-plugin/public';
 import type { DataViewEditorStart } from '@kbn/data-view-editor-plugin/public';
 import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
 import type { MlSharedServices } from './application/services/get_shared_ml_services';
 import { getMlSharedServices } from './application/services/get_shared_ml_services';
 import { registerManagementSection } from './application/management';
@@ -225,6 +224,7 @@ export class MlPlugin implements Plugin<MlPluginSetup, MlPluginStart> {
           const { capabilities } = coreStart.application;
           const mlCapabilities = capabilities.ml as MlCapabilities;
 
+          const { ENABLE_ESQL } = await import('@kbn/esql-utils/constants');
           const isEsqlEnabled = core.uiSettings.get(ENABLE_ESQL);
 
           // register various ML plugin features which require a full license

--- a/x-pack/plugins/observability_solution/logs_explorer/public/hooks/use_esql.tsx
+++ b/x-pack/plugins/observability_solution/logs_explorer/public/hooks/use_esql.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { DataSourceSelection, isDatasetSelection } from '../../common/data_source_selection';
 import { useKibanaContextForPlugin } from '../utils/use_kibana';
 

--- a/x-pack/plugins/observability_solution/logs_explorer/public/hooks/use_esql.tsx
+++ b/x-pack/plugins/observability_solution/logs_explorer/public/hooks/use_esql.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
 import { DataSourceSelection, isDatasetSelection } from '../../common/data_source_selection';
 import { useKibanaContextForPlugin } from '../utils/use_kibana';
 

--- a/x-pack/plugins/security_solution/public/common/hooks/esql/use_esql_availability.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/esql/use_esql_availability.ts
@@ -6,7 +6,7 @@
  */
 
 import { useMemo } from 'react';
-import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { useKibana } from '../../lib/kibana';
 import { useIsExperimentalFeatureEnabled } from '../use_experimental_features';
 

--- a/x-pack/plugins/security_solution/public/common/hooks/esql/use_esql_availability.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/esql/use_esql_availability.ts
@@ -6,7 +6,7 @@
  */
 
 import { useMemo } from 'react';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
+import { ENABLE_ESQL } from '@kbn/esql-utils/constants';
 import { useKibana } from '../../lib/kibana';
 import { useIsExperimentalFeatureEnabled } from '../use_experimental_features';
 


### PR DESCRIPTION
## Summary

Async import `ENABLE_ESQL` to avoid adding full package to page load bundle, saves us some precious kBytes.

### Checklist

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
