### PR TITLE
[Dashboard] Await new services in exported listing table

### DIFF
--- a/src/plugins/dashboard/public/dashboard_listing/index.tsx
+++ b/src/plugins/dashboard/public/dashboard_listing/index.tsx
@@ -25,13 +25,10 @@ const LazyDashboardListing = React.lazy(() =>
     return {
       default: module.DashboardListingTable,
     };
-  })().then((module) => {
-    return module;
-  })
+  })().then((module) => module)
 );
 
 export const DashboardListingTable = (props: DashboardListingProps) => {
-  console.log('HERE!!');
   return (
     <Suspense fallback={<ListingTableLoadingIndicator />}>
       <LazyDashboardListing {...props} />

--- a/src/plugins/dashboard/public/dashboard_listing/index.tsx
+++ b/src/plugins/dashboard/public/dashboard_listing/index.tsx
@@ -7,10 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { Suspense } from 'react';
 import { EuiEmptyPrompt, EuiLoadingSpinner } from '@elastic/eui';
+import React, { Suspense } from 'react';
 
-import { servicesReady } from '../plugin';
+import { untilPluginStartServicesReady } from '../services/kibana_services';
 import { DashboardListingProps } from './types';
 
 const ListingTableLoadingIndicator = () => {
@@ -20,15 +20,18 @@ const ListingTableLoadingIndicator = () => {
 const LazyDashboardListing = React.lazy(() =>
   (async () => {
     const modulePromise = import('./dashboard_listing_table');
-    const [module] = await Promise.all([modulePromise, servicesReady]);
+    const [module] = await Promise.all([modulePromise, untilPluginStartServicesReady()]);
 
     return {
       default: module.DashboardListingTable,
     };
-  })().then((module) => module)
+  })().then((module) => {
+    return module;
+  })
 );
 
 export const DashboardListingTable = (props: DashboardListingProps) => {
+  console.log('HERE!!');
   return (
     <Suspense fallback={<ListingTableLoadingIndicator />}>
       <LazyDashboardListing {...props} />

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -138,7 +138,6 @@ export interface DashboardStart {
 }
 
 export let resolveServicesReady: () => void;
-export const servicesReady = new Promise<void>((resolve) => (resolveServicesReady = resolve));
 
 export class DashboardPlugin
   implements


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/194733

## Summary

In https://github.com/elastic/kibana/pull/193644, I forgot to remove references to the old `servicesReady` promise - this caused an issue where it never resolved `true`, so anywhere that depended on this would be stuck in a loading state. This PR fixes this by replacing all instances of `servicesReady` with the new `untilPluginStartServicesReady` promise. 

Specifically, this fixes the exported `DashboardListingTable` that the Security page uses:

- **Before:**

     https://github.com/user-attachments/assets/78fc8ad8-7bff-43bf-95ec-d52f4da91371

- **After:**


     https://github.com/user-attachments/assets/af1be9d3-9af5-4a30-9b5d-bc4352214a97


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->