### PR TITLE
[APM UI] Refactor to use `@timestamp` and make `timestamp.us` optional as fallback value

### DIFF
--- a/packages/kbn-apm-types/src/es_fields/apm.ts
+++ b/packages/kbn-apm-types/src/es_fields/apm.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export const TIMESTAMP = 'timestamp.us';
+export const TIMESTAMP = '@timestamp';
+export const FALLBACK_TIMESTAMP = 'timestamp.us';
 export const AGENT = 'agent';
 export const AGENT_NAME = 'agent.name';
 export const AGENT_VERSION = 'agent.version';

--- a/packages/kbn-apm-types/src/es_fields/apm.ts
+++ b/packages/kbn-apm-types/src/es_fields/apm.ts
@@ -8,7 +8,7 @@
  */
 
 export const TIMESTAMP = '@timestamp';
-export const FALLBACK_TIMESTAMP = 'timestamp.us';
+export const TIMESTAMP_US = 'timestamp.us';
 export const AGENT = 'agent';
 export const AGENT_NAME = 'agent.name';
 export const AGENT_VERSION = 'agent.version';

--- a/x-pack/plugins/observability_solution/apm/common/waterfall/typings.ts
+++ b/x-pack/plugins/observability_solution/apm/common/waterfall/typings.ts
@@ -12,6 +12,7 @@ import { TimestampUs } from '../../typings/es_schemas/raw/fields/timestamp_us';
 import { AgentName } from '../../typings/es_schemas/ui/fields/agent';
 
 export interface WaterfallTransaction {
+  '@timestamp': string;
   timestamp: TimestampUs;
   trace: { id: string };
   service: {
@@ -38,6 +39,7 @@ export interface WaterfallTransaction {
 }
 
 export interface WaterfallSpan {
+  '@timestamp': string;
   timestamp: TimestampUs;
   trace: { id: string };
   service: {
@@ -70,6 +72,7 @@ export interface WaterfallSpan {
 }
 
 export interface WaterfallError {
+  '@timestamp': string;
   timestamp: TimestampUs;
   trace?: { id: string };
   transaction?: { id: string };

--- a/x-pack/plugins/observability_solution/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/error_group_details/error_sampler/error_sample_detail.tsx
@@ -29,6 +29,7 @@ import { first } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import useAsync from 'react-use/lib/useAsync';
+import { getTimestamp } from '../../../../utils/get_timestamp';
 import { ERROR_GROUP_ID } from '../../../../../common/es_fields/apm';
 import { TraceSearchType } from '../../../../../common/trace_explorer';
 import { APMError } from '../../../../../typings/es_schemas/ui/apm_error';
@@ -175,6 +176,8 @@ export function ErrorSampleDetails({
     },
   });
 
+  const timestamp = getTimestamp(errorData?.error?.['@timestamp'], errorData?.error?.timestamp?.us);
+
   return (
     <EuiPanel hasBorder={true}>
       <EuiFlexGroup alignItems="center">
@@ -245,7 +248,7 @@ export function ErrorSampleDetails({
       ) : (
         <Summary
           items={[
-            <TimestampTooltip time={errorData ? error.timestamp.us / 1000 : 0} />,
+            <TimestampTooltip time={errorData ? timestamp / 1000 : 0} />,
             errorUrl && method ? (
               <HttpInfoSummaryItem url={errorUrl} method={method} status={status} />
             ) : null,

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/transaction_tabs.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/transaction_tabs.tsx
@@ -9,6 +9,7 @@ import { EuiSpacer, EuiTab, EuiTabs, EuiSkeletonText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { LogStream } from '@kbn/logs-shared-plugin/public';
 import React, { useMemo } from 'react';
+import { getTimestamp } from '../../../../utils/get_timestamp';
 import { Transaction } from '../../../../../typings/es_schemas/ui/transaction';
 import { TransactionMetadata } from '../../../shared/metadata_table/transaction_metadata';
 import { WaterfallContainer } from './waterfall_container';
@@ -43,6 +44,7 @@ export function TransactionTabs({
   showCriticalPath,
   onShowCriticalPathChange,
 }: Props) {
+  const timestamp = getTimestamp(transaction?.['@timestamp'], transaction?.timestamp?.us);
   const tabs: Record<TransactionTab, { label: string; component: React.ReactNode }> = useMemo(
     () => ({
       [TransactionTab.timeline]: {
@@ -73,7 +75,7 @@ export function TransactionTabs({
           <>
             {transaction && (
               <LogsTabContent
-                timestamp={transaction.timestamp.us}
+                timestamp={timestamp}
                 duration={transaction.transaction.duration.us}
                 traceId={transaction.trace.id}
               />
@@ -89,6 +91,7 @@ export function TransactionTabs({
       transaction,
       waterfall,
       waterfallItemId,
+      timestamp,
     ]
   );
 

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/span_flyout/index.tsx
@@ -25,6 +25,7 @@ import { euiStyled } from '@kbn/kibana-react-plugin/common';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { isEmpty } from 'lodash';
 import React, { Fragment } from 'react';
+import { getTimestamp } from '../../../../../../../utils/get_timestamp';
 import { PlaintextStacktrace } from '../../../../../error_group_details/error_sampler/plaintext_stacktrace';
 import { Span } from '../../../../../../../../typings/es_schemas/ui/span';
 import { Transaction } from '../../../../../../../../typings/es_schemas/ui/transaction';
@@ -261,13 +262,15 @@ function SpanFlyoutBody({
   ];
 
   const initialTab = tabs.find(({ id }) => id === flyoutDetailTab) ?? tabs[0];
+  const timestamp = getTimestamp(span['@timestamp'], span.timestamp.us);
+
   return (
     <>
       <StickySpanProperties span={span} transaction={parentTransaction} />
       <EuiSpacer size="m" />
       <Summary
         items={[
-          <TimestampTooltip time={span.timestamp.us / 1000} />,
+          <TimestampTooltip time={timestamp / 1000} />,
           <>
             <DurationSummaryItem
               duration={span.span.duration.us}

--- a/x-pack/plugins/observability_solution/apm/public/components/shared/summary/transaction_summary.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/shared/summary/transaction_summary.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { getTimestamp } from '../../../utils/get_timestamp';
 import { Transaction } from '../../../../typings/es_schemas/ui/transaction';
 import { Summary } from '.';
 import { TimestampTooltip } from '../timestamp_tooltip';
@@ -42,8 +43,9 @@ function getTransactionResultSummaryItem(transaction: Transaction) {
 }
 
 function TransactionSummary({ transaction, totalDuration, errorCount, coldStartBadge }: Props) {
+  const timestamp = getTimestamp(transaction['@timestamp'], transaction.timestamp.us);
   const items = [
-    <TimestampTooltip time={transaction.timestamp.us / 1000} />,
+    <TimestampTooltip time={timestamp / 1000} />,
     <DurationSummaryItem
       duration={transaction.transaction.duration.us}
       totalDuration={totalDuration}

--- a/x-pack/plugins/observability_solution/apm/public/components/shared/transaction_action_menu/sections.ts
+++ b/x-pack/plugins/observability_solution/apm/public/components/shared/transaction_action_menu/sections.ts
@@ -16,6 +16,7 @@ import type { ProfilingLocators } from '@kbn/observability-shared-plugin/public'
 import type { AssetDetailsLocator } from '@kbn/observability-shared-plugin/common';
 import { LocatorPublic } from '@kbn/share-plugin/common';
 import { SerializableRecord } from '@kbn/utility-types';
+import { getTimestamp } from '../../../utils/get_timestamp';
 import { Environment } from '../../../../common/environment_rt';
 import type { Transaction } from '../../../../typings/es_schemas/ui/transaction';
 import { getDiscoverHref } from '../links/discover_links/discover_link';
@@ -68,8 +69,8 @@ export const getSections = ({
   const hostName = transaction.host?.hostname;
   const podId = transaction.kubernetes?.pod?.uid;
   const containerId = transaction.container?.id;
-
-  const time = Math.round(transaction.timestamp.us / 1000);
+  const timestamp = getTimestamp(transaction['@timestamp'], transaction.timestamp.us);
+  const time = Math.round(timestamp / 1000);
   const infraMetricsQuery = getInfraMetricsQuery(transaction);
 
   const uptimeLink = uptimeLocator?.getRedirectUrl(

--- a/x-pack/plugins/observability_solution/apm/public/utils/get_timestamp.ts
+++ b/x-pack/plugins/observability_solution/apm/public/utils/get_timestamp.ts
@@ -7,7 +7,13 @@
 
 export function getTimestamp(timestamp?: string, fallbackTimestamp?: number): number {
   if (!fallbackTimestamp && timestamp) {
-    return new Date(timestamp).getTime() * 1000;
+    const date = new Date(timestamp);
+    const milliseconds = date.getTime() * 1000;
+
+    const microsecondsMatch = timestamp.match(/\.(\d{3})(\d{3})?Z$/);
+    const microseconds = microsecondsMatch ? parseInt(microsecondsMatch[2] || '000', 10) : 0;
+
+    return milliseconds + microseconds;
   }
 
   return fallbackTimestamp || 0;

--- a/x-pack/plugins/observability_solution/apm/public/utils/get_timestamp.ts
+++ b/x-pack/plugins/observability_solution/apm/public/utils/get_timestamp.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export function getTimestamp(timestamp?: string, fallbackTimestamp?: number): number {
+  if (!fallbackTimestamp && timestamp) {
+    return new Date(timestamp).getTime() * 1000;
+  }
+
+  return fallbackTimestamp || 0;
+}

--- a/x-pack/plugins/observability_solution/apm/public/utils/get_timestamp.ts
+++ b/x-pack/plugins/observability_solution/apm/public/utils/get_timestamp.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-export function getTimestamp(timestamp?: string, fallbackTimestamp?: number): number {
-  if (!fallbackTimestamp && timestamp) {
+export function getTimestamp(timestamp?: string, timestampUs?: number): number {
+  if (!timestampUs && timestamp) {
     const date = new Date(timestamp);
     const milliseconds = date.getTime() * 1000;
 
@@ -16,5 +16,5 @@ export function getTimestamp(timestamp?: string, fallbackTimestamp?: number): nu
     return milliseconds + microseconds;
   }
 
-  return fallbackTimestamp || 0;
+  return timestampUs || 0;
 }

--- a/x-pack/plugins/observability_solution/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/traces/get_trace_items.ts
@@ -22,6 +22,7 @@ import {
   ERROR_LOG_MESSAGE,
   EVENT_OUTCOME,
   FAAS_COLDSTART,
+  FALLBACK_TIMESTAMP,
   PARENT_ID,
   PROCESSOR_EVENT,
   SERVICE_ENVIRONMENT,
@@ -98,6 +99,7 @@ export async function getTraceItems({
       size: 1000,
       _source: [
         TIMESTAMP,
+        FALLBACK_TIMESTAMP,
         TRACE_ID,
         TRANSACTION_ID,
         PARENT_ID,
@@ -229,6 +231,7 @@ async function getTraceDocsPerPage({
     search_after: searchAfter,
     _source: [
       TIMESTAMP,
+      FALLBACK_TIMESTAMP,
       TRACE_ID,
       PARENT_ID,
       SERVICE_NAME,

--- a/x-pack/plugins/observability_solution/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/traces/get_trace_items.ts
@@ -22,7 +22,6 @@ import {
   ERROR_LOG_MESSAGE,
   EVENT_OUTCOME,
   FAAS_COLDSTART,
-  FALLBACK_TIMESTAMP,
   PARENT_ID,
   PROCESSOR_EVENT,
   SERVICE_ENVIRONMENT,
@@ -39,6 +38,7 @@ import {
   SPAN_SYNC,
   SPAN_TYPE,
   TIMESTAMP,
+  TIMESTAMP_US,
   TRACE_ID,
   TRANSACTION_DURATION,
   TRANSACTION_ID,
@@ -99,7 +99,7 @@ export async function getTraceItems({
       size: 1000,
       _source: [
         TIMESTAMP,
-        FALLBACK_TIMESTAMP,
+        TIMESTAMP_US,
         TRACE_ID,
         TRANSACTION_ID,
         PARENT_ID,
@@ -231,7 +231,7 @@ async function getTraceDocsPerPage({
     search_after: searchAfter,
     _source: [
       TIMESTAMP,
-      FALLBACK_TIMESTAMP,
+      TIMESTAMP_US,
       TRACE_ID,
       PARENT_ID,
       SERVICE_NAME,


### PR DESCRIPTION
## Summary
> [!WARNING]  
> This is still a WIP, I want to gather some feedback on the proposed solutions and explore other options.

Closes #191046 

This PR aims to use `@timestamp` as the primary value, instead of `timestamp.us` as we have done until now.
This change will be possible once we have `date_nanos` for `@timestamp`, so we can get more precise dates.
Also, we want to stop maintaining 2 timestamp values.

To make this change easy and backward-safe, I created a shared function that will get the timestamp, following the criteria of the parent issue:
- If we don't have `timestamp.us`, we return `@timestamp` ✅ 
- (Optional) If `@timestamp` is `date_nanos`, prefer it over `timestamp.us` ❌ 


Some drawbacks I've encountered:
- Both values use different formats, `long` for `timestamp.us` and `string` for `@timestamp`. Something we need to adapt when working with them, as right now the UI depends on `timestamp.us`
- Javascript doesn't support nanoseconds https://github.com/elastic/kibana/issues/40183

Open questions:
- How can we know if `@timestamp` is `date_nanos` on the client?

