### PR TITLE
[CI] Add timeouts for retries for docker image build

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/build_docker_sh.template.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/build_docker_sh.template.ts
@@ -57,7 +57,8 @@ function generator({
         echo "Docker pull successful."
         break
       else
-        echo "Docker pull unsuccessful, attempt '$attempt'."
+        echo "Docker pull unsuccessful, attempt '$attempt'. Retrying in 15s"
+        sleep 15
       fi
 
     done


### PR DESCRIPTION
## Summary
The generated version of the docker image builder script didn't have timeouts between retries, so a temporary outage on `docker.elastic.co` would cause a docker pull error, failing the build (see: https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/4845#01927b40-43f9-471e-9e2c-407320fac978)

This PR adds a fix 15s per retry to the docker build runner.

<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->