### PR TITLE
[FTR][Ownership] Assign Ownership to canvas/logstash_lens ES Archives

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -918,9 +918,9 @@ packages/kbn-test-eui-helpers @elastic/kibana-visualizations
 x-pack/test/licensing_plugin/plugins/test_feature_usage @elastic/kibana-security
 packages/kbn-test-jest-helpers @elastic/kibana-operations @elastic/appex-qa
 packages/kbn-test-subj-selector @elastic/kibana-operations @elastic/appex-qa
-x-pack/test_serverless 
-test 
-x-pack/test 
+x-pack/test_serverless
+test
+x-pack/test
 x-pack/performance @elastic/appex-qa
 x-pack/examples/testing_embedded_lens @elastic/kibana-visualizations
 x-pack/examples/third_party_lens_navigation_prompt @elastic/kibana-visualizations
@@ -1239,6 +1239,7 @@ x-pack/test/observability_ai_assistant_functional @elastic/obs-ai-assistant
 /x-pack/test/functional/apps/canvas/ @elastic/kibana-presentation
 /x-pack/test_serverless/functional/test_suites/search/dashboards/ @elastic/kibana-presentation
 /test/plugin_functional/test_suites/panel_actions @elastic/kibana-presentation
+/x-pack/test/functional/es_archives/canvas/logstash_lens @elastic/kibana-presentation
 #CC# /src/plugins/kibana_react/public/code_editor/ @elastic/kibana-presentation
 
 # Machine Learning

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -918,9 +918,9 @@ packages/kbn-test-eui-helpers @elastic/kibana-visualizations
 x-pack/test/licensing_plugin/plugins/test_feature_usage @elastic/kibana-security
 packages/kbn-test-jest-helpers @elastic/kibana-operations @elastic/appex-qa
 packages/kbn-test-subj-selector @elastic/kibana-operations @elastic/appex-qa
-x-pack/test_serverless
-test
-x-pack/test
+x-pack/test_serverless 
+test 
+x-pack/test 
 x-pack/performance @elastic/appex-qa
 x-pack/examples/testing_embedded_lens @elastic/kibana-visualizations
 x-pack/examples/third_party_lens_navigation_prompt @elastic/kibana-visualizations


### PR DESCRIPTION
## Summary

Modify code owner declarations for `x-pack/test/functional/es_archives/canvas/logstash_lens` in .github/CODEOWNERS

### For reviewers

To verify this pr, you can use the `scripts/get_owners_for_file.js` script
E.g:
```
 node scripts/get_owners_for_file.js --file x-pack/test/functional/es_archives/canvas/logstash_lens # Or any other file
```

#### Notes
All of these are a best guess effort.  The more help from the dev teams, the more accurate this will be for reporting in the future.

Contributes to: https://github.com/elastic/kibana/issues/192979