### PR TITLE
[Response Ops][Task Manager] Handle errors in `getCapacity` function during task polling

### DIFF
--- a/x-pack/plugins/task_manager/server/polling/task_poller.ts
+++ b/x-pack/plugins/task_manager/server/polling/task_poller.ts
@@ -61,14 +61,15 @@ export function createTaskPoller<T, H>({
   async function runCycle() {
     timeoutId = null;
     const start = Date.now();
-    if (hasCapacity()) {
-      try {
+    try {
+      if (hasCapacity()) {
         const result = await work();
         subject.next(asOk(result));
-      } catch (e) {
-        subject.next(asPollingError<T>(e, PollingErrorType.WorkError));
       }
+    } catch (e) {
+      subject.next(asPollingError<T>(e, PollingErrorType.WorkError));
     }
+
     if (running) {
       // Set the next runCycle call
       timeoutId = setTimeout(

--- a/x-pack/plugins/task_manager/server/task_claimers/strategy_mget.ts
+++ b/x-pack/plugins/task_manager/server/task_claimers/strategy_mget.ts
@@ -247,6 +247,16 @@ async function claimAvailableTasks(opts: TaskClaimerOpts): Promise<ClaimOwnershi
     []
   );
 
+  // Look for tasks that have a null startedAt value, log them and manually set a startedAt field
+  for (const task of fullTasksToRun) {
+    if (task.startedAt == null) {
+      logger.warn(
+        `Task ${task.id} has a null startedAt value, setting to current time - ownerId ${task.ownerId}, status ${task.status}`
+      );
+      task.startedAt = now;
+    }
+  }
+
   // separate update for removed tasks; shouldn't happen often, so unlikely
   // a performance concern, and keeps the rest of the logic simpler
   let removedCount = 0;


### PR DESCRIPTION
## Summary

* Moves the `getCapacity` call during task polling within the try/catch so any errors with this function will be caught and logged under the `Failed to poll for work` message and polling continues
* During `mget` claim strategy, perform a final check after the `bulkGet` to check for tasks with a null `startedAt` value. If any tasks meet this condition, log some basic info and manually assign the `startedAt`. This is a stop-gap measure to ensure we understand why we might be seeing tasks with null `startedAt` values. In the future we may choose to filter out these tasks from running in this cycle.

<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->