### PR TITLE
[8.x] Use the same date for set alert timestmap (#192668)

### DIFF
--- a/x-pack/plugins/rule_registry/server/utils/create_persistence_rule_type_wrapper.ts
+++ b/x-pack/plugins/rule_registry/server/utils/create_persistence_rule_type_wrapper.ts
@@ -65,16 +65,18 @@ const augmentAlerts = <T>({
   intendedTimestamp: Date | undefined;
 }) => {
   const commonRuleFields = getCommonAlertFields(options);
+  const currentDate = new Date();
+  const timestampOverrideOrCurrent = currentTimeOverride ?? currentDate;
   return alerts.map((alert) => {
     return {
       ...alert,
       _source: {
-        [ALERT_RULE_EXECUTION_TIMESTAMP]: new Date(),
-        [ALERT_START]: currentTimeOverride ?? new Date(),
-        [ALERT_LAST_DETECTED]: currentTimeOverride ?? new Date(),
+        [ALERT_RULE_EXECUTION_TIMESTAMP]: currentDate,
+        [ALERT_START]: timestampOverrideOrCurrent,
+        [ALERT_LAST_DETECTED]: timestampOverrideOrCurrent,
         [ALERT_INTENDED_TIMESTAMP]: intendedTimestamp
           ? intendedTimestamp
-          : currentTimeOverride ?? new Date(),
+          : timestampOverrideOrCurrent,
         [VERSION]: kibanaVersion,
         ...(options?.maintenanceWindowIds?.length
           ? { [ALERT_MAINTENANCE_WINDOW_IDS]: options.maintenanceWindowIds }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Use the same date for set alert timestmap (#192668)](https://github.com/elastic/kibana/pull/192668)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Khristinin Nikita","email":"nikita.khristinin@elastic.co"},"sourceCommit":{"committedDate":"2024-09-13T11:16:48Z","message":"Use the same date for set alert timestmap (#192668)\n\n## Summary\r\n\r\nLooks like [there can\r\nbe](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6918#0191e0e0-8cde-48a7-a47e-d0919db0f220)\r\nsituation when new Date() can produce slightly different result for\r\nthose fields\r\n\r\nSo, I just extract them into 1 variable","sha":"e5f01344644a31f068a79279df24a36c264080af","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0"],"title":"Use the same date for set alert timestmap","number":192668,"url":"https://github.com/elastic/kibana/pull/192668","mergeCommit":{"message":"Use the same date for set alert timestmap (#192668)\n\n## Summary\r\n\r\nLooks like [there can\r\nbe](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6918#0191e0e0-8cde-48a7-a47e-d0919db0f220)\r\nsituation when new Date() can produce slightly different result for\r\nthose fields\r\n\r\nSo, I just extract them into 1 variable","sha":"e5f01344644a31f068a79279df24a36c264080af"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/192668","number":192668,"mergeCommit":{"message":"Use the same date for set alert timestmap (#192668)\n\n## Summary\r\n\r\nLooks like [there can\r\nbe](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/6918#0191e0e0-8cde-48a7-a47e-d0919db0f220)\r\nsituation when new Date() can produce slightly different result for\r\nthose fields\r\n\r\nSo, I just extract them into 1 variable","sha":"e5f01344644a31f068a79279df24a36c264080af"}}]}] BACKPORT-->