### PR TITLE
[Security Solution] Skip recently added tests for updating restricted fields in prebuilt rules

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
@@ -241,7 +241,8 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+      // Unskip: https://github.com/elastic/kibana/issues/195921
+      it('@skipInServerlessMKI throws an error if rule has external rule source and non-customizable fields are changed', async () => {
         // Install base prebuilt detection rule
         await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
           createRuleAssetSavedObject({ rule_id: 'rule-1', author: ['elastic'] }),

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules_bulk.ts
@@ -351,7 +351,8 @@ export default ({ getService }: FtrProviderContext) => {
         ]);
       });
 
-      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+      // Unskip: https://github.com/elastic/kibana/issues/195921
+      it('@skipInServerlessMKI throws an error if rule has external rule source and non-customizable fields are changed', async () => {
         // Install base prebuilt detection rule
         await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
           createRuleAssetSavedObject({ rule_id: 'rule-1', author: ['elastic'] }),

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules.ts
@@ -313,7 +313,8 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+      // Unskip: https://github.com/elastic/kibana/issues/195921
+      it('@skipInServerlessMKI throws an error if rule has external rule source and non-customizable fields are changed', async () => {
         // Install base prebuilt detection rule
         await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
           createRuleAssetSavedObject({ rule_id: 'rule-1', license: 'elastic' }),

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules_bulk.ts
@@ -374,7 +374,8 @@ export default ({ getService }: FtrProviderContext) => {
         ]);
       });
 
-      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+      // Unskip: https://github.com/elastic/kibana/issues/195921
+      it('@skipInServerlessMKI throws an error if rule has external rule source and non-customizable fields are changed', async () => {
         // Install base prebuilt detection rule
         await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
           createRuleAssetSavedObject({ rule_id: 'rule-1', author: ['elastic'] }),


### PR DESCRIPTION
## Summary

The new tests added yesterday in https://github.com/elastic/kibana/pull/195318 have failed in the periodic pipeline ([build](https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-rule-management/builds/1408#019279c2-233d-405e-8758-7864b84d0524)).

Skipping for now in MKI pipelines (periodic pipeline and the 2nd quality gate), otherwise it will block the next Serverless release.

Ticket for unskipping: https://github.com/elastic/kibana/issues/195921
