### PR TITLE
[8.x] [Fleet] add escapeMultilineString Handlebar helper (#195159)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.test.ts
@@ -261,6 +261,80 @@ New lines and \\n escaped values.`,
     });
   });
 
+  describe('escape_multiline_string helper', () => {
+    it('should escape new lines', () => {
+      const streamTemplate = `
+      input: log
+      multiline_text: "{{escape_multiline_string multiline_text}}"
+            `;
+
+      const vars = {
+        multiline_text: {
+          type: 'textarea',
+          value: `This is a text with
+New lines and \n escaped values.`,
+        },
+      };
+
+      const output = compileTemplate(vars, streamTemplate);
+      expect(output).toEqual({
+        input: 'log',
+        multiline_text: `This is a text with
+New lines and 
+escaped values.`,
+      });
+    });
+
+    it('should escape single quotes', () => {
+      const streamTemplate = `
+      input: log
+      multiline_text: "{{escape_multiline_string multiline_text}}"
+            `;
+
+      const vars = {
+        multiline_text: {
+          type: 'textarea',
+          value: `This is a multiline text with
+'escaped values.'`,
+        },
+      };
+
+      const output = compileTemplate(vars, streamTemplate);
+      expect(output).toEqual({
+        input: 'log',
+        multiline_text: `This is a multiline text with
+''escaped values.''`,
+      });
+    });
+
+    it('should allow concatenation of multiline strings', () => {
+      const streamTemplate = `
+input: log
+multiline_text: "{{escape_multiline_string multiline_text}}{{escape_multiline_string "
+This is a concatenated text
+with new lines"}}"
+      `;
+
+      const vars = {
+        multiline_text: {
+          type: 'textarea',
+          value: `This is a text with
+New lines and\nescaped values.`,
+        },
+      };
+
+      const output = compileTemplate(vars, streamTemplate);
+      expect(output).toEqual({
+        input: 'log',
+        multiline_text: `This is a text with
+New lines and
+escaped values.
+This is a concatenated text
+with new lines`,
+      });
+    });
+  });
+
   describe('to_json helper', () => {
     const streamTemplate = `
 input: log

--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
@@ -131,6 +131,18 @@ function escapeStringHelper(str: string) {
 }
 handlebars.registerHelper('escape_string', escapeStringHelper);
 
+/**
+ * escapeMultilineStringHelper will escape a multiline string by doubling the newlines
+ * and escaping single quotes.
+ * This is useful when the string is multiline and needs to be escaped in a yaml file
+ * without wrapping it in single quotes.
+ */
+function escapeMultilineStringHelper(str: string) {
+  if (!str) return undefined;
+  return str.replace(/\'/g, "''").replace(/\n/g, '\n\n');
+}
+handlebars.registerHelper('escape_multiline_string', escapeMultilineStringHelper);
+
 // toJsonHelper will convert any object to a Json string.
 function toJsonHelper(value: any) {
   if (typeof value === 'string') {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Fleet] add escapeMultilineString Handlebar helper (#195159)](https://github.com/elastic/kibana/pull/195159)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Paulo Silva","email":"paulo.henrique@elastic.co"},"sourceCommit":{"committedDate":"2024-10-08T18:56:08Z","message":"[Fleet] add escapeMultilineString Handlebar helper (#195159)\n\n## Summary\r\n\r\nAdding a handlebar helper to escape multiline strings. It has the same\r\nfunction as `escapeStringHelper`, but does not wrap strings in single\r\nquotes, allowing concatenation of escaped variables in the `hbs`\r\ntemplate such as this example:\r\n\r\n```hbs\r\naudit_rules: \"{{escape_multiline_string audit_rules}}\r\n  {{escape_multiline_string \"\r\n  # Session data audit rules\r\n  -a always,exit -F arch=b64 -S execve,execveat -k exec\r\n  -a always,exit -F arch=b64 -S exit_group\r\n  -a always,exit -F arch=b64 -S setsid\"}}\"\r\n{{else}}\r\n  {{#if audit_rules}}\r\naudit_rules: {{escape_string audit_rules}}\r\n  {{/if}}\r\n{{/if}}\r\n```\r\n\r\nThe above would not be possible using only `escape_string` as\r\n`audit_rules` would be wrapped in single quotes.\r\n\r\n## Screenshots\r\n\r\nThe example above illustrates how this option allows the Auditd manager\r\nintegration to append Session data audit rules to the `audit_rules`\r\nfield when Session data is enabled in the integration\r\n([PR](https://github.com/elastic/integrations/pull/11336)).\r\n\r\n<img width=\"872\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/325d784d-26a4-4dfe-9d0e-54d51c3ed060\">\r\n\r\n<img width=\"801\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/ebd521c0-4471-48f9-ba8d-94630ea0efd2\">","sha":"407137a6befb38f34cb11f6a3b6a741a27977031","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","v8.16.0","backport:version"],"number":195159,"url":"https://github.com/elastic/kibana/pull/195159","mergeCommit":{"message":"[Fleet] add escapeMultilineString Handlebar helper (#195159)\n\n## Summary\r\n\r\nAdding a handlebar helper to escape multiline strings. It has the same\r\nfunction as `escapeStringHelper`, but does not wrap strings in single\r\nquotes, allowing concatenation of escaped variables in the `hbs`\r\ntemplate such as this example:\r\n\r\n```hbs\r\naudit_rules: \"{{escape_multiline_string audit_rules}}\r\n  {{escape_multiline_string \"\r\n  # Session data audit rules\r\n  -a always,exit -F arch=b64 -S execve,execveat -k exec\r\n  -a always,exit -F arch=b64 -S exit_group\r\n  -a always,exit -F arch=b64 -S setsid\"}}\"\r\n{{else}}\r\n  {{#if audit_rules}}\r\naudit_rules: {{escape_string audit_rules}}\r\n  {{/if}}\r\n{{/if}}\r\n```\r\n\r\nThe above would not be possible using only `escape_string` as\r\n`audit_rules` would be wrapped in single quotes.\r\n\r\n## Screenshots\r\n\r\nThe example above illustrates how this option allows the Auditd manager\r\nintegration to append Session data audit rules to the `audit_rules`\r\nfield when Session data is enabled in the integration\r\n([PR](https://github.com/elastic/integrations/pull/11336)).\r\n\r\n<img width=\"872\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/325d784d-26a4-4dfe-9d0e-54d51c3ed060\">\r\n\r\n<img width=\"801\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/ebd521c0-4471-48f9-ba8d-94630ea0efd2\">","sha":"407137a6befb38f34cb11f6a3b6a741a27977031"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/195159","number":195159,"mergeCommit":{"message":"[Fleet] add escapeMultilineString Handlebar helper (#195159)\n\n## Summary\r\n\r\nAdding a handlebar helper to escape multiline strings. It has the same\r\nfunction as `escapeStringHelper`, but does not wrap strings in single\r\nquotes, allowing concatenation of escaped variables in the `hbs`\r\ntemplate such as this example:\r\n\r\n```hbs\r\naudit_rules: \"{{escape_multiline_string audit_rules}}\r\n  {{escape_multiline_string \"\r\n  # Session data audit rules\r\n  -a always,exit -F arch=b64 -S execve,execveat -k exec\r\n  -a always,exit -F arch=b64 -S exit_group\r\n  -a always,exit -F arch=b64 -S setsid\"}}\"\r\n{{else}}\r\n  {{#if audit_rules}}\r\naudit_rules: {{escape_string audit_rules}}\r\n  {{/if}}\r\n{{/if}}\r\n```\r\n\r\nThe above would not be possible using only `escape_string` as\r\n`audit_rules` would be wrapped in single quotes.\r\n\r\n## Screenshots\r\n\r\nThe example above illustrates how this option allows the Auditd manager\r\nintegration to append Session data audit rules to the `audit_rules`\r\nfield when Session data is enabled in the integration\r\n([PR](https://github.com/elastic/integrations/pull/11336)).\r\n\r\n<img width=\"872\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/325d784d-26a4-4dfe-9d0e-54d51c3ed060\">\r\n\r\n<img width=\"801\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/ebd521c0-4471-48f9-ba8d-94630ea0efd2\">","sha":"407137a6befb38f34cb11f6a3b6a741a27977031"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->