### PR TITLE
[dashboard] do not async import dashboard actions on plugin load

### DIFF
--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -78,6 +78,7 @@ import {
 } from './dashboard_container/panel_placement';
 import type { FindDashboardsService } from './services/dashboard_content_management_service/types';
 import { setKibanaServices, untilPluginStartServicesReady } from './services/kibana_services';
+import { buildAllDashboardActions } from './dashboard_actions';
 
 export interface DashboardFeatureFlagConfig {
   allowByValueEmbeddables: boolean;
@@ -322,14 +323,12 @@ export class DashboardPlugin
   public start(core: CoreStart, plugins: DashboardStartDependencies): DashboardStart {
     setKibanaServices(core, plugins);
 
-    Promise.all([import('./dashboard_actions'), untilPluginStartServicesReady()]).then(
-      ([{ buildAllDashboardActions }]) => {
-        buildAllDashboardActions({
-          plugins,
-          allowByValueEmbeddables: this.dashboardFeatureFlagConfig?.allowByValueEmbeddables,
-        });
-      }
-    );
+    untilPluginStartServicesReady().then(() => {
+      buildAllDashboardActions({
+        plugins,
+        allowByValueEmbeddables: this.dashboardFeatureFlagConfig?.allowByValueEmbeddables,
+      });
+    });
 
     return {
       locator: this.locator,


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/194171

Notice in the screen shot below, how opening Kibana home page loads async dashboard chunks.
<img width="500" alt="Screenshot 2024-10-09 at 8 38 24 AM" src="https://github.com/user-attachments/assets/2cfdb512-03e4-4634-bb0c-a8d163f98540">

This PR replaces async import with a sync import. The page load bundle size increases but this is no different than the current behavior, just the import is now properly accounted for in page load stats. The next step is to resolve https://github.com/elastic/kibana/issues/191642 and reduce the page load impact of registering uiActions (but this is out of scope for this PR).


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->