### PR TITLE
[ML] Various fixes for possible prototype pollution vulnerabilities

### DIFF
--- a/x-pack/packages/ml/nested_property/src/set_nested_property.test.ts
+++ b/x-pack/packages/ml/nested_property/src/set_nested_property.test.ts
@@ -72,5 +72,9 @@ describe('object_utils', () => {
     const test12 = setNestedProperty(getTestObj(), 'the.__proto__', 'update');
     expect(test12.the).toBe('update');
     expect(test12.the.__proto__.update).toBe(undefined);
+
+    const test13 = setNestedProperty(getTestObj(), 'the.prototype', 'update');
+    expect(test13.the).toBe('update');
+    expect(test13.the.prototype.update).toBe(undefined);
   });
 });

--- a/x-pack/packages/ml/nested_property/src/set_nested_property.test.ts
+++ b/x-pack/packages/ml/nested_property/src/set_nested_property.test.ts
@@ -68,5 +68,9 @@ describe('object_utils', () => {
 
     const test11 = setNestedProperty(getFalseyObject(), 'the.other_nested.value', 'update');
     expect(test11.the.other_nested.value).toBe('update');
+
+    const test12 = setNestedProperty(getTestObj(), 'the.__proto__', 'update');
+    expect(test12.the).toBe('update');
+    expect(test12.the.__proto__.update).toBe(undefined);
   });
 });

--- a/x-pack/packages/ml/nested_property/src/set_nested_property.test.ts
+++ b/x-pack/packages/ml/nested_property/src/set_nested_property.test.ts
@@ -75,6 +75,6 @@ describe('object_utils', () => {
 
     const test13 = setNestedProperty(getTestObj(), 'the.prototype', 'update');
     expect(test13.the).toBe('update');
-    expect(test13.the.prototype.update).toBe(undefined);
+    expect(test13.the.prototype?.update).toBe(undefined);
   });
 });

--- a/x-pack/packages/ml/nested_property/src/set_nested_property.test.ts
+++ b/x-pack/packages/ml/nested_property/src/set_nested_property.test.ts
@@ -69,12 +69,14 @@ describe('object_utils', () => {
     const test11 = setNestedProperty(getFalseyObject(), 'the.other_nested.value', 'update');
     expect(test11.the.other_nested.value).toBe('update');
 
-    const test12 = setNestedProperty(getTestObj(), 'the.__proto__', 'update');
-    expect(test12.the).toBe('update');
-    expect(test12.the.__proto__.update).toBe(undefined);
-
-    const test13 = setNestedProperty(getTestObj(), 'the.prototype', 'update');
-    expect(test13.the).toBe('update');
-    expect(test13.the.prototype?.update).toBe(undefined);
+    expect(() => {
+      setNestedProperty(getTestObj(), 'the.__proto__', 'update');
+    }).toThrow('Invalid accessor');
+    expect(() => {
+      setNestedProperty(getTestObj(), 'the.prototype', 'update');
+    }).toThrow('Invalid accessor');
+    expect(() => {
+      setNestedProperty(getTestObj(), 'the.constructor', 'update');
+    }).toThrow('Invalid accessor');
   });
 });

--- a/x-pack/packages/ml/nested_property/src/set_nested_property.ts
+++ b/x-pack/packages/ml/nested_property/src/set_nested_property.ts
@@ -7,7 +7,7 @@
 
 export const setNestedProperty = (obj: Record<string, any>, accessor: string, value: any) => {
   let ref = obj;
-  const accessors = accessor.split('.');
+  const accessors = accessor.split('.').filter((a) => a !== '__proto__');
   const len = accessors.length;
   for (let i = 0; i < len - 1; i++) {
     const attribute = accessors[i];

--- a/x-pack/packages/ml/nested_property/src/set_nested_property.ts
+++ b/x-pack/packages/ml/nested_property/src/set_nested_property.ts
@@ -7,7 +7,7 @@
 
 export const setNestedProperty = (obj: Record<string, any>, accessor: string, value: any) => {
   let ref = obj;
-  const accessors = accessor.split('.').filter((a) => a !== '__proto__');
+  const accessors = accessor.split('.').filter((a) => a !== '__proto__' && a !== 'prototype');
   const len = accessors.length;
   for (let i = 0; i < len - 1; i++) {
     const attribute = accessors[i];

--- a/x-pack/packages/ml/nested_property/src/set_nested_property.ts
+++ b/x-pack/packages/ml/nested_property/src/set_nested_property.ts
@@ -5,9 +5,15 @@
  * 2.0.
  */
 
+const INVALID_ACCESSORS = ['__proto__', 'prototype', 'constructor'];
+
 export const setNestedProperty = (obj: Record<string, any>, accessor: string, value: any) => {
   let ref = obj;
-  const accessors = accessor.split('.').filter((a) => a !== '__proto__' && a !== 'prototype');
+  const accessors = accessor.split('.');
+  if (accessors.some((a) => INVALID_ACCESSORS.includes(a))) {
+    throw new Error('Invalid accessor');
+  }
+
   const len = accessors.length;
   for (let i = 0; i < len - 1; i++) {
     const attribute = accessors[i];

--- a/x-pack/plugins/ml/server/saved_objects/service.ts
+++ b/x-pack/plugins/ml/server/saved_objects/service.ts
@@ -328,7 +328,7 @@ export function mlSavedObjectServiceFactory(
       if (id.match('\\*') === null) {
         return jobIds.includes(id);
       }
-      const regex = new RegExp(id.replace('*', '.*'));
+      const regex = new RegExp(id.replaceAll('*', '.*'));
       return jobIds.some((jId) => typeof jId === 'string' && regex.exec(jId));
     });
   }
@@ -640,7 +640,7 @@ export function mlSavedObjectServiceFactory(
       if (id.match('\\*') === null) {
         return modelIds.includes(id);
       }
-      const regex = new RegExp(id.replace('*', '.*'));
+      const regex = new RegExp(id.replaceAll('*', '.*'));
       return modelIds.some((jId) => typeof jId === 'string' && regex.exec(jId));
     });
   }


### PR DESCRIPTION
Fixes potential prototype pollution vulnerability in `setNestedProperty` function.
Fixes incomplete string escaping issue in ML's saved object service.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->