### PR TITLE
[Spaces] Filtering out features that do not have space scope

### DIFF
--- a/x-pack/plugins/spaces/public/management/create_space/create_space_page.tsx
+++ b/x-pack/plugins/spaces/public/management/create_space/create_space_page.tsx
@@ -22,6 +22,7 @@ import React, { Component } from 'react';
 
 import type { Capabilities, NotificationsStart, ScopedHistory } from '@kbn/core/public';
 import { SectionLoading } from '@kbn/es-ui-shared-plugin/public';
+import { KibanaFeatureScope } from '@kbn/features-plugin/common';
 import type { FeaturesPluginStart, KibanaFeature } from '@kbn/features-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -91,6 +92,10 @@ export class CreateSpacePage extends Component<Props, State> {
     };
   }
 
+  private filterSpaceFeatures = (features: KibanaFeature[]) => {
+    return features.filter((feature) => feature.scope?.includes(KibanaFeatureScope.Spaces));
+  };
+
   public async componentDidMount() {
     if (!this.props.capabilities.spaces.manage) {
       return;
@@ -103,7 +108,8 @@ export class CreateSpacePage extends Component<Props, State> {
         await this.loadSpace(spaceId, getFeatures());
       } else {
         const features = await getFeatures();
-        this.setState({ isLoading: false, features });
+
+        this.setState({ isLoading: false, features: this.filterSpaceFeatures(features) });
       }
     } catch (e) {
       notifications.toasts.addError(e, {
@@ -410,6 +416,7 @@ export class CreateSpacePage extends Component<Props, State> {
         spacesManager.getSpace(spaceId),
         featuresPromise,
       ]);
+
       if (space) {
         if (onLoadSpace) {
           onLoadSpace(space);
@@ -426,7 +433,7 @@ export class CreateSpacePage extends Component<Props, State> {
               !!space.initials && getSpaceInitials({ name: space.name }) !== space.initials,
             customAvatarColor: !!space.color && getSpaceColor({ name: space.name }) !== space.color,
           },
-          features,
+          features: this.filterSpaceFeatures(features),
           originalSpace: space,
           isLoading: false,
         });


### PR DESCRIPTION
## Summary

 Filtering out features that do not have space scope in `create_space_page`


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

__Fixes: https://github.com/elastic/kibana/issues/194134__

## Release Note
Filtering out features that do not have space scope in `create_space_page`


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->