### PR TITLE
Fix flaky test around search cancellation pt2

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/cancellable/rule.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/cancellable/rule.ts
@@ -146,7 +146,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
           `test.cancellableRule:${ruleId}: execution cancelled due to timeout - exceeded rule type timeout of 3s`,
         ].includes(rule.execution_status.error.message)
       ).to.eql(true);
-      expect(rule.execution_status.error.reason).to.eql('timeout');
+      expect(['timeout', 'execute'].includes(rule.execution_status.error.reason)).to.eql(true);
     });
 
     it('throws an error if execution is short circuited', async () => {
@@ -195,7 +195,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
           `test.cancellableRule:${ruleId}: execution cancelled due to timeout - exceeded rule type timeout of 3s`,
         ].includes(rule.execution_status.error.message)
       ).to.eql(true);
-      expect(rule.execution_status.error.reason).to.eql('timeout');
+      expect(['timeout', 'execute'].includes(rule.execution_status.error.reason)).to.eql(true);
     });
 
     interface CreateRuleParams {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/long_running/rule.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/long_running/rule.ts
@@ -80,7 +80,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
           `test.patternLongRunning.cancelAlertsOnRuleTimeout:${ruleId}: execution cancelled due to timeout - exceeded rule type timeout of 3s`,
         ].includes(lastErrorStatus?.error.message || '')
       ).to.eql(true);
-      expect(lastErrorStatus?.error.reason).to.eql('timeout');
+      expect(['timeout', 'execute'].includes(lastErrorStatus?.error.reason || '')).to.eql(true);
     });
 
     it('writes event log document for timeout for each rule execution that ends in timeout - some executions times out', async () => {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/192914.

Follow up from https://github.com/elastic/kibana/pull/193008 as the GitHub issue got re-opened (https://github.com/elastic/kibana/issues/192914#issuecomment-2383972707).

In the first PR, I fixed the assertion on the error message, in this PR, I'm fixing the assertion on the status reason which varies from `timeout` and `execute` depending on where the error initiated from (abort controller vs ES client).

Note: Test is not skipped as of PR creation

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7065

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->