### PR TITLE
[8.15] fix dashboard scroll issue for when lens inline config is opened. (#188236)

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -856,7 +856,7 @@ export class Embeddable
     this.updateInput({ attributes: attrs, savedObjectId });
   }
 
-  async openConfingPanel(
+  async openConfigPanel(
     startDependencies: LensPluginStartDependencies,
     isNewPanel?: boolean,
     deletePanel?: () => void

--- a/x-pack/plugins/lens/public/trigger_actions/open_lens_config/edit_action.test.tsx
+++ b/x-pack/plugins/lens/public/trigger_actions/open_lens_config/edit_action.test.tsx
@@ -95,7 +95,7 @@ describe('open config panel action', () => {
           };
         },
         getIsEditable: () => true,
-        openConfingPanel: jest.fn().mockResolvedValue(<span>Lens Config Panel Component</span>),
+        openConfigPanel: jest.fn().mockResolvedValue(<span>Lens Config Panel Component</span>),
         getRoot: () => {
           return {
             openOverlay: jest.fn(),

--- a/x-pack/plugins/lens/public/trigger_actions/open_lens_config/edit_action_helpers.ts
+++ b/x-pack/plugins/lens/public/trigger_actions/open_lens_config/edit_action_helpers.ts
@@ -6,9 +6,10 @@
  */
 import React from 'react';
 import './helpers.scss';
-import { tracksOverlays } from '@kbn/presentation-containers';
-import { IEmbeddable } from '@kbn/embeddable-plugin/public';
 import { toMountPoint } from '@kbn/react-kibana-mount';
+import { tracksOverlays } from '@kbn/presentation-containers';
+import type { IEmbeddable } from '@kbn/embeddable-plugin/public';
+import { ViewMode } from '@kbn/embeddable-plugin/common';
 import { IncompatibleActionError } from '@kbn/ui-actions-plugin/public';
 import { isLensEmbeddable } from '../utils';
 import type { LensPluginStartDependencies } from '../../plugin';
@@ -24,9 +25,59 @@ interface Context extends StartServices {
 export async function isEditActionCompatible(embeddable: IEmbeddable) {
   if (!embeddable?.getInput) return false;
   // display the action only if dashboard is on editable mode
-  const inDashboardEditMode = embeddable.getInput().viewMode === 'edit';
+  const inDashboardEditMode = embeddable.getInput().viewMode === ViewMode.EDIT;
   return Boolean(isLensEmbeddable(embeddable) && embeddable.getIsEditable() && inDashboardEditMode);
 }
+
+type PanelConfigElement<T = {}> = React.ReactElement<T & { closeFlyout: () => void }>;
+
+const openInlineLensConfigEditor = (
+  startServices: StartServices,
+  embeddable: IEmbeddable,
+  EmbeddableInlineConfigEditor: PanelConfigElement
+) => {
+  const rootEmbeddable = embeddable.getRoot();
+  const overlayTracker = tracksOverlays(rootEmbeddable) ? rootEmbeddable : undefined;
+
+  const handle = startServices.overlays.openFlyout(
+    toMountPoint(
+      React.createElement(function InlineLensConfigEditor() {
+        React.useEffect(() => {
+          document.body.style.overflowY = 'hidden';
+
+          return () => {
+            document.body.style.overflowY = 'initial';
+          };
+        }, []);
+
+        return React.cloneElement(EmbeddableInlineConfigEditor, {
+          closeFlyout: () => {
+            overlayTracker?.clearOverlays();
+            handle.close();
+          },
+        });
+      }),
+      startServices
+    ),
+    {
+      size: 's',
+      type: 'push',
+      paddingSize: 'm',
+      'data-test-subj': 'customizeLens',
+      className: 'lnsConfigPanel__overlay',
+      hideCloseButton: true,
+      onClose: (overlayRef) => {
+        overlayTracker?.clearOverlays();
+        overlayRef.close();
+      },
+      outsideClickCloses: true,
+    }
+  );
+
+  overlayTracker?.openOverlay(handle, {
+    focusedPanelId: embeddable.id,
+  });
+};
 
 export async function executeEditAction({
   embeddable,
@@ -39,35 +90,10 @@ export async function executeEditAction({
   if (!isCompatibleAction || !isLensEmbeddable(embeddable)) {
     throw new IncompatibleActionError();
   }
-  const rootEmbeddable = embeddable.getRoot();
-  const overlayTracker = tracksOverlays(rootEmbeddable) ? rootEmbeddable : undefined;
-  const ConfigPanel = await embeddable.openConfingPanel(startDependencies, isNewPanel, deletePanel);
+
+  const ConfigPanel = await embeddable.openConfigPanel(startDependencies, isNewPanel, deletePanel);
 
   if (ConfigPanel) {
-    const handle = startServices.overlays.openFlyout(
-      toMountPoint(
-        React.cloneElement(ConfigPanel, {
-          closeFlyout: () => {
-            if (overlayTracker) overlayTracker.clearOverlays();
-            handle.close();
-          },
-        }),
-        startServices
-      ),
-      {
-        className: 'lnsConfigPanel__overlay',
-        size: 's',
-        'data-test-subj': 'customizeLens',
-        type: 'push',
-        paddingSize: 'm',
-        hideCloseButton: true,
-        onClose: (overlayRef) => {
-          if (overlayTracker) overlayTracker.clearOverlays();
-          overlayRef.close();
-        },
-        outsideClickCloses: true,
-      }
-    );
-    overlayTracker?.openOverlay(handle, { focusedPanelId: embeddable.id });
+    openInlineLensConfigEditor(startServices, embeddable, ConfigPanel);
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [fix dashboard scroll issue for when lens inline config is opened. (#188236)](https://github.com/elastic/kibana/pull/188236)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-07-12T17:53:47Z","message":"fix dashboard scroll issue for when lens inline config is opened. (#188236)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/185895\r\n\r\nThis PR adds a side effect to opening the inline config editor to\r\ndisable scroll on the document body, this way the user's scroll\r\ninteraction if any remains within the open inline lens config editor,\r\nwhilst keeping ~on~ the panel whose configuration is being modified in\r\nfocus.\r\n\r\n#### Previously:\r\n\r\n![ScreenRecording2024-07-12at15 23 35-ezgif\r\ncom-video-to-gif-converter](https://github.com/user-attachments/assets/1ed0823f-24f4-4b05-a17e-04a5b1218763)\r\n\r\n#### After\r\n\r\n![ScreenRecording2024-07-12at16 20 27-ezgif\r\ncom-video-to-gif-converter](https://github.com/user-attachments/assets/d6e136ca-778b-4216-8beb-1a9f2e2aa6e5)\r\n\r\n\r\n<!--\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n\r\n### Risk Matrix\r\n\r\nDelete this section if it is not applicable to this PR.\r\n\r\nBefore closing this PR, invite QA, stakeholders, and other developers to\r\nidentify risks that should be tested prior to the change/feature\r\nrelease.\r\n\r\nWhen forming the risk matrix, consider some of the following examples\r\nand how they may potentially impact the change:\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space.\r\n| Low | High | Integration tests will verify that all features are still\r\nsupported in non-default Kibana Space and when user switches between\r\nspaces. |\r\n| Multiple nodes&mdash;Elasticsearch polling might have race conditions\r\nwhen multiple Kibana nodes are polling for the same tasks. | High | Low\r\n| Tasks are idempotent, so executing them multiple times will not result\r\nin logical error, but will degrade performance. To test for this case we\r\nadd plenty of unit tests around this logic and document manual testing\r\nprocedure. |\r\n| Code should gracefully handle cases when feature X or plugin Y are\r\ndisabled. | Medium | High | Unit tests will verify that any feature flag\r\nor plugin combination still results in our service operational. |\r\n| [See more potential risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n-->","sha":"fdd67f7070037a548494b3830f9cfde64873f1be","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","loe:small","release_note:skip","impact:medium","backport:skip","Project:Dashboard Usability","v8.16.0"],"number":188236,"url":"https://github.com/elastic/kibana/pull/188236","mergeCommit":{"message":"fix dashboard scroll issue for when lens inline config is opened. (#188236)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/185895\r\n\r\nThis PR adds a side effect to opening the inline config editor to\r\ndisable scroll on the document body, this way the user's scroll\r\ninteraction if any remains within the open inline lens config editor,\r\nwhilst keeping ~on~ the panel whose configuration is being modified in\r\nfocus.\r\n\r\n#### Previously:\r\n\r\n![ScreenRecording2024-07-12at15 23 35-ezgif\r\ncom-video-to-gif-converter](https://github.com/user-attachments/assets/1ed0823f-24f4-4b05-a17e-04a5b1218763)\r\n\r\n#### After\r\n\r\n![ScreenRecording2024-07-12at16 20 27-ezgif\r\ncom-video-to-gif-converter](https://github.com/user-attachments/assets/d6e136ca-778b-4216-8beb-1a9f2e2aa6e5)\r\n\r\n\r\n<!--\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n\r\n### Risk Matrix\r\n\r\nDelete this section if it is not applicable to this PR.\r\n\r\nBefore closing this PR, invite QA, stakeholders, and other developers to\r\nidentify risks that should be tested prior to the change/feature\r\nrelease.\r\n\r\nWhen forming the risk matrix, consider some of the following examples\r\nand how they may potentially impact the change:\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space.\r\n| Low | High | Integration tests will verify that all features are still\r\nsupported in non-default Kibana Space and when user switches between\r\nspaces. |\r\n| Multiple nodes&mdash;Elasticsearch polling might have race conditions\r\nwhen multiple Kibana nodes are polling for the same tasks. | High | Low\r\n| Tasks are idempotent, so executing them multiple times will not result\r\nin logical error, but will degrade performance. To test for this case we\r\nadd plenty of unit tests around this logic and document manual testing\r\nprocedure. |\r\n| Code should gracefully handle cases when feature X or plugin Y are\r\ndisabled. | Medium | High | Unit tests will verify that any feature flag\r\nor plugin combination still results in our service operational. |\r\n| [See more potential risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n-->","sha":"fdd67f7070037a548494b3830f9cfde64873f1be"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/188236","number":188236,"mergeCommit":{"message":"fix dashboard scroll issue for when lens inline config is opened. (#188236)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/185895\r\n\r\nThis PR adds a side effect to opening the inline config editor to\r\ndisable scroll on the document body, this way the user's scroll\r\ninteraction if any remains within the open inline lens config editor,\r\nwhilst keeping ~on~ the panel whose configuration is being modified in\r\nfocus.\r\n\r\n#### Previously:\r\n\r\n![ScreenRecording2024-07-12at15 23 35-ezgif\r\ncom-video-to-gif-converter](https://github.com/user-attachments/assets/1ed0823f-24f4-4b05-a17e-04a5b1218763)\r\n\r\n#### After\r\n\r\n![ScreenRecording2024-07-12at16 20 27-ezgif\r\ncom-video-to-gif-converter](https://github.com/user-attachments/assets/d6e136ca-778b-4216-8beb-1a9f2e2aa6e5)\r\n\r\n\r\n<!--\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n\r\n### Risk Matrix\r\n\r\nDelete this section if it is not applicable to this PR.\r\n\r\nBefore closing this PR, invite QA, stakeholders, and other developers to\r\nidentify risks that should be tested prior to the change/feature\r\nrelease.\r\n\r\nWhen forming the risk matrix, consider some of the following examples\r\nand how they may potentially impact the change:\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space.\r\n| Low | High | Integration tests will verify that all features are still\r\nsupported in non-default Kibana Space and when user switches between\r\nspaces. |\r\n| Multiple nodes&mdash;Elasticsearch polling might have race conditions\r\nwhen multiple Kibana nodes are polling for the same tasks. | High | Low\r\n| Tasks are idempotent, so executing them multiple times will not result\r\nin logical error, but will degrade performance. To test for this case we\r\nadd plenty of unit tests around this logic and document manual testing\r\nprocedure. |\r\n| Code should gracefully handle cases when feature X or plugin Y are\r\ndisabled. | Medium | High | Unit tests will verify that any feature flag\r\nor plugin combination still results in our service operational. |\r\n| [See more potential risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n-->","sha":"fdd67f7070037a548494b3830f9cfde64873f1be"}}]}] BACKPORT-->