### PR TITLE
[8.x] Fix flaky test #194043 (#194670)

### DIFF
--- a/test/functional/apps/discover/context_awareness/extensions/_get_row_indicator_provider.ts
+++ b/test/functional/apps/discover/context_awareness/extensions/_get_row_indicator_provider.ts
@@ -24,8 +24,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
   const dataViews = getService('dataViews');
 
-  // Failing: See https://github.com/elastic/kibana/issues/194043
-  describe.skip('extension getRowIndicatorProvider', () => {
+  describe('extension getRowIndicatorProvider', () => {
     before(async () => {
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
     });
@@ -129,6 +128,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await browser.refresh();
       await header.waitUntilLoadingHasFinished();
+      await discover.waitUntilSearchingHasFinished();
 
       anchorCell = await dataGrid.getCellElement(0, 0);
       anchorColorIndicator = await anchorCell.findByTestSubject(

--- a/x-pack/test_serverless/functional/test_suites/common/discover/context_awareness/extensions/_get_row_indicator_provider.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/context_awareness/extensions/_get_row_indicator_provider.ts
@@ -120,6 +120,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await browser.refresh();
       await PageObjects.header.waitUntilLoadingHasFinished();
+      await PageObjects.discover.waitUntilSearchingHasFinished();
 
       anchorCell = await dataGrid.getCellElement(0, 0);
       anchorColorIndicator = await anchorCell.findByTestSubject(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix flaky test #194043 (#194670)](https://github.com/elastic/kibana/pull/194670)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Matthias Wilhelm","email":"matthias.wilhelm@elastic.co"},"sourceCommit":{"committedDate":"2024-10-02T13:43:59Z","message":"Fix flaky test #194043 (#194670)\n\nFixing `getRowIndicatorProvider should render log.level row indicators on Surrounding documents page` by waiting a bit longer for the table to be rendered.","sha":"b7af143114d9055934f1c7e30f4706ef5b34aec8","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:DataDiscovery","backport:prev-minor"],"number":194670,"url":"https://github.com/elastic/kibana/pull/194670","mergeCommit":{"message":"Fix flaky test #194043 (#194670)\n\nFixing `getRowIndicatorProvider should render log.level row indicators on Surrounding documents page` by waiting a bit longer for the table to be rendered.","sha":"b7af143114d9055934f1c7e30f4706ef5b34aec8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/194670","number":194670,"mergeCommit":{"message":"Fix flaky test #194043 (#194670)\n\nFixing `getRowIndicatorProvider should render log.level row indicators on Surrounding documents page` by waiting a bit longer for the table to be rendered.","sha":"b7af143114d9055934f1c7e30f4706ef5b34aec8"}}]}] BACKPORT-->