### PR TITLE
[Discover] Fix many_fields performance journey

### DIFF
--- a/x-pack/performance/journeys_e2e/many_fields_discover.ts
+++ b/x-pack/performance/journeys_e2e/many_fields_discover.ts
@@ -9,8 +9,6 @@ import { Journey } from '@kbn/journeys';
 import { subj } from '@kbn/test-subj-selector';
 
 export const journey = new Journey({
-  // Failing: See https://github.com/elastic/kibana/issues/193305
-  skipped: true,
   kbnArchives: ['test/functional/fixtures/kbn_archiver/many_fields_data_view'],
   esArchives: ['test/functional/fixtures/es_archiver/many_fields'],
 })
@@ -24,9 +22,9 @@ export const journey = new Journey({
     await page.waitForSelector('[data-test-subj="discoverDocTable"][data-render-complete="true"]');
     await page.waitForSelector(subj('globalLoadingIndicator-hidden'));
   })
-  .step('Expand the first document', async ({ page }) => {
+  .step('Expand a document', async ({ page }) => {
     const expandButtons = page.locator(subj('docTableExpandToggleColumn'));
-    await expandButtons.last().click();
+    await expandButtons.nth(3).click();
     await page.waitForSelector(subj('docTableRowAction'));
     await page.click(subj('docTableRowAction'));
     await page.waitForSelector(subj('globalLoadingIndicator-hidden'));


### PR DESCRIPTION
## Summary

This PR fixes the many_fields performance journey skipped in #193305. The journey started failing the same time #192698 was merged, so it looks to be related to the test change from that PR. This PR changes the test to click the 4th row's expand button instead of the final button, which seemed to be flaky, since the 4th button still avoids the search sessions popover.

Flaky test runs:
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7079

Fixes #193305.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->