### PR TITLE
[Fleet] Update tooltip for disabled add integration button

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
@@ -426,7 +426,7 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
                         ) : (
                           <FormattedMessage
                             id="xpack.fleet.epm.addPackagePolicyButtonPrivilegesRequiredTooltip"
-                            defaultMessage="Elastic Agent Integrations require the All privilege for Fleet and All privilege for Integrations. Contact your administrator."
+                            defaultMessage="Elastic Agent Integrations require the All privilege for Agent policies and All privilege for Integrations. Contact your administrator."
                           />
                         ),
                       }

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/add_integration_button.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/components/add_integration_button.tsx
@@ -32,7 +32,7 @@ export function AddIntegrationButton(props: AddIntegrationButtonProps) {
         ) : (
           <FormattedMessage
             id="xpack.fleet.epm.addPackagePolicyButtonPrivilegesRequiredTooltip"
-            defaultMessage="Elastic Agent Integrations require the All privilege for Fleet and All privilege for Integrations. Contact your administrator."
+            defaultMessage="Elastic Agent Integrations require the All privilege for Agent policies and All privilege for Integrations. Contact your administrator."
           />
         ),
       }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/191569

With the introduction of Fleet sub-feature privileges, the user needs at least `Agent policies: all` and `Integrations: All` privileges to add integrations. This PR updates the tooltip for when the button is disabled accordingly.

### Steps to reproduce

1. Create a role with `None` privilege on all Fleet sub-features (or any combination without `All` on Agent policies) and `All` on Integrations.
 
<img width="718" alt="Screenshot 2024-10-09 at 11 32 56" src="https://github.com/user-attachments/assets/2ecd4473-6c4f-4366-bac9-b79d6dafb028">

2. Assign the role to a test user and log in with it.
3. Attempt to add an integration. The button should be disabled and the tooltip should say that `Agent policies: all` and  `Integrations: All` privileges are needed.

<img width="1815" alt="Screenshot 2024-10-09 at 11 30 40" src="https://github.com/user-attachments/assets/a322c2f9-8617-4422-8ac8-c1f881706bcd">


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->