### PR TITLE
[8.15] [Automatic Import] Add experimental features to integration_assistant plugin (#194699)

### DIFF
--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -273,6 +273,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.index_management.ui.enabled (boolean)',
         'xpack.infra.sources.default.fields.message (array)',
         'xpack.index_management.enableTogglingDataRetention (any)', // It's a boolean (any because schema.conditional)
+        'xpack.integration_assistant.enableExperimental (array)',
         /**
          * Feature flags bellow are conditional based on traditional/serverless offering
          * and will all resolve to xpack.infra.featureFlags.* (boolean)

--- a/x-pack/plugins/integration_assistant/common/experimental_features.ts
+++ b/x-pack/plugins/integration_assistant/common/experimental_features.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type ExperimentalFeatures = typeof allowedExperimentalValues;
+
+const _allowedExperimentalValues = {
+  // Leaving this in here until we have a 'real' experimental feature
+  testFeature: false,
+};
+
+/**
+ * A list of allowed values that can be used in `xpack.integration_assistant.enableExperimental`.
+ * This object is then used to validate and parse the value entered.
+ */
+export const allowedExperimentalValues = Object.freeze<
+  Record<keyof typeof _allowedExperimentalValues, boolean>
+>({ ..._allowedExperimentalValues });
+
+type ExperimentalConfigKey = keyof ExperimentalFeatures;
+type ExperimentalConfigKeys = ExperimentalConfigKey[];
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+const allowedKeys = Object.keys(allowedExperimentalValues) as Readonly<ExperimentalConfigKeys>;
+
+/**
+ * Parses the string value used in `xpack.integration_assistant.enableExperimental` kibana configuration,
+ * which should be a string of values delimited by a comma (`,`)
+ *
+ * @param configValue
+ */
+export const parseExperimentalConfigValue = (configValue: string[]): ExperimentalFeatures => {
+  const enabledFeatures: Mutable<ExperimentalFeatures> = { ...allowedExperimentalValues };
+
+  for (const value of configValue) {
+    if (isValidExperimentalValue(value)) {
+      enabledFeatures[value] = true;
+    }
+  }
+
+  return {
+    ...allowedExperimentalValues,
+    ...enabledFeatures,
+  };
+};
+
+export const isValidExperimentalValue = (value: string): value is ExperimentalConfigKey => {
+  return (allowedKeys as string[]).includes(value);
+};
+
+export const getExperimentalAllowedValues = (): string[] => [...allowedKeys];

--- a/x-pack/plugins/integration_assistant/public/index.ts
+++ b/x-pack/plugins/integration_assistant/public/index.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
+import type { PluginInitializerContext } from '@kbn/core/public';
 import { IntegrationAssistantPlugin } from './plugin';
 export type { IntegrationAssistantPluginSetup, IntegrationAssistantPluginStart } from './types';
 
-export function plugin() {
-  return new IntegrationAssistantPlugin();
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new IntegrationAssistantPlugin(initializerContext);
 }

--- a/x-pack/plugins/integration_assistant/public/plugin.ts
+++ b/x-pack/plugins/integration_assistant/public/plugin.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { CoreStart, Plugin, CoreSetup } from '@kbn/core/public';
+import type { CoreStart, Plugin, CoreSetup, PluginInitializerContext } from '@kbn/core/public';
 import { BehaviorSubject } from 'rxjs';
 import type {
   IntegrationAssistantPluginSetup,
@@ -14,16 +14,33 @@ import type {
 } from './types';
 import { getCreateIntegrationLazy } from './components/create_integration';
 import { getCreateIntegrationCardButtonLazy } from './components/create_integration_card_button';
-import { Telemetry, type Services, type RenderUpselling } from './services';
+import {
+  Telemetry,
+  ExperimentalFeaturesService,
+  type Services,
+  type RenderUpselling,
+} from './services';
+import { parseExperimentalConfigValue } from '../common/experimental_features';
+import type { ExperimentalFeatures } from '../common/experimental_features';
+import { type IntegrationAssistantConfigType } from '../server/config';
 
 export class IntegrationAssistantPlugin
   implements Plugin<IntegrationAssistantPluginSetup, IntegrationAssistantPluginStart>
 {
   private telemetry = new Telemetry();
   private renderUpselling$ = new BehaviorSubject<RenderUpselling | undefined>(undefined);
+  private config: IntegrationAssistantConfigType;
+  private experimentalFeatures: ExperimentalFeatures;
+
+  constructor(private readonly initializerContext: PluginInitializerContext) {
+    this.config = this.initializerContext.config.get<IntegrationAssistantConfigType>();
+    this.experimentalFeatures = parseExperimentalConfigValue(this.config.enableExperimental || []);
+    ExperimentalFeaturesService.init(this.experimentalFeatures);
+  }
 
   public setup(core: CoreSetup): IntegrationAssistantPluginSetup {
     this.telemetry.setup(core.analytics);
+    this.config = this.config;
     return {};
   }
 

--- a/x-pack/plugins/integration_assistant/public/services/experimental_features_service.ts
+++ b/x-pack/plugins/integration_assistant/public/services/experimental_features_service.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ExperimentalFeatures } from '../../common/experimental_features';
+
+export class ExperimentalFeaturesService {
+  private static experimentalFeatures?: ExperimentalFeatures;
+
+  public static init(experimentalFeatures: ExperimentalFeatures) {
+    this.experimentalFeatures = experimentalFeatures;
+  }
+
+  public static get(): ExperimentalFeatures {
+    if (!this.experimentalFeatures) {
+      this.throwUninitializedError();
+    }
+
+    return this.experimentalFeatures;
+  }
+
+  private static throwUninitializedError(): never {
+    throw new Error('Experimental features service not initialized');
+  }
+}

--- a/x-pack/plugins/integration_assistant/public/services/index.ts
+++ b/x-pack/plugins/integration_assistant/public/services/index.ts
@@ -6,3 +6,4 @@
  */
 export * from './types';
 export { Telemetry } from './telemetry/service';
+export { ExperimentalFeaturesService } from './experimental_features_service';

--- a/x-pack/plugins/integration_assistant/server/config.ts
+++ b/x-pack/plugins/integration_assistant/server/config.ts
@@ -10,9 +10,27 @@ import type { PluginConfigDescriptor } from '@kbn/core/server';
 
 export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: true }),
