### PR TITLE
[Stateful sidenav] Fix side nav panel clipping

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/project/navigation.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/project/navigation.tsx
@@ -42,7 +42,6 @@ export const ProjectNavigation: FC<PropsWithChildren<Props>> = ({
       }, 50);
     });
 
-    // Observe changes to the document's styles or any element that might influence the variable
     observer.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ['style'],

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/project/navigation.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/project/navigation.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { FC, PropsWithChildren, useEffect, useState } from 'react';
+import React, { FC, PropsWithChildren } from 'react';
 import { EuiCollapsibleNavBeta } from '@elastic/eui';
 import useObservable from 'react-use/lib/useObservable';
 import type { Observable } from 'rxjs';
@@ -25,34 +25,6 @@ export const ProjectNavigation: FC<PropsWithChildren<Props>> = ({
   toggleSideNav,
 }) => {
   const isCollapsed = useObservable(isSideNavCollapsed$, false);
-  const [collapsibleNavOffset, setCollapsibleNavOffset] = useState(0);
-  const clipPathWidth = collapsibleNavOffset + PANEL_WIDTH;
-
-  useEffect(() => {
-    let timeoutId: NodeJS.Timeout | undefined;
-    const observer = new MutationObserver(() => {
-      clearTimeout(timeoutId);
-
-      // Debounce the CSS variable change to avoid unnecessary re-renders
-      timeoutId = setTimeout(() => {
-        const offSet = getComputedStyle(document.documentElement).getPropertyValue(
-          '--euiCollapsibleNavOffset'
-        );
-        setCollapsibleNavOffset(parseFloat(offSet));
-      }, 50);
-    });
-
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['style'],
-      subtree: true,
-      childList: true,
-    });
-
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
 
   return (
     <EuiCollapsibleNavBeta
@@ -61,7 +33,7 @@ export const ProjectNavigation: FC<PropsWithChildren<Props>> = ({
       onCollapseToggle={toggleSideNav}
       css={{
         overflow: 'visible',
-        clipPath: `polygon(0 0, ${clipPathWidth}px 0, ${clipPathWidth}px 100%, 0 100%)`,
+        clipPath: `polygon(0 0, calc(var(--euiCollapsibleNavOffset) + ${PANEL_WIDTH}px) 0, calc(var(--euiCollapsibleNavOffset) + ${PANEL_WIDTH}px) 100%, 0 100%)`,
       }}
     >
       {children}


### PR DESCRIPTION
In this PR I've fixed a bug in the side nav panel that was clipped when the side nav was collapsed.

In https://github.com/elastic/kibana/pull/191735 we allowed opening the panel from inside the stack management landing page. I didn't take into consideration that the side nav could be collapsed. This PR fixes it.

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/7b243d36-6b5c-4e26-ba82-594ffb2cc855)

### After

<img width="1314" alt="Screenshot 2024-09-27 at 10 18 46" src="https://github.com/user-attachments/assets/9a186728-f623-4168-bcff-8828d2dbb361">

<img width="1227" alt="Screenshot 2024-09-27 at 10 18 38" src="https://github.com/user-attachments/assets/96645075-98dc-427d-88f6-72553a2e31c9">



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->