### PR TITLE
[Discover] [ES|QL] Disable ES|QL multivalue filtering in Unified Doc Viewer

### DIFF
--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/__snapshots__/table_cell_actions.test.tsx.snap
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/__snapshots__/table_cell_actions.test.tsx.snap
@@ -4,12 +4,20 @@ exports[`TableActions getFieldCellActions should render correctly for undefined 
 Array [
   <ToggleColumn
     Component={[Function]}
+    isEsqlMode={false}
     onToggleColumn={[MockFunction]}
     row={
       FieldRow {
         "columnsMeta": undefined,
-        "dataViewField": undefined,
-        "flattenedValue": "flattenedField",
+        "dataViewField": Object {
+          "aggregatable": false,
+          "displayName": "message",
+          "filterable": false,
+          "name": "message",
+          "scripted": false,
+          "type": "string",
+        },
+        "flattenedValue": "test",
         "isPinned": false,
         "name": "message",
       }
@@ -24,12 +32,20 @@ exports[`TableActions getFieldCellActions should render the panels correctly for
 Array [
   <FilterExist
     Component={[Function]}
+    isEsqlMode={false}
     onFilter={[MockFunction]}
     row={
       FieldRow {
         "columnsMeta": undefined,
-        "dataViewField": undefined,
-        "flattenedValue": "flattenedField",
+        "dataViewField": Object {
+          "aggregatable": false,
+          "displayName": "message",
+          "filterable": false,
+          "name": "message",
+          "scripted": false,
+          "type": "string",
+        },
+        "flattenedValue": "test",
         "isPinned": false,
         "name": "message",
       }
@@ -37,12 +53,20 @@ Array [
   />,
   <ToggleColumn
     Component={[Function]}
+    isEsqlMode={false}
     onToggleColumn={[MockFunction]}
     row={
       FieldRow {
         "columnsMeta": undefined,
-        "dataViewField": undefined,
-        "flattenedValue": "flattenedField",
+        "dataViewField": Object {
+          "aggregatable": false,
+          "displayName": "message",
+          "filterable": false,
+          "name": "message",
+          "scripted": false,
+          "type": "string",
+        },
+        "flattenedValue": "test",
         "isPinned": false,
         "name": "message",
       }
@@ -57,12 +81,20 @@ exports[`TableActions getFieldValueCellActions should render the panels correctl
 Array [
   <FilterIn
     Component={[Function]}
+    isEsqlMode={false}
     onFilter={[MockFunction]}
     row={
       FieldRow {
         "columnsMeta": undefined,
-        "dataViewField": undefined,
-        "flattenedValue": "flattenedField",
+        "dataViewField": Object {
+          "aggregatable": false,
+          "displayName": "message",
+          "filterable": false,
+          "name": "message",
+          "scripted": false,
+          "type": "string",
+        },
+        "flattenedValue": "test",
         "isPinned": false,
         "name": "message",
       }
@@ -70,12 +102,20 @@ Array [
   />,
   <FilterOut
     Component={[Function]}
+    isEsqlMode={false}
     onFilter={[MockFunction]}
     row={
       FieldRow {
         "columnsMeta": undefined,
-        "dataViewField": undefined,
-        "flattenedValue": "flattenedField",
+        "dataViewField": Object {
+          "aggregatable": false,
+          "displayName": "message",
+          "filterable": false,
+          "name": "message",
+          "scripted": false,
+          "type": "string",
+        },
+        "flattenedValue": "test",
         "isPinned": false,
         "name": "message",
       }

--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
@@ -324,12 +324,12 @@ export const DocViewerTable = ({
   }, [showPagination, curPageIndex, pageSize, onChangePageSize, changePageIndex]);
 
   const fieldCellActions = useMemo(
-    () => getFieldCellActions({ rows, onFilter: filter, onToggleColumn }),
-    [rows, filter, onToggleColumn]
+    () => getFieldCellActions({ rows, isEsqlMode, onFilter: filter, onToggleColumn }),
+    [rows, isEsqlMode, filter, onToggleColumn]
   );
   const fieldValueCellActions = useMemo(
-    () => getFieldValueCellActions({ rows, onFilter: filter }),
-    [rows, filter]
+    () => getFieldValueCellActions({ rows, isEsqlMode, onFilter: filter }),
+    [rows, isEsqlMode, filter]
   );
 
   useWindowSize(); // trigger re-render on window resize to recalculate the grid container height


### PR DESCRIPTION
## Summary

This PR disables ES|QL multivalue filtering in Unified Doc Viewer, similar to what we did for Unified Data Table in #193415:
![image](https://github.com/user-attachments/assets/f86c3ba9-05e9-4245-97f6-a8f9413950e9)

Part of https://github.com/elastic/kibana/issues/193015.

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->