### PR TITLE
Updates load-json-file dependency to 7.0.1 and handles changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1153,7 +1153,7 @@
     "langchain": "^0.2.11",
     "langsmith": "^0.1.55",
     "launchdarkly-js-client-sdk": "^3.4.0",
-    "load-json-file": "^6.2.0",
+    "load-json-file": "^7.0.1",
     "lodash": "^4.17.21",
     "lru-cache": "^4.1.5",
     "lz-string": "^1.4.4",

--- a/packages/core/test-helpers/core-test-helpers-kbn-server/src/create_root.ts
+++ b/packages/core/test-helpers/core-test-helpers-kbn-server/src/create_root.ts
@@ -8,7 +8,7 @@
  */
 
 import { join } from 'path';
-import loadJsonFile from 'load-json-file';
+import { loadJsonFileSync } from 'load-json-file';
 import { defaultsDeep } from 'lodash';
 import { BehaviorSubject } from 'rxjs';
 import supertest from 'supertest';
@@ -55,7 +55,7 @@ export function createRootWithSettings(
 ) {
   let pkg: RawPackageInfo | undefined;
   if (customKibanaVersion) {
-    pkg = loadJsonFile.sync(join(REPO_ROOT, 'package.json')) as RawPackageInfo;
+    pkg = loadJsonFileSync(join(REPO_ROOT, 'package.json')) as RawPackageInfo;
     pkg.version = customKibanaVersion;
   }
 

--- a/packages/kbn-config/src/env.ts
+++ b/packages/kbn-config/src/env.ts
@@ -8,7 +8,7 @@
  */
 
 import { resolve, join } from 'path';
-import loadJsonFile from 'load-json-file';
+import { loadJsonFileSync } from 'load-json-file';
 import { getPluginSearchPaths } from '@kbn/repo-packages';
 import type { Package } from '@kbn/repo-packages';
 import { PackageInfo, EnvironmentMode } from './types';
@@ -57,7 +57,7 @@ export class Env {
    */
   public static createDefault(repoRoot: string, options: EnvOptions, pkg?: RawPackageInfo): Env {
     if (!pkg) {
-      pkg = loadJsonFile.sync(join(repoRoot, 'package.json')) as RawPackageInfo;
+      pkg = loadJsonFileSync(join(repoRoot, 'package.json')) as RawPackageInfo;
     }
     return new Env(repoRoot, pkg, options);
   }

--- a/packages/kbn-plugin-helpers/src/config.ts
+++ b/packages/kbn-plugin-helpers/src/config.ts
@@ -9,7 +9,7 @@
 
 import Path from 'path';
 
-import loadJsonFile from 'load-json-file';
+import { loadJsonFile } from 'load-json-file';
 
 import { ToolingLog } from '@kbn/tooling-log';
 import { Plugin } from './load_kibana_platform_plugin';

--- a/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
+++ b/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
@@ -16,7 +16,7 @@ import { createStripAnsiSerializer, createReplaceSerializer } from '@kbn/jest-se
 import extract from 'extract-zip';
 import del from 'del';
 import globby from 'globby';
-import loadJsonFile from 'load-json-file';
+import { loadJsonFileSync } from 'load-json-file';
 
 const PLUGIN_DIR = Path.resolve(REPO_ROOT, 'plugins/foo_test_plugin');
 const PLUGIN_BUILD_DIR = Path.resolve(PLUGIN_DIR, 'build');
@@ -115,7 +115,7 @@ it('builds a generated plugin into a viable archive', async () => {
     ]
   `);
 
-  expect(loadJsonFile.sync(Path.resolve(TMP_DIR, 'kibana', 'fooTestPlugin', 'kibana.json')))
+  expect(loadJsonFileSync(Path.resolve(TMP_DIR, 'kibana', 'fooTestPlugin', 'kibana.json')))
     .toMatchInlineSnapshot(`
     Object {
       "description": "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22385,15 +22385,10 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-load-json-file@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-6.2.0.tgz#5c7770b42cafa97074ca2848707c61662f4251a1"
-  integrity sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==
-  dependencies:
-    graceful-fs "^4.1.15"
-    parse-json "^5.0.0"
-    strip-bom "^4.0.0"
-    type-fest "^0.6.0"
+load-json-file@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-7.0.1.tgz#a3c9fde6beffb6bedb5acf104fad6bb1604e1b00"
+  integrity sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ==
 
 loader-runner@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
`loadJsonFile.sync` changed to `loadJsonFileSync` in 7.0.1. The async API didn't change.

[6.2.0 APIs](https://www.npmjs.com/package/load-json-file/v/6.2.0)
[7.0.1 APIs](https://www.npmjs.com/package/load-json-file/v/7.0.1) 

