### PR TITLE
chore(deps): add `lodash` to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -117,6 +117,14 @@
       "enabled": true
     },
     {
+      "groupName": "lodash",
+      "matchDepNames": ["lodash", "@types/lodash"],
+      "reviewers": ["team:kibana-core"],
+      "matchBaseBranches": ["main"],
+      "labels": ["release_note:skip", "Team:Core", "backport:skip"],
+      "enabled": true
+    },
+    {
       "groupName": "ansi-regex",
       "matchDepNames": ["ansi-regex"],
       "reviewers": ["team:kibana-core"],


### PR DESCRIPTION
## Summary

`lodash` hasn't been updated in 4 years, but its types are actively maintained. Let's keep them up-to-date.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
