### PR TITLE
[Security solution] Update ebt fields script to new Vault policy

### DIFF
--- a/x-pack/plugins/security_solution/scripts/telemetry/README.md
+++ b/x-pack/plugins/security_solution/scripts/telemetry/README.md
@@ -13,7 +13,7 @@ If you have further events to be included in the data views, please update the s
 
 ### Usage
 
-1. Login with Vault (`vault login -method github`), ensure you have siem-team access. If you have never accessed Vault before, follow [these instructions](https://github.com/elastic/infra/blob/master/docs/vault/README.md)
+1. Login with Vault (`vault login -method oidc`), ensure you have siem-team access. If you have never accessed Vault before, follow [these instructions](https://github.com/elastic/infra/blob/master/docs/vault/README.md)
 2. cd into this directory
 3. Run the script with the appropriate arguments. By default, the script will run for the `security-solution-ebt-kibana-browser` data view in the `securitysolution` space. If you want to run the script for the server data view, pass the `--telemetry_type` argument with the value `server`.
 

--- a/x-pack/plugins/security_solution/scripts/telemetry/build_ebt_data_view.ts
+++ b/x-pack/plugins/security_solution/scripts/telemetry/build_ebt_data_view.ts
@@ -11,7 +11,7 @@ import { events as genAiEvents } from '@kbn/elastic-assistant-plugin/server/lib/
 
 import { events as securityEvents } from '../../server/lib/telemetry/event_based/events';
 import { telemetryEvents } from '../../public/common/lib/telemetry/events/telemetry_events';
-// uncomment and add to run script, but do not commit as creates cirular dependency
+// uncomment and add to run script, but do not commit as creates circular dependency
 // import { telemetryEvents as serverlessEvents } from '@kbn/security-solution-serverless/server/telemetry/event_based_telemetry';
 
 const logger = new ToolingLog({


### PR DESCRIPTION
## Summary

Fixes bad instructions in the `README.md` that instruct the user to login to Infra Vault with GtiHub when we switched to Okta (OIDC) authentication in July. Also fixes a small typo

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->