+  /**
+   * For internal use. A list of string values (comma delimited) that will enable experimental
+   * type of functionality that is not yet released. Valid values for this settings need to
+   * be defined in:
+   * `x-pack/plugins/integration_assistant/common/experimental_features.ts`
+   * under the `allowedExperimentalValues` object
+   *
+   * @example
+   * xpack.integration_assistant.enableExperimental:
+   *   - someCrazyFeature
+   *   - someEvenCrazierFeature
+   */
+  enableExperimental: schema.arrayOf(schema.string(), {
+    defaultValue: () => [],
+  }),
 });
-export type ServerlessSecuritySchema = TypeOf<typeof configSchema>;
+export type IntegrationAssistantConfigType = TypeOf<typeof configSchema>;
 
-export const config: PluginConfigDescriptor<ServerlessSecuritySchema> = {
+export const config: PluginConfigDescriptor<IntegrationAssistantConfigType> = {
+  exposeToBrowser: {
+    enableExperimental: true,
+  },
   schema: configSchema,
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Automatic Import] Add experimental features to integration_assistant plugin (#194699)](https://github.com/elastic/kibana/pull/194699)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kylie Meli","email":"kylie.geller@elastic.co"},"sourceCommit":{"committedDate":"2024-10-03T13:09:52Z","message":"[Automatic Import] Add experimental features to integration_assistant plugin (#194699)\n\n## Summary\r\n\r\nThis PR adds experimental features to the integration_assistant plugin.\r\nI used the fleet and security solutions plugins as references, and\r\nimplemented them exactly as they have. Currently nothing is actually\r\nusing this.\r\n\r\nTo be able to utilize this, add\r\n`xpack.integration_assistant.enableExperimental: ['testFeature']` to the\r\nconfig.\r\n\r\nTested by adding to the config and verifying correct output in console\r\nvia [test\r\nlogs](https://github.com/elastic/kibana/commit/74ddf3786e38ac226b21b471abfaf1e4c40c4f9c#diff-177cfac6e94662a2089f6c56000726e1a1924f9222caaf8bcb1312a7583c110eR60).","sha":"c0e2d95050962021979531a82de20fc3877d4db0","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-major","Team:Security-Scalability","Feature:AutomaticImport"],"number":194699,"url":"https://github.com/elastic/kibana/pull/194699","mergeCommit":{"message":"[Automatic Import] Add experimental features to integration_assistant plugin (#194699)\n\n## Summary\r\n\r\nThis PR adds experimental features to the integration_assistant plugin.\r\nI used the fleet and security solutions plugins as references, and\r\nimplemented them exactly as they have. Currently nothing is actually\r\nusing this.\r\n\r\nTo be able to utilize this, add\r\n`xpack.integration_assistant.enableExperimental: ['testFeature']` to the\r\nconfig.\r\n\r\nTested by adding to the config and verifying correct output in console\r\nvia [test\r\nlogs](https://github.com/elastic/kibana/commit/74ddf3786e38ac226b21b471abfaf1e4c40c4f9c#diff-177cfac6e94662a2089f6c56000726e1a1924f9222caaf8bcb1312a7583c110eR60).","sha":"c0e2d95050962021979531a82de20fc3877d4db0"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/194699","number":194699,"mergeCommit":{"message":"[Automatic Import] Add experimental features to integration_assistant plugin (#194699)\n\n## Summary\r\n\r\nThis PR adds experimental features to the integration_assistant plugin.\r\nI used the fleet and security solutions plugins as references, and\r\nimplemented them exactly as they have. Currently nothing is actually\r\nusing this.\r\n\r\nTo be able to utilize this, add\r\n`xpack.integration_assistant.enableExperimental: ['testFeature']` to the\r\nconfig.\r\n\r\nTested by adding to the config and verifying correct output in console\r\nvia [test\r\nlogs](https://github.com/elastic/kibana/commit/74ddf3786e38ac226b21b471abfaf1e4c40c4f9c#diff-177cfac6e94662a2089f6c56000726e1a1924f9222caaf8bcb1312a7583c110eR60).","sha":"c0e2d95050962021979531a82de20fc3877d4db0"}},{"url":"https://github.com/elastic/kibana/pull/194833","number":194833,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->