### PR TITLE
[Watcher] Fix code scanning alert 

### DIFF
--- a/x-pack/plugins/watcher/public/application/sections/watch_edit/components/watch_edit.tsx
+++ b/x-pack/plugins/watcher/public/application/sections/watch_edit/components/watch_edit.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useReducer } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual, has, isFunction } from 'lodash';
 
 import { EuiPageContent } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -47,6 +47,12 @@ const watchReducer = (state: any, action: any) => {
   const { command, payload } = action;
   const { watch } = state;
 
+  const watchTypes = Watch.getWatchTypes();
+  const WatchType =
+    watch && has(watchTypes, watch.type) && isFunction(watchTypes[watch.type])
+      ? watchTypes[watch.type]
+      : null;
+
   switch (command) {
     case 'setWatch':
       return {
@@ -59,23 +65,32 @@ const watchReducer = (state: any, action: any) => {
       if (isEqual(watch[property], value)) {
         return state;
       } else {
-        return {
-          ...state,
-          watch: new (Watch.getWatchTypes()[watch.type])({
-            ...watch,
-            [property]: value,
-          }),
-        };
+        if (WatchType) {
+          return {
+            ...state,
+            watch: new WatchType({
+              ...watch,
+              [property]: value,
+            }),
+          };
+        }
+
+        return state;
       }
 
     case 'addAction':
       const { type, defaults } = payload;
-      const newWatch = new (Watch.getWatchTypes()[watch.type])(watch);
-      newWatch.createAction(type, defaults);
-      return {
-        ...state,
-        watch: newWatch,
-      };
+      if (WatchType) {
+        const newWatch = new WatchType(watch);
+        newWatch.createAction(type, defaults);
+
+        return {
+          ...state,
+          watch: newWatch,
+        };
+      } else {
+        return state;
+      }
 
     case 'setError':
       return {
@@ -119,9 +134,14 @@ export const WatchEdit = ({
           dispatch({ command: 'setError', payload: error.body });
         }
       } else if (type) {
-        const WatchType = Watch.getWatchTypes()[type];
-        if (WatchType) {
+        const watchTypes = Watch.getWatchTypes();
+
+        if (has(watchTypes, type) && isFunction(watchTypes[type])) {
+          const WatchType = watchTypes[type];
+
           dispatch({ command: 'setWatch', payload: new WatchType() });
+        } else {
+          dispatch({ command: 'setError', payload: { message: 'Invalid watch type' } });
         }
       }
     };


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/security/code-scanning/351

## Summary

To fix the problem, we need to validate the type parameter before using it to access a property in the Watch.getWatchTypes() object. We can achieve this by checking if the type exists in the Watch.getWatchTypes() object and if it is a function.

1) Modify the code in the useEffect hook to validate the type parameter.
2) Ensure that the type corresponds to a valid key in the Watch.getWatchTypes() object and that the value is a function.