### PR TITLE
[Search] Update connectors docs URLs and doc link

### DIFF
--- a/docs/search/playground/index.asciidoc
+++ b/docs/search/playground/index.asciidoc
@@ -136,7 +136,7 @@ _You can skip this step if you already have data in one or more {es} indices._
 There are many options for ingesting data into {es}, including:
 
 * The {enterprise-search-ref}/crawler.html[Elastic crawler] for web content (*NOTE*: Not yet available in _Serverless_)
-* {enterprise-search-ref}/connectors.html[Elastic connectors] for data synced from third-party sources
+* {ref}/es-connectors.html[Elastic connectors] for data synced from third-party sources
 * The {es} {ref}/docs-bulk.html[Bulk API] for JSON documents
 +
 .*Expand* for example

--- a/docs/setup/connect-to-elasticsearch.asciidoc
+++ b/docs/setup/connect-to-elasticsearch.asciidoc
@@ -26,7 +26,7 @@ A good place to start is with one of our Elastic solutions, which
 offer experiences for common use cases.
 
 * *Elastic connectors and crawler.*
-** Create searchable mirrors of your data in Sharepoint Online, S3, Google Drive, and many other web services using our open code {enterprise-search-ref}/connectors.html[Elastic connectors].
+** Create searchable mirrors of your data in Sharepoint Online, S3, Google Drive, and many other web services using our open code {ref}/es-connectors.html[Elastic connectors].
 ** Discover, extract, and index your web content into {es} using the
 {enterprise-search-ref}/crawler.html[Elastic web crawler].
 

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -157,7 +157,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       behavioralAnalytics: `${ELASTICSEARCH_DOCS}behavioral-analytics-overview.html`,
       behavioralAnalyticsCORS: `${ELASTICSEARCH_DOCS}behavioral-analytics-cors.html`,
       behavioralAnalyticsEvents: `${ELASTICSEARCH_DOCS}behavioral-analytics-event.html`,
-      buildConnector: `${ENTERPRISE_SEARCH_DOCS}build-connector.html`,
+      buildConnector: `${ELASTICSEARCH_DOCS}es-build-connector.html`,
       bulkApi: `${ELASTICSEARCH_DOCS}docs-bulk.html`,
       configuration: `${ENTERPRISE_SEARCH_DOCS}configuration.html`,
       connectors: `${ELASTICSEARCH_DOCS}es-connectors.html`,


### PR DESCRIPTION
Missed one in https://github.com/elastic/kibana/pull/194423

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->