### PR TITLE
[embeddable] avoid uncaught error when embeddable factory is not found

### DIFF
--- a/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
+++ b/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
@@ -102,22 +102,10 @@ export const ReactEmbeddableRenderer = <
        */
       return (async () => {
         const parentApi = getParentApi();
-        const factory = await getReactEmbeddableFactory<SerializedState, RuntimeState, Api>(type);
         const subscriptions = new Subscription();
 
-        const setApi = (
-          apiRegistration: SetReactEmbeddableApiRegistration<SerializedState, RuntimeState, Api>
-        ) => {
-          return {
-            ...apiRegistration,
-            uuid,
-            phase$,
-            parentApi,
-            type: factory.type,
-          } as unknown as Api;
-        };
-
         const buildEmbeddable = async () => {
+          const factory = await getReactEmbeddableFactory<SerializedState, RuntimeState, Api>(type);
           const serializedState = parentApi.getSerializedStateForChild(uuid);
           const lastSavedRuntimeState = serializedState
             ? await factory.deserializeState(serializedState)
@@ -130,6 +118,18 @@ export const ReactEmbeddableRenderer = <
             : ({} as Partial<RuntimeState>);
 
           const initialRuntimeState = { ...lastSavedRuntimeState, ...partialRuntimeState };
+
+          const setApi = (
+            apiRegistration: SetReactEmbeddableApiRegistration<SerializedState, RuntimeState, Api>
+          ) => {
+            return {
+              ...apiRegistration,
+              uuid,
+              phase$,
+              parentApi,
+              type: factory.type,
+            } as unknown as Api;
+          };
 
           const buildApi = (
             apiRegistration: BuildReactEmbeddableApiRegistration<
@@ -179,7 +179,10 @@ export const ReactEmbeddableRenderer = <
               ...unsavedChanges.api,
             } as unknown as SetReactEmbeddableApiRegistration<SerializedState, RuntimeState, Api>);
 
-            cleanupFunction.current = () => unsavedChanges.cleanup();
+            cleanupFunction.current = () => {
+              subscriptions.unsubscribe();
+              unsavedChanges.cleanup();
+            };
             return fullApi as Api & HasSnapshottableState<RuntimeState>;
           };
 


### PR DESCRIPTION
Small clean-up of ReactEmbeddableRenderer
1. avoid uncaught error when embeddable factory is not found. Move `getReactEmbeddableFactory` into `buildEmbeddable` so that if factory is not found and `getReactEmbeddableFactory` throws, its caught by try/catch wrapping `buildEmbeddable`.
2. unsubscribe from `subscriptions`

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->