### PR TITLE
[ci] Rebuild image after elasticsearch promotion

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
@@ -46,19 +46,19 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
       schedules:
         Daily build (main):
-          cronline: 0 9 * * * America/New_York
+          cronline: 0 22 * * * America/New_York
           message: Daily build
           branch: main
         Daily build (8.x):
-          cronline: 0 9 * * * America/New_York
+          cronline: 0 22 * * * America/New_York
           message: Daily build
           branch: '8.x'
         Daily build (8.15):
-          cronline: 0 9 * * * America/New_York
+          cronline: 0 22 * * * America/New_York
           message: Daily build
           branch: '8.15'
         Daily build (7.17):
-          cronline: 0 9 * * * America/New_York
+          cronline: 0 22 * * * America/New_York
           message: Daily build
           branch: '7.17'
       tags:

--- a/.buildkite/scripts/steps/es_snapshots/promote.sh
+++ b/.buildkite/scripts/steps/es_snapshots/promote.sh
@@ -16,4 +16,12 @@ ts-node "$(dirname "${0}")/promote_manifest.ts" "$ES_SNAPSHOT_MANIFEST"
 if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
   echo "--- Trigger agent packer cache pipeline"
   ts-node .buildkite/scripts/steps/trigger_pipeline.ts kibana-agent-packer-cache main
+  cat << EOF | buildkite-agent pipeline upload
+steps:
+  - label: "Builds Kibana VM images for cache update"
+    trigger: ci-vm-images
+    build:
+      env:
+        IMAGES_CONFIG="kibana/images.yml"
+EOF
 fi


### PR DESCRIPTION
1) After an elasticsearch image is promoted, this triggers a VM rebuild to update the snapshot cache
1) Moves elasticsearch builds to later in the day, when there's less activity.