### PR TITLE
[Cloud Security] [CDR] Handle grouping fields with missing mapping

### DIFF
--- a/packages/kbn-grouping/src/containers/query/index.ts
+++ b/packages/kbn-grouping/src/containers/query/index.ts
@@ -56,8 +56,8 @@ export const getGroupingQuery = ({
       type: 'keyword',
       script: {
         source:
-          // when doc misses the field, or it's size()==0, emits a uniqueValue as the value to represent this group  else join by uniqueValue.
-          "if (!doc.containsKey(params['selectedGroup']) || doc[params['selectedGroup']].empty || doc[params['selectedGroup']].size() == 0) { emit(params['uniqueValue']) }" +
+          // when size()==0, emits a uniqueValue as the value to represent this group  else join by uniqueValue.
+          "if (doc[params['selectedGroup']].size()==0) { emit(params['uniqueValue']) }" +
           // Else, join the values with uniqueValue. We cannot simply emit the value like doc[params['selectedGroup']].value,
           // the runtime field will only return the first value in an array.
           // The docs advise that if the field has multiple values, "Scripts can call the emit method multiple times to emit multiple values."

--- a/packages/kbn-grouping/src/containers/query/index.ts
+++ b/packages/kbn-grouping/src/containers/query/index.ts
@@ -56,8 +56,8 @@ export const getGroupingQuery = ({
       type: 'keyword',
       script: {
         source:
-          // when size()==0, emits a uniqueValue as the value to represent this group  else join by uniqueValue.
-          "if (doc[params['selectedGroup']].size()==0) { emit(params['uniqueValue']) }" +
+          // when doc misses the field, or it's size()==0, emits a uniqueValue as the value to represent this group  else join by uniqueValue.
+          "if (!doc.containsKey(params['selectedGroup']) || doc[params['selectedGroup']].empty || doc[params['selectedGroup']].size() == 0) { emit(params['uniqueValue']) }" +
           // Else, join the values with uniqueValue. We cannot simply emit the value like doc[params['selectedGroup']].value,
           // the runtime field will only return the first value in an array.
           // The docs advise that if the field has multiple values, "Scripts can call the emit method multiple times to emit multiple values."

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
@@ -115,6 +115,52 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
 };
 
 /**
+ * Get runtime mappings for the given group field
+ * Some fields require additional runtime mappings to aggregate additional information
+ * Fallback to keyword type to support custom fields grouping
+ */
+const getRuntimeMappingsByGroupField = (
+  field: string
+): Record<string, { type: 'keyword' }> | undefined => {
+  switch (field) {
+    case FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME:
+      return {
+        'resource.id': {
+          type: 'keyword',
+        },
+        'resource.sub_type': {
+          type: 'keyword',
+        },
+        'resource.type': {
+          type: 'keyword',
+        },
+      };
+    case FINDINGS_GROUPING_OPTIONS.RULE_NAME:
+      return {
+        'rule.benchmark.version': {
+          type: 'keyword',
+        },
+      };
+    case FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME:
+    case FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME:
+      return {
+        'rule.benchmark.name': {
+          type: 'keyword',
+        },
+        'rule.benchmark.id': {
+          type: 'keyword',
+        },
+      };
+    default:
+      return {
+        [field]: {
+          type: 'keyword',
+        },
+      };
+  }
+};
+
+/**
  * Type Guard for checking if the given source is a FindingsRootGroupingAggregation
  */
 export const isFindingsRootGroupingAggregation = (
@@ -189,6 +235,12 @@ export const useLatestFindingsGrouping = ({
     size: pageSize,
     sort: [{ groupByField: { order: 'desc' } }, { complianceScore: { order: 'asc' } }],
     statsAggregations: getAggregationsByGroupField(currentSelectedGroup),
+    runtimeMappings: {
+      ...getRuntimeMappingsByGroupField(currentSelectedGroup),
+      'result.evaluation': {
+        type: 'keyword',
+      },
+    },
     rootAggregations: [
       {
         failedFindings: {

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
@@ -125,6 +125,9 @@ const getRuntimeMappingsByGroupField = (
   switch (field) {
     case FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME:
       return {
+        [FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME]: {
+          type: 'keyword',
+        },
         'resource.id': {
           type: 'keyword',
         },
@@ -137,13 +140,30 @@ const getRuntimeMappingsByGroupField = (
       };
     case FINDINGS_GROUPING_OPTIONS.RULE_NAME:
       return {
+        [FINDINGS_GROUPING_OPTIONS.RULE_NAME]: {
+          type: 'keyword',
+        },
         'rule.benchmark.version': {
           type: 'keyword',
         },
       };
     case FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME:
+      return {
+        [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME]: {
+          type: 'keyword',
+        },
+        'rule.benchmark.name': {
+          type: 'keyword',
+        },
+        'rule.benchmark.id': {
+          type: 'keyword',
+        },
+      };
     case FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME:
       return {
+        [FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME]: {
+          type: 'keyword',
+        },
         'rule.benchmark.name': {
           type: 'keyword',
         },

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
@@ -163,6 +163,11 @@ export const useLatestVulnerabilitiesGrouping = ({
     size: pageSize,
     sort: [{ groupByField: { order: 'desc' } }],
     statsAggregations: getAggregationsByGroupField(currentSelectedGroup),
+    runtimeMappings: {
+      'cloud.provider': {
+        type: 'keyword',
+      },
+    },
   });
 
   const { data, isFetching } = useGroupedVulnerabilities({

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
@@ -88,6 +88,8 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
         ...aggMetrics,
         getTermAggregation('cloudProvider', VULNERABILITY_FIELDS.CLOUD_PROVIDER),
       ];
+    case VULNERABILITY_GROUPING_OPTIONS.CVE:
+      return [...aggMetrics, getTermAggregation('description', VULNERABILITY_FIELDS.DESCRIPTION)];
   }
   return aggMetrics;
 };
@@ -103,13 +105,28 @@ const getRuntimeMappingsByGroupField = (
   switch (field) {
     case VULNERABILITY_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME:
       return {
+        [VULNERABILITY_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME]: {
+          type: 'keyword',
+        },
         [VULNERABILITY_FIELDS.CLOUD_PROVIDER]: {
           type: 'keyword',
         },
       };
     case VULNERABILITY_GROUPING_OPTIONS.RESOURCE_NAME:
       return {
+        [VULNERABILITY_GROUPING_OPTIONS.RESOURCE_NAME]: {
+          type: 'keyword',
+        },
         [VULNERABILITY_FIELDS.RESOURCE_ID]: {
+          type: 'keyword',
+        },
+      };
+    case VULNERABILITY_GROUPING_OPTIONS.CVE:
+      return {
+        [VULNERABILITY_GROUPING_OPTIONS.CVE]: {
+          type: 'keyword',
+        },
+        [VULNERABILITY_FIELDS.DESCRIPTION]: {
           type: 'keyword',
         },
       };

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/utils/custom_sort_script.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/utils/custom_sort_script.ts
@@ -14,7 +14,13 @@ export const getCaseInsensitiveSortScript = (field: string, direction: string) =
       type: 'string',
       order: direction,
       script: {
-        source: `doc["${field}"].value.toLowerCase()`,
+        source: `
+          if (doc.containsKey('${field}') && !doc['${field}'].empty) {
+            return doc['${field}'].value.toLowerCase();
+          } else {
+            return "";
+          }
+        `,
         lang: 'painless',
       },
     },

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
@@ -102,7 +102,7 @@ export const getQuery = (
       type: 'keyword',
       script: {
         source:
-          "if (doc[params['selectedGroup']].size()==0) { emit(params['uniqueValue']) } else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}",
+          "if (!doc.containsKey(params['selectedGroup']) || doc[params['selectedGroup']].empty || doc[params['selectedGroup']].size() == 0) { emit(params['uniqueValue']) } else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}",
         params: {
           selectedGroup,
           uniqueValue,

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
@@ -102,7 +102,7 @@ export const getQuery = (
       type: 'keyword',
       script: {
         source:
-          "if (!doc.containsKey(params['selectedGroup']) || doc[params['selectedGroup']].empty || doc[params['selectedGroup']].size() == 0) { emit(params['uniqueValue']) } else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}",
+          "if (doc[params['selectedGroup']].size()==0) { emit(params['uniqueValue']) } else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}",
         params: {
           selectedGroup,
           uniqueValue,


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/elastic/security-team/issues/10632 by adding runtime mapping support for fields that are missing in mapping, this is useful when querying a DataView that points to multiple indices where the mapping is not guaranteed to exist as it's the case with CDR that adds supports to Third Party data.

Also added runtime mapping to sorted fields, as it's not guaranteed that all fields shown on the table have mapped fields.



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->