### PR TITLE
[Migrations] Reenable tests fixed by #194151

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions.test.ts
@@ -61,8 +61,7 @@ const { startES } = createTestServers({
 });
 let esServer: TestElasticsearchUtils;
 
-// Failing: See https://github.com/elastic/kibana/issues/166190
-describe.skip('migration actions', () => {
+describe('migration actions', () => {
   let client: ElasticsearchClient;
   let esCapabilities: ReturnType<typeof elasticsearchServiceMock.createCapabilities>;
 

--- a/src/core/server/integration_tests/saved_objects/migrations/group3/fail_on_rollback.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/fail_on_rollback.test.ts
@@ -20,8 +20,7 @@ import { delay } from '../test_utils';
 import { getUpToDateMigratorTestKit } from '../kibana_migrator_test_kit.fixtures';
 import { BASELINE_TEST_ARCHIVE_1K } from '../kibana_migrator_archive_utils';
 
-// Failing: See https://github.com/elastic/kibana/issues/193756
-describe.skip('when rolling back to an older version', () => {
+describe('when rolling back to an older version', () => {
   let esServer: TestElasticsearchUtils['es'];
 
   beforeAll(async () => {


### PR DESCRIPTION
## Summary

* Unskips https://github.com/elastic/kibana/issues/193756
* Unskips https://github.com/elastic/kibana/issues/166190

Both should be addressed by https://github.com/elastic/kibana/pull/194151