### PR TITLE
[ci] Split artifacts-container-image alerts

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
@@ -18,7 +18,7 @@ spec:
       description: Kibana container image artifact builds
     spec:
       env:
-        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-serverless-test-alerts'
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
       branch_configuration: main

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -133,6 +133,7 @@ steps:
       env:
         SERVICE_COMMIT_HASH: "$GIT_ABBREV_COMMIT"
         SERVICE: kibana
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-serverless-test-alerts'
         REMOTE_SERVICE_CONFIG: https://raw.githubusercontent.com/elastic/serverless-gitops/main/gen/gpctl/kibana/dev.yaml
         GPCTL_PROMOTE_DRY_RUN: ${DRY_RUN:-false}
 EOF


### PR DESCRIPTION
This modifies alerts to route build failures to our general alert channel and leaves test failures to the test alerts channel