### PR TITLE
[Usage counters] Use `refresh=false`

### DIFF
--- a/src/plugins/usage_collection/server/usage_counters/saved_objects.test.ts
+++ b/src/plugins/usage_collection/server/usage_counters/saved_objects.test.ts
@@ -80,6 +80,7 @@ describe('storeCounter', () => {
         ],
         Object {
           "namespace": "default",
+          "refresh": false,
           "upsertAttributes": Object {
             "counterName": "b",
             "counterType": "c",

--- a/src/plugins/usage_collection/server/usage_counters/saved_objects.ts
+++ b/src/plugins/usage_collection/server/usage_counters/saved_objects.ts
@@ -122,6 +122,7 @@ export const storeCounter = async ({ metric, soRepository }: StoreCounterParams)
         counterType,
         source,
       },
+      refresh: false,
     }
   );
 };

--- a/src/plugins/usage_collection/server/usage_counters/usage_counters_service.test.ts
+++ b/src/plugins/usage_collection/server/usage_counters/usage_counters_service.test.ts
@@ -157,6 +157,7 @@ describe('UsageCountersService', () => {
             },
           ],
           Object {
+            "refresh": false,
             "upsertAttributes": Object {
               "counterName": "counterA",
               "counterType": "count",
@@ -175,6 +176,7 @@ describe('UsageCountersService', () => {
             },
           ],
           Object {
+            "refresh": false,
             "upsertAttributes": Object {
               "counterName": "counterB",
               "counterType": "count",


### PR DESCRIPTION
## Summary

Usage Counters are updated by known IDs. We shouldn't need hold the update requests (and keep their sockets blocked) waiting for refreshes.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->