### PR TITLE
[8.15] [Discover] Fix test skipped in #193293 (#194889)

### DIFF
--- a/test/functional/apps/discover/group6/_time_field_column.ts
+++ b/test/functional/apps/discover/group6/_time_field_column.ts
@@ -310,8 +310,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             });
           });
 
-          // Fails in chrome 129+: https://github.com/elastic/kibana-operations/issues/199
-          it.skip('should render selected columns correctly', async () => {
+          it('should render selected columns correctly', async () => {
             await PageObjects.discover.selectTextBaseLang();
 
             await checkSelectedColumns({

--- a/test/functional/apps/discover/group6/index.ts
+++ b/test/functional/apps/discover/group6/index.ts
@@ -13,7 +13,7 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
   describe('discover/group6', function () {
     before(async function () {
-      await browser.setWindowSize(1300, 800);
+      await browser.setWindowSize(1600, 1200);
     });
 
     after(async function unloadMakelogs() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Discover] Fix test skipped in #193293 (#194889)](https://github.com/elastic/kibana/pull/194889)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2024-10-04T04:12:07Z","message":"[Discover] Fix test skipped in #193293 (#194889)\n\n## Summary\r\n\r\nThis PR fixes the test skipped in #193293 after the Chrome 129 upgrade.\r\nThe issue was slightly less screen space causing the saved search save\r\npopover to get in the way of the `@timestamp` column header, which we\r\nwere trying to click.\r\n\r\nFlaky test runs:\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7080\r\n\r\nPart of #193354.\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2653000d63c5451b9448a1cf0c1e992adc84329a","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:DataDiscovery","backport:prev-minor","backport:prev-major","v8.16.0"],"number":194889,"url":"https://github.com/elastic/kibana/pull/194889","mergeCommit":{"message":"[Discover] Fix test skipped in #193293 (#194889)\n\n## Summary\r\n\r\nThis PR fixes the test skipped in #193293 after the Chrome 129 upgrade.\r\nThe issue was slightly less screen space causing the saved search save\r\npopover to get in the way of the `@timestamp` column header, which we\r\nwere trying to click.\r\n\r\nFlaky test runs:\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7080\r\n\r\nPart of #193354.\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2653000d63c5451b9448a1cf0c1e992adc84329a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/194889","number":194889,"mergeCommit":{"message":"[Discover] Fix test skipped in #193293 (#194889)\n\n## Summary\r\n\r\nThis PR fixes the test skipped in #193293 after the Chrome 129 upgrade.\r\nThe issue was slightly less screen space causing the saved search save\r\npopover to get in the way of the `@timestamp` column header, which we\r\nwere trying to click.\r\n\r\nFlaky test runs:\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7080\r\n\r\nPart of #193354.\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2653000d63c5451b9448a1cf0c1e992adc84329a"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/194893","number":194893,"state":"MERGED","mergeCommit":{"sha":"8a604f12cde997b3ec3d7a720d0821d2cb200407","message":"[8.x] [Discover] Fix test skipped in #193293 (#194889) (#194893)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Discover] Fix test skipped in #193293\n(#194889)](https://github.com/elastic/kibana/pull/194889)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Davis\nMcPhee\",\"email\":\"davis.mcphee@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-10-04T04:12:07Z\",\"message\":\"[Discover]\nFix test skipped in #193293 (#194889)\\n\\n## Summary\\r\\n\\r\\nThis PR fixes\nthe test skipped in #193293 after the Chrome 129 upgrade.\\r\\nThe issue\nwas slightly less screen space causing the saved search save\\r\\npopover\nto get in the way of the `@timestamp` column header, which we\\r\\nwere\ntrying to click.\\r\\n\\r\\nFlaky test\nruns:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7080\\r\\n\\r\\nPart\nof #193354.\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [ ] Any text added follows\n[EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\n[\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n- [x] [Unit\nor\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [x] [Flaky\nTest\\r\\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1)\nwas\\r\\nused on any tests changed\\r\\n- [ ] Any UI touched in this PR is\nusable by keyboard only (learn more\\r\\nabout [keyboard\naccessibility](https://webaim.org/techniques/keyboard/))\\r\\n- [ ] Any UI\ntouched in this PR does not create any new axe failures\\r\\n(run axe in\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\n[ ] If a plugin configuration key changed, check if it needs to\nbe\\r\\nallowlisted in the cloud and added to the\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\n[ ] This renders correctly on smaller devices using a\nresponsive\\r\\nlayout. (You can test this [in\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\n[ ] This was checked for\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\\r\\n\\r\\n###\nFor maintainers\\r\\n\\r\\n- [ ] This was checked for breaking API changes\nand was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"2653000d63c5451b9448a1cf0c1e992adc84329a\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.16.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"Team:DataDiscovery\",\"backport:prev-minor\",\"backport:prev-major\"],\"title\":\"[Discover]\nFix test skipped in\n#193293\",\"number\":194889,\"url\":\"https://github.com/elastic/kibana/pull/194889\",\"mergeCommit\":{\"message\":\"[Discover]\nFix test skipped in #193293 (#194889)\\n\\n## Summary\\r\\n\\r\\nThis PR fixes\nthe test skipped in #193293 after the Chrome 129 upgrade.\\r\\nThe issue\nwas slightly less screen space causing the saved search save\\r\\npopover\nto get in the way of the `@timestamp` column header, which we\\r\\nwere\ntrying to click.\\r\\n\\r\\nFlaky test\nruns:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7080\\r\\n\\r\\nPart\nof #193354.\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [ ] Any text added follows\n[EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\n[\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n- [x] [Unit\nor\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [x] [Flaky\nTest\\r\\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1)\nwas\\r\\nused on any tests changed\\r\\n- [ ] Any UI touched in this PR is\nusable by keyboard only (learn more\\r\\nabout [keyboard\naccessibility](https://webaim.org/techniques/keyboard/))\\r\\n- [ ] Any UI\ntouched in this PR does not create any new axe failures\\r\\n(run axe in\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\n[ ] If a plugin configuration key changed, check if it needs to\nbe\\r\\nallowlisted in the cloud and added to the\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\n[ ] This renders correctly on smaller devices using a\nresponsive\\r\\nlayout. (You can test this [in\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\n[ ] This was checked for\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\\r\\n\\r\\n###\nFor maintainers\\r\\n\\r\\n- [ ] This was checked for breaking API changes\nand was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"2653000d63c5451b9448a1cf0c1e992adc84329a\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/194889\",\"number\":194889,\"mergeCommit\":{\"message\":\"[Discover]\nFix test skipped in #193293 (#194889)\\n\\n## Summary\\r\\n\\r\\nThis PR fixes\nthe test skipped in #193293 after the Chrome 129 upgrade.\\r\\nThe issue\nwas slightly less screen space causing the saved search save\\r\\npopover\nto get in the way of the `@timestamp` column header, which we\\r\\nwere\ntrying to click.\\r\\n\\r\\nFlaky test\nruns:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7080\\r\\n\\r\\nPart\nof #193354.\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [ ] Any text added follows\n[EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\n[\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n- [x] [Unit\nor\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [x] [Flaky\nTest\\r\\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1)\nwas\\r\\nused on any tests changed\\r\\n- [ ] Any UI touched in this PR is\nusable by keyboard only (learn more\\r\\nabout [keyboard\naccessibility](https://webaim.org/techniques/keyboard/))\\r\\n- [ ] Any UI\ntouched in this PR does not create any new axe failures\\r\\n(run axe in\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\n[ ] If a plugin configuration key changed, check if it needs to\nbe\\r\\nallowlisted in the cloud and added to the\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\n[ ] This renders correctly on smaller devices using a\nresponsive\\r\\nlayout. (You can test this [in\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\n[ ] This was checked for\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\\r\\n\\r\\n###\nFor maintainers\\r\\n\\r\\n- [ ] This was checked for breaking API changes\nand was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"2653000d63c5451b9448a1cf0c1e992adc84329a\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>"}}]}] BACKPORT-->