### PR TITLE
[ResponseOps][Cases] Fix case actions bug in serverless security

### DIFF
--- a/x-pack/plugins/cases/common/utils/owner.test.ts
+++ b/x-pack/plugins/cases/common/utils/owner.test.ts
@@ -42,7 +42,7 @@ describe('owner utils', () => {
 
     it.each(owners)('returns owner %s correctly for consumer', (owner) => {
       for (const consumer of owner.validRuleConsumers ?? []) {
-        const result = getOwnerFromRuleConsumerProducer(consumer);
+        const result = getOwnerFromRuleConsumerProducer({ consumer });
 
         expect(result).toBe(owner.id);
       }
@@ -50,23 +50,33 @@ describe('owner utils', () => {
 
     it.each(owners)('returns owner %s correctly for producer', (owner) => {
       for (const producer of owner.validRuleConsumers ?? []) {
-        const result = getOwnerFromRuleConsumerProducer(undefined, producer);
+        const result = getOwnerFromRuleConsumerProducer({ producer });
 
         expect(result).toBe(owner.id);
       }
     });
 
     it('returns cases as a default owner', () => {
-      const owner = getOwnerFromRuleConsumerProducer();
+      const owner = getOwnerFromRuleConsumerProducer({});
 
       expect(owner).toBe(OWNER_INFO.cases.id);
     });
 
-    it('returns owner as per consumer when both values are passed ', () => {
-      const owner = getOwnerFromRuleConsumerProducer(
-        AlertConsumers.SIEM,
-        AlertConsumers.OBSERVABILITY
-      );
+    it('returns owner as per consumer when both values are passed', () => {
+      const owner = getOwnerFromRuleConsumerProducer({
+        consumer: AlertConsumers.SIEM,
+        producer: AlertConsumers.OBSERVABILITY,
+      });
+
+      expect(owner).toBe(OWNER_INFO.securitySolution.id);
+    });
+
+    it('returns securitySolution owner if project isServerlessSecurity', () => {
+      const owner = getOwnerFromRuleConsumerProducer({
+        consumer: AlertConsumers.OBSERVABILITY,
+        producer: AlertConsumers.OBSERVABILITY,
+        isServerlessSecurity: true,
+      });
 
       expect(owner).toBe(OWNER_INFO.securitySolution.id);
     });

--- a/x-pack/plugins/cases/common/utils/owner.ts
+++ b/x-pack/plugins/cases/common/utils/owner.ts
@@ -14,7 +14,21 @@ export const isValidOwner = (owner: string): owner is keyof typeof OWNER_INFO =>
 export const getCaseOwnerByAppId = (currentAppId?: string) =>
   Object.values(OWNER_INFO).find((info) => info.appId === currentAppId)?.id;
 
-export const getOwnerFromRuleConsumerProducer = (consumer?: string, producer?: string): Owner => {
+export const getOwnerFromRuleConsumerProducer = ({
+  consumer,
+  producer,
+  isServerlessSecurity,
+}: {
+  consumer?: string;
+  producer?: string;
+  isServerlessSecurity?: boolean;
+}): Owner => {
+  // This is a workaround for a very specific bug with the cases action in serverless security
+  // More info here: https://github.com/elastic/kibana/issues/186270
+  if (isServerlessSecurity) {
+    return OWNER_INFO.securitySolution.id;
+  }
+
   for (const value of Object.values(OWNER_INFO)) {
     const foundConsumer = value.validRuleConsumers?.find(
       (validConsumer) => validConsumer === consumer || validConsumer === producer

--- a/x-pack/plugins/cases/kibana.jsonc
+++ b/x-pack/plugins/cases/kibana.jsonc
@@ -30,6 +30,7 @@
       "uiActions",
     ],
     "optionalPlugins": [
+      "cloud",
       "home",
       "taskManager",
       "usageCollection",

--- a/x-pack/plugins/cases/public/components/system_actions/cases/cases_params.tsx
+++ b/x-pack/plugins/cases/public/components/system_actions/cases/cases_params.tsx
@@ -43,7 +43,7 @@ export const CasesParamsFieldsComponent: React.FunctionComponent<
     notifications: { toasts },
     data: { dataViews: dataViewsService },
   } = useKibana().services;
-  const owner = getOwnerFromRuleConsumerProducer(featureId, producerId);
+  const owner = getOwnerFromRuleConsumerProducer({ consumer: featureId, producer: producerId });
 
   const { dataView, isLoading: loadingAlertDataViews } = useAlertsDataView({
     http,

--- a/x-pack/plugins/cases/server/connectors/cases/index.ts
+++ b/x-pack/plugins/cases/server/connectors/cases/index.ts
@@ -16,7 +16,11 @@ import type { SavedObjectsClientContract } from '@kbn/core/server';
 import type { ConnectorAdapter } from '@kbn/alerting-plugin/server';
 import { CasesConnector } from './cases_connector';
 import { DEFAULT_MAX_OPEN_CASES } from './constants';
-import { CASES_CONNECTOR_ID, CASES_CONNECTOR_TITLE } from '../../../common/constants';
+import {
+  CASES_CONNECTOR_ID,
+  CASES_CONNECTOR_TITLE,
+  SECURITY_SOLUTION_OWNER,
+} from '../../../common/constants';
 import { getOwnerFromRuleConsumerProducer } from '../../../common/utils/owner';
 
 import type {
@@ -40,12 +44,14 @@ interface GetCasesConnectorTypeArgs {
     savedObjectTypes: string[]
   ) => Promise<SavedObjectsClientContract>;
   getSpaceId: (request?: KibanaRequest) => string;
+  isServerlessSecurity?: boolean;
 }
 
 export const getCasesConnectorType = ({
   getCasesClient,
   getSpaceId,
   getUnsecuredSavedObjectsClient,
+  isServerlessSecurity,
 }: GetCasesConnectorTypeArgs): SubActionConnectorType<
   CasesConnectorConfig,
   CasesConnectorSecrets
@@ -69,27 +75,34 @@ export const getCasesConnectorType = ({
   minimumLicenseRequired: 'platinum' as const,
   isSystemActionType: true,
   getKibanaPrivileges: ({ params } = { params: { subAction: 'run', subActionParams: {} } }) => {
-    const owner = params?.subActionParams?.owner as string;
-
-    if (!owner) {
+    if (!params?.subActionParams?.owner) {
       throw new Error('Cannot authorize cases. Owner is not defined in the subActionParams.');
     }
+
+    const owner = isServerlessSecurity
+      ? SECURITY_SOLUTION_OWNER
+      : (params?.subActionParams?.owner as string);
 
     return constructRequiredKibanaPrivileges(owner);
   },
 });
 
-export const getCasesConnectorAdapter = (): ConnectorAdapter<
-  CasesConnectorRuleActionParams,
-  CasesConnectorParams
-> => {
+export const getCasesConnectorAdapter = ({
+  isServerlessSecurity,
+}: {
+  isServerlessSecurity?: boolean;
+}): ConnectorAdapter<CasesConnectorRuleActionParams, CasesConnectorParams> => {
   return {
     connectorTypeId: CASES_CONNECTOR_ID,
     ruleActionParamsSchema: CasesConnectorRuleActionParamsSchema,
     buildActionParams: ({ alerts, rule, params, spaceId, ruleUrl }) => {
       const caseAlerts = [...alerts.new.data, ...alerts.ongoing.data];
 
-      const owner = getOwnerFromRuleConsumerProducer(rule.consumer, rule.producer);
+      const owner = getOwnerFromRuleConsumerProducer({
+        consumer: rule.consumer,
+        producer: rule.producer,
+        isServerlessSecurity,
+      });
 
       const subActionParams = {
         alerts: caseAlerts,
@@ -105,7 +118,7 @@ export const getCasesConnectorAdapter = (): ConnectorAdapter<
       return { subAction: 'run', subActionParams };
     },
     getKibanaPrivileges: ({ consumer, producer }) => {
-      const owner = getOwnerFromRuleConsumerProducer(consumer, producer);
+      const owner = getOwnerFromRuleConsumerProducer({ consumer, producer, isServerlessSecurity });
       return constructRequiredKibanaPrivileges(owner);
     },
   };

--- a/x-pack/plugins/cases/server/connectors/index.ts
+++ b/x-pack/plugins/cases/server/connectors/index.ts
@@ -22,12 +22,14 @@ export function registerConnectorTypes({
   core,
   getCasesClient,
   getSpaceId,
+  isServerlessSecurity,
 }: {
   actions: ActionsPluginSetupContract;
   alerting: AlertingPluginSetup;
   core: CoreSetup;
   getCasesClient: (request: KibanaRequest) => Promise<CasesClient>;
   getSpaceId: (request?: KibanaRequest) => string;
+  isServerlessSecurity?: boolean;
 }) {
   const getUnsecuredSavedObjectsClient = async (
     request: KibanaRequest,
@@ -53,8 +55,13 @@ export function registerConnectorTypes({
   };
 
   actions.registerSubActionConnectorType(
-    getCasesConnectorType({ getCasesClient, getSpaceId, getUnsecuredSavedObjectsClient })
+    getCasesConnectorType({
+      getCasesClient,
+      getSpaceId,
+      getUnsecuredSavedObjectsClient,
+      isServerlessSecurity,
+    })
   );
 
-  alerting.registerConnectorAdapter(getCasesConnectorAdapter());
+  alerting.registerConnectorAdapter(getCasesConnectorAdapter({ isServerlessSecurity }));
 }

--- a/x-pack/plugins/cases/server/plugin.ts
+++ b/x-pack/plugins/cases/server/plugin.ts
@@ -145,12 +145,16 @@ export class CasePlugin
       return plugins.spaces?.spacesService.getSpaceId(request) ?? DEFAULT_SPACE_ID;
     };
 
+    const isServerlessSecurity =
+      plugins.cloud?.isServerlessEnabled && plugins.cloud?.serverless.projectType === 'security';
+
     registerConnectorTypes({
       actions: plugins.actions,
       alerting: plugins.alerting,
       core,
       getCasesClient,
       getSpaceId,
+      isServerlessSecurity,
     });
 
     return {

--- a/x-pack/plugins/cases/server/types.ts
+++ b/x-pack/plugins/cases/server/types.ts
@@ -30,6 +30,7 @@ import type { LicensingPluginSetup, LicensingPluginStart } from '@kbn/licensing-
 import type { NotificationsPluginStart } from '@kbn/notifications-plugin/server';
 import type { RuleRegistryPluginStartContract } from '@kbn/rule-registry-plugin/server';
 import type { PluginSetupContract as AlertingPluginSetup } from '@kbn/alerting-plugin/server';
+import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { CasesClient } from './client';
 import type { AttachmentFramework } from './attachment_framework/types';
 import type { ExternalReferenceAttachmentTypeRegistry } from './attachment_framework/external_reference_registry';
@@ -46,6 +47,7 @@ export interface CasesServerSetupDependencies {
   taskManager?: TaskManagerSetupContract;
   usageCollection?: UsageCollectionSetup;
   spaces?: SpacesPluginSetup;
+  cloud?: CloudSetup;
 }
 
 export interface CasesServerStartDependencies {

--- a/x-pack/plugins/cases/tsconfig.json
+++ b/x-pack/plugins/cases/tsconfig.json
@@ -76,6 +76,7 @@
     "@kbn/core-http-router-server-internal",
     "@kbn/presentation-publishing",
     "@kbn/alerts-ui-shared",
+    "@kbn/cloud-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
Fixes #186270

## Summary

This PR ensures that cases created by the case action in stack management rules in serverless security projects are assigned the correct owner.


### How to test

1. Add the following line to `serverless.yml` - `xpack.cloud.serverless.project_id: test-123`
2. Start elastic search in serverless security mode - `yarn es serverless --projectType security`
3. Start Kibana in serverless security mode - `yarn start --serverless=security`
4. Go to stack and create a rule with the cases action.
5. When an alert is triggered confirm you can view the case in `Security > Cases`


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->