### PR TITLE
[fix] type issue from race condition on merge

### DIFF
--- a/packages/kbn-search-api-keys-components/src/providers/search_api_key_provider.tsx
+++ b/packages/kbn-search-api-keys-components/src/providers/search_api_key_provider.tsx
@@ -72,7 +72,7 @@ export const ApiKeyContext = createContext<APIKeyContext>({
   initialiseKey: () => {},
 });
 
-export const SearchApiKeyProvider: React.FC = ({ children }) => {
+export const SearchApiKeyProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { http } = useKibana().services;
   const [state, dispatch] = useReducer(reducer, initialState);
 


### PR DESCRIPTION
## Summary
https://github.com/elastic/kibana/pull/191926 introduces something that's in contradiction with https://github.com/elastic/kibana/pull/194144 

This PR adds a fix.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->