### PR TITLE
[Discover] Reproduce the issue

### DIFF
--- a/src/plugins/discover/public/application/discover_router.tsx
+++ b/src/plugins/discover/public/application/discover_router.tsx
@@ -14,6 +14,7 @@ import { History } from 'history';
 import { EuiErrorBoundary } from '@elastic/eui';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import useObservable from 'react-use/lib/useObservable';
+import { PerformanceContextProvider } from '@kbn/ebt-tools';
 import type { Observable } from 'rxjs';
 import type { ExperimentalFeatures } from '../../server/config';
 import { ContextAppRoute } from './context';
@@ -73,29 +74,31 @@ export const DiscoverRoutes = ({
   ...routeProps
 }: DiscoverRoutesProps) => {
   return (
-    <Routes>
-      <Route path="/context/:dataViewId/:id">
-        <ContextAppRoute />
-      </Route>
-      <Route
-        path="/doc/:dataView/:index/:type"
-        render={(props) => (
-          <Redirect to={`/doc/${props.match.params.dataView}/${props.match.params.index}`} />
-        )}
-      />
-      <Route path="/doc/:dataViewId/:index">
-        <SingleDocRoute />
-      </Route>
-      <Route path="/viewAlert/:id">
-        <ViewAlertRoute />
-      </Route>
-      <Route path="/view/:id">
-        <DiscoverMainRoute customizationContext={customizationContext} {...routeProps} />
-      </Route>
-      <Route path="/" exact>
-        <DiscoverMainRoute customizationContext={customizationContext} {...routeProps} />
-      </Route>
-      <NotFoundRoute />
-    </Routes>
+    <PerformanceContextProvider>
+      <Routes>
+        <Route path="/context/:dataViewId/:id">
+          <ContextAppRoute />
+        </Route>
+        <Route
+          path="/doc/:dataView/:index/:type"
+          render={(props) => (
+            <Redirect to={`/doc/${props.match.params.dataView}/${props.match.params.index}`} />
+          )}
+        />
+        <Route path="/doc/:dataViewId/:index">
+          <SingleDocRoute />
+        </Route>
+        <Route path="/viewAlert/:id">
+          <ViewAlertRoute />
+        </Route>
+        <Route path="/view/:id">
+          <DiscoverMainRoute customizationContext={customizationContext} {...routeProps} />
+        </Route>
+        <Route path="/" exact>
+          <DiscoverMainRoute customizationContext={customizationContext} {...routeProps} />
+        </Route>
+        <NotFoundRoute />
+      </Routes>
+    </PerformanceContextProvider>
   );
 };

--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
@@ -18,6 +18,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
+import { usePageReady } from '@kbn/ebt-tools';
 import { DataView } from '@kbn/data-views-plugin/public';
 import { SortOrder } from '@kbn/saved-search-plugin/public';
 import { CellActionsProvider } from '@kbn/cell-actions';
@@ -404,7 +405,11 @@ function DiscoverDocumentsComponent({
     [viewModeToggle, callouts, loadingIndicator]
   );
 
-  if (isDataViewLoading || (isEmptyDataResult && isDataLoading)) {
+  const isPageLoading = isDataViewLoading || (isEmptyDataResult && isDataLoading);
+
+  usePageReady({ isReady: !isPageLoading });
+
+  if (isPageLoading) {
     return (
       <div className="dscDocuments__loading">
         <EuiText size="xs" color="subdued">


### PR DESCRIPTION
- For https://github.com/elastic/kibana/issues/186129

## Summary

These changes show that simply after adding EBT Performance provider and starting to include `usePageReady` for accessing the EBT performance context, Discover does not respond to navigational changes. In my example, I add a filter and then press "New" - this should reset the filter but it does not for some reason. I was not able to spot yet what's causing it. 

Since accessing the EBT performance context API (to call `onPageReady` via `usePageReady` or other hooks) is important to continue with https://github.com/elastic/kibana/pull/194754, we should first find how to make the simple usage working within Discover plugin.

![Oct-07-2024 16-00-36](https://github.com/user-attachments/assets/05d89d8c-834e-4bc4-bbf6-9e3f867b8d14)

Or we should change the New action (if it's the only case when it causes problems). Current implementation: https://github.com/elastic/kibana/blob/b6287708f687d4e3288851052c0c6ae4ade8ce60/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx#L125
