### PR TITLE
Fixes Failing test: X-Pack Alerting API Integration Tests.x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/task_runner·ts - alerting api integration security and spaces enabled Alerts - Group 1 alerts backfill rule runs ad hoc backfill task should run all execution sets of a scheduled backfill and correctly generate alerts

### DIFF
--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/task_runner.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/task_runner.ts
@@ -165,7 +165,7 @@ export default function createBackfillTaskRunnerTests({ getService }: FtrProvide
       const ruleId = response1.body.id;
       objectRemover.add(spaceId, ruleId, 'rule', 'alerting');
 
-      const start = moment().utc().startOf('day').subtract(13, 'days').toISOString();
+      const start = moment(originalDocTimestamps[1]).utc().startOf('day').toISOString();
       const end = moment().utc().startOf('day').subtract(9, 'days').toISOString();
 
       // Schedule backfill for this rule


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/192144

## Summary

This flakiness is occurring due to the time of the test run. We create a pre-timestamped set of documents and run a backfill job over them using `startOf(now - X days)`

For example, our documents have these timestamps:

```
    "2024-09-25T23:51:24.793Z",
    
    // should be in the first execution
    "2024-09-26T00:10:00.000Z",
    "2024-09-26T00:11:00.000Z",
    "2024-09-26T00:12:00.000Z",

    // should be in the second execution
    "2024-09-27T00:20:00.000Z",

    // should be in the third execution    
    "2024-09-28T00:30:00.000Z",
    "2024-09-28T00:31:00.000Z",
    "2024-09-28T00:32:00.000Z",
    "2024-09-28T00:33:00.000Z",
    "2024-09-28T00:34:00.000Z",
    
    // should be in the fifth execution
    "2024-09-30T00:40:00.000Z",
    "2024-09-30T00:41:00.000Z"
```

and our scheduled backfill job should run from `2024-09-26T00:00:00.000Z` to `2024-10-01T00:00:00.000Z` but because test ran right around midnight UTC, the job actually ends up being scheduled with a start of `2024-09-27T00:00:00.000Z`.

This PR fixes this flakiness by basing the start of the backfill job to directly use one of the generated doc timestamps

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->