### PR TITLE
[Fleet] Fix fleet server host removal from managed policies

### DIFF
--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -939,7 +939,8 @@ class AgentPolicyService {
    */
   public async removeFleetServerHostFromAll(
     esClient: ElasticsearchClient,
-    fleetServerHostId: string
+    fleetServerHostId: string,
+    options?: { force?: boolean }
   ) {
     const savedObjectType = await getAgentPolicySavedObjectType();
     const agentPolicies = (
@@ -965,6 +966,9 @@ class AgentPolicyService {
             agentPolicy.id,
             {
               fleet_server_host_id: null,
+            },
+            {
+              force: options?.force,
             }
           ),
         {

--- a/x-pack/plugins/fleet/server/services/fleet_server_host.ts
+++ b/x-pack/plugins/fleet/server/services/fleet_server_host.ts
@@ -142,7 +142,9 @@ export async function deleteFleetServerHost(
     );
   }
 
-  await agentPolicyService.removeFleetServerHostFromAll(esClient, id);
+  await agentPolicyService.removeFleetServerHostFromAll(esClient, id, {
+    force: options?.fromPreconfiguration,
+  });
 
   return await soClient.delete(FLEET_SERVER_HOST_SAVED_OBJECT_TYPE, id);
 }


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/193407

That PR allow to remove a fleet server host that was used in a managed agent policies, it was previously failing due to missing force flag, that we use for all operation from the preconfiguration.

<img width="1230" alt="Screenshot 2024-10-08 at 12 18 20 PM" src="https://github.com/user-attachments/assets/fef191ce-959c-45ba-9e03-f254d1bb3e4d">



## How to test

You can add then remove the following to your kibana config 

```
xpack.fleet.fleetServerHosts:
  - id: default-fleet-server
    name: Default Fleet server
    is_default: true
    host_urls: ['https://fleetserver:8220']
  - id: test1
    name: test1
    is_default: false
    host_urls: ['https://fleetserver:8220']

xpack.fleet.agentPolicies:
  - name: Test policy
    description: TEST
    id: test-policy
    is_default: false
    is_managed: true
    is_default_fleet_server: false
    package_policies: []
    fleet_server_host_id: test1
```

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->