### PR TITLE
[ci] Update verify_es_serverless_image.yml patterns

### DIFF
--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -54,7 +54,7 @@ steps:
         env:
           FTR_CONFIGS_SCRIPT: "TEST_ES_SERVERLESS_IMAGE=$ES_SERVERLESS_IMAGE .buildkite/scripts/steps/test/ftr_configs.sh"
           JEST_INTEGRATION_SCRIPT: "TEST_ES_SERVERLESS_IMAGE=$ES_SERVERLESS_IMAGE .buildkite/scripts/steps/test/jest_integration.sh"
-          FTR_CONFIG_PATTERNS: "**/test_serverless/**,**/test/security_solution_api_integration/**/serverless.config.ts"
+          FTR_CONFIG_PATTERNS: "**/test_serverless/**,**/test/security_solution_api_integration/**/serverless.config.ts,x-pack/test/api_integration/deployment_agnostic/configs/serverless/**"
           FTR_EXTRA_ARGS: "$FTR_EXTRA_ARGS"
           LIMIT_CONFIG_TYPE: "functional,integration"
         retry:


### PR DESCRIPTION
To make sure these test suites are run during elasticsearch image verification.

Related to https://github.com/elastic/kibana/issues/195811