### PR TITLE
[Security Solution][Notes] - allow filtering by note association

### DIFF
--- a/oas_docs/output/kibana.serverless.staging.yaml
+++ b/oas_docs/output/kibana.serverless.staging.yaml
@@ -35266,6 +35266,10 @@ paths:
           schema:
             nullable: true
             type: string
+        - in: query
+          name: associatedFilter
+          schema:
+            $ref: '#/components/schemas/Security_Timeline_API_AssociatedFilterType'
       responses:
         '200':
           content:
@@ -49419,6 +49423,14 @@ components:
     Security_Osquery_API_VersionOrUndefined:
       $ref: '#/components/schemas/Security_Osquery_API_Version'
       nullable: true
+    Security_Timeline_API_AssociatedFilterType:
+      description: Filter notes based on their association with a document or saved object.
+      enum:
+        - document_only
+        - saved_object_only
+        - document_and_saved_object
+        - orphan
+      type: string
     Security_Timeline_API_BareNote:
       type: object
       properties:

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -35266,6 +35266,10 @@ paths:
           schema:
             nullable: true
             type: string
+        - in: query
+          name: associatedFilter
+          schema:
+            $ref: '#/components/schemas/Security_Timeline_API_AssociatedFilterType'
       responses:
         '200':
           content:
@@ -49419,6 +49423,14 @@ components:
     Security_Osquery_API_VersionOrUndefined:
       $ref: '#/components/schemas/Security_Osquery_API_Version'
       nullable: true
+    Security_Timeline_API_AssociatedFilterType:
+      description: Filter notes based on their association with a document or saved object.
+      enum:
+        - document_only
+        - saved_object_only
+        - document_and_saved_object
+        - orphan
+      type: string
     Security_Timeline_API_BareNote:
       type: object
       properties:

--- a/oas_docs/output/kibana.staging.yaml
+++ b/oas_docs/output/kibana.staging.yaml
@@ -38697,6 +38697,10 @@ paths:
           schema:
             nullable: true
             type: string
+        - in: query
+          name: associatedFilter
+          schema:
+            $ref: '#/components/schemas/Security_Timeline_API_AssociatedFilterType'
       responses:
         '200':
           content:
@@ -58185,6 +58189,14 @@ components:
     Security_Osquery_API_VersionOrUndefined:
       $ref: '#/components/schemas/Security_Osquery_API_Version'
       nullable: true
+    Security_Timeline_API_AssociatedFilterType:
+      description: Filter notes based on their association with a document or saved object.
+      enum:
+        - document_only
+        - saved_object_only
+        - document_and_saved_object
+        - orphan
+      type: string
     Security_Timeline_API_BareNote:
       type: object
       properties:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -38697,6 +38697,10 @@ paths:
           schema:
             nullable: true
             type: string
+        - in: query
+          name: associatedFilter
+          schema:
+            $ref: '#/components/schemas/Security_Timeline_API_AssociatedFilterType'
       responses:
         '200':
           content:
@@ -58185,6 +58189,14 @@ components:
     Security_Osquery_API_VersionOrUndefined:
       $ref: '#/components/schemas/Security_Osquery_API_Version'
       nullable: true
+    Security_Timeline_API_AssociatedFilterType:
+      description: Filter notes based on their association with a document or saved object.
+      enum:
+        - document_only
+        - saved_object_only
+        - document_and_saved_object
+        - orphan
+      type: string
     Security_Timeline_API_BareNote:
       type: object
       properties:

--- a/x-pack/plugins/security_solution/common/api/timeline/get_notes/get_notes_route.gen.ts
+++ b/x-pack/plugins/security_solution/common/api/timeline/get_notes/get_notes_route.gen.ts
@@ -18,6 +18,19 @@ import { z } from '@kbn/zod';
 
 import { Note } from '../model/components.gen';
 
