### PR TITLE
Skip Backfill groups in the periodic pipeline

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_details/backfill_group.cy.ts
@@ -34,7 +34,7 @@ import {
 describe(
   'Backfill groups',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@skipInServerlessMKI'],
   },
   function () {
     before(() => {


### PR DESCRIPTION
## Summary

This PR rolls back tags for `backfill_group.cy.ts` changes in https://github.com/elastic/kibana/pull/193833. This test shouldn't run in periodic pipeline. We expect only FTR and Cypress running in periodic and 2nd quality gate pipelines enabled in https://github.com/elastic/kibana/pull/193666.



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->