### PR TITLE
[Cloud Security] remove retention period from queries on csp indexes

### DIFF
--- a/x-pack/packages/kbn-cloud-security-posture-common/constants.ts
+++ b/x-pack/packages/kbn-cloud-security-posture-common/constants.ts
@@ -36,6 +36,9 @@ export const CDR_LATEST_THIRD_PARTY_VULNERABILITIES_INDEX_PATTERN =
 export const CDR_VULNERABILITIES_INDEX_PATTERN = `${CDR_LATEST_THIRD_PARTY_VULNERABILITIES_INDEX_PATTERN},${CDR_LATEST_NATIVE_VULNERABILITIES_INDEX_PATTERN}`;
 export const LATEST_VULNERABILITIES_RETENTION_POLICY = '3d';
 
+// TODO: update grouping component to make from/to optional
+export const CDR_3P_RETENTION_POLICY = '365d'; // arbitrary big value, as some retention required for grouping queries
+
 export const VULNERABILITIES_SEVERITY: Record<VulnSeverity, VulnSeverity> = {
   LOW: 'LOW',
   MEDIUM: 'MEDIUM',

--- a/x-pack/packages/kbn-cloud-security-posture/src/hooks/use_vulnerabilities_preview.ts
+++ b/x-pack/packages/kbn-cloud-security-posture/src/hooks/use_vulnerabilities_preview.ts
@@ -14,10 +14,7 @@ import {
   AggregationsMultiBucketAggregateBase,
   AggregationsStringRareTermsBucketKeys,
 } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import {
-  CDR_VULNERABILITIES_INDEX_PATTERN,
-  LATEST_VULNERABILITIES_RETENTION_POLICY,
-} from '@kbn/cloud-security-posture-common';
+import { CDR_VULNERABILITIES_INDEX_PATTERN } from '@kbn/cloud-security-posture-common';
 import type { CspVulnerabilityFinding } from '@kbn/cloud-security-posture-common/schema/vulnerabilities/latest';
 import type { CoreStart } from '@kbn/core/public';
 import type { CspClientPluginStartDeps, UseCspOptions } from '../../type';
@@ -45,17 +42,7 @@ const getVulnerabilitiesQuery = ({ query }: UseCspOptions, isPreview = false) =>
     ...query,
     bool: {
       ...query?.bool,
-      filter: [
-        ...(query?.bool?.filter ?? []),
-        {
-          range: {
-            '@timestamp': {
-              gte: `now-${LATEST_VULNERABILITIES_RETENTION_POLICY}`,
-              lte: 'now',
-            },
-          },
-        },
-      ],
+      filter: [...(query?.bool?.filter ?? [])],
     },
   },
 });

--- a/x-pack/packages/kbn-cloud-security-posture/src/utils/hooks_utils.ts
+++ b/x-pack/packages/kbn-cloud-security-posture/src/utils/hooks_utils.ts
@@ -6,10 +6,7 @@
  */
 
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import {
-  CDR_MISCONFIGURATIONS_INDEX_PATTERN,
-  LATEST_FINDINGS_RETENTION_POLICY,
-} from '@kbn/cloud-security-posture-common';
+import { CDR_MISCONFIGURATIONS_INDEX_PATTERN } from '@kbn/cloud-security-posture-common';
 import type { CspBenchmarkRulesStates } from '@kbn/cloud-security-posture-common/schema/rules/latest';
 import { buildMutedRulesFilter } from '@kbn/cloud-security-posture-common';
 import type { UseCspOptions } from '../../type';
@@ -96,17 +93,7 @@ const buildMisconfigurationsFindingsQueryWithFilters = (
     ...query,
     bool: {
       ...query?.bool,
-      filter: [
-        ...(query?.bool?.filter ?? []),
-        {
-          range: {
-            '@timestamp': {
-              gte: `now-${LATEST_FINDINGS_RETENTION_POLICY}`,
-              lte: 'now',
-            },
-          },
-        },
-      ],
+      filter: [...(query?.bool?.filter ?? [])],
       must_not: [...mutedRulesFilterQuery],
     },
   };

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings.ts
@@ -13,10 +13,7 @@ import { buildDataTableRecord } from '@kbn/discover-utils';
 import { EsHitRecord } from '@kbn/discover-utils/types';
 import { showErrorToast } from '@kbn/cloud-security-posture';
 import { MAX_FINDINGS_TO_LOAD, buildMutedRulesFilter } from '@kbn/cloud-security-posture-common';
-import {
-  CDR_MISCONFIGURATIONS_INDEX_PATTERN,
-  LATEST_FINDINGS_RETENTION_POLICY,
-} from '@kbn/cloud-security-posture-common';
+import { CDR_MISCONFIGURATIONS_INDEX_PATTERN } from '@kbn/cloud-security-posture-common';
 import type { CspFinding } from '@kbn/cloud-security-posture-common';
 import type { CspBenchmarkRulesStates } from '@kbn/cloud-security-posture-common/schema/rules/latest';
 import type { FindingsBaseEsQuery } from '@kbn/cloud-security-posture';
@@ -56,17 +53,7 @@ export const getFindingsQuery = (
       ...query,
       bool: {
         ...query?.bool,
-        filter: [
-          ...(query?.bool?.filter ?? []),
-          {
-            range: {
-              '@timestamp': {
-                gte: `now-${LATEST_FINDINGS_RETENTION_POLICY}`,
-                lte: 'now',
-              },
-            },
-          },
-        ],
+        filter: [...(query?.bool?.filter ?? [])],
         must_not: [...(query?.bool?.must_not ?? []), ...mutedRulesFilterQuery],
       },
     },

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
@@ -15,10 +15,7 @@ import {
 } from '@kbn/grouping/src';
 import { useMemo } from 'react';
 import { buildEsQuery, Filter } from '@kbn/es-query';
