### PR TITLE
[ML] [7.17] Potential prototype pollution vulnerability 

### DIFF
--- a/x-pack/plugins/transform/common/utils/object_utils.test.ts
+++ b/x-pack/plugins/transform/common/utils/object_utils.test.ts
@@ -74,6 +74,6 @@ describe('object_utils', () => {
 
     const test13 = setNestedProperty(testObj, 'the.prototype', 'update');
     expect(test13.the).toBe('update');
-    expect(test13.the.prototype.update).toBe(undefined);
+    expect(test13.the.prototype?.update).toBe(undefined);
   });
 });

--- a/x-pack/plugins/transform/common/utils/object_utils.test.ts
+++ b/x-pack/plugins/transform/common/utils/object_utils.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { getNestedProperty } from './object_utils';
+import { getNestedProperty, setNestedProperty } from './object_utils';
 
 describe('object_utils', () => {
   test('getNestedProperty()', () => {
@@ -67,5 +67,9 @@ describe('object_utils', () => {
     const test11 = getNestedProperty(falseyObj, 'the.other_nested.value');
     expect(typeof test11).toBe('number');
     expect(test11).toBe(0);
+
+    const test12 = setNestedProperty(testObj, 'the.__proto__', 'update');
+    expect(test12.the).toBe('update');
+    expect(test12.the.__proto__.update).toBe(undefined);
   });
 });

--- a/x-pack/plugins/transform/common/utils/object_utils.test.ts
+++ b/x-pack/plugins/transform/common/utils/object_utils.test.ts
@@ -68,12 +68,14 @@ describe('object_utils', () => {
     expect(typeof test11).toBe('number');
     expect(test11).toBe(0);
 
-    const test12 = setNestedProperty(testObj, 'the.__proto__', 'update');
-    expect(test12.the).toBe('update');
-    expect(test12.the.__proto__.update).toBe(undefined);
-
-    const test13 = setNestedProperty(testObj, 'the.prototype', 'update');
-    expect(test13.the).toBe('update');
-    expect(test13.the.prototype?.update).toBe(undefined);
+    expect(() => {
+      setNestedProperty(testObj, 'the.__proto__', 'update');
+    }).toThrow('Invalid accessor');
+    expect(() => {
+      setNestedProperty(testObj, 'the.prototype', 'update');
+    }).toThrow('Invalid accessor');
+    expect(() => {
+      setNestedProperty(testObj, 'the.constructor', 'update');
+    }).toThrow('Invalid accessor');
   });
 });

--- a/x-pack/plugins/transform/common/utils/object_utils.test.ts
+++ b/x-pack/plugins/transform/common/utils/object_utils.test.ts
@@ -71,5 +71,9 @@ describe('object_utils', () => {
     const test12 = setNestedProperty(testObj, 'the.__proto__', 'update');
     expect(test12.the).toBe('update');
     expect(test12.the.__proto__.update).toBe(undefined);
+
+    const test13 = setNestedProperty(testObj, 'the.prototype', 'update');
+    expect(test13.the).toBe('update');
+    expect(test13.the.prototype.update).toBe(undefined);
   });
 });

--- a/x-pack/plugins/transform/common/utils/object_utils.ts
+++ b/x-pack/plugins/transform/common/utils/object_utils.ts
@@ -36,7 +36,7 @@ export function getNestedProperty(
 
 export const setNestedProperty = (obj: Record<string, any>, accessor: string, value: any) => {
   let ref = obj;
-  const accessors = accessor.split('.').filter((a) => a !== '__proto__');
+  const accessors = accessor.split('.').filter((a) => a !== '__proto__' && a !== 'prototype');
   const len = accessors.length;
   for (let i = 0; i < len - 1; i++) {
     const attribute = accessors[i];

--- a/x-pack/plugins/transform/common/utils/object_utils.ts
+++ b/x-pack/plugins/transform/common/utils/object_utils.ts
@@ -34,9 +34,15 @@ export function getNestedProperty(
   return o;
 }
 
+const INVALID_ACCESSORS = ['__proto__', 'prototype', 'constructor'];
+
 export const setNestedProperty = (obj: Record<string, any>, accessor: string, value: any) => {
   let ref = obj;
-  const accessors = accessor.split('.').filter((a) => a !== '__proto__' && a !== 'prototype');
+  const accessors = accessor.split('.');
+  if (accessors.some((a) => INVALID_ACCESSORS.includes(a))) {
+    throw new Error('Invalid accessor');
+  }
+
   const len = accessors.length;
   for (let i = 0; i < len - 1; i++) {
     const attribute = accessors[i];

--- a/x-pack/plugins/transform/common/utils/object_utils.ts
+++ b/x-pack/plugins/transform/common/utils/object_utils.ts
@@ -36,7 +36,7 @@ export function getNestedProperty(
 
 export const setNestedProperty = (obj: Record<string, any>, accessor: string, value: any) => {
   let ref = obj;
-  const accessors = accessor.split('.');
+  const accessors = accessor.split('.').filter((a) => a !== '__proto__');
   const len = accessors.length;
   for (let i = 0; i < len - 1; i++) {
     const attribute = accessors[i];


### PR DESCRIPTION
Fixes potential prototype pollution vulnerability in `setNestedProperty` function.