### PR TITLE
[7.17] [UII] Adjust test based on ES version tested against (#195508)

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/epm/install_overrides.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_overrides.ts
@@ -116,34 +116,45 @@ export default function (providerContext: FtrProviderContext) {
       // omit routings
       delete body.template.settings.index.routing;
 
-      expect(body).to.eql({
-        template: {
-          settings: {
-            index: {
-              codec: 'best_compression',
-              lifecycle: {
-                name: 'overridden by user',
-              },
-              mapping: {
-                total_fields: {
-                  limit: '10000',
-                },
-              },
-              number_of_shards: '3',
+      expect(Object.keys(body)).to.eql(['template', 'overlapping']);
+      expect(body.template).to.eql({
+        settings: {
+          index: {
+            codec: 'best_compression',
+            lifecycle: {
+              name: 'overridden by user',
             },
+            mapping: {
+              total_fields: {
+                limit: '10000',
+              },
+            },
+            number_of_shards: '3',
           },
-          mappings: {
-            dynamic: 'false',
-          },
-          aliases: {},
         },
-        overlapping: [
-          {
-            name: 'logs',
-            index_patterns: ['logs-*-*'],
-          },
-        ],
+        mappings: {
+          dynamic: 'false',
+        },
+        aliases: {},
       });
+
+      // otel logs templates were added in 8.16 but these tests also run against
+      // previous versions, so we conditionally test based on the ES version
+      const esVersion = getService('esVersion');
+      expect(body.overlapping).to.eql([
+        {
+          name: 'logs',
+          index_patterns: ['logs-*-*'],
+        },
+        ...(esVersion.matchRange('>=8.16.0')
+          ? [
+              {
+                index_patterns: ['logs-*.otel-*'],
+                name: 'logs-otel@template',
+              },
+            ]
+          : []),
+      ]);
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[UII] Adjust test based on ES version tested against (#195508)](https://github.com/elastic/kibana/pull/195508)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2024-10-09T07:05:56Z","message":"[UII] Adjust test based on ES version tested against (#195508)\n\n## Summary\r\n\r\nFollow up to #194764. This test was also failing on 7.17 branch when\r\nthey 8.x ES compatibility tests were run, so this PR adjusts the test\r\nbased on the ES version it runs against. This will be backported to 8.x\r\nand 7.17.","sha":"ab2d7aa5682bb18514a9fbdb2a539914d36b2c7b","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","backport:all-open","v8.16.0"],"number":195508,"url":"https://github.com/elastic/kibana/pull/195508","mergeCommit":{"message":"[UII] Adjust test based on ES version tested against (#195508)\n\n## Summary\r\n\r\nFollow up to #194764. This test was also failing on 7.17 branch when\r\nthey 8.x ES compatibility tests were run, so this PR adjusts the test\r\nbased on the ES version it runs against. This will be backported to 8.x\r\nand 7.17.","sha":"ab2d7aa5682bb18514a9fbdb2a539914d36b2c7b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/195508","number":195508,"mergeCommit":{"message":"[UII] Adjust test based on ES version tested against (#195508)\n\n## Summary\r\n\r\nFollow up to #194764. This test was also failing on 7.17 branch when\r\nthey 8.x ES compatibility tests were run, so this PR adjusts the test\r\nbased on the ES version it runs against. This will be backported to 8.x\r\nand 7.17.","sha":"ab2d7aa5682bb18514a9fbdb2a539914d36b2c7b"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/195535","number":195535,"state":"MERGED","mergeCommit":{"sha":"327ce6a52181b2d6a7228a97f776a60a8909afd5","message":"[8.x] [UII] Adjust test based on ES version tested against (#195508) (#195535)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[UII] Adjust test based on ES version tested against\n(#195508)](https://github.com/elastic/kibana/pull/195508)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jen\nHuang\",\"email\":\"its.jenetic@gmail.com\"},\"sourceCommit\":{\"committedDate\":\"2024-10-09T07:05:56Z\",\"message\":\"[UII]\nAdjust test based on ES version tested against (#195508)\\n\\n##\nSummary\\r\\n\\r\\nFollow up to #194764. This test was also failing on 7.17\nbranch when\\r\\nthey 8.x ES compatibility tests were run, so this PR\nadjusts the test\\r\\nbased on the ES version it runs against. This will\nbe backported to 8.x\\r\\nand\n7.17.\",\"sha\":\"ab2d7aa5682bb18514a9fbdb2a539914d36b2c7b\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.16.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"Team:Fleet\",\"v9.0.0\",\"backport:all-open\"],\"title\":\"[UII]\nAdjust test based on ES version tested\nagainst\",\"number\":195508,\"url\":\"https://github.com/elastic/kibana/pull/195508\",\"mergeCommit\":{\"message\":\"[UII]\nAdjust test based on ES version tested against (#195508)\\n\\n##\nSummary\\r\\n\\r\\nFollow up to #194764. This test was also failing on 7.17\nbranch when\\r\\nthey 8.x ES compatibility tests were run, so this PR\nadjusts the test\\r\\nbased on the ES version it runs against. This will\nbe backported to 8.x\\r\\nand\n7.17.\",\"sha\":\"ab2d7aa5682bb18514a9fbdb2a539914d36b2c7b\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/195508\",\"number\":195508,\"mergeCommit\":{\"message\":\"[UII]\nAdjust test based on ES version tested against (#195508)\\n\\n##\nSummary\\r\\n\\r\\nFollow up to #194764. This test was also failing on 7.17\nbranch when\\r\\nthey 8.x ES compatibility tests were run, so this PR\nadjusts the test\\r\\nbased on the ES version it runs against. This will\nbe backported to 8.x\\r\\nand\n7.17.\",\"sha\":\"ab2d7aa5682bb18514a9fbdb2a539914d36b2c7b\"}}]}] BACKPORT-->\n\nCo-authored-by: Jen Huang <its.jenetic@gmail.com>"}}]}] BACKPORT-->