### PR TITLE
[Auto Import] Add run names to LangSmith traces

### DIFF
--- a/x-pack/plugins/integration_assistant/server/graphs/categorization/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/categorization/graph.ts
@@ -243,6 +243,6 @@ export async function getCategorizationGraph({ client, model }: CategorizationGr
       }
     );
 
-  const compiledCategorizationGraph = workflow.compile();
+  const compiledCategorizationGraph = workflow.compile().withConfig({ runName: 'Categorization' });
   return compiledCategorizationGraph;
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/graph.ts
@@ -78,8 +78,7 @@ export async function getEcsSubGraph({ model }: EcsGraphParams) {
     })
     .addEdge('modelSubOutput', END);
 
-  const compiledEcsSubGraph = workflow.compile();
-
+  const compiledEcsSubGraph = workflow.compile().withConfig({ runName: 'ECS Mapping (Chunk)' });
   return compiledEcsSubGraph;
 }
 
@@ -120,7 +119,7 @@ export async function getEcsGraph({ model }: EcsGraphParams) {
     })
     .addEdge('modelOutput', END);
 
-  const compiledEcsGraph = workflow.compile();
+  const compiledEcsGraph = workflow.compile().withConfig({ runName: 'ECS Mapping' });
 
   return compiledEcsGraph;
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/ecs/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/ecs/graph.ts
@@ -120,6 +120,5 @@ export async function getEcsGraph({ model }: EcsGraphParams) {
     .addEdge('modelOutput', END);
 
   const compiledEcsGraph = workflow.compile().withConfig({ runName: 'ECS Mapping' });
-
   return compiledEcsGraph;
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/kv/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/kv/graph.ts
@@ -139,6 +139,6 @@ export async function getKVGraph({ model, client }: KVGraphParams) {
     })
     .addEdge('modelOutput', END);
 
-  const compiledKVGraph = workflow.compile();
+  const compiledKVGraph = workflow.compile().withConfig({ runName: 'Key-Value' });
   return compiledKVGraph;
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/log_type_detection/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/log_type_detection/graph.ts
@@ -128,6 +128,6 @@ export async function getLogFormatDetectionGraph({ model, client }: LogDetection
       }
     );
 
-  const compiledLogFormatDetectionGraph = workflow.compile();
+  const compiledLogFormatDetectionGraph = workflow.compile().withConfig({ runName: 'Log Format' });
   return compiledLogFormatDetectionGraph;
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/related/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/related/graph.ts
@@ -207,6 +207,6 @@ export async function getRelatedGraph({ client, model }: RelatedGraphParams) {
       }
     );
 
-  const compiledRelatedGraph = workflow.compile();
+  const compiledRelatedGraph = workflow.compile().withConfig({ runName: 'Related' });
   return compiledRelatedGraph;
 }

--- a/x-pack/plugins/integration_assistant/server/graphs/unstructured/graph.ts
+++ b/x-pack/plugins/integration_assistant/server/graphs/unstructured/graph.ts
@@ -107,6 +107,6 @@ export async function getUnstructuredGraph({ model, client }: UnstructuredGraphP
     .addEdge('handleUnstructuredError', 'handleUnstructuredValidate')
     .addEdge('modelOutput', END);
 
-  const compiledUnstructuredGraph = workflow.compile();
+  const compiledUnstructuredGraph = workflow.compile().withConfig({ runName: 'Unstructured' });
   return compiledUnstructuredGraph;
 }


### PR DESCRIPTION
## Summary

Adds a name wherever a LangSmith graph is compiled. This allows us to review the traces faster: 

<img width="508" alt="image" src="https://github.com/user-attachments/assets/5d8d5a49-b02a-4dec-a549-633a0fe6613a">

## Testing

Generated: [ai_teleport_202410091437-1.0.0.zip](https://github.com/user-attachments/files/17307458/ai_teleport_202410091437-1.0.0.zip)


<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->