### PR TITLE
[ES|QL] Pass the took time to the inspector

### DIFF
--- a/packages/kbn-es-types/src/search.ts
+++ b/packages/kbn-es-types/src/search.ts
@@ -681,6 +681,7 @@ export interface ESQLSearchResponse {
   // while columns only the available ones (non nulls)
   all_columns?: ESQLColumn[];
   values: ESQLRow[];
+  took?: number;
 }
 
 export interface ESQLSearchParams {

--- a/src/plugins/data/common/search/expressions/esql.ts
+++ b/src/plugins/data/common/search/expressions/esql.ts
@@ -271,6 +271,22 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
                         defaultMessage: 'The number of documents returned by the query.',
                       }),
                     },
+                    ...(rawResponse?.took && {
+                      queryTime: {
+                        label: i18n.translate('data.search.es_search.queryTimeLabel', {
+                          defaultMessage: 'Query time',
+                        }),
+                        value: i18n.translate('data.search.es_search.queryTimeValue', {
+                          defaultMessage: '{queryTime}ms',
+                          values: { queryTime: rawResponse.took },
+                        }),
+                        description: i18n.translate('data.search.es_search.queryTimeDescription', {
+                          defaultMessage:
+                            'The time it took to process the query. ' +
+                            'Does not include the time to send the request or parse it in the browser.',
+                        }),
+                      },
+                    }),
                   })
                   .json(params)
                   .ok({ json: rawResponse, requestParams });


### PR DESCRIPTION
## Summary

Now that this PR https://github.com/elastic/elasticsearch/pull/112595 landed in our snapshot, we can have the query time in the inspector.

<img width="798" alt="image" src="https://github.com/user-attachments/assets/1ba1c59e-f094-4a56-964d-d76bdc1db8b3">


<img width="1017" alt="image" src="https://github.com/user-attachments/assets/48464d7c-60c0-4924-bfcb-85f82b7caa40">


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->