### PR TITLE
Remove Sass `@euiPanel` mixin usage

### DIFF
--- a/src/plugins/vis_types/timeseries/public/application/components/_annotations_editor.scss
+++ b/src/plugins/vis_types/timeseries/public/application/components/_annotations_editor.scss
@@ -3,8 +3,6 @@
   background-color: $euiColorLightestShade;
 }
 
-@include euiPanel('.tvbAnnotationsEditor');
-
 .tvbAnnotationsEditor {
   margin-bottom: $euiSize;
   padding: $euiSizeS;

--- a/src/plugins/vis_types/timeseries/public/application/components/_series_editor.scss
+++ b/src/plugins/vis_types/timeseries/public/application/components/_series_editor.scss
@@ -2,8 +2,6 @@
   padding: $euiSize;
 }
 
-@include euiPanel('.tvbSeriesEditor');
-
 .tvbSeriesEditor {
   margin-bottom: $euiSize;
   padding: $euiSizeS;

--- a/x-pack/plugins/searchprofiler/public/application/_app.scss
+++ b/x-pack/plugins/searchprofiler/public/application/_app.scss
@@ -37,6 +37,7 @@ $bodyOffset: $euiSize * 3;
 
 .prfDevTool__main {
   height: 100%;
+  flex-grow: 1;
   order: 2;
   margin-left: $euiSize;
   display: flex;
@@ -48,8 +49,6 @@ $bodyOffset: $euiSize * 3;
     flex-shrink: 0;
   }
 }
-
-@include euiPanel('.prfDevTool__main');
 
 @include euiBreakpoint('xs', 's') {
   .prfDevTool__container {


### PR DESCRIPTION
## Summary

This PR is part of EUI's ongoing Emotion migration. We are actively deprecating/removing Sass mixins and variables that are component-specific.

In this case, the `@mixin euiPanel` **only** sets `flex-grow: 1;` as its default CSS and creates a bunch of modifier classes, none of which were being used in Kibana - hence various removals (see git commits for more specifics).

### QA

- [x] Checked Search Profiler for visual regressions
- [x] Checked Visualize Library > TSVB for visual regressions

### Checklist

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->