### PR TITLE
chore(deps): Add `joi` to the hapi group in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -136,7 +136,7 @@
     },
     {
       "groupName": "HAPI ecosystem",
-      "matchDepNames": ["@hapi/**", "brok"],
+      "matchDepNames": ["@hapi/**", "brok", "joi"],
       "reviewers": ["team:kibana-core"],
       "matchBaseBranches": ["main"],
       "labels": ["release_note:skip", "Team:Core", "backport:prev-minor"],


### PR DESCRIPTION
## Summary

Add `joi` to renovate. I chose to add it to the group `hapi ecosystem`, as potential compatibility issues might be addressed when updating them together.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

I decided to use `backport:prev-minor` as this is a follow up to #180986


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->