### PR TITLE
[Search] Fix issue with crawler not getting deleted

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
@@ -56,8 +56,6 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({ isCr
     setInputConnectorName('');
   }, [isDeleteModalVisible, isCrawler]);
 
-  console.log('test', isCrawler);
-
   return isDeleteModalVisible ? (
     <EuiConfirmModal
       title={

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
@@ -56,6 +56,8 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({ isCr
     setInputConnectorName('');
   }, [isDeleteModalVisible, isCrawler]);
 
+  console.log('test', isCrawler);
+
   return isDeleteModalVisible ? (
     <EuiConfirmModal
       title={

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -14,7 +14,12 @@ import { schema } from '@kbn/config-schema';
 
 import { i18n } from '@kbn/i18n';
 
-import { deleteConnectorSecret, updateConnectorIndexName } from '@kbn/search-connectors';
+import {
+  CRAWLER_SERVICE_TYPE,
+  deleteConnectorSecret,
+  deleteConnectorById,
+  updateConnectorIndexName,
+} from '@kbn/search-connectors';
 import {
   fetchConnectorByIndexName,
   fetchConnectors,
@@ -207,13 +212,17 @@ export function registerIndexRoutes({
         }
 
         if (connector) {
-          // detach the deleted index without removing the connector
-          await updateConnectorIndexName(client.asCurrentUser, connector.id, null);
-          if (connector.api_key_id) {
-            await client.asCurrentUser.security.invalidateApiKey({ ids: [connector.api_key_id] });
-          }
-          if (connector.api_key_secret_id) {
-            await deleteConnectorSecret(client.asCurrentUser, connector.api_key_secret_id);
+          if (connector.service_type === CRAWLER_SERVICE_TYPE) {
+            await deleteConnectorById(client.asCurrentUser, connector.id);
+          } else {
+            // detach the deleted index without removing the connector
+            await updateConnectorIndexName(client.asCurrentUser, connector.id, null);
+            if (connector.api_key_id) {
+              await client.asCurrentUser.security.invalidateApiKey({ ids: [connector.api_key_id] });
+            }
+            if (connector.api_key_secret_id) {
+              await deleteConnectorSecret(client.asCurrentUser, connector.api_key_secret_id);
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

The bug is that connector doc can be of `elastic-crawler` service type, we forgot about this in the logic that handles detaching the index from connector upon index delation.

This change checks if a connector doc, matching the `index_name` to be deleted, is of crawler type:
- If yes, delete the connector (crawler) doc, as crawler is always tied 1:1 to an index
- If no, detach the index, leave the connector doc in the connector index

This bug was likely introduced as a part of: https://github.com/elastic/kibana/pull/183833 (some lazy engineer forgot to test for this edge case ...)

## Validation

### Delete Crawler case 1: Delete Crawler deletes crawler doc + related index

https://github.com/user-attachments/assets/68ad14f7-4a7f-408c-8731-6ed0465f9ef1

### Delete Crawler case 2: Delete crawler-related index deletes crawler doc 

https://github.com/user-attachments/assets/e2995697-32c4-4f8f-90ce-9c06c7e6d208






<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->