### PR TITLE
[Fleet] Do not enable uninstall command link without Agents:All

### DIFF
--- a/x-pack/plugins/fleet/public/components/missing_privileges_tooltip.tsx
+++ b/x-pack/plugins/fleet/public/components/missing_privileges_tooltip.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiToolTip, type EuiToolTipProps } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export const MissingPrivilegesToolTip: React.FC<{
+  children: React.ReactElement;
+  missingPrivilege?: string;
+  position?: EuiToolTipProps['position'];
+}> = ({ children, missingPrivilege, position }) => {
+  if (!missingPrivilege) {
+    return children;
+  }
+  return (
+    <EuiToolTip
+      content={i18n.translate('xpack.fleet.missingPrivilegesToolTip', {
+        defaultMessage:
+          'You are not authorized to perform that action. It requires the {missingPrivilege} Kibana privilege for Fleet.',
+        values: {
+          missingPrivilege,
+        },
+      })}
+      position={position}
+    >
+      {children}
+    </EuiToolTip>
+  );
+};


### PR DESCRIPTION
## Summary

Resolve #192055 

Do not enable uninstall command link when user do not have Agents:All, we also show a tooltip explaining why it's disabled

## UI Change

<img width="1293" alt="Screenshot 2024-10-07 at 10 17 17 AM" src="https://github.com/user-attachments/assets/b05fe303-3f53-4590-8cbb-66d3c45dc471">


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->