### PR TITLE
[Console] Only suggest dot-prefixed indices when user types a dot

### DIFF
--- a/src/plugins/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
+++ b/src/plugins/console/public/application/containers/editor/utils/autocomplete_utils.test.ts
@@ -160,6 +160,10 @@ describe('autocomplete_utils', () => {
           name: 'index2',
           meta: 'index',
         },
+        {
+          name: '.index',
+          meta: 'index',
+        },
       ] as AutoCompleteContext['autoCompleteSet'];
       // mock the populateContext function that finds the correct autocomplete endpoint object and puts it into the context object
       mockPopulateContext.mockImplementation((...args) => {
@@ -189,7 +193,7 @@ describe('autocomplete_utils', () => {
       expect(items.every((item) => item.detail === 'index')).toBe(true);
     });
 
-    it('suggest endpoints and index names if no comma', () => {
+    it('suggest endpoints and index names, excluding dot-prefixed ones, if no comma and no dot', () => {
       const mockModel = {
         getValueInRange: () => 'GET _search',
         getWordUntilPosition: () => ({ startColumn: 12 }),
@@ -197,6 +201,19 @@ describe('autocomplete_utils', () => {
       const mockPosition = { lineNumber: 1, column: 12 } as unknown as monaco.Position;
       const items = getUrlPathCompletionItems(mockModel, mockPosition);
       expect(items.length).toBe(4);
+      expect(
+        items.every((item) => typeof item.label === 'string' && item.label.startsWith('.'))
+      ).toBe(false);
+    });
+
+    it('suggests all endpoints and indices, including dot-prefixed ones, if last char is a dot', () => {
+      const mockModel = {
+        getValueInRange: () => 'GET .',
+        getWordUntilPosition: () => ({ startColumn: 6 }),
+      } as unknown as monaco.editor.ITextModel;
+      const mockPosition = { lineNumber: 1, column: 6 } as unknown as monaco.Position;
+      const items = getUrlPathCompletionItems(mockModel, mockPosition);
+      expect(items.length).toBe(5);
     });
   });
 });

--- a/src/plugins/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/plugins/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -156,14 +156,16 @@ export const getUrlPathCompletionItems = (
     filterTermsWithoutName(autoCompleteSet)
       // map autocomplete items to completion items
       .map((item) => {
-        return {
-          label: item.name + '',
-          insertText: item.name + '',
-          detail: item.meta ?? i18nTexts.endpoint,
-          // the kind is only used to configure the icon
-          kind: monaco.languages.CompletionItemKind.Constant,
-          range,
-        };
+        if (!item.name.startsWith('.') || lineContent.trim().endsWith('.')) {
+          return {
+            label: item.name + '',
+            insertText: item.name + '',
+            detail: item.meta ?? i18nTexts.endpoint,
+            // the kind is only used to configure the icon
+            kind: monaco.languages.CompletionItemKind.Constant,
+            range,
+          };
+        }
       })
   );
 };

--- a/src/plugins/console/public/application/containers/editor/utils/autocomplete_utils.ts
+++ b/src/plugins/console/public/application/containers/editor/utils/autocomplete_utils.ts
@@ -154,18 +154,22 @@ export const getUrlPathCompletionItems = (
   };
   return (
     filterTermsWithoutName(autoCompleteSet)
+      .filter(
+        (term) =>
+          // Only keep dot-prefixed terms if the user typed in a dot
+          !(typeof term.name === 'string' && term.name.startsWith('.')) ||
+          lineContent.trim().endsWith('.')
+      )
       // map autocomplete items to completion items
       .map((item) => {
-        if (!item.name.startsWith('.') || lineContent.trim().endsWith('.')) {
-          return {
-            label: item.name + '',
-            insertText: item.name + '',
-            detail: item.meta ?? i18nTexts.endpoint,
-            // the kind is only used to configure the icon
-            kind: monaco.languages.CompletionItemKind.Constant,
-            range,
-          };
-        }
+        return {
+          label: item.name + '',
+          insertText: item.name + '',
+          detail: item.meta ?? i18nTexts.endpoint,
+          // the kind is only used to configure the icon
+          kind: monaco.languages.CompletionItemKind.Constant,
+          range,
+        };
       })
   );
 };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/194801

## Summary

This PR filters the Console autocomplete suggestions in the URL path so that dot-prefixed indices are suggested only if a dot is typed in.

https://github.com/user-attachments/assets/fe7fc155-f9a8-4fb0-953e-b84b0d052f2a




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->