### PR TITLE
[Inventory] Removes environment from Service type identity fields

### DIFF
--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
@@ -20,7 +20,7 @@ const serviceTransactionFilter = (additionalFilters: string[] = []) => {
 
 export const builtInServicesFromEcsEntityDefinition: EntityDefinition =
   entityDefinitionSchema.parse({
-    version: '2.0.0',
+    version: '0.2.0',
     id: `${BUILT_IN_ID_PREFIX}services_from_ecs_data`,
     name: 'Services from ECS data',
     description:

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
@@ -20,7 +20,7 @@ const serviceTransactionFilter = (additionalFilters: string[] = []) => {
 
 export const builtInServicesFromEcsEntityDefinition: EntityDefinition =
   entityDefinitionSchema.parse({
-    version: '1.0.3',
+    version: '1.0.4',
     id: `${BUILT_IN_ID_PREFIX}services_from_ecs_data`,
     name: 'Services from ECS data',
     description:

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
@@ -42,8 +42,8 @@ export const builtInServicesFromEcsEntityDefinition: EntityDefinition =
         syncDelay: '2m',
       },
     },
-    identityFields: ['service.name', { field: 'service.environment', optional: true }],
-    displayNameTemplate: '{{service.name}}{{#service.environment}}:{{.}}{{/service.environment}}',
+    identityFields: ['service.name'],
+    displayNameTemplate: '{{service.name}}',
     metadata: [
       { source: '_index', destination: 'sourceIndex' },
       { source: 'agent.name', aggregation: { type: 'terms', limit: 100 } },

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
@@ -20,7 +20,7 @@ const serviceTransactionFilter = (additionalFilters: string[] = []) => {
 
 export const builtInServicesFromEcsEntityDefinition: EntityDefinition =
   entityDefinitionSchema.parse({
-    version: '1.0.4',
+    version: '2.0.0',
     id: `${BUILT_IN_ID_PREFIX}services_from_ecs_data`,
     name: 'Services from ECS data',
     description:


### PR DESCRIPTION
When we started working with EEM, we were focusing on the APM UI pages, thus we added the service environment as an identifier field. Now that we are moving away from it, we no longer need it listed on the Service type definition.

<img width="1579" alt="Screenshot 2024-09-30 at 16 29 02" src="https://github.com/user-attachments/assets/1b8f8835-f083-44fc-b7f8-2142c48ed8e3">


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->