### PR TITLE
[CI] Add tags for kibana pipelines

### DIFF
--- a/.buildkite/pipeline-resource-definitions/_templates/_new_pipeline.yml
+++ b/.buildkite/pipeline-resource-definitions/_templates/_new_pipeline.yml
@@ -70,3 +70,5 @@ spec:
           # Optionally, set schedule-specific env-vars here
           env:
             SCHEDULED: 'true'
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-api-docs.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-api-docs.yml
@@ -49,3 +49,5 @@ spec:
           cronline: 0 0 * * * America/New_York
           message: Daily build
           branch: main
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-apis-capacity-testing-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-apis-capacity-testing-daily.yml
@@ -47,3 +47,5 @@ spec:
           cronline: 0 1/3 * * * Europe/Berlin
           message: Capacity every 3h testing
           branch: main
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
@@ -42,3 +42,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
@@ -43,3 +43,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
@@ -43,3 +43,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-trigger.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-trigger.yml
@@ -44,3 +44,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-chrome-forward-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-chrome-forward-testing.yml
@@ -47,3 +47,5 @@ spec:
           cronline: 0 12 * * *
           message: Daily Chrome Forward Testing
           branch: main
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-codeql.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-codeql.yml
@@ -32,3 +32,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
@@ -48,3 +48,5 @@ spec:
           cronline: 0 5 * * *
           message: Daily 6 am UTC
           branch: main
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing.yml
@@ -40,3 +40,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
@@ -53,3 +53,5 @@ spec:
           env:
             PUBLISH_DOCKER_TAG: 'true'
           branch: main
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
@@ -61,6 +61,8 @@ spec:
           cronline: 0 9 * * * America/New_York
           message: Daily build
           branch: '7.17'
+      tags:
+        - kibana
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
@@ -108,6 +110,8 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
@@ -156,3 +160,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-esql-grammar-sync.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-esql-grammar-sync.yml
@@ -51,3 +51,5 @@ spec:
           cronline: 0 0 * * 1 America/New_York
           message: Weekly build
           branch: main
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
@@ -38,3 +38,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-flaky.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-flaky.yml
@@ -39,3 +39,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-fleet-packages-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-fleet-packages-daily.yml
@@ -47,3 +47,5 @@ spec:
           message: Single user daily test
           env: {}
           branch: main
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-migration-staging.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-migration-staging.yml
@@ -30,3 +30,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml
@@ -44,3 +44,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
@@ -47,3 +47,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-performance-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-performance-daily.yml
@@ -48,3 +48,5 @@ spec:
           cronline: 0 */3 * * * Europe/Berlin
           message: Single user daily test
           branch: main
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-performance-data-set-extraction-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-performance-data-set-extraction-daily.yml
@@ -47,3 +47,5 @@ spec:
           cronline: 0 3/8 * * * Europe/Berlin
           message: Extract APM traces
           branch: main
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-pointer-compression.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-pointer-compression.yml
@@ -36,3 +36,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-pr.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-pr.yml
@@ -47,3 +47,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-purge-cloud-deployments.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-purge-cloud-deployments.yml
@@ -49,3 +49,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-emergency-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-emergency-release.yml
@@ -28,3 +28,5 @@ spec:
           access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
@@ -31,3 +31,5 @@ spec:
           access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates.yml
@@ -31,3 +31,5 @@ spec:
           access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
@@ -44,3 +44,5 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         kibana-tech-leads:
           access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
@@ -46,3 +46,5 @@ spec:
           env:
             AUTO_SELECT_COMMIT: 'true'
           branch: main
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/scalability_testing-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/scalability_testing-daily.yml
@@ -47,3 +47,5 @@ spec:
           cronline: 0 6 * * * Europe/Berlin
           message: Scalability daily benchmarking
           branch: main
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/security-solution-ess/security-solution-ess.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-ess/security-solution-ess.yml
@@ -35,3 +35,6 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      tags:
+        - kibana
+        - security-solution

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
@@ -36,3 +36,6 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      tags:
+        - kibana
+        - security-solution

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
@@ -36,3 +36,6 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      tags:
+        - kibana
+        - security-solution

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
@@ -36,3 +36,6 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      tags:
+        - kibana
+        - security-solution

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
@@ -36,3 +36,6 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      tags:
+        - kibana
+        - security-solution

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
@@ -36,3 +36,6 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      tags:
+        - kibana
+        - security-solution

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
@@ -36,3 +36,6 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      tags:
+        - kibana
+        - security-solution

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
@@ -36,3 +36,6 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+      tags:
+        - kibana
+        - security-solution

--- a/.buildkite/pipeline-resource-definitions/trigger-version-dependent-jobs.yml
+++ b/.buildkite/pipeline-resource-definitions/trigger-version-dependent-jobs.yml
@@ -69,3 +69,5 @@ spec:
           env:
             TRIGGER_PIPELINE_SET: artifacts-trigger
             MESSAGE: Daily build
+      tags:
+        - kibana


### PR DESCRIPTION
## Summary
Kibana-related pipelines are hard to find on Buildkite, due to other, ingest-related pipelines having 'kibana' in their names.

This pipeline adds tags to pipelines serving `kibana` CI duties, so they can be easily found using Buildkite's tags/labels.

The tags added are mostly `kibana` but some pipelines also got the `security-solution` label, as these pipelines can be easily associated with the served solution.