-import {
-  LATEST_FINDINGS_RETENTION_POLICY,
-  buildMutedRulesFilter,
-} from '@kbn/cloud-security-posture-common';
+import { CDR_3P_RETENTION_POLICY, buildMutedRulesFilter } from '@kbn/cloud-security-posture-common';
 import { useGetCspBenchmarkRulesStatesApi } from '@kbn/cloud-security-posture/src/hooks/use_get_benchmark_rules_state_api';
 import {
   FINDINGS_GROUPING_OPTIONS,
@@ -183,7 +180,7 @@ export const useLatestFindingsGrouping = ({
     additionalFilters: query ? [query, additionalFilters] : [additionalFilters],
     groupByField: currentSelectedGroup,
     uniqueValue,
-    from: `now-${LATEST_FINDINGS_RETENTION_POLICY}`,
+    from: `now-${CDR_3P_RETENTION_POLICY}`,
     to: 'now',
     pageNumber: activePageIndex * pageSize,
     size: pageSize,

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities.tsx
@@ -19,7 +19,6 @@ import { EsHitRecord } from '@kbn/discover-utils/types';
 import {
   MAX_FINDINGS_TO_LOAD,
   CDR_VULNERABILITIES_INDEX_PATTERN,
-  LATEST_VULNERABILITIES_RETENTION_POLICY,
 } from '@kbn/cloud-security-posture-common';
 import { FindingsBaseEsQuery, showErrorToast } from '@kbn/cloud-security-posture';
 import type { CspVulnerabilityFinding } from '@kbn/cloud-security-posture-common/schema/vulnerabilities/latest';
@@ -64,17 +63,7 @@ export const getVulnerabilitiesQuery = (
     ...query,
     bool: {
       ...query?.bool,
-      filter: [
-        ...(query?.bool?.filter ?? []),
-        {
-          range: {
-            '@timestamp': {
-              gte: `now-${LATEST_VULNERABILITIES_RETENTION_POLICY}`,
-              lte: 'now',
-            },
-          },
-        },
-      ],
+      filter: [...(query?.bool?.filter ?? [])],
     },
   },
   ...(pageParam ? { from: pageParam } : {}),

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
@@ -15,7 +15,7 @@ import {
 } from '@kbn/grouping/src';
 import { useMemo } from 'react';
 import {
-  LATEST_VULNERABILITIES_RETENTION_POLICY,
+  CDR_3P_RETENTION_POLICY,
   VULNERABILITIES_SEVERITY,
 } from '@kbn/cloud-security-posture-common';
 import { buildEsQuery, Filter } from '@kbn/es-query';
@@ -157,7 +157,7 @@ export const useLatestVulnerabilitiesGrouping = ({
     additionalFilters: query ? [query, additionalFilters] : [additionalFilters],
     groupByField: currentSelectedGroup,
     uniqueValue,
-    from: `now-${LATEST_VULNERABILITIES_RETENTION_POLICY}`,
+    from: `now-${CDR_3P_RETENTION_POLICY}`,
     to: 'now',
     pageNumber: activePageIndex * pageSize,
     size: pageSize,

--- a/x-pack/plugins/cloud_security_posture/server/routes/status/status.ts
+++ b/x-pack/plugins/cloud_security_posture/server/routes/status/status.ts
@@ -149,27 +149,12 @@ const assertResponse = (resp: CspSetupStatus, logger: CspApiRequestHandlerContex
 const checkIndexHasFindings = async (
   esClient: ElasticsearchClient,
   index: string,
-  retentionPolicy: string,
   logger: Logger
 ) => {
   try {
     const response = await esClient.search({
       index,
       size: 0, // We only need to know if there are any hits, so we don't need to retrieve documents
-      query: {
-        bool: {
-          filter: [
-            {
-              range: {
-                '@timestamp': {
-                  gte: `now-${retentionPolicy}`,
-                  lte: 'now',
-                },
-              },
-            },
-          ],
-        },
-      },
       ignore_unavailable: true,
     });
 
@@ -215,18 +200,8 @@ export const getCspStatus = async ({
     installedPackagePoliciesVulnMgmt,
     installedPolicyTemplates,
   ] = await Promise.all([
-    checkIndexHasFindings(
-      esClient,
-      CDR_MISCONFIGURATIONS_INDEX_PATTERN,
-      LATEST_FINDINGS_RETENTION_POLICY,
-      logger
-    ),
-    checkIndexHasFindings(
-      esClient,
-      CDR_VULNERABILITIES_INDEX_PATTERN,
-      LATEST_VULNERABILITIES_RETENTION_POLICY,
-      logger
-    ),
+    checkIndexHasFindings(esClient, CDR_MISCONFIGURATIONS_INDEX_PATTERN, logger),
+    checkIndexHasFindings(esClient, CDR_VULNERABILITIES_INDEX_PATTERN, logger),
     checkIndexStatus(esClient, LATEST_FINDINGS_INDEX_DEFAULT_NS, logger, {
       postureType: POSTURE_TYPE_ALL,
       retentionTime: LATEST_VULNERABILITIES_RETENTION_POLICY,


### PR DESCRIPTION
## Summary

POC of removing retention period from CSP queries to cater for longer retention periods of 3rd party integrations

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


