### PR TITLE
Support global_data_tags in the policy update request

### DIFF
--- a/oas_docs/output/kibana.serverless.staging.yaml
+++ b/oas_docs/output/kibana.serverless.staging.yaml
@@ -19977,6 +19977,17 @@ components:
         force:
           description: Force agent policy creation even if packages are not verified.
           type: boolean
+        global_data_tags:
+          items:
+            additionalProperties:
+              oneOf:
+                - type: string
+                - type: number
+            description: >-
+              User defined data tags that are added to all of the inputs. The
+              values can be strings or numbers.
+            type: object
+          type: array
         inactivity_timeout:
           type: integer
         is_protected:

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -12821,6 +12821,17 @@ components:
         force:
           description: Force agent policy creation even if packages are not verified.
           type: boolean
+        global_data_tags:
+          items:
+            additionalProperties:
+              oneOf:
+                - type: string
+                - type: number
+            description: >-
+              User defined data tags that are added to all of the inputs. The
+              values can be strings or numbers.
+            type: object
+          type: array
         inactivity_timeout:
           type: integer
         is_protected:

--- a/oas_docs/output/kibana.staging.yaml
+++ b/oas_docs/output/kibana.staging.yaml
@@ -27753,6 +27753,17 @@ components:
         force:
           description: Force agent policy creation even if packages are not verified.
           type: boolean
+        global_data_tags:
+          items:
+            additionalProperties:
+              oneOf:
+                - type: string
+                - type: number
+            description: >-
+              User defined data tags that are added to all of the inputs. The
+              values can be strings or numbers.
+            type: object
+          type: array
         inactivity_timeout:
           type: integer
         is_protected:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -19780,6 +19780,17 @@ components:
         force:
           description: Force agent policy creation even if packages are not verified.
           type: boolean
+        global_data_tags:
+          items:
+            additionalProperties:
+              oneOf:
+                - type: string
+                - type: number
+            description: >-
+              User defined data tags that are added to all of the inputs. The
+              values can be strings or numbers.
+            type: object
+          type: array
         inactivity_timeout:
           type: integer
         is_protected:

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -7812,6 +7812,23 @@
           "force": {
             "type": "boolean",
             "description": "Force agent policy creation even if packages are not verified."
+          },
+          "global_data_tags": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "description": "User defined data tags that are added to all of the inputs. The values can be strings or numbers."
+            }
           }
         },
         "required": [

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -5011,6 +5011,17 @@ components:
         force:
           type: boolean
           description: Force agent policy creation even if packages are not verified.
+        global_data_tags:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: string
+                - type: number
+            description: >-
+              User defined data tags that are added to all of the inputs. The
+              values can be strings or numbers.
       required:
         - name
         - namespace

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_update_request.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_update_request.yaml
@@ -47,6 +47,15 @@ properties:
   force:
     type: boolean
     description: Force agent policy creation even if packages are not verified.
+  global_data_tags:
+    type: array
+    items:
+      type: object
+      additionalProperties:
+        oneOf:
+          - type: string
+          - type: number
+      description: User defined data tags that are added to all of the inputs. The values can be strings or numbers.
 required:
   - name
   - namespace


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/pull/183563 adds support for `global_data_tags` however the field is not added to the update request definition in the OpenAPI spec. This PR defines the field within the API spec. 
Related to https://github.com/elastic/terraform-provider-elasticstack/pull/730


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->