### PR TITLE
[Security Solution][Notes] - updating colors for the save timeline callouts

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/attach_to_active_timeline.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/attach_to_active_timeline.test.tsx
@@ -15,11 +15,17 @@ import {
 import { AttachToActiveTimeline } from './attach_to_active_timeline';
 import { createMockStore, mockGlobalState, TestProviders } from '../../../../common/mock';
 import { TimelineId } from '../../../../../common/types';
+import { useUserPrivileges } from '../../../../common/components/user_privileges';
+
+jest.mock('../../../../common/components/user_privileges');
 
 const mockSetAttachToTimeline = jest.fn();
 
 describe('AttachToActiveTimeline', () => {
   it('should render the component for an unsaved timeline', () => {
+    (useUserPrivileges as jest.Mock).mockReturnValue({
+      kibanaSecuritySolutionsPrivileges: { crud: true },
+    });
     const mockStore = createMockStore({
       ...mockGlobalState,
       timeline: {
@@ -43,14 +49,15 @@ describe('AttachToActiveTimeline', () => {
     );
 
     expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toHaveStyle('background-color: #FEC514');
+    expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toHaveTextContent('Save timeline');
     expect(queryByTestId(ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID)).not.toBeInTheDocument();
-
+    expect(getByTestId(ATTACH_TO_TIMELINE_CALLOUT_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(ATTACH_TO_TIMELINE_CALLOUT_TEST_ID)).toHaveClass('euiCallOut--warning');
     expect(getByText('Attach to timeline')).toBeInTheDocument();
     expect(
       getByText('Before attaching a note to the timeline, you need to save the timeline first.')
     ).toBeInTheDocument();
-
-    expect(getByTestId(ATTACH_TO_TIMELINE_CALLOUT_TEST_ID)).toBeInTheDocument();
   });
 
   it('should render the saved timeline texts in the callout', () => {
@@ -76,13 +83,15 @@ describe('AttachToActiveTimeline', () => {
         />
       </TestProviders>
     );
-    expect(getByTestId(ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID)).toBeInTheDocument();
+
     expect(queryByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).not.toBeInTheDocument();
+    expect(getByTestId(ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(ATTACH_TO_TIMELINE_CALLOUT_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(ATTACH_TO_TIMELINE_CALLOUT_TEST_ID)).toHaveClass('euiCallOut--primary');
     expect(getByText('Attach to timeline')).toBeInTheDocument();
     expect(
       getByText('You can associate the newly created note to the active timeline.')
     ).toBeInTheDocument();
-    expect(getByTestId(ATTACH_TO_TIMELINE_CALLOUT_TEST_ID)).toBeInTheDocument();
   });
 
   it('should call the callback when user click on the checkbox', () => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/attach_to_active_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/attach_to_active_timeline.tsx
@@ -20,6 +20,8 @@ import {
 } from './test_ids';
 import { timelineSelectors } from '../../../../timelines/store';
 
+const timelineCheckBoxId = 'xpack.securitySolution.flyout.notes.attachToTimeline.checkboxId';
+
 export const ATTACH_TO_TIMELINE_CALLOUT_TITLE = i18n.translate(
   'xpack.securitySolution.flyout.left.notes.attachToTimeline.calloutTitle',
   {
@@ -44,14 +46,12 @@ export const ATTACH_TO_TIMELINE_CHECKBOX = i18n.translate(
     defaultMessage: 'Attach to active timeline',
   }
 );
-
-const timelineCheckBoxId = 'xpack.securitySolution.flyout.notes.attachToTimeline.checkboxId';
-const saveTimelineButtonOptions = {
-  buttonText: i18n.translate('xpack.securitySolution.flyout.left.notes.savedTimelineButtonLabel', {
+export const SAVE_TIMELINE_BUTTON = i18n.translate(
+  'xpack.securitySolution.flyout.left.notes.savedTimelineButtonLabel',
+  {
     defaultMessage: 'Save timeline',
-  }),
-  color: 'warning' as const,
-};
+  }
+);
 
 export interface AttachToActiveTimelineProps {
   /**
@@ -119,7 +119,8 @@ export const AttachToActiveTimeline = memo(
             ) : (
               <SaveTimelineButton
                 timelineId={TimelineId.active}
-                options={saveTimelineButtonOptions}
+                buttonText={SAVE_TIMELINE_BUTTON}
+                buttonColor="warning"
                 data-test-subj={SAVE_TIMELINE_BUTTON_TEST_ID}
               />
             )}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/attach_to_active_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/attach_to_active_timeline.tsx
@@ -20,8 +20,6 @@ import {
 } from './test_ids';
 import { timelineSelectors } from '../../../../timelines/store';
 
-const timelineCheckBoxId = 'xpack.securitySolution.flyout.notes.attachToTimeline.checkboxId';
-
 export const ATTACH_TO_TIMELINE_CALLOUT_TITLE = i18n.translate(
   'xpack.securitySolution.flyout.left.notes.attachToTimeline.calloutTitle',
   {
@@ -46,12 +44,14 @@ export const ATTACH_TO_TIMELINE_CHECKBOX = i18n.translate(
     defaultMessage: 'Attach to active timeline',
   }
 );
-export const SAVE_TIMELINE_BUTTON = i18n.translate(
-  'xpack.securitySolution.flyout.left.notes.savedTimelineButtonLabel',
-  {
+
+const timelineCheckBoxId = 'xpack.securitySolution.flyout.notes.attachToTimeline.checkboxId';
+const saveTimelineButtonOptions = {
+  buttonText: i18n.translate('xpack.securitySolution.flyout.left.notes.savedTimelineButtonLabel', {
     defaultMessage: 'Save timeline',
-  }
-);
+  }),
+  color: 'warning' as const,
+};
 
 export interface AttachToActiveTimelineProps {
   /**
@@ -93,7 +93,7 @@ export const AttachToActiveTimeline = memo(
     return (
       <EuiCallOut
         title={ATTACH_TO_TIMELINE_CALLOUT_TITLE}
-        color={'primary'}
+        color={isTimelineSaved ? 'primary' : 'warning'}
         iconType="iInCircle"
         data-test-subj={ATTACH_TO_TIMELINE_CALLOUT_TEST_ID}
         css={css`
@@ -119,7 +119,7 @@ export const AttachToActiveTimeline = memo(
             ) : (
               <SaveTimelineButton
                 timelineId={TimelineId.active}
-                buttonText={SAVE_TIMELINE_BUTTON}
+                options={saveTimelineButtonOptions}
                 data-test-subj={SAVE_TIMELINE_BUTTON_TEST_ID}
               />
             )}

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/actions/save_timeline_button.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/actions/save_timeline_button.test.tsx
@@ -58,11 +58,12 @@ describe('SaveTimelineButton', () => {
 
     expect(getByTestId('timeline-modal-save-timeline')).toBeInTheDocument();
     expect(getByText('Save')).toBeInTheDocument();
+    expect(getByTestId('timeline-modal-save-timeline')).toHaveStyle('background-color: #07C');
 
     expect(queryByTestId('save-timeline-modal')).not.toBeInTheDocument();
   });
 
-  it('should override the default text in the button', async () => {
+  it('should override the default text and color of the button', async () => {
     (useUserPrivileges as jest.Mock).mockReturnValue({
       kibanaSecuritySolutionsPrivileges: { crud: true },
     });
@@ -73,14 +74,19 @@ describe('SaveTimelineButton', () => {
     });
     (useCreateTimeline as jest.Mock).mockReturnValue({});
 
-    const { getByText, queryByText } = render(
+    const { getByTestId, getByText, queryByText } = render(
       <TestProviders>
-        <SaveTimelineButton timelineId="timeline-1" buttonText={'TEST'} />
+        <SaveTimelineButton
+          timelineId="timeline-1"
+          options={{ buttonText: 'TEST', color: 'warning' }}
+          data-test-subj={'TEST_ID'}
+        />
       </TestProviders>
     );
 
     expect(queryByText('Save')).not.toBeInTheDocument();
     expect(getByText('TEST')).toBeInTheDocument();
+    expect(getByTestId('TEST_ID')).toHaveStyle('background-color: #FEC514');
   });
 
   it('should open the timeline save modal', async () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/actions/save_timeline_button.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/actions/save_timeline_button.test.tsx
@@ -78,7 +78,8 @@ describe('SaveTimelineButton', () => {
       <TestProviders>
         <SaveTimelineButton
           timelineId="timeline-1"
-          options={{ buttonText: 'TEST', color: 'warning' }}
+          buttonText="TEST"
+          buttonColor="warning"
           data-test-subj={'TEST_ID'}
         />
       </TestProviders>

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/actions/save_timeline_button.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/actions/save_timeline_button.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
+import type { EuiButtonProps } from '@elastic/eui';
 import { EuiButton, EuiToolTip } from '@elastic/eui';
 import { useSelector } from 'react-redux';
 import { TimelineStatusEnum } from '../../../../../common/api/timeline';
@@ -22,18 +23,13 @@ export interface SaveTimelineButtonProps {
    */
   timelineId: string;
   /**
-   * Customize the button
+   * Ability to customize the text of the button
    */
-  options?: {
-    /**
-     * Ability to customize the text of the button
-     */
-    buttonText?: string;
-    /**
-     * Ability to customize the color of the button
-     */
-    color?: 'text' | 'accent' | 'primary' | 'success' | 'warning' | 'danger';
-  };
+  buttonText?: string;
+  /**
+   * Ability to customize the color of the button
+   */
+  buttonColor?: EuiButtonProps['color'];
   /**
    * Optional data-test-subj value
    */
@@ -47,7 +43,8 @@ export interface SaveTimelineButtonProps {
 export const SaveTimelineButton = React.memo<SaveTimelineButtonProps>(
   ({
     timelineId,
-    options = { buttonText: i18n.SAVE, color: 'primary' },
+    buttonText = i18n.SAVE,
+    buttonColor = 'primary',
     'data-test-subj': dataTestSubj = 'timeline-modal-save-timeline',
   }) => {
     const [showEditTimelineOverlay, setShowEditTimelineOverlay] = useState<boolean>(false);
@@ -81,14 +78,14 @@ export const SaveTimelineButton = React.memo<SaveTimelineButtonProps>(
             id={TIMELINE_TOUR_CONFIG_ANCHORS.SAVE_TIMELINE}
             fill
             size="s"
-            color={options.color}
+            color={buttonColor}
             iconType="save"
             isLoading={isSaving}
             disabled={!canSaveTimeline}
             data-test-subj={dataTestSubj}
             onClick={toggleSaveTimeline}
           >
-            {options.buttonText}
+            {buttonText}
           </EuiButton>
         </EuiToolTip>
         {showEditTimelineOverlay && canSaveTimeline ? (

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/actions/save_timeline_button.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/actions/save_timeline_button.tsx
@@ -22,9 +22,18 @@ export interface SaveTimelineButtonProps {
    */
   timelineId: string;
   /**
-   * Ability to customize the text of the button
+   * Customize the button
    */
-  buttonText?: string;
+  options?: {
+    /**
+     * Ability to customize the text of the button
+     */
+    buttonText?: string;
+    /**
+     * Ability to customize the color of the button
+     */
+    color?: 'text' | 'accent' | 'primary' | 'success' | 'warning' | 'danger';
+  };
   /**
    * Optional data-test-subj value
    */
@@ -38,7 +47,7 @@ export interface SaveTimelineButtonProps {
 export const SaveTimelineButton = React.memo<SaveTimelineButtonProps>(
   ({
     timelineId,
-    buttonText = i18n.SAVE,
+    options = { buttonText: i18n.SAVE, color: 'primary' },
     'data-test-subj': dataTestSubj = 'timeline-modal-save-timeline',
   }) => {
     const [showEditTimelineOverlay, setShowEditTimelineOverlay] = useState<boolean>(false);
@@ -72,13 +81,14 @@ export const SaveTimelineButton = React.memo<SaveTimelineButtonProps>(
             id={TIMELINE_TOUR_CONFIG_ANCHORS.SAVE_TIMELINE}
             fill
             size="s"
+            color={options.color}
             iconType="save"
             isLoading={isSaving}
             disabled={!canSaveTimeline}
             data-test-subj={dataTestSubj}
             onClick={toggleSaveTimeline}
           >
-            {buttonText}
+            {options.buttonText}
           </EuiButton>
         </EuiToolTip>
         {showEditTimelineOverlay && canSaveTimeline ? (

--- a/x-pack/plugins/security_solution/public/timelines/components/notes/save_timeline.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/notes/save_timeline.test.tsx
@@ -11,9 +11,16 @@ import { SaveTimelineCallout } from './save_timeline';
 import { SAVE_TIMELINE_BUTTON_TEST_ID, SAVE_TIMELINE_CALLOUT_TEST_ID } from './test_ids';
 import { createMockStore, mockGlobalState, TestProviders } from '../../../common/mock';
 import { TimelineId } from '../../../../common/types';
+import { useUserPrivileges } from '../../../common/components/user_privileges';
+
+jest.mock('../../../common/components/user_privileges');
 
 describe('SaveTimelineCallout', () => {
   it('should render the callout and save components', () => {
+    (useUserPrivileges as jest.Mock).mockReturnValue({
+      kibanaSecuritySolutionsPrivileges: { crud: true },
+    });
+
     const mockStore = createMockStore({
       ...mockGlobalState,
       timeline: {
@@ -33,11 +40,13 @@ describe('SaveTimelineCallout', () => {
       </TestProviders>
     );
 
+    expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toHaveStyle('background-color: #BD271E');
+    expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toHaveTextContent('Save timeline');
     expect(getByTestId(SAVE_TIMELINE_CALLOUT_TEST_ID)).toBeInTheDocument();
     expect(getAllByText('Save timeline')).toHaveLength(2);
     expect(
       getByText('You need to save your timeline before creating notes for it.')
     ).toBeInTheDocument();
-    expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/notes/save_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/notes/save_timeline.tsx
@@ -25,13 +25,12 @@ export const SAVE_TIMELINE_CALLOUT_CONTENT = i18n.translate(
     defaultMessage: 'You need to save your timeline before creating notes for it.',
   }
 );
-
-const saveTimelineButtonOptions = {
-  buttonText: i18n.translate('xpack.securitySolution.flyout.left.notes.savedTimelineButtonLabel', {
+export const SAVE_TIMELINE_BUTTON = i18n.translate(
+  'xpack.securitySolution.flyout.left.notes.savedTimelineButtonLabel',
+  {
     defaultMessage: 'Save timeline',
-  }),
-  color: 'danger' as const,
-};
+  }
+);
 
 /**
  * Renders a callout to let the user know they have to save the timeline before creating notes
@@ -54,7 +53,8 @@ export const SaveTimelineCallout = memo(() => {
         <EuiFlexItem grow={false}>
           <SaveTimelineButton
             timelineId={TimelineId.active}
-            options={saveTimelineButtonOptions}
+            buttonText={SAVE_TIMELINE_BUTTON}
+            buttonColor="danger"
             data-test-subj={SAVE_TIMELINE_BUTTON_TEST_ID}
           />
         </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/timelines/components/notes/save_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/notes/save_timeline.tsx
@@ -25,12 +25,13 @@ export const SAVE_TIMELINE_CALLOUT_CONTENT = i18n.translate(
     defaultMessage: 'You need to save your timeline before creating notes for it.',
   }
 );
-export const SAVE_TIMELINE_BUTTON = i18n.translate(
-  'xpack.securitySolution.flyout.left.notes.savedTimelineButtonLabel',
-  {
+
+const saveTimelineButtonOptions = {
+  buttonText: i18n.translate('xpack.securitySolution.flyout.left.notes.savedTimelineButtonLabel', {
     defaultMessage: 'Save timeline',
-  }
-);
+  }),
+  color: 'danger' as const,
+};
 
 /**
  * Renders a callout to let the user know they have to save the timeline before creating notes
@@ -39,7 +40,7 @@ export const SaveTimelineCallout = memo(() => {
   return (
     <EuiCallOut
       title={SAVE_TIMELINE_CALLOUT_TITLE}
-      color="warning"
+      color="danger"
       iconType="iInCircle"
       data-test-subj={SAVE_TIMELINE_CALLOUT_TEST_ID}
       css={css`
@@ -53,7 +54,7 @@ export const SaveTimelineCallout = memo(() => {
         <EuiFlexItem grow={false}>
           <SaveTimelineButton
             timelineId={TimelineId.active}
-            buttonText={SAVE_TIMELINE_BUTTON}
+            options={saveTimelineButtonOptions}
             data-test-subj={SAVE_TIMELINE_BUTTON_TEST_ID}
           />
         </EuiFlexItem>


### PR DESCRIPTION
## Summary

This previous [PR](https://github.com/elastic/kibana/pull/193930) introduced callouts to the Notes tab of Timeline and flyout when the timeline hasn't been saved. This PR makes a small tweak to the colors used in these callouts:
- in Timeline, the callout is now red with a red `Save timeline` button to highlight that no notes can be created without saving the timeline first
- in the flyout, the callout is now yellow to let the user know that in order to associate a note with a timeline, it must be saved first. This is not a requirement to create a new note so red does not make sense.

#### Timeline Notes tab

![Screenshot 2024-10-02 at 12 30 36 PM](https://github.com/user-attachments/assets/44a8d1a3-f4fc-485f-a3a1-878407b519e9)

#### Flyout Notes tab (unsaved timeline)

![Screenshot 2024-10-02 at 12 31 04 PM](https://github.com/user-attachments/assets/dcd1dbe0-c651-4067-8d0c-e69c8c4e1dd6)

#### Flyout Notes tab (saved timeline)

The last callout remains unchanged, blue as it is just un information.

![Screenshot 2024-10-02 at 12 37 10 PM](https://github.com/user-attachments/assets/7b9e3c53-428e-46e5-ae70-69bed54d037e)

https://github.com/elastic/kibana/issues/193098

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->