+/**
+ * Filter notes based on their association with a document or saved object.
+ */
+export type AssociatedFilterType = z.infer<typeof AssociatedFilterType>;
+export const AssociatedFilterType = z.enum([
+  'document_only',
+  'saved_object_only',
+  'document_and_saved_object',
+  'orphan',
+]);
+export type AssociatedFilterTypeEnum = typeof AssociatedFilterType.enum;
+export const AssociatedFilterTypeEnum = AssociatedFilterType.enum;
+
 export type DocumentIds = z.infer<typeof DocumentIds>;
 export const DocumentIds = z.union([z.array(z.string()), z.string()]);
 
@@ -41,6 +54,7 @@ export const GetNotesRequestQuery = z.object({
   sortOrder: z.string().nullable().optional(),
   filter: z.string().nullable().optional(),
   userFilter: z.string().nullable().optional(),
+  associatedFilter: AssociatedFilterType.optional(),
 });
 export type GetNotesRequestQueryInput = z.input<typeof GetNotesRequestQuery>;
 

--- a/x-pack/plugins/security_solution/common/api/timeline/get_notes/get_notes_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/timeline/get_notes/get_notes_route.schema.yaml
@@ -56,6 +56,10 @@ paths:
           schema:
             nullable: true
             type: string
+        - name: associatedFilter
+          in: query
+          schema:
+            $ref: '#/components/schemas/AssociatedFilterType'
       responses:
         '200':
           description: Indicates the requested notes were returned.
@@ -68,6 +72,14 @@ paths:
 
 components:
   schemas:
+    AssociatedFilterType:
+        type: string
+        enum:
+            - document_only
+            - saved_object_only
+            - document_and_saved_object
+            - orphan
+        description: Filter notes based on their association with a document or saved object.
     DocumentIds:
       oneOf:
         - type: array

--- a/x-pack/plugins/security_solution/common/notes/constants.ts
+++ b/x-pack/plugins/security_solution/common/notes/constants.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export enum AssociatedFilter {
+  all = 'all',
+  documentOnly = 'document_only',
+  savedObjectOnly = 'saved_object_only',
+  documentAndSavedObject = 'document_and_saved_object',
+  orphan = 'orphan',
+}

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
@@ -102,6 +102,10 @@ paths:
           schema:
             nullable: true
             type: string
+        - in: query
+          name: associatedFilter
+          schema:
+            $ref: '#/components/schemas/AssociatedFilterType'
       responses:
         '200':
           content:
@@ -921,6 +925,14 @@ paths:
         - access:securitySolution
 components:
   schemas:
+    AssociatedFilterType:
+      description: Filter notes based on their association with a document or saved object.
+      enum:
+        - document_only
+        - saved_object_only
+        - document_and_saved_object
+        - orphan
+      type: string
     BareNote:
       type: object
       properties:

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
@@ -102,6 +102,10 @@ paths:
           schema:
             nullable: true
             type: string
+        - in: query
+          name: associatedFilter
+          schema:
+            $ref: '#/components/schemas/AssociatedFilterType'
       responses:
         '200':
           content:
@@ -921,6 +925,14 @@ paths:
         - access:securitySolution
 components:
   schemas:
+    AssociatedFilterType:
+      description: Filter notes based on their association with a document or saved object.
+      enum:
+        - document_only
+        - saved_object_only
+        - document_and_saved_object
+        - orphan
+      type: string
     BareNote:
       type: object
       properties:

--- a/x-pack/plugins/security_solution/public/common/mock/global_state.ts
+++ b/x-pack/plugins/security_solution/public/common/mock/global_state.ts
@@ -7,6 +7,7 @@
 
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
+import { AssociatedFilter } from '../../../common/notes/constants';
 import { ReqStatus } from '../../notes/store/notes.slice';
 import { HostsFields } from '../../../common/api/search_strategy/hosts/model/sort';
 import { InputsModelId } from '../store/inputs/constants';
@@ -550,6 +551,7 @@ export const mockGlobalState: State = {
     },
     filter: '',
     userFilter: '',
+    associatedFilter: AssociatedFilter.all,
     search: '',
     selectedIds: [],
     pendingDeleteIds: [],

--- a/x-pack/plugins/security_solution/public/notes/api/api.ts
+++ b/x-pack/plugins/security_solution/public/notes/api/api.ts
@@ -11,6 +11,7 @@ import type {
   GetNotesResponse,
   PersistNoteRouteResponse,
 } from '../../../common/api/timeline';
