### PR TITLE
[Security Solution][Notes] - update cases alerts table action column width to show analyzer and session view icons

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
@@ -20,12 +20,14 @@ import { Actions } from './actions';
 import { initialUserPrivilegesState as mockInitialUserPrivilegesState } from '../user_privileges/user_privileges_context';
 import { useUserPrivileges } from '../user_privileges';
 import { useHiddenByFlyout } from '../guided_onboarding_tour/use_hidden_by_flyout';
+// import { useUiSetting$ } from '../../lib/kibana';
 
 const useHiddenByFlyoutMock = useHiddenByFlyout as jest.Mock;
 jest.mock('../guided_onboarding_tour/use_hidden_by_flyout', () => ({
   useHiddenByFlyout: jest.fn(),
 }));
 jest.mock('../guided_onboarding_tour');
+jest.mock('../user_privileges');
 jest.mock('../user_privileges');
 jest.mock('../../../detections/components/user_info', () => ({
   useUserData: jest.fn().mockReturnValue([{ canUserCRUD: true, hasIndexWrite: true }]),
@@ -44,6 +46,15 @@ jest.mock(
     }),
   })
 );
+
+const mockUseUiSetting = jest.fn().mockReturnValue([true]);
+jest.mock('@kbn/kibana-react-plugin/public', () => {
+  const original = jest.requireActual('@kbn/kibana-react-plugin/public');
+  return {
+    ...original,
+    useUiSetting$: () => mockUseUiSetting(),
+  };
+});
 
 jest.mock('./add_note_icon_item', () => {
   return {
@@ -143,6 +154,7 @@ describe('Actions', () => {
         incrementStep: incrementStepMock,
         isTourShown: () => true,
       });
+      // (useUiSetting$ as jest.Mock).mockReturnValue([true]);
       jest.clearAllMocks();
     });
 
@@ -249,6 +261,7 @@ describe('Actions', () => {
       expect(wrapper.find(GuidedOnboardingTourStep).exists()).toEqual(true);
       expect(wrapper.find(SecurityTourStep).exists()).toEqual(false);
     });
+
     describe.each(Object.keys(isTourAnchorConditions))('tour condition true: %s', (key: string) => {
       it('Single condition does not make tour step exist', () => {
         const wrapper = mount(
@@ -281,6 +294,7 @@ describe('Actions', () => {
         wrapper.find('[data-test-subj="timeline-context-menu-button"]').first().prop('isDisabled')
       ).toBe(true);
     });
+
     test('it enables for eventType=signal', () => {
       const ecsData = {
         ...mockTimelineData[0].ecs,
@@ -296,6 +310,7 @@ describe('Actions', () => {
         wrapper.find('[data-test-subj="timeline-context-menu-button"]').first().prop('isDisabled')
       ).toBe(false);
     });
+
     test('it disables for event.kind: undefined and agent.type: endpoint', () => {
       const ecsData = {
         ...mockTimelineData[0].ecs,
@@ -311,6 +326,7 @@ describe('Actions', () => {
         wrapper.find('[data-test-subj="timeline-context-menu-button"]').first().prop('isDisabled')
       ).toBe(true);
     });
+
     test('it enables for event.kind: event and agent.type: endpoint', () => {
       const ecsData = {
         ...mockTimelineData[0].ecs,
@@ -327,6 +343,7 @@ describe('Actions', () => {
         wrapper.find('[data-test-subj="timeline-context-menu-button"]').first().prop('isDisabled')
       ).toBe(false);
     });
+
     test('it disables for event.kind: alert and agent.type: endpoint', () => {
       const ecsData = {
         ...mockTimelineData[0].ecs,
@@ -343,6 +360,7 @@ describe('Actions', () => {
         wrapper.find('[data-test-subj="timeline-context-menu-button"]').first().prop('isDisabled')
       ).toBe(true);
     });
+
     test('it shows the analyze event button when the event is from an endpoint', () => {
       const ecsData = {
         ...mockTimelineData[0].ecs,
@@ -358,6 +376,7 @@ describe('Actions', () => {
 
       expect(wrapper.find('[data-test-subj="view-in-analyzer"]').exists()).toBe(true);
     });
+
     test('it does not render the analyze event button when the event is from an unsupported source', () => {
       const ecsData = {
         ...mockTimelineData[0].ecs,
@@ -371,6 +390,60 @@ describe('Actions', () => {
       );
 
       expect(wrapper.find('[data-test-subj="view-in-analyzer"]').exists()).toBe(false);
+    });
+
+    test('it does not render the analyze event button on the cases alerts table with advanced settings disabled', () => {
+      const ecsData = {
+        ...mockTimelineData[0].ecs,
+        event: { kind: ['alert'] },
+        agent: { type: ['endpoint'] },
+        process: { entity_id: ['1'] },
+      };
+      mockUseUiSetting.mockReturnValue([false]);
+
+      const wrapper = mount(
+        <TestProviders>
+          <Actions {...defaultProps} ecsData={ecsData} timelineId={TableId.alertsOnCasePage} />
+        </TestProviders>
+      );
+
+      expect(wrapper.find('[data-test-subj="view-in-analyzer"]').exists()).toBe(false);
+    });
+
+    test('it does render the analyze event button on the cases alerts table with advanced settings enabled', () => {
+      const ecsData = {
+        ...mockTimelineData[0].ecs,
+        event: { kind: ['alert'] },
+        agent: { type: ['endpoint'] },
+        process: { entity_id: ['1'] },
+      };
+      mockUseUiSetting.mockReturnValue([true]);
+
+      const wrapper = mount(
+        <TestProviders>
+          <Actions {...defaultProps} ecsData={ecsData} timelineId={TableId.alertsOnCasePage} />
+        </TestProviders>
+      );
+
+      expect(wrapper.find('[data-test-subj="view-in-analyzer"]').exists()).toBe(true);
+    });
+
+    test('it does render the analyze event button on the alerts page alerts table even with advanced settings disabled', () => {
+      const ecsData = {
+        ...mockTimelineData[0].ecs,
+        event: { kind: ['alert'] },
+        agent: { type: ['endpoint'] },
+        process: { entity_id: ['1'] },
+      };
+      mockUseUiSetting.mockReturnValue([false]);
+
+      const wrapper = mount(
+        <TestProviders>
+          <Actions {...defaultProps} ecsData={ecsData} timelineId={TableId.alertsOnAlertsPage} />
+        </TestProviders>
+      );
+
+      expect(wrapper.find('[data-test-subj="view-in-analyzer"]').exists()).toBe(true);
     });
 
     test('it should not show session view button on action tabs for basic users', () => {
@@ -433,6 +506,44 @@ describe('Actions', () => {
       );
 
       expect(wrapper.find('[data-test-subj="session-view-button"]').exists()).toEqual(true);
+    });
+
+    test('it does not render the session view button on the cases alerts table with advanced settings disabled', () => {
+      const ecsData = {
+        ...mockTimelineData[0].ecs,
+        event: { kind: ['alert'] },
+        agent: { type: ['endpoint'] },
+        process: { entry_leader: { entity_id: ['test_id'], start: ['2022-05-08T13:44:00.13Z'] } },
+        _index: '.ds-logs-endpoint.events.process-default',
+      };
+      mockUseUiSetting.mockReturnValue([false]);
+
+      const wrapper = mount(
+        <TestProviders>
+          <Actions {...defaultProps} ecsData={ecsData} timelineId={TableId.alertsOnCasePage} />
+        </TestProviders>
+      );
+
+      expect(wrapper.find('[data-test-subj="session-view-button"]').exists()).toBe(false);
+    });
+
+    test('it does render the session view button on the cases alerts table with advanced settings enabled', () => {
+      const ecsData = {
+        ...mockTimelineData[0].ecs,
+        event: { kind: ['alert'] },
+        agent: { type: ['endpoint'] },
+        process: { entry_leader: { entity_id: ['test_id'], start: ['2022-05-08T13:44:00.13Z'] } },
+        _index: '.ds-logs-endpoint.events.process-default',
+      };
+      mockUseUiSetting.mockReturnValue([true]);
+
+      const wrapper = mount(
+        <TestProviders>
+          <Actions {...defaultProps} ecsData={ecsData} timelineId={TableId.alertsOnCasePage} />
+        </TestProviders>
+      );
+
+      expect(wrapper.find('[data-test-subj="session-view-button"]').exists()).toBe(true);
     });
   });
 

--- a/x-pack/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/actions.test.tsx
@@ -20,7 +20,6 @@ import { Actions } from './actions';
 import { initialUserPrivilegesState as mockInitialUserPrivilegesState } from '../user_privileges/user_privileges_context';
 import { useUserPrivileges } from '../user_privileges';
 import { useHiddenByFlyout } from '../guided_onboarding_tour/use_hidden_by_flyout';
-// import { useUiSetting$ } from '../../lib/kibana';
 
 const useHiddenByFlyoutMock = useHiddenByFlyout as jest.Mock;
 jest.mock('../guided_onboarding_tour/use_hidden_by_flyout', () => ({
@@ -154,7 +153,6 @@ describe('Actions', () => {
         incrementStep: incrementStepMock,
         isTourShown: () => true,
       });
-      // (useUiSetting$ as jest.Mock).mockReturnValue([true]);
       jest.clearAllMocks();
     });
 

--- a/x-pack/plugins/security_solution/public/common/components/header_actions/actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/actions.tsx
@@ -130,7 +130,6 @@ const ActionsComponent: React.FC<ActionProps> = ({
     scopeId: timelineId,
   });
 
-  const isDisabled = !useIsInvestigateInResolverActionEnabled(ecsData);
   const { setGlobalFullScreen } = useGlobalFullScreen();
   const { setTimelineFullScreen } = useTimelineFullScreen();
   const handleClick = useCallback(() => {

--- a/x-pack/plugins/security_solution/public/common/components/header_actions/actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/actions.tsx
@@ -82,8 +82,6 @@ const ActionsComponent: React.FC<ActionProps> = ({
 
   const { startTransaction } = useStartTransaction();
 
-  const isEnterprisePlus = useLicense().isEnterprise();
-
   const onPinEvent: OnPinEvent = useCallback(
     (evtId) => dispatch(timelineActions.pinEvent({ id: timelineId, eventId: evtId })),
     [dispatch, timelineId]
@@ -292,6 +290,30 @@ const ActionsComponent: React.FC<ActionProps> = ({
     [documentBasedNotes, timelineNoteIds, securitySolutionNotesEnabled]
   );
 
+  // we hide the analyzer icon if the data is not available for the resolver
+  // or if we are on the cases alerts table and the the visualization in flyout advanced setting is disabled
+  const ecsHasDataForAnalyzer = useIsInvestigateInResolverActionEnabled(ecsData);
+  const showAnalyzerIcon = useMemo(() => {
+    return (
+      ecsHasDataForAnalyzer &&
+      (timelineId !== TableId.alertsOnCasePage ||
+        (timelineId === TableId.alertsOnCasePage && visualizationInFlyoutEnabled))
+    );
+  }, [ecsHasDataForAnalyzer, timelineId, visualizationInFlyoutEnabled]);
+
+  // we hide the session view icon if the session view is not available
+  // or if we are on the cases alerts table and the the visualization in flyout advanced setting is disabled
+  // or if the user is not on an enterprise license or on the kubernetes page
+  const isEnterprisePlus = useLicense().isEnterprise();
+  const showSessionViewIcon = useMemo(() => {
+    return (
+      sessionViewConfig !== null &&
+      (isEnterprisePlus || timelineId === TableId.kubernetesPageSessions) &&
+      (timelineId !== TableId.alertsOnCasePage ||
+        (timelineId === TableId.alertsOnCasePage && visualizationInFlyoutEnabled))
+    );
+  }, [sessionViewConfig, isEnterprisePlus, timelineId, visualizationInFlyoutEnabled]);
+
   return (
     <ActionsContainer data-test-subj="actions-container">
       <>
@@ -359,7 +381,7 @@ const ActionsComponent: React.FC<ActionProps> = ({
           onRuleChange={onRuleChange}
           refetch={refetch}
         />
-        {isDisabled === false ? (
+        {showAnalyzerIcon ? (
           <div>
             <EventsTdContent textAlign="center" width={DEFAULT_ACTION_BUTTON_WIDTH}>
               <EuiToolTip
@@ -380,8 +402,7 @@ const ActionsComponent: React.FC<ActionProps> = ({
             </EventsTdContent>
           </div>
         ) : null}
-        {sessionViewConfig !== null &&
-        (isEnterprisePlus || timelineId === TableId.kubernetesPageSessions) ? (
+        {showSessionViewIcon ? (
           <div>
             <EventsTdContent textAlign="center" width={DEFAULT_ACTION_BUTTON_WIDTH}>
               <EuiToolTip data-test-subj="expand-event-tool-tip" content={i18n.OPEN_SESSION_VIEW}>

--- a/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_actions_column.tsx
+++ b/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_actions_column.tsx
@@ -13,6 +13,8 @@ import type {
   RenderCustomActionsRowArgs,
 } from '@kbn/triggers-actions-ui-plugin/public/types';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import { ENABLE_VISUALIZATIONS_IN_FLYOUT_SETTING } from '../../../../common/constants';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { StatefulEventContext } from '../../../common/components/events_viewer/stateful_event_context';
 import { eventsViewerSelector } from '../../../common/components/events_viewer/selectors';
@@ -28,7 +30,7 @@ export const getUseActionColumnHook =
   () => {
     const license = useLicense();
     const isEnterprisePlus = license.isEnterprise();
-    let ACTION_BUTTON_COUNT = tableId === TableId.alertsOnCasePage ? 4 : isEnterprisePlus ? 6 : 5;
+    let ACTION_BUTTON_COUNT = isEnterprisePlus ? 6 : 5;
 
     // we only want to show the note icon if the expandable flyout and the new notes system are enabled
     // TODO delete most likely in 8.16
@@ -37,6 +39,15 @@ export const getUseActionColumnHook =
     );
     if (!securitySolutionNotesEnabled) {
       ACTION_BUTTON_COUNT--;
+    }
+
+    // we do not show the analyzer graph and session view icons on the cases alerts tab alerts table
+    // if the visualization in flyout advanced settings is disabled because these aren't supported inside the table
+    const [visualizationInFlyoutEnabled] = useUiSetting$<boolean>(
+      ENABLE_VISUALIZATIONS_IN_FLYOUT_SETTING
+    );
+    if (!visualizationInFlyoutEnabled && tableId === TableId.alertsOnCasePage) {
+      ACTION_BUTTON_COUNT -= 2;
     }
 
     const eventContext = useContext(StatefulEventContext);


### PR DESCRIPTION
## Summary

This PR makes a small change to the width of the actions column for the alerts table displayed in the Alerts tab of Cases. An issue was introduced when this EUI [PR](https://github.com/elastic/kibana/pull/193805) was merged a few weeks back. It removed some css that was hiding some icons with a `overflow: hidden`

| Before EUI merge  | After EUI merge |
| ------------- | ------------- |
| ![Screenshot 2024-10-10 at 11 44 31 AM](https://github.com/user-attachments/assets/12d5f756-c24d-444c-91da-7fc4cdce45c8) | ![Screenshot 2024-10-10 at 11 48 08 AM](https://github.com/user-attachments/assets/7e4e2acb-3981-46ee-a122-0675aae903e3) |

One fix could have to just hide the session view and analyzer graph icons on the Cases alerts table, but with this upcoming change ([PR](https://github.com/elastic/kibana/pull/195687)) we can now display those icons on the cases alerts table. We were previously hiding the icons because we did not have the ability to visualize session view and analyzer graph within the table, but we now that we have the ability to render these two in the flyout we can show the icons and have a consistent UI between all alerts tables.
Note that the visualization in flyout is controlled via an advanced settings (`securitySolution:enableVisualizationsInFlyout`).

Here are the scenario we want to support and that should be tested when reviewing this PR:
- alert page
  - session view and analyzer graph icon should always be visible (granted the data for the alerts allows it) wether the aforementioned advanced settings in enabled or disabled
- cases page
  - hide the analyzer graph and session view icons if the aforementioned advanced settings is disabled
  - show the analyzer graph and session view icons if the aforementioned advanced settings is enabled

Also take into account when testing that the `securitySolutionNotesEnabled` feature flag can be toggled on or off, which has an impact on how many icons we show in the actions columns.

Current behavior

![Screenshot 2024-10-09 at 6 34 37 PM](https://github.com/user-attachments/assets/eacef6a3-c5bd-4143-bab3-47da8b263ff7)

New behavior when visualization in flyout advanced settings are enabled

![Screenshot 2024-10-09 at 7 01 19 PM](https://github.com/user-attachments/assets/3fa4f65e-f2a2-43db-8bc7-5aed8ecaebe5)

New behavior when visualization in flyout advanced settings are disabled
![Screenshot 2024-10-09 at 7 12 57 PM](https://github.com/user-attachments/assets/6dca3200-e320-45af-b478-f920d072a9b9)

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->