### PR TITLE
[Security Solution] add usage-api configs

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/metering.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/metering.cy.ts
@@ -25,7 +25,7 @@ describe(
       ftrConfig: {
         kbnServerArgs: [
           `--xpack.securitySolutionServerless.usageReportingTaskInterval=1m`,
-          `--xpack.securitySolutionServerless.usageReportingApiUrl=https://localhost:3623`,
+          `--xpack.securitySolutionServerless.usageApi.url=https://localhost:3623`,
         ],
       },
     },

--- a/x-pack/plugins/security_solution_serverless/server/config.ts
+++ b/x-pack/plugins/security_solution_serverless/server/config.ts
@@ -5,13 +5,30 @@
  * 2.0.
  */
 
-import { schema, type TypeOf } from '@kbn/config-schema';
+import type { TypeOf } from '@kbn/config-schema';
 import type { PluginConfigDescriptor, PluginInitializerContext } from '@kbn/core/server';
 import type { SecuritySolutionPluginSetup } from '@kbn/security-solution-plugin/server/plugin_contract';
-import { USAGE_SERVICE_USAGE_URL } from './constants';
-import { productTypes } from '../common/config';
+
+import { schema } from '@kbn/config-schema';
+
 import type { ExperimentalFeatures } from '../common/experimental_features';
+
+import { productTypes } from '../common/config';
 import { parseExperimentalConfigValue } from '../common/experimental_features';
+
+const usageApiConfig = schema.maybe(
+  schema.object({
+    enabled: schema.maybe(schema.boolean()),
+    url: schema.string(),
+    tls: schema.maybe(
+      schema.object({
+        certificate: schema.string(),
+        key: schema.string(),
+        ca: schema.string(),
+      })
+    ),
+  })
+);
 
 export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: false }),
@@ -34,10 +51,6 @@ export const configSchema = schema.object({
   usageReportingTaskTimeout: schema.string({ defaultValue: '1m' }),
 
   /**
-   * Usage Reporting: the URL to send usage data to
-   */
-  usageReportingApiUrl: schema.string({ defaultValue: USAGE_SERVICE_USAGE_URL }),
-  /**
    * For internal use. A list of string values (comma delimited) that will enable experimental
    * type of functionality that is not yet released. Valid values for this settings need to
    * be defined in:
@@ -52,6 +65,8 @@ export const configSchema = schema.object({
   enableExperimental: schema.arrayOf(schema.string(), {
     defaultValue: () => [],
   }),
+
+  usageApi: usageApiConfig,
 });
 export type ServerlessSecuritySchema = TypeOf<typeof configSchema>;
 

--- a/x-pack/plugins/security_solution_serverless/server/task_manager/usage_reporting_task.test.ts
+++ b/x-pack/plugins/security_solution_serverless/server/task_manager/usage_reporting_task.test.ts
@@ -150,7 +150,7 @@ describe('SecurityUsageReportingTask', () => {
           productTypes: [
             { product_line: ProductLine.endpoint, product_tier: ProductTier.complete },
           ],
-          usageReportingApiUrl: USAGE_SERVICE_USAGE_URL,
+          usageApi: { url: USAGE_SERVICE_USAGE_URL },
         } as ServerlessSecurityConfig,
       });
       mockTask = new SecurityUsageReportingTask(taskArgs);
@@ -227,7 +227,7 @@ describe('SecurityUsageReportingTask', () => {
       });
       taskArgs = buildTaskArgs({
         config: {
-          usageReportingApiUrl: USAGE_SERVICE_USAGE_URL,
+          usageApi: { url: USAGE_SERVICE_USAGE_URL },
         } as ServerlessSecurityConfig,
       });
       mockTask = new SecurityUsageReportingTask(taskArgs);

--- a/x-pack/plugins/security_solution_serverless/server/task_manager/usage_reporting_task.ts
+++ b/x-pack/plugins/security_solution_serverless/server/task_manager/usage_reporting_task.ts
@@ -165,7 +165,7 @@ export class SecurityUsageReportingTask {
 
         usageReportResponse = await usageReportingService.reportUsage(
           usageRecords,
-          this.config.usageReportingApiUrl
+          this.config.usageApi?.url
         );
 
         if (!usageReportResponse.ok) {

--- a/x-pack/test_serverless/api_integration/test_suites/security/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/config.ts
@@ -24,6 +24,6 @@ export default createTestConfig({
     // useful for testing (also enabled in MKI QA)
     '--coreApp.allowDynamicConfigOverrides=true',
     `--xpack.securitySolutionServerless.cloudSecurityUsageReportingTaskInterval=5s`,
-    `--xpack.securitySolutionServerless.usageReportingApiUrl=http://localhost:8081/api/v1/usage`,
+    `--xpack.securitySolutionServerless.usageApi.url=http://localhost:8081/api/v1/usage`,
   ],
 });


### PR DESCRIPTION
## Summary

Add usage-api configs in preparation for mTLS. Also moves `usageReportingApiUrl` config into `usageApi.url`.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
