### PR TITLE
[ML] Fix file upload when pipeline is used

### DIFF
--- a/x-pack/plugins/file_upload/server/import_data.ts
+++ b/x-pack/plugins/file_upload/server/import_data.ts
@@ -24,7 +24,6 @@ export function importDataProvider({ asCurrentUser }: IScopedClusterClient) {
     ingestPipeline: IngestPipelineWrapper | undefined,
     data: InputData
   ): Promise<ImportResponse> {
-    let createdIndex;
     const docCount = data.length;
     const pipelineId = ingestPipeline?.id;
     const pipeline = ingestPipeline?.pipeline;
@@ -35,7 +34,6 @@ export function importDataProvider({ asCurrentUser }: IScopedClusterClient) {
         id = generateId();
 
         await createIndex(index, settings, mappings);
-        createdIndex = index;
 
         // create the pipeline if one has been supplied
         if (pipelineId !== undefined) {
@@ -44,8 +42,6 @@ export function importDataProvider({ asCurrentUser }: IScopedClusterClient) {
             throw resp;
           }
         }
-      } else {
-        createdIndex = index;
       }
 
       let failures: ImportFailure[] = [];
@@ -66,7 +62,7 @@ export function importDataProvider({ asCurrentUser }: IScopedClusterClient) {
       return {
         success: true,
         id,
-        index: createdIndex,
+        index,
         pipelineId,
         docCount,
         failures,
@@ -75,7 +71,7 @@ export function importDataProvider({ asCurrentUser }: IScopedClusterClient) {
       return {
         success: false,
         id: id!,
-        index: createdIndex,
+        index,
         pipelineId,
         error: error.body !== undefined ? error.body : error,
         docCount,

--- a/x-pack/test/functional/apps/ml/data_visualizer/file_data_visualizer.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/file_data_visualizer.ts
@@ -405,7 +405,6 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.testExecution.logTestStep('closes filebeat config');
           await ml.dataVisualizerFileBased.closeCreateFilebeatConfig();
 
-          // await new Promise((r) => setTimeout(r, 400000));
           await ml.dataVisualizerFileBased.assertDocCountInIndex(
             testData.indexName,
             testData.expected.ingestedDocCount

--- a/x-pack/test/functional/apps/ml/data_visualizer/file_data_visualizer.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/file_data_visualizer.ts
@@ -85,6 +85,24 @@ export default function ({ getService }: FtrProviderContext) {
             docCountFormatted: '19 (100%)',
           },
         ],
+        allFields: [
+          '@timestamp',
+          'http',
+          'http.request',
+          'http.request.method',
+          'http.response',
+          'http.response.body',
+          'http.response.body.bytes',
+          'http.response.status_code',
+          'http.version',
+          'message',
+          'source',
+          'source.address',
+          'url',
+          'url.original',
+          'user_agent',
+          'user_agent.original',
+        ],
         visibleMetricFieldsCount: 3,
         totalMetricFieldsCount: 3,
         populatedFieldsCount: 9,
@@ -127,6 +145,7 @@ export default function ({ getService }: FtrProviderContext) {
             exampleCount: 7,
           },
         ],
+        allFields: ['Coordinates', 'Location'],
         visibleMetricFieldsCount: 0,
         totalMetricFieldsCount: 0,
         populatedFieldsCount: 3,
@@ -171,6 +190,7 @@ export default function ({ getService }: FtrProviderContext) {
             exampleCount: 3,
           },
         ],
+        allFields: ['description', 'title', 'value'],
         visibleMetricFieldsCount: 0,
         totalMetricFieldsCount: 0,
         populatedFieldsCount: 3,
@@ -206,6 +226,41 @@ export default function ({ getService }: FtrProviderContext) {
             docCountFormatted: '20 (100%)',
             exampleCount: 11,
           },
+        ],
+        allFields: [
+          'AvgTicketPrice',
+          'Cancelled',
+          'Carrier',
+          'Dest',
+          'DestAirportID',
+          'DestCityName',
+          'DestCountry',
+          'DestLocation',
+          'DestLocation.lat',
+          'DestLocation.lat.keyword',
+          'DestLocation.lon',
+          'DestLocation.lon.keyword',
+          'DestRegion',
+          'DestWeather',
+          'DistanceKilometers',
+          'FlightDelayMin',
+          'FlightDelayType',
+          'FlightNum',
+          'FlightTimeHour',
+          'FlightTimeMin',
+          'Origin',
+          'OriginAirportID',
+          'OriginCityName',
+          'OriginCountry',
+          'OriginLocation',
+          'OriginLocation.lat',
+          'OriginLocation.lat.keyword',
+          'OriginLocation.lon',
+          'OriginLocation.lon.keyword',
+          'OriginRegion',
+          'OriginWeather',
+          'dayOfWeek',
+          'timestamp',
         ],
         visibleMetricFieldsCount: 0,
         totalMetricFieldsCount: 0,
@@ -349,6 +404,17 @@ export default function ({ getService }: FtrProviderContext) {
 
           await ml.testExecution.logTestStep('closes filebeat config');
           await ml.dataVisualizerFileBased.closeCreateFilebeatConfig();
+
+          // await new Promise((r) => setTimeout(r, 400000));
+          await ml.dataVisualizerFileBased.assertDocCountInIndex(
+            testData.indexName,
+            testData.expected.ingestedDocCount
+          );
+
+          await ml.dataVisualizerFileBased.assertFieldsFromIndex(
+            testData.indexName,
+            testData.expected.allFields
+          );
         });
       });
     }

