### PR TITLE
[ES|QL] Returns the columns used in the ES|QL query

### DIFF
--- a/packages/kbn-esql-utils/index.ts
+++ b/packages/kbn-esql-utils/index.ts
@@ -28,6 +28,7 @@ export {
   prettifyQuery,
   isQueryWrappedByPipes,
   retrieveMetadataColumns,
+  getQueryColumnsFromESQLQuery,
   TextBasedLanguages,
 } from './src';
 

--- a/packages/kbn-esql-utils/src/index.ts
+++ b/packages/kbn-esql-utils/src/index.ts
@@ -20,6 +20,7 @@ export {
   prettifyQuery,
   isQueryWrappedByPipes,
   retrieveMetadataColumns,
+  getQueryColumnsFromESQLQuery,
 } from './utils/query_parsing_helpers';
 export { appendToESQLQuery, appendWhereClauseToESQLQuery } from './utils/append_to_query';
 export {

--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -16,6 +16,7 @@ import {
   prettifyQuery,
   isQueryWrappedByPipes,
   retrieveMetadataColumns,
+  getQueryColumnsFromESQLQuery,
 } from './query_parsing_helpers';
 
 describe('esql query helpers', () => {
@@ -227,6 +228,42 @@ describe('esql query helpers', () => {
 
     it('should return empty columns if metadata doesnt exist', () => {
       expect(retrieveMetadataColumns('from a | eval b = 1')).toStrictEqual([]);
+    });
+  });
+
+  describe('getQueryColumnsFromESQLQuery', () => {
+    it('should return the columns used in stats', () => {
+      expect(
+        getQueryColumnsFromESQLQuery('from a | stats var0 = avg(bytes) by dest')
+      ).toStrictEqual(['var0', 'bytes', 'dest']);
+    });
+
+    it('should return the columns used in eval', () => {
+      expect(
+        getQueryColumnsFromESQLQuery('from a | eval dest = geo.dest, var1 = bytes')
+      ).toStrictEqual(['dest', 'geo.dest', 'var1', 'bytes']);
+    });
+
+    it('should return the columns used in eval and stats', () => {
+      expect(
+        getQueryColumnsFromESQLQuery('from a | stats var0 = avg(bytes) by dest | eval meow = var0')
+      ).toStrictEqual(['var0', 'bytes', 'dest', 'meow', 'var0']);
+    });
+
+    it('should return the metadata columns', () => {
+      expect(
+        getQueryColumnsFromESQLQuery('from a  metadata _id, _ignored | eval b = 1')
+      ).toStrictEqual(['_id', '_ignored', 'b']);
+    });
+
+    it('should return the keep columns', () => {
+      expect(getQueryColumnsFromESQLQuery('from a | keep b, c, d')).toStrictEqual(['b', 'c', 'd']);
+    });
+
+    it('should return the where columns', () => {
+      expect(
+        getQueryColumnsFromESQLQuery('from a | where field > 1000 and abs(fieldb) < 20')
+      ).toStrictEqual(['field', 'fieldb']);
     });
   });
 });

--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -265,5 +265,12 @@ describe('esql query helpers', () => {
         getQueryColumnsFromESQLQuery('from a | where field > 1000 and abs(fieldb) < 20')
       ).toStrictEqual(['field', 'fieldb']);
     });
+
+    it('should return the rename columns', () => {
+      expect(getQueryColumnsFromESQLQuery('from a | rename field as fieldb')).toStrictEqual([
+        'field',
+        'fieldb',
+      ]);
+    });
   });
 });

--- a/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/packages/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -136,3 +136,14 @@ export const retrieveMetadataColumns = (esql: string): string[] => {
   const metadataOptions = options.find(({ name }) => name === 'metadata');
   return metadataOptions?.args.map((column) => (column as ESQLColumn).name) ?? [];
 };
+
+export const getQueryColumnsFromESQLQuery = (esql: string): string[] => {
+  const { root } = parse(esql);
+  const columns: ESQLColumn[] = [];
+
+  walk(root, {
+    visitColumn: (node) => columns.push(node),
+  });
+
+  return columns.map((column) => column.name);
+};


### PR DESCRIPTION
## Summary

Creates a helper function to retrieve the columns / fields used in an ES|QL query

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->