### PR TITLE
Fix date format for manual rule run

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_gaps/components/manual_rule_run/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_gaps/components/manual_rule_run/index.tsx
@@ -21,6 +21,7 @@ import moment from 'moment';
 import React, { useCallback, useMemo, useState } from 'react';
 import { MAX_MANUAL_RULE_RUN_LOOKBACK_WINDOW_DAYS } from '../../../../../common/constants';
 import { BETA, BETA_TOOLTIP } from '../../../../common/translations';
+import { useKibana } from '../../../../common/lib/kibana';
 
 import * as i18n from './translations';
 
@@ -33,6 +34,12 @@ interface ManualRuleRunModalProps {
 
 const ManualRuleRunModalComponent = ({ onCancel, onConfirm }: ManualRuleRunModalProps) => {
   const modalTitleId = useGeneratedHtmlId();
+
+  const {
+    uiSettings,
+  } = useKibana().services;
+
+  const dateFormat = uiSettings.get('dateFormat');
 
   const now = moment();
 
@@ -94,8 +101,10 @@ const ManualRuleRunModalComponent = ({ onCancel, onConfirm }: ManualRuleRunModal
         >
           <EuiDatePickerRange
             data-test-subj="manual-rule-run-time-range"
+            fullWidth
             startDateControl={
               <EuiDatePicker
+                fullWidth
                 className="start-date-picker"
                 aria-label="Start date range"
                 selected={startDate}
@@ -103,10 +112,12 @@ const ManualRuleRunModalComponent = ({ onCancel, onConfirm }: ManualRuleRunModal
                 startDate={startDate}
                 endDate={endDate}
                 showTimeSelect={true}
+                dateFormat={dateFormat}
               />
             }
             endDateControl={
               <EuiDatePicker
+                fullWidth
                 className="end-date-picker"
                 aria-label="End date range"
                 selected={endDate}
@@ -114,6 +125,7 @@ const ManualRuleRunModalComponent = ({ onCancel, onConfirm }: ManualRuleRunModal
                 startDate={startDate}
                 endDate={endDate}
                 showTimeSelect={true}
+                dateFormat={dateFormat}
               />
             }
           />


### PR DESCRIPTION
## Summary

Date range picker support global date format.

Blocked by this pr from EUI, because currently input not expand: https://github.com/elastic/kibana/pull/195525


<img width="769" alt="Screenshot 2024-10-10 at 14 05 43" src="https://github.com/user-attachments/assets/68237081-4924-481b-ad84-9deeadf86c61">
