### PR TITLE
Rollback to 3 parallel migrators

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kb_nodes.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kb_nodes.test.ts
@@ -34,7 +34,7 @@ import { delay, parseLogFile } from '../test_utils';
 import '../jest_matchers';
 import { expectDocumentsMigratedToHighestVersion } from '../kibana_migrator_test_kit.expect';
 
-const PARALLEL_MIGRATORS = 4;
+const PARALLEL_MIGRATORS = 3;
 type Job<T> = () => Promise<T>;
 
 const getLogFile = (node: number) => join(__dirname, `multiple_kb_nodes_${node}.log`);


### PR DESCRIPTION
## Summary

Address https://github.com/elastic/kibana/issues/194490
This test used to have 3 parallel migrators.
I updated it to 4 during the `9.0.0` migrations' tests upgrades.
It seems that it could be a bit too much for CI.
This PR sets the value back to 3.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->