### PR TITLE
[EDR Workflows] Fix failing cases test in Osquery

### DIFF
--- a/x-pack/plugins/osquery/cypress/tasks/live_query.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/live_query.ts
@@ -140,7 +140,7 @@ export const addLiveQueryToCase = (actionId: string, caseId: string) => {
   addToCase(caseId);
 };
 
-const casesOsqueryResultRegex = /attached Osquery results[\s]?[\d]+[\s]?seconds ago/;
+const casesOsqueryResultRegex = /attached Osquery results[\s]?[\d]+[\s]?second(?:s)? ago/;
 export const viewRecentCaseAndCheckResults = () => {
   cy.contains('View case').click();
   cy.contains(casesOsqueryResultRegex);


### PR DESCRIPTION
Sometimes tests were soo fast that it took 1 second while we were expecting `x seconds`. 

<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->