### PR TITLE
Tag pipelines related to Kibana serverless release

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-container-image.yml
@@ -44,3 +44,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
+        - kibana-serverless-release

--- a/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
@@ -55,3 +55,4 @@ spec:
           branch: main
       tags:
         - kibana
+        - kibana-serverless-release

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
@@ -49,3 +49,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
+        - kibana-serverless-release

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-emergency-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-emergency-release.yml
@@ -30,3 +30,4 @@ spec:
           access_level: READ_ONLY
       tags:
         - kibana
+        - kibana-serverless-release

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates-emergency.yml
@@ -33,3 +33,4 @@ spec:
           access_level: READ_ONLY
       tags:
         - kibana
+        - kibana-serverless-release

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-quality-gates.yml
@@ -33,3 +33,4 @@ spec:
           access_level: READ_ONLY
       tags:
         - kibana
+        - kibana-serverless-release

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
@@ -46,3 +46,4 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       tags:
         - kibana
+        - kibana-serverless-release

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
@@ -48,3 +48,4 @@ spec:
           branch: main
       tags:
         - kibana
+        - kibana-serverless-release


### PR DESCRIPTION
## Summary

This PR tags all pipelines that are related to the Kibana serverless release (including requirements like on-merge and artifacts build) with `kibana-serverless-release`. This will allow us to easily find these pipelines in Buildkite.