### PR TITLE
Update deprecations carried over from 8

### DIFF
--- a/packages/core/application/core-application-browser/src/app_mount.ts
+++ b/packages/core/application/core-application-browser/src/app_mount.ts
@@ -89,7 +89,7 @@ export interface AppMountParameters<HistoryLocationState = unknown> {
    * This string should not include the base path from HTTP.
    *
    * @deprecated Use {@link AppMountParameters.history} instead.
-   * @removeBy 8.8.0
+   * remove after https://github.com/elastic/kibana/issues/132600 is done
    *
    * @example
    *

--- a/packages/core/elasticsearch/core-elasticsearch-server/src/contracts.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-server/src/contracts.ts
@@ -81,7 +81,7 @@ export interface ElasticsearchServiceSetup {
   setUnauthorizedErrorHandler: (handler: UnauthorizedErrorHandler) => void;
 
   /**
-   * @deprecated
+   * @deprecated Can be removed when https://github.com/elastic/kibana/issues/119862 is done.
    */
   legacy: {
     /**

--- a/packages/core/plugins/core-plugins-server-internal/src/plugin.ts
+++ b/packages/core/plugins/core-plugins-server-internal/src/plugin.ts
@@ -15,7 +15,6 @@ import { isConfigSchema } from '@kbn/config-schema';
 import type { Logger } from '@kbn/logging';
 import { type PluginOpaqueId, PluginType } from '@kbn/core-base-common';
 import type {
-  AsyncPlugin,
   Plugin,
   PluginConfigDescriptor,
   PluginInitializer,
@@ -58,8 +57,7 @@ export class PluginWrapper<
 
   private instance?:
     | Plugin<TSetup, TStart, TPluginsSetup, TPluginsStart>
-    | PrebootPlugin<TSetup, TPluginsSetup>
-    | AsyncPlugin<TSetup, TStart, TPluginsSetup, TPluginsStart>;
+    | PrebootPlugin<TSetup, TPluginsSetup>;
 
   private readonly startDependencies$ = new Subject<[CoreStart, TPluginsStart, TStart]>();
   public readonly startDependencies = firstValueFrom(this.startDependencies$);

--- a/packages/core/plugins/core-plugins-server/index.ts
+++ b/packages/core/plugins/core-plugins-server/index.ts
@@ -10,7 +10,6 @@
 export type {
   PrebootPlugin,
   Plugin,
-  AsyncPlugin,
   PluginConfigDescriptor,
   PluginConfigSchema,
   PluginInitializer,

--- a/packages/core/plugins/core-plugins-server/src/index.ts
+++ b/packages/core/plugins/core-plugins-server/src/index.ts
@@ -10,7 +10,6 @@
 export type {
   PrebootPlugin,
   Plugin,
-  AsyncPlugin,
   PluginConfigDescriptor,
   PluginConfigSchema,
   PluginInitializer,

--- a/packages/core/plugins/core-plugins-server/src/types.ts
+++ b/packages/core/plugins/core-plugins-server/src/types.ts
@@ -302,26 +302,6 @@ export interface Plugin<
 }
 
 /**
- * A plugin with asynchronous lifecycle methods.
- *
- * @deprecated Asynchronous lifecycles are deprecated, and should be migrated to sync {@link Plugin | plugin}
- * @removeBy 8.8.0
- * @public
- */
-export interface AsyncPlugin<
-  TSetup = void,
-  TStart = void,
-  TPluginsSetup extends object = object,
-  TPluginsStart extends object = object
-> {
-  setup(core: CoreSetup, plugins: TPluginsSetup): TSetup | Promise<TSetup>;
-
-  start(core: CoreStart, plugins: TPluginsStart): TStart | Promise<TStart>;
-
-  stop?(): MaybePromise<void>;
-}
-
-/**
  * @public
  */
 export type SharedGlobalConfig = RecursiveReadonly<{
@@ -478,7 +458,5 @@ export type PluginInitializer<
 > = (
   core: PluginInitializerContext
 ) => Promise<
-  | Plugin<TSetup, TStart, TPluginsSetup, TPluginsStart>
-  | PrebootPlugin<TSetup, TPluginsSetup>
-  | AsyncPlugin<TSetup, TStart, TPluginsSetup, TPluginsStart>
+  Plugin<TSetup, TStart, TPluginsSetup, TPluginsStart> | PrebootPlugin<TSetup, TPluginsSetup>
 >;

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -267,7 +267,6 @@ export { PluginType } from '@kbn/core-base-common';
 export type {
   PrebootPlugin,
   Plugin,
-  AsyncPlugin,
   PluginConfigDescriptor,
   PluginConfigSchema,
   PluginInitializer,


### PR DESCRIPTION
Fix https://github.com/elastic/kibana/issues/142915

### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Third party plugin types throw type errors | Low | Low | type checks will error when using a deprecated type. Plugin authors should extend the supported types or define new ones inline |

### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) (no breaking changes)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->