### PR TITLE
Skip only Risk Engine initializing test with a FIPS issue

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/init_and_status_apis.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/init_and_status_apis.ts
@@ -26,8 +26,7 @@ export default ({ getService }: FtrProviderContext) => {
   const riskEngineRoutes = riskEngineRouteHelpersFactory(supertest);
   const log = getService('log');
 
-  // Failing: See https://github.com/elastic/kibana/issues/191637
-  describe.skip('@ess @serverless @serverlessQA init_and_status_apis', () => {
+  describe('@ess @serverless @serverlessQA init_and_status_apis', () => {
     before(async () => {
       await riskEngineRoutes.cleanUp();
     });
@@ -298,8 +297,8 @@ export default ({ getService }: FtrProviderContext) => {
           firstResponse?.saved_objects?.[0]?.id
         );
       });
-
-      describe('remove legacy risk score transform', function () {
+      // Failing: See https://github.com/elastic/kibana/issues/191637
+      describe.skip('remove legacy risk score transform', function () {
         this.tags('skipFIPS');
         it('should remove legacy risk score transform if it exists', async () => {
           await installLegacyRiskScore({ supertest });


### PR DESCRIPTION
## Summary

More investigation is needed to ensure that the `remove legacy risk score transform` test is passing in promotion pipelines. However, that particular feature that the test asserts (Legacy Entity Risk Scoring) was never available in Serverless. Therefore, we're enabling the broader tests, and just skipping the one containing the FIPS issue. 