### PR TITLE
chore(deps): upgrade `rxjs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1237,7 +1237,7 @@
     "reselect": "^4.1.8",
     "resize-observer-polyfill": "1.5.1",
     "rison-node": "1.0.2",
-    "rxjs": "^7.5.5",
+    "rxjs": "^7.8.1",
     "safe-squel": "^5.12.5",
     "seedrandom": "^3.0.5",
     "semver": "^7.6.3",

--- a/renovate.json
+++ b/renovate.json
@@ -109,6 +109,14 @@
       "enabled": true
     },
     {
+      "groupName": "RxJS",
+      "matchDepNames": ["rxjs"],
+      "reviewers": ["team:kibana-core"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "Team:Core", "backport:skip"],
+      "enabled": true
+    },
+    {
       "groupName": "@elastic/ebt",
       "matchDepNames": ["@elastic/ebt"],
       "reviewers": ["team:kibana-core"],


### PR DESCRIPTION
## Summary

Change list: https://github.com/ReactiveX/rxjs/compare/7.5.5...7.8.1


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->