### PR TITLE
[Search] [Onboarding] update onboarding key for create index

### DIFF
--- a/x-pack/plugins/search_indices/public/components/start/api_key_callout.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/api_key_callout.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { ApiKeyForm } from '@kbn/search-api-keys-components';
+
+interface APIKeyCalloutProps {
+  apiKey: string | null;
+}
+
+export const APIKeyCallout = ({ apiKey }: APIKeyCalloutProps) => {
+  const title = apiKey
+    ? i18n.translate('xpack.searchIndices.startPage.codeView.apiKeyTitle', {
+        defaultMessage: 'Copy your API key',
+      })
+    : i18n.translate('xpack.searchIndices.startPage.codeView.explicitGenerate.apiKeyTitle', {
+        defaultMessage: 'Create an API key',
+      });
+
+  const description = apiKey
+    ? i18n.translate('xpack.searchIndices.startPage.codeView.apiKeyDescription', {
+        defaultMessage:
+          'Make sure you keep it somewhere safe. You won’t be able to retrieve it later.',
+      })
+    : i18n.translate('xpack.searchIndices.startPage.codeView.explicitGenerate.apiKeyDescription', {
+        defaultMessage: 'Create an API key to connect to Elasticsearch.',
+      });
+
+  const dataTestSubj = apiKey ? 'apiKeyHasBeenGenerated' : 'apiKeyHasNotBeenGenerated';
+
+  return (
+    <EuiPanel
+      paddingSize="m"
+      hasShadow={false}
+      hasBorder={true}
+      color="plain"
+      data-test-subj={dataTestSubj}
+    >
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiFlexItem>
+          <EuiText>
+            <h5>{title}</h5>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText color="subdued">
+            <p>{description}</p>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="m" />
+      <ApiKeyForm hasTitle={false} />
+    </EuiPanel>
+  );
+};

--- a/x-pack/plugins/search_indices/public/components/start/create_index_code.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/create_index_code.tsx
@@ -5,11 +5,11 @@
  * 2.0.
  */
 import React, { useCallback, useMemo } from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { TryInConsoleButton } from '@kbn/try-in-console';
 
-import { ApiKeyForm, useSearchApiKey } from '@kbn/search-api-keys-components';
+import { useSearchApiKey } from '@kbn/search-api-keys-components';
 import { AnalyticsEvents } from '../../analytics/constants';
 import { Languages, AvailableLanguages, LanguageOptions } from '../../code_examples';
 
@@ -22,15 +22,18 @@ import { LanguageSelector } from '../shared/language_selector';
 
 import { CreateIndexFormState } from './types';
 import { useStartPageCodingExamples } from './hooks/use_coding_examples';
