### PR TITLE
[SecuritySolution] [Postponed] Add DataView support to Entity Manager plugin

### DIFF
--- a/x-pack/packages/kbn-entities-schema/src/schema/entity_definition.test.ts
+++ b/x-pack/packages/kbn-entities-schema/src/schema/entity_definition.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { entityDefinitionSchema, entityDefinitionUpdateSchema } from './entity_definition';
+
+const partialEntityDefinition = {
+  id: 'entity-1',
+  version: '1.0.0',
+  name: 'Test Entity',
+  type: 'test-type',
+  filter: '',
+  identityFields: [],
+  displayNameTemplate: 'Test Entity',
+  history: {
+    timestampField: 'timestamp',
+    interval: '1d',
+    settings: {},
+  },
+};
+
+describe('entityDefinitionSchema', () => {
+  it('should throw an error if both indexPatterns and dataViewId are defined', () => {
+    const invalidEntity = {
+      ...partialEntityDefinition,
+      indexPatterns: ['pattern1'],
+      dataViewId: 'dataView1',
+    };
+
+    expect(() => entityDefinitionSchema.parse(invalidEntity)).toThrow(
+      "dataViewId can't bet set if indexPatterns is defined"
+    );
+  });
+
+  it('should throw an error if neither indexPatterns nor dataViewId are defined', () => {
+    expect(() => entityDefinitionSchema.parse(partialEntityDefinition)).toThrow(
+      "dataViewId should be set if indexPatterns isn't"
+    );
+  });
+});
+
+describe('entityDefinitionUpdateSchema', () => {
+  it('should throw an error if both indexPatterns and dataViewId are defined in update', () => {
+    const invalidEntityUpdate = {
+      version: '1.0.1',
+      indexPatterns: ['pattern1'],
+      dataViewId: 'dataView1',
+    };
+
+    expect(() => entityDefinitionUpdateSchema.parse(invalidEntityUpdate)).toThrow(
+      "dataViewId can't bet set if indexPatterns is defined"
+    );
+  });
+
+  it('should not throw an error if neither indexPatterns nor dataViewId are defined in update', () => {
+    const validEntityUpdate = {
+      version: '1.0.1',
+    };
+
+    expect(() => entityDefinitionUpdateSchema.parse(validEntityUpdate)).not.toThrow();
+  });
+});

--- a/x-pack/packages/kbn-entities-schema/src/schema/entity_definition.ts
+++ b/x-pack/packages/kbn-entities-schema/src/schema/entity_definition.ts
@@ -23,7 +23,7 @@ const IndexPatternsSchema = z.object({
 });
 
 const DataViewIdSchema = z.object({
-  data_view_id: z.string(),
+  dataViewId: z.string(),
 });
 
 const baseEntityDefinitionSchema = z.object({
@@ -75,21 +75,6 @@ export const entityDefinitionSchema = z.union([
   entityDefinitionSchemaWithDataViewId,
 ]);
 
-// TODO do wer need to add this check for the update schema?
-// can we change indexpatterns during update?
-// export const entityDefinitionSchema = baseEntityDefinitionSchema.superRefine((data, ctx) => {
-//   if (!data.indexPatterns && !data.data_view_id) {
-//     ctx.addIssue({
-//       code: z.ZodIssueCode.custom,
-//       path: ['data_view_id'],
-//       message: "data_view_id should be set if indexPatterns isn't",
-//     });
-//   }
-// });
-// I couldn't use union because it doesn't support partial and merge
-// z.union([z.object({ indexPatterns: arrayOfStringsSchema }), z.object({ data_view_id: z.string() })]);
-// .or(z.object({ data_view_id: z.string() }));
-
 export const entityDefinitionUpdateSchema = baseEntityDefinitionSchema
   .omit({
     id: true,
@@ -105,7 +90,17 @@ export const entityDefinitionUpdateSchema = baseEntityDefinitionSchema
       history: z.optional(baseEntityDefinitionSchema.shape.history.partial()),
       version: semVerSchema,
     })
-  );
+  )
+  // TODO test it
+  .superRefine((data, ctx) => {
+    if (data.indexPatterns && data.dataViewId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['dataViewId'],
+        message: "dataViewId can't bet set if indexPatterns is defined",
+      });
+    }
+  });
 
 export type EntityDefinition = z.infer<typeof entityDefinitionSchema>;
 export type EntityDefinitionUpdate = z.infer<typeof entityDefinitionUpdateSchema>;

