### PR TITLE
Update telemetry-settings.asciidoc

### DIFF
--- a/docs/settings/telemetry-settings.asciidoc
+++ b/docs/settings/telemetry-settings.asciidoc
@@ -15,6 +15,9 @@ from the user's browser, in case a firewall is blocking the connections from the
 [[telemetry-general-settings]]
 ==== General telemetry settings
 
+`telemetry.enabled`::
+Set to `false` to remove the telemetry configuration option from *Stack Management > {kib} > Advanced Settings > Global Settings > Usage collection*. *Default: `true`.*
+
 [[telemetry-optIn]] `telemetry.optIn`::
   Set to `false` to stop sending any telemetry data to Elastic. Reporting your
 cluster statistics helps us improve your user experience. *Default: `true`.* +


### PR DESCRIPTION
## Summary

`telemetry.enabled` setting missing from documentation, adding description and default value. 


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
