### PR TITLE
[8.x] [UII] Add types to return content packages correctly (#195505)

### DIFF
--- a/oas_docs/output/kibana.serverless.staging.yaml
+++ b/oas_docs/output/kibana.serverless.staging.yaml
@@ -21405,6 +21405,31 @@ components:
       title: Package information
       type: object
       properties:
+        agent:
+          type: object
+          properties:
+            privileges:
+              type: object
+              properties:
+                root:
+                  type: boolean
+        asset_tags:
+          items:
+            type: object
+            properties:
+              asset_ids:
+                items:
+                  type: string
+                type: array
+              asset_types:
+                items:
+                  type: string
+                type: array
+              text:
+                type: string
+            required:
+              - text
+          type: array
         assets:
           items:
             type: string
@@ -21469,6 +21494,18 @@ components:
           type: array
         description:
           type: string
+        discovery:
+          type: object
+          properties:
+            fields:
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required:
+                  - name
+              type: array
         download:
           type: string
         elasticsearch:
@@ -21491,6 +21528,19 @@ components:
           type: boolean
         name:
           type: string
+        owner:
+          type: object
+          properties:
+            github:
+              type: string
+            type:
+              enum:
+                - elastic
+                - partner
+                - community
+              type: string
+          required:
+            - github
         path:
           type: string
         readme:
@@ -21534,6 +21584,10 @@ components:
         title:
           type: string
         type:
+          enum:
+            - integration
+            - input
+            - content
           type: string
         version:
           type: string
@@ -21549,6 +21603,7 @@ components:
         - format_version
         - download
         - path
+        - owner
     Fleet_package_policy:
       allOf:
         - type: object

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -21405,6 +21405,31 @@ components:
       title: Package information
       type: object
       properties:
+        agent:
+          type: object
+          properties:
+            privileges:
+              type: object
+              properties:
+                root:
+                  type: boolean
+        asset_tags:
+          items:
+            type: object
+            properties:
+              asset_ids:
+                items:
+                  type: string
+                type: array
+              asset_types:
+                items:
+                  type: string
+                type: array
+              text:
+                type: string
+            required:
+              - text
+          type: array
         assets:
           items:
             type: string
@@ -21469,6 +21494,18 @@ components:
           type: array
         description:
           type: string
+        discovery:
+          type: object
+          properties:
+            fields:
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required:
+                  - name
+              type: array
         download:
           type: string
         elasticsearch:
@@ -21491,6 +21528,19 @@ components:
           type: boolean
         name:
           type: string
+        owner:
+          type: object
+          properties:
+            github:
+              type: string
+            type:
+              enum:
+                - elastic
+                - partner
+                - community
+              type: string
+          required:
+            - github
         path:
           type: string
         readme:
@@ -21534,6 +21584,10 @@ components:
         title:
           type: string
         type:
+          enum:
+            - integration
+            - input
+            - content
           type: string
         version:
           type: string
@@ -21549,6 +21603,7 @@ components:
         - format_version
         - download
         - path
+        - owner
     Fleet_package_policy:
       allOf:
         - type: object

--- a/oas_docs/output/kibana.staging.yaml
+++ b/oas_docs/output/kibana.staging.yaml
@@ -29184,6 +29184,31 @@ components:
       title: Package information
       type: object
       properties:
+        agent:
+          type: object
+          properties:
+            privileges:
+              type: object
+              properties:
+                root:
+                  type: boolean
+        asset_tags:
+          items:
+            type: object
+            properties:
+              asset_ids:
+                items:
+                  type: string
+                type: array
+              asset_types:
+                items:
+                  type: string
+                type: array
+              text:
+                type: string
+            required:
+              - text
+          type: array
         assets:
           items:
             type: string
@@ -29248,6 +29273,18 @@ components:
           type: array
         description:
           type: string
+        discovery:
+          type: object
+          properties:
+            fields:
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required:
+                  - name
+              type: array
         download:
           type: string
         elasticsearch:
@@ -29270,6 +29307,19 @@ components:
           type: boolean
         name:
           type: string
+        owner:
+          type: object
+          properties:
+            github:
+              type: string
+            type:
+              enum:
+                - elastic
+                - partner
+                - community
+              type: string
+          required:
+            - github
         path:
           type: string
         readme:
@@ -29313,6 +29363,10 @@ components:
         title:
           type: string
         type:
+          enum:
+            - integration
+            - input
+            - content
           type: string
         version:
           type: string
@@ -29328,6 +29382,7 @@ components:
         - format_version
         - download
         - path
+        - owner
     Fleet_package_policy:
       allOf:
         - type: object

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -29184,6 +29184,31 @@ components:
       title: Package information
       type: object
       properties:
+        agent:
+          type: object
+          properties:
+            privileges:
+              type: object
+              properties:
+                root:
+                  type: boolean
+        asset_tags:
+          items:
+            type: object
+            properties:
+              asset_ids:
+                items:
+                  type: string
+                type: array
+              asset_types:
+                items:
+                  type: string
+                type: array
+              text:
+                type: string
+            required:
+              - text
+          type: array
         assets:
           items:
             type: string
@@ -29248,6 +29273,18 @@ components:
           type: array
         description:
           type: string
+        discovery:
+          type: object
+          properties:
+            fields:
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required:
+                  - name
+              type: array
         download:
           type: string
         elasticsearch:
@@ -29270,6 +29307,19 @@ components:
           type: boolean
         name:
           type: string
+        owner:
+          type: object
+          properties:
+            github:
+              type: string
+            type:
+              enum:
+                - elastic
+                - partner
+                - community
+              type: string
+          required:
+            - github
         path:
           type: string
         readme:
@@ -29313,6 +29363,10 @@ components:
         title:
           type: string
         type:
+          enum:
+            - integration
+            - input
+            - content
           type: string
         version:
           type: string
@@ -29328,6 +29382,7 @@ components:
         - format_version
         - download
         - path
+        - owner
     Fleet_package_policy:
       allOf:
         - type: object

--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -6700,7 +6700,12 @@
             "type": "string"
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "integration",
+              "input",
+              "content"
+            ]
           },
           "categories": {
             "type": "array",
@@ -6853,6 +6858,83 @@
                 }
               }
             }