+import type { AssociatedFilter } from '../../../common/notes/constants';
 import { KibanaServices } from '../../common/lib/kibana';
 import { NOTE_URL } from '../../../common/constants';
 
@@ -43,6 +44,7 @@ export const fetchNotes = async ({
   sortOrder,
   filter,
   userFilter,
+  associatedFilter,
   search,
 }: {
   page: number;
@@ -51,6 +53,7 @@ export const fetchNotes = async ({
   sortOrder: string;
   filter: string;
   userFilter: string;
+  associatedFilter: AssociatedFilter;
   search: string;
 }) => {
   const response = await KibanaServices.get().http.get<GetNotesResponse>(NOTE_URL, {
@@ -61,6 +64,7 @@ export const fetchNotes = async ({
       sortOrder,
       filter,
       userFilter,
+      associatedFilter,
       search,
     },
     version: '2023-10-31',

--- a/x-pack/plugins/security_solution/public/notes/components/search_row.test.tsx
+++ b/x-pack/plugins/security_solution/public/notes/components/search_row.test.tsx
@@ -9,7 +9,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { SearchRow } from './search_row';
-import { SEARCH_BAR_TEST_ID, USER_SELECT_TEST_ID } from './test_ids';
+import { ASSOCIATED_NOT_SELECT_TEST_ID, SEARCH_BAR_TEST_ID, USER_SELECT_TEST_ID } from './test_ids';
+import { AssociatedFilter } from '../../../common/notes/constants';
 import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';
 
 jest.mock('../../common/components/user_profiles/use_suggest_users');
@@ -38,6 +39,7 @@ describe('SearchRow', () => {
 
     expect(getByTestId(SEARCH_BAR_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(USER_SELECT_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(ASSOCIATED_NOT_SELECT_TEST_ID)).toBeInTheDocument();
   });
 
   it('should call the correct action when entering a value in the search bar', async () => {
@@ -59,6 +61,15 @@ describe('SearchRow', () => {
 
     const option = await screen.findByText('test');
     fireEvent.click(option);
+
+    expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('should call the correct action when select a value in the associated note dropdown', async () => {
+    const { getByTestId } = render(<SearchRow />);
+
+    const associatedNoteSelect = getByTestId(ASSOCIATED_NOT_SELECT_TEST_ID);
+    await userEvent.selectOptions(associatedNoteSelect, [AssociatedFilter.documentOnly]);
 
     expect(mockDispatch).toHaveBeenCalled();
   });

--- a/x-pack/plugins/security_solution/public/notes/components/search_row.tsx
+++ b/x-pack/plugins/security_solution/public/notes/components/search_row.tsx
@@ -5,30 +5,48 @@
  * 2.0.
  */
 
-import { EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiSearchBar } from '@elastic/eui';
 import React, { useMemo, useCallback, useState } from 'react';
+import type { EuiSelectOption } from '@elastic/eui';
+import {
+  EuiComboBox,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSearchBar,
+  EuiSelect,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import { useDispatch } from 'react-redux';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { i18n } from '@kbn/i18n';
 import type { EuiComboBoxOptionOption } from '@elastic/eui/src/components/combo_box/types';
-import { SEARCH_BAR_TEST_ID, USER_SELECT_TEST_ID } from './test_ids';
+import { ASSOCIATED_NOT_SELECT_TEST_ID, SEARCH_BAR_TEST_ID, USER_SELECT_TEST_ID } from './test_ids';
 import { useSuggestUsers } from '../../common/components/user_profiles/use_suggest_users';
-import { userFilterUsers, userSearchedNotes } from '..';
+import { userFilterAssociatedNotes, userFilterUsers, userSearchedNotes } from '..';
+import { AssociatedFilter } from '../../../common/notes/constants';
 
 export const USERS_DROPDOWN = i18n.translate('xpack.securitySolution.notes.usersDropdownLabel', {
   defaultMessage: 'Users',
 });
+const FILTER_SELECT = i18n.translate('xpack.securitySolution.notes.management.filterSelect', {
+  defaultMessage: 'Select filter',
+});
+
+const searchBox = {
+  placeholder: 'Search note contents',
+  incremental: false,
+  'data-test-subj': SEARCH_BAR_TEST_ID,
+};
+const associatedNoteSelectOptions: EuiSelectOption[] = [
+  { value: AssociatedFilter.all, text: 'All' },
+  { value: AssociatedFilter.documentOnly, text: 'Attached to document only' },
+  { value: AssociatedFilter.savedObjectOnly, text: 'Attached to timeline only' },
+  { value: AssociatedFilter.documentAndSavedObject, text: 'Attached to document and timeline' },
+  { value: AssociatedFilter.orphan, text: 'Orphan' },
+];
 
 export const SearchRow = React.memo(() => {
   const dispatch = useDispatch();
-  const searchBox = useMemo(
-    () => ({
-      placeholder: 'Search note contents',
-      incremental: false,
-      'data-test-subj': SEARCH_BAR_TEST_ID,
-    }),
-    []
-  );
+  const associatedSelectId = useGeneratedHtmlId({ prefix: 'associatedSelectId' });
 
   const onQueryChange = useCallback(
     ({ queryText }: { queryText: string }) => {
@@ -57,6 +75,13 @@ export const SearchRow = React.memo(() => {
     [dispatch]
   );
 
+  const onAssociatedNoteSelectChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      dispatch(userFilterAssociatedNotes(e.target.value as AssociatedFilter));
+    },
+    [dispatch]
+  );
+
   return (
     <EuiFlexGroup gutterSize="m">
       <EuiFlexItem>
@@ -71,6 +96,16 @@ export const SearchRow = React.memo(() => {
           onChange={onChange}
           isLoading={isLoadingSuggestedUsers}
           data-test-subj={USER_SELECT_TEST_ID}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiSelect
+          id={associatedSelectId}
+          options={associatedNoteSelectOptions}
+          onChange={onAssociatedNoteSelectChange}
+          prepend={FILTER_SELECT}
+          aria-label={FILTER_SELECT}
+          data-test-subj={ASSOCIATED_NOT_SELECT_TEST_ID}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/notes/components/test_ids.ts
+++ b/x-pack/plugins/security_solution/public/notes/components/test_ids.ts
@@ -21,3 +21,4 @@ export const NOTE_CONTENT_BUTTON_TEST_ID = `${PREFIX}NoteContentButton` as const
 export const NOTE_CONTENT_POPOVER_TEST_ID = `${PREFIX}NoteContentPopover` as const;
 export const SEARCH_BAR_TEST_ID = `${PREFIX}SearchBar` as const;
 export const USER_SELECT_TEST_ID = `${PREFIX}UserSelect` as const;
+export const ASSOCIATED_NOT_SELECT_TEST_ID = `${PREFIX}AssociatedNoteSelect` as const;

--- a/x-pack/plugins/security_solution/public/notes/components/utility_bar.tsx
+++ b/x-pack/plugins/security_solution/public/notes/components/utility_bar.tsx
@@ -24,6 +24,7 @@ import {
   selectNotesTableSearch,
   userSelectedBulkDelete,
   selectNotesTableUserFilters,
+  selectNotesTableAssociatedFilter,
 } from '..';
 
 export const BATCH_ACTIONS = i18n.translate(
@@ -53,6 +54,7 @@ export const NotesUtilityBar = React.memo(() => {
   const sort = useSelector(selectNotesTableSort);
   const selectedItems = useSelector(selectNotesTableSelectedIds);
   const notesUserFilters = useSelector(selectNotesTableUserFilters);
+  const notesAssociatedFilters = useSelector(selectNotesTableAssociatedFilter);
   const resultsCount = useMemo(() => {
     const { perPage, page, total } = pagination;
     const startOfCurrentPage = perPage * (page - 1) + 1;
@@ -86,6 +88,7 @@ export const NotesUtilityBar = React.memo(() => {
         sortOrder: sort.direction,
         filter: '',
         userFilter: notesUserFilters,
+        associatedFilter: notesAssociatedFilters,
         search: notesSearch,
       })
     );
@@ -96,6 +99,7 @@ export const NotesUtilityBar = React.memo(() => {
     sort.field,
     sort.direction,
     notesUserFilters,
+    notesAssociatedFilters,
     notesSearch,
   ]);
   return (

--- a/x-pack/plugins/security_solution/public/notes/pages/note_management_page.tsx
+++ b/x-pack/plugins/security_solution/public/notes/pages/note_management_page.tsx
@@ -37,6 +37,7 @@ import {
   selectFetchNotesError,
   ReqStatus,
   selectNotesTableUserFilters,
+  selectNotesTableAssociatedFilter,
 } from '..';
 import type { NotesState } from '..';
 import { SearchRow } from '../components/search_row';
@@ -121,6 +122,7 @@ export const NoteManagementPage = () => {
   const sort = useSelector(selectNotesTableSort);
   const notesSearch = useSelector(selectNotesTableSearch);
   const notesUserFilters = useSelector(selectNotesTableUserFilters);
+  const notesAssociatedFilters = useSelector(selectNotesTableAssociatedFilter);
   const pendingDeleteIds = useSelector(selectNotesTablePendingDeleteIds);
   const isDeleteModalVisible = pendingDeleteIds.length > 0;
   const fetchNotesStatus = useSelector(selectFetchNotesStatus);
@@ -137,6 +139,7 @@ export const NoteManagementPage = () => {
         sortOrder: sort.direction,
         filter: '',
         userFilter: notesUserFilters,
+        associatedFilter: notesAssociatedFilters,
         search: notesSearch,
       })
     );
@@ -147,6 +150,7 @@ export const NoteManagementPage = () => {
     sort.field,
     sort.direction,
     notesUserFilters,
+    notesAssociatedFilters,
     notesSearch,
   ]);
 

--- a/x-pack/plugins/security_solution/public/notes/store/notes.slice.test.ts
+++ b/x-pack/plugins/security_solution/public/notes/store/notes.slice.test.ts
@@ -5,13 +5,15 @@
  * 2.0.
  */
 import * as uuid from 'uuid';
-import { miniSerializeError } from '@reduxjs/toolkit';
 import type { SerializedError } from '@reduxjs/toolkit';
+import { miniSerializeError } from '@reduxjs/toolkit';
+import type { NotesState } from './notes.slice';
 import {
   createNote,
   deleteNotes,
-  fetchNotesByDocumentIds,
   fetchNotes,
+  fetchNotesByDocumentIds,
+  fetchNotesBySavedObjectIds,
   initialNotesState,
   notesReducer,
   ReqStatus,
@@ -20,6 +22,7 @@ import {
   selectCreateNoteStatus,
   selectDeleteNotesError,
   selectDeleteNotesStatus,
+  selectDocumentNotesBySavedObjectId,
   selectFetchNotesByDocumentIdsError,
   selectFetchNotesByDocumentIdsStatus,
   selectFetchNotesError,
@@ -27,12 +30,16 @@ import {
   selectNoteById,
   selectNoteIds,
   selectNotesByDocumentId,
-  selectDocumentNotesBySavedObjectId,
+  selectNotesBySavedObjectId,
   selectNotesPagination,
   selectNotesTablePendingDeleteIds,
   selectNotesTableSearch,
   selectNotesTableSelectedIds,
   selectNotesTableSort,
+  selectSortedNotesByDocumentId,
+  selectSortedNotesBySavedObjectId,
+  selectNotesTableUserFilters,
+  selectNotesTableAssociatedFilter,
   userClosedDeleteModal,
   userFilteredNotes,
   userSearchedNotes,
@@ -42,17 +49,13 @@ import {
   userSelectedRow,
   userSelectedNotesForDeletion,
   userSortedNotes,
-  selectSortedNotesByDocumentId,
-  fetchNotesBySavedObjectIds,
-  selectNotesBySavedObjectId,
-  selectSortedNotesBySavedObjectId,
   userFilterUsers,
-  selectNotesTableUserFilters,
   userClosedCreateErrorToast,
+  userFilterAssociatedNotes,
 } from './notes.slice';
-import type { NotesState } from './notes.slice';
 import { mockGlobalState } from '../../common/mock';
 import type { Note } from '../../../common/api/timeline';
+import { AssociatedFilter } from '../../../common/notes/constants';
 
 const initalEmptyState = initialNotesState;
 
@@ -102,6 +105,7 @@ const initialNonEmptyState: NotesState = {
   },
   filter: '',
   userFilter: '',
+  associatedFilter: AssociatedFilter.all,
   search: '',
   selectedIds: [],
   pendingDeleteIds: [],
@@ -515,6 +519,17 @@ describe('notesSlice', () => {
       });
     });
 
+    describe('userFilterAssociatedNotes', () => {
+      it('should set correct value to filter associated notes', () => {
+        const action = { type: userFilterAssociatedNotes.type, payload: 'abc' };
+
+        expect(notesReducer(initalEmptyState, action)).toEqual({
+          ...initalEmptyState,
+          associatedFilter: 'abc',
+        });
+      });
+    });
+
     describe('userSearchedNotes', () => {
       it('should set correct value to search notes', () => {
         const action = { type: userSearchedNotes.type, payload: 'abc' };
@@ -851,12 +866,20 @@ describe('notesSlice', () => {
       expect(selectNotesTableSearch(state)).toBe('test search');
     });
 
-    it('should select associated filter', () => {
+    it('should select user filter', () => {
       const state = {
         ...mockGlobalState,
         notes: { ...initialNotesState, userFilter: 'abc' },
       };
       expect(selectNotesTableUserFilters(state)).toBe('abc');
+    });
+
+    it('should select associated filter', () => {
+      const state = {
+        ...mockGlobalState,
+        notes: { ...initialNotesState, associatedFilter: AssociatedFilter.all },
+      };
+      expect(selectNotesTableAssociatedFilter(state)).toBe(AssociatedFilter.all);
     });
 
     it('should select notes table pending delete ids', () => {

--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/notes/get_notes.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/notes/get_notes.ts
@@ -9,9 +9,13 @@ import type { IKibanaResponse } from '@kbn/core-http-server';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import type { SortOrder } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
-import type { SavedObjectsFindOptions } from '@kbn/core-saved-objects-api-server';
-import { nodeBuilder } from '@kbn/es-query';
+import type {
+  SavedObjectsFindOptions,
+  SavedObjectsFindOptionsReference,
+} from '@kbn/core-saved-objects-api-server';
 import type { KueryNode } from '@kbn/es-query';
+import { nodeBuilder, nodeTypes } from '@kbn/es-query';
+import { AssociatedFilter } from '../../../../../common/notes/constants';
 import { timelineSavedObjectType } from '../../saved_object_mappings';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
 import { MAX_UNASSOCIATED_NOTES, NOTE_URL } from '../../../../../common/constants';
@@ -22,6 +26,7 @@ import { getAllSavedNote } from '../../saved_object/notes';
 import { noteSavedObjectType } from '../../saved_object_mappings/notes';
 import { GetNotesRequestQuery, type GetNotesResponse } from '../../../../../common/api/timeline';
 
+/* eslint-disable complexity */
 export const getNotesRoute = (router: SecuritySolutionPluginRouter) => {
   router.versioned
     .get({
@@ -128,20 +133,69 @@ export const getNotesRoute = (router: SecuritySolutionPluginRouter) => {
             filter,
           };
 
+          // we need to combine the associatedFilter with the filter query
+          // we have to type case here because the filter is a string (from the schema) and that cannot be changed as it would be a breaking change
+          const filterAsKueryNode: KueryNode = (filter || '') as unknown as KueryNode;
+          const filterKueryNodeArray = [filterAsKueryNode];
+
           // retrieve all the notes created by a specific user
           const userFilter = queryParams?.userFilter;
           if (userFilter) {
-            // we need to combine the associatedFilter with the filter query
-            // we have to type case here because the filter is a string (from the schema) and that cannot be changed as it would be a breaking change
-            const filterAsKueryNode: KueryNode = (filter || '') as unknown as KueryNode;
-
-            options.filter = nodeBuilder.and([
-              nodeBuilder.is(`${noteSavedObjectType}.attributes.createdBy`, userFilter),
-              filterAsKueryNode,
-            ]);
-          } else {
-            options.filter = filter;
+            filterKueryNodeArray.push(
+              nodeBuilder.is(`${noteSavedObjectType}.attributes.createdBy`, userFilter)
+            );
           }
+
+          const associatedFilter = queryParams?.associatedFilter;
+          if (associatedFilter) {
+            // select documents that have or don't have a reference to an empty value
+            // used in combination with hasReference (not associated with a timeline) or hasNoReference (associated with a timeline)
+            const referenceToATimeline: SavedObjectsFindOptionsReference = {
+              type: timelineSavedObjectType,
+              id: '',
+            };
+
+            // select documents that don't have a value in the eventId field (not associated with a document)
+            const emptyDocumentIdFilter: KueryNode = nodeBuilder.is(
+              `${noteSavedObjectType}.attributes.eventId`,
+              ''
+            );
+
+            switch (associatedFilter) {
+              case AssociatedFilter.documentOnly:
+                // select documents that have a reference to an empty saved object id (not associated with a timeline)
+                // and have a value in the eventId field (associated with a document)
+                options.hasReference = referenceToATimeline;
+                filterKueryNodeArray.push(
+                  nodeTypes.function.buildNode('not', emptyDocumentIdFilter)
+                );
+                break;
+              case AssociatedFilter.savedObjectOnly:
+                // select documents that don't have a reference to an empty saved object id (associated with a timeline)
+                // and don't have a value in the eventId field (not associated with a document)
+                options.hasNoReference = referenceToATimeline;
+                filterKueryNodeArray.push(emptyDocumentIdFilter);
+                break;
+              case AssociatedFilter.documentAndSavedObject:
+                // select documents that don't have a reference to an empty saved object id (associated with a timeline)
+                // and have a value in the eventId field (associated with a document)
+                options.hasNoReference = referenceToATimeline;
+                filterKueryNodeArray.push(
+                  nodeTypes.function.buildNode('not', emptyDocumentIdFilter)
+                );
+                break;
+              case AssociatedFilter.orphan:
+                // select documents that have a reference to an empty saved object id (not associated with a timeline)
+                // and don't have a value in the eventId field (not associated with a document)
+                options.hasReference = referenceToATimeline;
+                // TODO we might want to also check for the existence of the eventId field, on top of getting eventId having empty values
+                filterKueryNodeArray.push(emptyDocumentIdFilter);
+                break;
+            }
+          }
+
+          // combine all filters
+          options.filter = nodeBuilder.and(filterKueryNodeArray);
 
           const res = await getAllSavedNote(frameworkRequest, options);
           const body: GetNotesResponse = res ?? {};

--- a/x-pack/test/security_solution_api_integration/test_suites/investigation/saved_objects/trial_license_complete_tier/notes.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/investigation/saved_objects/trial_license_complete_tier/notes.ts
@@ -407,11 +407,7 @@ export default function ({ getService }: FtrProviderContext) {
         expect(notes[2].eventId).to.be('1');
       });
 
-      // TODO should add more tests for the filter query parameter (I don't know how it's supposed to work)
-      // TODO should add more tests for the MAX_UNASSOCIATED_NOTES advanced settings values
-
       // TODO figure out why this test is failing on CI but not locally
-      // we can't really test for other users because the persistNote endpoint forces overrideOwner to be true then all the notes created here are owned by the elastic user
       it.skip('should retrieve all notes that have been created by a specific user', async () => {
         await Promise.all([
           createNote(supertest, { text: 'first note' }),
@@ -443,6 +439,116 @@ export default function ({ getService }: FtrProviderContext) {
 
         expect(totalCount).to.be(0);
       });
+
+      it('should retrieve all notes that have an association with a document only', async () => {
+        await Promise.all([
+          createNote(supertest, { documentId: eventId1, text: 'associated with event-1 only' }),
+          createNote(supertest, {
+            savedObjectId: timelineId1,
+            text: 'associated with timeline-1 only',
+          }),
+          createNote(supertest, {
+            documentId: eventId1,
+            savedObjectId: timelineId1,
+            text: 'associated with event-1 and timeline-1',
+          }),
+          createNote(supertest, { text: 'associated with nothing' }),
+        ]);
+
+        const response = await supertest
+          .get('/api/note?associatedFilter=document_only')
+          .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31');
+
+        const { totalCount, notes } = response.body;
+
+        expect(totalCount).to.be(1);
+        expect(notes[0].eventId).to.be(eventId1);
+      });
+
+      it('should retrieve all notes that have an association with a saved object only', async () => {
+        await Promise.all([
+          createNote(supertest, { documentId: eventId1, text: 'associated with event-1 only' }),
+          createNote(supertest, {
+            savedObjectId: timelineId1,
+            text: 'associated with timeline-1 only',
+          }),
+          createNote(supertest, {
+            documentId: eventId1,
+            savedObjectId: timelineId1,
+            text: 'associated with event-1 and timeline-1',
+          }),
+          createNote(supertest, { text: 'associated with nothing' }),
+        ]);
+
+        const response = await supertest
+          .get('/api/note?associatedFilter=saved_object_only')
+          .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31');
+
+        const { totalCount, notes } = response.body;
+
+        expect(totalCount).to.be(1);
+        expect(notes[0].timelineId).to.be(timelineId1);
+      });
+
+      it('should retrieve all notes that have an association with a document AND a saved object', async () => {
+        await Promise.all([
+          createNote(supertest, { documentId: eventId1, text: 'associated with event-1 only' }),
+          createNote(supertest, {
+            savedObjectId: timelineId1,
+            text: 'associated with timeline-1 only',
+          }),
+          createNote(supertest, {
+            documentId: eventId1,
+            savedObjectId: timelineId1,
+            text: 'associated with event-1 and timeline-1',
+          }),
+          createNote(supertest, { text: 'associated with nothing' }),
+        ]);
+
+        const response = await supertest
+          .get('/api/note?associatedFilter=document_and_saved_object')
+          .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31');
+
+        const { totalCount, notes } = response.body;
+
+        expect(totalCount).to.be(1);
+        expect(notes[0].eventId).to.be(eventId1);
+        expect(notes[0].timelineId).to.be(timelineId1);
+      });
+
+      it('should retrieve all notes that have an association with no document AND no saved object', async () => {
+        await Promise.all([
+          createNote(supertest, { documentId: eventId1, text: 'associated with event-1 only' }),
+          createNote(supertest, {
+            savedObjectId: timelineId1,
+            text: 'associated with timeline-1 only',
+          }),
+          createNote(supertest, {
+            documentId: eventId1,
+            savedObjectId: timelineId1,
+            text: 'associated with event-1 and timeline-1',
+          }),
+          createNote(supertest, { text: 'associated with nothing' }),
+        ]);
+
+        const response = await supertest
+          .get('/api/note?associatedFilter=orphan')
+          .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31');
+
+        const { totalCount, notes } = response.body;
+
+        expect(totalCount).to.be(1);
+        expect(notes[0].eventId).to.be('');
+        expect(notes[0].timelineId).to.be('');
+      });
+
+      // TODO should add more tests for the filter query parameter (I don't know how it's supposed to work)
+      // TODO should add more tests for the MAX_UNASSOCIATED_NOTES advanced settings values
+      // TODO add more tests to check the combination of filters (user, association and filter)
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR adds a filter to the Notes management page, to allow users to filter by the following:
- retrieve all notes
- filter for notes that are associated with a **document only**
- filter for notes that are associated with a **saved object only** (for example a timeline)
- filter for notes that are associated with a **document AND a saved object**
- filter for notes that are associated with **neither a document or a saved object** (orphan)

https://github.com/user-attachments/assets/c5009e16-cdab-40e1-ad1c-0351c5bcb65f

The server side code has been updated to handle having this new filter working in combination with the existing user filter added in [this previous PR](https://github.com/elastic/kibana/pull/195519).

API integration tests have been added to test the new functionality.

https://github.com/elastic/kibana/issues/193086

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->