### PR TITLE
[CI] Skip ci for devcontainer changes

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -30,7 +30,8 @@
         "^\\.backportrc\\.json$",
         "^nav-kibana-dev\\.docnav\\.json$",
         "^src/dev/prs/kibana_qa_pr_list\\.json$",
-        "^\\.buildkite/pull_requests\\.json$"
+        "^\\.buildkite/pull_requests\\.json$",
+        "^\\.devcontainer/"
       ],
       "always_require_ci_on_changed": [
         "^docs/developer/plugin-list.asciidoc$",


### PR DESCRIPTION
## Summary

For now it is not necessary to run any of CI for `.devcontainer` changes.