### PR TITLE
[CI] Update triggered pipeline name for Click-to-deploy

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -51,7 +51,7 @@
     {
       "repoOwner": "elastic",
       "repoName": "kibana",
-      "pipelineSlug": "kibana-deploy-project",
+      "pipelineSlug": "kibana-deploy-project-from-pr",
 
       "enabled": true,
       "allow_org_users": true,
@@ -64,7 +64,7 @@
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:deploy)\\W+(?:project))$",
       "kibana_versions_check": true,
       "kibana_build_reuse": true,
-      "kibana_build_reuse_pipeline_slugs": ["kibana-pull-request", "kibana-on-merge", "kibana-deploy-project"],
+      "kibana_build_reuse_pipeline_slugs": ["kibana-pull-request", "kibana-on-merge", "kibana-deploy-project-from-pr"],
       "kibana_build_reuse_regexes": [
         "^test/",
         "^x-pack/test/",


### PR DESCRIPTION
## Summary
We've added a new pipeline in #195581, where the name update wasn't synced to the PR configuration, so the new button is looking for a non-existent pipeline.

This PR updates the target 