### PR TITLE
Sustainable Kibana Architecture - Update platform plugins

### DIFF
--- a/src/plugins/advanced_settings/kibana.jsonc
+++ b/src/plugins/advanced_settings/kibana.jsonc
@@ -1,11 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/advanced-settings-plugin",
-  "owner": "@elastic/appex-sharedux @elastic/kibana-management",
+  "owner": [
+    "@elastic/appex-sharedux",
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "advancedSettings",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "management"
     ],
@@ -13,7 +18,6 @@
       "home",
       "usageCollection"
     ],
-    "requiredBundles": [
-    ]
+    "requiredBundles": []
   }
 }

--- a/src/plugins/ai_assistant_management/selection/kibana.jsonc
+++ b/src/plugins/ai_assistant_management/selection/kibana.jsonc
@@ -1,16 +1,28 @@
 {
   "type": "plugin",
   "id": "@kbn/ai-assistant-management-plugin",
-  "owner": "@elastic/obs-knowledge-team",
+  "owner": [
+    "@elastic/obs-knowledge-team"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "aiAssistantManagementSelection",
-    "server": true,
     "browser": true,
-    "requiredPlugins": ["management"],
-    "optionalPlugins": ["home", "serverless", "features"],
-    "requiredBundles": ["kibanaReact"],
+    "server": true,
     "configPath": [
       "aiAssistantManagementSelection"
     ],
-  },
+    "requiredPlugins": [
+      "management"
+    ],
+    "optionalPlugins": [
+      "home",
+      "serverless",
+      "features"
+    ],
+    "requiredBundles": [
+      "kibanaReact"
+    ]
+  }
 }

--- a/src/plugins/bfetch/kibana.jsonc
+++ b/src/plugins/bfetch/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/bfetch-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Considering using bfetch capabilities when fetching large amounts of data. This services supports batching HTTP requests and streaming responses back.",
   "plugin": {
     "id": "bfetch",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredBundles": [
       "kibanaUtils"
     ]

--- a/src/plugins/chart_expressions/common/kibana.jsonc
+++ b/src/plugins/chart_expressions/common/kibana.jsonc
@@ -1,5 +1,9 @@
 {
   "type": "shared-common",
   "id": "@kbn/chart-expressions-common",
-  "owner": "@elastic/kibana-visualizations"
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared"
 }