--- a/x-pack/plugins/entity_manager/kibana.jsonc
+++ b/x-pack/plugins/entity_manager/kibana.jsonc
@@ -6,7 +6,7 @@
   "plugin": {
     "id": "entityManager",
     "configPath": ["xpack", "entityManager"],
-    "requiredPlugins": ["security", "encryptedSavedObjects", "licensing"],
+    "requiredPlugins": ["security", "encryptedSavedObjects", "licensing", "dataViews"],
     "browser": true,
     "server": true,
     "requiredBundles": []

--- a/x-pack/plugins/entity_manager/server/lib/entities/create_and_install_transform.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/create_and_install_transform.ts
@@ -7,6 +7,7 @@
 
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { EntityDefinition } from '@kbn/entities-schema';
+import { DataViewsService } from '@kbn/data-views-plugin/common';
 import { retryTransientEsErrors } from './helpers/retry';
 import { generateLatestTransform } from './transform/generate_latest_transform';
 import {
@@ -16,11 +17,12 @@ import {
 
 export async function createAndInstallHistoryTransform(
   esClient: ElasticsearchClient,
+  dataViewsService: DataViewsService,
   definition: EntityDefinition,
   logger: Logger
 ) {
   try {
-    const historyTransform = generateHistoryTransform(definition);
+    const historyTransform = await generateHistoryTransform(definition, dataViewsService);
     await retryTransientEsErrors(() => esClient.transform.putTransform(historyTransform), {
       logger,
     });
@@ -32,11 +34,12 @@ export async function createAndInstallHistoryTransform(
 
 export async function createAndInstallHistoryBackfillTransform(
   esClient: ElasticsearchClient,
+  dataViewsService: DataViewsService,
   definition: EntityDefinition,
   logger: Logger
 ) {
   try {
-    const historyTransform = generateBackfillHistoryTransform(definition);
+    const historyTransform = await generateBackfillHistoryTransform(definition, dataViewsService);
     await retryTransientEsErrors(() => esClient.transform.putTransform(historyTransform), {
       logger,
     });

--- a/x-pack/plugins/entity_manager/server/lib/entities/helpers/merge_definition_update.test.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/helpers/merge_definition_update.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mergeEntityDefinitionUpdate } from './merge_definition_update';
+import { EntityDefinition } from '@kbn/entities-schema';
+
+const partialDefinition: EntityDefinition = {
+  id: 'originalId',
+  version: '1.0.0',
+  name: 'originalName',
+  type: 'originalType',
+  identityFields: [{ field: 'originalField', optional: false }],
+  displayNameTemplate: 'originalTemplate',
+  managed: false,
+  history: {
+    timestampField: 'timestamp',
+    interval: '1m',
+    settings: {
+      lookbackPeriod: '1d',
+    },
+  },
+};
+describe('mergeEntityDefinitionUpdate', () => {
+  it('should overwrite indexPatterns if dataViewId is set', () => {
+    const update = {
+      dataViewId: 'newDataViewId',
+      version: '1.0.1',
+    };
+
+    const result = mergeEntityDefinitionUpdate(
+      { ...partialDefinition, indexPatterns: ['testPattern'] },
+      update
+    );
+
+    expect(result.dataViewId).toEqual('newDataViewId');
+    expect(result.indexPatterns).toEqual(undefined);
+  });
+
+  it('should overwrite dataViewId if indexPatterns is set', () => {
+    const definition = {
+      ...partialDefinition,
+      dataViewId: 'originalDataViewId',
+    };
+    const update = {
+      indexPatterns: ['newIndexPattern'],
+      version: '1.0.1',
+    };
+
+    const result = mergeEntityDefinitionUpdate(definition, update);
+
+    expect(result.indexPatterns).toEqual(['newIndexPattern']);
+    expect(result.dataViewId).toEqual(undefined);
+  });
+});

--- a/x-pack/plugins/entity_manager/server/lib/entities/helpers/merge_definition_update.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/helpers/merge_definition_update.ts
@@ -14,9 +14,7 @@ export function mergeEntityDefinitionUpdate(
 ) {
   const validatedDefinition: EntityDefinitionUpdate = { ...definition };
 
-  // TODO add unit tests for this
-
-  // Make sure that if the users sets the dataViewId or indexPatterns we delete the other one
+  // Make sure that if dataViewId or indexPatterns is set we delete the other one
   if (update.dataViewId) {
     delete validatedDefinition.indexPatterns;
   } else if (update.indexPatterns) {

--- a/x-pack/plugins/entity_manager/server/lib/entities/helpers/merge_definition_update.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/helpers/merge_definition_update.ts
@@ -12,7 +12,17 @@ export function mergeEntityDefinitionUpdate(
   definition: EntityDefinition,
   update: EntityDefinitionUpdate
 ) {
-  const updatedDefinition = mergeWith(definition, update, (value, other) => {
+  const validatedDefinition: EntityDefinitionUpdate = { ...definition };
+
+  // TODO add unit tests for this
+
+  // Make sure that if the users sets the dataViewId or indexPatterns we delete the other one
+  if (update.dataViewId) {
+    delete validatedDefinition.indexPatterns;
+  } else if (update.indexPatterns) {
+    delete validatedDefinition.dataViewId;
+  }
+  const updatedDefinition = mergeWith(validatedDefinition, update, (value, other) => {
     // we don't want to merge arrays (metrics, metadata..) but overwrite them
     if (Array.isArray(value)) {
       return other;

--- a/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_history_transform.test.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_history_transform.test.ts
@@ -5,20 +5,59 @@
  * 2.0.
  */
 
+import { DataViewsService } from '@kbn/data-views-plugin/common';
 import { entityDefinition } from '../helpers/fixtures/entity_definition';
 import { entityDefinitionWithBackfill } from '../helpers/fixtures/entity_definition_with_backfill';
 import {
   generateBackfillHistoryTransform,
   generateHistoryTransform,
+  getIndexPatterns,
 } from './generate_history_transform';
 
+const mockGetDataView = jest.fn();
+const dataViewsService = { get: mockGetDataView } as unknown as DataViewsService;
+
+const dataViewId = 'dataViewId';
+const definitionWithDataViewId = {
+  ...entityDefinition,
+  indexPatterns: undefined,
+  dataViewId,
+};
+
 describe('generateHistoryTransform(definition)', () => {
-  it('should generate a valid history transform', () => {
-    const transform = generateHistoryTransform(entityDefinition);
+  it('should generate a valid history transform', async () => {
+    const transform = await generateHistoryTransform(entityDefinition, dataViewsService);
     expect(transform).toMatchSnapshot();
   });
-  it('should generate a valid history backfill transform', () => {
-    const transform = generateBackfillHistoryTransform(entityDefinitionWithBackfill);
+  it('should generate a valid history backfill transform', async () => {
+    const transform = await generateBackfillHistoryTransform(
+      entityDefinitionWithBackfill,
+      dataViewsService
+    );
     expect(transform).toMatchSnapshot();
+  });
+
+  describe('getIndexPatterns', () => {
+    it('should return indexPatterns if defined in the entity definition', async () => {
+      const definitionWithIndexPatterns = {
+        ...entityDefinition,
+        indexPatterns: ['pattern1', 'pattern2'],
+      };
+      const indexPatterns = await getIndexPatterns(definitionWithIndexPatterns, dataViewsService);
+      expect(indexPatterns).toEqual(['pattern1', 'pattern2']);
+    });
+
+    it('should return data view index pattern if dataViewId is defined', async () => {
+      mockGetDataView.mockResolvedValue({ getIndexPattern: () => 'dataViewPattern' });
+      const indexPatterns = await getIndexPatterns(definitionWithDataViewId, dataViewsService);
+      expect(indexPatterns).toEqual(['dataViewPattern']);
+    });
+
+    it('should throw an error if data view is not found', async () => {
+      mockGetDataView.mockRejectedValue(new Error('Data view not found'));
+      await expect(getIndexPatterns(definitionWithDataViewId, dataViewsService)).rejects.toThrow(
+        `Data view 'dataViewId' not found for entity definition '${definitionWithDataViewId.id}'. Data view not found`
+      );
+    });
   });
 });

--- a/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_history_transform.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_history_transform.ts
@@ -192,15 +192,15 @@ const getIndexPatterns = async (
   dataViewsService: DataViewsService
 ): Promise<string | string[]> => {
   if (isEntityDefinitionWithIndexPattern(definition)) {
-    return definition.indexPatterns; // data_view_id or indexPatterns must be defined
+    return definition.indexPatterns; // dataViewId or indexPatterns must be defined
   }
 
   try {
-    const dataView = await dataViewsService.get(definition.data_view_id);
+    const dataView = await dataViewsService.get(definition.dataViewId);
     return [dataView.getIndexPattern()];
   } catch (e) {
     throw new Error(
-      `Data view '${definition.data_view_id}' not found for entity definition '${definition.id}'.` +
+      `Data view '${definition.dataViewId}' not found for entity definition '${definition.id}'.` +
         e.message
     );
   }

--- a/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_history_transform.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_history_transform.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EntityDefinition, isEntityDefinitionWithIndexPattern } from '@kbn/entities-schema';
+import { EntityDefinition } from '@kbn/entities-schema';
 import {
   QueryDslQueryContainer,
   TransformPutTransformRequest,
@@ -186,21 +186,20 @@ const generateTransformPutRequest = async ({
   };
 };
 
-// TODO ADD UNIT TESTS
-const getIndexPatterns = async (
+export const getIndexPatterns = async (
   definition: EntityDefinition,
   dataViewsService: DataViewsService
 ): Promise<string | string[]> => {
-  if (isEntityDefinitionWithIndexPattern(definition)) {
-    return definition.indexPatterns; // dataViewId or indexPatterns must be defined
+  if (definition.indexPatterns) {
+    return definition.indexPatterns;
   }
 
   try {
-    const dataView = await dataViewsService.get(definition.dataViewId);
+    const dataView = await dataViewsService.get(definition.dataViewId!); // dataViewId or indexPatterns must be defined
     return [dataView.getIndexPattern()];
   } catch (e) {
     throw new Error(
-      `Data view '${definition.dataViewId}' not found for entity definition '${definition.id}'.` +
+      `Data view '${definition.dataViewId}' not found for entity definition '${definition.id}'. ` +
         e.message
     );
   }

--- a/x-pack/plugins/entity_manager/server/lib/entities/upgrade_entity_definition.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/upgrade_entity_definition.ts
@@ -35,13 +35,14 @@ export async function upgradeBuiltInEntityDefinitions({
     );
   }
 
-  const { esClient, soClient } = getClientsFromAPIKey({ apiKey, server });
+  const { esClient, soClient, dataViewsService } = await getClientsFromAPIKey({ apiKey, server });
 
   logger.debug(`Starting built-in definitions upgrade`);
   const upgradedDefinitions = await installBuiltInEntityDefinitions({
     esClient,
     soClient,
     definitions,
+    dataViewsService,
     logger,
   });
 

--- a/x-pack/plugins/entity_manager/server/lib/entity_client.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entity_client.ts
@@ -9,6 +9,7 @@ import { EntityDefinition } from '@kbn/entities-schema';
 import { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { Logger } from '@kbn/logging';
+import type { DataViewsService } from '@kbn/data-views-plugin/server';
 import { installEntityDefinition } from './entities/install_entity_definition';
 import { startTransforms } from './entities/start_transforms';
 import { findEntityDefinitions } from './entities/find_entity_definition';
@@ -22,6 +23,7 @@ export class EntityClient {
     private options: {
       esClient: ElasticsearchClient;
       soClient: SavedObjectsClientContract;
+      dataViewsService: DataViewsService;
       logger: Logger;
     }
   ) {}
@@ -37,6 +39,7 @@ export class EntityClient {
       definition,
       soClient: this.options.soClient,
       esClient: this.options.esClient,
+      dataViewsService: this.options.dataViewsService,
       logger: this.options.logger,
     });
 

--- a/x-pack/plugins/entity_manager/server/lib/utils.ts
+++ b/x-pack/plugins/entity_manager/server/lib/utils.ts
@@ -8,18 +8,30 @@
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import { getFakeKibanaRequest } from '@kbn/security-plugin/server/authentication/api_keys/fake_kibana_request';
+import { DataViewsService } from '@kbn/data-views-plugin/common';
 import { EntityManagerServerSetup } from '../types';
 import { EntityDiscoveryAPIKey } from './auth/api_key/api_key';
 
-export const getClientsFromAPIKey = ({
+export const getClientsFromAPIKey = async ({
   apiKey,
   server,
 }: {
   apiKey: EntityDiscoveryAPIKey;
   server: EntityManagerServerSetup;
-}): { esClient: ElasticsearchClient; soClient: SavedObjectsClientContract } => {
+}): Promise<{
+  esClient: ElasticsearchClient;
+  soClient: SavedObjectsClientContract;
+  dataViewsService: DataViewsService;
+}> => {
   const fakeRequest = getFakeKibanaRequest({ id: apiKey.id, api_key: apiKey.apiKey });
   const esClient = server.core.elasticsearch.client.asScoped(fakeRequest).asSecondaryAuthUser;
   const soClient = server.core.savedObjects.getScopedClient(fakeRequest);
-  return { esClient, soClient };
+
+  const dataViewsService = await server.dataViews.dataViewsServiceFactory(
+    soClient,
+    esClient,
+    fakeRequest
+  );
+
+  return { esClient, soClient, dataViewsService };
 };

--- a/x-pack/plugins/entity_manager/server/routes/enablement/check.ts
+++ b/x-pack/plugins/entity_manager/server/routes/enablement/check.ts
@@ -61,7 +61,10 @@ export const checkEntityDiscoveryEnabledRoute = createEntityManagerServerRoute({
         return response.ok({ body: { enabled: false, reason: ERROR_API_KEY_NOT_VALID } });
       }
 
-      const { esClient, soClient } = getClientsFromAPIKey({ apiKey, server });
+      const { esClient, soClient } = await getClientsFromAPIKey({
+        apiKey,
+        server,
+      });
 
       const entityDiscoveryState = await Promise.all(
         builtInDefinitions.map(async (builtInDefinition) => {

--- a/x-pack/plugins/entity_manager/server/routes/enablement/enable.ts
+++ b/x-pack/plugins/entity_manager/server/routes/enablement/enable.ts
@@ -117,10 +117,17 @@ export const enableEntityDiscoveryRoute = createEntityManagerServerRoute({
 
       await saveEntityDiscoveryAPIKey(soClient, apiKey);
 
+      const dataViewsService = await server.dataViews.dataViewsServiceFactory(
+        soClient,
+        esClient,
+        request
+      );
+
       const installedDefinitions = await installBuiltInEntityDefinitions({
         esClient,
         soClient,
         logger,
+        dataViewsService,
         definitions: builtInDefinitions,
       });
 

--- a/x-pack/plugins/entity_manager/server/routes/entities/update.ts
+++ b/x-pack/plugins/entity_manager/server/routes/entities/update.ts
@@ -66,10 +66,15 @@ export const updateEntityDefinitionRoute = createEntityManagerServerRoute({
     query: createEntityDefinitionQuerySchema,
     body: entityDefinitionUpdateSchema,
   }),
-  handler: async ({ context, response, params, logger }) => {
+  handler: async ({ context, response, params, logger, server, request }) => {
     const core = await context.core;
     const soClient = core.savedObjects.client;
     const esClient = core.elasticsearch.client.asCurrentUser;
+    const dataViewsService = await server.dataViews.dataViewsServiceFactory(
+      soClient,
+      esClient,
+      request
+    );
 
     try {
       const installedDefinition = await findEntityDefinitionById({
@@ -100,6 +105,7 @@ export const updateEntityDefinitionRoute = createEntityManagerServerRoute({
         soClient,
         esClient,
         logger,
+        dataViewsService,
         definition: installedDefinition,
         definitionUpdate: params.body,
       });

--- a/x-pack/plugins/entity_manager/server/types.ts
+++ b/x-pack/plugins/entity_manager/server/types.ts
@@ -12,6 +12,7 @@ import {
   EncryptedSavedObjectsPluginStart,
 } from '@kbn/encrypted-saved-objects-plugin/server';
 import { LicensingPluginStart } from '@kbn/licensing-plugin/server';
+import type { PluginStart as DataViewsPluginStart } from '@kbn/data-views-plugin/server';
 import { EntityManagerConfig } from '../common/config';
 
 export interface EntityManagerServerSetup {
@@ -21,6 +22,7 @@ export interface EntityManagerServerSetup {
   security: SecurityPluginStart;
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
   isServerless: boolean;
+  dataViews: DataViewsPluginStart;
 }
 
 export interface ElasticsearchAccessorOptions {
@@ -35,4 +37,5 @@ export interface EntityManagerPluginStartDependencies {
   security: SecurityPluginStart;
   encryptedSavedObjects: EncryptedSavedObjectsPluginStart;
   licensing: LicensingPluginStart;
+  dataViews: DataViewsPluginStart;
 }

--- a/x-pack/plugins/entity_manager/tsconfig.json
+++ b/x-pack/plugins/entity_manager/tsconfig.json
@@ -34,5 +34,6 @@
     "@kbn/zod-helpers",
     "@kbn/encrypted-saved-objects-plugin",
     "@kbn/licensing-plugin",
+    "@kbn/data-views-plugin",
   ]
 }

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/common.gen.ts
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/common.gen.ts
@@ -21,19 +21,20 @@ export const EntityType = z.enum(['user', 'host']);
 export type EntityTypeEnum = typeof EntityType.enum;
 export const EntityTypeEnum = EntityType.enum;
 
-export type IndexPattern = z.infer<typeof IndexPattern>;
-export const IndexPattern = z.string();
-
 export type EngineStatus = z.infer<typeof EngineStatus>;
 export const EngineStatus = z.enum(['installing', 'started', 'stopped']);
 export type EngineStatusEnum = typeof EngineStatus.enum;
 export const EngineStatusEnum = EngineStatus.enum;
 
+export type IndexPattern = z.infer<typeof IndexPattern>;
+export const IndexPattern = z.string();
+
 export type EngineDescriptor = z.infer<typeof EngineDescriptor>;
 export const EngineDescriptor = z.object({
   type: EntityType.optional(),
-  indexPattern: IndexPattern.optional(),
   status: EngineStatus.optional(),
+  indexPattern: IndexPattern.optional(),
+  dataViewId: z.string().optional(),
   filter: z.string().optional(),
 });
 

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/common.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/common.schema.yaml
@@ -17,10 +17,12 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/EntityType'
-        indexPattern:
-          $ref: '#/components/schemas/IndexPattern'
         status:
           $ref: '#/components/schemas/EngineStatus'
+        indexPattern:
+          $ref: '#/components/schemas/IndexPattern'
+        dataViewId:
+          type: string
         filter:
           type: string
 

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/engine/init.gen.ts
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/engine/init.gen.ts
@@ -16,7 +16,7 @@
 
 import { z } from '@kbn/zod';
 
-import { EntityType, IndexPattern, EngineDescriptor } from '../common.gen';
+import { EntityType, EngineDescriptor } from '../common.gen';
 
 export type InitEntityEngineRequestParams = z.infer<typeof InitEntityEngineRequestParams>;
 export const InitEntityEngineRequestParams = z.object({
@@ -29,7 +29,6 @@ export type InitEntityEngineRequestParamsInput = z.input<typeof InitEntityEngine
 
 export type InitEntityEngineRequestBody = z.infer<typeof InitEntityEngineRequestBody>;
 export const InitEntityEngineRequestBody = z.object({
-  indexPattern: IndexPattern.optional(),
   filter: z.string().optional(),
 });
 export type InitEntityEngineRequestBodyInput = z.input<typeof InitEntityEngineRequestBody>;

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/engine/init.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/engine/init.schema.yaml
@@ -4,7 +4,7 @@ info:
   title: Init Entity Engine
   version: '2023-10-31'
 paths:
-   /api/entity_store/engines/{entityType}/init:
+  /api/entity_store/engines/{entityType}/init:
     post:
       x-labels: [ess, serverless]
       x-codegen-enabled: true
@@ -25,8 +25,6 @@ paths:
             schema:
               type: object
               properties:
-                indexPattern:
-                  $ref: '../common.schema.yaml#/components/schemas/IndexPattern'
                 filter:
                   type: string
       responses:
@@ -36,4 +34,3 @@ paths:
             application/json:
               schema:
                 $ref: '../common.schema.yaml#/components/schemas/EngineDescriptor'
-                  

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/definition.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/definition.ts
@@ -6,7 +6,7 @@
  */
 
 import { entityDefinitionSchema, type EntityDefinition } from '@kbn/entities-schema';
-import { ENTITY_STORE_DEFAULT_SOURCE_INDICES } from './constants';
+import { DEFAULT_DATA_VIEW_ID } from '../../../../common/constants';
 import { buildEntityDefinitionId } from './utils/utils';
 
 export const buildHostEntityDefinition = (space: string): EntityDefinition =>
@@ -14,7 +14,7 @@ export const buildHostEntityDefinition = (space: string): EntityDefinition =>
     id: buildEntityDefinitionId('host', space),
     name: 'EA Host Store',
     type: 'host',
-    indexPatterns: ENTITY_STORE_DEFAULT_SOURCE_INDICES,
+    data_view_id: `${DEFAULT_DATA_VIEW_ID}-${space}`,
     identityFields: ['host.name'],
     displayNameTemplate: '{{host.name}}',
     metadata: [
@@ -40,7 +40,7 @@ export const buildUserEntityDefinition = (space: string): EntityDefinition =>
     id: buildEntityDefinitionId('user', space),
     name: 'EA User Store',
     type: 'user',
-    indexPatterns: ENTITY_STORE_DEFAULT_SOURCE_INDICES,
+    data_view_id: `${DEFAULT_DATA_VIEW_ID}-${space}`,
     identityFields: ['user.name'],
     displayNameTemplate: '{{user.name}}',
     metadata: ['user.email', 'user.full_name', 'user.hash', 'user.id', 'user.name', 'user.roles'],

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
@@ -55,7 +55,7 @@ export class EntityStoreDataClient {
 
   public async init(
     entityType: EntityType,
-    { indexPattern = '', filter = '' }: InitEntityEngineRequestBody
+    { filter = '' }: InitEntityEngineRequestBody
   ): Promise<InitEntityEngineResponse> {
     const { entityClient, assetCriticalityMigrationClient, logger } = this.options;
     const requiresMigration = await assetCriticalityMigrationClient.isEcsDataMigrationRequired();
@@ -75,9 +75,6 @@ export class EntityStoreDataClient {
       definition: {
         ...definition,
         filter,
-        indexPatterns: indexPattern
-          ? [...definition.indexPatterns, ...indexPattern.split(',')]
-          : definition.indexPatterns,
       },
     });
     const updated = await this.engineClient.update(definition.id, ENGINE_STATUS.STARTED);

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/saved_object/engine_descriptor.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/saved_object/engine_descriptor.ts
@@ -36,7 +36,7 @@ export class EngineDescriptorClient {
 
     const dataSourceAttribute = isEntityDefinitionWithIndexPattern(definition)
       ? { indexPatterns: definition.indexPatterns.join(',') }
-      : { dataViewId: definition.data_view_id };
+      : { dataViewId: definition.dataViewId };
 
     const { attributes } = await this.deps.soClient.create<EngineDescriptor>(
       entityEngineDescriptorTypeName,

--- a/x-pack/test/api_integration/apis/entity_manager/helpers/request.ts
+++ b/x-pack/test/api_integration/apis/entity_manager/helpers/request.ts
@@ -35,15 +35,16 @@ export const installDefinition = async (
   params: {
     definition: EntityDefinition;
     installOnly?: boolean;
+    expectedCode?: number;
   }
 ) => {
-  const { definition, installOnly = false } = params;
+  const { definition, installOnly = false, expectedCode = 200 } = params;
   return supertest
     .post('/internal/entities/definition')
     .query({ installOnly })
     .set('kbn-xsrf', 'xxx')
     .send(definition)
-    .expect(200);
+    .expect(expectedCode);
 };
 
 export const uninstallDefinition = (


### PR DESCRIPTION
## Summary

Add a new parameter to Entity Manager that allows users to define a `dataViewId` as the transform data source instead of an index pattern. 
*** Users are not allowed to set both fields simultaneously.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
