### PR TITLE
[SecuritySolution][Threat Intelligence] - re-enable Cypress test skipped because of removal of bsearch

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/indicators.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/indicators.cy.ts
@@ -67,8 +67,7 @@ const URL = '/app/security/threat_intelligence/indicators';
 const URL_WITH_CONTRADICTORY_FILTERS =
   '/app/security/threat_intelligence/indicators?indicators=(filterQuery:(language:kuery,query:%27%27),filters:!((%27$state%27:(store:appState),meta:(alias:!n,disabled:!f,index:%27%27,key:threat.indicator.type,negate:!f,params:(query:file),type:phrase),query:(match_phrase:(threat.indicator.type:file))),(%27$state%27:(store:appState),meta:(alias:!n,disabled:!f,index:%27%27,key:threat.indicator.type,negate:!f,params:(query:url),type:phrase),query:(match_phrase:(threat.indicator.type:url)))),timeRange:(from:now/d,to:now/d))';
 
-// Failing: See https://github.com/elastic/kibana/issues/195804
-describe.skip('Single indicator', { tags: ['@ess'] }, () => {
+describe('Single indicator', { tags: ['@ess'] }, () => {
   before(() => cy.task('esArchiverLoad', { archiveName: 'ti_indicators_data_single' }));
 
   after(() => cy.task('esArchiverUnload', { archiveName: 'ti_indicators_data_single' }));
@@ -270,6 +269,7 @@ describe('Multiple indicators', { tags: ['@ess'] }, () => {
     });
 
     it('should handle all search actions', () => {
+      // TODO fix
       cy.log('should narrow the results to url indicators when respective KQL search is executed');
 
       enterQuery('threat.indicator.type: "url"{enter}');
@@ -299,7 +299,7 @@ describe('Multiple indicators', { tags: ['@ess'] }, () => {
 
       cy.log('should reload the data when refresh button is pressed');
 
-      cy.intercept(/bsearch/).as('search');
+      cy.intercept('POST', '/internal/search/threatIntelligenceSearchStrategy').as('search');
       cy.get(REFRESH_BUTTON).should('exist').click();
       cy.wait('@search');
     });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/indicators.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/indicators.cy.ts
@@ -269,7 +269,6 @@ describe('Multiple indicators', { tags: ['@ess'] }, () => {
     });
 
     it('should handle all search actions', () => {
-      // TODO fix
       cy.log('should narrow the results to url indicators when respective KQL search is executed');
 
       enterQuery('threat.indicator.type: "url"{enter}');


### PR DESCRIPTION
## Summary

A Threat Intelligence Cypress test [was skipped](https://github.com/elastic/kibana/commit/35bbb49176c3a933ca6d68e770602bdb2931e71f) (see ticket [here](https://github.com/elastic/kibana/issues/195804)) because [this PR](https://github.com/elastic/kibana/pull/192789) that disables `bfetch` by default was merged shortly before. I'm not sure why we merged a PR that breaks Cypress tests, and skipped these tests instead of reverting the PR...

This PR fixes the issue by intercepting the correct `/internal/search/threatIntelligenceSearchStrategy` call and re-enables the test suite.

![Screenshot 2024-10-10 at 3 52 05 PM](https://github.com/user-attachments/assets/af7245b8-3bb9-438f-a0ec-2b69fa3a0300)
