### PR TITLE
Reapply "[workflows] Add condition to if backport:skip event  (#194158)"

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -26,7 +26,7 @@ jobs:
               contains(github.event.pull_request.labels.*.name, 'backport:current-major') ||
               contains(github.event.pull_request.labels.*.name, 'backport:all-open') ||
               contains(github.event.pull_request.labels.*.name, 'backport:version') ||
-              contains(github.event.pull_request.labels.*.name, 'auto-backport'))));
+              contains(github.event.pull_request.labels.*.name, 'auto-backport'))))
     steps:
       - name: Checkout Actions
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -10,21 +10,23 @@ jobs:
     name: 'Label and Backport'
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.merged == true
-      && (
-        (
-          github.event.action == 'labeled' && (
-            github.event.label.name == 'backport:prev-minor'
-            || github.event.label.name == 'backport:prev-major'
-            || github.event.label.name == 'backport:current-major'
-            || github.event.label.name == 'backport:all-open'
-            || github.event.label.name == 'backport:version'
-            || github.event.label.name == 'auto-backport'
-          )
-        )
-        || (github.event.action == 'unlabeled' && github.event.label.name == 'backport:skip')
-        || (github.event.action == 'closed')
-      )
+      github.event.pull_request.merged == true &&
+        (github.event.action == 'closed' ||
+          (github.event.action == 'labeled' &&
+            (github.event.label.name == 'backport:prev-minor' ||
+              github.event.label.name == 'backport:prev-major' ||
+              github.event.label.name == 'backport:current-major' ||
+              github.event.label.name == 'backport:all-open' ||
+              github.event.label.name == 'backport:version' ||
+              github.event.label.name == 'auto-backport')) ||
+          (github.event.action == 'unlabeled' &&
+            github.event.label.name == 'backport:skip' &&
+            (contains(github.event.pull_request.labels.*.name, 'backport:prev-minor') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:prev-major') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:current-major') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:all-open') ||
+              contains(github.event.pull_request.labels.*.name, 'backport:version') ||
+              contains(github.event.pull_request.labels.*.name, 'auto-backport'))));
     steps:
       - name: Checkout Actions
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
This reverts commit 1992a394438da98f4295c3dc07cd30af9aa74746.

Reapply's #194158 without the extraneous semicolon.

Tested at https://github.com/jbudz/test-github-actions/actions/runs/11056774576

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->