### PR TITLE
[Fleet] Add missing privilege callout in Integrations Policies table

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -67,6 +67,8 @@ import {
 import type { WithHeaderLayoutProps } from '../../../../layouts';
 import { WithHeaderLayout } from '../../../../layouts';
 
+import { PermissionsError } from '../../../../../fleet/layouts';
+
 import { DeferredAssetsWarning } from './assets/deferred_assets_warning';
 import { useIsFirstTimeAgentUserQuery } from './hooks';
 import { getInstallPkgRouteOptions } from './utils';
@@ -826,7 +828,14 @@ export function Detail() {
             <Configs packageInfo={packageInfo} />
           </Route>
           <Route path={INTEGRATIONS_ROUTING_PATHS.integration_details_policies}>
-            <PackagePoliciesPage name={packageInfo.name} version={packageInfo.version} />
+            {canReadIntegrationPolicies ? (
+              <PackagePoliciesPage name={packageInfo.name} version={packageInfo.version} />
+            ) : (
+              <PermissionsError
+                error="MISSING_PRIVILEGES"
+                requiredFleetRole="Agent Policies Read and Integrations Read"
+              />
+            )}
           </Route>
           <Route path={INTEGRATIONS_ROUTING_PATHS.integration_details_custom}>
             <CustomViewPage packageInfo={packageInfo} />


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/191800

## Summary
Add missing privilege callout in Integrations Policies table. 
Currently the route `app/integrations/detail/{pkgName}-{version}/policies` is available even though the policies tab is not visible with limited privileges. 

### Testing 
- Install `osquery_manager`
- Enable rbac feature flag
- Create role with privileges
![Screenshot 2024-10-08 at 16 24 46](https://github.com/user-attachments/assets/774de651-ac91-4365-9151-2df18efc811c)
- Log in with user with the above role
- Navigate to `app/integrations/detail/osquery_manager-1.14.0/policies`
- Verify that a limited privileges callout is displayed
![Screenshot 2024-10-08 at 16 12 23](https://github.com/user-attachments/assets/4498cbc1-243b-4fa9-a028-8899670f8e14)




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->