### PR TITLE
[Discover] Fix test skipped in #193293

### DIFF
--- a/test/functional/apps/discover/group6/_time_field_column.ts
+++ b/test/functional/apps/discover/group6/_time_field_column.ts
@@ -308,8 +308,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             });
           });
 
-          // Fails in chrome 129+: https://github.com/elastic/kibana-operations/issues/199
-          it.skip('should render selected columns correctly', async () => {
+          it('should render selected columns correctly', async () => {
             await discover.selectTextBaseLang();
 
             await checkSelectedColumns({

--- a/test/functional/apps/discover/group6/index.ts
+++ b/test/functional/apps/discover/group6/index.ts
@@ -15,7 +15,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
   describe('discover/group6', function () {
     before(async function () {
-      await browser.setWindowSize(1300, 800);
+      await browser.setWindowSize(1600, 1200);
     });
 
     after(async function unloadMakelogs() {


### PR DESCRIPTION
## Summary

This PR fixes the test skipped in #193293 after the Chrome 129 upgrade. The issue was slightly less screen space causing the saved search save popover to get in the way of the `@timestamp` column header, which we were trying to click.

Flaky test runs:
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7080

Part of #193354.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->