### PR TITLE
[8.15] [Logs Explorer] Fix Privileges Accessibility (#193894)

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/apps/logs_app.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/apps/logs_app.tsx
@@ -57,7 +57,7 @@ const LogsApp: React.FC<{
   storage: Storage;
   theme$: AppMountParameters['theme$'];
 }> = ({ core, history, pluginStart, plugins, setHeaderActionMenu, storage, theme$ }) => {
-  const uiCapabilities = core.application.capabilities;
+  const { logs, discover, fleet } = core.application.capabilities;
 
   return (
     <CoreProviders core={core} pluginStart={pluginStart} plugins={plugins} theme$={theme$}>
@@ -74,17 +74,21 @@ const LogsApp: React.FC<{
             toastsService={core.notifications.toasts}
           >
             <Routes>
-              <Route
-                path="/"
-                exact
-                render={() =>
-                  plugins.share.url.locators
-                    .get<AllDatasetsLocatorParams>(ALL_DATASETS_LOCATOR_ID)
-                    ?.navigate({})
-                }
-              />
+              {Boolean(discover?.show && fleet?.read) && (
+                <Route
+                  path="/"
+                  exact
+                  render={() => {
+                    plugins.share.url.locators
+                      .get<AllDatasetsLocatorParams>(ALL_DATASETS_LOCATOR_ID)
+                      ?.navigate({});
+
+                    return null;
+                  }}
+                />
+              )}
               <Route path="/link-to" component={LinkToLogsPage} />
-              {uiCapabilities?.logs?.show && <Route path="/" component={LogsPage} />}
+              {logs?.show && <Route path="/" component={LogsPage} />}
             </Routes>
           </KbnUrlStateStorageFromRouterProvider>
         </Router>

--- a/x-pack/plugins/observability_solution/infra/public/pages/logs/page_content.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/logs/page_content.tsx
@@ -107,6 +107,7 @@ export const LogsPageContent: React.FunctionComponent = () => {
         )}
         <RedirectWithQueryParams from={'/analysis'} to={anomaliesTab.pathname} exact />
         <RedirectWithQueryParams from={'/log-rate'} to={anomaliesTab.pathname} exact />
+        <RedirectWithQueryParams from={'/'} to={streamTab.pathname} exact />
         <Route
           render={() => (
             <NotFoundPage

--- a/x-pack/plugins/observability_solution/infra/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/infra/public/plugin.ts
@@ -123,19 +123,24 @@ export class Plugin implements InfraClientPluginClass {
             ],
             isInfrastructureHostsViewEnabled,
           ]) => {
+            const { infrastructure, logs, discover, fleet } = capabilities;
             return [
-              ...(capabilities.logs.show
+              ...(logs.show
                 ? [
                     {
                       label: 'Logs',
                       sortKey: 200,
                       entries: [
-                        {
-                          label: 'Explorer',
-                          app: 'observability-logs-explorer',
-                          path: '/',
-                          isBetaFeature: true,
-                        },
+                        ...(discover?.show && fleet?.read
+                          ? [
+                              {
+                                label: 'Explorer',
+                                app: 'observability-logs-explorer',
+                                path: '/',
+                                isBetaFeature: true,
+                              },
+                            ]
+                          : []),
                         ...(this.config.featureFlags.logsUIEnabled
                           ? [
                               { label: 'Stream', app: 'logs', path: '/stream' },
@@ -147,7 +152,7 @@ export class Plugin implements InfraClientPluginClass {
                     },
                   ]
                 : []),
-              ...(capabilities.infrastructure.show
+              ...(infrastructure.show
                 ? [
                     {
                       label: 'Infrastructure',

--- a/x-pack/plugins/observability_solution/observability_logs_explorer/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/observability_logs_explorer/public/plugin.ts
@@ -7,6 +7,8 @@
 
 import {
   AppMountParameters,
+  AppStatus,
+  AppUpdater,
   CoreSetup,
   CoreStart,
   DEFAULT_APP_CATEGORIES,
@@ -14,6 +16,7 @@ import {
   PluginInitializerContext,
 } from '@kbn/core/public';
 import { OBSERVABILITY_LOGS_EXPLORER_APP_ID } from '@kbn/deeplinks-observability';
+import { BehaviorSubject } from 'rxjs';
 import {
   AllDatasetsLocatorDefinition,
   ObservabilityLogsExplorerLocators,
@@ -35,6 +38,7 @@ export class ObservabilityLogsExplorerPlugin
 {
   private config: ObservabilityLogsExplorerConfig;
   private locators?: ObservabilityLogsExplorerLocators;
+  private appStateUpdater = new BehaviorSubject<AppUpdater>(() => ({}));
 
   constructor(context: PluginInitializerContext<ObservabilityLogsExplorerConfig>) {
     this.config = context.config.get();
@@ -56,6 +60,7 @@ export class ObservabilityLogsExplorerPlugin
         ? ['globalSearch', 'sideNav']
         : ['globalSearch'],
       keywords: ['logs', 'log', 'explorer', 'logs explorer'],
+      updater$: this.appStateUpdater,
       mount: async (appMountParams: ObservabilityLogsExplorerAppMountParameters) => {
         const [coreStart, pluginsStart, ownPluginStart] = await core.getStartServices();
         const { renderObservabilityLogsExplorer } = await import(
@@ -123,7 +128,16 @@ export class ObservabilityLogsExplorerPlugin
     };
   }
 
-  public start(_core: CoreStart, _pluginsStart: ObservabilityLogsExplorerStartDeps) {
+  public start(core: CoreStart, _pluginsStart: ObservabilityLogsExplorerStartDeps) {
+    const { discover, fleet, logs } = core.application.capabilities;
+
+    if (!(discover?.show && fleet?.read && logs?.show)) {
+      this.appStateUpdater.next(() => ({
+        status: AppStatus.inaccessible,
+        visibleIn: [],
+      }));
+    }
+
     return {};
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Logs Explorer] Fix Privileges Accessibility (#193894)](https://github.com/elastic/kibana/pull/193894)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"mohamedhamed-ahmed","email":"mohamed.ahmed@elastic.co"},"sourceCommit":{"committedDate":"2024-10-01T11:38:16Z","message":"[Logs Explorer] Fix Privileges Accessibility (#193894)\n\ncloses https://github.com/elastic/kibana/issues/192062\r\n\r\n## 📝  Summary\r\n\r\nThis PR adds privileges checks for `Logs Explorerer` it checks for\r\n`Discover & Fleet` privileges before allowing the user access to `Logs\r\nExplorer`.\r\nClicking on the `Logs` tab from the side nav defaults to `Stream`, as\r\nlong as its not depricated, in case the user doesn't have access to\r\n`Logs Explorer`\r\n\r\n## 🎥 Demo\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/a4105ec0-7681-40ee-b2fd-e39b9c178dcf","sha":"dbfd4f0879aa89c49b379cc2c6c5feb74f5c16c7","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","ci:project-deploy-observability","Team:obs-ux-logs","Team:obs-ux-infra_services","apm:review","v8.15.0","v8.16.0","backport:version"],"number":193894,"url":"https://github.com/elastic/kibana/pull/193894","mergeCommit":{"message":"[Logs Explorer] Fix Privileges Accessibility (#193894)\n\ncloses https://github.com/elastic/kibana/issues/192062\r\n\r\n## 📝  Summary\r\n\r\nThis PR adds privileges checks for `Logs Explorerer` it checks for\r\n`Discover & Fleet` privileges before allowing the user access to `Logs\r\nExplorer`.\r\nClicking on the `Logs` tab from the side nav defaults to `Stream`, as\r\nlong as its not depricated, in case the user doesn't have access to\r\n`Logs Explorer`\r\n\r\n## 🎥 Demo\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/a4105ec0-7681-40ee-b2fd-e39b9c178dcf","sha":"dbfd4f0879aa89c49b379cc2c6c5feb74f5c16c7"}},"sourceBranch":"main","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/193894","number":193894,"mergeCommit":{"message":"[Logs Explorer] Fix Privileges Accessibility (#193894)\n\ncloses https://github.com/elastic/kibana/issues/192062\r\n\r\n## 📝  Summary\r\n\r\nThis PR adds privileges checks for `Logs Explorerer` it checks for\r\n`Discover & Fleet` privileges before allowing the user access to `Logs\r\nExplorer`.\r\nClicking on the `Logs` tab from the side nav defaults to `Stream`, as\r\nlong as its not depricated, in case the user doesn't have access to\r\n`Logs Explorer`\r\n\r\n## 🎥 Demo\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/a4105ec0-7681-40ee-b2fd-e39b9c178dcf","sha":"dbfd4f0879aa89c49b379cc2c6c5feb74f5c16c7"}},{"branch":"8.15","label":"v8.15.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/194557","number":194557,"state":"MERGED","mergeCommit":{"sha":"ee920811f6c17f6ea264cc5e3527e63cd2c0fd46","message":"[8.x] [Logs Explorer] Fix Privileges Accessibility (#193894) (#194557)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Logs Explorer] Fix Privileges Accessibility\n(#193894)](https://github.com/elastic/kibana/pull/193894)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT\n[{\"author\":{\"name\":\"mohamedhamed-ahmed\",\"email\":\"mohamed.ahmed@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-10-01T11:38:16Z\",\"message\":\"[Logs\nExplorer] Fix Privileges Accessibility (#193894)\\n\\ncloses\nhttps://github.com/elastic/kibana/issues/192062\\r\\n\\r\\n## 📝\nSummary\\r\\n\\r\\nThis PR adds privileges checks for `Logs Explorerer` it\nchecks for\\r\\n`Discover & Fleet` privileges before allowing the user\naccess to `Logs\\r\\nExplorer`.\\r\\nClicking on the `Logs` tab from the\nside nav defaults to `Stream`, as\\r\\nlong as its not depricated, in case\nthe user doesn't have access to\\r\\n`Logs Explorer`\\r\\n\\r\\n## 🎥\nDemo\\r\\n\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/a4105ec0-7681-40ee-b2fd-e39b9c178dcf\",\"sha\":\"dbfd4f0879aa89c49b379cc2c6c5feb74f5c16c7\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.16.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"ci:project-deploy-observability\",\"Team:obs-ux-logs\",\"Team:obs-ux-infra_services\",\"v8.15.0\",\"v8.16.0\",\"backport:version\"],\"title\":\"[Logs\nExplorer] Fix Privileges\nAccessibility\",\"number\":193894,\"url\":\"https://github.com/elastic/kibana/pull/193894\",\"mergeCommit\":{\"message\":\"[Logs\nExplorer] Fix Privileges Accessibility (#193894)\\n\\ncloses\nhttps://github.com/elastic/kibana/issues/192062\\r\\n\\r\\n## 📝\nSummary\\r\\n\\r\\nThis PR adds privileges checks for `Logs Explorerer` it\nchecks for\\r\\n`Discover & Fleet` privileges before allowing the user\naccess to `Logs\\r\\nExplorer`.\\r\\nClicking on the `Logs` tab from the\nside nav defaults to `Stream`, as\\r\\nlong as its not depricated, in case\nthe user doesn't have access to\\r\\n`Logs Explorer`\\r\\n\\r\\n## 🎥\nDemo\\r\\n\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/a4105ec0-7681-40ee-b2fd-e39b9c178dcf\",\"sha\":\"dbfd4f0879aa89c49b379cc2c6c5feb74f5c16c7\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.15\",\"8.x\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/193894\",\"number\":193894,\"mergeCommit\":{\"message\":\"[Logs\nExplorer] Fix Privileges Accessibility (#193894)\\n\\ncloses\nhttps://github.com/elastic/kibana/issues/192062\\r\\n\\r\\n## 📝\nSummary\\r\\n\\r\\nThis PR adds privileges checks for `Logs Explorerer` it\nchecks for\\r\\n`Discover & Fleet` privileges before allowing the user\naccess to `Logs\\r\\nExplorer`.\\r\\nClicking on the `Logs` tab from the\nside nav defaults to `Stream`, as\\r\\nlong as its not depricated, in case\nthe user doesn't have access to\\r\\n`Logs Explorer`\\r\\n\\r\\n## 🎥\nDemo\\r\\n\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/a4105ec0-7681-40ee-b2fd-e39b9c178dcf\",\"sha\":\"dbfd4f0879aa89c49b379cc2c6c5feb74f5c16c7\"}},{\"branch\":\"8.15\",\"label\":\"v8.15.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.x\",\"label\":\"v8.16.0\",\"branchLabelMappingKey\":\"^v8.16.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: mohamedhamed-ahmed <mohamed.ahmed@elastic.co>"}}]}] BACKPORT-->