--- a/x-pack/test/functional/services/ml/data_visualizer_file_based.ts
+++ b/x-pack/test/functional/services/ml/data_visualizer_file_based.ts
@@ -16,6 +16,7 @@ export function MachineLearningDataVisualizerFileBasedProvider(
   { getService, getPageObjects }: FtrProviderContext,
   mlCommonUI: MlCommonUI
 ) {
+  const es = getService('es');
   const log = getService('log');
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
@@ -176,6 +177,47 @@ export function MachineLearningDataVisualizerFileBasedProvider(
     async closeCreateFilebeatConfig() {
       await testSubjects.click('fileBeatConfigFlyoutCloseButton');
       await testSubjects.missingOrFail('fileDataVisFilebeatConfigPanel');
+    },
+
+    async assertDocCountInIndex(index: string, expectedCount: number) {
+      await retry.tryForTime(60 * 1000, async () => {
+        const count = await this.getDocCountFromIndex(index);
+        expect(count).to.eql(
+          expectedCount,
+          `Expected document count in index '${index}' to be '${expectedCount}' (got '${count}')`
+        );
+      });
+    },
+
+    async getDocCountFromIndex(index: string) {
+      const resp = await es.search({
+        index,
+        body: {
+          size: 0,
+          query: {
+            match_all: {},
+          },
+        },
+      });
+      // @ts-expect-error
+      return resp.hits.total?.value;
+    },
+
+    async assertFieldsFromIndex(index: string, fields: string[]) {
+      await retry.tryForTime(1 * 1000, async () => {
+        const sortedFields = fields.sort();
+        const fieldCaps = await es.fieldCaps({
+          index,
+          fields: '*',
+          filters: '-metadata',
+          include_empty_fields: false,
+        });
+        const fieldsFromIndex = Object.keys(fieldCaps.fields).sort();
+        expect(fieldsFromIndex).to.eql(
+          sortedFields,
+          `Expected fields to be ${sortedFields} (got ${fieldsFromIndex})`
+        );
+      });
     },
   };
 }

--- a/x-pack/test/functional/services/ml/data_visualizer_file_based.ts
+++ b/x-pack/test/functional/services/ml/data_visualizer_file_based.ts
@@ -199,7 +199,7 @@ export function MachineLearningDataVisualizerFileBasedProvider(
           },
         },
       });
-      // @ts-expect-error
+      // @ts-expect-error incorrect type definition
       return resp.hits.total?.value;
     },
 

--- a/x-pack/test/functional/services/ml/data_visualizer_file_based.ts
+++ b/x-pack/test/functional/services/ml/data_visualizer_file_based.ts
@@ -204,7 +204,7 @@ export function MachineLearningDataVisualizerFileBasedProvider(
     },
 
     async assertFieldsFromIndex(index: string, fields: string[]) {
-      await retry.tryForTime(1 * 1000, async () => {
+      await retry.tryForTime(60 * 1000, async () => {
         const sortedFields = fields.sort();
         const fieldCaps = await es.fieldCaps({
           index,


### PR DESCRIPTION
Fixes bug introduced in https://github.com/elastic/kibana/pull/193744

If a file is uploaded with an ingest pipeline, the pipeline is created, but not used when uploading the data.

Adds tests to check that the data exists in the index and the expected fields exist and are populated.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->