### PR TITLE
docs(): fix dynamic config url

### DIFF
--- a/packages/core/plugins/core-plugins-server/src/types.ts
+++ b/packages/core/plugins/core-plugins-server/src/types.ts
@@ -107,7 +107,7 @@ export interface PluginConfigDescriptor<T = any> {
    */
   exposeToBrowser?: ExposedToBrowserDescriptor<T>;
   /**
-   * List of configuration properties that can be dynamically changed via the PUT /_settings API.
+   * List of configuration properties that can be dynamically changed via the PUT /internal/core/_settings API.
    */
   dynamicConfig?: DynamicConfigDescriptor<T>;
   /**


### PR DESCRIPTION
## Summary

Just fixing the path of the `dynamicConfig` jsdocs.




### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->