### PR TITLE
Remove Sass `@euiToolTip` mixin usages

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/public/components/tooltip/tooltip.scss
+++ b/src/plugins/chart_expressions/expression_xy/public/components/tooltip/tooltip.scss
@@ -2,13 +2,11 @@
   pointer-events: none;
   & { // stylelint-disable-line no-duplicate-selectors
     max-width: $euiSizeXL * 10;
+    width: max-content;
     overflow: hidden;
     padding: $euiSizeS;
   }
   table {
-    table-layout: fixed;
-    width: 100%;
-
     td,
     th {
       text-align: left;

--- a/src/plugins/chart_expressions/expression_xy/public/components/tooltip/tooltip.scss
+++ b/src/plugins/chart_expressions/expression_xy/public/components/tooltip/tooltip.scss
@@ -1,6 +1,5 @@
 .detailedTooltip {
   pointer-events: none;
-  @include euiToolTipStyle('s');
   & { // stylelint-disable-line no-duplicate-selectors
     max-width: $euiSizeXL * 10;
     overflow: hidden;

--- a/src/plugins/chart_expressions/expression_xy/public/components/tooltip/tooltip.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/components/tooltip/tooltip.tsx
@@ -8,6 +8,9 @@
  */
 
 import { TooltipInfo, XYChartSeriesIdentifier } from '@elastic/charts';
+import { useEuiMemoizedStyles } from '@elastic/eui';
+// @ts-ignore Kibana does not have types for eui/lib
+import { euiToolTipStyles } from '@elastic/eui/lib/components/tool_tip/tool_tip.styles';
 import { FormatFactory } from '@kbn/field-formats-plugin/common';
 import { getAccessorByDimension } from '@kbn/visualizations-plugin/common/utils';
 import React, { FC } from 'react';
@@ -49,6 +52,8 @@ export const Tooltip: FC<Props> = ({
   xDomain,
   layers,
 }) => {
+  const styles = useEuiMemoizedStyles(euiToolTipStyles);
+
   const pickedValue = values.find(({ isHighlighted }) => isHighlighted);
 
   if (!pickedValue) {
@@ -126,7 +131,7 @@ export const Tooltip: FC<Props> = ({
   const renderEndzoneTooltip = header ? isEndzoneBucket(header?.value, xDomain) : false;
 
   return (
-    <div className="detailedTooltip">
+    <div className="detailedTooltip" css={styles.euiToolTip}>
       {renderEndzoneTooltip && (
         <div className="detailedTooltip__header">
           <EndzoneTooltipHeader />

--- a/src/plugins/vis_types/vislib/public/vislib/components/tooltip/_tooltip.scss
+++ b/src/plugins/vis_types/vislib/public/vislib/components/tooltip/_tooltip.scss
@@ -1,12 +1,15 @@
 .visTooltip,
 .visTooltip__sizingClone {
-  @include euiToolTipStyle('s');
+  z-index: $euiZLevel9;
   visibility: hidden;
   pointer-events: none;
   position: fixed;
   max-width: $euiSizeXL * 10;
   overflow: hidden;
   padding: 0;
+  color: $euiColorGhost;
+  background-color: $euiColorFullShade;
+  border-radius: $euiBorderRadius;
 
   > :last-child {
     margin-bottom: $euiSizeS;

--- a/x-pack/plugins/canvas/public/components/layout_annotations/layout_annotations.scss
+++ b/x-pack/plugins/canvas/public/components/layout_annotations/layout_annotations.scss
@@ -72,7 +72,6 @@
 }
 
 .tooltipAnnotation {
-  @include euiToolTipStyle($size: 's');
   position: absolute;
   transform-origin: center center; /* the default, only for clarity */
   transform-style: preserve-3d;

--- a/x-pack/plugins/canvas/public/components/layout_annotations/layout_annotations.scss
+++ b/x-pack/plugins/canvas/public/components/layout_annotations/layout_annotations.scss
@@ -77,4 +77,5 @@
   transform-style: preserve-3d;
   outline: none;
   pointer-events: none;
+  line-height: 1;
 }

--- a/x-pack/plugins/canvas/public/components/layout_annotations/tooltip_annotation.tsx
+++ b/x-pack/plugins/canvas/public/components/layout_annotations/tooltip_annotation.tsx
@@ -7,6 +7,9 @@
 
 import React, { FC } from 'react';
 import PropTypes from 'prop-types';
+import { useEuiMemoizedStyles } from '@elastic/eui';
+// @ts-ignore Kibana does not have types for eui/lib
+import { euiToolTipStyles } from '@elastic/eui/lib/components/tool_tip/tool_tip.styles';
 import { matrixToCSS } from '../../lib/dom';
 import { TransformMatrix3d } from '../../lib/aeroelastic';
 
@@ -19,8 +22,9 @@ export const TooltipAnnotation: FC<Props> = ({ transformMatrix, text }) => {
   const newStyle = {
     transform: `${matrixToCSS(transformMatrix)} translate(1em, -1em)`,
   };
+  const { euiToolTip } = useEuiMemoizedStyles(euiToolTipStyles);
   return (
-    <div className="tooltipAnnotation canvasLayoutAnnotation" style={newStyle}>
+    <div className="tooltipAnnotation canvasLayoutAnnotation" css={euiToolTip} style={newStyle}>
       <p>{text}°</p>
     </div>
   );

--- a/x-pack/plugins/ml/public/application/components/chart_tooltip/_chart_tooltip.scss
+++ b/x-pack/plugins/ml/public/application/components/chart_tooltip/_chart_tooltip.scss
@@ -4,7 +4,8 @@
   transition: opacity $euiAnimSpeedNormal;
   pointer-events: none;
   user-select: none;
-  max-width: 512px;
+  max-width: max(512px, 90vw);
+  width: max-content;
 
   &__list {
     margin: $euiSizeXS;

--- a/x-pack/plugins/ml/public/application/components/chart_tooltip/_chart_tooltip.scss
+++ b/x-pack/plugins/ml/public/application/components/chart_tooltip/_chart_tooltip.scss
@@ -1,5 +1,4 @@
 .mlChartTooltip {
-  @include euiToolTipStyle('s');
   @include euiFontSizeXS;
   padding: 0;
   transition: opacity $euiAnimSpeedNormal;
@@ -13,7 +12,6 @@
   }
 
   &__header {
-    @include euiToolTipTitle;
     padding: $euiSizeXS ($euiSizeXS * 2);
   }
 

--- a/x-pack/plugins/ml/public/application/components/chart_tooltip/chart_tooltip.tsx
+++ b/x-pack/plugins/ml/public/application/components/chart_tooltip/chart_tooltip.tsx
@@ -62,7 +62,7 @@ export const FormattedTooltip: FC<{ tooltipData: TooltipData }> = ({ tooltipData
                     borderLeftColor: color,
                   }}
                 >
-                  <EuiFlexGroup>
+                  <EuiFlexGroup responsive={false}>
                     <EuiFlexItem className="eui-textBreakWord mlChartTooltip__label" grow={false}>
                       {label}
                     </EuiFlexItem>

--- a/x-pack/plugins/ml/public/application/components/chart_tooltip/chart_tooltip.tsx
+++ b/x-pack/plugins/ml/public/application/components/chart_tooltip/chart_tooltip.tsx
@@ -9,7 +9,9 @@ import type { FC } from 'react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import TooltipTrigger from 'react-popper-tooltip';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, useEuiMemoizedStyles } from '@elastic/eui';
+// @ts-ignore Kibana does not have types for eui/lib
+import { euiToolTipStyles } from '@elastic/eui/lib/components/tool_tip/tool_tip.styles';
 import type { TooltipValueFormatter } from '@elastic/charts';
 
 import './_index.scss';
@@ -30,10 +32,13 @@ const renderHeader = (headerData?: ChartTooltipValue, formatter?: TooltipValueFo
  * Pure component for rendering the tooltip content with a custom layout across the ML plugin.
  */
 export const FormattedTooltip: FC<{ tooltipData: TooltipData }> = ({ tooltipData }) => {
+  const styles = useEuiMemoizedStyles(euiToolTipStyles);
   return (
-    <div className="mlChartTooltip">
+    <div className="mlChartTooltip" css={styles.euiToolTip}>
       {tooltipData.length > 0 && tooltipData[0].skipHeader === undefined && (
-        <div className="mlChartTooltip__header">{renderHeader(tooltipData[0])}</div>
+        <div className="mlChartTooltip__header" css={styles.euiToolTip__title}>
+          {renderHeader(tooltipData[0])}
+        </div>
       )}
       {tooltipData.length > 1 && (
         <div className="mlChartTooltip__list">


### PR DESCRIPTION
## Summary

This PR is part of EUI's ongoing Emotion migration, and removes EuiToolTip Sass mixins that will shortly be removed/deprecated from EUI.

3 usages of tooltip style mixins have been replaced with its migrated Emotion/CSS-in-JS equivalent. This is a somewhat stopgap measure - if possible, we'd prefer consumers not reach directly into our internal/styles and use the baseline `<EuiToolTip>` component instead. That being said, I've QA'd (almost) all instances and have confirmed that the affected tooltips still look the same as before (see below inline comment threads for before/after screenshots).

### Checklist

- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)