### PR TITLE
[Search] Add UI kbn feature flag for Inference Endpoints

### DIFF
--- a/x-pack/plugins/search_inference_endpoints/public/index.ts
+++ b/x-pack/plugins/search_inference_endpoints/public/index.ts
@@ -17,3 +17,5 @@ export type {
   SearchInferenceEndpointsPluginSetup,
   SearchInferenceEndpointsPluginStart,
 } from './types';
+
+export const INFERENCE_ENDPOINTS_UI_FLAG = 'inferenceEndpointsUi:enabled';

--- a/x-pack/plugins/search_inference_endpoints/public/plugin.ts
+++ b/x-pack/plugins/search_inference_endpoints/public/plugin.ts
@@ -21,6 +21,7 @@ import {
   SearchInferenceEndpointsPluginSetup,
   SearchInferenceEndpointsPluginStart,
 } from './types';
+import { INFERENCE_ENDPOINTS_UI_FLAG } from '.';
 
 export class SearchInferenceEndpointsPlugin
   implements Plugin<SearchInferenceEndpointsPluginSetup, SearchInferenceEndpointsPluginStart>
@@ -34,8 +35,11 @@ export class SearchInferenceEndpointsPlugin
   public setup(
     core: CoreSetup<AppPluginStartDependencies, SearchInferenceEndpointsPluginStart>
   ): SearchInferenceEndpointsPluginSetup {
-    if (!this.config.ui?.enabled) return {};
-
+    if (
+      !this.config.ui?.enabled &&
+      !core.uiSettings.get<boolean>(INFERENCE_ENDPOINTS_UI_FLAG, false)
+    )
+      return {};
     core.application.register({
       id: PLUGIN_ID,
       appRoute: '/app/search_inference_endpoints',


### PR DESCRIPTION
This adds a UI feature flag for the inference endpoints plugin.

Call this to enable:
```
POST kbn:/internal/kibana/settings/inferenceEndpointsUi:enabled
{"value": true}
```

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->