### PR TITLE
Assign ownership of platform security serverless tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1367,6 +1367,8 @@ x-pack/test/**/deployment_agnostic/ @elastic/appex-qa #temporarily to monitor te
 /x-pack/test_serverless/**/test_suites/common/saved_objects_management/ @elastic/kibana-core
 /x-pack/test_serverless/api_integration/test_suites/common/core/ @elastic/kibana-core
 /x-pack/test_serverless/api_integration/test_suites/**/telemetry/ @elastic/kibana-core
+/x-pack/test_serverless/api_integration/test_suites/common/platform_security/ @elastic/kibana-security
+/x-pack/test_serverless/functional/test_suites/common/platform_security/ @elastic/kibana-security
 #CC# /src/core/server/csp/ @elastic/kibana-core
 #CC# /src/plugins/saved_objects/ @elastic/kibana-core
 #CC# /x-pack/plugins/cloud/ @elastic/kibana-core
@@ -1511,7 +1513,6 @@ x-pack/test/api_integration/apis/management/index_management/inference_endpoints
 /x-pack/test/functional/es_archives/auditbeat/default @elastic/security-solution
 /x-pack/test/functional/es_archives/auditbeat/hosts @elastic/security-solution
 /x-pack/test_serverless/functional/page_objects/svl_management_page.ts @elastic/security-solution
-/x-pack/test_serverless/api_integration/test_suites/common/platform_security/ @elastic/security-solution
 /x-pack/test_serverless/api_integration/test_suites/security @elastic/security-solution
 /x-pack/test_serverless/functional/page_objects/svl_sec_landing_page.ts @elastic/security-solution
 


### PR DESCRIPTION
## Summary

Follow up to #194819. Assigns ownership of

- `/x-pack/test_serverless/api_integration/test_suites/common/platform_security/` and
- `/x-pack/test_serverless/functional/test_suites/common/platform_security/`

to the Appex Platform Services Security team, AKA @elastic/kibana-security