### PR TITLE
Fixes `/internal/security/me` serverless test

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/platform_security/authentication.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/platform_security/authentication.ts
@@ -160,7 +160,7 @@ export default function ({ getService }: FtrProviderContext) {
                 type: 'saml',
               },
               enabled: true,
-              full_name: 'test viewer',
+              roles: [expect.stringContaining('viewer')],
             })
           );
           expect(status).toBe(200);


### PR DESCRIPTION
## Summary

Replaces the name check with role check. The full name of the user is different between local and MKI environments. 