+import { APIKeyCallout } from './api_key_callout';
 
 export interface CreateIndexCodeViewProps {
   createIndexForm: CreateIndexFormState;
   changeCodingLanguage: (language: AvailableLanguages) => void;
+  canCreateApiKey?: boolean;
 }
 
 export const CreateIndexCodeView = ({
   createIndexForm,
   changeCodingLanguage,
+  canCreateApiKey,
 }: CreateIndexCodeViewProps) => {
   const { application, share, console: consolePlugin } = useKibana().services;
   const usageTracker = useUsageTracker();
@@ -63,33 +66,11 @@ export const CreateIndexCodeView = ({
 
   return (
     <EuiFlexGroup direction="column" data-test-subj="createIndexCodeView">
-      <EuiFlexItem grow={true}>
-        <EuiPanel paddingSize="m" hasShadow={false} hasBorder={true} color="plain">
-          <EuiFlexGroup direction="column" gutterSize="s">
-            <EuiFlexItem>
-              <EuiText>
-                <h5>
-                  {i18n.translate('xpack.searchIndices.startPage.codeView.apiKeyTitle', {
-                    defaultMessage: 'Copy your API key',
-                  })}
-                </h5>
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiText color="subdued">
-                <p>
-                  {i18n.translate('xpack.searchIndices.startPage.codeView.apiKeyDescription', {
-                    defaultMessage:
-                      'Make sure you keep it somewhere safe. You won’t be able to retrieve it later.',
-                  })}
-                </p>
-              </EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size="m" />
-          <ApiKeyForm hasTitle={false} />
-        </EuiPanel>
-      </EuiFlexItem>
+      {canCreateApiKey && (
+        <EuiFlexItem grow={true}>
+          <APIKeyCallout apiKey={apiKey} />
+        </EuiFlexItem>
+      )}
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
         <EuiFlexItem css={{ maxWidth: '300px' }}>
           <LanguageSelector

--- a/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/elasticsearch_start.tsx
@@ -197,6 +197,7 @@ export const ElasticsearchStart = ({ userPrivileges }: ElasticsearchStartProps) 
             <CreateIndexCodeView
               createIndexForm={formState}
               changeCodingLanguage={onChangeCodingLanguage}
+              canCreateApiKey={userPrivileges?.privileges.canCreateApiKeys}
             />
           )}
         </EuiFlexGroup>

--- a/x-pack/test_serverless/functional/page_objects/svl_api_keys.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_api_keys.ts
@@ -101,8 +101,8 @@ export function SvlApiKeysProvider({ getService, getPageObjects }: FtrProviderCo
       await pageObjects.apiKeys.clickSubmitButtonOnApiKeyFlyout();
     },
 
-    async expectNoPermissionsMessage() {
-      await testSubjects.existOrFail('apiKeyFormNoUserPrivileges');
+    async expectAPIKeyNotAvailable() {
+      await testSubjects.missingOrFail('apiKeyFormAPIKey');
     },
   };
 }

--- a/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
@@ -96,5 +96,18 @@ export function SvlSearchElasticsearchStartPageProvider({ getService }: FtrProvi
         expect(await testSubjects.getVisibleText('createIndex-code-block')).to.contain(apiKey);
       });
     },
+
+    async expectAPIKeyPreGenerated() {
+      await testSubjects.existOrFail('apiKeyHasBeenGenerated');
+    },
+
+    async expectAPIKeyNotPreGenerated() {
+      await testSubjects.existOrFail('apiKeyHasNotBeenGenerated');
+    },
+
+    async expectAPIKeyFormNotAvailable() {
+      await testSubjects.missingOrFail('apiKeyHasNotBeenGenerated');
+      await testSubjects.missingOrFail('apiKeyHasBeenGenerated');
+    },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
@@ -100,6 +100,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await browser.refresh();
         await pageObjects.svlSearchElasticsearchStartPage.clickCodeViewButton();
         await pageObjects.svlApiKeys.expectAPIKeyAvailable();
+        await pageObjects.svlSearchElasticsearchStartPage.expectAPIKeyPreGenerated();
         const refreshBrowserApiKeyUI = await pageObjects.svlApiKeys.getAPIKeyFromUI();
         expect(refreshBrowserApiKeyUI).to.eql(apiKeyUI);
 
@@ -174,7 +175,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         it('should not create an API key if the user only has viewer permissions', async () => {
           await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnStartPage();
           await pageObjects.svlSearchElasticsearchStartPage.clickCodeViewButton();
-          await pageObjects.svlApiKeys.expectNoPermissionsMessage();
+          await pageObjects.svlSearchElasticsearchStartPage.expectAPIKeyFormNotAvailable();
           const apiKey = await pageObjects.svlApiKeys.getAPIKeyFromSessionStorage();
           expect(apiKey).to.be(null);
         });


### PR DESCRIPTION
## Summary

**Key automatically created**
![Screenshot 2024-10-03 at 16 33 56](https://github.com/user-attachments/assets/530f827b-e41a-4fcd-a25f-9eff5d537a5d)

**Key needing to be generated**
![Screenshot 2024-10-03 at 16 33 13](https://github.com/user-attachments/assets/6f0bfd83-6057-4fbe-b653-1209fc9587a6)

**User doesn't have permissions**
![Screenshot 2024-10-03 at 16 32 57](https://github.com/user-attachments/assets/e59e4707-1448-4f2b-835f-5cdd5c6627da)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->