### PR TITLE
[Automatic Import] Fix deploy error after editing the pipeline

### DIFF
--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/state.ts
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/state.ts
@@ -51,7 +51,11 @@ export const reducer = (state: State, action: Action): State => {
     case 'SET_IS_GENERATING':
       return { ...state, isGenerating: action.payload };
     case 'SET_GENERATED_RESULT':
-      return { ...state, result: action.payload };
+      return {
+        ...state,
+        // keep original result as the samplesFormat is not always included in the payload
+        result: state.result ? { ...state.result, ...action.payload } : action.payload,
+      };
     default:
       return state;
   }


### PR DESCRIPTION
## Release Note

Fixes a bug that is causing the deploy step to fail after a pipeline edit/save.

## Summary

 #190407 introduced a bug that deployment fails when a pipeline is edited and saved in the review step.

The issue is that after the edit pipeline flow is executed the review step's result is overridden and `samplesFormat` is removed which if not present [the `useEffect` in Deploy step](https://github.com/elastic/kibana/blob/main/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/deploy_step/use_deploy_integration.ts#L41) fails.

This PR fixes the issue by saving the `samplesFormat` that is present in the original result before the edit pipeline flow is executed there by having samplesFormat in the result.


<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->