### PR TITLE
[Monitoring] Fix system index label in Stack Monitoring screen

### DIFF
--- a/x-pack/plugins/monitoring/public/components/elasticsearch/indices/indices.js
+++ b/x-pack/plugins/monitoring/public/components/elasticsearch/indices/indices.js
@@ -138,7 +138,7 @@ const getNoDataMessage = () => {
       <p>
         <FormattedMessage
           id="xpack.monitoring.elasticsearch.indices.howToShowSystemIndicesDescription"
-          defaultMessage="If you are looking for system indices (e.g., .kibana), try checking &lsquo;Show system indices&rsquo;."
+          defaultMessage="If you are looking for system indices (e.g., .kibana), try checking &lsquo;Filter for system indices&rsquo;."
         />
       </p>
     </div>


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/194838

## Summary

This PR wraps up the change made in https://github.com/elastic/kibana/pull/76946 (issue https://github.com/elastic/kibana/issues/77492)

The change was about relabeling the "Show system indices" toggle showing below to "Filter for system indices", but when no indices show up, the warning message still contains the old text, i.e. "Show system indices"

![Image](https://github.com/user-attachments/assets/9c3003a8-5689-4d3a-8175-8e707d1ec40a)

![Image](https://github.com/user-attachments/assets/cfdd9ba1-d87d-47ae-afb9-4fa81473230d)

### Checklist

- [X] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [X] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [X] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)