+          },
+          "owner": {
+            "type": "object",
+            "properties": {
+              "github": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "elastic",
+                  "partner",
+                  "community"
+                ]
+              }
+            },
+            "required": [
+              "github"
+            ]
+          },
+          "agent": {
+            "type": "object",
+            "properties": {
+              "privileges": {
+                "type": "object",
+                "properties": {
+                  "root": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          },
+          "asset_tags": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": "string"
+                },
+                "asset_types": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "asset_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "text"
+              ]
+            }
+          },
+          "discovery": {
+            "type": "object",
+            "properties": {
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }
+              }
+            }
           }
         },
         "required": [
@@ -6866,7 +6948,8 @@
           "assets",
           "format_version",
           "download",
-          "path"
+          "path",
+          "owner"
         ]
       },
       "package_usage_stats": {

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -4233,6 +4233,10 @@ components:
           type: string
         type:
           type: string
+          enum:
+            - integration
+            - input
+            - content
         categories:
           type: array
           items:
@@ -4335,6 +4339,56 @@ components:
                   type: array
                   items:
                     type: string
+        owner:
+          type: object
+          properties:
+            github:
+              type: string
+            type:
+              type: string
+              enum:
+                - elastic
+                - partner
+                - community
+          required:
+            - github
+        agent:
+          type: object
+          properties:
+            privileges:
+              type: object
+              properties:
+                root:
+                  type: boolean
+        asset_tags:
+          type: array
+          items:
+            type: object
+            properties:
+              text:
+                type: string
+              asset_types:
+                type: array
+                items:
+                  type: string
+              asset_ids:
+                type: array
+                items:
+                  type: string
+            required:
+              - text
+        discovery:
+          type: object
+          properties:
+            fields:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                required:
+                  - name
       required:
         - name
         - title
@@ -4347,6 +4401,7 @@ components:
         - format_version
         - download
         - path
+        - owner
     package_usage_stats:
       title: Package usage stats
       type: object

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/package_info.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/package_info.yaml
@@ -29,6 +29,10 @@ properties:
     type: string
   type:
     type: string
+    enum:
+      - integration
+      - input
+      - content
   categories:
     type: array
     items:
@@ -131,6 +135,56 @@ properties:
             type: array
             items:
               type: string
+  owner: 
+    type: object
+    properties:
+      github:
+        type: string
+      type:
+        type: string
+        enum:
+          - elastic
+          - partner
+          - community
+    required:
+      - github
+  agent:
+    type: object
+    properties:
+      privileges:
+        type: object
+        properties:
+          root:
+            type: boolean
+  asset_tags:
+    type: array
+    items:
+      type: object
+      properties:
+        text:
+          type: string
+        asset_types:
+          type: array
+          items:
+            type: string
+        asset_ids:
+          type: array
+          items:
+            type: string
+      required:
+        - text
+  discovery:
+    type: object
+    properties:
+      fields:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+          required:
+            - name
 required:
   - name
   - title
@@ -143,3 +197,4 @@ required:
   - format_version
   - download
   - path
+  - owner

--- a/x-pack/plugins/fleet/common/types/models/package_spec.ts
+++ b/x-pack/plugins/fleet/common/types/models/package_spec.ts
@@ -18,7 +18,7 @@ export interface PackageSpecManifest {
   source?: {
     license: string;
   };
-  type?: 'integration' | 'input';
+  type?: PackageSpecPackageType;
   release?: 'experimental' | 'beta' | 'ga';
   categories?: Array<PackageSpecCategory | undefined>;
   conditions?: PackageSpecConditions;
@@ -35,6 +35,11 @@ export interface PackageSpecManifest {
     privileges?: { root?: boolean };
   };
   asset_tags?: PackageSpecTags[];
+  discovery?: {
+    fields?: Array<{
+      name: string;
+    }>;
+  };
 }
 export interface PackageSpecTags {
   text: string;
@@ -42,7 +47,7 @@ export interface PackageSpecTags {
   asset_ids?: string[];
 }
 
-export type PackageSpecPackageType = 'integration' | 'input';
+export type PackageSpecPackageType = 'integration' | 'input' | 'content';
 
 export type PackageSpecCategory =
   | 'advanced_analytics_ueba'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[UII] Add types to return content packages correctly (#195505)](https://github.com/elastic/kibana/pull/195505)

Note that this includes manual changes to openapi spec files. This change is not present on the original PR as the main branch no longer uses openapi spec files.

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2024-10-09T20:08:18Z","message":"[UII] Add types to return content packages correctly (#195505)\n\n## Summary\r\n\r\nRelated to #192484. This PR adding [new content package types and\r\nschemas](https://github.com/elastic/package-spec/pull/777) so that\r\ncontent packages can be returned correctly from EPR to unblock\r\ndevelopment of those packages.\r\n\r\nThe only current content package is `kubernetes_otel`. You will need to\r\nbump up the max allowed spec version and search with beta (prerelease)\r\npackages enabled to find it:\r\n```\r\nxpack.fleet.internal.registry.spec.max: '3.4'\r\n```\r\n\r\nTests will come with the rest of work for #192484\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bd6533f30b58fc831670d400f25a61321379902c","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","backport:prev-minor"],"number":195505,"url":"https://github.com/elastic/kibana/pull/195505","mergeCommit":{"message":"[UII] Add types to return content packages correctly (#195505)\n\n## Summary\r\n\r\nRelated to #192484. This PR adding [new content package types and\r\nschemas](https://github.com/elastic/package-spec/pull/777) so that\r\ncontent packages can be returned correctly from EPR to unblock\r\ndevelopment of those packages.\r\n\r\nThe only current content package is `kubernetes_otel`. You will need to\r\nbump up the max allowed spec version and search with beta (prerelease)\r\npackages enabled to find it:\r\n```\r\nxpack.fleet.internal.registry.spec.max: '3.4'\r\n```\r\n\r\nTests will come with the rest of work for #192484\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bd6533f30b58fc831670d400f25a61321379902c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/195505","number":195505,"mergeCommit":{"message":"[UII] Add types to return content packages correctly (#195505)\n\n## Summary\r\n\r\nRelated to #192484. This PR adding [new content package types and\r\nschemas](https://github.com/elastic/package-spec/pull/777) so that\r\ncontent packages can be returned correctly from EPR to unblock\r\ndevelopment of those packages.\r\n\r\nThe only current content package is `kubernetes_otel`. You will need to\r\nbump up the max allowed spec version and search with beta (prerelease)\r\npackages enabled to find it:\r\n```\r\nxpack.fleet.internal.registry.spec.max: '3.4'\r\n```\r\n\r\nTests will come with the rest of work for #192484\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bd6533f30b58fc831670d400f25a61321379902c"}}]}] BACKPORT-->