### PR TITLE
[Search][Onboarding] Start Page File Upload & O11y links

### DIFF
--- a/x-pack/plugins/search_indices/common/doc_links.ts
+++ b/x-pack/plugins/search_indices/common/doc_links.ts
@@ -10,12 +10,14 @@ import { DocLinks } from '@kbn/doc-links';
 class SearchIndicesDocLinks {
   public apiReference: string = '';
   public setupSemanticSearch: string = '';
+  public analyzeLogs: string = '';
 
   constructor() {}
 
   setDocLinks(newDocLinks: DocLinks) {
     this.apiReference = newDocLinks.apiReference;
     this.setupSemanticSearch = newDocLinks.enterpriseSearch.semanticSearch;
+    this.analyzeLogs = newDocLinks.serverlessSearch.integrations;
   }
 }
 export const docLinks = new SearchIndicesDocLinks();

--- a/x-pack/plugins/search_indices/public/analytics/constants.ts
+++ b/x-pack/plugins/search_indices/public/analytics/constants.ts
@@ -13,6 +13,7 @@ export enum AnalyticsEvents {
   startCreateIndexLanguageSelect = 'start_code_lang_select',
   startCreateIndexCodeCopyInstall = 'start_code_copy_install',
   startCreateIndexCodeCopy = 'start_code_copy',
+  startFileUploadClick = 'start_file_upload',
   indexDetailsInstallCodeCopy = 'index_details_code_copy_install',
   indexDetailsAddMappingsCodeCopy = 'index_details_add_mappings_code_copy',
   indexDetailsIngestDocumentsCodeCopy = 'index_details_ingest_documents_code_copy',

--- a/x-pack/plugins/search_indices/public/code_examples/create_index.ts
+++ b/x-pack/plugins/search_indices/public/code_examples/create_index.ts
@@ -13,6 +13,7 @@ import { PythonServerlessCreateIndexExamples } from './python';
 import { ConsoleCreateIndexExamples } from './sense';
 
 export const DefaultServerlessCodeExamples: CreateIndexCodeExamples = {
+  exampleType: 'search',
   sense: ConsoleCreateIndexExamples.default,
   curl: CurlCreateIndexExamples.default,
   python: PythonServerlessCreateIndexExamples.default,
@@ -20,6 +21,7 @@ export const DefaultServerlessCodeExamples: CreateIndexCodeExamples = {
 };
 
 export const DenseVectorSeverlessCodeExamples: CreateIndexCodeExamples = {
+  exampleType: 'vector',
   sense: ConsoleCreateIndexExamples.dense_vector,
   curl: CurlCreateIndexExamples.dense_vector,
   python: PythonServerlessCreateIndexExamples.dense_vector,

--- a/x-pack/plugins/search_indices/public/components/start/create_index.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/create_index.tsx
@@ -195,7 +195,6 @@ export const CreateIndexForm = ({
           </EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiSpacer size="s" />
     </>
   );
 };

--- a/x-pack/plugins/search_indices/public/components/start/create_index.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/create_index.tsx
@@ -13,12 +13,15 @@ import {
   EuiFlexItem,
   EuiForm,
   EuiFormRow,
+  EuiHorizontalRule,
   EuiIcon,
+  EuiLink,
   EuiSpacer,
   EuiText,
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import type { UserStartPrivilegesResponse } from '../../../common';
 import { AnalyticsEvents } from '../../analytics/constants';
@@ -28,6 +31,7 @@ import { isValidIndexName } from '../../utils/indices';
 import { useCreateIndex } from './hooks/use_create_index';
 
 import { CreateIndexFormState } from './types';
+import { useKibana } from '../../hooks/use_kibana';
 
 const CREATE_INDEX_CONTENT = i18n.translate(
   'xpack.searchIndices.startPage.createIndex.action.text',
@@ -47,6 +51,7 @@ export const CreateIndexForm = ({
   formState,
   setFormState,
 }: CreateIndexFormProps) => {
+  const { application } = useKibana().services;
   const [indexNameHasError, setIndexNameHasError] = useState<boolean>(false);
   const usageTracker = useUsageTracker();
   const { createIndex, isLoading } = useCreateIndex();
@@ -65,94 +70,132 @@ export const CreateIndexForm = ({
       setIndexNameHasError(invalidIndexName);
     }
   };
+  const onFileUpload = useCallback(() => {
+    usageTracker.click(AnalyticsEvents.startFileUploadClick);
+    application.navigateToApp('ml', { path: 'filedatavisualizer' });
+  }, [usageTracker, application]);
 
   return (
-    <EuiForm data-test-subj="createIndexUIView" fullWidth component="form">
-      <EuiFormRow
-        label={i18n.translate('xpack.searchIndices.startPage.createIndex.name.label', {
-          defaultMessage: 'Name your index',
-        })}
-        helpText={i18n.translate('xpack.searchIndices.startPage.createIndex.name.helpText', {
-          defaultMessage: 'Index names must be lowercase and can only contain hyphens and numbers',
-        })}
-        fullWidth
-        isInvalid={indexNameHasError}
-      >
-        <EuiFieldText
-          autoFocus
+    <>
+      <EuiForm data-test-subj="createIndexUIView" fullWidth component="form">
+        <EuiFormRow
+          label={i18n.translate('xpack.searchIndices.startPage.createIndex.name.label', {
+            defaultMessage: 'Name your index',
+          })}
+          helpText={i18n.translate('xpack.searchIndices.startPage.createIndex.name.helpText', {
+            defaultMessage:
+              'Index names must be lowercase and can only contain hyphens and numbers',
+          })}
           fullWidth
-          data-test-subj="indexNameField"
-          name="indexName"
-          value={formState.indexName}
           isInvalid={indexNameHasError}
-          disabled={userPrivileges?.privileges?.canCreateIndex === false}
-          onChange={onIndexNameChange}
-          placeholder={i18n.translate(
-            'xpack.searchIndices.startPage.createIndex.name.placeholder',
-            {
-              defaultMessage: 'Enter a name for your index',
-            }
-          )}
-        />
-      </EuiFormRow>
-      <EuiSpacer />
-      <EuiFlexGroup alignItems="center">
-        <EuiFlexItem grow={false}>
-          {userPrivileges?.privileges?.canCreateIndex === false ? (
-            <EuiToolTip
-              content={
-                <p>
-                  {i18n.translate('xpack.searchIndices.startPage.createIndex.permissionTooltip', {
-                    defaultMessage: 'You do not have permission to create an index.',
-                  })}
-                </p>
+        >
+          <EuiFieldText
+            autoFocus
+            fullWidth
+            data-test-subj="indexNameField"
+            name="indexName"
+            value={formState.indexName}
+            isInvalid={indexNameHasError}
+            disabled={userPrivileges?.privileges?.canCreateIndex === false}
+            onChange={onIndexNameChange}
+            placeholder={i18n.translate(
+              'xpack.searchIndices.startPage.createIndex.name.placeholder',
+              {
+                defaultMessage: 'Enter a name for your index',
               }
-            >
+            )}
+          />
+        </EuiFormRow>
+        <EuiSpacer />
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem grow={false}>
+            {userPrivileges?.privileges?.canCreateIndex === false ? (
+              <EuiToolTip
+                content={
+                  <p>
+                    {i18n.translate('xpack.searchIndices.startPage.createIndex.permissionTooltip', {
+                      defaultMessage: 'You do not have permission to create an index.',
+                    })}
+                  </p>
+                }
+              >
+                <EuiButton
+                  fill
+                  color="primary"
+                  iconSide="left"
+                  iconType="sparkles"
+                  data-test-subj="createIndexBtn"
+                  disabled={true}
+                >
+                  {CREATE_INDEX_CONTENT}
+                </EuiButton>
+              </EuiToolTip>
+            ) : (
               <EuiButton
                 fill
                 color="primary"
                 iconSide="left"
                 iconType="sparkles"
+                data-telemetry-id="searchIndices-start-createIndexBtn"
                 data-test-subj="createIndexBtn"
-                disabled={true}
+                disabled={indexNameHasError || isLoading}
+                isLoading={isLoading}
+                onClick={onCreateIndex}
+                type="submit"
               >
                 {CREATE_INDEX_CONTENT}
               </EuiButton>
-            </EuiToolTip>
-          ) : (
-            <EuiButton
-              fill
-              color="primary"
-              iconSide="left"
-              iconType="sparkles"
-              data-test-subj="createIndexBtn"
-              disabled={indexNameHasError || isLoading}
-              isLoading={isLoading}
-              onClick={onCreateIndex}
-              type="submit"
-            >
-              {CREATE_INDEX_CONTENT}
-            </EuiButton>
-          )}
+            )}
+          </EuiFlexItem>
+          <EuiFlexItem>
+            {userPrivileges?.privileges?.canCreateApiKeys && (
+              <EuiFlexGroup gutterSize="s">
+                <EuiIcon size="l" type="key" color="subdued" />
+                <EuiText size="s" data-test-subj="apiKeyLabel">
+                  <p>
+                    {i18n.translate(
+                      'xpack.searchIndices.startPage.createIndex.apiKeyCreation.description',
+                      {
+                        defaultMessage: "We'll create an API key for this index",
+                      }
+                    )}
+                  </p>
+                </EuiText>
+              </EuiFlexGroup>
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiForm>
+      <EuiHorizontalRule margin="s" />
+      <EuiFlexGroup gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiIcon type="documents" />
         </EuiFlexItem>
         <EuiFlexItem>
-          {userPrivileges?.privileges?.canCreateApiKeys && (
-            <EuiFlexGroup gutterSize="s">
-              <EuiIcon size="l" type="key" color="subdued" />
-              <EuiText size="s" data-test-subj="apiKeyLabel">
-                <p>
-                  {i18n.translate(
-                    'xpack.searchIndices.startPage.createIndex.apiKeyCreation.description',
-                    {
-                      defaultMessage: "We'll create an API key for this index",
-                    }
-                  )}
-                </p>
-              </EuiText>
-            </EuiFlexGroup>
-          )}
+          <EuiText color="subdued" size="s">
+            <p>
+              <FormattedMessage
+                id="xpack.searchIndices.startPage.createIndex.fileUpload.text"
+                defaultMessage="Already have some data? {link}"
+                values={{
+                  link: (
+                    <EuiLink
+                      data-telemetry-id="searchIndices-start-uploadFile"
+                      data-test-subj="uploadFileLink"
+                      onClick={onFileUpload}
+                    >
+                      {i18n.translate('xpack.searchIndices.startPage.createIndex.fileUpload.link', {
+                        defaultMessage: 'Upload a file',
+                      })}
+                    </EuiLink>
+                  ),
+                }}
+              />
+            </p>
+          </EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
-    </EuiForm>
+      <EuiSpacer size="s" />
+    </>
   );
 };

--- a/x-pack/plugins/search_indices/public/components/start/create_index.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/create_index.tsx
@@ -168,7 +168,7 @@ export const CreateIndexForm = ({
         </EuiFlexGroup>
       </EuiForm>
       <EuiHorizontalRule margin="none" />
-      <EuiPanel color='transparent' paddingSize='s'>
+      <EuiPanel color="transparent" paddingSize="s">
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiIcon type="documents" />
@@ -186,9 +186,12 @@ export const CreateIndexForm = ({
                         data-test-subj="uploadFileLink"
                         onClick={onFileUpload}
                       >
-                        {i18n.translate('xpack.searchIndices.startPage.createIndex.fileUpload.link', {
-                          defaultMessage: 'Upload a file',
-                        })}
+                        {i18n.translate(
+                          'xpack.searchIndices.startPage.createIndex.fileUpload.link',
+                          {
+                            defaultMessage: 'Upload a file',
+                          }
+                        )}
                       </EuiLink>
                     ),
                   }}

--- a/x-pack/plugins/search_indices/public/components/start/create_index.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/create_index.tsx
@@ -16,6 +16,7 @@ import {
   EuiHorizontalRule,
   EuiIcon,
   EuiLink,
+  EuiPanel,
   EuiSpacer,
   EuiText,
   EuiToolTip,
@@ -150,7 +151,7 @@ export const CreateIndexForm = ({
           <EuiFlexItem>
             {userPrivileges?.privileges?.canCreateApiKeys && (
               <EuiFlexGroup gutterSize="s">
-                <EuiIcon size="l" type="key" color="subdued" />
+                <EuiIcon size="m" type="key" color="subdued" />
                 <EuiText size="s" data-test-subj="apiKeyLabel">
                   <p>
                     {i18n.translate(
@@ -166,35 +167,37 @@ export const CreateIndexForm = ({
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiForm>
-      <EuiHorizontalRule margin="s" />
-      <EuiFlexGroup gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiIcon type="documents" />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText color="subdued" size="s">
-            <p>
-              <FormattedMessage
-                id="xpack.searchIndices.startPage.createIndex.fileUpload.text"
-                defaultMessage="Already have some data? {link}"
-                values={{
-                  link: (
-                    <EuiLink
-                      data-telemetry-id="searchIndices-start-uploadFile"
-                      data-test-subj="uploadFileLink"
-                      onClick={onFileUpload}
-                    >
-                      {i18n.translate('xpack.searchIndices.startPage.createIndex.fileUpload.link', {
-                        defaultMessage: 'Upload a file',
-                      })}
-                    </EuiLink>
-                  ),
-                }}
-              />
-            </p>
-          </EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiHorizontalRule margin="none" />
+      <EuiPanel color='transparent' paddingSize='s'>
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiIcon type="documents" />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText color="subdued" size="s">
+              <p>
+                <FormattedMessage
+                  id="xpack.searchIndices.startPage.createIndex.fileUpload.text"
+                  defaultMessage="Already have some data? {link}"
+                  values={{
+                    link: (
+                      <EuiLink
+                        data-telemetry-id="searchIndices-start-uploadFile"
+                        data-test-subj="uploadFileLink"
+                        onClick={onFileUpload}
+                      >
+                        {i18n.translate('xpack.searchIndices.startPage.createIndex.fileUpload.link', {
+                          defaultMessage: 'Upload a file',
+                        })}
+                      </EuiLink>
+                    ),
+                  }}
+                />
+              </p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
     </>
   );
 };

--- a/x-pack/plugins/search_indices/public/components/start/create_index.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/create_index.tsx
@@ -67,7 +67,7 @@ export const CreateIndexForm = ({
   };
 
   return (
-    <EuiForm data-test-subj="createIndexUIView" fullWidth>
+    <EuiForm data-test-subj="createIndexUIView" fullWidth component="form">
       <EuiFormRow
         label={i18n.translate('xpack.searchIndices.startPage.createIndex.name.label', {
           defaultMessage: 'Name your index',
@@ -129,6 +129,7 @@ export const CreateIndexForm = ({
               disabled={indexNameHasError || isLoading}
               isLoading={isLoading}
               onClick={onCreateIndex}
+              type="submit"
             >
               {CREATE_INDEX_CONTENT}
             </EuiButton>

--- a/x-pack/plugins/search_indices/public/components/start/create_index_code.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/create_index_code.tsx
@@ -4,46 +4,47 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { TryInConsoleButton } from '@kbn/try-in-console';
 
 import { AnalyticsEvents } from '../../analytics/constants';
 import { Languages, AvailableLanguages, LanguageOptions } from '../../code_examples';
-import { DenseVectorSeverlessCodeExamples } from '../../code_examples/create_index';
+
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
 import { useKibana } from '../../hooks/use_kibana';
 import { useElasticsearchUrl } from '../../hooks/use_elasticsearch_url';
-import { getDefaultCodingLanguage } from '../../utils/language';
 
 import { CodeSample } from '../shared/code_sample';
 import { LanguageSelector } from '../shared/language_selector';
 
 import { CreateIndexFormState } from './types';
+import { useStartPageCodingExamples } from './hooks/use_coding_examples';
 
 export interface CreateIndexCodeViewProps {
   createIndexForm: CreateIndexFormState;
+  changeCodingLanguage: (language: AvailableLanguages) => void;
 }
 
-// TODO: this will be dynamic based on stack / es3 & onboarding token
-const SelectedCodeExamples = DenseVectorSeverlessCodeExamples;
-
-export const CreateIndexCodeView = ({ createIndexForm }: CreateIndexCodeViewProps) => {
+export const CreateIndexCodeView = ({
+  createIndexForm,
+  changeCodingLanguage,
+}: CreateIndexCodeViewProps) => {
   const { application, share, console: consolePlugin } = useKibana().services;
   const usageTracker = useUsageTracker();
+  const selectedCodeExamples = useStartPageCodingExamples();
 
-  const [selectedLanguage, setSelectedLanguage] =
-    useState<AvailableLanguages>(getDefaultCodingLanguage);
+  const { codingLanguage: selectedLanguage } = createIndexForm;
   const onSelectLanguage = useCallback(
     (value: AvailableLanguages) => {
-      setSelectedLanguage(value);
+      changeCodingLanguage(value);
       usageTracker.count([
         AnalyticsEvents.startCreateIndexLanguageSelect,
         `${AnalyticsEvents.startCreateIndexLanguageSelect}_${value}`,
       ]);
     },
-    [usageTracker]
+    [usageTracker, changeCodingLanguage]
   );
   const elasticsearchUrl = useElasticsearchUrl();
   const codeParams = useMemo(() => {
@@ -53,8 +54,8 @@ export const CreateIndexCodeView = ({ createIndexForm }: CreateIndexCodeViewProp
     };
   }, [createIndexForm.indexName, elasticsearchUrl]);
   const selectedCodeExample = useMemo(() => {
-    return SelectedCodeExamples[selectedLanguage];
-  }, [selectedLanguage]);
+    return selectedCodeExamples[selectedLanguage];
+  }, [selectedLanguage, selectedCodeExamples]);
 
   return (
     <EuiFlexGroup direction="column" data-test-subj="createIndexCodeView">
@@ -69,7 +70,7 @@ export const CreateIndexCodeView = ({ createIndexForm }: CreateIndexCodeViewProp
         {selectedLanguage === 'curl' && (
           <EuiFlexItem grow={false}>
             <TryInConsoleButton
-              request={SelectedCodeExamples.sense.createIndex(codeParams)}
+              request={selectedCodeExamples.sense.createIndex(codeParams)}
               application={application}
               sharePlugin={share}
               consolePlugin={consolePlugin}
@@ -102,8 +103,7 @@ export const CreateIndexCodeView = ({ createIndexForm }: CreateIndexCodeViewProp
           usageTracker.click([
             AnalyticsEvents.startCreateIndexCodeCopy,
             `${AnalyticsEvents.startCreateIndexCodeCopy}_${selectedLanguage}`,
-            // TODO: vector should be a parameter when have multiple options
-            `${AnalyticsEvents.startCreateIndexCodeCopy}_${selectedLanguage}_vector`,
+            `${AnalyticsEvents.startCreateIndexCodeCopy}_${selectedLanguage}_${selectedCodeExamples.exampleType}`,
           ]);
         }}
       />

--- a/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
@@ -111,12 +111,12 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
       paddingSize="l"
       style={{ maxWidth: MAX_WIDTH, margin: '0 auto' }}
     >
-      <EuiFlexGroup alignItems="flexStart">
-        <EuiFlexItem grow={false}>
-          <EuiIcon type="logoElasticsearch" size="xl" />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiPanel paddingSize="none" color="transparent">
+      <EuiPanel color='transparent' paddingSize='m'>
+        <EuiFlexGroup alignItems="center" gutterSize='m'>
+          <EuiFlexItem grow={false}>
+            <EuiIcon type="logoElasticsearch" size="xl" />
+          </EuiFlexItem>
+          <EuiFlexItem>
             <EuiTitle size="xs">
               <h1>
                 {i18n.translate('xpack.searchIndices.startPage.pageTitle', {
@@ -124,21 +124,21 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
                 })}
               </h1>
             </EuiTitle>
-            <EuiSpacer size="s" />
-            <EuiTitle size="l">
-              <h2>
-                {i18n.translate('xpack.searchIndices.startPage.pageDescription', {
-                  defaultMessage: 'Vectorize, search, and visualize your data',
-                })}
-              </h2>
-            </EuiTitle>
-          </EuiPanel>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size='m' />
+        <EuiTitle size="l">
+          <h2>
+            {i18n.translate('xpack.searchIndices.startPage.pageDescription', {
+              defaultMessage: 'Vectorize, search, and visualize your data',
+            })}
+          </h2>
+        </EuiTitle>
+      </EuiPanel>
       <EuiSpacer />
       <EuiPanel>
         <EuiFlexGroup direction="column" gutterSize="m">
-          <EuiFlexGroup>
+          <EuiFlexGroup alignItems='center'>
             <EuiFlexItem>
               <EuiTitle size="xs">
                 <h4>

--- a/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
@@ -25,13 +25,16 @@ import { AnalyticsEvents } from '../../analytics/constants';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
 
 import { generateRandomIndexName } from '../../utils/indices';
+import { getDefaultCodingLanguage } from '../../utils/language';
 import { CreateIndexForm } from './create_index';
 import { CreateIndexCodeView } from './create_index_code';
 import { CreateIndexFormState } from './types';
+import { AvailableLanguages } from '../../code_examples';
 
 function initCreateIndexState(): CreateIndexFormState {
   return {
     indexName: generateRandomIndexName(),
+    codingLanguage: getDefaultCodingLanguage(),
   };
 }
 
@@ -50,7 +53,7 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
   const [createIndexView, setCreateIndexView] = useState<CreateIndexView>(
     userPrivileges?.privileges.canCreateIndex === false ? CreateIndexView.Code : CreateIndexView.UI
   );
-  const [formState, setFormState] = useState<CreateIndexFormState>(initCreateIndexState());
+  const [formState, setFormState] = useState<CreateIndexFormState>(initCreateIndexState);
   const usageTracker = useUsageTracker();
   useEffect(() => {
     usageTracker.load(AnalyticsEvents.startPageOpened);
@@ -75,6 +78,15 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
       }
     },
     [usageTracker]
+  );
+  const onChangeCodingLanguage = useCallback(
+    (language: AvailableLanguages) => {
+      setFormState({
+        ...formState,
+        codingLanguage: language,
+      });
+    },
+    [formState, setFormState]
   );
 
   return (
@@ -169,7 +181,10 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
               />
             )}
             {createIndexView === CreateIndexView.Code && (
-              <CreateIndexCodeView createIndexForm={formState} />
+              <CreateIndexCodeView
+                createIndexForm={formState}
+                changeCodingLanguage={onChangeCodingLanguage}
+              />
             )}
           </EuiFlexGroup>
         </EuiForm>

--- a/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
@@ -111,8 +111,8 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
       paddingSize="l"
       style={{ maxWidth: MAX_WIDTH, margin: '0 auto' }}
     >
-      <EuiPanel color='transparent' paddingSize='m'>
-        <EuiFlexGroup alignItems="center" gutterSize='m'>
+      <EuiPanel color="transparent" paddingSize="m">
+        <EuiFlexGroup alignItems="center" gutterSize="m">
           <EuiFlexItem grow={false}>
             <EuiIcon type="logoElasticsearch" size="xl" />
           </EuiFlexItem>
@@ -126,7 +126,7 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
             </EuiTitle>
           </EuiFlexItem>
         </EuiFlexGroup>
-        <EuiSpacer size='m' />
+        <EuiSpacer size="m" />
         <EuiTitle size="l">
           <h2>
             {i18n.translate('xpack.searchIndices.startPage.pageDescription', {
@@ -138,7 +138,7 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
       <EuiSpacer />
       <EuiPanel>
         <EuiFlexGroup direction="column" gutterSize="m">
-          <EuiFlexGroup alignItems='center'>
+          <EuiFlexGroup alignItems="center">
             <EuiFlexItem>
               <EuiTitle size="xs">
                 <h4>

--- a/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
@@ -5,31 +5,34 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  EuiButtonEmpty,
   EuiButtonGroup,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiForm,
   EuiIcon,
   EuiPanel,
   EuiSpacer,
   EuiText,
+  EuiTextAlign,
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import type { IndicesStatusResponse, UserStartPrivilegesResponse } from '../../../common';
+import { docLinks } from '../../../common/doc_links';
 
 import { AnalyticsEvents } from '../../analytics/constants';
+import { AvailableLanguages } from '../../code_examples';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
-
 import { generateRandomIndexName } from '../../utils/indices';
 import { getDefaultCodingLanguage } from '../../utils/language';
+
 import { CreateIndexForm } from './create_index';
 import { CreateIndexCodeView } from './create_index_code';
 import { CreateIndexFormState } from './types';
-import { AvailableLanguages } from '../../code_examples';
+import { useKibana } from '../../hooks/use_kibana';
 
 function initCreateIndexState(): CreateIndexFormState {
   return {
@@ -50,11 +53,13 @@ export interface ElasticsearchStartProps {
 }
 
 export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) => {
+  const { cloud, http } = useKibana().services;
   const [createIndexView, setCreateIndexView] = useState<CreateIndexView>(
     userPrivileges?.privileges.canCreateIndex === false ? CreateIndexView.Code : CreateIndexView.UI
   );
   const [formState, setFormState] = useState<CreateIndexFormState>(initCreateIndexState);
   const usageTracker = useUsageTracker();
+
   useEffect(() => {
     usageTracker.load(AnalyticsEvents.startPageOpened);
   }, [usageTracker]);
@@ -64,6 +69,16 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
       setCreateIndexView(CreateIndexView.Code);
     }
   }, [userPrivileges]);
+
+  const o11yTrialLink = useMemo(() => {
+    if (cloud && cloud.isServerlessEnabled) {
+      return `${
+        cloud?.projectsUrl ?? 'https://cloud.elastic.co/projects/'
+      }create/observability/start`;
+    }
+    return http.basePath.prepend('/app/observability/onboarding');
+  }, [cloud, http]);
+
   const onChangeView = useCallback(
     (id) => {
       switch (id) {
@@ -123,71 +138,140 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
       </EuiFlexGroup>
       <EuiSpacer />
       <EuiPanel>
-        <EuiForm component="form" fullWidth>
-          <EuiFlexGroup direction="column" gutterSize="m">
-            <EuiFlexGroup>
-              <EuiFlexItem>
-                <EuiTitle size="xs">
-                  <h4>
-                    {i18n.translate('xpack.searchIndices.startPage.createIndex.title', {
-                      defaultMessage: 'Create your first index',
-                    })}
-                  </h4>
-                </EuiTitle>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButtonGroup
-                  legend={i18n.translate(
-                    'xpack.searchIndices.startPage.createIndex.viewSelec.legend',
-                    { defaultMessage: 'Create index view selection' }
-                  )}
-                  options={[
-                    {
-                      id: CreateIndexView.UI,
-                      label: i18n.translate(
-                        'xpack.searchIndices.startPage.createIndex.viewSelect.ui',
-                        { defaultMessage: 'UI' }
-                      ),
-                      'data-test-subj': 'createIndexUIViewBtn',
-                    },
-                    {
-                      id: CreateIndexView.Code,
-                      label: i18n.translate(
-                        'xpack.searchIndices.startPage.createIndex.viewSelect.code',
-                        { defaultMessage: 'Code' }
-                      ),
-                      'data-test-subj': 'createIndexCodeViewBtn',
-                    },
-                  ]}
-                  buttonSize="compressed"
-                  idSelected={createIndexView}
-                  onChange={onChangeView}
-                />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-            <EuiText color="subdued">
-              <p>
-                {i18n.translate('xpack.searchIndices.startPage.createIndex.description', {
-                  defaultMessage:
-                    'An index stores your data and defines the schema, or field mappings, for your searches',
-                })}
-              </p>
-            </EuiText>
-            {createIndexView === CreateIndexView.UI && (
-              <CreateIndexForm
-                userPrivileges={userPrivileges}
-                formState={formState}
-                setFormState={setFormState}
+        <EuiFlexGroup direction="column" gutterSize="m">
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiTitle size="xs">
+                <h4>
+                  {i18n.translate('xpack.searchIndices.startPage.createIndex.title', {
+                    defaultMessage: 'Create your first index',
+                  })}
+                </h4>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonGroup
+                legend={i18n.translate(
+                  'xpack.searchIndices.startPage.createIndex.viewSelec.legend',
+                  { defaultMessage: 'Create index view selection' }
+                )}
+                options={[
+                  {
+                    id: CreateIndexView.UI,
+                    label: i18n.translate(
+                      'xpack.searchIndices.startPage.createIndex.viewSelect.ui',
+                      { defaultMessage: 'UI' }
+                    ),
+                    'data-test-subj': 'createIndexUIViewBtn',
+                  },
+                  {
+                    id: CreateIndexView.Code,
+                    label: i18n.translate(
+                      'xpack.searchIndices.startPage.createIndex.viewSelect.code',
+                      { defaultMessage: 'Code' }
+                    ),
+                    'data-test-subj': 'createIndexCodeViewBtn',
+                  },
+                ]}
+                buttonSize="compressed"
+                idSelected={createIndexView}
+                onChange={onChangeView}
               />
-            )}
-            {createIndexView === CreateIndexView.Code && (
-              <CreateIndexCodeView
-                createIndexForm={formState}
-                changeCodingLanguage={onChangeCodingLanguage}
-              />
-            )}
+            </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiForm>
+          <EuiText color="subdued">
+            <p>
+              {i18n.translate('xpack.searchIndices.startPage.createIndex.description', {
+                defaultMessage:
+                  'An index stores your data and defines the schema, or field mappings, for your searches',
+              })}
+            </p>
+          </EuiText>
+          {createIndexView === CreateIndexView.UI && (
+            <CreateIndexForm
+              userPrivileges={userPrivileges}
+              formState={formState}
+              setFormState={setFormState}
+            />
+          )}
+          {createIndexView === CreateIndexView.Code && (
+            <CreateIndexCodeView
+              createIndexForm={formState}
+              changeCodingLanguage={onChangeCodingLanguage}
+            />
+          )}
+        </EuiFlexGroup>
+      </EuiPanel>
+      <EuiSpacer />
+      <EuiPanel color="transparent">
+        <EuiTextAlign textAlign="center">
+          <EuiTitle size="xs">
+            <h5>
+              {i18n.translate('xpack.searchIndices.startPage.observabilityCallout.title', {
+                defaultMessage: 'Looking to store your logs or metrics data?',
+              })}
+            </h5>
+          </EuiTitle>
+        </EuiTextAlign>
+        <EuiSpacer size="m" />
+        <EuiFlexGroup alignItems="center" justifyContent="center">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              color="text"
+              iconSide="right"
+              iconType="popout"
+              data-test-subj="logstashDocsBtn"
+              data-telemetry-id="searchIndicesStartCollectLogsLink"
+              href={docLinks.analyzeLogs}
+              target="_blank"
+            >
+              {i18n.translate('xpack.searchIndices.startPage.observabilityCallout.logs.button', {
+                defaultMessage: 'Collect and analyze logs',
+              })}
+            </EuiButtonEmpty>
+            <EuiText color="subdued" size="s" textAlign="center">
+              <small>
+                {i18n.translate(
+                  'xpack.searchIndices.startPage.observabilityCallout.logs.subTitle',
+                  {
+                    defaultMessage: 'Explore Logstash and Beats',
+                  }
+                )}
+              </small>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiText>or</EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              color="text"
+              iconSide="right"
+              iconType="popout"
+              data-test-subj="startO11yTrialBtn"
+              data-telemetry-id="searchIndicesStartO11yTrialLink"
+              href={o11yTrialLink}
+              target="_blank"
+            >
+              {i18n.translate(
+                'xpack.searchIndices.startPage.observabilityCallout.o11yTrial.button',
+                {
+                  defaultMessage: 'Start an Observability trial',
+                }
+              )}
+            </EuiButtonEmpty>
+            <EuiText color="subdued" size="s" textAlign="center">
+              <small>
+                {i18n.translate(
+                  'xpack.searchIndices.startPage.observabilityCallout.o11yTrial.subTitle',
+                  {
+                    defaultMessage: 'Powerful performance monitoring',
+                  }
+                )}
+              </small>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiPanel>
     </EuiPanel>
   );

--- a/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
@@ -72,9 +72,8 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
 
   const o11yTrialLink = useMemo(() => {
     if (cloud && cloud.isServerlessEnabled) {
-      return `${
-        cloud?.projectsUrl ?? 'https://cloud.elastic.co/projects/'
-      }create/observability/start`;
+      const baseUrl = cloud?.projectsUrl ?? 'https://cloud.elastic.co/projects/';
+      return `${baseUrl}create/observability/start`;
     }
     return http.basePath.prepend('/app/observability/onboarding');
   }, [cloud, http]);
@@ -220,7 +219,7 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
               color="text"
               iconSide="right"
               iconType="popout"
-              data-test-subj="logstashDocsBtn"
+              data-test-subj="analyzeLogsBtn"
               data-telemetry-id="searchIndicesStartCollectLogsLink"
               href={docLinks.analyzeLogs}
               target="_blank"

--- a/x-pack/plugins/search_indices/public/components/start/hooks/use_coding_examples.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/hooks/use_coding_examples.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CreateIndexCodeExamples } from '../../../types';
+import { DenseVectorSeverlessCodeExamples } from '../../../code_examples/create_index';
+
+export const useStartPageCodingExamples = (): CreateIndexCodeExamples => {
+  // TODO: in the future this will be dynamic based on the onboarding token
+  // or project sub-type
+  return DenseVectorSeverlessCodeExamples;
+};

--- a/x-pack/plugins/search_indices/public/components/start/types.ts
+++ b/x-pack/plugins/search_indices/public/components/start/types.ts
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
+import type { AvailableLanguages } from '../../code_examples';
+
 export interface CreateIndexFormState {
   indexName: string;
+  codingLanguage: AvailableLanguages;
 }

--- a/x-pack/plugins/search_indices/public/plugin.ts
+++ b/x-pack/plugins/search_indices/public/plugin.ts
@@ -7,6 +7,8 @@
 
 import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
+
+import { docLinks } from '../common/doc_links';
 import type {
   SearchIndicesAppPluginStartDependencies,
   SearchIndicesPluginSetup,
@@ -64,6 +66,7 @@ export class SearchIndicesPlugin
   }
 
   public start(core: CoreStart): SearchIndicesPluginStart {
+    docLinks.setDocLinks(core.docLinks.links);
     return {};
   }
 

--- a/x-pack/plugins/search_indices/public/types.ts
+++ b/x-pack/plugins/search_indices/public/types.ts
@@ -77,6 +77,7 @@ export interface CreateIndexCodeDefinition {
 }
 
 export interface CreateIndexCodeExamples {
+  exampleType: string;
   sense: CreateIndexCodeDefinition;
   curl: CreateIndexCodeDefinition;
   python: CreateIndexCodeDefinition;

--- a/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
@@ -30,6 +30,11 @@ export function SvlSearchElasticsearchStartPageProvider({ getService }: FtrProvi
         );
       });
     },
+    async expectToBeOnMLFileUploadPage() {
+      await retry.tryForTime(60 * 1000, async () => {
+        expect(await browser.getCurrentUrl()).contain('/app/ml/filedatavisualizer');
+      });
+    },
     async expectIndexNameToExist() {
       await testSubjects.existOrFail('indexNameField');
     },
@@ -66,6 +71,24 @@ export function SvlSearchElasticsearchStartPageProvider({ getService }: FtrProvi
     async clickCodeViewButton() {
       await testSubjects.existOrFail('createIndexCodeViewBtn');
       await testSubjects.click('createIndexCodeViewBtn');
+    },
+    async clickFileUploadLink() {
+      await testSubjects.existOrFail('uploadFileLink');
+      await testSubjects.click('uploadFileLink');
+    },
+    async expectAnalyzeLogsLink() {
+      await testSubjects.existOrFail('analyzeLogsBtn');
+      expect(await testSubjects.getAttribute('analyzeLogsBtn', 'href')).equal(
+        'https://docs.elastic.co/serverless/elasticsearch/ingest-your-data'
+      );
+      expect(await testSubjects.getAttribute('analyzeLogsBtn', 'target')).equal('_blank');
+    },
+    async expectO11yTrialLink() {
+      await testSubjects.existOrFail('startO11yTrialBtn');
+      expect(await testSubjects.getAttribute('startO11yTrialBtn', 'href')).equal(
+        'https://cloud.elastic.co/projects/create/observability/start'
+      );
+      expect(await testSubjects.getAttribute('startO11yTrialBtn', 'target')).equal('_blank');
     },
   };
 }

--- a/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
@@ -86,7 +86,7 @@ export function SvlSearchElasticsearchStartPageProvider({ getService }: FtrProvi
     async expectO11yTrialLink() {
       await testSubjects.existOrFail('startO11yTrialBtn');
       expect(await testSubjects.getAttribute('startO11yTrialBtn', 'href')).equal(
-        'https://cloud.elastic.co/projects/create/observability/start'
+        'https://fake-cloud.elastic.co/projects/create/observability/start'
       );
       expect(await testSubjects.getAttribute('startO11yTrialBtn', 'target')).equal('_blank');
     },

--- a/x-pack/test_serverless/functional/test_suites/search/config.feature_flags.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/config.feature_flags.ts
@@ -21,7 +21,7 @@ export default createTestConfig({
   kbnServerArgs: [
     `--xpack.cloud.id=ES3_FTR_TESTS:ZmFrZS1kb21haW4uY2xkLmVsc3RjLmNvJGZha2Vwcm9qZWN0aWQuZXMkZmFrZXByb2plY3RpZC5rYg==`,
     `--xpack.cloud.serverless.project_id=fakeprojectid`,
-    `--xpack.cloud.base_url=https://cloud.elastic.co`,
+    `--xpack.cloud.base_url=https://fake-cloud.elastic.co`,
     `--xpack.cloud.projects_url=/projects/`,
     `--xpack.cloud.organization_url=/account/members`,
     `--xpack.security.roleManagementEnabled=true`,

--- a/x-pack/test_serverless/functional/test_suites/search/config.feature_flags.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/config.feature_flags.ts
@@ -19,10 +19,11 @@ export default createTestConfig({
   suiteTags: { exclude: ['skipSvlSearch'] },
   // add feature flags
   kbnServerArgs: [
-    `--xpack.cloud.id='ES3_FTR_TESTS:ZmFrZS1kb21haW4uY2xkLmVsc3RjLmNvJGZha2Vwcm9qZWN0aWQuZXMkZmFrZXByb2plY3RpZC5rYg=='`,
-    `--xpack.cloud.serverless.project_id='fakeprojectid'`,
-    `--xpack.cloud.base_url='https://cloud.elastic.co'`,
-    `--xpack.cloud.organization_url='/account/members'`,
+    `--xpack.cloud.id=ES3_FTR_TESTS:ZmFrZS1kb21haW4uY2xkLmVsc3RjLmNvJGZha2Vwcm9qZWN0aWQuZXMkZmFrZXByb2plY3RpZC5rYg==`,
+    `--xpack.cloud.serverless.project_id=fakeprojectid`,
+    `--xpack.cloud.base_url=https://cloud.elastic.co`,
+    `--xpack.cloud.projects_url=/projects/`,
+    `--xpack.cloud.organization_url=/account/members`,
     `--xpack.security.roleManagementEnabled=true`,
     `--xpack.spaces.maxSpaces=100`, // enables spaces UI capabilities
     `--xpack.searchIndices.enabled=true`, // global empty state FF

--- a/x-pack/test_serverless/functional/test_suites/search/config.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/config.ts
@@ -19,7 +19,9 @@ export default createTestConfig({
   // https://github.com/elastic/project-controller/blob/main/internal/project/esproject/config/elasticsearch.yml
   esServerArgs: [],
   kbnServerArgs: [
-    `--xpack.cloud.id='ES3_FTR_TESTS:ZmFrZS1kb21haW4uY2xkLmVsc3RjLmNvJGZha2Vwcm9qZWN0aWQuZXMkZmFrZXByb2plY3RpZC5rYg=='`,
-    `--xpack.cloud.serverless.project_id='fakeprojectid'`,
+    `--xpack.cloud.id=ES3_FTR_TESTS:ZmFrZS1kb21haW4uY2xkLmVsc3RjLmNvJGZha2Vwcm9qZWN0aWQuZXMkZmFrZXByb2plY3RpZC5rYg==`,
+    `--xpack.cloud.serverless.project_id=fakeprojectid`,
+    `--xpack.cloud.base_url=https://cloud.elastic.co`,
+    `--xpack.cloud.projects_url=/projects/`,
   ],
 });

--- a/x-pack/test_serverless/functional/test_suites/search/config.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/config.ts
@@ -21,7 +21,7 @@ export default createTestConfig({
   kbnServerArgs: [
     `--xpack.cloud.id=ES3_FTR_TESTS:ZmFrZS1kb21haW4uY2xkLmVsc3RjLmNvJGZha2Vwcm9qZWN0aWQuZXMkZmFrZXByb2plY3RpZC5rYg==`,
     `--xpack.cloud.serverless.project_id=fakeprojectid`,
-    `--xpack.cloud.base_url=https://cloud.elastic.co`,
+    `--xpack.cloud.base_url=https://fake-cloud.elastic.co`,
     `--xpack.cloud.projects_url=/projects/`,
   ],
 });

--- a/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
@@ -81,6 +81,18 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await pageObjects.svlSearchElasticsearchStartPage.clickUIViewButton();
         await pageObjects.svlSearchElasticsearchStartPage.expectCreateIndexUIView();
       });
+
+      it('should have file upload link', async () => {
+        await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnStartPage();
+        await pageObjects.svlSearchElasticsearchStartPage.clickFileUploadLink();
+        await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnMLFileUploadPage();
+      });
+
+      it('should have o11y links', async () => {
+        await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnStartPage();
+        await pageObjects.svlSearchElasticsearchStartPage.expectAnalyzeLogsLink();
+        await pageObjects.svlSearchElasticsearchStartPage.expectO11yTrialLink();
+      });
     });
     describe('viewer', function () {
       before(async () => {


### PR DESCRIPTION
## Summary

- Clean-up for start page
  - enabled submitting create index form w/ enter in index name input
  - extracted start page example to hook to make it easier to update later
  - Moved start page language up so changes are saved when switching between UI & Code views
- Added File Upload link to the ML file uploader
- Added callouts for O11y  

### Screenshots
<img width="1458" alt="image" src="https://github.com/user-attachments/assets/3a705ab3-69b7-4f26-83c4-0f4d1642db1b">

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->