### PR TITLE
Tag deployment agnostic serverless tests with esGate

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.index.ts
@@ -7,7 +7,9 @@
 import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
-  describe('Serverless Observability - Deployment-agnostic api integration tests', () => {
+  describe('Serverless Observability - Deployment-agnostic api integration tests', function () {
+    this.tags(['esGate']);
+
     // load new oblt and platform deployment-agnostic test here
     loadTestFile(require.resolve('../../apis/console'));
     loadTestFile(require.resolve('../../apis/core'));

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/search.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/search.index.ts
@@ -7,7 +7,9 @@
 import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
-  describe('Serverless Search - Deployment-agnostic api integration tests', () => {
+  describe('Serverless Search - Deployment-agnostic api integration tests', function () {
+    this.tags(['esGate']);
+
     // load new search and platform deployment-agnostic test here
     loadTestFile(require.resolve('../../apis/console'));
     loadTestFile(require.resolve('../../apis/core'));

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/security.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/security.index.ts
@@ -7,7 +7,9 @@
 import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
-  describe('Serverless Security - Deployment-agnostic api integration tests', () => {
+  describe('Serverless Security - Deployment-agnostic api integration tests', function () {
+    this.tags(['esGate']);
+
     // load new security and platform deployment-agnostic test here
     loadTestFile(require.resolve('../../apis/console'));
     loadTestFile(require.resolve('../../apis/core'));


### PR DESCRIPTION
## Summary

This PR adds the `esGate` tag to the serverless tests in the deployment agnostic test directory. This will make sure these tests are run as part of the Elasticsearch serverless checks.

Related to #195813 where the deployment agnostic test configs are added to the pipeline for the Kibana side.