--- a/src/plugins/chart_expressions/expression_gauge/kibana.jsonc
+++ b/src/plugins/chart_expressions/expression_gauge/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-gauge-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Expression Gauge plugin adds a `gauge` renderer and function to the expression plugin. The renderer will display the `gauge` chart.",
   "plugin": {
     "id": "expressionGauge",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "fieldFormats",

--- a/src/plugins/chart_expressions/expression_heatmap/kibana.jsonc
+++ b/src/plugins/chart_expressions/expression_heatmap/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-heatmap-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Expression Heatmap plugin adds a `heatmap` renderer and function to the expression plugin. The renderer will display the `heatmap` chart.",
   "plugin": {
     "id": "expressionHeatmap",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "fieldFormats",

--- a/src/plugins/chart_expressions/expression_legacy_metric/kibana.jsonc
+++ b/src/plugins/chart_expressions/expression_legacy_metric/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-legacy-metric-vis-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds a `metric` renderer and function to the expression plugin. The renderer will display the `legacy metric` chart.",
   "plugin": {
     "id": "expressionLegacyMetricVis",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "fieldFormats",

--- a/src/plugins/chart_expressions/expression_metric/kibana.jsonc
+++ b/src/plugins/chart_expressions/expression_metric/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-metric-vis-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds a `metric` renderer and function to the expression plugin. The renderer will display the `metric` chart.",
   "plugin": {
     "id": "expressionMetricVis",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "fieldFormats",

--- a/src/plugins/chart_expressions/expression_partition_vis/kibana.jsonc
+++ b/src/plugins/chart_expressions/expression_partition_vis/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-partition-vis-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Expression Partition Visualization plugin adds a `partitionVis` renderer and `pieVis`, `mosaicVis`, `treemapVis`, `waffleVis` functions to the expression plugin. The renderer will display the `pie`, `waffle`, `treemap` and `mosaic` charts.",
   "plugin": {
     "id": "expressionPartitionVis",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "charts",
       "data",

--- a/src/plugins/chart_expressions/expression_tagcloud/kibana.jsonc
+++ b/src/plugins/chart_expressions/expression_tagcloud/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-tagcloud-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Expression Tagcloud plugin adds a `tagcloud` renderer and function to the expression plugin. The renderer will display the `Wordcloud` chart.",
   "plugin": {
     "id": "expressionTagcloud",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "data",
       "expressions",

--- a/src/plugins/chart_expressions/expression_xy/kibana.jsonc
+++ b/src/plugins/chart_expressions/expression_xy/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-xy-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Expression XY plugin adds a `xy` renderer and function to the expression plugin. The renderer will display the `xy` chart.",
   "plugin": {
     "id": "expressionXY",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "charts",

--- a/src/plugins/charts/kibana.jsonc
+++ b/src/plugins/charts/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/charts-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "charts",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "data"

--- a/src/plugins/console/kibana.jsonc
+++ b/src/plugins/console/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/console-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "console",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "console"
     ],

--- a/src/plugins/content_management/kibana.jsonc
+++ b/src/plugins/content_management/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/content-management-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Content management app",
   "plugin": {
     "id": "contentManagement",
-    "server": true,
     "browser": true,
+    "server": true,
     "optionalPlugins": [
       "usageCollection"
     ]

--- a/src/plugins/controls/kibana.jsonc
+++ b/src/plugins/controls/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/controls-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "The Controls Plugin contains embeddable components intended to create a simple query interface for end users, and a powerful editing suite that allows dashboard authors to build controls",
   "plugin": {
     "id": "controls",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "presentationUtil",
       "embeddable",
@@ -15,7 +19,9 @@
       "unifiedSearch",
       "uiActions"
     ],
-    "extraPublicDirs": ["common"],
-    "requiredBundles": []
+    "requiredBundles": [],
+    "extraPublicDirs": [
+      "common"
+    ]
   }
 }

--- a/src/plugins/custom_integrations/kibana.jsonc
+++ b/src/plugins/custom_integrations/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/custom-integrations-plugin",
-  "owner": "@elastic/fleet",
+  "owner": [
+    "@elastic/fleet"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Add custom data integrations so they can be displayed in the Fleet integrations app",
   "plugin": {
     "id": "customIntegrations",
-    "server": true,
     "browser": true,
+    "server": true,
     "extraPublicDirs": [
       "common"
     ]

--- a/src/plugins/dashboard/kibana.jsonc
+++ b/src/plugins/dashboard/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/dashboard-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds the Dashboard app to Kibana",
   "plugin": {
     "id": "dashboard",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "data",
       "dataViews",

--- a/src/plugins/data/kibana.jsonc
+++ b/src/plugins/data/kibana.jsonc
@@ -5,6 +5,8 @@
     "@elastic/kibana-visualizations",
     "@elastic/kibana-data-discovery"
   ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Data services are useful for searching and querying data from Elasticsearch. Helpful utilities include: a re-usable react query bar, KQL autocomplete, async search, Data Views (Index Patterns) and field formatters.",
   "serviceFolders": [
     "search",
@@ -13,8 +15,8 @@
   ],
   "plugin": {
     "id": "data",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "bfetch",
       "expressions",

--- a/src/plugins/data_view_editor/kibana.jsonc
+++ b/src/plugins/data_view_editor/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/data-view-editor-plugin",
-  "owner": "@elastic/kibana-data-discovery",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "This plugin provides the ability to create data views via a modal flyout inside Kibana apps",
   "plugin": {
     "id": "dataViewEditor",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "data",
       "dataViews"

--- a/src/plugins/data_view_field_editor/kibana.jsonc
+++ b/src/plugins/data_view_field_editor/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/data-view-field-editor-plugin",
-  "owner": "@elastic/kibana-data-discovery",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Reusable data view field editor across Kibana",
   "plugin": {
     "id": "dataViewFieldEditor",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "data",
       "fieldFormats",

--- a/src/plugins/data_view_management/kibana.jsonc
+++ b/src/plugins/data_view_management/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/data-view-management-plugin",
-  "owner": "@elastic/kibana-data-discovery",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Data view management app",
   "plugin": {
     "id": "dataViewManagement",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "management",
       "data",

--- a/src/plugins/data_views/kibana.jsonc
+++ b/src/plugins/data_views/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/data-views-plugin",
-  "owner": "@elastic/kibana-data-discovery",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Data services are useful for searching and querying data from Elasticsearch. Helpful utilities include: a re-usable react query bar, KQL autocomplete, async search, Data Views (Index Patterns) and field formatters.",
   "plugin": {
     "id": "dataViews",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "fieldFormats",
       "expressions",
@@ -18,7 +22,9 @@
     "requiredBundles": [
       "kibanaUtils"
     ],
-    "runtimePluginDependencies" : ["security"],
+    "runtimePluginDependencies": [
+      "security"
+    ],
     "extraPublicDirs": [
       "common"
     ]

--- a/src/plugins/dev_tools/kibana.jsonc
+++ b/src/plugins/dev_tools/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/dev-tools-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "devTools",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "urlForwarding"
     ],

--- a/src/plugins/discover/kibana.jsonc
+++ b/src/plugins/discover/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/discover-plugin",
-  "owner": "@elastic/kibana-data-discovery",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "This plugin contains the Discover application and the saved search embeddable.",
   "plugin": {
     "id": "discover",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "charts",
       "data",
@@ -44,7 +48,14 @@
       "fieldsMetadata",
       "logsDataAccess"
     ],
-    "requiredBundles": ["kibanaUtils", "kibanaReact", "unifiedSearch", "savedObjects"],
-    "extraPublicDirs": ["common"]
+    "requiredBundles": [
+      "kibanaUtils",
+      "kibanaReact",
+      "unifiedSearch",
+      "savedObjects"
+    ],
+    "extraPublicDirs": [
+      "common"
+    ]
   }
 }

--- a/src/plugins/embeddable/kibana.jsonc
+++ b/src/plugins/embeddable/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/embeddable-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds embeddables service to Kibana",
   "plugin": {
     "id": "embeddable",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "data",
       "inspector",
@@ -15,8 +19,17 @@
       "savedObjectsManagement",
       "contentManagement"
     ],
-    "optionalPlugins": ["savedObjectsTaggingOss", "usageCollection"],
-    "requiredBundles": ["savedObjects", "kibanaUtils", "presentationPanel"],
-    "extraPublicDirs": ["common"]
+    "optionalPlugins": [
+      "savedObjectsTaggingOss",
+      "usageCollection"
+    ],
+    "requiredBundles": [
+      "savedObjects",
+      "kibanaUtils",
+      "presentationPanel"
+    ],
+    "extraPublicDirs": [
+      "common"
+    ]
   }
 }

--- a/src/plugins/es_ui_shared/kibana.jsonc
+++ b/src/plugins/es_ui_shared/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/es-ui-shared-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "esUiShared",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredBundles": [
       "dataViews"
     ],

--- a/src/plugins/event_annotation/kibana.jsonc
+++ b/src/plugins/event_annotation/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/event-annotation-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "The Event Annotation service contains expressions for event annotations",
   "plugin": {
     "id": "eventAnnotation",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "data",
@@ -18,12 +22,12 @@
       "contentManagement"
     ],
     "optionalPlugins": [
-      "savedObjectsTagging",
+      "savedObjectsTagging"
     ],
     "requiredBundles": [
       "data",
       "savedObjectsFinder",
-      "dataViews",
+      "dataViews"
     ],
     "extraPublicDirs": [
       "common"

--- a/src/plugins/event_annotation_listing/kibana.jsonc
+++ b/src/plugins/event_annotation_listing/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/event-annotation-listing-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "The listing page for event annotations.",
   "plugin": {
     "id": "eventAnnotationListing",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "savedObjectsManagement",
       "eventAnnotation",
@@ -16,11 +20,11 @@
       "dataViews",
       "unifiedSearch",
       "kibanaUtils",
-      "contentManagement",
+      "contentManagement"
     ],
     "optionalPlugins": [
       "savedObjectsTagging",
-      "lens",
+      "lens"
     ],
     "requiredBundles": [],
     "extraPublicDirs": []

--- a/src/plugins/expression_error/kibana.jsonc
+++ b/src/plugins/expression_error/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-error-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds 'error' renderer to expressions",
   "plugin": {
     "id": "expressionError",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "expressions",
       "presentationUtil"

--- a/src/plugins/expression_image/kibana.jsonc
+++ b/src/plugins/expression_image/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-image-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds 'image' function and renderer to expressions",
   "plugin": {
     "id": "expressionImage",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "presentationUtil"

--- a/src/plugins/expression_metric/kibana.jsonc
+++ b/src/plugins/expression_metric/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-metric-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds 'metric' function and renderer to expressions",
   "plugin": {
     "id": "expressionMetric",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "presentationUtil"

--- a/src/plugins/expression_repeat_image/kibana.jsonc
+++ b/src/plugins/expression_repeat_image/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-repeat-image-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds 'repeatImage' function and renderer to expressions",
   "plugin": {
     "id": "expressionRepeatImage",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "presentationUtil"

--- a/src/plugins/expression_reveal_image/kibana.jsonc
+++ b/src/plugins/expression_reveal_image/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-reveal-image-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds 'revealImage' function and renderer to expressions",
   "plugin": {
     "id": "expressionRevealImage",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "presentationUtil"

--- a/src/plugins/expression_shape/kibana.jsonc
+++ b/src/plugins/expression_shape/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expression-shape-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds 'shape' function and renderer to expressions",
   "plugin": {
     "id": "expressionShape",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "presentationUtil"

--- a/src/plugins/expressions/kibana.jsonc
+++ b/src/plugins/expressions/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/expressions-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds expression runtime to Kibana",
   "plugin": {
     "id": "expressions",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredBundles": [
       "kibanaUtils",
       "inspector"

--- a/src/plugins/field_formats/kibana.jsonc
+++ b/src/plugins/field_formats/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/field-formats-plugin",
-  "owner": "@elastic/kibana-data-discovery",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Index pattern fields and ambiguous values formatters",
   "plugin": {
     "id": "fieldFormats",
-    "server": true,
     "browser": true,
+    "server": true,
     "extraPublicDirs": [
       "common"
     ]

--- a/src/plugins/files/kibana.jsonc
+++ b/src/plugins/files/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/files-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "File upload, download, sharing, and serving over HTTP implementation in Kibana.",
   "plugin": {
     "id": "files",
-    "server": true,
     "browser": true,
+    "server": true,
     "optionalPlugins": [
       "security",
       "usageCollection"

--- a/src/plugins/files_management/kibana.jsonc
+++ b/src/plugins/files_management/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/files-management-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Simple UI for managing files in Kibana",
   "plugin": {
     "id": "filesManagement",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "files",
       "management"

--- a/src/plugins/ftr_apis/kibana.jsonc
+++ b/src/plugins/ftr_apis/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/ftr-apis-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "ftrApis",
-    "server": true,
     "browser": false,
+    "server": true,
     "configPath": [
       "ftr_apis"
     ]

--- a/src/plugins/guided_onboarding/kibana.jsonc
+++ b/src/plugins/guided_onboarding/kibana.jsonc
@@ -1,13 +1,20 @@
 {
   "type": "plugin",
   "id": "@kbn/guided-onboarding-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Guided onboarding framework",
   "plugin": {
     "id": "guidedOnboarding",
-    "server": true,
     "browser": true,
-    "optionalPlugins": ["cloud", "features"],
+    "server": true,
+    "optionalPlugins": [
+      "cloud",
+      "features"
+    ],
     "requiredBundles": []
   }
 }

--- a/src/plugins/home/kibana.jsonc
+++ b/src/plugins/home/kibana.jsonc
@@ -1,18 +1,28 @@
 {
   "type": "plugin",
   "id": "@kbn/home-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "home",
-    "server": true,
     "browser": true,
-    "requiredPlugins": ["dataViews", "share", "urlForwarding"],
-    "requiredBundles": ["kibanaReact"],
+    "server": true,
+    "requiredPlugins": [
+      "dataViews",
+      "share",
+      "urlForwarding"
+    ],
     "optionalPlugins": [
       "usageCollection",
       "customIntegrations",
       "cloud",
       "guidedOnboarding"
+    ],
+    "requiredBundles": [
+      "kibanaReact"
     ]
   }
 }

--- a/src/plugins/image_embeddable/kibana.jsonc
+++ b/src/plugins/image_embeddable/kibana.jsonc
@@ -1,14 +1,27 @@
 {
   "type": "plugin",
   "id": "@kbn/image-embeddable-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Image embeddable",
   "plugin": {
     "id": "imageEmbeddable",
-    "server": false,
     "browser": true,
-    "requiredPlugins": ["embeddable", "files", "uiActions", "kibanaReact"],
-    "optionalPlugins": ["security", "screenshotMode", "embeddableEnhanced"],
+    "server": false,
+    "requiredPlugins": [
+      "embeddable",
+      "files",
+      "uiActions",
+      "kibanaReact"
+    ],
+    "optionalPlugins": [
+      "security",
+      "screenshotMode",
+      "embeddableEnhanced"
+    ],
     "requiredBundles": []
   }
 }

--- a/src/plugins/input_control_vis/kibana.jsonc
+++ b/src/plugins/input_control_vis/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/input-control-vis-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Adds Input Control visualization to Kibana",
   "plugin": {
     "id": "inputControlVis",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "data",
       "expressions",
@@ -16,7 +20,8 @@
       "uiActions"
     ],
     "requiredBundles": [
-      "kibanaReact", "embeddable"
+      "kibanaReact",
+      "embeddable"
     ]
   }
 }

--- a/src/plugins/inspector/kibana.jsonc
+++ b/src/plugins/inspector/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/inspector-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "inspector",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "share"
     ],

--- a/src/plugins/interactive_setup/kibana.jsonc
+++ b/src/plugins/interactive_setup/kibana.jsonc
@@ -1,13 +1,17 @@
 {
   "type": "plugin",
   "id": "@kbn/interactive-setup-plugin",
-  "owner": "@elastic/kibana-security",
+  "owner": [
+    "@elastic/kibana-security"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "This plugin provides UI and APIs for the interactive setup mode.",
   "plugin": {
     "id": "interactiveSetup",
-    "type": "preboot",
-    "server": true,
     "browser": true,
+    "server": true,
+    "type": "preboot",
     "configPath": [
       "interactiveSetup"
     ]

--- a/src/plugins/kibana_overview/kibana.jsonc
+++ b/src/plugins/kibana_overview/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/kibana-overview-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "kibanaOverview",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "navigation",
       "dataViews",

--- a/src/plugins/kibana_react/kibana.jsonc
+++ b/src/plugins/kibana_react/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/kibana-react-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "kibanaReact",
-    "server": false,
     "browser": true,
+    "server": false,
     "extraPublicDirs": [
       "common"
     ]

--- a/src/plugins/kibana_usage_collection/kibana.jsonc
+++ b/src/plugins/kibana_usage_collection/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/kibana-usage-collection-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "kibanaUsageCollection",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "usageCollection"
     ]

--- a/src/plugins/kibana_utils/kibana.jsonc
+++ b/src/plugins/kibana_utils/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/kibana-utils-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "kibanaUtils",
-    "server": false,
     "browser": true,
+    "server": false,
     "extraPublicDirs": [
       "common",
       "demos/state_containers/todomvc",

--- a/src/plugins/links/kibana.jsonc
+++ b/src/plugins/links/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/links-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "A dashboard panel for creating links to dashboards or external links.",
   "plugin": {
     "id": "links",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "contentManagement",
       "dashboard",
@@ -18,7 +22,12 @@
       "uiActionsEnhanced",
       "visualizations"
     ],
-    "optionalPlugins": ["triggersActionsUi", "usageCollection"],
-    "requiredBundles": ["savedObjects"]
+    "optionalPlugins": [
+      "triggersActionsUi",
+      "usageCollection"
+    ],
+    "requiredBundles": [
+      "savedObjects"
+    ]
   }
 }

--- a/src/plugins/management/kibana.jsonc
+++ b/src/plugins/management/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/management-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "management",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "share"
     ],

--- a/src/plugins/maps_ems/kibana.jsonc
+++ b/src/plugins/maps_ems/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/maps-ems-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "mapsEms",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "map"
     ],

--- a/src/plugins/navigation/kibana.jsonc
+++ b/src/plugins/navigation/kibana.jsonc
@@ -1,13 +1,22 @@
 {
   "type": "plugin",
   "id": "@kbn/navigation-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "navigation",
-    "server": true,
     "browser": true,
-    "optionalPlugins": ["cloud", "spaces"],
-    "requiredPlugins": ["unifiedSearch"],
+    "server": true,
+    "requiredPlugins": [
+      "unifiedSearch"
+    ],
+    "optionalPlugins": [
+      "cloud",
+      "spaces"
+    ],
     "requiredBundles": []
   }
 }

--- a/src/plugins/newsfeed/kibana.jsonc
+++ b/src/plugins/newsfeed/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/newsfeed-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "newsfeed",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "screenshotMode"
     ],

--- a/src/plugins/no_data_page/kibana.jsonc
+++ b/src/plugins/no_data_page/kibana.jsonc
@@ -1,10 +1,14 @@
 {
   "type": "plugin",
   "id": "@kbn/no-data-page-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "noDataPage",
-    "server": true,
-    "browser": true
+    "browser": true,
+    "server": true
   }
 }

--- a/src/plugins/presentation_panel/kibana.jsonc
+++ b/src/plugins/presentation_panel/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/presentation-panel-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Adds a standardized Presentation panel which allows any forward ref component to interface with various Kibana systems.",
   "plugin": {
     "id": "presentationPanel",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "data",
       "inspector",
@@ -16,6 +20,9 @@
       "savedObjectsManagement",
       "savedObjectsTaggingOss"
     ],
-    "requiredBundles": ["kibanaReact", "unifiedSearch"]
+    "requiredBundles": [
+      "kibanaReact",
+      "unifiedSearch"
+    ]
   }
 }

--- a/src/plugins/presentation_util/kibana.jsonc
+++ b/src/plugins/presentation_util/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/presentation-util-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "The Presentation Utility Plugin is a set of common, shared components and toolkits for solutions within the Presentation space, (e.g. Dashboards, Canvas).",
   "plugin": {
     "id": "presentationUtil",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "kibanaReact",
       "contentManagement",
@@ -15,7 +19,11 @@
       "dataViews",
       "uiActions"
     ],
-    "extraPublicDirs": ["common"],
-    "requiredBundles": ["savedObjects"],
+    "requiredBundles": [
+      "savedObjects"
+    ],
+    "extraPublicDirs": [
+      "common"
+    ]
   }
 }

--- a/src/plugins/saved_objects/kibana.jsonc
+++ b/src/plugins/saved_objects/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/saved-objects-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "savedObjects",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "data",
       "dataViews"

--- a/src/plugins/saved_objects_finder/kibana.jsonc
+++ b/src/plugins/saved_objects_finder/kibana.jsonc
@@ -1,11 +1,17 @@
 {
   "type": "plugin",
   "id": "@kbn/saved-objects-finder-plugin",
-  "owner": "@elastic/kibana-data-discovery",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "savedObjectsFinder",
-    "server": true,
     "browser": true,
-    "requiredBundles": ["savedObjectsManagement"]
+    "server": true,
+    "requiredBundles": [
+      "savedObjectsManagement"
+    ]
   }
 }

--- a/src/plugins/saved_objects_management/kibana.jsonc
+++ b/src/plugins/saved_objects_management/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/saved-objects-management-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "savedObjectsManagement",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "management",
       "data",

--- a/src/plugins/saved_objects_tagging_oss/kibana.jsonc
+++ b/src/plugins/saved_objects_tagging_oss/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/saved-objects-tagging-oss-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "savedObjectsTaggingOss",
-    "server": false,
     "browser": true,
+    "server": false,
     "optionalPlugins": [
       "savedObjects"
     ]

--- a/src/plugins/saved_search/kibana.jsonc
+++ b/src/plugins/saved_search/kibana.jsonc
@@ -1,15 +1,29 @@
 {
   "type": "plugin",
   "id": "@kbn/saved-search-plugin",
-  "owner": "@elastic/kibana-data-discovery",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "This plugin contains the definition and helper methods around saved searches, used by discover and visualizations.",
   "plugin": {
     "id": "savedSearch",
-    "server": true,
     "browser": true,
-    "requiredPlugins": ["data", "contentManagement", "embeddable", "expressions"],
-    "optionalPlugins": ["spaces", "savedObjectsTaggingOss"],
+    "server": true,
+    "requiredPlugins": [
+      "data",
+      "contentManagement",
+      "embeddable",
+      "expressions"
+    ],
+    "optionalPlugins": [
+      "spaces",
+      "savedObjectsTaggingOss"
+    ],
     "requiredBundles": [],
-    "extraPublicDirs": ["common"]
+    "extraPublicDirs": [
+      "common"
+    ]
   }
 }

--- a/src/plugins/screenshot_mode/kibana.jsonc
+++ b/src/plugins/screenshot_mode/kibana.jsonc
@@ -1,10 +1,14 @@
 {
   "type": "plugin",
   "id": "@kbn/screenshot-mode-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "screenshotMode",
-    "server": true,
-    "browser": true
+    "browser": true,
+    "server": true
   }
 }

--- a/src/plugins/share/kibana.jsonc
+++ b/src/plugins/share/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/share-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds URL Service and sharing capabilities to Kibana",
   "plugin": {
     "id": "share",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredBundles": [
       "kibanaUtils"
     ]

--- a/src/plugins/telemetry/kibana.jsonc
+++ b/src/plugins/telemetry/kibana.jsonc
@@ -1,12 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/telemetry-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "telemetry",
-    "server": true,
     "browser": true,
-    "enabledOnAnonymousPages": true,
+    "server": true,
     "requiredPlugins": [
       "telemetryCollectionManager",
       "usageCollection",
@@ -19,6 +22,7 @@
     "requiredBundles": [
       "kibanaUtils"
     ],
+    "enabledOnAnonymousPages": true,
     "extraPublicDirs": [
       "common/constants"
     ]

--- a/src/plugins/telemetry_collection_manager/kibana.jsonc
+++ b/src/plugins/telemetry_collection_manager/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/telemetry-collection-manager-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "telemetryCollectionManager",
-    "server": true,
     "browser": false,
+    "server": true,
     "requiredPlugins": [
       "usageCollection"
     ]

--- a/src/plugins/telemetry_management_section/kibana.jsonc
+++ b/src/plugins/telemetry_management_section/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/telemetry-management-section-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "telemetryManagementSection",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "telemetry",
       "advancedSettings"

--- a/src/plugins/ui_actions/kibana.jsonc
+++ b/src/plugins/ui_actions/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/ui-actions-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Adds UI Actions service to Kibana",
   "plugin": {
     "id": "uiActions",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [],
     "requiredBundles": [
       "kibanaUtils"

--- a/src/plugins/ui_actions_enhanced/kibana.jsonc
+++ b/src/plugins/ui_actions_enhanced/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/ui-actions-enhanced-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Extends UI Actions plugin with more functionality",
   "plugin": {
     "id": "uiActionsEnhanced",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "src",
       "ui_actions_enhanced"

--- a/src/plugins/unified_doc_viewer/kibana.jsonc
+++ b/src/plugins/unified_doc_viewer/kibana.jsonc
@@ -1,15 +1,26 @@
 {
   "type": "plugin",
   "id": "@kbn/unified-doc-viewer-plugin",
-  "owner": "@elastic/kibana-data-discovery",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "This plugin contains services reliant on the plugin lifecycle for the unified doc viewer component (see @kbn/unified-doc-viewer).",
   "plugin": {
     "id": "unifiedDocViewer",
-    "server": false,
     "browser": true,
-    "requiredBundles": ["kibanaUtils"],
-    "requiredPlugins": ["data", "fieldFormats", "share"],
-    "optionalPlugins": ["fieldsMetadata"]
+    "server": false,
+    "requiredPlugins": [
+      "data",
+      "fieldFormats",
+      "share"
+    ],
+    "optionalPlugins": [
+      "fieldsMetadata"
+    ],
+    "requiredBundles": [
+      "kibanaUtils"
+    ]
   }
 }
-  

--- a/src/plugins/unified_histogram/kibana.jsonc
+++ b/src/plugins/unified_histogram/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/unified-histogram-plugin",
-  "owner": "@elastic/kibana-data-discovery",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "The `unifiedHistogram` plugin provides UI components to create a layout including a resizable histogram and a main display.",
   "plugin": {
     "id": "unifiedHistogram",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredBundles": [
       "data",
       "dataViews",

--- a/src/plugins/unified_search/kibana.jsonc
+++ b/src/plugins/unified_search/kibana.jsonc
@@ -1,15 +1,19 @@
 {
   "type": "plugin",
   "id": "@kbn/unified-search-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Contains all the key functionality of Kibana's unified search experience.Contains all the key functionality of Kibana's unified search experience.",
   "serviceFolders": [
     "autocomplete"
   ],
   "plugin": {
     "id": "unifiedSearch",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "unifiedSearch"
     ],

--- a/src/plugins/url_forwarding/kibana.jsonc
+++ b/src/plugins/url_forwarding/kibana.jsonc
@@ -1,10 +1,14 @@
 {
   "type": "plugin",
   "id": "@kbn/url-forwarding-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "urlForwarding",
-    "server": false,
-    "browser": true
+    "browser": true,
+    "server": false
   }
 }

--- a/src/plugins/usage_collection/kibana.jsonc
+++ b/src/plugins/usage_collection/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/usage-collection-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "usageCollection",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "usageCollection"
     ],

--- a/src/plugins/vis_default_editor/kibana.jsonc
+++ b/src/plugins/vis_default_editor/kibana.jsonc
@@ -1,15 +1,19 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-default-editor-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "The default editor used in most aggregation-based visualizations.",
   "plugin": {
     "id": "visDefaultEditor",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "dataViews",
-      "unifiedSearch",
+      "unifiedSearch"
     ],
     "optionalPlugins": [
       "visualizations"

--- a/src/plugins/vis_type_markdown/kibana.jsonc
+++ b/src/plugins/vis_type_markdown/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-markdown-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Adds a markdown visualization type",
   "plugin": {
     "id": "visTypeMarkdown",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "visualizations"

--- a/src/plugins/vis_types/gauge/kibana.jsonc
+++ b/src/plugins/vis_types/gauge/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-gauge-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Contains the gauge chart implementation using the elastic-charts library. The goal is to eventually deprecate the old implementation and keep only this. Until then, the library used is defined by the Legacy charts library advanced setting.",
   "plugin": {
     "id": "visTypeGauge",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "charts",
       "data",

--- a/src/plugins/vis_types/heatmap/kibana.jsonc
+++ b/src/plugins/vis_types/heatmap/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-heatmap-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Contains the heatmap implementation using the elastic-charts library. The goal is to eventually deprecate the old implementation and keep only this. Until then, the library used is defined by the Legacy heatmap charts library advanced setting.",
   "plugin": {
     "id": "visTypeHeatmap",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "charts",
       "data",

--- a/src/plugins/vis_types/metric/kibana.jsonc
+++ b/src/plugins/vis_types/metric/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-metric-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Registers the Metric aggregation-based visualization.",
   "plugin": {
     "id": "visTypeMetric",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "data",
       "visualizations",

--- a/src/plugins/vis_types/pie/kibana.jsonc
+++ b/src/plugins/vis_types/pie/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-pie-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Contains the pie chart implementation using the elastic-charts library. The goal is to eventually deprecate the old implementation and keep only this. Until then, the library used is defined by the Legacy charts library advanced setting.",
   "plugin": {
     "id": "visTypePie",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "charts",
       "data",

--- a/src/plugins/vis_types/table/kibana.jsonc
+++ b/src/plugins/vis_types/table/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-table-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Registers the datatable aggregation-based visualization.",
   "plugin": {
     "id": "visTypeTable",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "expressions",
       "visualizations",

--- a/src/plugins/vis_types/tagcloud/kibana.jsonc
+++ b/src/plugins/vis_types/tagcloud/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-tagcloud-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Registers the tagcloud visualization. It is based on elastic-charts wordcloud.",
   "plugin": {
     "id": "visTypeTagcloud",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "data",
       "expressions",

--- a/src/plugins/vis_types/timelion/kibana.jsonc
+++ b/src/plugins/vis_types/timelion/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-timelion-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Registers the timelion visualization. Also contains the backend for both timelion app and timelion visualization.",
   "plugin": {
     "id": "visTypeTimelion",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "visualizations",
       "data",

--- a/src/plugins/vis_types/timeseries/kibana.jsonc
+++ b/src/plugins/vis_types/timeseries/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-timeseries-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Registers the TSVB visualization. TSVB has its one editor, works with index patterns and index strings and contains 6 types of charts: timeseries, topN, table. markdown, metric and gauge.",
   "plugin": {
     "id": "visTypeTimeseries",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "charts",
       "data",

--- a/src/plugins/vis_types/vega/kibana.jsonc
+++ b/src/plugins/vis_types/vega/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-vega-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Registers the vega visualization. Is the elastic version of vega and vega-lite libraries.",
   "plugin": {
     "id": "visTypeVega",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "data",
       "visualizations",

--- a/src/plugins/vis_types/vislib/kibana.jsonc
+++ b/src/plugins/vis_types/vislib/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-vislib-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Contains the vislib visualizations. These are the classical area/line/bar, gauge/goal and heatmap charts. We want to replace them with elastic-charts.",
   "plugin": {
     "id": "visTypeVislib",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "charts",
       "data",

--- a/src/plugins/vis_types/xy/kibana.jsonc
+++ b/src/plugins/vis_types/xy/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/vis-type-xy-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Contains the new xy-axis chart using the elastic-charts library, which will eventually replace the vislib xy-axis charts including bar, area, and line.",
   "plugin": {
     "id": "visTypeXy",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "charts",
       "visualizations",

--- a/src/plugins/visualizations/kibana.jsonc
+++ b/src/plugins/visualizations/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/visualizations-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Contains the shared architecture among all the legacy visualizations, e.g. the visualization type registry or the visualization embeddable.",
   "plugin": {
     "id": "visualizations",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "data",
       "charts",
@@ -37,7 +41,12 @@
       "noDataPage",
       "embeddableEnhanced"
     ],
-    "requiredBundles": ["kibanaUtils", "kibanaReact", "charts", "savedObjects"],
+    "requiredBundles": [
+      "kibanaUtils",
+      "kibanaReact",
+      "charts",
+      "savedObjects"
+    ],
     "extraPublicDirs": [
       "common/constants",
       "common/utils",

--- a/x-pack/plugins/actions/kibana.jsonc
+++ b/x-pack/plugins/actions/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/actions-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": [
+    "@elastic/response-ops"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "actions",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "actions"

--- a/x-pack/plugins/aiops/kibana.jsonc
+++ b/x-pack/plugins/aiops/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/aiops-plugin",
-  "owner": "@elastic/ml-ui",
+  "owner": [
+    "@elastic/ml-ui"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "AIOps plugin maintained by ML team.",
   "plugin": {
     "id": "aiops",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "charts",
       "data",
@@ -31,7 +35,7 @@
       "kibanaReact",
       "kibanaUtils",
       "embeddable",
-      "cases",
+      "cases"
     ]
   }
 }

--- a/x-pack/plugins/alerting/kibana.jsonc
+++ b/x-pack/plugins/alerting/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/alerting-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": [
+    "@elastic/response-ops"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "alerting",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "alerting"
@@ -32,7 +36,7 @@
       "security",
       "monitoringCollection",
       "spaces",
-      "serverless",
+      "serverless"
     ],
     "extraPublicDirs": [
       "common",

--- a/x-pack/plugins/banners/kibana.jsonc
+++ b/x-pack/plugins/banners/kibana.jsonc
@@ -1,22 +1,26 @@
 {
   "type": "plugin",
   "id": "@kbn/banners-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "banners",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "banners"
     ],
-    "enabledOnAnonymousPages": true,
     "requiredPlugins": [
       "licensing"
     ],
     "optionalPlugins": [
       "screenshotMode"
     ],
-    "requiredBundles": []
+    "requiredBundles": [],
+    "enabledOnAnonymousPages": true
   }
 }

--- a/x-pack/plugins/canvas/kibana.jsonc
+++ b/x-pack/plugins/canvas/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/canvas-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Adds Canvas application to Kibana",
   "plugin": {
     "id": "canvas",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "canvas"
@@ -36,7 +40,7 @@
       "home",
       "reporting",
       "spaces",
-      "usageCollection",
+      "usageCollection"
     ],
     "requiredBundles": [
       "kibanaReact",
@@ -45,6 +49,6 @@
       "maps",
       "visualizations",
       "fieldFormats"
-    ],
+    ]
   }
 }

--- a/x-pack/plugins/cases/kibana.jsonc
+++ b/x-pack/plugins/cases/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/cases-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": [
+    "@elastic/response-ops"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "The Case management system in Kibana",
   "plugin": {
     "id": "cases",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "cases"
@@ -27,7 +31,7 @@
       "ruleRegistry",
       "files",
       "contentManagement",
-      "uiActions",
+      "uiActions"
     ],
     "optionalPlugins": [
       "cloud",
@@ -35,13 +39,13 @@
       "taskManager",
       "usageCollection",
       "spaces",
-      "serverless",
+      "serverless"
     ],
     "requiredBundles": [
       "esUiShared",
       "kibanaReact",
       "kibanaUtils",
-      "savedObjectsFinder",
+      "savedObjectsFinder"
     ],
     "extraPublicDirs": [
       "common"

--- a/x-pack/plugins/cloud/kibana.jsonc
+++ b/x-pack/plugins/cloud/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/cloud-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "cloud",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "cloud"

--- a/x-pack/plugins/cloud_integrations/cloud_chat/kibana.jsonc
+++ b/x-pack/plugins/cloud_integrations/cloud_chat/kibana.jsonc
@@ -1,7 +1,11 @@
 {
   "type": "plugin",
   "id": "@kbn/cloud-chat-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Chat available on Elastic Cloud deployments for quicker assistance.",
   "plugin": {
     "id": "cloudChat",
@@ -15,9 +19,7 @@
     "requiredPlugins": [
       "cloud"
     ],
-    "requiredBundles": [
-    ],
-    "optionalPlugins": [
-    ]
+    "optionalPlugins": [],
+    "requiredBundles": []
   }
 }

--- a/x-pack/plugins/cloud_integrations/cloud_data_migration/kibana.jsonc
+++ b/x-pack/plugins/cloud_integrations/cloud_data_migration/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/cloud-data-migration-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Static migration page where self-managed users can see text/copy about migrating to Elastic Cloud",
   "plugin": {
     "id": "cloudDataMigration",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "cloud_integrations",

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/kibana.jsonc
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/cloud-experiments-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Provides the necessary APIs to implement A/B testing scenarios, fetching the variations in configuration and reporting back metrics to track conversion rates of the experiments.",
   "plugin": {
     "id": "cloudExperiments",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "cloud_integrations",

--- a/x-pack/plugins/cloud_integrations/cloud_full_story/kibana.jsonc
+++ b/x-pack/plugins/cloud_integrations/cloud_full_story/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/cloud-full-story-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "When Kibana runs on Elastic Cloud, this plugin registers FullStory as a shipper for telemetry.",
   "plugin": {
     "id": "cloudFullStory",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "cloud_integrations",

--- a/x-pack/plugins/cloud_integrations/cloud_links/kibana.jsonc
+++ b/x-pack/plugins/cloud_integrations/cloud_links/kibana.jsonc
@@ -1,20 +1,24 @@
 {
   "type": "plugin",
   "id": "@kbn/cloud-links-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Adds the links to the Elastic Cloud console",
   "plugin": {
     "id": "cloudLinks",
-    "server": false,
     "browser": true,
+    "server": false,
+    "requiredPlugins": [
+      "share"
+    ],
     "optionalPlugins": [
       "cloud",
       "security",
       "guidedOnboarding"
     ],
-    "requiredBundles": [],
-    "requiredPlugins": [
-      "share"
-    ]
+    "requiredBundles": []
   }
 }

--- a/x-pack/plugins/cross_cluster_replication/kibana.jsonc
+++ b/x-pack/plugins/cross_cluster_replication/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/cross-cluster-replication-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "crossClusterReplication",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "ccr"

--- a/x-pack/plugins/custom_branding/kibana.jsonc
+++ b/x-pack/plugins/custom_branding/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/custom-branding-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": " Enables customization of Kibana",
   "plugin": {
     "id": "customBranding",
-    "server": true,
     "browser": false,
+    "server": true,
     "requiredPlugins": [
       "licensing",
       "licenseApiGuard"

--- a/x-pack/plugins/dashboard_enhanced/kibana.jsonc
+++ b/x-pack/plugins/dashboard_enhanced/kibana.jsonc
@@ -1,12 +1,19 @@
 {
   "type": "plugin",
   "id": "@kbn/dashboard-enhanced-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "dashboardEnhanced",
-    "server": true,
     "browser": true,
-    "configPath": ["xpack", "dashboardEnhanced"],
+    "server": true,
+    "configPath": [
+      "xpack",
+      "dashboardEnhanced"
+    ],
     "requiredPlugins": [
       "dashboard",
       "data",

--- a/x-pack/plugins/data_visualizer/kibana.jsonc
+++ b/x-pack/plugins/data_visualizer/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/data-visualizer-plugin",
-  "owner": "@elastic/ml-ui",
+  "owner": [
+    "@elastic/ml-ui"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "The Data Visualizer tools help you understand your data, by analyzing the metrics and fields in a log file or an existing Elasticsearch index.",
   "plugin": {
     "id": "dataVisualizer",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "data",
       "usageCollection",

--- a/x-pack/plugins/discover_enhanced/kibana.jsonc
+++ b/x-pack/plugins/discover_enhanced/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/discover-enhanced-plugin",
-  "owner": "@elastic/kibana-data-discovery",
+  "owner": [
+    "@elastic/kibana-data-discovery"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "discoverEnhanced",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "discoverEnhanced"

--- a/x-pack/plugins/drilldowns/url_drilldown/kibana.jsonc
+++ b/x-pack/plugins/drilldowns/url_drilldown/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/url-drilldown-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Adds drilldown implementations to Kibana",
   "plugin": {
     "id": "urlDrilldown",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "embeddable",
       "uiActionsEnhanced"

--- a/x-pack/plugins/embeddable_enhanced/kibana.jsonc
+++ b/x-pack/plugins/embeddable_enhanced/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/embeddable-enhanced-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Extends embeddable plugin with more functionality",
   "plugin": {
     "id": "embeddableEnhanced",
-    "server": false,
     "browser": true,
+    "server": false,
     "requiredPlugins": [
       "embeddable",
       "kibanaReact",

--- a/x-pack/plugins/encrypted_saved_objects/kibana.jsonc
+++ b/x-pack/plugins/encrypted_saved_objects/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/encrypted-saved-objects-plugin",
-  "owner": "@elastic/kibana-security",
+  "owner": [
+    "@elastic/kibana-security"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "This plugin provides encryption and decryption utilities for saved objects containing sensitive information.",
   "plugin": {
     "id": "encryptedSavedObjects",
-    "server": true,
     "browser": false,
+    "server": true,
     "configPath": [
       "xpack",
       "encryptedSavedObjects"

--- a/x-pack/plugins/event_log/kibana.jsonc
+++ b/x-pack/plugins/event_log/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/event-log-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": [
+    "@elastic/response-ops"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "eventLog",
-    "server": true,
     "browser": false,
+    "server": true,
     "configPath": [
       "xpack",
       "eventLog"

--- a/x-pack/plugins/features/kibana.jsonc
+++ b/x-pack/plugins/features/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/features-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "features",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "features"

--- a/x-pack/plugins/file_upload/kibana.jsonc
+++ b/x-pack/plugins/file_upload/kibana.jsonc
@@ -1,12 +1,17 @@
 {
   "type": "plugin",
   "id": "@kbn/file-upload-plugin",
-  "owner": ["@elastic/kibana-presentation", "@elastic/ml-ui"],
+  "owner": [
+    "@elastic/kibana-presentation",
+    "@elastic/ml-ui"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "The file upload plugin contains components and services for uploading a file, analyzing its data, and then importing the data into an Elasticsearch index. Supported file types include CSV, TSV, newline-delimited JSON and GeoJSON.",
   "plugin": {
     "id": "fileUpload",
-    "server": true,
     "browser": true,
+    "server": true,
     "requiredPlugins": [
       "data",
       "usageCollection"

--- a/x-pack/plugins/fleet/kibana.jsonc
+++ b/x-pack/plugins/fleet/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/fleet-plugin",
-  "owner": "@elastic/fleet",
+  "owner": [
+    "@elastic/fleet"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "fleet",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "fleet"
@@ -38,7 +42,7 @@
       "ingestPipelines",
       "spaces",
       "guidedOnboarding",
-      "integrationAssistant",
+      "integrationAssistant"
     ],
     "requiredBundles": [
       "kibanaReact",

--- a/x-pack/plugins/global_search/kibana.jsonc
+++ b/x-pack/plugins/global_search/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/global-search-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "globalSearch",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "global_search"

--- a/x-pack/plugins/global_search_bar/kibana.jsonc
+++ b/x-pack/plugins/global_search_bar/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/global-search-bar-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "globalSearchBar",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "global_search_bar"

--- a/x-pack/plugins/global_search_providers/kibana.jsonc
+++ b/x-pack/plugins/global_search_providers/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/global-search-providers-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "globalSearchProviders",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "global_search_providers"

--- a/x-pack/plugins/graph/kibana.jsonc
+++ b/x-pack/plugins/graph/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/graph-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "graph",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "graph"

--- a/x-pack/plugins/grokdebugger/kibana.jsonc
+++ b/x-pack/plugins/grokdebugger/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/grokdebugger-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "grokdebugger",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "grokdebugger"

--- a/x-pack/plugins/index_management/kibana.jsonc
+++ b/x-pack/plugins/index_management/kibana.jsonc
@@ -1,14 +1,38 @@
 {
   "type": "plugin",
   "id": "@kbn/index-management-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "indexManagement",
-    "server": true,
     "browser": true,
-    "configPath": ["xpack", "index_management"],
-    "requiredPlugins": ["home", "management", "features", "share"],
-    "optionalPlugins": ["security", "usageCollection", "fleet", "cloud", "ml", "console","licensing"],
-    "requiredBundles": ["kibanaReact", "esUiShared", "runtimeFields"]
+    "server": true,
+    "configPath": [
+      "xpack",
+      "index_management"
+    ],
+    "requiredPlugins": [
+      "home",
+      "management",
+      "features",
+      "share"
+    ],
+    "optionalPlugins": [
+      "security",
+      "usageCollection",
+      "fleet",
+      "cloud",
+      "ml",
+      "console",
+      "licensing"
+    ],
+    "requiredBundles": [
+      "kibanaReact",
+      "esUiShared",
+      "runtimeFields"
+    ]
   }
 }

--- a/x-pack/plugins/lens/kibana.jsonc
+++ b/x-pack/plugins/lens/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/lens-plugin",
-  "owner": "@elastic/kibana-visualizations",
+  "owner": [
+    "@elastic/kibana-visualizations"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "Visualization editor allowing to quickly and easily configure compelling visualizations to use on dashboards and canvas workpads. Exposes components to embed visualizations and link into the Lens editor from within other apps in Kibana.",
   "plugin": {
     "id": "lens",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "lens"
@@ -35,7 +39,7 @@
       "expressionTagcloud",
       "eventAnnotation",
       "unifiedSearch",
-      "contentManagement",
+      "contentManagement"
     ],
     "optionalPlugins": [
       "expressionLegacyMetricVis",
@@ -57,7 +61,7 @@
       "fieldFormats",
       "charts",
       "esqlDataGrid",
-      "esql",
+      "esql"
     ],
     "extraPublicDirs": [
       "common/constants"

--- a/x-pack/plugins/license_api_guard/kibana.jsonc
+++ b/x-pack/plugins/license_api_guard/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/license-api-guard-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "licenseApiGuard",
-    "server": true,
     "browser": false,
+    "server": true,
     "configPath": [
       "xpack",
       "licenseApiGuard"

--- a/x-pack/plugins/license_management/kibana.jsonc
+++ b/x-pack/plugins/license_management/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/license-management-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "licenseManagement",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "license_management"

--- a/x-pack/plugins/licensing/kibana.jsonc
+++ b/x-pack/plugins/licensing/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/licensing-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "licensing",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "licensing"

--- a/x-pack/plugins/maps/kibana.jsonc
+++ b/x-pack/plugins/maps/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/maps-plugin",
-  "owner": "@elastic/kibana-presentation",
+  "owner": [
+    "@elastic/kibana-presentation"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "maps",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "maps"
@@ -50,7 +54,7 @@
       "unifiedSearch",
       "fieldFormats",
       "esql",
-      "savedObjects",
+      "savedObjects"
     ],
     "extraPublicDirs": [
       "common"

--- a/x-pack/plugins/ml/kibana.jsonc
+++ b/x-pack/plugins/ml/kibana.jsonc
@@ -1,13 +1,20 @@
 {
   "type": "plugin",
   "id": "@kbn/ml-plugin",
-  "owner": "@elastic/ml-ui",
+  "owner": [
+    "@elastic/ml-ui"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "This plugin provides access to the machine learning features provided by Elastic.",
   "plugin": {
     "id": "ml",
-    "server": true,
     "browser": true,
-    "configPath": ["xpack", "ml"],
+    "server": true,
+    "configPath": [
+      "xpack",
+      "ml"
+    ],
     "requiredPlugins": [
       "aiops",
       "charts",
@@ -58,6 +65,8 @@
       "savedObjectsFinder",
       "usageCollection"
     ],
-    "extraPublicDirs": ["common"]
+    "extraPublicDirs": [
+      "common"
+    ]
   }
 }

--- a/x-pack/plugins/notifications/kibana.jsonc
+++ b/x-pack/plugins/notifications/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/notifications-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "notifications",
-    "server": true,
     "browser": false,
+    "server": true,
     "optionalPlugins": [
       "actions",
       "licensing"

--- a/x-pack/plugins/painless_lab/kibana.jsonc
+++ b/x-pack/plugins/painless_lab/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/painless-lab-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "painlessLab",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "painless_lab"

--- a/x-pack/plugins/remote_clusters/kibana.jsonc
+++ b/x-pack/plugins/remote_clusters/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/remote-clusters-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "remoteClusters",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "remote_clusters"

--- a/x-pack/plugins/reporting/kibana.jsonc
+++ b/x-pack/plugins/reporting/kibana.jsonc
@@ -1,13 +1,20 @@
 {
   "type": "plugin",
   "id": "@kbn/reporting-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Reporting Services enables applications to feature reports that the user can automate with Watcher and download later.",
   "plugin": {
     "id": "reporting",
-    "server": true,
     "browser": true,
-    "configPath": ["xpack", "reporting"],
+    "server": true,
+    "configPath": [
+      "xpack",
+      "reporting"
+    ],
     "requiredPlugins": [
       "data",
       "discover",
@@ -21,7 +28,16 @@
       "share",
       "features"
     ],
-    "optionalPlugins": ["security", "spaces", "usageCollection", "screenshotting"],
-    "requiredBundles": ["embeddable", "esUiShared", "kibanaReact"]
+    "optionalPlugins": [
+      "security",
+      "spaces",
+      "usageCollection",
+      "screenshotting"
+    ],
+    "requiredBundles": [
+      "embeddable",
+      "esUiShared",
+      "kibanaReact"
+    ]
   }
 }

--- a/x-pack/plugins/rollup/kibana.jsonc
+++ b/x-pack/plugins/rollup/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/rollup-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "rollup",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "rollup"

--- a/x-pack/plugins/rule_registry/kibana.jsonc
+++ b/x-pack/plugins/rule_registry/kibana.jsonc
@@ -5,10 +5,12 @@
     "@elastic/response-ops",
     "@elastic/obs-ux-management-team"
   ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "ruleRegistry",
-    "server": true,
     "browser": false,
+    "server": true,
     "configPath": [
       "xpack",
       "ruleRegistry"

--- a/x-pack/plugins/runtime_fields/kibana.jsonc
+++ b/x-pack/plugins/runtime_fields/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/runtime-fields-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "runtimeFields",
-    "server": false,
     "browser": true,
+    "server": false,
     "configPath": [
       "xpack",
       "runtime_fields"

--- a/x-pack/plugins/saved_objects_tagging/kibana.jsonc
+++ b/x-pack/plugins/saved_objects_tagging/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/saved-objects-tagging-plugin",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "savedObjectsTagging",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "saved_object_tagging"

--- a/x-pack/plugins/screenshotting/kibana.jsonc
+++ b/x-pack/plugins/screenshotting/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/screenshotting-plugin",
-  "owner": "@elastic/kibana-reporting-services",
+  "owner": [
+    "@elastic/kibana-reporting-services"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "Kibana Screenshotting Plugin",
   "plugin": {
     "id": "screenshotting",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "screenshotting"

--- a/x-pack/plugins/searchprofiler/kibana.jsonc
+++ b/x-pack/plugins/searchprofiler/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/searchprofiler-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "searchprofiler",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "searchprofiler"

--- a/x-pack/plugins/security/kibana.jsonc
+++ b/x-pack/plugins/security/kibana.jsonc
@@ -1,17 +1,20 @@
 {
   "type": "plugin",
   "id": "@kbn/security-plugin",
-  "owner": "@elastic/kibana-security",
+  "owner": [
+    "@elastic/kibana-security"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "This plugin provides authentication and authorization features, and exposes functionality to understand the capabilities of the currently authenticated user.",
   "plugin": {
     "id": "security",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "security"
     ],
-    "enabledOnAnonymousPages": true,
     "requiredPlugins": [
       "features",
       "licensing",
@@ -31,6 +34,7 @@
       "spaces",
       "esUiShared",
       "remoteClusters"
-    ]
+    ],
+    "enabledOnAnonymousPages": true
   }
 }

--- a/x-pack/plugins/serverless/kibana.jsonc
+++ b/x-pack/plugins/serverless/kibana.jsonc
@@ -1,16 +1,20 @@
 {
   "type": "plugin",
   "id": "@kbn/serverless",
-  "owner": "@elastic/appex-sharedux",
+  "owner": [
+    "@elastic/appex-sharedux"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "The core Serverless plugin, providing APIs to Serverless Project plugins.",
   "plugin": {
     "id": "serverless",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "serverless",
-      "plugin",
+      "plugin"
     ],
     "requiredPlugins": [
       "cloud"

--- a/x-pack/plugins/snapshot_restore/kibana.jsonc
+++ b/x-pack/plugins/snapshot_restore/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/snapshot-restore-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "snapshotRestore",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "snapshot_restore"

--- a/x-pack/plugins/spaces/kibana.jsonc
+++ b/x-pack/plugins/spaces/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/spaces-plugin",
-  "owner": "@elastic/kibana-security",
+  "owner": [
+    "@elastic/kibana-security"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "description": "This plugin provides the Spaces feature, which allows saved objects to be organized into meaningful categories.",
   "plugin": {
     "id": "spaces",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "spaces"
@@ -19,15 +23,17 @@
       "home",
       "management",
       "usageCollection",
-      "cloud",
+      "cloud"
     ],
     "requiredBundles": [
       "esUiShared",
       "kibanaReact"
     ],
+    "runtimePluginDependencies": [
+      "security"
+    ],
     "extraPublicDirs": [
       "common"
-    ],
-    "runtimePluginDependencies": ["security"]
+    ]
   }
 }

--- a/x-pack/plugins/stack_alerts/kibana.jsonc
+++ b/x-pack/plugins/stack_alerts/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/stack-alerts-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": [
+    "@elastic/response-ops"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "stackAlerts",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "stack_alerts"
@@ -24,6 +28,8 @@
       "esUiShared",
       "esql"
     ],
-    "extraPublicDirs": ["common"]
+    "extraPublicDirs": [
+      "common"
+    ]
   }
 }

--- a/x-pack/plugins/stack_connectors/kibana.jsonc
+++ b/x-pack/plugins/stack_connectors/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/stack-connectors-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": [
+    "@elastic/response-ops"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "stackConnectors",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "stack_connectors"

--- a/x-pack/plugins/task_manager/kibana.jsonc
+++ b/x-pack/plugins/task_manager/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/task-manager-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": [
+    "@elastic/response-ops"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "taskManager",
-    "server": true,
     "browser": false,
+    "server": true,
     "configPath": [
       "xpack",
       "task_manager"

--- a/x-pack/plugins/telemetry_collection_xpack/kibana.jsonc
+++ b/x-pack/plugins/telemetry_collection_xpack/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/telemetry-collection-xpack-plugin",
-  "owner": "@elastic/kibana-core",
+  "owner": [
+    "@elastic/kibana-core"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "telemetryCollectionXpack",
-    "server": true,
     "browser": false,
+    "server": true,
     "requiredPlugins": [
       "telemetryCollectionManager"
     ]

--- a/x-pack/plugins/transform/kibana.jsonc
+++ b/x-pack/plugins/transform/kibana.jsonc
@@ -1,12 +1,16 @@
 {
   "type": "plugin",
   "id": "@kbn/transform-plugin",
-  "owner": "@elastic/ml-ui",
+  "owner": [
+    "@elastic/ml-ui"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "description": "This plugin provides access to the transforms features provided by Elastic. Transforms enable you to convert existing Elasticsearch indices into summarized indices, which provide opportunities for new insights and analytics.",
   "plugin": {
     "id": "transform",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "transform"
@@ -26,7 +30,7 @@
       "charts",
       "savedObjectsFinder",
       "savedObjectsManagement",
-      "contentManagement",
+      "contentManagement"
     ],
     "optionalPlugins": [
       "dataViewEditor",
@@ -39,7 +43,7 @@
       "esUiShared",
       "discover",
       "kibanaUtils",
-      "kibanaReact",
+      "kibanaReact"
     ],
     "extraPublicDirs": [
       "common"

--- a/x-pack/plugins/translations/kibana.jsonc
+++ b/x-pack/plugins/translations/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/translations-plugin",
-  "owner": "@elastic/kibana-localization",
+  "owner": [
+    "@elastic/kibana-localization"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "translations",
-    "server": true,
     "browser": false,
+    "server": true,
     "configPath": [
       "x-pack",
       "translations"

--- a/x-pack/plugins/triggers_actions_ui/kibana.jsonc
+++ b/x-pack/plugins/triggers_actions_ui/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/triggers-actions-ui-plugin",
-  "owner": "@elastic/response-ops",
+  "owner": [
+    "@elastic/response-ops"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "plugin": {
     "id": "triggersActionsUi",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "trigger_actions_ui"
@@ -45,7 +49,7 @@
     ],
     "extraPublicDirs": [
       "public/common",
-      "public/common/constants",
+      "public/common/constants"
     ]
   }
 }

--- a/x-pack/plugins/watcher/kibana.jsonc
+++ b/x-pack/plugins/watcher/kibana.jsonc
@@ -1,11 +1,15 @@
 {
   "type": "plugin",
   "id": "@kbn/watcher-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": [
+    "@elastic/kibana-management"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "watcher",
-    "server": true,
     "browser": true,
+    "server": true,
     "configPath": [
       "xpack",
       "watcher"


### PR DESCRIPTION
## Summary

As part of the Sustainable Kibana Architecture initiative, this PR leverages the mechanisms and concepts introduced in https://github.com/elastic/kibana/pull/194810, updating plugins that were considered as part of the `'platform'` group, in Luke's [PoC](https://github.com/elastic/kibana/pull/179710).

This might trigger linting rule violations in CI, and help uncover conflicts related to forbidden dependencies.
As soon as they are resolved, we can proceed to classify solutions' plugins.