### PR TITLE
[ES|QL] Don't store duplicate queries even of different formatting

### DIFF
--- a/packages/kbn-esql-editor/src/history_local_storage.test.ts
+++ b/packages/kbn-esql-editor/src/history_local_storage.test.ts
@@ -46,6 +46,24 @@ describe('history local storage', function () {
     );
   });
 
+  it('should update queries to cache correctly if they are the same with different format', function () {
+    addQueriesToCache({
+      queryString: 'from kibana_sample_data_flights | limit 10 | stats meow = avg(woof)      ',
+      timeZone: 'Browser',
+      status: 'success',
+    });
+
+    const historyItems = getCachedQueries();
+    expect(historyItems.length).toBe(2);
+    expect(historyItems[1].timeRan).toBeDefined();
+    expect(historyItems[1].status).toBe('success');
+
+    expect(mockSetItem).toHaveBeenCalledWith(
+      'QUERY_HISTORY_ITEM_KEY',
+      JSON.stringify(historyItems)
+    );
+  });
+
   it('should allow maximum x queries ', function () {
     addQueriesToCache(
       {

--- a/packages/kbn-esql-editor/src/history_local_storage.ts
+++ b/packages/kbn-esql-editor/src/history_local_storage.ts
@@ -27,7 +27,7 @@ export interface QueryHistoryItem {
 const MAX_QUERIES_NUMBER = 20;
 
 const getKey = (queryString: string) => {
-  return queryString.replaceAll('\n', '').trim();
+  return queryString.replaceAll('\n', '').trim().replace(/\s\s+/g, ' ');
 };
 
 const getMomentTimeZone = (timeZone?: string) => {
@@ -60,6 +60,9 @@ export const addQueriesToCache = (
   item: QueryHistoryItem,
   maxQueriesAllowed = MAX_QUERIES_NUMBER
 ) => {
+  // if the user is working on multiple tabs
+  // the cachedQueries Map might not contain all
+  // the localStorage queries
   const queries = getHistoryItems('desc');
   queries.forEach((queryItem) => {
     const trimmedQueryString = getKey(queryItem.queryString);
@@ -77,15 +80,7 @@ export const addQueriesToCache = (
     });
   }
 
-  const queriesToStore = getCachedQueries();
-  const localStorageQueries = getHistoryItems('desc');
-  // if the user is working on multiple tabs
-  // the cachedQueries Map might not contain all
-  // the localStorage queries
-  const newQueries = localStorageQueries.filter(
-    (ls) => !queriesToStore.find((cachedQuery) => cachedQuery.queryString === ls.queryString)
-  );
-  let allQueries = [...queriesToStore, ...newQueries];
+  let allQueries = [...getCachedQueries()];
 
   if (allQueries.length >= maxQueriesAllowed + 1) {
     const sortedByDate = allQueries.sort((a, b) =>


### PR DESCRIPTION
## Summary

One of the things that bother me in the history component is that you can have different spaces in the queries but they query is actually the same. These appear 2 times which I find very annoying.

This PR identifies if the query is the same, regardless of the formatting, and if yes it will display it only once (it actually updates the cache old item with the new one)

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->