### PR TITLE
no_deprecated_authz_config eslint rule fixes

### DIFF
--- a/packages/kbn-eslint-plugin-eslint/index.js
+++ b/packages/kbn-eslint-plugin-eslint/index.js
@@ -20,5 +20,6 @@ module.exports = {
     no_this_in_property_initializers: require('./rules/no_this_in_property_initializers'),
     no_unsafe_console: require('./rules/no_unsafe_console'),
     no_unsafe_hash: require('./rules/no_unsafe_hash'),
+    no_deprecated_authz_config: require('./rules/no_deprecated_authz_config'),
   },
 };

--- a/packages/kbn-eslint-plugin-eslint/rules/no_deprecated_authz_config.test.js
+++ b/packages/kbn-eslint-plugin-eslint/rules/no_deprecated_authz_config.test.js
@@ -163,6 +163,28 @@ ruleTester.run('no_deprecated_authz_config', rule, {
         router.get({
           path: '/some/path',
           options: {
+            tags: ['access:ml:someTag', 'access:prefix:someTag'],
+          },
+        });
+      `,
+      errors: [{ message: "Move 'access' tags to security.authz.requiredPrivileges." }],
+      output: `
+        router.get({
+          path: '/some/path',
+          security: {
+                authz: {
+                  requiredPrivileges: ['ml:someTag', 'prefix:someTag'],
+                },
+              },
+        });
+      `,
+      name: 'invalid: access tags have multiple prefixes, move to security.authz.requiredPrivileges',
+    },
+    {
+      code: `
+        router.get({
+          path: '/some/path',
+          options: {
             tags: [\`access:\${APP_ID}-entity-analytics\`],
           },
         });
@@ -179,6 +201,30 @@ ruleTester.run('no_deprecated_authz_config', rule, {
         });
       `,
       name: 'invalid: access tags are template literals, move to security.authz.requiredPrivileges',
+    },
+    {
+      code: `
+        router.get({
+          path: '/some/path',
+          options: {
+            tags: ['access:securitySolution', routeTagHelper('someTag')],
+          },
+        });
+      `,
+      errors: [{ message: "Move 'access' tags to security.authz.requiredPrivileges." }],
+      output: `
+        router.get({
+          path: '/some/path',
+          security: {
+                authz: {
+                  requiredPrivileges: ['securitySolution'],
+                },
+              },options: {
+            tags: [routeTagHelper('someTag')],
+          },
+        });
+      `,
+      name: 'invalid: access tags and tags made with helper function, only access tags are moved to security.authz.requiredPrivileges',
     },
     {
       code: `


### PR DESCRIPTION
## Summary

ESLint was not correctly migrating tags that involved tags with multiple prefixes or helper functions. Specifically, it was failing to handle:
- Tags using helper functions, such as: `['access:securitySolution', routeTagHelper('someTag')]`.
- Nested prefixes like: `['access:ml:some-tag']`.

This resulted in incomplete tag migrations.

Also added `MIGRATE_DISABLED_AUTHZ` flag which allows to skip migration for routes opted out from authorization with `MIGRATE_DISABLED_AUTHZ=false`


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


__Closes: https://github.com/elastic/kibana/issues/194798__
