### PR TITLE
[APM][Otel] Errors: Add fallback to span id if the parent id is `undefined`

### DIFF
--- a/x-pack/plugins/observability_solution/apm/common/waterfall/typings.ts
+++ b/x-pack/plugins/observability_solution/apm/common/waterfall/typings.ts
@@ -33,6 +33,7 @@ export interface WaterfallTransaction {
     coldstart?: boolean;
   };
   span?: {
+    id?: string;
     links?: SpanLink[];
   };
 }
@@ -74,6 +75,7 @@ export interface WaterfallError {
   trace?: { id: string };
   transaction?: { id: string };
   parent?: { id: string };
+  span?: { id?: string };
   error: {
     id: string;
     log?: {

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -161,15 +161,15 @@ function getSpanItem(span: WaterfallSpan, linkedChildrenCount: number = 0): IWat
   };
 }
 
-function getErrorItem(
+export function getErrorItem(
   error: WaterfallError,
   items: IWaterfallItem[],
   entryWaterfallTransaction?: IWaterfallTransaction
 ): IWaterfallError {
   const entryTimestamp = entryWaterfallTransaction?.doc.timestamp.us ?? 0;
-  const parent = items.find((waterfallItem) => waterfallItem.id === error.parent?.id) as
-    | IWaterfallSpanOrTransaction
-    | undefined;
+  const parent = items.find(
+    (waterfallItem) => waterfallItem.id === (error.parent?.id ?? error.span?.id)
+  ) as IWaterfallSpanOrTransaction | undefined;
 
   const errorItem: IWaterfallError = {
     docType: 'error',


### PR DESCRIPTION
Closes #195731

## Summary

This PR fixes a bug with error correlations not displayed correctly in the APM waterfall when using Otel native data. In Otel native data `parent.id` is never defined so in this case we need to fallback to `span.id`

## Testing
>[!WARNING]
> The changes of https://github.com/elastic/kibana/pull/195242 are required to properly test this. so there is a unit test to cover that before the [PR](https://github.com/elastic/kibana/pull/195242) is merged

Using the e2e PoC: navigate to a service overview - > Transactions and scroll to the waterfall: 
- Using both Otel native and APM server setups (the results should be the same: the error link should appear for both)

<img width="1519" alt="image" src="https://github.com/user-attachments/assets/8a42c709-15ee-44da-bfcf-b77b056cadb0">
