### PR TITLE
[8.x] Upgrade EUI to v96.1.0 (#194619)

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@elastic/ecs": "^8.11.1",
     "@elastic/elasticsearch": "^8.15.0",
     "@elastic/ems-client": "8.5.3",
-    "@elastic/eui": "95.12.0-backport.0",
+    "@elastic/eui": "96.1.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "1.2.1",
     "@elastic/numeral": "^2.5.1",

--- a/packages/kbn-securitysolution-exception-list-components/src/list_header/__snapshots__/list_header.test.tsx.snap
+++ b/packages/kbn-securitysolution-exception-list-components/src/list_header/__snapshots__/list_header.test.tsx.snap
@@ -48,10 +48,10 @@ Object {
               class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
             />
             <div
-              class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+              class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-grow-1"
+                class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
               >
                 <h1
                   class="euiTitle emotion-euiTitle-l"
@@ -149,71 +149,67 @@ Object {
                 </div>
               </div>
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
+                class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
               >
                 <div
-                  class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
+                  class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
                   <div
-                    class="euiFlexItem emotion-euiFlexItem-growZero"
+                    class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
+                    data-test-subj="RightSideMenuItemsContainer"
                   >
                     <div
-                      class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
-                      data-test-subj="RightSideMenuItemsContainer"
+                      class="euiFlexItem emotion-euiFlexItem-grow-1"
                     >
-                      <div
-                        class="euiFlexItem emotion-euiFlexItem-grow-1"
+                      <span
+                        class="emotion-EuiTextColor"
+                        data-test-subj="noLinkedRules"
+                      >
+                        Linked to 0 rules
+                      </span>
+                    </div>
+                    <div
+                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    >
+                      <button
+                        class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
+                        data-test-subj="RightSideMenuItemsLinkRulesButton"
+                        type="button"
                       >
                         <span
-                          class="emotion-EuiTextColor"
-                          data-test-subj="noLinkedRules"
-                        >
-                          Linked to 0 rules
-                        </span>
-                      </div>
-                      <div
-                        class="euiFlexItem emotion-euiFlexItem-grow-1"
-                      >
-                        <button
-                          class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
-                          data-test-subj="RightSideMenuItemsLinkRulesButton"
-                          type="button"
+                          class="emotion-euiButtonDisplayContent"
                         >
                           <span
-                            class="emotion-euiButtonDisplayContent"
+                            class="eui-textTruncate"
                           >
-                            <span
-                              class="eui-textTruncate"
-                            >
-                              Link rules
-                            </span>
+                            Link rules
                           </span>
-                        </button>
-                      </div>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    >
                       <div
-                        class="euiFlexItem emotion-euiFlexItem-grow-1"
+                        class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
                       >
                         <div
-                          class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+                          class="euiPopover emotion-euiPopover-inline-block"
+                          data-test-subj="RightSideMenuItemsMenuActionsItems"
                         >
-                          <div
-                            class="euiPopover emotion-euiPopover-inline-block"
-                            data-test-subj="RightSideMenuItemsMenuActionsItems"
+                          <button
+                            aria-label="Header menu Button Icon"
+                            class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
+                            data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
+                            type="button"
                           >
-                            <button
-                              aria-label="Header menu Button Icon"
-                              class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
-                              data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
-                              type="button"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="euiButtonIcon__icon"
-                                color="inherit"
-                                data-euiicon-type="boxesHorizontal"
-                              />
-                            </button>
-                          </div>
+                            <span
+                              aria-hidden="true"
+                              class="euiButtonIcon__icon"
+                              color="inherit"
+                              data-euiicon-type="boxesHorizontal"
+                            />
+                          </button>
                         </div>
                       </div>
                     </div>
@@ -433,10 +429,10 @@ Object {
             class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
           />
           <div
-            class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+            class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
           >
             <div
-              class="euiFlexItem emotion-euiFlexItem-grow-1"
+              class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
             >
               <h1
                 class="euiTitle emotion-euiTitle-l"
@@ -534,71 +530,67 @@ Object {
               </div>
             </div>
             <div
-              class="euiFlexItem emotion-euiFlexItem-growZero"
+              class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
             >
               <div
-                class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
                 <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
+                  class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
+                  data-test-subj="RightSideMenuItemsContainer"
                 >
                   <div
-                    class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
-                    data-test-subj="RightSideMenuItemsContainer"
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
                   >
-                    <div
-                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    <span
+                      class="emotion-EuiTextColor"
+                      data-test-subj="noLinkedRules"
+                    >
+                      Linked to 0 rules
+                    </span>
+                  </div>
+                  <div
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  >
+                    <button
+                      class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
+                      data-test-subj="RightSideMenuItemsLinkRulesButton"
+                      type="button"
                     >
                       <span
-                        class="emotion-EuiTextColor"
-                        data-test-subj="noLinkedRules"
-                      >
-                        Linked to 0 rules
-                      </span>
-                    </div>
-                    <div
-                      class="euiFlexItem emotion-euiFlexItem-grow-1"
-                    >
-                      <button
-                        class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
-                        data-test-subj="RightSideMenuItemsLinkRulesButton"
-                        type="button"
+                        class="emotion-euiButtonDisplayContent"
                       >
                         <span
-                          class="emotion-euiButtonDisplayContent"
+                          class="eui-textTruncate"
                         >
-                          <span
-                            class="eui-textTruncate"
-                          >
-                            Link rules
-                          </span>
+                          Link rules
                         </span>
-                      </button>
-                    </div>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  >
                     <div
-                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                      class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
                     >
                       <div
-                        class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+                        class="euiPopover emotion-euiPopover-inline-block"
+                        data-test-subj="RightSideMenuItemsMenuActionsItems"
                       >
-                        <div
-                          class="euiPopover emotion-euiPopover-inline-block"
-                          data-test-subj="RightSideMenuItemsMenuActionsItems"
+                        <button
+                          aria-label="Header menu Button Icon"
+                          class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
+                          data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
+                          type="button"
                         >
-                          <button
-                            aria-label="Header menu Button Icon"
-                            class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
-                            data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
-                            type="button"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              color="inherit"
-                              data-euiicon-type="boxesHorizontal"
-                            />
-                          </button>
-                        </div>
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="boxesHorizontal"
+                          />
+                        </button>
                       </div>
                     </div>
                   </div>
@@ -712,10 +704,10 @@ Object {
               class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
             />
             <div
-              class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+              class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-grow-1"
+                class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
               >
                 <h1
                   class="euiTitle emotion-euiTitle-l"
@@ -813,71 +805,67 @@ Object {
                 </div>
               </div>
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
+                class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
               >
                 <div
-                  class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
+                  class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
                   <div
-                    class="euiFlexItem emotion-euiFlexItem-growZero"
+                    class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
+                    data-test-subj="RightSideMenuItemsContainer"
                   >
                     <div
-                      class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
-                      data-test-subj="RightSideMenuItemsContainer"
+                      class="euiFlexItem emotion-euiFlexItem-grow-1"
                     >
-                      <div
-                        class="euiFlexItem emotion-euiFlexItem-grow-1"
+                      <span
+                        class="emotion-EuiTextColor"
+                        data-test-subj="noLinkedRules"
+                      >
+                        Linked to 0 rules
+                      </span>
+                    </div>
+                    <div
+                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    >
+                      <button
+                        class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
+                        data-test-subj="RightSideMenuItemsLinkRulesButton"
+                        type="button"
                       >
                         <span
-                          class="emotion-EuiTextColor"
-                          data-test-subj="noLinkedRules"
-                        >
-                          Linked to 0 rules
-                        </span>
-                      </div>
-                      <div
-                        class="euiFlexItem emotion-euiFlexItem-grow-1"
-                      >
-                        <button
-                          class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
-                          data-test-subj="RightSideMenuItemsLinkRulesButton"
-                          type="button"
+                          class="emotion-euiButtonDisplayContent"
                         >
                           <span
-                            class="emotion-euiButtonDisplayContent"
+                            class="eui-textTruncate"
                           >
-                            <span
-                              class="eui-textTruncate"
-                            >
-                              Link rules
-                            </span>
+                            Link rules
                           </span>
-                        </button>
-                      </div>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    >
                       <div
-                        class="euiFlexItem emotion-euiFlexItem-grow-1"
+                        class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
                       >
                         <div
-                          class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+                          class="euiPopover emotion-euiPopover-inline-block"
+                          data-test-subj="RightSideMenuItemsMenuActionsItems"
                         >
-                          <div
-                            class="euiPopover emotion-euiPopover-inline-block"
-                            data-test-subj="RightSideMenuItemsMenuActionsItems"
+                          <button
+                            aria-label="Header menu Button Icon"
+                            class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
+                            data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
+                            type="button"
                           >
-                            <button
-                              aria-label="Header menu Button Icon"
-                              class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
-                              data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
-                              type="button"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="euiButtonIcon__icon"
-                                color="inherit"
-                                data-euiicon-type="boxesHorizontal"
-                              />
-                            </button>
-                          </div>
+                            <span
+                              aria-hidden="true"
+                              class="euiButtonIcon__icon"
+                              color="inherit"
+                              data-euiicon-type="boxesHorizontal"
+                            />
+                          </button>
                         </div>
                       </div>
                     </div>
@@ -934,10 +922,10 @@ Object {
             class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
           />
           <div
-            class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+            class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
           >
             <div
-              class="euiFlexItem emotion-euiFlexItem-grow-1"
+              class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
             >
               <h1
                 class="euiTitle emotion-euiTitle-l"
@@ -1035,71 +1023,67 @@ Object {
               </div>
             </div>
             <div
-              class="euiFlexItem emotion-euiFlexItem-growZero"
+              class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
             >
               <div
-                class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
                 <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
+                  class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
+                  data-test-subj="RightSideMenuItemsContainer"
                 >
                   <div
-                    class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
-                    data-test-subj="RightSideMenuItemsContainer"
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
                   >
-                    <div
-                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    <span
+                      class="emotion-EuiTextColor"
+                      data-test-subj="noLinkedRules"
+                    >
+                      Linked to 0 rules
+                    </span>
+                  </div>
+                  <div
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  >
+                    <button
+                      class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
+                      data-test-subj="RightSideMenuItemsLinkRulesButton"
+                      type="button"
                     >
                       <span
-                        class="emotion-EuiTextColor"
-                        data-test-subj="noLinkedRules"
-                      >
-                        Linked to 0 rules
-                      </span>
-                    </div>
-                    <div
-                      class="euiFlexItem emotion-euiFlexItem-grow-1"
-                    >
-                      <button
-                        class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
-                        data-test-subj="RightSideMenuItemsLinkRulesButton"
-                        type="button"
+                        class="emotion-euiButtonDisplayContent"
                       >
                         <span
-                          class="emotion-euiButtonDisplayContent"
+                          class="eui-textTruncate"
                         >
-                          <span
-                            class="eui-textTruncate"
-                          >
-                            Link rules
-                          </span>
+                          Link rules
                         </span>
-                      </button>
-                    </div>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  >
                     <div
-                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                      class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
                     >
                       <div
-                        class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+                        class="euiPopover emotion-euiPopover-inline-block"
+                        data-test-subj="RightSideMenuItemsMenuActionsItems"
                       >
-                        <div
-                          class="euiPopover emotion-euiPopover-inline-block"
-                          data-test-subj="RightSideMenuItemsMenuActionsItems"
+                        <button
+                          aria-label="Header menu Button Icon"
+                          class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
+                          data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
+                          type="button"
                         >
-                          <button
-                            aria-label="Header menu Button Icon"
-                            class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
-                            data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
-                            type="button"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              color="inherit"
-                              data-euiicon-type="boxesHorizontal"
-                            />
-                          </button>
-                        </div>
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="boxesHorizontal"
+                          />
+                        </button>
                       </div>
                     </div>
                   </div>
@@ -1213,10 +1197,10 @@ Object {
               class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
             />
             <div
-              class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+              class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-grow-1"
+                class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
               >
                 <h1
                   class="euiTitle emotion-euiTitle-l"
@@ -1286,72 +1270,68 @@ Object {
                 </div>
               </div>
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
+                class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
               >
                 <div
-                  class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
+                  class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
                   <div
-                    class="euiFlexItem emotion-euiFlexItem-growZero"
+                    class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
+                    data-test-subj="RightSideMenuItemsContainer"
                   >
                     <div
-                      class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
-                      data-test-subj="RightSideMenuItemsContainer"
+                      class="euiFlexItem emotion-euiFlexItem-grow-1"
                     >
-                      <div
-                        class="euiFlexItem emotion-euiFlexItem-grow-1"
+                      <span
+                        class="emotion-EuiTextColor"
+                        data-test-subj="noLinkedRules"
+                      >
+                        Linked to 0 rules
+                      </span>
+                    </div>
+                    <div
+                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    >
+                      <button
+                        class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
+                        data-test-subj="RightSideMenuItemsLinkRulesButton"
+                        type="button"
                       >
                         <span
-                          class="emotion-EuiTextColor"
-                          data-test-subj="noLinkedRules"
-                        >
-                          Linked to 0 rules
-                        </span>
-                      </div>
-                      <div
-                        class="euiFlexItem emotion-euiFlexItem-grow-1"
-                      >
-                        <button
-                          class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
-                          data-test-subj="RightSideMenuItemsLinkRulesButton"
-                          type="button"
+                          class="emotion-euiButtonDisplayContent"
                         >
                           <span
-                            class="emotion-euiButtonDisplayContent"
+                            class="eui-textTruncate"
                           >
-                            <span
-                              class="eui-textTruncate"
-                            >
-                              Link rules
-                            </span>
+                            Link rules
                           </span>
-                        </button>
-                      </div>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    >
                       <div
-                        class="euiFlexItem emotion-euiFlexItem-grow-1"
+                        class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
                       >
                         <div
-                          class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+                          class="euiPopover emotion-euiPopover-inline-block"
+                          data-test-subj="RightSideMenuItemsMenuActionsItems"
                         >
-                          <div
-                            class="euiPopover emotion-euiPopover-inline-block"
-                            data-test-subj="RightSideMenuItemsMenuActionsItems"
+                          <button
+                            aria-label="Header menu Button Icon"
+                            class="euiButtonIcon emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                            data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
+                            disabled=""
+                            type="button"
                           >
-                            <button
-                              aria-label="Header menu Button Icon"
-                              class="euiButtonIcon emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                              data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
-                              disabled=""
-                              type="button"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="euiButtonIcon__icon"
-                                color="inherit"
-                                data-euiicon-type="boxesHorizontal"
-                              />
-                            </button>
-                          </div>
+                            <span
+                              aria-hidden="true"
+                              class="euiButtonIcon__icon"
+                              color="inherit"
+                              data-euiicon-type="boxesHorizontal"
+                            />
+                          </button>
                         </div>
                       </div>
                     </div>
@@ -1408,10 +1388,10 @@ Object {
             class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
           />
           <div
-            class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+            class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
           >
             <div
-              class="euiFlexItem emotion-euiFlexItem-grow-1"
+              class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
             >
               <h1
                 class="euiTitle emotion-euiTitle-l"
@@ -1481,72 +1461,68 @@ Object {
               </div>
             </div>
             <div
-              class="euiFlexItem emotion-euiFlexItem-growZero"
+              class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
             >
               <div
-                class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
                 <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
+                  class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
+                  data-test-subj="RightSideMenuItemsContainer"
                 >
                   <div
-                    class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
-                    data-test-subj="RightSideMenuItemsContainer"
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
                   >
-                    <div
-                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    <span
+                      class="emotion-EuiTextColor"
+                      data-test-subj="noLinkedRules"
+                    >
+                      Linked to 0 rules
+                    </span>
+                  </div>
+                  <div
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  >
+                    <button
+                      class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
+                      data-test-subj="RightSideMenuItemsLinkRulesButton"
+                      type="button"
                     >
                       <span
-                        class="emotion-EuiTextColor"
-                        data-test-subj="noLinkedRules"
-                      >
-                        Linked to 0 rules
-                      </span>
-                    </div>
-                    <div
-                      class="euiFlexItem emotion-euiFlexItem-grow-1"
-                    >
-                      <button
-                        class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
-                        data-test-subj="RightSideMenuItemsLinkRulesButton"
-                        type="button"
+                        class="emotion-euiButtonDisplayContent"
                       >
                         <span
-                          class="emotion-euiButtonDisplayContent"
+                          class="eui-textTruncate"
                         >
-                          <span
-                            class="eui-textTruncate"
-                          >
-                            Link rules
-                          </span>
+                          Link rules
                         </span>
-                      </button>
-                    </div>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  >
                     <div
-                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                      class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
                     >
                       <div
-                        class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+                        class="euiPopover emotion-euiPopover-inline-block"
+                        data-test-subj="RightSideMenuItemsMenuActionsItems"
                       >
-                        <div
-                          class="euiPopover emotion-euiPopover-inline-block"
-                          data-test-subj="RightSideMenuItemsMenuActionsItems"
+                        <button
+                          aria-label="Header menu Button Icon"
+                          class="euiButtonIcon emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+                          data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
+                          disabled=""
+                          type="button"
                         >
-                          <button
-                            aria-label="Header menu Button Icon"
-                            class="euiButtonIcon emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
-                            data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
-                            disabled=""
-                            type="button"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              color="inherit"
-                              data-euiicon-type="boxesHorizontal"
-                            />
-                          </button>
-                        </div>
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="boxesHorizontal"
+                          />
+                        </button>
                       </div>
                     </div>
                   </div>
@@ -1660,10 +1636,10 @@ Object {
               class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
             />
             <div
-              class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+              class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-grow-1"
+                class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
               >
                 <h1
                   class="euiTitle emotion-euiTitle-l"
@@ -1733,52 +1709,48 @@ Object {
                 </div>
               </div>
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
+                class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
               >
                 <div
-                  class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
+                  class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
                   <div
-                    class="euiFlexItem emotion-euiFlexItem-growZero"
+                    class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
+                    data-test-subj="RightSideMenuItemsContainer"
                   >
                     <div
-                      class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
-                      data-test-subj="RightSideMenuItemsContainer"
+                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    >
+                      <span
+                        class="emotion-EuiTextColor"
+                        data-test-subj="noLinkedRules"
+                      >
+                        Linked to 0 rules
+                      </span>
+                    </div>
+                    <div
+                      class="euiFlexItem emotion-euiFlexItem-grow-1"
                     >
                       <div
-                        class="euiFlexItem emotion-euiFlexItem-grow-1"
-                      >
-                        <span
-                          class="emotion-EuiTextColor"
-                          data-test-subj="noLinkedRules"
-                        >
-                          Linked to 0 rules
-                        </span>
-                      </div>
-                      <div
-                        class="euiFlexItem emotion-euiFlexItem-grow-1"
+                        class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
                       >
                         <div
-                          class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+                          class="euiPopover emotion-euiPopover-inline-block"
+                          data-test-subj="RightSideMenuItemsMenuActionsItems"
                         >
-                          <div
-                            class="euiPopover emotion-euiPopover-inline-block"
-                            data-test-subj="RightSideMenuItemsMenuActionsItems"
+                          <button
+                            aria-label="Header menu Button Icon"
+                            class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
+                            data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
+                            type="button"
                           >
-                            <button
-                              aria-label="Header menu Button Icon"
-                              class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
-                              data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
-                              type="button"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="euiButtonIcon__icon"
-                                color="inherit"
-                                data-euiicon-type="boxesHorizontal"
-                              />
-                            </button>
-                          </div>
+                            <span
+                              aria-hidden="true"
+                              class="euiButtonIcon__icon"
+                              color="inherit"
+                              data-euiicon-type="boxesHorizontal"
+                            />
+                          </button>
                         </div>
                       </div>
                     </div>
@@ -1925,10 +1897,10 @@ Object {
             class="euiSpacer euiSpacer--s emotion-euiSpacer-s"
           />
           <div
-            class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+            class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
           >
             <div
-              class="euiFlexItem emotion-euiFlexItem-grow-1"
+              class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
             >
               <h1
                 class="euiTitle emotion-euiTitle-l"
@@ -1998,52 +1970,48 @@ Object {
               </div>
             </div>
             <div
-              class="euiFlexItem emotion-euiFlexItem-growZero"
+              class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
             >
               <div
-                class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
+                class="euiFlexItem emotion-euiFlexItem-growZero"
               >
                 <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
+                  class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
+                  data-test-subj="RightSideMenuItemsContainer"
                 >
                   <div
-                    class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
-                    data-test-subj="RightSideMenuItemsContainer"
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  >
+                    <span
+                      class="emotion-EuiTextColor"
+                      data-test-subj="noLinkedRules"
+                    >
+                      Linked to 0 rules
+                    </span>
+                  </div>
+                  <div
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
                   >
                     <div
-                      class="euiFlexItem emotion-euiFlexItem-grow-1"
-                    >
-                      <span
-                        class="emotion-EuiTextColor"
-                        data-test-subj="noLinkedRules"
-                      >
-                        Linked to 0 rules
-                      </span>
-                    </div>
-                    <div
-                      class="euiFlexItem emotion-euiFlexItem-grow-1"
+                      class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
                     >
                       <div
-                        class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+                        class="euiPopover emotion-euiPopover-inline-block"
+                        data-test-subj="RightSideMenuItemsMenuActionsItems"
                       >
-                        <div
-                          class="euiPopover emotion-euiPopover-inline-block"
-                          data-test-subj="RightSideMenuItemsMenuActionsItems"
+                        <button
+                          aria-label="Header menu Button Icon"
+                          class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
+                          data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
+                          type="button"
                         >
-                          <button
-                            aria-label="Header menu Button Icon"
-                            class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
-                            data-test-subj="RightSideMenuItemsMenuActionsButtonIcon"
-                            type="button"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              color="inherit"
-                              data-euiicon-type="boxesHorizontal"
-                            />
-                          </button>
-                        </div>
+                          <span
+                            aria-hidden="true"
+                            class="euiButtonIcon__icon"
+                            color="inherit"
+                            data-euiicon-type="boxesHorizontal"
+                          />
+                        </button>
                       </div>
                     </div>
                   </div>

--- a/packages/kbn-test/src/jest/setup/emotion.js
+++ b/packages/kbn-test/src/jest/setup/emotion.js
@@ -29,5 +29,14 @@ console.error = (message, ...rest) => {
   ) {
     return;
   }
+  // @see https://github.com/jsdom/jsdom/issues/2177
+  // JSDOM doesn't yet know how to parse @container CSS queries -
+  // all we can do is silence its errors for now
+  if (
+    typeof message === 'object' &&
+    message?.message?.startsWith('Could not parse CSS stylesheet')
+  ) {
+    return;
+  }
   consoleError(message, ...rest);
 };

--- a/packages/shared-ux/page/kibana_template/impl/src/__snapshots__/page_template.test.tsx.snap
+++ b/packages/shared-ux/page/kibana_template/impl/src/__snapshots__/page_template.test.tsx.snap
@@ -18,10 +18,10 @@ exports[`KibanaPageTemplate render basic template 1`] = `
         style="max-width:1200px"
       >
         <div
-          class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+          class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
         >
           <div
-            class="euiFlexItem emotion-euiFlexItem-grow-1"
+            class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
           >
             <div
               class="euiText emotion-euiText-constrainedWidth-m"
@@ -32,16 +32,12 @@ exports[`KibanaPageTemplate render basic template 1`] = `
             </div>
           </div>
           <div
-            class="euiFlexItem emotion-euiFlexItem-growZero"
+            class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
           >
             <div
-              class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
             >
-              <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-              >
-                test
-              </div>
+              test
             </div>
           </div>
         </div>

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -87,7 +87,7 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.5.3': ['Elastic License 2.0'],
-  '@elastic/eui@95.12.0-backport.0': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
+  '@elastic/eui@96.1.0': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
   'buffers@0.1.1': ['MIT'], // license in importing module https://www.npmjs.com/package/binary
   '@bufbuild/protobuf@1.2.1': ['Apache-2.0'], // license (Apache-2.0 AND BSD-3-Clause)

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/__snapshots__/header.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/__snapshots__/header.test.tsx.snap
@@ -8,10 +8,10 @@ exports[`Intro component renders correctly 1`] = `
     class="euiPageHeaderContent emotion-euiPageHeaderContent-border-l"
   >
     <div
-      class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+      class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
     >
       <div
-        class="euiFlexItem emotion-euiFlexItem-grow-1"
+        class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
       >
         <h1
           class="euiTitle emotion-euiTitle-l"
@@ -20,50 +20,46 @@ exports[`Intro component renders correctly 1`] = `
         </h1>
       </div>
       <div
-        class="euiFlexItem emotion-euiFlexItem-growZero"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
       >
         <div
-          class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
+          class="euiFlexItem emotion-euiFlexItem-growZero"
         >
-          <div
-            class="euiFlexItem emotion-euiFlexItem-growZero"
+          <button
+            class="euiButton emotion-euiButtonDisplay-s-defaultMinWidth-base-danger"
+            data-test-subj="savedObjectEditDelete"
+            type="button"
           >
-            <button
-              class="euiButton emotion-euiButtonDisplay-s-defaultMinWidth-base-danger"
-              data-test-subj="savedObjectEditDelete"
-              type="button"
+            <span
+              class="emotion-euiButtonDisplayContent"
             >
               <span
-                class="emotion-euiButtonDisplayContent"
-              >
-                <span
-                  color="inherit"
-                  data-euiicon-type="trash"
-                />
-                Delete
-              </span>
-            </button>
-          </div>
-          <div
-            class="euiFlexItem emotion-euiFlexItem-growZero"
+                color="inherit"
+                data-euiicon-type="trash"
+              />
+              Delete
+            </span>
+          </button>
+        </div>
+        <div
+          class="euiFlexItem emotion-euiFlexItem-growZero"
+        >
+          <a
+            class="euiButton emotion-euiButtonDisplay-s-defaultMinWidth-base-primary"
+            data-test-subj="savedObjectEditViewInApp"
+            href="/some-url"
+            rel="noreferrer"
           >
-            <a
-              class="euiButton emotion-euiButtonDisplay-s-defaultMinWidth-base-primary"
-              data-test-subj="savedObjectEditViewInApp"
-              href="/some-url"
-              rel="noreferrer"
+            <span
+              class="emotion-euiButtonDisplayContent"
             >
               <span
-                class="emotion-euiButtonDisplayContent"
-              >
-                <span
-                  color="inherit"
-                  data-euiicon-type="eye"
-                />
-                View saved object
-              </span>
-            </a>
-          </div>
+                color="inherit"
+                data-euiicon-type="eye"
+              />
+              View saved object
+            </span>
+          </a>
         </div>
       </div>
     </div>

--- a/src/plugins/unified_search/public/filters_builder/filter_item/filter_item.tsx
+++ b/src/plugins/unified_search/public/filters_builder/filter_item/filter_item.tsx
@@ -251,6 +251,7 @@ export function FilterItem({
             hasInteractiveChildren={true}
             disableInteractiveElementBlocking
             className={cx(disabledDraggableCss)}
+            usePortal
           >
             {(provided) => (
               <EuiFlexGroup

--- a/src/plugins/unified_search/public/query_string_input/add_filter_popover.tsx
+++ b/src/plugins/unified_search/public/query_string_input/add_filter_popover.tsx
@@ -93,7 +93,6 @@ const AddFilterPopoverComponent = React.memo(function AddFilterPopover({
         initialFocus=".filterEditor__hiddenItem"
         ownFocus
         repositionOnScroll
-        hasDragDrop
       >
         <FilterEditorWrapper
           indexPatterns={indexPatterns}

--- a/src/plugins/unified_search/public/query_string_input/query_bar_menu.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_menu.tsx
@@ -267,7 +267,6 @@ function QueryBarMenuComponent({
       anchorPosition="downLeft"
       repositionOnScroll
       data-test-subj="queryBarMenuPopover"
-      hasDragDrop
     >
       {renderComponent()}
     </EuiPopover>

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
@@ -98,7 +98,6 @@ export const ColumnsPopover: React.FC<Props> = ({
       closePopover={closePopover}
       panelPaddingSize="s"
       anchorPosition="leftUp"
-      hasDragDrop
       zIndex={0}
       data-test-subj="column-selection-popover"
       button={
@@ -158,6 +157,7 @@ export const ColumnsPopover: React.FC<Props> = ({
                   css={{ height: euiTheme.size.xl, paddingLeft: euiTheme.size.base }}
                   customDragHandle
                   hasInteractiveChildren
+                  usePortal
                 >
                   {(provided) => (
                     <EuiFlexGroup alignItems="center" gutterSize="m" justifyContent="spaceBetween">

--- a/x-pack/plugins/license_management/__jest__/__snapshots__/license_page_header.test.js.snap
+++ b/x-pack/plugins/license_management/__jest__/__snapshots__/license_page_header.test.js.snap
@@ -9,10 +9,10 @@ Array [
       class="euiPageHeaderContent emotion-euiPageHeaderContent-border-l"
     >
       <div
-        class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+        class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
       >
         <div
-          class="euiFlexItem emotion-euiFlexItem-grow-1"
+          class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
         >
           <h1
             class="euiTitle emotion-euiTitle-l"
@@ -62,10 +62,10 @@ Array [
       class="euiPageHeaderContent emotion-euiPageHeaderContent-border-l"
     >
       <div
-        class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
+        class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__top"
       >
         <div
-          class="euiFlexItem emotion-euiFlexItem-grow-1"
+          class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
         >
           <h1
             class="euiTitle emotion-euiTitle-l"

--- a/x-pack/plugins/ml/public/application/components/chart_tooltip/_chart_tooltip.scss
+++ b/x-pack/plugins/ml/public/application/components/chart_tooltip/_chart_tooltip.scss
@@ -13,8 +13,10 @@
   }
 
   &__header {
-    @include euiToolTipTitle;
+    font-weight: $euiFontWeightBold;
     padding: $euiSizeXS ($euiSizeXS * 2);
+    margin-bottom: $euiSizeXS;
+    border-bottom: $euiBorderThin solid transparentize($euiBorderColor, .8);
   }
 
   &__item {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1741,10 +1741,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@95.12.0-backport.0":
-  version "95.12.0-backport.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-95.12.0-backport.0.tgz#de862ded9f23053b24e1f1939de1ff8f8109be60"
-  integrity sha512-hqhqWdAGw5tQwWTP/hn2VoM8YQE2k9IdMmGh0RdkG+JcD1GZySvSDWdTQgr9iA4/XaulJp9R3OenwDjkLLmjPw==
+"@elastic/eui@96.1.0":
+  version "96.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-96.1.0.tgz#cd75f2a7a2ca07df6fb8f9af985dff3f05172fb6"
+  integrity sha512-LmB92xr704Dfth9UnxCOm4b63lghb/7svXsnd0zcbSQA/BPqktUm1evZjWYIWFIek5D4JI4dmM+ygXLWdKSM+Q==
   dependencies:
     "@hello-pangea/dnd" "^16.6.0"
     "@types/lodash" "^4.14.202"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Upgrade EUI to v96.1.0 (#194619)](https://github.com/elastic/kibana/pull/194619)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Cee Chen","email":"549407+cee-chen@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-10-04T17:53:45Z","message":"Upgrade EUI to v96.1.0 (#194619)\n\n`v95.12.0`⏩`v96.1.0`\r\n\r\n_[Questions? Please see our Kibana upgrade\r\nFAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)_\r\n\r\n---\r\n\r\n## [`v96.0.0`](https://github.com/elastic/eui/releases/v96.0.0)\r\n\r\n- Improved `EuiPageHeader`/`EuiPageTemplate.Header`'s responsive UX:\r\n([#8044](https://github.com/elastic/eui/pull/8044))\r\n- `rightSideItems` are no longer pushed to the side by wide `tabs`\r\ncontent\r\n- `rightSideItems` now wrap more responsively at smaller container\r\nwidths\r\n- Updated `EuiDraggable` with a new `usePortal` prop.\r\n([#8048](https://github.com/elastic/eui/pull/8048))\r\n- This prop portals the dragged element to the body, allowing it to\r\nescape stacking contexts which prevents buggy drag positioning in e.g.\r\npopovers, modals, and flyouts.\r\n\r\n**Bug fixes**\r\n\r\n- Fixed `EuiProvider`'s system color mode detection causing errors\r\nduring server-side rendering\r\n([#8040](https://github.com/elastic/eui/pull/8040))\r\n- Fixed an `EuiDataGrid` rendering bug that was causing bouncing\r\nscrollbar issues ([#8041](https://github.com/elastic/eui/pull/8041))\r\n- Fixed `EuiSearchBox` skips input when running with React 18 in Legacy\r\nMode ([#8047](https://github.com/elastic/eui/pull/8047))\r\n\r\n**Deprecations**\r\n\r\n- Deprecated `EuiPopover`'s `hasDragDrop` prop. Use `EuiDraggable`'s new\r\n`usePortal` prop instead.\r\n([#8048](https://github.com/elastic/eui/pull/8048))\r\n\r\n**Breaking changes**\r\n\r\n- Removed the following exported `.css` files:\r\n([#8045](https://github.com/elastic/eui/pull/8045))\r\n  - `@elastic/eui/dist/eui_theme_light.css`\r\n  - `@elastic/eui/dist/eui_theme_light.min.css`\r\n  - `@elastic/eui/dist/eui_theme_dark.css`\r\n  - `@elastic/eui/dist/eui_theme_dark.min.css`\r\n- All EUI components are now on CSS-in-JS. A CSS file/import in\r\nconsuming applications is no longer needed, and is safe to remove.\r\n([#8045](https://github.com/elastic/eui/pull/8045))\r\n- Removed all `src/theme/legacy` Sass exports\r\n([#8054](https://github.com/elastic/eui/pull/8054))\r\n\r\n**CSS-in-JS conversions**\r\n\r\n- Removed the following component-specific Sass variables:\r\n([#8031](https://github.com/elastic/eui/pull/8031))\r\n  - `$euiButtonColorDisabled`\r\n  - `$euiButtonColorDisabledText`\r\n  - `$euiButtonColorGhostDisabled`\r\n  - `$euiButtonFontWeight`\r\n  - `$euiFormControlIconSizes`\r\n  - `$euiFormControlLayoutGroupInputHeight`\r\n  - `$euiFormControlLayoutGroupInputCompressedHeight`\r\n  - `$euiFormControlLayoutGroupInputCompressedBorderRadius`\r\n  - `$euiPageSidebarMinWidth`\r\n  - `$euiPageDefaultMaxWidth`\r\n  - `$euiPanelPaddingModifiers`\r\n  - `$euiPanelBorderRadiusModifiers`\r\n  - `$euiPanelBackgroundColorModifiers`\r\n  - `$euiRangeTrackColor`\r\n  - `$euiRangeHighlightColor`\r\n  - `$euiRangeThumbHeight`\r\n  - `$euiRangeThumbWidth`\r\n  - `$euiRangeThumbBorderColor`\r\n  - `$euiRangeThumbBackgroundColor`\r\n  - `$euiRangeTrackWidth`\r\n  - `$euiRangeTrackHeight`\r\n  - `$euiRangeTrackCompressedHeight`\r\n  - `$euiRangeTrackBorderWidth`\r\n  - `$euiRangeTrackBorderColor`\r\n  - `$euiRangeTrackRadius`\r\n  - `$euiRangeDisabledOpacity`\r\n  - `$euiRangeHighlightHeight`\r\n  - `$euiRangeHighlightCompressedHeight`\r\n  - `$euiRangeHeight`\r\n  - `$euiRangeCompressedHeight`\r\n  - `$euiTooltipAnimations`\r\n  - `$euiTooltipBackgroundColor`\r\n  - `$euiTooltipBorderColor`\r\n- Removed the following Sass mixins due to low external usage:\r\n([#8031](https://github.com/elastic/eui/pull/8031))\r\n  - `euiHoverState`\r\n  - `euiFocusState`\r\n  - `euiDisabledState`\r\n  - `euiInteractiveStates`\r\n  - `euiFormControlStyle`\r\n  - `euiFormControlStyleCompressed`\r\n  - `euiFormControlFocusStyle`\r\n  - `euiFormControlInvalidStyle`\r\n  - `euiFormControlDisabledTextStyle`\r\n  - `euiFormControlDisabledStyle`\r\n  - `euiFormControlReadOnlyStyle`\r\n  - `euiFormControlText`\r\n  - `euiFormControlSize`\r\n  - `euiFormControlGradient`\r\n  - `euiFormControlLayoutPadding`\r\n  - `euiFormControlWithIcon`\r\n  - `euiFormControlIsLoading`\r\n  - `euiFormControlSideBorderRadius`\r\n  - `euiPlaceholderPerBrowser`\r\n  - `euiHiddenSelectableInput`\r\n  - `euiLink`\r\n  - `euiLoadingSpinnerBorderColors`\r\n  - `euiRangeTrackSize`\r\n  - `euiRangeTrackPerBrowser`\r\n  - `euiRangeThumbBorder`\r\n  - `euiRangeThumbBoxShadow`\r\n  - `euiRangeThumbFocusBoxShadow`\r\n  - `euiRangeThumbStyle`\r\n  - `euiRangeThumbPerBrowser`\r\n  - `euiRangeThumbFocus`\r\n  - `euiToolTipAnimation`\r\n\r\n## [`v96.1.0`](https://github.com/elastic/eui/releases/v96.1.0)\r\n\r\n**CSS-in-JS conversions**\r\n\r\n- Removed the following component-specific Sass mixins:\r\n([#8055](https://github.com/elastic/eui/pull/8055))\r\n  - `euiButton`\r\n  - `euiButtonBase`\r\n  - `euiButtonFocus`\r\n  - `euiButtonContent`\r\n  - `euiButtonContentDisabled`\r\n  - `euiButtonDefaultStyle`\r\n  - `euiButtonFillStyle`\r\n  - `euiPanel`\r\n  - `euiFormControlDefaultShadow`\r\n  - `euiToolTipTitle`","sha":"19e37bf5c52bd0ae3f788ae2b4015c614c901950","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","EUI","v9.0.0","v8.16.0","backport:version"],"number":194619,"url":"https://github.com/elastic/kibana/pull/194619","mergeCommit":{"message":"Upgrade EUI to v96.1.0 (#194619)\n\n`v95.12.0`⏩`v96.1.0`\r\n\r\n_[Questions? Please see our Kibana upgrade\r\nFAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)_\r\n\r\n---\r\n\r\n## [`v96.0.0`](https://github.com/elastic/eui/releases/v96.0.0)\r\n\r\n- Improved `EuiPageHeader`/`EuiPageTemplate.Header`'s responsive UX:\r\n([#8044](https://github.com/elastic/eui/pull/8044))\r\n- `rightSideItems` are no longer pushed to the side by wide `tabs`\r\ncontent\r\n- `rightSideItems` now wrap more responsively at smaller container\r\nwidths\r\n- Updated `EuiDraggable` with a new `usePortal` prop.\r\n([#8048](https://github.com/elastic/eui/pull/8048))\r\n- This prop portals the dragged element to the body, allowing it to\r\nescape stacking contexts which prevents buggy drag positioning in e.g.\r\npopovers, modals, and flyouts.\r\n\r\n**Bug fixes**\r\n\r\n- Fixed `EuiProvider`'s system color mode detection causing errors\r\nduring server-side rendering\r\n([#8040](https://github.com/elastic/eui/pull/8040))\r\n- Fixed an `EuiDataGrid` rendering bug that was causing bouncing\r\nscrollbar issues ([#8041](https://github.com/elastic/eui/pull/8041))\r\n- Fixed `EuiSearchBox` skips input when running with React 18 in Legacy\r\nMode ([#8047](https://github.com/elastic/eui/pull/8047))\r\n\r\n**Deprecations**\r\n\r\n- Deprecated `EuiPopover`'s `hasDragDrop` prop. Use `EuiDraggable`'s new\r\n`usePortal` prop instead.\r\n([#8048](https://github.com/elastic/eui/pull/8048))\r\n\r\n**Breaking changes**\r\n\r\n- Removed the following exported `.css` files:\r\n([#8045](https://github.com/elastic/eui/pull/8045))\r\n  - `@elastic/eui/dist/eui_theme_light.css`\r\n  - `@elastic/eui/dist/eui_theme_light.min.css`\r\n  - `@elastic/eui/dist/eui_theme_dark.css`\r\n  - `@elastic/eui/dist/eui_theme_dark.min.css`\r\n- All EUI components are now on CSS-in-JS. A CSS file/import in\r\nconsuming applications is no longer needed, and is safe to remove.\r\n([#8045](https://github.com/elastic/eui/pull/8045))\r\n- Removed all `src/theme/legacy` Sass exports\r\n([#8054](https://github.com/elastic/eui/pull/8054))\r\n\r\n**CSS-in-JS conversions**\r\n\r\n- Removed the following component-specific Sass variables:\r\n([#8031](https://github.com/elastic/eui/pull/8031))\r\n  - `$euiButtonColorDisabled`\r\n  - `$euiButtonColorDisabledText`\r\n  - `$euiButtonColorGhostDisabled`\r\n  - `$euiButtonFontWeight`\r\n  - `$euiFormControlIconSizes`\r\n  - `$euiFormControlLayoutGroupInputHeight`\r\n  - `$euiFormControlLayoutGroupInputCompressedHeight`\r\n  - `$euiFormControlLayoutGroupInputCompressedBorderRadius`\r\n  - `$euiPageSidebarMinWidth`\r\n  - `$euiPageDefaultMaxWidth`\r\n  - `$euiPanelPaddingModifiers`\r\n  - `$euiPanelBorderRadiusModifiers`\r\n  - `$euiPanelBackgroundColorModifiers`\r\n  - `$euiRangeTrackColor`\r\n  - `$euiRangeHighlightColor`\r\n  - `$euiRangeThumbHeight`\r\n  - `$euiRangeThumbWidth`\r\n  - `$euiRangeThumbBorderColor`\r\n  - `$euiRangeThumbBackgroundColor`\r\n  - `$euiRangeTrackWidth`\r\n  - `$euiRangeTrackHeight`\r\n  - `$euiRangeTrackCompressedHeight`\r\n  - `$euiRangeTrackBorderWidth`\r\n  - `$euiRangeTrackBorderColor`\r\n  - `$euiRangeTrackRadius`\r\n  - `$euiRangeDisabledOpacity`\r\n  - `$euiRangeHighlightHeight`\r\n  - `$euiRangeHighlightCompressedHeight`\r\n  - `$euiRangeHeight`\r\n  - `$euiRangeCompressedHeight`\r\n  - `$euiTooltipAnimations`\r\n  - `$euiTooltipBackgroundColor`\r\n  - `$euiTooltipBorderColor`\r\n- Removed the following Sass mixins due to low external usage:\r\n([#8031](https://github.com/elastic/eui/pull/8031))\r\n  - `euiHoverState`\r\n  - `euiFocusState`\r\n  - `euiDisabledState`\r\n  - `euiInteractiveStates`\r\n  - `euiFormControlStyle`\r\n  - `euiFormControlStyleCompressed`\r\n  - `euiFormControlFocusStyle`\r\n  - `euiFormControlInvalidStyle`\r\n  - `euiFormControlDisabledTextStyle`\r\n  - `euiFormControlDisabledStyle`\r\n  - `euiFormControlReadOnlyStyle`\r\n  - `euiFormControlText`\r\n  - `euiFormControlSize`\r\n  - `euiFormControlGradient`\r\n  - `euiFormControlLayoutPadding`\r\n  - `euiFormControlWithIcon`\r\n  - `euiFormControlIsLoading`\r\n  - `euiFormControlSideBorderRadius`\r\n  - `euiPlaceholderPerBrowser`\r\n  - `euiHiddenSelectableInput`\r\n  - `euiLink`\r\n  - `euiLoadingSpinnerBorderColors`\r\n  - `euiRangeTrackSize`\r\n  - `euiRangeTrackPerBrowser`\r\n  - `euiRangeThumbBorder`\r\n  - `euiRangeThumbBoxShadow`\r\n  - `euiRangeThumbFocusBoxShadow`\r\n  - `euiRangeThumbStyle`\r\n  - `euiRangeThumbPerBrowser`\r\n  - `euiRangeThumbFocus`\r\n  - `euiToolTipAnimation`\r\n\r\n## [`v96.1.0`](https://github.com/elastic/eui/releases/v96.1.0)\r\n\r\n**CSS-in-JS conversions**\r\n\r\n- Removed the following component-specific Sass mixins:\r\n([#8055](https://github.com/elastic/eui/pull/8055))\r\n  - `euiButton`\r\n  - `euiButtonBase`\r\n  - `euiButtonFocus`\r\n  - `euiButtonContent`\r\n  - `euiButtonContentDisabled`\r\n  - `euiButtonDefaultStyle`\r\n  - `euiButtonFillStyle`\r\n  - `euiPanel`\r\n  - `euiFormControlDefaultShadow`\r\n  - `euiToolTipTitle`","sha":"19e37bf5c52bd0ae3f788ae2b4015c614c901950"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/194619","number":194619,"mergeCommit":{"message":"Upgrade EUI to v96.1.0 (#194619)\n\n`v95.12.0`⏩`v96.1.0`\r\n\r\n_[Questions? Please see our Kibana upgrade\r\nFAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)_\r\n\r\n---\r\n\r\n## [`v96.0.0`](https://github.com/elastic/eui/releases/v96.0.0)\r\n\r\n- Improved `EuiPageHeader`/`EuiPageTemplate.Header`'s responsive UX:\r\n([#8044](https://github.com/elastic/eui/pull/8044))\r\n- `rightSideItems` are no longer pushed to the side by wide `tabs`\r\ncontent\r\n- `rightSideItems` now wrap more responsively at smaller container\r\nwidths\r\n- Updated `EuiDraggable` with a new `usePortal` prop.\r\n([#8048](https://github.com/elastic/eui/pull/8048))\r\n- This prop portals the dragged element to the body, allowing it to\r\nescape stacking contexts which prevents buggy drag positioning in e.g.\r\npopovers, modals, and flyouts.\r\n\r\n**Bug fixes**\r\n\r\n- Fixed `EuiProvider`'s system color mode detection causing errors\r\nduring server-side rendering\r\n([#8040](https://github.com/elastic/eui/pull/8040))\r\n- Fixed an `EuiDataGrid` rendering bug that was causing bouncing\r\nscrollbar issues ([#8041](https://github.com/elastic/eui/pull/8041))\r\n- Fixed `EuiSearchBox` skips input when running with React 18 in Legacy\r\nMode ([#8047](https://github.com/elastic/eui/pull/8047))\r\n\r\n**Deprecations**\r\n\r\n- Deprecated `EuiPopover`'s `hasDragDrop` prop. Use `EuiDraggable`'s new\r\n`usePortal` prop instead.\r\n([#8048](https://github.com/elastic/eui/pull/8048))\r\n\r\n**Breaking changes**\r\n\r\n- Removed the following exported `.css` files:\r\n([#8045](https://github.com/elastic/eui/pull/8045))\r\n  - `@elastic/eui/dist/eui_theme_light.css`\r\n  - `@elastic/eui/dist/eui_theme_light.min.css`\r\n  - `@elastic/eui/dist/eui_theme_dark.css`\r\n  - `@elastic/eui/dist/eui_theme_dark.min.css`\r\n- All EUI components are now on CSS-in-JS. A CSS file/import in\r\nconsuming applications is no longer needed, and is safe to remove.\r\n([#8045](https://github.com/elastic/eui/pull/8045))\r\n- Removed all `src/theme/legacy` Sass exports\r\n([#8054](https://github.com/elastic/eui/pull/8054))\r\n\r\n**CSS-in-JS conversions**\r\n\r\n- Removed the following component-specific Sass variables:\r\n([#8031](https://github.com/elastic/eui/pull/8031))\r\n  - `$euiButtonColorDisabled`\r\n  - `$euiButtonColorDisabledText`\r\n  - `$euiButtonColorGhostDisabled`\r\n  - `$euiButtonFontWeight`\r\n  - `$euiFormControlIconSizes`\r\n  - `$euiFormControlLayoutGroupInputHeight`\r\n  - `$euiFormControlLayoutGroupInputCompressedHeight`\r\n  - `$euiFormControlLayoutGroupInputCompressedBorderRadius`\r\n  - `$euiPageSidebarMinWidth`\r\n  - `$euiPageDefaultMaxWidth`\r\n  - `$euiPanelPaddingModifiers`\r\n  - `$euiPanelBorderRadiusModifiers`\r\n  - `$euiPanelBackgroundColorModifiers`\r\n  - `$euiRangeTrackColor`\r\n  - `$euiRangeHighlightColor`\r\n  - `$euiRangeThumbHeight`\r\n  - `$euiRangeThumbWidth`\r\n  - `$euiRangeThumbBorderColor`\r\n  - `$euiRangeThumbBackgroundColor`\r\n  - `$euiRangeTrackWidth`\r\n  - `$euiRangeTrackHeight`\r\n  - `$euiRangeTrackCompressedHeight`\r\n  - `$euiRangeTrackBorderWidth`\r\n  - `$euiRangeTrackBorderColor`\r\n  - `$euiRangeTrackRadius`\r\n  - `$euiRangeDisabledOpacity`\r\n  - `$euiRangeHighlightHeight`\r\n  - `$euiRangeHighlightCompressedHeight`\r\n  - `$euiRangeHeight`\r\n  - `$euiRangeCompressedHeight`\r\n  - `$euiTooltipAnimations`\r\n  - `$euiTooltipBackgroundColor`\r\n  - `$euiTooltipBorderColor`\r\n- Removed the following Sass mixins due to low external usage:\r\n([#8031](https://github.com/elastic/eui/pull/8031))\r\n  - `euiHoverState`\r\n  - `euiFocusState`\r\n  - `euiDisabledState`\r\n  - `euiInteractiveStates`\r\n  - `euiFormControlStyle`\r\n  - `euiFormControlStyleCompressed`\r\n  - `euiFormControlFocusStyle`\r\n  - `euiFormControlInvalidStyle`\r\n  - `euiFormControlDisabledTextStyle`\r\n  - `euiFormControlDisabledStyle`\r\n  - `euiFormControlReadOnlyStyle`\r\n  - `euiFormControlText`\r\n  - `euiFormControlSize`\r\n  - `euiFormControlGradient`\r\n  - `euiFormControlLayoutPadding`\r\n  - `euiFormControlWithIcon`\r\n  - `euiFormControlIsLoading`\r\n  - `euiFormControlSideBorderRadius`\r\n  - `euiPlaceholderPerBrowser`\r\n  - `euiHiddenSelectableInput`\r\n  - `euiLink`\r\n  - `euiLoadingSpinnerBorderColors`\r\n  - `euiRangeTrackSize`\r\n  - `euiRangeTrackPerBrowser`\r\n  - `euiRangeThumbBorder`\r\n  - `euiRangeThumbBoxShadow`\r\n  - `euiRangeThumbFocusBoxShadow`\r\n  - `euiRangeThumbStyle`\r\n  - `euiRangeThumbPerBrowser`\r\n  - `euiRangeThumbFocus`\r\n  - `euiToolTipAnimation`\r\n\r\n## [`v96.1.0`](https://github.com/elastic/eui/releases/v96.1.0)\r\n\r\n**CSS-in-JS conversions**\r\n\r\n- Removed the following component-specific Sass mixins:\r\n([#8055](https://github.com/elastic/eui/pull/8055))\r\n  - `euiButton`\r\n  - `euiButtonBase`\r\n  - `euiButtonFocus`\r\n  - `euiButtonContent`\r\n  - `euiButtonContentDisabled`\r\n  - `euiButtonDefaultStyle`\r\n  - `euiButtonFillStyle`\r\n  - `euiPanel`\r\n  - `euiFormControlDefaultShadow`\r\n  - `euiToolTipTitle`","sha":"19e37bf5c52bd0ae3f788ae2b4015c614c901950"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->