### PR TITLE
Disable “Assign roles to space” button if no privileges are selected

### DIFF
--- a/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assign_role_privilege_form.test.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assign_role_privilege_form.test.tsx
@@ -160,6 +160,32 @@ describe('PrivilegesRolesForm', () => {
     expect(screen.getByTestId('space-assign-role-create-roles-privilege-button')).toBeDisabled();
   });
 
+  it('renders with the assign roles button disabled when no base privileges or feature privileges are selected', async () => {
+    getRolesSpy.mockResolvedValue([]);
+    getAllKibanaPrivilegeSpy.mockResolvedValue(createRawKibanaPrivileges(kibanaFeatures));
+
+    const roles: Role[] = [
+      createRole('test_role_1', [{ base: [], feature: {}, spaces: [space.id] }]),
+    ];
+
+    renderPrivilegeRolesForm({
+      preSelectedRoles: roles,
+    });
+
+    await waitFor(() => null);
+
+    expect(screen.getByTestId(`${FEATURE_PRIVILEGES_READ}-privilege-button`)).toHaveAttribute(
+      'aria-pressed',
+      String(false)
+    );
+
+    expect(
+      screen.getByTestId('space-assign-role-privilege-customization-form')
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('space-update-role-create-roles-privilege-button')).toBeDisabled();
+  });
+
   it('preselects the privilege of the selected role when one is provided', async () => {
     getRolesSpy.mockResolvedValue([]);
     getAllKibanaPrivilegeSpy.mockResolvedValue(createRawKibanaPrivileges(kibanaFeatures));

--- a/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assign_role_privilege_form.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assign_role_privilege_form.tsx
@@ -543,11 +543,32 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
     );
   };
 
+  const canSave = useCallback(() => {
+    if (selectedRoles.length === 0) {
+      return false;
+    }
+
+    const form = roleCustomizationAnchor.value.kibana[roleCustomizationAnchor.privilegeIndex] ?? {};
+    const formBase = form.base ?? [];
+    const formFeature = form.feature ?? {};
+
+    // ensure that the form has base privileges or has selected features that are valid
+    if (
+      formBase.length === 0 &&
+      (Object.keys(formFeature).length === 0 ||
+        Object.values(formFeature).every((privileges) => privileges.length === 0))
+    ) {
+      return false;
+    }
+
+    return true;
+  }, [selectedRoles, roleCustomizationAnchor]);
+
   const getSaveButton = useCallback(() => {
     return (
       <EuiButton
         fill
-        disabled={!selectedRoles.length}
+        disabled={!canSave()}
         isLoading={assigningToRole}
         onClick={() => assignRolesToSpace()}
         data-test-subj={`space-${
@@ -563,7 +584,7 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
             })}
       </EuiButton>
     );
-  }, [assignRolesToSpace, assigningToRole, selectedRoles.length]);
+  }, [assignRolesToSpace, assigningToRole, canSave]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
## Summary

Disable “Assign roles to space” button if no base privileges or features are selected

**Before**

https://github.com/user-attachments/assets/4efa921b-6cc4-4496-99f7-0ee79dd318be

**After**

https://github.com/user-attachments/assets/fc8fe809-f03a-4f0b-a961-328596c9b2c7

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->