### PR TITLE
[RCA] Update alert details header buttons

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/pages/alert_details/components/header_actions.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/pages/alert_details/components/header_actions.tsx
@@ -201,6 +201,36 @@ export function HeaderActions({
   return (
     <>
       <EuiFlexGroup direction="row" gutterSize="s" justifyContent="flexEnd">
+        <EuiFlexItem grow={false}>
+          {Boolean(investigatePlugin) &&
+          alert?.fields[ALERT_RULE_TYPE_ID] === OBSERVABILITY_THRESHOLD_RULE_TYPE_ID ? (
+            <EuiButtonIcon
+              display="empty"
+              size="m"
+              iconType="bellSlash"
+              data-test-subj="snooze-rule-button"
+              onClick={handleOpenSnoozeModal}
+              disabled={!alert?.fields[ALERT_RULE_UUID] || !rule}
+              aria-label={i18n.translate('xpack.observability.alertDetails.editSnoozeRule', {
+                defaultMessage: 'Snooze the rule',
+              })}
+            />
+          ) : (
+            <EuiButton
+              fill
+              iconType="bellSlash"
+              onClick={handleOpenSnoozeModal}
+              disabled={!alert?.fields[ALERT_RULE_UUID] || !rule}
+              data-test-subj="snooze-rule-button"
+            >
+              <EuiText size="s">
+                {i18n.translate('xpack.observability.alertDetails.editSnoozeRule', {
+                  defaultMessage: 'Snooze the rule',
+                })}
+              </EuiText>
+            </EuiButton>
+          )}
+        </EuiFlexItem>
         {Boolean(investigatePlugin) &&
           alert?.fields[ALERT_RULE_TYPE_ID] === OBSERVABILITY_THRESHOLD_RULE_TYPE_ID && (
             <EuiFlexItem grow={false}>
@@ -222,21 +252,6 @@ export function HeaderActions({
               </EuiButton>
             </EuiFlexItem>
           )}
-        <EuiFlexItem grow={false}>
-          <EuiButton
-            fill
-            iconType="bellSlash"
-            onClick={handleOpenSnoozeModal}
-            disabled={!alert?.fields[ALERT_RULE_UUID] || !rule}
-            data-test-subj="snooze-rule-button"
-          >
-            <EuiText size="s">
-              {i18n.translate('xpack.observability.alertDetails.editSnoozeRule', {
-                defaultMessage: 'Snooze the rule',
-              })}
-            </EuiText>
-          </EuiButton>
-        </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiPopover
             panelPaddingSize="none"


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/193311

When investigation feature flag is on and visiting Custom threshold alert details page, "Snooze the rule" will be displayed as an icon instead of a button. For other cases, "Snooze the rule" button will be displayed.

### When investigation feature flag is on and visiting Custom threshold alert details page
<img width="1219" alt="Screenshot 2024-09-26 at 16 15 56" src="https://github.com/user-attachments/assets/147e7709-6784-46ff-bc62-2237d2a142d1">

### All other cases
<img width="1225" alt="Screenshot 2024-09-26 at 16 15 38" src="https://github.com/user-attachments/assets/4b288125-9fa7-4cdc-b513-274c22b05730">


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->