### PR TITLE
[8.x] [Dataset quality] Introducing dataTestSubject to selectable (#194008)

### DIFF
--- a/x-pack/plugins/observability_solution/dataset_quality/public/components/dataset_quality/filters/filters.tsx
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/components/dataset_quality/filters/filters.tsx
@@ -89,6 +89,7 @@ export default function Filters() {
           onIntegrationsChange={onIntegrationsChange}
         />
         <Selector
+          dataTestSubj="datasetQualityFilterType"
           label={typesLabel}
           searchPlaceholder={typesSearchPlaceholder}
           noneMatchingMessage={typesNoneMatching}

--- a/x-pack/plugins/observability_solution/dataset_quality/public/components/dataset_quality/filters/selector.tsx
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/components/dataset_quality/filters/selector.tsx
@@ -15,6 +15,7 @@ const selectorLoading = i18n.translate('xpack.datasetQuality.selector.loading', 
 });
 
 interface SelectorProps {
+  dataTestSubj?: string;
   isLoading?: boolean;
   options: Item[];
   loadingMessage?: string;
@@ -31,6 +32,7 @@ export interface Item {
 }
 
 export function Selector({
+  dataTestSubj = 'datasetQualitySelectable',
   isLoading,
   options,
   loadingMessage,
@@ -50,11 +52,15 @@ export function Selector({
     setIsPopoverOpen(false);
   };
 
-  const renderOption = (option: Item) => <EuiText size="s">{option.label}</EuiText>;
+  const renderOption = (option: Item) => (
+    <EuiText size="s" data-test-subj={`${dataTestSubj}Option-${option.label}`}>
+      {option.label}
+    </EuiText>
+  );
 
   const button = (
     <EuiFilterButton
-      data-test-subj="datasetQualitySelectableButton"
+      data-test-subj={`${dataTestSubj}Button`}
       iconType="arrowDown"
       badgeColor="success"
       onClick={onButtonClick}
@@ -75,7 +81,7 @@ export function Selector({
       panelPaddingSize="none"
     >
       <EuiSelectable
-        data-test-subj="datasetQualitySelectableOptions"
+        data-test-subj={`${dataTestSubj}Options`}
         searchable
         searchProps={{
           placeholder: searchPlaceholder,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Dataset quality] Introducing dataTestSubject to selectable (#194008)](https://github.com/elastic/kibana/pull/194008)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Yngrid Coello","email":"yngrid.coello@elastic.co"},"sourceCommit":{"committedDate":"2024-09-26T07:05:51Z","message":"[Dataset quality] Introducing dataTestSubject to selectable (#194008)\n\nRelates to https://github.com/elastic/observability-dev/issues/3873.\r\n\r\nThis PR aims to enable filter type to be easily targeted from FullStory.","sha":"85e7ae92f663cb3d19a7b11a619eb38f6292a836","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-major","ci:project-deploy-observability"],"number":194008,"url":"https://github.com/elastic/kibana/pull/194008","mergeCommit":{"message":"[Dataset quality] Introducing dataTestSubject to selectable (#194008)\n\nRelates to https://github.com/elastic/observability-dev/issues/3873.\r\n\r\nThis PR aims to enable filter type to be easily targeted from FullStory.","sha":"85e7ae92f663cb3d19a7b11a619eb38f6292a836"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/194008","number":194008,"mergeCommit":{"message":"[Dataset quality] Introducing dataTestSubject to selectable (#194008)\n\nRelates to https://github.com/elastic/observability-dev/issues/3873.\r\n\r\nThis PR aims to enable filter type to be easily targeted from FullStory.","sha":"85e7ae92f663cb3d19a7b11a619eb38f6292a836"}},{"url":"https://github.com/elastic/kibana/pull/194093","number":194093,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->