### PR TITLE
Ensure type is required for all output request bodies

### DIFF
--- a/oas_docs/output/kibana.serverless.staging.yaml
+++ b/oas_docs/output/kibana.serverless.staging.yaml
@@ -20883,6 +20883,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_create_request_kafka:
       title: kafka
       type: object
@@ -21144,6 +21145,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_update_request:
       discriminator:
         mapping:
@@ -21372,6 +21374,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_update_request_logstash:
       title: logstash
       type: object
@@ -21434,6 +21437,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_package_info:
       title: Package information
       type: object

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -13783,6 +13783,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_create_request_kafka:
       title: kafka
       type: object
@@ -14044,6 +14045,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_update_request:
       discriminator:
         mapping:
@@ -14272,6 +14274,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_update_request_logstash:
       title: logstash
       type: object
@@ -14334,6 +14337,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_package_info:
       title: Package information
       type: object

--- a/oas_docs/output/kibana.staging.yaml
+++ b/oas_docs/output/kibana.staging.yaml
@@ -28659,6 +28659,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_create_request_kafka:
       title: kafka
       type: object
@@ -28920,6 +28921,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_update_request:
       discriminator:
         mapping:
@@ -29148,6 +29150,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_update_request_logstash:
       title: logstash
       type: object
@@ -29210,6 +29213,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_package_info:
       title: Package information
       type: object

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -20742,6 +20742,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_create_request_kafka:
       title: kafka
       type: object
@@ -21003,6 +21004,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_update_request:
       discriminator:
         mapping:
@@ -21231,6 +21233,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_output_update_request_logstash:
       title: logstash
       type: object
@@ -21293,6 +21296,7 @@ components:
           type: string
       required:
         - name
+        - type
     Fleet_package_info:
       title: Package information
       type: object

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -8624,7 +8624,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "type"
         ]
       },
       "output_create_request_kafka": {
@@ -9013,7 +9014,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "type"
         ]
       },
       "output_create_request": {
@@ -9358,7 +9360,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "type"
         ]
       },
       "output_update_request_logstash": {
@@ -9452,7 +9455,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "type"
         ]
       },
       "output_update_request": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -5571,6 +5571,7 @@ components:
               type: boolean
       required:
         - name
+        - type
     output_create_request_kafka:
       title: kafka
       type: object
@@ -5832,6 +5833,7 @@ components:
               type: string
       required:
         - name
+        - type
     output_create_request:
       title: Output
       oneOf:
@@ -6062,6 +6064,7 @@ components:
           type: number
       required:
         - name
+        - type
     output_update_request_logstash:
       title: logstash
       type: object
@@ -6124,6 +6127,7 @@ components:
               type: boolean
       required:
         - name
+        - type
     output_update_request:
       title: Output
       oneOf:

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/output_create_request_elasticsearch.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/output_create_request_elasticsearch.yaml
@@ -61,3 +61,4 @@ properties:
         type: boolean
 required:
   - name
+  - type

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/output_create_request_remote_elasticsearch.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/output_create_request_remote_elasticsearch.yaml
@@ -27,3 +27,4 @@ properties:
           type: string
 required:
   - name
+  - type

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/output_update_request_kafka.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/output_update_request_kafka.yaml
@@ -132,3 +132,4 @@ properties:
     type: number
 required:
   - name
+  - type

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/output_update_request_logstash.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/output_update_request_logstash.yaml
@@ -58,3 +58,4 @@ properties:
         type: boolean
 required:
   - name
+  - type


### PR DESCRIPTION
## Summary

Some of the existing output bodies mark `type` as required, this PR ensures it's marked as required in all output bodies (since it is). For some reason a non-required type is breaking code generation. 


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
