### PR TITLE
[PoC] Attempt to add the took time in the query history

### DIFF
--- a/packages/kbn-es-types/src/search.ts
+++ b/packages/kbn-es-types/src/search.ts
@@ -681,6 +681,7 @@ export interface ESQLSearchResponse {
   // while columns only the available ones (non nulls)
   all_columns?: ESQLColumn[];
   values: ESQLRow[];
+  took?: number;
 }
 
 export interface ESQLSearchParams {

--- a/packages/kbn-esql-editor/src/editor_footer/index.tsx
+++ b/packages/kbn-esql-editor/src/editor_footer/index.tsx
@@ -60,7 +60,6 @@ interface EditorFooterProps {
   isSpaceReduced?: boolean;
   hideTimeFilterInfo?: boolean;
   hideQueryHistory?: boolean;
-  isInCompactMode?: boolean;
   displayDocumentationAsFlyout?: boolean;
 }
 
@@ -84,7 +83,6 @@ export const EditorFooter = memo(function EditorFooter({
   isLanguageComponentOpen,
   setIsLanguageComponentOpen,
   hideQueryHistory,
-  isInCompactMode,
   displayDocumentationAsFlyout,
   measuredContainerWidth,
   code,

--- a/packages/kbn-esql-editor/src/editor_footer/query_history.test.tsx
+++ b/packages/kbn-esql-editor/src/editor_footer/query_history.test.tsx
@@ -21,6 +21,7 @@ jest.mock('../history_local_storage', () => {
         timeZone: 'Browser',
         timeRan: 'Mar. 25, 24 08:45:27',
         queryRunning: false,
+        duration: '12ms',
         status: 'success',
       },
     ],
@@ -76,6 +77,16 @@ describe('QueryHistory', () => {
           width: '240px',
         },
         {
+          'data-test-subj': 'lastDuration',
+          field: 'duration',
+          name: 'Last duration',
+          sortable: false,
+          width: '120px',
+          css: {
+            justifyContent: 'flex-end',
+          },
+        },
+        {
           actions: [],
           'data-test-subj': 'actions',
           name: '',
@@ -112,6 +123,16 @@ describe('QueryHistory', () => {
         field: 'queryString',
         name: 'Recent queries',
         render: expect.anything(),
+      },
+      {
+        'data-test-subj': 'lastDuration',
+        field: 'duration',
+        name: 'Last duration',
+        sortable: false,
+        width: 'auto',
+        css: {
+          justifyContent: 'flex-end',
+        },
       },
       {
         actions: [],

--- a/packages/kbn-esql-editor/src/editor_footer/query_history.tsx
+++ b/packages/kbn-esql-editor/src/editor_footer/query_history.tsx
@@ -188,6 +188,19 @@ export const getTableColumns = (
       width: isOnReducedSpaceLayout ? 'auto' : '240px',
     },
     {
+      field: 'duration',
+      'data-test-subj': 'lastDuration',
+      name: i18n.translate(
+        'textBasedEditor.query.textBasedLanguagesEditor.lastDurationColumnLabel',
+        {
+          defaultMessage: 'Last duration',
+        }
+      ),
+      sortable: false,
+      width: isOnReducedSpaceLayout ? 'auto' : '120px',
+      css: { justifyContent: 'flex-end' as const }, // right alignment
+    },
+    {
       name: '',
       actions,
       'data-test-subj': 'actions',
@@ -303,6 +316,9 @@ export function QueryHistory({
     .euiTableRowCell {
       vertical-align: top;
       border: none;
+    }
+    .euiTable th[data-test-subj='tableHeaderCell_duration_3'] span {
+      justify-content: flex-end;
     }
     border-bottom-left-radius: ${euiTheme.border.radius.medium};
     border-top-left-radius: ${euiTheme.border.radius.medium};

--- a/packages/kbn-esql-editor/src/editor_footer/query_history_helpers.ts
+++ b/packages/kbn-esql-editor/src/editor_footer/query_history_helpers.ts
@@ -19,11 +19,11 @@ export const getReducedSpaceStyling = () => {
         }
         .euiTable thead tr {
           display: grid;
-          grid-template-columns: 40px 1fr 0 auto;
+          grid-template-columns: 40px 1fr 0 auto 72px;
         }
         .euiTable tbody tr {
           display: grid;
-          grid-template-columns: 40px 1fr auto;
+          grid-template-columns: 40px 1fr auto 72px;
           grid-template-areas:
             'status timeRan lastDuration actions'
             '. queryString queryString queryString';

--- a/packages/kbn-esql-editor/src/esql_editor.tsx
+++ b/packages/kbn-esql-editor/src/esql_editor.tsx
@@ -77,6 +77,7 @@ export const ESQLEditor = memo(function ESQLEditor({
   hideQueryHistory,
   hasOutline,
   displayDocumentationAsFlyout,
+  queryTime,
 }: ESQLEditorProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const datePickerOpenStatusRef = useRef<boolean>(false);
@@ -461,9 +462,10 @@ export const ESQLEditor = memo(function ESQLEditor({
         queryString: code,
         timeZone,
         status: clientParserStatus,
+        duration: queryTime ? `${queryTime}ms` : '',
       });
     }
-  }, [clientParserStatus, isLoading, isQueryLoading, parseMessages, code, timeZone]);
+  }, [clientParserStatus, isLoading, isQueryLoading, parseMessages, code, timeZone, queryTime]);
 
   const queryValidation = useCallback(
     async ({ active }: { active: boolean }) => {

--- a/packages/kbn-esql-editor/src/history_local_storage.test.ts
+++ b/packages/kbn-esql-editor/src/history_local_storage.test.ts
@@ -25,6 +25,7 @@ describe('history local storage', function () {
     const historyItems = getCachedQueries();
     expect(historyItems.length).toBe(1);
     expect(historyItems[0].timeRan).toBeDefined();
+    expect(historyItems[0].duration).toBeUndefined();
     expect(historyItems[0].status).toBeUndefined();
   });
 
@@ -33,11 +34,13 @@ describe('history local storage', function () {
       queryString: 'from kibana_sample_data_flights \n | limit 10 \n | stats meow = avg(woof)',
       timeZone: 'Browser',
       status: 'success',
+      duration: '1.2s',
     });
 
     const historyItems = getCachedQueries();
     expect(historyItems.length).toBe(2);
     expect(historyItems[1].timeRan).toBeDefined();
+    expect(historyItems[1].duration).toBeDefined();
     expect(historyItems[1].status).toBe('success');
 
     expect(mockSetItem).toHaveBeenCalledWith(

--- a/packages/kbn-esql-editor/src/history_local_storage.ts
+++ b/packages/kbn-esql-editor/src/history_local_storage.ts
@@ -22,6 +22,7 @@ export interface QueryHistoryItem {
   startDateMilliseconds?: number;
   timeRan?: string;
   timeZone?: string;
+  duration?: string;
 }
 
 const MAX_QUERIES_NUMBER = 20;

--- a/packages/kbn-esql-editor/src/types.ts
+++ b/packages/kbn-esql-editor/src/types.ts
@@ -64,6 +64,9 @@ export interface ESQLEditorProps {
 
   /** adds a documentation icon in the footer which opens the inline docs as a flyout **/
   displayDocumentationAsFlyout?: boolean;
+
+  /** Query took time, coming from ES **/
+  queryTime?: number;
 }
 
 export interface ESQLEditorDeps {

--- a/src/plugins/data/common/search/expressions/esql.ts
+++ b/src/plugins/data/common/search/expressions/esql.ts
@@ -271,6 +271,22 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
                         defaultMessage: 'The number of documents returned by the query.',
                       }),
                     },
+                    ...(rawResponse?.took && {
+                      queryTime: {
+                        label: i18n.translate('data.search.es_search.queryTimeLabel', {
+                          defaultMessage: 'Query time',
+                        }),
+                        value: i18n.translate('data.search.es_search.queryTimeValue', {
+                          defaultMessage: '{queryTime}ms',
+                          values: { queryTime: rawResponse.took },
+                        }),
+                        description: i18n.translate('data.search.es_search.queryTimeDescription', {
+                          defaultMessage:
+                            'The time it took to process the query. ' +
+                            'Does not include the time to send the request or parse it in the browser.',
+                        }),
+                      },
+                    }),
                   })
                   .json(params)
                   .ok({ json: rawResponse, requestParams });
@@ -318,6 +334,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
             columns: allColumns,
             rows,
             warning,
+            queryTime: body.took,
           } as Datatable;
         })
       );

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -279,6 +279,12 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
   const contentCentered = resultState === 'uninitialized' || resultState === 'none';
   const documentState = useDataState(stateContainer.dataState.data$.documents$);
 
+  const esqlQueryTime = useMemo(() => {
+    if (isEsqlMode) {
+      return documentState.esqlQueryTime;
+    }
+  }, [documentState.esqlQueryTime, isEsqlMode]);
+
   const esqlModeWarning = useMemo(() => {
     if (isEsqlMode) {
       return documentState.esqlHeaderWarning;
@@ -396,6 +402,7 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
         stateContainer={stateContainer}
         esqlModeErrors={esqlModeErrors}
         esqlModeWarning={esqlModeWarning}
+        esqlQueryTime={esqlQueryTime}
         onFieldEdited={onFieldEdited}
         isLoading={isLoading}
         onCancelClick={onCancelClick}

--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -31,6 +31,7 @@ export interface DiscoverTopNavProps {
   stateContainer: DiscoverStateContainer;
   esqlModeErrors?: Error;
   esqlModeWarning?: string;
+  esqlQueryTime?: number;
   onFieldEdited: () => Promise<void>;
   isLoading?: boolean;
   onCancelClick?: () => void;
@@ -41,6 +42,7 @@ export const DiscoverTopNav = ({
   stateContainer,
   esqlModeErrors,
   esqlModeWarning,
+  esqlQueryTime,
   onFieldEdited,
   isLoading,
   onCancelClick,
@@ -280,6 +282,7 @@ export const DiscoverTopNav = ({
         displayStyle="detached"
         textBasedLanguageModeErrors={esqlModeErrors ? [esqlModeErrors] : undefined}
         textBasedLanguageModeWarning={esqlModeWarning}
+        esqlQueryTime={esqlQueryTime}
         prependFilterBar={
           searchBarCustomization?.PrependFilterBar ? (
             <searchBarCustomization.PrependFilterBar />

--- a/src/plugins/discover/public/application/main/data_fetching/fetch_esql.ts
+++ b/src/plugins/discover/public/application/main/data_fetching/fetch_esql.ts
@@ -76,6 +76,7 @@ export function fetchEsql({
         let esqlQueryColumns: Datatable['columns'] | undefined;
         let error: string | undefined;
         let esqlHeaderWarning: string | undefined;
+        let esqlQueryTime: number | undefined;
         execution.pipe(pluck('result')).subscribe((resp) => {
           const response = resp as Datatable | EsqlErrorResponse;
           if (response.type === 'error') {
@@ -85,6 +86,7 @@ export function fetchEsql({
             const rows = table?.rows ?? [];
             esqlQueryColumns = table?.columns ?? undefined;
             esqlHeaderWarning = table.warning ?? undefined;
+            esqlQueryTime = table.queryTime ?? undefined;
             finalData = rows.map((row, idx) => {
               const record: DataTableRecord = {
                 id: String(idx),
@@ -104,6 +106,7 @@ export function fetchEsql({
               records: finalData || [],
               esqlQueryColumns,
               esqlHeaderWarning,
+              esqlQueryTime,
             };
           }
         });
@@ -112,6 +115,7 @@ export function fetchEsql({
         records: [],
         esqlQueryColumns: [],
         esqlHeaderWarning: undefined,
+        esqlQueryTime: undefined,
       };
     })
     .catch((err) => {

--- a/src/plugins/discover/public/application/main/state_management/discover_data_state_container.ts
+++ b/src/plugins/discover/public/application/main/state_management/discover_data_state_container.ts
@@ -70,6 +70,7 @@ export interface DataDocumentsMsg extends DataMsg {
   result?: DataTableRecord[];
   esqlQueryColumns?: DatatableColumn[]; // columns from ES|QL request
   esqlHeaderWarning?: string;
+  esqlQueryTime?: number;
   interceptedWarnings?: SearchResponseWarning[]; // warnings (like shard failures)
 }
 

--- a/src/plugins/discover/public/application/types.ts
+++ b/src/plugins/discover/public/application/types.ts
@@ -25,6 +25,7 @@ export interface RecordsFetchResponse {
   esqlQueryColumns?: DatatableColumn[];
   esqlHeaderWarning?: string;
   interceptedWarnings?: SearchResponseWarning[];
+  esqlQueryTime?: number;
 }
 
 export interface SidebarToggleState {

--- a/src/plugins/expressions/common/expression_types/specs/datatable.ts
+++ b/src/plugins/expressions/common/expression_types/specs/datatable.ts
@@ -141,6 +141,7 @@ export interface Datatable {
   meta?: DatatableMeta;
   rows: DatatableRow[];
   warning?: string;
+  queryTime?: number;
 }
 
 export interface SerializedDatatable extends Datatable {

--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -168,6 +168,7 @@ export interface QueryBarTopRowProps<QT extends Query | AggregateQuery = Query> 
   dataViewPickerComponentProps?: DataViewPickerProps;
   textBasedLanguageModeErrors?: Error[];
   textBasedLanguageModeWarning?: string;
+  esqlQueryTime?: number;
   filterBar?: React.ReactNode;
   showDatePickerAsBadge?: boolean;
   showSubmitButton?: boolean;
@@ -734,6 +735,7 @@ export const QueryBarTopRow = React.memo(
             onTextLangQueryChange={props.onTextLangQueryChange}
             errors={props.textBasedLanguageModeErrors}
             warning={props.textBasedLanguageModeWarning}
+            queryTime={props.esqlQueryTime}
             detectedTimestamp={detectedTimestamp}
             onTextLangQuerySubmit={async () =>
               onSubmit({

--- a/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
@@ -263,6 +263,7 @@ export function createSearchBar({
             dataViewPickerComponentProps={props.dataViewPickerComponentProps}
             textBasedLanguageModeErrors={props.textBasedLanguageModeErrors}
             textBasedLanguageModeWarning={props.textBasedLanguageModeWarning}
+            esqlQueryTime={props.esqlQueryTime}
             displayStyle={props.displayStyle}
             isScreenshotMode={isScreenshotMode}
             dataTestSubj={props.dataTestSubj}

--- a/src/plugins/unified_search/public/search_bar/search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/search_bar.tsx
@@ -123,6 +123,7 @@ export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
   dataViewPickerComponentProps?: DataViewPickerProps;
   textBasedLanguageModeErrors?: Error[];
   textBasedLanguageModeWarning?: string;
+  esqlQueryTime?: number;
   showSubmitButton?: boolean;
   submitButtonStyle?: QueryBarTopRowProps['submitButtonStyle'];
   // defines size of suggestions query popover
@@ -651,6 +652,7 @@ class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> extends C
           dataViewPickerComponentProps={this.props.dataViewPickerComponentProps}
           textBasedLanguageModeErrors={this.props.textBasedLanguageModeErrors}
           textBasedLanguageModeWarning={this.props.textBasedLanguageModeWarning}
+          esqlQueryTime={this.props.esqlQueryTime}
           showDatePickerAsBadge={this.shouldShowDatePickerAsBadge()}
           filterBar={filterBar}
           suggestionsSize={this.props.suggestionsSize}

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_esql.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_esql.tsx
@@ -276,6 +276,7 @@ export const IndexDataVisualizerESQL: FC<IndexDataVisualizerESQLProps> = (dataVi
             hideRunQueryText={false}
             isLoading={queryHistoryStatus ?? false}
             displayDocumentationAsFlyout
+            hideQueryHistory
           />
         </EuiFlexItem>
 

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/esql/use_esql_overall_stats_data.ts
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/hooks/esql/use_esql_overall_stats_data.ts
@@ -40,7 +40,12 @@ interface ESQLColumn {
   name: string;
 }
 interface ESQLResponse {
-  rawResponse: { columns: ESQLColumn[]; all_columns: ESQLColumn[]; values: unknown[][] };
+  rawResponse: {
+    columns: ESQLColumn[];
+    all_columns: ESQLColumn[];
+    values: unknown[][];
+    took?: number;
+  };
 }
 export interface Column extends ESQLColumn {
   secondaryType: string;

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
@@ -27,6 +27,7 @@ export interface ESQLDataGridAttrs {
   rows: ESQLRow[];
   dataView: DataView;
   columns: DatatableColumn[];
+  queryTime?: number;
 }
 
 const getDSLFilter = (queryService: DataPublicPluginStart['query'], timeFieldName?: string) => {
@@ -76,6 +77,7 @@ export const getGridAttrs = async (
     rows: results.response.values,
     dataView,
     columns,
+    queryTime: results.response.took,
   };
 };
 
@@ -90,7 +92,7 @@ export const getSuggestions = async (
   setDataGridAttrs?: (attrs: ESQLDataGridAttrs) => void
 ) => {
   try {
-    const { dataView, columns, rows } = await getGridAttrs(
+    const { dataView, columns, rows, queryTime } = await getGridAttrs(
       query,
       adHocDataViews,
       deps,
@@ -101,6 +103,7 @@ export const getSuggestions = async (
       rows,
       dataView,
       columns,
+      queryTime,
     });
 
     const context = {

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -138,7 +138,7 @@ export function LensEditConfigurationFlyout({
     const abortController = new AbortController();
     const getESQLGridAttrs = async () => {
       if (!dataGridAttrs && isOfAggregateQueryType(query)) {
-        const { dataView, columns, rows } = await getGridAttrs(
+        const { dataView, columns, rows, queryTime } = await getGridAttrs(
           query,
           adHocDataViews,
           startDependencies,
@@ -149,6 +149,7 @@ export function LensEditConfigurationFlyout({
           rows,
           dataView,
           columns,
+          queryTime,
         });
       }
     };
@@ -505,6 +506,7 @@ export function LensEditConfigurationFlyout({
                 isDisabled={false}
                 allowQueryCancellation
                 isLoading={isVisualizationLoading}
+                queryTime={dataGridAttrs?.queryTime}
               />
             </EuiFlexItem>
           )}

--- a/x-pack/plugins/maps/public/classes/sources/esql_source/esql_editor.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/esql_editor.tsx
@@ -93,6 +93,7 @@ export function ESQLEditor(props: Props) {
         hideRunQueryText
         isLoading={isLoading}
         disableSubmitAction={isEqual(localQuery, props.esql)}
+        hideQueryHistory
       />
     </>
   );

--- a/x-pack/plugins/maps/public/classes/sources/esql_source/esql_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/esql_source.tsx
@@ -258,6 +258,7 @@ export class ESQLSource
         resultsCount,
         areResultsTrimmed: resultsCount >= limit,
       },
+      queryTime: esqlSearchResponse.took,
     };
   }
 

--- a/x-pack/plugins/maps/public/classes/sources/vector_source/vector_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/vector_source/vector_source.tsx
@@ -53,6 +53,7 @@ export interface SourceStatus {
 export interface GeoJsonWithMeta {
   data: FeatureCollection;
   meta?: DataRequestMeta;
+  queryTime?: number;
 }
 
 export interface BoundsRequestMeta {

--- a/x-pack/plugins/stack_alerts/public/rule_types/es_query/expression/esql_query_expression.tsx
+++ b/x-pack/plugins/stack_alerts/public/rule_types/es_query/expression/esql_query_expression.tsx
@@ -64,6 +64,7 @@ export const EsqlQueryExpression: React.FC<
   const [timeFieldOptions, setTimeFieldOptions] = useState([firstFieldOption]);
   const [detectedTimestamp, setDetectedTimestamp] = useState<string | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [queryTime, setQueryTime] = useState<number | undefined>(undefined);
 
   const setParam = useCallback(
     (paramField: string, paramValue: unknown) => {
@@ -125,6 +126,7 @@ export const EsqlQueryExpression: React.FC<
       const esqlTable = transformDatatableToEsqlTable(table);
       const hits = toEsQueryHits(esqlTable);
       setIsLoading(false);
+      setQueryTime(table.queryTime);
       return {
         testResults: parseAggregationResults({
           isCountAgg: true,
@@ -200,6 +202,7 @@ export const EsqlQueryExpression: React.FC<
           isLoading={isLoading}
           editorIsInline
           hasOutline
+          queryTime={queryTime}
         />
       </EuiFormRow>
       <EuiSpacer />


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)