### PR TITLE
Add CA certificate path to actions config

### DIFF
--- a/x-pack/plugins/actions/server/config.ts
+++ b/x-pack/plugins/actions/server/config.ts
@@ -145,6 +145,15 @@ export const configSchema = schema.object({
       max: schema.maybe(schema.number({ min: MIN_QUEUED_MAX, defaultValue: DEFAULT_QUEUED_MAX })),
     })
   ),
+  usage: schema.maybe(
+    schema.object({
+      cert: schema.maybe(
+        schema.object({
+          path: schema.string(),
+        })
+      ),
+    })
+  ),
 });
 
 export type ActionsConfig = TypeOf<typeof configSchema>;


### PR DESCRIPTION
Towards: #https://github.com/elastic/response-ops-team/issues/209
This PR adds usage-api CA certificate path to actions plugin's config.
So we can add it to serverless config in gitops.

The tasks that pushes the usage data will use this path to load the CA certificate. 

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->