### PR TITLE
[React@18] fix incorrect `useEffect` return value

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/elasticsearch_guide/elasticsearch_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/elasticsearch/components/elasticsearch_guide/elasticsearch_guide.tsx
@@ -35,7 +35,9 @@ export const ElasticsearchGuide = () => {
   const { data } = useValues(FetchApiKeysAPILogic);
   const apiKeys = data?.api_keys || [];
 
-  useEffect(() => makeRequest({}), []);
+  useEffect(() => {
+    makeRequest({});
+  }, []);
 
   return (
     <EnterpriseSearchElasticsearchPageTemplate>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/api_key/api_key_panel.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/api_key/api_key_panel.tsx
@@ -42,7 +42,9 @@ export const ApiKeyPanel: React.FC = () => {
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
   const elasticsearchEndpoint = esConfig.elasticsearch_host;
 
-  useEffect(() => makeRequest({}), []);
+  useEffect(() => {
+    makeRequest({});
+  }, []);
 
   const apiKeys = data?.api_keys || [];
   const cloudId = cloud?.cloudId;


### PR DESCRIPTION
## Summary

This is a prep for React@18 upgrade
When running functional tests with React@18 we've found places where `useEffect` function returns an object [(related failure)](https://buildkite.com/elastic/kibana-pull-request/builds/235998#01920fd4-ddb6-4bc5-9965-57712bc47437). This fails with a runtime error in React@18 as only `undefined` or an unmount funciton is a valid return value



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->