### PR TITLE
[workflows] Add condition to if backport:skip event 

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -10,30 +10,23 @@ jobs:
     name: 'Label and Backport'
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.merged == true
-      && (
-        (
-          github.event.action == 'labeled' && (
-            github.event.label.name == 'backport:prev-minor'
-            || github.event.label.name == 'backport:prev-major'
-            || github.event.label.name == 'backport:current-major'
-            || github.event.label.name == 'backport:all-open'
-            || github.event.label.name == 'backport:version'
-            || github.event.label.name == 'auto-backport'
-          )
-        )
-        || ( 
-            (github.event.action == 'unlabeled' && github.event.label.name == 'backport:skip') && (
-              contains(github.event.pull_request.labels.*.name, 'backport:prev-minor')
-              || contains(github.event.pull_request.labels.*.name, 'backport:prev-major')
-              || contains(github.event.pull_request.labels.*.name, 'backport:current-major')
-              || contains(github.event.pull_request.labels.*.name, 'backport:all-open')
-              || contains(github.event.pull_request.labels.*.name, 'backport:version')
-              || contains(github.event.pull_request.labels.*.name, 'auto-backport')
-            )
-          )
-        || (github.event.action == 'closed')
-      )
+      github.event.pull_request.merged == true &&
+        (github.event.action == 'closed' ||
+          (github.event.action == 'labeled' &&
+            (github.event.label.name == 'backport:prev-minor' ||
+              github.event.label.name == 'backport:prev-major' ||
+              github.event.label.name == 'backport:current-major' ||
+              github.event.label.name == 'backport:all-open' ||
+              github.event.label.name == 'backport:version' ||
+              github.event.label.name == 'auto-backport')) ||
+          (github.event.action == 'unlabeled' &&
+            github.event.label.name == 'backport:skip' &&
+            (contains(github.event.pull_request.labels.*.name, 'backport:prev-minor') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:prev-major') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:current-major') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:all-open') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:version') ||
+              contains(github.event.pull_request.labels.*.name, 'auto-backport'))));
     steps:
       - name: Checkout Actions
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -22,7 +22,16 @@ jobs:
             || github.event.label.name == 'auto-backport'
           )
         )
-        || (github.event.action == 'unlabeled' && github.event.label.name == 'backport:skip')
+        || ( 
+            (github.event.action == 'unlabeled' && github.event.label.name == 'backport:skip') && (
+              contains(github.event.pull_request.labels.*.name, 'backport:prev-minor')
+              || contains(github.event.pull_request.labels.*.name, 'backport:prev-major')
+              || contains(github.event.pull_request.labels.*.name, 'backport:current-major')
+              || contains(github.event.pull_request.labels.*.name, 'backport:all-open')
+              || contains(github.event.pull_request.labels.*.name, 'backport:version')
+              || contains(github.event.pull_request.labels.*.name, 'auto-backport')
+            )
+          )
         || (github.event.action == 'closed')
       )
     steps:


### PR DESCRIPTION
To only run when the label is removed and a backport:* label exists.

The on-merge workflow has historically supported version labels without
the existence of backport labels when a pull request is closed.
This isn't an expected use case now that we've enforced the label check,
but it still is possible to trigger.

Testing

1) Merge pull request
2) Add v8.16.0 , backport:skip labels 
3) Remove backport:skip label (current trigger 1)
4) Add backport:prev-minor label (current trigger 2)

Should trigger the action once via step 4.

This PR is split into two commits, the first with the condition and the
second with the changes run through a formatter.