### PR TITLE
[Cloud Security] Filtering offline agentless agents from Fleet agent list

### DIFF
--- a/x-pack/plugins/fleet/common/services/agent_status.ts
+++ b/x-pack/plugins/fleet/common/services/agent_status.ts
@@ -57,6 +57,13 @@ export function buildKueryForInactiveAgents() {
   return 'status:inactive';
 }
 
+export function buildKueryForFilteringOutOfflineAgentlessAgents(kuery: string) {
+  if (kuery.length > 0) {
+    return `not (local_metadata.host.hostname : "agentless*" and status:offline) and (${kuery})`;
+  }
+  return `not (local_metadata.host.hostname : "agentless*" and status:offline)`;
+}
+
 export const AGENT_UPDATING_TIMEOUT_HOURS = 2;
 
 export function isStuckInUpdating(agent: Agent): boolean {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.test.tsx
@@ -146,7 +146,7 @@ describe('useFetchAgentsData', () => {
       },
     });
     expect(result?.current.kuery).toEqual(
-      'status:online or (status:error or status:degraded) or (status:updating or status:unenrolling or status:enrolling) or status:offline'
+      'not (local_metadata.host.hostname : "agentless*" and status:offline) and (status:online or (status:error or status:degraded) or (status:updating or status:unenrolling or status:enrolling) or status:offline)'
     );
     expect(result?.current.currentRequestRef).toEqual({ current: 2 });
     expect(result?.current.pagination).toEqual({ currentPage: 1, pageSize: 5 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
@@ -16,43 +16,54 @@ describe('getKuery', () => {
   const healthyStatuses = ['healthy', 'updating'];
   const inactiveStatuses = ['unhealthy', 'offline', 'inactive', 'unenrolled'];
 
+  const appendAgentlessOffline = (kuery: string) =>
+    kuery && kuery.length > 0
+      ? `not (local_metadata.host.hostname : "agentless*" and status:offline) and ( ${kuery})`
+      : `not (local_metadata.host.hostname : "agentless*" and status:offline)`;
+
   it('should return a kuery with base search', () => {
     expect(getKuery({ search })).toEqual('base search');
   });
 
   it('should return a kuery with selected tags', () => {
     expect(getKuery({ selectedTags })).toEqual(
-      'fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")'
+      appendAgentlessOffline('fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")')
     );
   });
 
   it('should return a kuery with selected agent policies', () => {
     expect(getKuery({ selectedAgentPolicies })).toEqual(
-      'fleet-agents.policy_id : ("policy1" or "policy2" or "policy3")'
+      appendAgentlessOffline('fleet-agents.policy_id : ("policy1" or "policy2" or "policy3")')
     );
   });
 
   it('should return a kuery with selected agent ids', () => {
     expect(getKuery({ selectedAgentIds })).toEqual(
-      'fleet-agents.agent.id : ("agent_id1" or "agent_id2")'
+      appendAgentlessOffline('fleet-agents.agent.id : ("agent_id1" or "agent_id2")')
     );
   });
 
   it('should return a kuery with healthy selected status', () => {
     expect(getKuery({ selectedStatus: healthyStatuses })).toEqual(
-      'status:online or (status:updating or status:unenrolling or status:enrolling)'
+      appendAgentlessOffline(
+        'status:online or (status:updating or status:unenrolling or status:enrolling)'
+      )
     );
   });
 
   it('should return a kuery with unhealthy selected status', () => {
     expect(getKuery({ selectedStatus: inactiveStatuses })).toEqual(
-      '(status:error or status:degraded) or status:offline or status:inactive or status:unenrolled'
+      appendAgentlessOffline(
+        '(status:error or status:degraded) or status:offline or status:inactive or status:unenrolled'
+      )
     );
   });
 
   it('should return a kuery with a combination of previous kueries', () => {
     expect(getKuery({ search, selectedTags, selectedStatus })).toEqual(
-      '((base search) and fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")) and (status:online or (status:error or status:degraded))'
+      appendAgentlessOffline(
+        '((base search) and fleet-agents.tags : ("tag_1" or "tag_2" or "tag_3")) and (status:online or (status:error or status:degraded))'
+      )
     );
   });
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.test.ts
@@ -18,11 +18,11 @@ describe('getKuery', () => {
 
   const appendAgentlessOffline = (kuery: string) =>
     kuery && kuery.length > 0
-      ? `not (local_metadata.host.hostname : "agentless*" and status:offline) and ( ${kuery})`
+      ? `not (local_metadata.host.hostname : "agentless*" and status:offline) and (${kuery})`
       : `not (local_metadata.host.hostname : "agentless*" and status:offline)`;
 
   it('should return a kuery with base search', () => {
-    expect(getKuery({ search })).toEqual('base search');
+    expect(getKuery({ search })).toEqual(appendAgentlessOffline('base search'));
   });
 
   it('should return a kuery with selected tags', () => {
@@ -68,6 +68,6 @@ describe('getKuery', () => {
   });
 
   it('should return empty string if nothing is passed', () => {
-    expect(getKuery({})).toEqual('');
+    expect(getKuery({})).toEqual(appendAgentlessOffline(''));
   });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -85,11 +85,8 @@ export const getKuery = ({
     }
   }
 
-  if (kueryBuilder.length > 0) {
-    kueryBuilder = `not (local_metadata.host.hostname : "agentless*" and status:offline) and (${kueryBuilder})`;
-  } else {
-    kueryBuilder = `not (local_metadata.host.hostname : "agentless*" and status:offline)`;
-  }
+  kueryBuilder =
+    AgentStatusKueryHelper.buildKueryForFilteringOutOfflineAgentlessAgents(kueryBuilder);
 
   return kueryBuilder.trim();
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -82,7 +82,6 @@ export const getKuery = ({
       kueryBuilder = kueryStatus;
     }
 
-    // kueryBuilder = `(not local_metadata.host.hostname : "agentless*")`;
     kueryBuilder = `not (local_metadata.host.hostname : "agentless*" and status:offline) and (${kueryBuilder})`;
   }
   return kueryBuilder.trim();

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -21,6 +21,8 @@ export const getKuery = ({
   selectedStatus?: string[];
   selectedAgentIds?: string[];
 }) => {
+  const addSpaceBetweenTerms = () => (kueryBuilder.length > 0 ? ' ' : '');
+
   let kueryBuilder = '';
   if (search) {
     kueryBuilder = search.trim();
@@ -30,7 +32,7 @@ export const getKuery = ({
     if (kueryBuilder) {
       kueryBuilder = `(${kueryBuilder}) and`;
     }
-    kueryBuilder = `${kueryBuilder} ${AGENTS_PREFIX}.policy_id : (${selectedAgentPolicies
+    kueryBuilder = `${kueryBuilder}${addSpaceBetweenTerms()}${AGENTS_PREFIX}.policy_id : (${selectedAgentPolicies
       .map((agentPolicy) => `"${agentPolicy}"`)
       .join(' or ')})`;
   }
@@ -39,7 +41,7 @@ export const getKuery = ({
     if (kueryBuilder) {
       kueryBuilder = `(${kueryBuilder}) and`;
     }
-    kueryBuilder = `${kueryBuilder} ${AGENTS_PREFIX}.tags : (${selectedTags
+    kueryBuilder = `${kueryBuilder}${addSpaceBetweenTerms()}${AGENTS_PREFIX}.tags : (${selectedTags
       .map((tag) => `"${tag}"`)
       .join(' or ')})`;
   }
@@ -48,7 +50,7 @@ export const getKuery = ({
     if (kueryBuilder) {
       kueryBuilder = `(${kueryBuilder}) and`;
     }
-    kueryBuilder = `${kueryBuilder} ${AGENTS_PREFIX}.agent.id : (${selectedAgentIds
+    kueryBuilder = `${kueryBuilder}${addSpaceBetweenTerms()}${AGENTS_PREFIX}.agent.id : (${selectedAgentIds
       .map((id) => `"${id}"`)
       .join(' or ')})`;
   }
@@ -84,7 +86,6 @@ export const getKuery = ({
   }
 
   if (kueryBuilder.length > 0) {
-    kueryBuilder.trim();
     kueryBuilder = `not (local_metadata.host.hostname : "agentless*" and status:offline) and (${kueryBuilder})`;
   } else {
     kueryBuilder = `not (local_metadata.host.hostname : "agentless*" and status:offline)`;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -81,8 +81,14 @@ export const getKuery = ({
     } else {
       kueryBuilder = kueryStatus;
     }
-
-    kueryBuilder = `not (local_metadata.host.hostname : "agentless*" and status:offline) and (${kueryBuilder})`;
   }
+
+  if (kueryBuilder.length > 0) {
+    kueryBuilder.trim();
+    kueryBuilder = `not (local_metadata.host.hostname : "agentless*" and status:offline) and (${kueryBuilder})`;
+  } else {
+    kueryBuilder = `not (local_metadata.host.hostname : "agentless*" and status:offline)`;
+  }
+
   return kueryBuilder.trim();
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -81,6 +81,8 @@ export const getKuery = ({
     } else {
       kueryBuilder = kueryStatus;
     }
+
+    kueryBuilder = `${kueryBuilder} and !( status: offline and local_metadata.host.hostname : agentless)`;
   }
   return kueryBuilder.trim();
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/utils/get_kuery.ts
@@ -82,7 +82,8 @@ export const getKuery = ({
       kueryBuilder = kueryStatus;
     }
 
-    kueryBuilder = `${kueryBuilder} and !( status: offline and local_metadata.host.hostname : agentless)`;
+    // kueryBuilder = `(not local_metadata.host.hostname : "agentless*")`;
+    kueryBuilder = `not (local_metadata.host.hostname : "agentless*" and status:offline) and (${kueryBuilder})`;
   }
   return kueryBuilder.trim();
 };

--- a/x-pack/test/fleet_api_integration/apis/agents/index.js
+++ b/x-pack/test/fleet_api_integration/apis/agents/index.js
@@ -12,20 +12,20 @@ export default function loadTests({ loadTestFile, getService }) {
     before(async () => {
       await setupTestUsers(getService('security'));
     });
-    loadTestFile(require.resolve('./delete'));
+    // loadTestFile(require.resolve('./delete'));
     loadTestFile(require.resolve('./list'));
-    loadTestFile(require.resolve('./unenroll'));
-    loadTestFile(require.resolve('./actions'));
-    loadTestFile(require.resolve('./upgrade'));
-    loadTestFile(require.resolve('./action_status'));
-    loadTestFile(require.resolve('./reassign'));
-    loadTestFile(require.resolve('./status'));
-    loadTestFile(require.resolve('./update'));
-    loadTestFile(require.resolve('./update_agent_tags'));
-    loadTestFile(require.resolve('./available_versions'));
-    loadTestFile(require.resolve('./request_diagnostics'));
-    loadTestFile(require.resolve('./uploads'));
-    loadTestFile(require.resolve('./get_agents_by_actions'));
-    loadTestFile(require.resolve('./privileges'));
+    // loadTestFile(require.resolve('./unenroll'));
+    // loadTestFile(require.resolve('./actions'));
+    // loadTestFile(require.resolve('./upgrade'));
+    // loadTestFile(require.resolve('./action_status'));
+    // loadTestFile(require.resolve('./reassign'));
+    // loadTestFile(require.resolve('./status'));
+    // loadTestFile(require.resolve('./update'));
+    // loadTestFile(require.resolve('./update_agent_tags'));
+    // loadTestFile(require.resolve('./available_versions'));
+    // loadTestFile(require.resolve('./request_diagnostics'));
+    // loadTestFile(require.resolve('./uploads'));
+    // loadTestFile(require.resolve('./get_agents_by_actions'));
+    // loadTestFile(require.resolve('./privileges'));
   });
 }

--- a/x-pack/test/fleet_api_integration/apis/agents/index.js
+++ b/x-pack/test/fleet_api_integration/apis/agents/index.js
@@ -12,20 +12,20 @@ export default function loadTests({ loadTestFile, getService }) {
     before(async () => {
       await setupTestUsers(getService('security'));
     });
-    // loadTestFile(require.resolve('./delete'));
+    loadTestFile(require.resolve('./delete'));
     loadTestFile(require.resolve('./list'));
-    // loadTestFile(require.resolve('./unenroll'));
-    // loadTestFile(require.resolve('./actions'));
-    // loadTestFile(require.resolve('./upgrade'));
-    // loadTestFile(require.resolve('./action_status'));
-    // loadTestFile(require.resolve('./reassign'));
-    // loadTestFile(require.resolve('./status'));
-    // loadTestFile(require.resolve('./update'));
-    // loadTestFile(require.resolve('./update_agent_tags'));
-    // loadTestFile(require.resolve('./available_versions'));
-    // loadTestFile(require.resolve('./request_diagnostics'));
-    // loadTestFile(require.resolve('./uploads'));
-    // loadTestFile(require.resolve('./get_agents_by_actions'));
-    // loadTestFile(require.resolve('./privileges'));
+    loadTestFile(require.resolve('./unenroll'));
+    loadTestFile(require.resolve('./actions'));
+    loadTestFile(require.resolve('./upgrade'));
+    loadTestFile(require.resolve('./action_status'));
+    loadTestFile(require.resolve('./reassign'));
+    loadTestFile(require.resolve('./status'));
+    loadTestFile(require.resolve('./update'));
+    loadTestFile(require.resolve('./update_agent_tags'));
+    loadTestFile(require.resolve('./available_versions'));
+    loadTestFile(require.resolve('./request_diagnostics'));
+    loadTestFile(require.resolve('./uploads'));
+    loadTestFile(require.resolve('./get_agents_by_actions'));
+    loadTestFile(require.resolve('./privileges'));
   });
 }

--- a/x-pack/test/functional/es_archives/fleet/agents/data.json
+++ b/x-pack/test/functional/es_archives/fleet/agents/data.json
@@ -156,27 +156,3 @@
     }
   }
 }
-
-{
-  "type": "doc",
-  "value": {
-    "id": "agentless-agent",
-    "index": ".fleet-agents",
-    "source": {
-      "access_api_key_id": "api-key-5",
-      "active": true,
-      "policy_id": "policy-agentless",
-      "type": "PERMANENT",
-      "local_metadata": { "host": {"hostname": "agentless-agent"}, "elastic": {
-        "agent": {
-          "version": "8.7.0"
-        }
-      }},
-      "user_provided_metadata": {},
-      "enrolled_at": "2022-06-21T12:14:25Z",
-      "last_checkin": "2022-06-27T12:26:29Z",
-      "tags": ["existingTag", "tag1"],
-      "status": "offline"
-    }
-  }
-}

--- a/x-pack/test/functional/es_archives/fleet/agents/data.json
+++ b/x-pack/test/functional/es_archives/fleet/agents/data.json
@@ -156,3 +156,27 @@
     }
   }
 }
+
+{
+  "type": "doc",
+  "value": {
+    "id": "agentless-agent",
+    "index": ".fleet-agents",
+    "source": {
+      "access_api_key_id": "api-key-5",
+      "active": true,
+      "policy_id": "policy-agentless",
+      "type": "PERMANENT",
+      "local_metadata": { "host": {"hostname": "agentless-agent"}, "elastic": {
+        "agent": {
+          "version": "8.7.0"
+        }
+      }},
+      "user_provided_metadata": {},
+      "enrolled_at": "2022-06-21T12:14:25Z",
+      "last_checkin": "2022-06-27T12:26:29Z",
+      "tags": ["existingTag", "tag1"],
+      "status": "offline"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

We are filtering out of the Agents list in the Fleet UI agentless agents that are offline.  We are doing this because the agentless agent might be restarted for various reasons such as updating the Elastic Agent version or updating the policy.  

The agents are still online however the have a different ID,  and the previous instance shows as offline. 

![image](https://github.com/user-attachments/assets/3a0709d8-399d-4ec3-90c5-95aefe336f5b)


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
