### PR TITLE
[TopNav] Ability for menu items to collapse into popover at custom breakpoints

### DIFF
--- a/src/plugins/navigation/public/index.ts
+++ b/src/plugins/navigation/public/index.ts
@@ -14,12 +14,7 @@ export function plugin(initializerContext: PluginInitializerContext) {
   return new NavigationPublicPlugin(initializerContext);
 }
 
-export type {
-  TopNavMenuData,
-  TopNavMenuDataWithIconType,
-  TopNavMenuProps,
-  TopNavMenuBadgeProps,
-} from './top_nav_menu';
+export type { TopNavMenuData, TopNavMenuProps, TopNavMenuBadgeProps } from './top_nav_menu';
 export { TopNavMenu, TopNavMenuItems, TopNavMenuBadges } from './top_nav_menu';
 
 export type {

--- a/src/plugins/navigation/public/index.ts
+++ b/src/plugins/navigation/public/index.ts
@@ -14,7 +14,12 @@ export function plugin(initializerContext: PluginInitializerContext) {
   return new NavigationPublicPlugin(initializerContext);
 }
 
-export type { TopNavMenuData, TopNavMenuProps, TopNavMenuBadgeProps } from './top_nav_menu';
+export type {
+  TopNavMenuData,
+  TopNavMenuDataWithIconType,
+  TopNavMenuProps,
+  TopNavMenuBadgeProps,
+} from './top_nav_menu';
 export { TopNavMenu, TopNavMenuItems, TopNavMenuBadges } from './top_nav_menu';
 
 export type {

--- a/src/plugins/navigation/public/top_nav_menu/index.ts
+++ b/src/plugins/navigation/public/top_nav_menu/index.ts
@@ -10,7 +10,7 @@
 export { createTopNav } from './create_top_nav_menu';
 export type { TopNavMenuProps } from './top_nav_menu';
 export { TopNavMenu } from './top_nav_menu';
-export type { TopNavMenuData, TopNavMenuDataWithIconType } from './top_nav_menu_data';
+export type { TopNavMenuData } from './top_nav_menu_data';
 export type { TopNavMenuExtensionsRegistrySetup } from './top_nav_menu_extensions_registry';
 export { TopNavMenuExtensionsRegistry } from './top_nav_menu_extensions_registry';
 export { TopNavMenuItems } from './top_nav_menu_items';

--- a/src/plugins/navigation/public/top_nav_menu/index.ts
+++ b/src/plugins/navigation/public/top_nav_menu/index.ts
@@ -10,7 +10,7 @@
 export { createTopNav } from './create_top_nav_menu';
 export type { TopNavMenuProps } from './top_nav_menu';
 export { TopNavMenu } from './top_nav_menu';
-export type { TopNavMenuData } from './top_nav_menu_data';
+export type { TopNavMenuData, TopNavMenuDataWithIconType } from './top_nav_menu_data';
 export type { TopNavMenuExtensionsRegistrySetup } from './top_nav_menu_extensions_registry';
 export { TopNavMenuExtensionsRegistry } from './top_nav_menu_extensions_registry';
 export { TopNavMenuItems } from './top_nav_menu_items';

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -19,11 +19,24 @@ import { TopNavMenuData } from './top_nav_menu_data';
 import { TopNavMenuItems } from './top_nav_menu_items';
 import { TopNavMenuBadgeProps, TopNavMenuBadges } from './top_nav_menu_badges';
 
+type TopNavMenuIconType = { mobileIconType: string } | { iconType: string };
+interface TopNavMenuPropsWithMobileIconTypes {
+  /** If `useMobileIconTypes=true`, then each data item requires either iconType or mobileIconType */
+  config?: Array<TopNavMenuData & TopNavMenuIconType>;
+  useMobileIconTypes: true;
+}
+interface TopNavMenuPropsWithoutMobileIconTypes {
+  config?: TopNavMenuData[];
+  useMobileIconTypes?: boolean;
+}
+type TopNavMenuPropsWithConfig =
+  | TopNavMenuPropsWithMobileIconTypes
+  | TopNavMenuPropsWithoutMobileIconTypes;
+
 export type TopNavMenuProps<QT extends Query | AggregateQuery = Query> = Omit<
   StatefulSearchBarProps<QT>,
   'kibana' | 'intl' | 'timeHistory'
 > & {
-  config?: TopNavMenuData[];
   badges?: TopNavMenuBadgeProps[];
   showSearchBar?: boolean;
   showQueryInput?: boolean;
@@ -51,7 +64,7 @@ export type TopNavMenuProps<QT extends Query | AggregateQuery = Query> = Omit<
    * ```
    */
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
-};
+} & TopNavMenuPropsWithConfig;
 
 /*
  * Top Nav Menu is a convenience wrapper component for:
@@ -65,7 +78,7 @@ export type TopNavMenuProps<QT extends Query | AggregateQuery = Query> = Omit<
 export function TopNavMenu<QT extends AggregateQuery | Query = Query>(
   props: TopNavMenuProps<QT>
 ): ReactElement | null {
-  const { config, badges, showSearchBar, ...searchBarProps } = props;
+  const { config, useMobileIconTypes, badges, showSearchBar, ...searchBarProps } = props;
 
   if ((!config || config.length === 0) && (!showSearchBar || !props.unifiedSearch)) {
     return null;
@@ -76,7 +89,13 @@ export function TopNavMenu<QT extends AggregateQuery | Query = Query>(
   }
 
   function renderMenu(className: string): ReactElement | null {
-    return <TopNavMenuItems config={config} className={className} />;
+    return (
+      <TopNavMenuItems
+        config={config}
+        className={className}
+        useMobileIconTypes={useMobileIconTypes}
+      />
+    );
   }
 
   function renderSearchBar(): ReactElement | null {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -15,6 +15,7 @@ import { MountPointPortal } from '@kbn/react-kibana-mount';
 import { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import { StatefulSearchBarProps } from '@kbn/unified-search-plugin/public';
 import { AggregateQuery, Query } from '@kbn/es-query';
+import { EuiBreakpointSize } from '@elastic/eui';
 import { TopNavMenuData } from './top_nav_menu_data';
 import { TopNavMenuItems } from './top_nav_menu_items';
 import { TopNavMenuBadgeProps, TopNavMenuBadges } from './top_nav_menu_badges';
@@ -51,6 +52,12 @@ export type TopNavMenuProps<QT extends Query | AggregateQuery = Query> = Omit<
    * ```
    */
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
+
+  /**
+   * A list of named breakpoints at which to show the popover version. If this is not provided, the top nav
+   * menu items will use the default set of ['xs', 's']
+   */
+  popoverBreakpoints?: EuiBreakpointSize[];
 };
 
 /*
@@ -76,7 +83,13 @@ export function TopNavMenu<QT extends AggregateQuery | Query = Query>(
   }
 
   function renderMenu(className: string): ReactElement | null {
-    return <TopNavMenuItems config={config} className={className} />;
+    return (
+      <TopNavMenuItems
+        config={config}
+        className={className}
+        popoverBreakpoints={props.popoverBreakpoints}
+      />
+    );
   }
 
   function renderSearchBar(): ReactElement | null {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -10,15 +10,15 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 
-import { MountPoint } from '@kbn/core/public';
+import type { MountPoint } from '@kbn/core/public';
 import { MountPointPortal } from '@kbn/react-kibana-mount';
-import { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
-import { StatefulSearchBarProps } from '@kbn/unified-search-plugin/public';
-import { AggregateQuery, Query } from '@kbn/es-query';
-import { EuiBreakpointSize } from '@elastic/eui';
-import { TopNavMenuData } from './top_nav_menu_data';
+import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
+import type { StatefulSearchBarProps } from '@kbn/unified-search-plugin/public';
+import type { AggregateQuery, Query } from '@kbn/es-query';
+import type { EuiBreakpointSize } from '@elastic/eui';
+import type { TopNavMenuData } from './top_nav_menu_data';
 import { TopNavMenuItems } from './top_nav_menu_items';
-import { TopNavMenuBadgeProps, TopNavMenuBadges } from './top_nav_menu_badges';
+import { type TopNavMenuBadgeProps, TopNavMenuBadges } from './top_nav_menu_badges';
 
 export type TopNavMenuProps<QT extends Query | AggregateQuery = Query> = Omit<
   StatefulSearchBarProps<QT>,
@@ -54,8 +54,7 @@ export type TopNavMenuProps<QT extends Query | AggregateQuery = Query> = Omit<
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
 
   /**
-   * A list of named breakpoints at which to show the popover version. If this is not provided, the top nav
-   * menu items will use the default set of ['xs', 's']
+   * A list of named breakpoints at which to show the popover version. If not provided, it will use the default set of ['xs', 's'] that is internally provided by EUI.
    */
   popoverBreakpoints?: EuiBreakpointSize[];
 };

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
@@ -19,24 +19,11 @@ import { TopNavMenuData } from './top_nav_menu_data';
 import { TopNavMenuItems } from './top_nav_menu_items';
 import { TopNavMenuBadgeProps, TopNavMenuBadges } from './top_nav_menu_badges';
 
-type TopNavMenuIconType = { mobileIconType: string } | { iconType: string };
-interface TopNavMenuPropsWithMobileIconTypes {
-  /** If `useMobileIconTypes=true`, then each data item requires either iconType or mobileIconType */
-  config?: Array<TopNavMenuData & TopNavMenuIconType>;
-  useMobileIconTypes: true;
-}
-interface TopNavMenuPropsWithoutMobileIconTypes {
-  config?: TopNavMenuData[];
-  useMobileIconTypes?: boolean;
-}
-type TopNavMenuPropsWithConfig =
-  | TopNavMenuPropsWithMobileIconTypes
-  | TopNavMenuPropsWithoutMobileIconTypes;
-
 export type TopNavMenuProps<QT extends Query | AggregateQuery = Query> = Omit<
   StatefulSearchBarProps<QT>,
   'kibana' | 'intl' | 'timeHistory'
 > & {
+  config?: TopNavMenuData[];
   badges?: TopNavMenuBadgeProps[];
   showSearchBar?: boolean;
   showQueryInput?: boolean;
@@ -64,7 +51,7 @@ export type TopNavMenuProps<QT extends Query | AggregateQuery = Query> = Omit<
    * ```
    */
   setMenuMountPoint?: (menuMount: MountPoint | undefined) => void;
-} & TopNavMenuPropsWithConfig;
+};
 
 /*
  * Top Nav Menu is a convenience wrapper component for:
@@ -78,7 +65,7 @@ export type TopNavMenuProps<QT extends Query | AggregateQuery = Query> = Omit<
 export function TopNavMenu<QT extends AggregateQuery | Query = Query>(
   props: TopNavMenuProps<QT>
 ): ReactElement | null {
-  const { config, useMobileIconTypes, badges, showSearchBar, ...searchBarProps } = props;
+  const { config, badges, showSearchBar, ...searchBarProps } = props;
 
   if ((!config || config.length === 0) && (!showSearchBar || !props.unifiedSearch)) {
     return null;
@@ -89,13 +76,7 @@ export function TopNavMenu<QT extends AggregateQuery | Query = Query>(
   }
 
   function renderMenu(className: string): ReactElement | null {
-    return (
-      <TopNavMenuItems
-        config={config}
-        className={className}
-        useMobileIconTypes={useMobileIconTypes}
-      />
-    );
+    return <TopNavMenuItems config={config} className={className} />;
   }
 
   function renderSearchBar(): ReactElement | null {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
@@ -26,12 +26,26 @@ export interface TopNavMenuData {
   fill?: boolean;
   color?: string;
   isLoading?: boolean;
-  iconType?: string;
   iconSide?: EuiButtonProps['iconSide'];
   target?: string;
   href?: string;
   intl?: InjectedIntl;
+  /**
+   * iconType places an icon to the side of the item label.
+   *
+   * On mobile, the label will be replaced with a button icon using this type, unless mobileIconType is specified.
+   * (requires the TopNavMenu prop useMobileIconTypes=true)
+   */
+  iconType?: string;
+  /**
+   * mobileIconType replaces the item label with an icon for mobile.
+   * (requires the TopNavMenu prop useMobileIconTypes=true)
+   */
+  mobileIconType?: string;
 }
+
+type TopNavMenuDataIconType = { mobileIconType: string } | { iconType: string };
+export type TopNavMenuDataWithIconType = TopNavMenuData & TopNavMenuDataIconType;
 
 export interface RegisteredTopNavMenuData extends TopNavMenuData {
   appName?: string;

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
@@ -26,26 +26,12 @@ export interface TopNavMenuData {
   fill?: boolean;
   color?: string;
   isLoading?: boolean;
+  iconType?: string;
   iconSide?: EuiButtonProps['iconSide'];
   target?: string;
   href?: string;
   intl?: InjectedIntl;
-  /**
-   * iconType places an icon to the side of the item label.
-   *
-   * On mobile, the label will be replaced with a button icon using this type, unless mobileIconType is specified.
-   * (requires the TopNavMenu prop useMobileIconTypes=true)
-   */
-  iconType?: string;
-  /**
-   * mobileIconType replaces the item label with an icon for mobile.
-   * (requires the TopNavMenu prop useMobileIconTypes=true)
-   */
-  mobileIconType?: string;
 }
-
-type TopNavMenuDataIconType = { mobileIconType: string } | { iconType: string };
-export type TopNavMenuDataWithIconType = TopNavMenuData & TopNavMenuDataIconType;
 
 export interface RegisteredTopNavMenuData extends TopNavMenuData {
   appName?: string;

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
@@ -9,10 +9,33 @@
 
 import { upperFirst, isFunction } from 'lodash';
 import React, { MouseEvent } from 'react';
-import { EuiToolTip, EuiButton, EuiHeaderLink, EuiBetaBadge, EuiButtonColor } from '@elastic/eui';
+import {
+  EuiToolTip,
+  EuiButton,
+  EuiHeaderLink,
+  EuiBetaBadge,
+  EuiButtonColor,
+  EuiButtonIcon,
+} from '@elastic/eui';
 import { TopNavMenuData } from './top_nav_menu_data';
 
-export function TopNavMenuItem(props: TopNavMenuData) {
+/** If forButtonIcons=true, then the iconType should be a valid string */
+interface TopNavMenuItemPropsButtonIcons {
+  forButtonIcons: true;
+  label?: TopNavMenuData['label'] | undefined;
+  iconType: string;
+  tooltip: TopNavMenuData['tooltip'];
+}
+interface TopNavMenuItemPropsTextLabel {
+  forButtonIcons?: false;
+  label: TopNavMenuData['label'] | undefined;
+}
+
+type TopNavMenuItemPropsLabelConfig = TopNavMenuItemPropsButtonIcons | TopNavMenuItemPropsTextLabel;
+
+type TopNavMenuItemProps = Omit<TopNavMenuData, 'label'> & TopNavMenuItemPropsLabelConfig;
+
+export function TopNavMenuItem(props: TopNavMenuItemProps) {
   function isDisabled(): boolean {
     const val = isFunction(props.disableButton) ? props.disableButton() : props.disableButton;
     return val!;
@@ -59,16 +82,25 @@ export function TopNavMenuItem(props: TopNavMenuData) {
       ? { onClick: undefined, href: props.href, target: props.target }
       : {};
 
-  // fill is not compatible with EuiHeaderLink
-  const btn = props.emphasize ? (
-    <EuiButton size="s" {...commonButtonProps} fill={props.fill ?? true}>
-      {getButtonContainer()}
-    </EuiButton>
-  ) : (
-    <EuiHeaderLink size="s" {...commonButtonProps} {...overrideProps}>
-      {getButtonContainer()}
-    </EuiHeaderLink>
-  );
+  let btn: React.JSX.Element;
+  if (props.forButtonIcons) {
+    btn = (
+      <EuiButtonIcon size="s" {...commonButtonProps} iconType={props.iconType}>
+        {getButtonContainer()}
+      </EuiButtonIcon>
+    );
+  } else {
+    // fill is not compatible with EuiHeaderLink
+    btn = props.emphasize ? (
+      <EuiButton size="s" {...commonButtonProps} fill={props.fill ?? true}>
+        {getButtonContainer()}
+      </EuiButton>
+    ) : (
+      <EuiHeaderLink size="s" {...commonButtonProps} {...overrideProps}>
+        {getButtonContainer()}
+      </EuiHeaderLink>
+    );
+  }
 
   const tooltip = getTooltip();
   if (tooltip) {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
@@ -9,33 +9,10 @@
 
 import { upperFirst, isFunction } from 'lodash';
 import React, { MouseEvent } from 'react';
-import {
-  EuiToolTip,
-  EuiButton,
-  EuiHeaderLink,
-  EuiBetaBadge,
-  EuiButtonColor,
-  EuiButtonIcon,
-} from '@elastic/eui';
+import { EuiToolTip, EuiButton, EuiHeaderLink, EuiBetaBadge, EuiButtonColor } from '@elastic/eui';
 import { TopNavMenuData } from './top_nav_menu_data';
 
-/** If forButtonIcons=true, then the iconType should be a valid string */
-interface TopNavMenuItemPropsButtonIcons {
-  forButtonIcons: true;
-  label?: TopNavMenuData['label'] | undefined;
-  iconType: string;
-  tooltip: TopNavMenuData['tooltip'];
-}
-interface TopNavMenuItemPropsTextLabel {
-  forButtonIcons?: false;
-  label: TopNavMenuData['label'] | undefined;
-}
-
-type TopNavMenuItemPropsLabelConfig = TopNavMenuItemPropsButtonIcons | TopNavMenuItemPropsTextLabel;
-
-type TopNavMenuItemProps = Omit<TopNavMenuData, 'label'> & TopNavMenuItemPropsLabelConfig;
-
-export function TopNavMenuItem(props: TopNavMenuItemProps) {
+export function TopNavMenuItem(props: TopNavMenuData) {
   function isDisabled(): boolean {
     const val = isFunction(props.disableButton) ? props.disableButton() : props.disableButton;
     return val!;
@@ -82,25 +59,16 @@ export function TopNavMenuItem(props: TopNavMenuItemProps) {
       ? { onClick: undefined, href: props.href, target: props.target }
       : {};
 
-  let btn: React.JSX.Element;
-  if (props.forButtonIcons) {
-    btn = (
-      <EuiButtonIcon size="s" {...commonButtonProps} iconType={props.iconType}>
-        {getButtonContainer()}
-      </EuiButtonIcon>
-    );
-  } else {
-    // fill is not compatible with EuiHeaderLink
-    btn = props.emphasize ? (
-      <EuiButton size="s" {...commonButtonProps} fill={props.fill ?? true}>
-        {getButtonContainer()}
-      </EuiButton>
-    ) : (
-      <EuiHeaderLink size="s" {...commonButtonProps} {...overrideProps}>
-        {getButtonContainer()}
-      </EuiHeaderLink>
-    );
-  }
+  // fill is not compatible with EuiHeaderLink
+  const btn = props.emphasize ? (
+    <EuiButton size="s" {...commonButtonProps} fill={props.fill ?? true}>
+      {getButtonContainer()}
+    </EuiButton>
+  ) : (
+    <EuiHeaderLink size="s" {...commonButtonProps} {...overrideProps}>
+      {getButtonContainer()}
+    </EuiHeaderLink>
+  );
 
   const tooltip = getTooltip();
   if (tooltip) {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_items.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_items.tsx
@@ -7,21 +7,30 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiHeaderLinks } from '@elastic/eui';
+import { EuiBreakpointSize, EuiHeaderLinks } from '@elastic/eui';
 import React from 'react';
 import type { TopNavMenuData } from './top_nav_menu_data';
 import { TopNavMenuItem } from './top_nav_menu_item';
 
+interface TopNavMenuItemsProps {
+  config: TopNavMenuData[] | undefined;
+  className?: string;
+  popoverBreakpoints?: EuiBreakpointSize[];
+}
+
 export const TopNavMenuItems = ({
   config,
   className,
-}: {
-  config: TopNavMenuData[] | undefined;
-  className?: string;
-}) => {
+  popoverBreakpoints,
+}: TopNavMenuItemsProps) => {
   if (!config || config.length === 0) return null;
   return (
-    <EuiHeaderLinks data-test-subj="top-nav" gutterSize="xs" className={className}>
+    <EuiHeaderLinks
+      data-test-subj="top-nav"
+      gutterSize="xs"
+      className={className}
+      popoverBreakpoints={popoverBreakpoints}
+    >
       {config.map((menuItem: TopNavMenuData, i: number) => {
         return <TopNavMenuItem key={`nav-menu-${i}`} {...menuItem} />;
       })}

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_items.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_items.tsx
@@ -7,67 +7,19 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiHeaderLinks, EuiShowFor } from '@elastic/eui';
+import { EuiHeaderLinks } from '@elastic/eui';
 import React from 'react';
 import type { TopNavMenuData } from './top_nav_menu_data';
 import { TopNavMenuItem } from './top_nav_menu_item';
 
-/** If useMobileIconTypes=true, then the config array should contain items that have a valid iconType or mobileIconType */
-type TopNavMenuItemsIconType = { mobileIconType: string } | { iconType: string };
-interface TopNavMenuItemsPropsButtonIcons {
-  config: Array<TopNavMenuData & TopNavMenuItemsIconType>;
-  useMobileIconTypes: true;
-}
-/** If useMobileIconTypes=false, then the config array will have "typical" TopNavMenuData items */
-interface TopNavMenuItemsPropsTextLabel {
+export const TopNavMenuItems = ({
+  config,
+  className,
+}: {
   config: TopNavMenuData[] | undefined;
-  useMobileIconTypes?: boolean;
-}
-
-type TopNavMenuItemsPropsButtonConfig =
-  | TopNavMenuItemsPropsButtonIcons
-  | TopNavMenuItemsPropsTextLabel;
-
-type TopNavMenuItemsProps = {
   className?: string;
-} & TopNavMenuItemsPropsButtonConfig;
-
-export const TopNavMenuItems = (props: TopNavMenuItemsProps) => {
-  const { config, className, useMobileIconTypes } = props;
+}) => {
   if (!config || config.length === 0) return null;
-
-  // on ['m'] size, button icons will overlap the breadcrumbs on the left-hand-side of the top nav
-  const sizesForButtonIcons = ['m'];
-  // on ['xs', 's'] size, text buttons will appear inside of a popover
-  const sizesForTextButtons = ['xs', 's', 'l', 'xl'];
-
-  if (useMobileIconTypes) {
-    return (
-      <EuiHeaderLinks data-test-subj="top-nav" gutterSize="xs" className={className}>
-        <EuiShowFor sizes={sizesForButtonIcons}>
-          {config.map((menuItem, i) => {
-            const { mobileIconType, iconType, label, tooltip, ...navMenuItem } = menuItem;
-            const navItemIconType = mobileIconType ?? iconType;
-            return (
-              <TopNavMenuItem
-                key={`nav-menu-${i}`}
-                forButtonIcons={true}
-                iconType={navItemIconType!}
-                tooltip={tooltip ?? label}
-                {...navMenuItem}
-              />
-            );
-          })}
-        </EuiShowFor>
-        <EuiShowFor sizes={sizesForTextButtons}>
-          {config.map((menuItem: TopNavMenuData, i: number) => {
-            return <TopNavMenuItem key={`nav-menu-${i}`} {...menuItem} />;
-          })}
-        </EuiShowFor>
-      </EuiHeaderLinks>
-    );
-  }
-
   return (
     <EuiHeaderLinks data-test-subj="top-nav" gutterSize="xs" className={className}>
       {config.map((menuItem: TopNavMenuData, i: number) => {

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_items.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_items.tsx
@@ -7,19 +7,67 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiHeaderLinks } from '@elastic/eui';
+import { EuiHeaderLinks, EuiShowFor } from '@elastic/eui';
 import React from 'react';
 import type { TopNavMenuData } from './top_nav_menu_data';
 import { TopNavMenuItem } from './top_nav_menu_item';
 
-export const TopNavMenuItems = ({
-  config,
-  className,
-}: {
+/** If useMobileIconTypes=true, then the config array should contain items that have a valid iconType or mobileIconType */
+type TopNavMenuItemsIconType = { mobileIconType: string } | { iconType: string };
+interface TopNavMenuItemsPropsButtonIcons {
+  config: Array<TopNavMenuData & TopNavMenuItemsIconType>;
+  useMobileIconTypes: true;
+}
+/** If useMobileIconTypes=false, then the config array will have "typical" TopNavMenuData items */
+interface TopNavMenuItemsPropsTextLabel {
   config: TopNavMenuData[] | undefined;
+  useMobileIconTypes?: boolean;
+}
+
+type TopNavMenuItemsPropsButtonConfig =
+  | TopNavMenuItemsPropsButtonIcons
+  | TopNavMenuItemsPropsTextLabel;
+
+type TopNavMenuItemsProps = {
   className?: string;
-}) => {
+} & TopNavMenuItemsPropsButtonConfig;
+
+export const TopNavMenuItems = (props: TopNavMenuItemsProps) => {
+  const { config, className, useMobileIconTypes } = props;
   if (!config || config.length === 0) return null;
+
+  // on ['m'] size, button icons will overlap the breadcrumbs on the left-hand-side of the top nav
+  const sizesForButtonIcons = ['m'];
+  // on ['xs', 's'] size, text buttons will appear inside of a popover
+  const sizesForTextButtons = ['xs', 's', 'l', 'xl'];
+
+  if (useMobileIconTypes) {
+    return (
+      <EuiHeaderLinks data-test-subj="top-nav" gutterSize="xs" className={className}>
+        <EuiShowFor sizes={sizesForButtonIcons}>
+          {config.map((menuItem, i) => {
+            const { mobileIconType, iconType, label, tooltip, ...navMenuItem } = menuItem;
+            const navItemIconType = mobileIconType ?? iconType;
+            return (
+              <TopNavMenuItem
+                key={`nav-menu-${i}`}
+                forButtonIcons={true}
+                iconType={navItemIconType!}
+                tooltip={tooltip ?? label}
+                {...navMenuItem}
+              />
+            );
+          })}
+        </EuiShowFor>
+        <EuiShowFor sizes={sizesForTextButtons}>
+          {config.map((menuItem: TopNavMenuData, i: number) => {
+            return <TopNavMenuItem key={`nav-menu-${i}`} {...menuItem} />;
+          })}
+        </EuiShowFor>
+      </EuiHeaderLinks>
+    );
+  }
+
   return (
     <EuiHeaderLinks data-test-subj="top-nav" gutterSize="xs" className={className}>
       {config.map((menuItem: TopNavMenuData, i: number) => {

--- a/x-pack/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.test.tsx
@@ -204,7 +204,6 @@ describe('Lens App', () => {
           topNavMenuEntryGenerators: [
             () => ({
               label: 'My entry',
-              iconType: 'pencil',
               run: runFn,
             }),
           ],

--- a/x-pack/plugins/lens/public/app_plugin/app.test.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.test.tsx
@@ -204,6 +204,7 @@ describe('Lens App', () => {
           topNavMenuEntryGenerators: [
             () => ({
               label: 'My entry',
+              iconType: 'pencil',
               run: runFn,
             }),
           ],

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -10,7 +10,7 @@ import { i18n } from '@kbn/i18n';
 import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { AggregateQuery, isOfAggregateQueryType, Query } from '@kbn/es-query';
 import { useStore } from 'react-redux';
-import { TopNavMenuDataWithIconType, TopNavMenuProps } from '@kbn/navigation-plugin/public';
+import { TopNavMenuData, TopNavMenuProps } from '@kbn/navigation-plugin/public';
 import { getEsQueryConfig } from '@kbn/data-plugin/public';
 import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -111,7 +111,7 @@ function getLensTopNavConfig(options: {
   showReplaceInDashboard: boolean;
   showReplaceInCanvas: boolean;
   contextFromEmbeddable?: boolean;
-}): TopNavMenuDataWithIconType[] {
+}): TopNavMenuData[] {
   const {
     actions,
     savingToLibraryPermitted,
@@ -122,7 +122,7 @@ function getLensTopNavConfig(options: {
     contextFromEmbeddable,
     isByValueMode,
   } = options;
-  const topNavMenu: TopNavMenuDataWithIconType[] = [];
+  const topNavMenu: TopNavMenuData[] = [];
 
   const showSaveAndReturn = actions.saveAndReturn.visible;
 
@@ -148,7 +148,6 @@ function getLensTopNavConfig(options: {
         defaultMessage: `Go back to {contextOriginatingApp}`,
         values: { contextOriginatingApp },
       }),
-      mobileIconType: 'exit',
       run: actions.goBack.execute,
       className: 'lnsNavItem__withDivider',
       testId: 'lnsApp_goBackToAppButton',
@@ -167,7 +166,6 @@ function getLensTopNavConfig(options: {
 
     topNavMenu.push({
       label: exploreDataInDiscoverLabel,
-      mobileIconType: 'discoverApp',
       run: actions.getUnderlyingDataUrl.execute,
       testId: 'lnsApp_openInDiscover',
       className: 'lnsNavItem__withDivider',
@@ -183,7 +181,6 @@ function getLensTopNavConfig(options: {
     label: i18n.translate('xpack.lens.app.inspect', {
       defaultMessage: 'Inspect',
     }),
-    mobileIconType: 'inspect',
     run: actions.inspect.execute,
     testId: 'lnsApp_inspectButton',
     description: i18n.translate('xpack.lens.app.inspectAriaLabel', {
@@ -197,7 +194,6 @@ function getLensTopNavConfig(options: {
       label: i18n.translate('xpack.lens.app.shareTitle', {
         defaultMessage: 'Share',
       }),
-      mobileIconType: 'share',
       run: actions.share.execute,
       testId: 'lnsApp_shareButton',
       description: i18n.translate('xpack.lens.app.shareTitleAria', {
@@ -212,7 +208,6 @@ function getLensTopNavConfig(options: {
     label: i18n.translate('xpack.lens.app.settings', {
       defaultMessage: 'Settings',
     }),
-    mobileIconType: 'gear',
     run: actions.openSettings.execute,
     className: 'lnsNavItem__withDivider',
     testId: 'lnsApp_settingsButton',
@@ -226,7 +221,6 @@ function getLensTopNavConfig(options: {
       label: i18n.translate('xpack.lens.app.cancel', {
         defaultMessage: 'Cancel',
       }),
-      mobileIconType: 'crossInCircle',
       run: actions.cancel.execute,
       testId: 'lnsApp_cancelButton',
       description: i18n.translate('xpack.lens.app.cancelButtonAriaLabel', {
@@ -237,7 +231,6 @@ function getLensTopNavConfig(options: {
 
   topNavMenu.push({
     label: saveButtonLabel,
-    mobileIconType: 'save',
     iconType: (showReplaceInDashboard || showReplaceInCanvas ? false : !showSaveAndReturn)
       ? 'save'
       : undefined,
@@ -260,7 +253,6 @@ function getLensTopNavConfig(options: {
   if (saveButtonMeta) {
     topNavMenu.push({
       ...saveButtonMeta,
-      mobileIconType: saveButtonMeta.iconType ?? 'save',
       run: actions.saveAndReturn.execute,
       disableButton: !actions.saveAndReturn.enabled,
     });
@@ -470,7 +462,7 @@ export const LensTopNavMenu = ({
     defaultMessage: 'Lens Visualization [{date}]',
     values: { date: moment().toISOString(true) },
   });
-  const additionalMenuEntries = useMemo<TopNavMenuDataWithIconType[] | undefined>(() => {
+  const additionalMenuEntries = useMemo(() => {
     if (!visualization.activeId) return undefined;
     const visualizationId = visualization.activeId;
     const entries = topNavMenuEntryGenerators.flatMap((menuEntryGenerator) => {
@@ -535,7 +527,7 @@ export const LensTopNavMenu = ({
 
   const adHocDataViews = indexPatterns.filter((pattern) => !pattern.isPersisted());
 
-  const topNavConfig = useMemo<TopNavMenuDataWithIconType[]>(() => {
+  const topNavConfig = useMemo(() => {
     const showReplaceInDashboard =
       initialContext?.originatingApp === 'dashboards' &&
       !(initialInput as LensByReferenceInput)?.savedObjectId;
@@ -1080,7 +1072,6 @@ export const LensTopNavMenu = ({
     <AggregateQueryTopNavMenu
       setMenuMountPoint={setHeaderActionMenu}
       config={topNavConfig}
-      useMobileIconTypes={true}
       saveQueryMenuVisibility={
         application.capabilities.visualize.saveQuery
           ? 'allowed_by_app_privilege'

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -10,7 +10,7 @@ import { i18n } from '@kbn/i18n';
 import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { AggregateQuery, isOfAggregateQueryType, Query } from '@kbn/es-query';
 import { useStore } from 'react-redux';
-import { TopNavMenuData, TopNavMenuProps } from '@kbn/navigation-plugin/public';
+import { TopNavMenuDataWithIconType, TopNavMenuProps } from '@kbn/navigation-plugin/public';
 import { getEsQueryConfig } from '@kbn/data-plugin/public';
 import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -111,7 +111,7 @@ function getLensTopNavConfig(options: {
   showReplaceInDashboard: boolean;
   showReplaceInCanvas: boolean;
   contextFromEmbeddable?: boolean;
-}): TopNavMenuData[] {
+}): TopNavMenuDataWithIconType[] {
   const {
     actions,
     savingToLibraryPermitted,
@@ -122,7 +122,7 @@ function getLensTopNavConfig(options: {
     contextFromEmbeddable,
     isByValueMode,
   } = options;
-  const topNavMenu: TopNavMenuData[] = [];
+  const topNavMenu: TopNavMenuDataWithIconType[] = [];
 
   const showSaveAndReturn = actions.saveAndReturn.visible;
 
@@ -148,6 +148,7 @@ function getLensTopNavConfig(options: {
         defaultMessage: `Go back to {contextOriginatingApp}`,
         values: { contextOriginatingApp },
       }),
+      mobileIconType: 'exit',
       run: actions.goBack.execute,
       className: 'lnsNavItem__withDivider',
       testId: 'lnsApp_goBackToAppButton',
@@ -166,6 +167,7 @@ function getLensTopNavConfig(options: {
 
     topNavMenu.push({
       label: exploreDataInDiscoverLabel,
+      mobileIconType: 'discoverApp',
       run: actions.getUnderlyingDataUrl.execute,
       testId: 'lnsApp_openInDiscover',
       className: 'lnsNavItem__withDivider',
@@ -181,6 +183,7 @@ function getLensTopNavConfig(options: {
     label: i18n.translate('xpack.lens.app.inspect', {
       defaultMessage: 'Inspect',
     }),
+    mobileIconType: 'inspect',
     run: actions.inspect.execute,
     testId: 'lnsApp_inspectButton',
     description: i18n.translate('xpack.lens.app.inspectAriaLabel', {
@@ -194,6 +197,7 @@ function getLensTopNavConfig(options: {
       label: i18n.translate('xpack.lens.app.shareTitle', {
         defaultMessage: 'Share',
       }),
+      mobileIconType: 'share',
       run: actions.share.execute,
       testId: 'lnsApp_shareButton',
       description: i18n.translate('xpack.lens.app.shareTitleAria', {
@@ -208,6 +212,7 @@ function getLensTopNavConfig(options: {
     label: i18n.translate('xpack.lens.app.settings', {
       defaultMessage: 'Settings',
     }),
+    mobileIconType: 'gear',
     run: actions.openSettings.execute,
     className: 'lnsNavItem__withDivider',
     testId: 'lnsApp_settingsButton',
@@ -221,6 +226,7 @@ function getLensTopNavConfig(options: {
       label: i18n.translate('xpack.lens.app.cancel', {
         defaultMessage: 'Cancel',
       }),
+      mobileIconType: 'crossInCircle',
       run: actions.cancel.execute,
       testId: 'lnsApp_cancelButton',
       description: i18n.translate('xpack.lens.app.cancelButtonAriaLabel', {
@@ -231,6 +237,7 @@ function getLensTopNavConfig(options: {
 
   topNavMenu.push({
     label: saveButtonLabel,
+    mobileIconType: 'save',
     iconType: (showReplaceInDashboard || showReplaceInCanvas ? false : !showSaveAndReturn)
       ? 'save'
       : undefined,
@@ -253,6 +260,7 @@ function getLensTopNavConfig(options: {
   if (saveButtonMeta) {
     topNavMenu.push({
       ...saveButtonMeta,
+      mobileIconType: saveButtonMeta.iconType ?? 'save',
       run: actions.saveAndReturn.execute,
       disableButton: !actions.saveAndReturn.enabled,
     });
@@ -462,7 +470,7 @@ export const LensTopNavMenu = ({
     defaultMessage: 'Lens Visualization [{date}]',
     values: { date: moment().toISOString(true) },
   });
-  const additionalMenuEntries = useMemo(() => {
+  const additionalMenuEntries = useMemo<TopNavMenuDataWithIconType[] | undefined>(() => {
     if (!visualization.activeId) return undefined;
     const visualizationId = visualization.activeId;
     const entries = topNavMenuEntryGenerators.flatMap((menuEntryGenerator) => {
@@ -527,7 +535,7 @@ export const LensTopNavMenu = ({
 
   const adHocDataViews = indexPatterns.filter((pattern) => !pattern.isPersisted());
 
-  const topNavConfig = useMemo(() => {
+  const topNavConfig = useMemo<TopNavMenuDataWithIconType[]>(() => {
     const showReplaceInDashboard =
       initialContext?.originatingApp === 'dashboards' &&
       !(initialInput as LensByReferenceInput)?.savedObjectId;
@@ -1072,6 +1080,7 @@ export const LensTopNavMenu = ({
     <AggregateQueryTopNavMenu
       setMenuMountPoint={setHeaderActionMenu}
       config={topNavConfig}
+      useMobileIconTypes={true}
       saveQueryMenuVisibility={
         application.capabilities.visualize.saveQuery
           ? 'allowed_by_app_privilege'

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -1071,6 +1071,7 @@ export const LensTopNavMenu = ({
   return (
     <AggregateQueryTopNavMenu
       setMenuMountPoint={setHeaderActionMenu}
+      popoverBreakpoints={['xs', 's', 'm']}
       config={topNavConfig}
       saveQueryMenuVisibility={
         application.capabilities.visualize.saveQuery

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -8,6 +8,7 @@ import type { Ast } from '@kbn/interpreter';
 import type { IconType } from '@elastic/eui/src/components/icon/icon';
 import type { CoreStart, SavedObjectReference, ResolvedSimpleSavedObject } from '@kbn/core/public';
 import type { ColorMapping, PaletteOutput } from '@kbn/coloring';
+import type { TopNavMenuData } from '@kbn/navigation-plugin/public';
 import type { MutableRefObject, ReactElement } from 'react';
 import type { Filter, TimeRange } from '@kbn/es-query';
 import type {
@@ -45,7 +46,6 @@ import { EventAnnotationGroupConfig } from '@kbn/event-annotation-common';
 import type { DraggingIdentifier, DragDropIdentifier, DropType } from '@kbn/dom-drag-drop';
 import type { AccessorConfig } from '@kbn/visualization-ui-components';
 import type { ChartSizeEvent } from '@kbn/chart-expressions-common';
-import { TopNavMenuDataWithIconType } from '@kbn/navigation-plugin/public';
 import type { DateRange, LayerType, SortingHint } from '../common/types';
 import type {
   LensSortActionData,
@@ -1455,7 +1455,7 @@ export type LensTopNavMenuEntryGenerator = (props: {
   filters: Filter[];
   initialContext?: VisualizeFieldContext | VisualizeEditorContext;
   currentDoc: Document | undefined;
-}) => undefined | TopNavMenuDataWithIconType;
+}) => undefined | TopNavMenuData;
 
 export interface LensCellValueAction {
   id: string;

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -8,7 +8,6 @@ import type { Ast } from '@kbn/interpreter';
 import type { IconType } from '@elastic/eui/src/components/icon/icon';
 import type { CoreStart, SavedObjectReference, ResolvedSimpleSavedObject } from '@kbn/core/public';
 import type { ColorMapping, PaletteOutput } from '@kbn/coloring';
-import type { TopNavMenuData } from '@kbn/navigation-plugin/public';
 import type { MutableRefObject, ReactElement } from 'react';
 import type { Filter, TimeRange } from '@kbn/es-query';
 import type {
@@ -46,6 +45,7 @@ import { EventAnnotationGroupConfig } from '@kbn/event-annotation-common';
 import type { DraggingIdentifier, DragDropIdentifier, DropType } from '@kbn/dom-drag-drop';
 import type { AccessorConfig } from '@kbn/visualization-ui-components';
 import type { ChartSizeEvent } from '@kbn/chart-expressions-common';
+import { TopNavMenuDataWithIconType } from '@kbn/navigation-plugin/public';
 import type { DateRange, LayerType, SortingHint } from '../common/types';
 import type {
   LensSortActionData,
@@ -1455,7 +1455,7 @@ export type LensTopNavMenuEntryGenerator = (props: {
   filters: Filter[];
   initialContext?: VisualizeFieldContext | VisualizeEditorContext;
   currentDoc: Document | undefined;
-}) => undefined | TopNavMenuData;
+}) => undefined | TopNavMenuDataWithIconType;
 
 export interface LensCellValueAction {
   id: string;


### PR DESCRIPTION
## Summary

Closes #154414

Allows customization of `popoverBreakpoints` that are passed to `EuiHeaderLinks`. See https://eui.elastic.co/#/layout/header#header-links

BEFORE

![before-bldx7lhzrxkzrxkyzr](https://github.com/user-attachments/assets/798836b1-f254-4f11-bda4-803caf0e02e5)

AFTER

![after-bldx7lhzrxkzrxkyzr](https://github.com/user-attachments/assets/c227746b-00b0-4a41-9982-00b7cfb7e084)

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->