### PR TITLE
[Visualizations] Show TSVB and Agg based as "legacy" when users create visualizations from the library

### DIFF
--- a/src/plugins/vis_type_markdown/public/markdown_vis.ts
+++ b/src/plugins/vis_type_markdown/public/markdown_vis.ts
@@ -21,7 +21,7 @@ export const markdownVisDefinition: VisTypeDefinition<MarkdownVisParams> = {
   title: 'Markdown',
   isAccessible: true,
   icon: 'visText',
-  group: VisGroups.TOOLS,
+  group: VisGroups.LEGACY,
   titleInWizard: i18n.translate('visTypeMarkdown.markdownTitleInWizard', {
     defaultMessage: 'Markdown text',
   }),

--- a/src/plugins/vis_type_markdown/public/markdown_vis.ts
+++ b/src/plugins/vis_type_markdown/public/markdown_vis.ts
@@ -26,7 +26,7 @@ export const markdownVisDefinition: VisTypeDefinition<MarkdownVisParams> = {
     defaultMessage: 'Markdown text',
   }),
   description: i18n.translate('visTypeMarkdown.markdownDescription', {
-    defaultMessage: 'Legacy tool for adding text or images to dashboards.',
+    defaultMessage: 'Add custom text or images to dashboards.',
   }),
   order: 30,
   toExpressionAst,

--- a/src/plugins/vis_type_markdown/public/markdown_vis.ts
+++ b/src/plugins/vis_type_markdown/public/markdown_vis.ts
@@ -21,7 +21,7 @@ export const markdownVisDefinition: VisTypeDefinition<MarkdownVisParams> = {
   title: 'Markdown',
   isAccessible: true,
   icon: 'visText',
-  group: VisGroups.LEGACY,
+  group: VisGroups.TOOLS,
   titleInWizard: i18n.translate('visTypeMarkdown.markdownTitleInWizard', {
     defaultMessage: 'Markdown text',
   }),

--- a/src/plugins/vis_type_markdown/public/markdown_vis.ts
+++ b/src/plugins/vis_type_markdown/public/markdown_vis.ts
@@ -23,10 +23,10 @@ export const markdownVisDefinition: VisTypeDefinition<MarkdownVisParams> = {
   icon: 'visText',
   group: VisGroups.TOOLS,
   titleInWizard: i18n.translate('visTypeMarkdown.markdownTitleInWizard', {
-    defaultMessage: 'Text',
+    defaultMessage: 'Markdown text',
   }),
   description: i18n.translate('visTypeMarkdown.markdownDescription', {
-    defaultMessage: 'Add text and images to your dashboard.',
+    defaultMessage: 'Legacy tool for adding text or images to dashboards.',
   }),
   order: 30,
   toExpressionAst,

--- a/src/plugins/vis_types/timeseries/public/metrics_type.ts
+++ b/src/plugins/vis_types/timeseries/public/metrics_type.ts
@@ -102,7 +102,7 @@ export const metricsVisDefinition: VisTypeDefinition<
   name: VIS_TYPE,
   title: i18n.translate('visTypeTimeseries.kbnVisTypes.metricsTitle', { defaultMessage: 'TSVB' }),
   description: i18n.translate('visTypeTimeseries.kbnVisTypes.metricsDescription', {
-    defaultMessage: 'Legacy editor used to visualize and analyze time series data.',
+    defaultMessage: 'Create visualizations using time series data.',
   }),
   icon: 'visVisualBuilder',
   group: VisGroups.LEGACY,

--- a/src/plugins/vis_types/timeseries/public/metrics_type.ts
+++ b/src/plugins/vis_types/timeseries/public/metrics_type.ts
@@ -102,7 +102,7 @@ export const metricsVisDefinition: VisTypeDefinition<
   name: VIS_TYPE,
   title: i18n.translate('visTypeTimeseries.kbnVisTypes.metricsTitle', { defaultMessage: 'TSVB' }),
   description: i18n.translate('visTypeTimeseries.kbnVisTypes.metricsDescription', {
-    defaultMessage: 'Perform advanced analysis of your time series data.',
+    defaultMessage: 'Legacy editor used to visualize and analyze time series data.',
   }),
   icon: 'visVisualBuilder',
   group: VisGroups.LEGACY,

--- a/src/plugins/vis_types/vega/public/vega_type.ts
+++ b/src/plugins/vis_types/vega/public/vega_type.ts
@@ -32,11 +32,8 @@ export const createVegaTypeDefinition = (): VisTypeDefinition<VisParams> => {
     title: 'Vega',
     getInfoMessage,
     description: i18n.translate('visTypeVega.type.vegaDescription', {
-      defaultMessage: 'Use Vega to create new types of visualizations.',
+      defaultMessage: 'Use the Vega syntax to create new types of visualizations.',
       description: 'Vega and Vega-Lite are product names and should not be translated',
-    }),
-    note: i18n.translate('visTypeVega.type.vegaNote', {
-      defaultMessage: 'Requires knowledge of Vega syntax.',
     }),
     icon: 'visVega',
     group: VisGroups.PROMOTED,

--- a/src/plugins/visualizations/public/wizard/agg_based_selection/agg_based_selection.test.tsx
+++ b/src/plugins/visualizations/public/wizard/agg_based_selection/agg_based_selection.test.tsx
@@ -70,18 +70,18 @@ describe('AggBasedSelection', () => {
     jest.clearAllMocks();
   });
 
-  it('should call the toggleGroups if the user clicks the goBack link', () => {
-    const toggleGroups = jest.fn();
+  it('should call the showMainDialog if the user clicks the goBack link', () => {
+    const showMainDialog = jest.fn();
     const wrapper = mountWithIntl(
       <AggBasedSelection
         visTypesRegistry={visTypes}
-        toggleGroups={toggleGroups}
+        showMainDialog={showMainDialog}
         onVisTypeSelected={jest.fn()}
       />
     );
     const aggBasedGroupCard = wrapper.find('[data-test-subj="goBackLink"]').last();
     aggBasedGroupCard.simulate('click');
-    expect(toggleGroups).toHaveBeenCalled();
+    expect(showMainDialog).toHaveBeenCalled();
   });
 
   describe('filter for visualization types', () => {
@@ -89,7 +89,7 @@ describe('AggBasedSelection', () => {
       const wrapper = mountWithIntl(
         <AggBasedSelection
           visTypesRegistry={visTypes}
-          toggleGroups={jest.fn()}
+          showMainDialog={jest.fn()}
           onVisTypeSelected={jest.fn()}
         />
       );

--- a/src/plugins/visualizations/public/wizard/agg_based_selection/agg_based_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/agg_based_selection/agg_based_selection.tsx
@@ -39,7 +39,7 @@ interface AggBasedSelectionProps {
   openedAsRoot?: boolean;
   onVisTypeSelected: (visType: BaseVisType) => void;
   visTypesRegistry: TypesStart;
-  toggleGroups: (flag: boolean) => void;
+  showMainDialog: (flag: boolean) => void;
 }
 interface AggBasedSelectionState {
   query: string;
@@ -67,7 +67,7 @@ class AggBasedSelection extends React.Component<AggBasedSelectionProps, AggBased
         </EuiModalHeader>
         <EuiModalBody>
           {this.props.openedAsRoot ? null : (
-            <DialogNavigation goBack={() => this.props.toggleGroups(true)} />
+            <DialogNavigation goBack={() => this.props.showMainDialog(true)} />
           )}
           <EuiFieldSearch
             placeholder="Filter"

--- a/src/plugins/visualizations/public/wizard/dialog.scss
+++ b/src/plugins/visualizations/public/wizard/dialog.scss
@@ -1,5 +1,5 @@
-$modalWidth: $euiSizeL * 34;
-$modalHeight: $euiSizeL * 30;
+$modalWidth: $euiSizeS * 100;
+$modalHeight: $euiSizeS * 90;
 
 .visNewVisDialog {
   max-width: $modalWidth;

--- a/src/plugins/visualizations/public/wizard/group_selection/group_selection.test.tsx
+++ b/src/plugins/visualizations/public/wizard/group_selection/group_selection.test.tsx
@@ -128,7 +128,7 @@ describe('GroupSelection', () => {
     expect(screen.queryByRole('tab', { name: /recommended/i })).toBeNull();
   });
 
-  it('should render the aggBased group card if an aggBased group vis is registered', async () => {
+  it('should render tabs and the aggBased group card if an aggBased group vis is registered', async () => {
     const aggBasedVisType = {
       name: 'visWithSearch',
       title: 'Vis with search',
@@ -141,23 +141,9 @@ describe('GroupSelection', () => {
       tab: 'legacy',
     });
 
+    expect(screen.queryByRole('tab', { name: /legacy/i })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: /recommended/i })).toBeInTheDocument();
     expect(screen.getByTestId('visType-aggbased')).toHaveTextContent('Aggregation-based');
-  });
-
-  it('should render the tools group card if a tools group vis is registered', async () => {
-    const toolsVisType = {
-      name: 'vis3',
-      title: 'Vis3',
-      stage: 'production',
-      group: VisGroups.TOOLS,
-
-      ...defaultVisTypeParams,
-    };
-    renderGroupSelectionComponent({
-      tab: 'legacy',
-      visTypesRegistry: visTypesRegistry([..._visTypes, toolsVisType] as BaseVisType[]),
-    });
-    expect(screen.getByTestId('visType-vis3')).toHaveTextContent('Vis3');
   });
 
   it('should call the showMainDialog if the aggBased group card is clicked', async () => {

--- a/src/plugins/visualizations/public/wizard/group_selection/group_selection.test.tsx
+++ b/src/plugins/visualizations/public/wizard/group_selection/group_selection.test.tsx
@@ -176,7 +176,7 @@ describe('GroupSelection', () => {
     });
 
     await userEvent.click(screen.getByRole('button', { name: /Aggregation-based/i }));
-    expect(showMainDialog).toHaveBeenCalled();
+    expect(showMainDialog).toHaveBeenCalledWith(false);
   });
 
   it('should only show promoted visualizations in recommended tab', () => {

--- a/src/plugins/visualizations/public/wizard/group_selection/group_selection.test.tsx
+++ b/src/plugins/visualizations/public/wizard/group_selection/group_selection.test.tsx
@@ -105,11 +105,12 @@ describe('GroupSelection', () => {
     return render(
       <I18nProvider>
         <GroupSelection
+          tab="recommended"
+          setTab={jest.fn()}
           visTypesRegistry={visTypesRegistry(_visTypes)}
           docLinks={docLinks as DocLinksStart}
-          toggleGroups={jest.fn()}
+          showMainDialog={jest.fn()}
           onVisTypeSelected={jest.fn()}
-          showExperimental={true}
           {...overrideProps}
         />
       </I18nProvider>
@@ -137,9 +138,9 @@ describe('GroupSelection', () => {
     };
     renderGroupSelectionComponent({
       visTypesRegistry: visTypesRegistry([..._visTypes, aggBasedVisType] as BaseVisType[]),
+      tab: 'legacy',
     });
 
-    await userEvent.click(screen.getByRole('tab', { name: /legacy/i }));
     expect(screen.getByTestId('visType-aggbased')).toHaveTextContent('Aggregation-based');
   });
 
@@ -149,19 +150,18 @@ describe('GroupSelection', () => {
       title: 'Vis3',
       stage: 'production',
       group: VisGroups.TOOLS,
+
       ...defaultVisTypeParams,
     };
     renderGroupSelectionComponent({
+      tab: 'legacy',
       visTypesRegistry: visTypesRegistry([..._visTypes, toolsVisType] as BaseVisType[]),
     });
-
-    expect(screen.queryByTestId('visType-vis3')).toBeNull();
-    await userEvent.click(screen.getByRole('tab', { name: /legacy/i }));
     expect(screen.getByTestId('visType-vis3')).toHaveTextContent('Vis3');
   });
 
-  it('should call the toggleGroups if the aggBased group card is clicked', async () => {
-    const toggleGroups = jest.fn();
+  it('should call the showMainDialog if the aggBased group card is clicked', async () => {
+    const showMainDialog = jest.fn();
     const aggBasedVisType = {
       name: 'visWithSearch',
       title: 'Vis with search',
@@ -170,13 +170,13 @@ describe('GroupSelection', () => {
       ...defaultVisTypeParams,
     };
     renderGroupSelectionComponent({
-      toggleGroups,
+      showMainDialog,
       visTypesRegistry: visTypesRegistry([..._visTypes, aggBasedVisType] as BaseVisType[]),
+      tab: 'legacy',
     });
 
-    await userEvent.click(screen.getByRole('tab', { name: /legacy/i }));
     await userEvent.click(screen.getByRole('button', { name: /Aggregation-based/i }));
-    expect(toggleGroups).toHaveBeenCalled();
+    expect(showMainDialog).toHaveBeenCalled();
   });
 
   it('should only show promoted visualizations in recommended tab', () => {

--- a/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
@@ -27,7 +27,6 @@ import {
   EuiTabs,
   EuiTab,
   EuiIconTip,
-  IconType,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { DocLinksStart } from '@kbn/core/public';
@@ -114,11 +113,10 @@ function GroupSelection({
 
   const aggBasedTypes = getVisTypesFromGroup(visTypesRegistry, VisGroups.AGGBASED);
   const legacyTypes = getVisTypesFromGroup(visTypesRegistry, VisGroups.LEGACY);
-  const toolsTypes = getVisTypesFromGroup(visTypesRegistry, VisGroups.TOOLS);
 
-  const shouldDisplayLegacyTab = legacyTypes.length + aggBasedTypes.length + toolsTypes.length > 0;
+  const shouldDisplayLegacyTab = legacyTypes.length + aggBasedTypes.length;
 
-  const [tsvbProps, ...restLegacyProps] = legacyTypes.map((visType) => ({
+  const [tsvbProps] = legacyTypes.map((visType) => ({
     visType: {
       ...visType,
       icon: visType.name === 'metrics' ? 'visualizeApp' : (visType.icon as string),
@@ -169,7 +167,7 @@ function GroupSelection({
               ))}
             </EuiFlexGrid>
           ) : (
-            <EuiFlexGrid columns={3} data-test-subj="visNewDialogGroups">
+            <EuiFlexGrid columns={2} data-test-subj="visNewDialogGroups">
               {tsvbProps ? <VisGroup {...tsvbProps} /> : null}
               {
                 <VisGroup
@@ -192,16 +190,6 @@ function GroupSelection({
                   }}
                 />
               }
-              {restLegacyProps.map((visType) => (
-                <VisGroup {...visType} />
-              ))}
-              {toolsTypes.map((visType) => (
-                <VisGroup
-                  visType={visType}
-                  key={visType.name}
-                  onVisTypeSelected={props.onVisTypeSelected}
-                />
-              ))}
             </EuiFlexGrid>
           )}
 

--- a/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
@@ -39,14 +39,14 @@ export interface GroupSelectionProps {
   onVisTypeSelected: (visType: BaseVisType | VisTypeAlias) => void;
   visTypesRegistry: TypesStart;
   docLinks: DocLinksStart;
-  toggleGroups: (flag: boolean) => void;
-  showExperimental: boolean;
+  showMainDialog: (flag: boolean) => void;
+  tab: 'recommended' | 'legacy';
+  setTab: (tab: 'recommended' | 'legacy') => void;
 }
 
 interface VisCardProps {
   onVisTypeSelected: (visType: BaseVisType | VisTypeAlias) => void;
   visType: BaseVisType | VisTypeAlias;
-  showExperimental?: boolean | undefined;
   shouldStretch?: boolean;
 }
 
@@ -82,7 +82,7 @@ const tabs: Array<{ id: 'recommended' | 'legacy'; label: ReactNode; dataTestSubj
   },
 ];
 
-function GroupSelection(props: GroupSelectionProps) {
+function GroupSelection({ tab = 'recommended', setTab, ...props }: GroupSelectionProps) {
   const visualizeGuideLink = props.docLinks.links.dashboard.guide;
   const promotedVisGroups = useMemo(
     () =>
@@ -114,8 +114,6 @@ function GroupSelection(props: GroupSelectionProps) {
     visType: { ...tsvbType[0], icon: 'visualizeApp' },
     onVisTypeSelected: props.onVisTypeSelected,
   };
-
-  const [tab, setTab] = React.useState(tabs[0].id);
 
   return (
     <>
@@ -169,7 +167,7 @@ function GroupSelection(props: GroupSelectionProps) {
                     description: i18n.translate(
                       'visualizations.newVisWizard.aggBasedGroupDescription',
                       {
-                        defaultMessage: 'Legacy library for creating charts based on aggregations.',
+                        defaultMessage: 'Craft charts using basic aggregations.',
                       }
                     ),
                     icon: 'indexPatternApp',
@@ -178,7 +176,7 @@ function GroupSelection(props: GroupSelectionProps) {
                     }),
                   }}
                   onVisTypeSelected={() => {
-                    props.toggleGroups(false);
+                    props.showMainDialog(false);
                   }}
                 />
               }
@@ -211,6 +209,7 @@ const ModalFooter = ({ visualizeGuideLink }: { visualizeGuideLink: string }) => 
       <EuiDescriptionList
         className="visNewVisDialogGroupSelection__footerDescriptionList"
         type="responsiveColumn"
+        compressed
       >
         <EuiDescriptionListTitle className="visNewVisDialogGroupSelection__footerDescriptionListTitle">
           <FormattedMessage

--- a/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/group_selection/group_selection.tsx
@@ -50,39 +50,37 @@ interface VisCardProps {
   shouldStretch?: boolean;
 }
 
-const tabs: Array<{ id: 'recommended' | 'legacy'; label: ReactNode; ['data-test-subj']: string }> =
-  [
-    {
-      id: 'recommended',
-      label: i18n.translate('visualizations.newVisWizard.recommendedTab', {
-        defaultMessage: 'Recommended',
-      }),
-      ['data-test-subj']: 'groupModalRecommendedTab',
-    },
-    {
-      id: 'legacy',
-      ['data-test-subj']: 'groupModalLegacyTab',
-      label: (
-        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-          <EuiFlexItem grow={false}>
-            {i18n.translate('visualizations.newVisWizard.legacyTab', {
-              defaultMessage: 'Legacy',
-            })}
-          </EuiFlexItem>
+const tabs: Array<{ id: 'recommended' | 'legacy'; label: ReactNode; dataTestSubj: string }> = [
+  {
+    id: 'recommended',
+    label: i18n.translate('visualizations.newVisWizard.recommendedTab', {
+      defaultMessage: 'Recommended',
+    }),
+    dataTestSubj: 'groupModalRecommendedTab',
+  },
+  {
+    id: 'legacy',
+    dataTestSubj: 'groupModalLegacyTab',
+    label: (
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        <EuiFlexItem grow={false}>
+          {i18n.translate('visualizations.newVisWizard.legacyTab', {
+            defaultMessage: 'Legacy',
+          })}
+        </EuiFlexItem>
 
-          <EuiFlexItem grow={false}>
-            <EuiIconTip
-              content={i18n.translate('visualizations.newVisWizard.legacyTabDescription', {
-                defaultMessage:
-                  'Legacy visualizations are scheduled for deprecation in Kibana 9.0.',
-              })}
-              position="top"
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      ),
-    },
-  ];
+        <EuiFlexItem grow={false}>
+          <EuiIconTip
+            content={i18n.translate('visualizations.newVisWizard.legacyTabDescription', {
+              defaultMessage: 'Legacy visualizations are scheduled for deprecation in the future.',
+            })}
+            position="top"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    ),
+  },
+];
 
 function GroupSelection(props: GroupSelectionProps) {
   const visualizeGuideLink = props.docLinks.links.dashboard.guide;
@@ -92,8 +90,6 @@ function GroupSelection(props: GroupSelectionProps) {
         [
           ...props.visTypesRegistry.getAliases(),
           ...props.visTypesRegistry.getByGroup(VisGroups.PROMOTED),
-          // Include so TSVB still gets displayed
-          // ...props.visTypesRegistry.getByGroup(VisGroups.LEGACY),
         ].filter((visDefinition) => {
           return !visDefinition.disableCreate;
         }),
@@ -137,7 +133,7 @@ function GroupSelection(props: GroupSelectionProps) {
             <EuiTabs>
               {tabs.map((t) => (
                 <EuiTab
-                  data-test-subj={t['data-test-subj']}
+                  data-test-subj={t.dataTestSubj}
                   isSelected={tab === t.id}
                   onClick={() => setTab(t.id)}
                   key={t.id}

--- a/src/plugins/visualizations/public/wizard/new_vis_modal.test.tsx
+++ b/src/plugins/visualizations/public/wizard/new_vis_modal.test.tsx
@@ -8,13 +8,15 @@
  */
 
 import React from 'react';
-import { mountWithIntl } from '@kbn/test-jest-helpers';
 import { TypesStart, VisGroups, BaseVisType } from '../vis_types';
-import NewVisModal from './new_vis_modal';
+import NewVisModal, { TypeSelectionProps } from './new_vis_modal';
 import { ApplicationStart, DocLinksStart } from '@kbn/core/public';
 import { embeddablePluginMock } from '@kbn/embeddable-plugin/public/mocks';
 import { contentManagementMock } from '@kbn/content-management-plugin/public/mocks';
 import { VisParams } from '../../common';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@kbn/i18n-react';
+import userEvent from '@testing-library/user-event';
 
 describe('NewVisModal', () => {
   const defaultVisTypeParams = {
@@ -96,116 +98,67 @@ describe('NewVisModal', () => {
     jest.clearAllMocks();
   });
 
-  it('should show the aggbased group but not the visualization assigned to this group', () => {
-    const wrapper = mountWithIntl(
-      <NewVisModal
-        isOpen={true}
-        onClose={() => null}
-        visTypesRegistry={visTypes}
-        addBasePath={addBasePath}
-        uiSettings={uiSettings}
-        application={{} as ApplicationStart}
-        docLinks={docLinks as DocLinksStart}
-        contentClient={contentManagement.client}
-      />
+  const renderNewVisModal = (propsOverrides?: Partial<TypeSelectionProps>) => {
+    return render(
+      <I18nProvider>
+        <NewVisModal
+          isOpen={true}
+          onClose={() => null}
+          visTypesRegistry={visTypes}
+          addBasePath={addBasePath}
+          uiSettings={uiSettings}
+          application={{} as ApplicationStart}
+          docLinks={docLinks as DocLinksStart}
+          contentClient={contentManagement.client}
+          {...propsOverrides}
+        />
+      </I18nProvider>
     );
-    expect(wrapper.find('[data-test-subj="visGroup-aggbased"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test-subj="visType-visWithSearch"]').exists()).toBe(false);
-  });
+  };
 
-  it('should show the tools group', () => {
-    const wrapper = mountWithIntl(
-      <NewVisModal
-        isOpen={true}
-        onClose={() => null}
-        visTypesRegistry={visTypes}
-        addBasePath={addBasePath}
-        uiSettings={uiSettings}
-        application={{} as ApplicationStart}
-        docLinks={docLinks as DocLinksStart}
-        contentClient={contentManagement.client}
-      />
-    );
-    expect(wrapper.find('[data-test-subj="visGroup-tools"]').exists()).toBe(true);
+  it('should show the aggbased group but not the visualization assigned to this group', async () => {
+    renderNewVisModal();
+    expect(screen.queryByText('Aggregation-based')).not.toBeInTheDocument();
+    expect(screen.queryByText('Vis with search')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('tab', { name: /Legacy/i }));
+    expect(screen.queryByText('Aggregation-based')).toBeInTheDocument();
+    expect(screen.queryByText('Vis with search')).not.toBeInTheDocument();
   });
 
   it('should display the visualizations of the other group', () => {
-    const wrapper = mountWithIntl(
-      <NewVisModal
-        isOpen={true}
-        onClose={() => null}
-        visTypesRegistry={visTypes}
-        addBasePath={addBasePath}
-        uiSettings={uiSettings}
-        application={{} as ApplicationStart}
-        docLinks={docLinks as DocLinksStart}
-        contentClient={contentManagement.client}
-      />
-    );
-    expect(wrapper.find('[data-test-subj="visType-vis2"]').exists()).toBe(true);
+    renderNewVisModal();
+    expect(screen.queryByText('Vis Type 2')).toBeInTheDocument();
   });
 
   describe('open editor', () => {
-    it('should open the editor for visualizations without search', () => {
-      const wrapper = mountWithIntl(
-        <NewVisModal
-          isOpen={true}
-          onClose={() => null}
-          visTypesRegistry={visTypes}
-          addBasePath={addBasePath}
-          uiSettings={uiSettings}
-          application={{} as ApplicationStart}
-          docLinks={docLinks as DocLinksStart}
-          contentClient={contentManagement.client}
-        />
-      );
-      const visCard = wrapper.find('[data-test-subj="visType-vis"]').last();
-      visCard.simulate('click');
+    it('should open the editor for visualizations without search', async () => {
+      renderNewVisModal();
+      await userEvent.click(screen.getByText('Vis Type 1'));
       expect(window.location.assign).toBeCalledWith('testbasepath/app/visualize#/create?type=vis');
     });
 
-    it('passes through editor params to the editor URL', () => {
-      const wrapper = mountWithIntl(
-        <NewVisModal
-          isOpen={true}
-          onClose={() => null}
-          visTypesRegistry={visTypes}
-          editorParams={['foo=true', 'bar=42']}
-          addBasePath={addBasePath}
-          uiSettings={uiSettings}
-          application={{} as ApplicationStart}
-          docLinks={docLinks as DocLinksStart}
-          contentClient={contentManagement.client}
-        />
-      );
-      const visCard = wrapper.find('[data-test-subj="visType-vis"]').last();
-      visCard.simulate('click');
+    it('passes through editor params to the editor URL', async () => {
+      renderNewVisModal({
+        editorParams: ['foo=true', 'bar=42'],
+      });
+      await userEvent.click(screen.getByText('Vis Type 1'));
       expect(window.location.assign).toBeCalledWith(
         'testbasepath/app/visualize#/create?type=vis&foo=true&bar=42'
       );
     });
 
-    it('closes and redirects properly if visualization with alias.path and originatingApp in props', () => {
+    it('closes and redirects properly if visualization with alias.path and originatingApp in props', async () => {
       const onClose = jest.fn();
       const navigateToApp = jest.fn();
       const stateTransfer = embeddablePluginMock.createStartContract().getStateTransfer();
-      const wrapper = mountWithIntl(
-        <NewVisModal
-          isOpen={true}
-          onClose={onClose}
-          visTypesRegistry={visTypes}
-          editorParams={['foo=true', 'bar=42']}
-          originatingApp={'coolJestTestApp'}
-          addBasePath={addBasePath}
-          uiSettings={uiSettings}
-          application={{ navigateToApp } as unknown as ApplicationStart}
-          docLinks={docLinks as DocLinksStart}
-          stateTransfer={stateTransfer}
-          contentClient={contentManagement.client}
-        />
-      );
-      const visCard = wrapper.find('[data-test-subj="visType-visWithAliasUrl"]').last();
-      visCard.simulate('click');
+      renderNewVisModal({
+        editorParams: ['foo=true', 'bar=42'],
+        onClose,
+        application: { navigateToApp } as unknown as ApplicationStart,
+        originatingApp: 'coolJestTestApp',
+        stateTransfer,
+      });
+      await userEvent.click(screen.getByText('Vis with alias Url'));
       expect(stateTransfer.navigateToEditor).toBeCalledWith('otherApp', {
         path: '#/aliasUrl',
         state: { originatingApp: 'coolJestTestApp' },
@@ -213,48 +166,28 @@ describe('NewVisModal', () => {
       expect(onClose).toHaveBeenCalled();
     });
 
-    it('closes and redirects properly if visualization with aliasApp and without originatingApp in props', () => {
+    it('closes and redirects properly if visualization with aliasApp and without originatingApp in props', async () => {
       const onClose = jest.fn();
       const navigateToApp = jest.fn();
-      const wrapper = mountWithIntl(
-        <NewVisModal
-          isOpen={true}
-          onClose={onClose}
-          visTypesRegistry={visTypes}
-          editorParams={['foo=true', 'bar=42']}
-          addBasePath={addBasePath}
-          uiSettings={uiSettings}
-          application={{ navigateToApp } as unknown as ApplicationStart}
-          docLinks={docLinks as DocLinksStart}
-          contentClient={contentManagement.client}
-        />
-      );
-      const visCard = wrapper.find('[data-test-subj="visType-visWithAliasUrl"]').last();
-      visCard.simulate('click');
+
+      renderNewVisModal({
+        editorParams: ['foo=true', 'bar=42'],
+        onClose,
+        application: { navigateToApp } as unknown as ApplicationStart,
+      });
+      await userEvent.click(screen.getByText('Vis with alias Url'));
       expect(navigateToApp).toBeCalledWith('otherApp', { path: '#/aliasUrl' });
       expect(onClose).toHaveBeenCalled();
     });
   });
 
   describe('aggBased visualizations', () => {
-    it('should render as expected', () => {
-      const wrapper = mountWithIntl(
-        <NewVisModal
-          isOpen={true}
-          onClose={() => null}
-          visTypesRegistry={visTypes}
-          addBasePath={addBasePath}
-          uiSettings={uiSettings}
-          application={{} as ApplicationStart}
-          docLinks={docLinks as DocLinksStart}
-          contentClient={contentManagement.client}
-        />
-      );
-      const aggBasedGroupCard = wrapper
-        .find('[data-test-subj="visGroupAggBasedExploreLink"]')
-        .last();
-      aggBasedGroupCard.simulate('click');
-      expect(wrapper.find('[data-test-subj="visType-visWithSearch"]').exists()).toBe(true);
+    it('should render as expected', async () => {
+      renderNewVisModal();
+      await userEvent.click(screen.getByRole('tab', { name: /Legacy/i }));
+      expect(screen.queryByText('Aggregation-based')).toBeInTheDocument();
+      await userEvent.click(screen.getByText('Aggregation-based'));
+      expect(screen.queryByText('Vis with search')).toBeInTheDocument();
     });
   });
 });

--- a/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
+++ b/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
@@ -41,8 +41,9 @@ export interface TypeSelectionProps {
 
 interface TypeSelectionState {
   showSearchVisModal: boolean;
-  showGroups: boolean;
+  isMainDialogShown: boolean;
   visType?: BaseVisType;
+  tab: 'recommended' | 'legacy';
 }
 
 // TODO: redirect logic is specific to visualise & dashboard
@@ -64,10 +65,15 @@ class NewVisModal extends React.Component<TypeSelectionProps, TypeSelectionState
 
     this.state = {
       showSearchVisModal: Boolean(this.props.selectedVisType),
-      showGroups: !this.props.showAggsSelection,
+      isMainDialogShown: !this.props.showAggsSelection,
       visType: this.props.selectedVisType,
+      tab: 'recommended',
     };
   }
+
+  public setTab = (tab: 'recommended' | 'legacy') => {
+    this.setState({ tab });
+  };
 
   public render() {
     if (!this.props.isOpen) {
@@ -82,7 +88,7 @@ class NewVisModal extends React.Component<TypeSelectionProps, TypeSelectionState
       }
     );
 
-    const WizardComponent = this.state.showGroups ? GroupSelection : AggBasedSelection;
+    const WizardComponent = this.state.isMainDialogShown ? GroupSelection : AggBasedSelection;
 
     const selectionModal =
       this.state.showSearchVisModal && this.state.visType ? (
@@ -98,15 +104,21 @@ class NewVisModal extends React.Component<TypeSelectionProps, TypeSelectionState
       ) : (
         <EuiModal
           onClose={this.onCloseModal}
-          className={this.state.showGroups ? 'visNewVisDialog' : 'visNewVisDialog--aggbased'}
+          className={this.state.isMainDialogShown ? 'visNewVisDialog' : 'visNewVisDialog--aggbased'}
           aria-label={visNewVisDialogAriaLabel}
         >
           <WizardComponent
-            showExperimental={true}
             onVisTypeSelected={this.onVisTypeSelected}
             visTypesRegistry={this.props.visTypesRegistry}
             docLinks={this.props.docLinks}
-            toggleGroups={(flag: boolean) => this.setState({ showGroups: flag })}
+            setTab={this.setTab}
+            tab={this.state.tab}
+            showMainDialog={(shouldMainBeShown: boolean) => {
+              this.setState({ isMainDialogShown: shouldMainBeShown });
+              if (shouldMainBeShown) {
+                this.setTab('legacy');
+              }
+            }}
             openedAsRoot={this.props.showAggsSelection && !this.props.selectedVisType}
           />
         </EuiModal>

--- a/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
+++ b/src/plugins/visualizations/public/wizard/new_vis_modal.tsx
@@ -22,7 +22,7 @@ import { AggBasedSelection } from './agg_based_selection';
 import type { TypesStart, BaseVisType, VisTypeAlias } from '../vis_types';
 import './dialog.scss';
 
-interface TypeSelectionProps {
+export interface TypeSelectionProps {
   contentClient: ContentClient;
   isOpen: boolean;
   onClose: () => void;

--- a/test/functional/apps/dashboard/group1/edit_visualizations.js
+++ b/test/functional/apps/dashboard/group1/edit_visualizations.js
@@ -191,7 +191,7 @@ export default function ({ getService, getPageObjects }) {
       it('should lose its connection to the dashboard when creating new visualization', async () => {
         await visualize.gotoVisualizationLandingPage();
         await visualize.clickNewVisualization();
-        await visualize.clickMarkdownWidget();
+        await visualize.clickVisualBuilder();
         await visualize.notLinkedToOriginatingApp();
 
         // return to origin should not be present in save modal

--- a/test/functional/apps/dashboard/group5/legacy_urls.ts
+++ b/test/functional/apps/dashboard/group5/legacy_urls.ts
@@ -86,13 +86,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('resolves markdown link', async () => {
-        await visualize.navigateToNewVisualization();
-        await visualize.clickMarkdownWidget();
+        await dashboard.gotoDashboardLandingPage();
+        await dashboard.clickNewDashboard();
+        await dashboardAddPanel.clickMarkdownQuickButton();
         await visEditor.setMarkdownTxt(`[abc](#/dashboard/${testDashboardId})`);
         await visEditor.clickGo();
-
-        await visualize.saveVisualizationExpectSuccess('legacy url markdown');
-
+        await visualize.saveVisualization('legacy url markdown', { redirectToOrigin: true });
         await (await find.byLinkText('abc')).click();
 
         await header.waitUntilLoadingHasFinished();

--- a/test/functional/apps/dashboard_elements/markdown/_markdown_vis.ts
+++ b/test/functional/apps/dashboard_elements/markdown/_markdown_vis.ts
@@ -12,25 +12,26 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const { visualize, visEditor, visChart, header } = getPageObjects([
-    'visualize',
+  const { visEditor, visChart, header, dashboard } = getPageObjects([
+    'dashboard',
     'visEditor',
     'visChart',
     'header',
   ]);
   const find = getService('find');
   const inspector = getService('inspector');
+  const dashboardAddPanel = getService('dashboardAddPanel');
   const markdown = `
 # Heading 1
 
 <h3>Inline HTML that should not be rendered as html</h3>
   `;
 
-  describe('markdown app in visualize app', () => {
+  describe('markdown app', () => {
     before(async function () {
-      await visualize.initTests();
-      await visualize.navigateToNewVisualization();
-      await visualize.clickMarkdownWidget();
+      await dashboard.initTests();
+      await dashboard.clickNewDashboard();
+      await dashboardAddPanel.clickMarkdownQuickButton();
       await visEditor.setMarkdownTxt(markdown);
       await visEditor.clickGo();
     });

--- a/test/functional/apps/visualize/group1/_chart_types.ts
+++ b/test/functional/apps/visualize/group1/_chart_types.ts
@@ -22,14 +22,18 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await visualize.navigateToNewVisualization();
     });
 
-    it('should show the promoted vis types for the first step', async function () {
-      const expectedChartTypes = ['Custom visualization', 'Lens', 'Maps', 'TSVB'];
+    it('should show the expected visualizations types for both recommended and legacy tabs', async function () {
+      const expectedRecommendedChartTypes = ['Custom visualization', 'Lens', 'Maps'];
+      const expectedLegacyChartTypes = ['Aggregation-based', 'Markdown text', 'TSVB'];
 
       // find all the chart types and make sure there all there
-      const chartTypes = (await visualize.getPromotedVisTypes()).sort();
+      const chartTypes = await visualize.getVisibleVisTypes();
       log.debug('returned chart types = ' + chartTypes);
-      log.debug('expected chart types = ' + expectedChartTypes);
-      expect(chartTypes).to.eql(expectedChartTypes);
+      log.debug('expected chart types = ' + expectedRecommendedChartTypes);
+      expect(chartTypes).to.eql(expectedRecommendedChartTypes);
+      await visualize.clickLegacyTab();
+      const legacyChartTypes = await visualize.getVisibleVisTypes();
+      expect(legacyChartTypes).to.eql(expectedLegacyChartTypes);
     });
 
     it('should show the correct agg based chart types', async function () {

--- a/test/functional/apps/visualize/group1/_chart_types.ts
+++ b/test/functional/apps/visualize/group1/_chart_types.ts
@@ -24,7 +24,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('should show the expected visualizations types for both recommended and legacy tabs', async function () {
       const expectedRecommendedChartTypes = ['Custom visualization', 'Lens', 'Maps'];
-      const expectedLegacyChartTypes = ['Aggregation-based', 'Markdown text', 'TSVB'];
+      const expectedLegacyChartTypes = ['Aggregation-based', 'TSVB'];
 
       // find all the chart types and make sure there all there
       const chartTypes = await visualize.getVisibleVisTypes();

--- a/test/functional/apps/visualize/group3/_visualize_listing.ts
+++ b/test/functional/apps/visualize/group3/_visualize_listing.ts
@@ -10,7 +10,7 @@
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const { visualize, visEditor } = getPageObjects(['visualize', 'visEditor']);
+  const { visualize, visualBuilder } = getPageObjects(['visualize', 'visualBuilder']);
   const listingTable = getService('listingTable');
 
   describe('visualize listing page', function describeIndexTests() {
@@ -24,18 +24,18 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('create new viz', async function () {
-        // type markdown is used for simplicity
-        await visualize.createSimpleMarkdownViz(vizName);
+        // type tsvb is used for simplicity
+        await visualize.createSimpleTSVBViz(vizName);
         await visualize.gotoVisualizationLandingPage();
         await listingTable.expectItemsCount('visualize', 1);
       });
 
       it('delete all viz', async function () {
-        await visualize.createSimpleMarkdownViz(vizName + '1');
+        await visualize.createSimpleTSVBViz(vizName + '1');
         await visualize.gotoVisualizationLandingPage();
         await listingTable.expectItemsCount('visualize', 2);
 
-        await visualize.createSimpleMarkdownViz(vizName + '2');
+        await visualize.createSimpleTSVBViz(vizName + '2');
         await visualize.gotoVisualizationLandingPage();
         await listingTable.expectItemsCount('visualize', 3);
 
@@ -48,9 +48,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       before(async function () {
         // create one new viz
         await visualize.navigateToNewVisualization();
-        await visualize.clickMarkdownWidget();
-        await visEditor.setMarkdownTxt('HELLO');
-        await visEditor.clickGo();
+        await visualize.clickVisualBuilder();
+        await visualBuilder.checkVisualBuilderIsPresent();
         await visualize.saveVisualization('Hello World');
         await visualize.gotoVisualizationLandingPage();
       });

--- a/test/functional/page_objects/visualize_page.ts
+++ b/test/functional/page_objects/visualize_page.ts
@@ -41,7 +41,6 @@ export class VisualizePageObject extends FtrService {
   private readonly elasticChart = this.ctx.getService('elasticChart');
   private readonly common = this.ctx.getPageObject('common');
   private readonly header = this.ctx.getPageObject('header');
-  private readonly visEditor = this.ctx.getPageObject('visEditor');
   private readonly visChart = this.ctx.getPageObject('visChart');
   private readonly toasts = this.ctx.getService('toasts');
 
@@ -226,11 +225,6 @@ export class VisualizePageObject extends FtrService {
     await this.testSubjects.click('groupModalLegacyTab');
   }
 
-  public async clickMarkdownWidget() {
-    await this.clickLegacyTab();
-    await this.clickVisType('markdown');
-  }
-
   public async clickMetric() {
     await this.clickVisType('metric');
   }
@@ -288,12 +282,10 @@ export class VisualizePageObject extends FtrService {
     return await this.hasVisType('maps');
   }
 
-  public async createSimpleMarkdownViz(vizName: string) {
+  public async createSimpleTSVBViz(vizName: string) {
     await this.gotoVisualizationLandingPage();
     await this.navigateToNewVisualization();
-    await this.clickMarkdownWidget();
-    await this.visEditor.setMarkdownTxt(vizName);
-    await this.visEditor.clickGo();
+    await this.clickVisualBuilder();
     await this.saveVisualization(vizName);
   }
 

--- a/test/functional/page_objects/visualize_page.ts
+++ b/test/functional/page_objects/visualize_page.ts
@@ -106,7 +106,8 @@ export class VisualizePageObject extends FtrService {
   }
 
   public async clickAggBasedVisualizations() {
-    await this.testSubjects.click('visGroupAggBasedExploreLink');
+    await this.clickLegacyTab();
+    await this.testSubjects.click('visType-aggbased');
   }
 
   public async goBackToGroups() {
@@ -125,7 +126,7 @@ export class VisualizePageObject extends FtrService {
       .map((chart) => $(chart).findTestSubject('visTypeTitle').text().trim());
   }
 
-  public async getPromotedVisTypes() {
+  public async getVisibleVisTypes() {
     const chartTypeField = await this.testSubjects.find('visNewDialogGroups');
     const $ = await chartTypeField.parseDomContent();
     const promotedVisTypes: string[] = [];
@@ -137,7 +138,7 @@ export class VisualizePageObject extends FtrService {
           promotedVisTypes.push(title);
         }
       });
-    return promotedVisTypes;
+    return promotedVisTypes.sort();
   }
 
   public async waitForVisualizationSelectPage() {
@@ -221,7 +222,12 @@ export class VisualizePageObject extends FtrService {
     await this.clickVisType('line');
   }
 
+  public async clickLegacyTab() {
+    await this.testSubjects.click('groupModalLegacyTab');
+  }
+
   public async clickMarkdownWidget() {
+    await this.clickLegacyTab();
     await this.clickVisType('markdown');
   }
 
@@ -254,6 +260,7 @@ export class VisualizePageObject extends FtrService {
   }
 
   public async clickVisualBuilder() {
+    await this.clickLegacyTab();
     await this.clickVisType('metrics');
   }
 

--- a/x-pack/plugins/lens/public/vis_type_alias.ts
+++ b/x-pack/plugins/lens/public/vis_type_alias.ts
@@ -22,7 +22,7 @@ export const getLensAliasConfig = (): VisTypeAlias => ({
   }),
   description: i18n.translate('xpack.lens.visTypeAlias.description', {
     defaultMessage:
-      'Easily create a variety of visualizations by dragging and dropping fields. Smart suggestions guide you toward building visualizations that follow best practices and effectively communicate your data.',
+      'Create visualizations using an intuitive drag-and-drop interface. Smart suggestions help you follow best practices and find the chart types that best match your data.',
   }),
   order: 60,
   icon: 'lensApp',

--- a/x-pack/plugins/lens/public/vis_type_alias.ts
+++ b/x-pack/plugins/lens/public/vis_type_alias.ts
@@ -22,10 +22,7 @@ export const getLensAliasConfig = (): VisTypeAlias => ({
   }),
   description: i18n.translate('xpack.lens.visTypeAlias.description', {
     defaultMessage:
-      'Create visualizations with our drag and drop editor. Switch between visualization types at any time.',
-  }),
-  note: i18n.translate('xpack.lens.visTypeAlias.note', {
-    defaultMessage: 'Recommended for most users.',
+      'Easily create of variety of visualizations by dragging-and-dropping fields. Smart suggestions guide you towards crafting visualizations that use best practices and effectively communicate your data.',
   }),
   order: 60,
   icon: 'lensApp',

--- a/x-pack/plugins/lens/public/vis_type_alias.ts
+++ b/x-pack/plugins/lens/public/vis_type_alias.ts
@@ -22,7 +22,7 @@ export const getLensAliasConfig = (): VisTypeAlias => ({
   }),
   description: i18n.translate('xpack.lens.visTypeAlias.description', {
     defaultMessage:
-      'Easily create of variety of visualizations by dragging-and-dropping fields. Smart suggestions guide you towards crafting visualizations that use best practices and effectively communicate your data.',
+      'Easily create a variety of visualizations by dragging and dropping fields. Smart suggestions guide you toward building visualizations that follow best practices and effectively communicate your data.',
   }),
   order: 60,
   icon: 'lensApp',

--- a/x-pack/test/saved_object_tagging/functional/tests/visualize_integration.ts
+++ b/x-pack/test/saved_object_tagging/functional/tests/visualize_integration.ts
@@ -32,14 +32,12 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     }
     await testSubjects.click('savedObjectTitle');
   };
-  // creates a simple markdown vis with a tag provided.
+  // creates a simple tsvb vis with a tag provided.
   const createSimpleMarkdownVis = async (opts: Record<string, string>) => {
-    const { visName, visText, tagName } = opts;
+    const { visName, tagName } = opts;
     await PageObjects.visualize.navigateToNewVisualization();
 
-    await PageObjects.visualize.clickMarkdownWidget();
-    await PageObjects.visEditor.setMarkdownTxt(visText);
-    await PageObjects.visEditor.clickGo();
+    await PageObjects.visualize.clickVisualBuilder();
 
     await PageObjects.visualize.ensureSavePanelOpen();
     await PageObjects.visualize.setSaveModalValues(visName, {
@@ -150,10 +148,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         await PageObjects.visualize.navigateToNewVisualization();
 
-        await PageObjects.visualize.clickMarkdownWidget();
-        await PageObjects.visEditor.setMarkdownTxt('Just some markdown');
-        await PageObjects.visEditor.clickGo();
-
+        await PageObjects.visualize.clickVisualBuilder();
         await PageObjects.visualize.ensureSavePanelOpen();
         await PageObjects.visualize.setSaveModalValues('vis-with-new-tag', {
           saveAsNew: false,


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/191489

Redesign of "Create Visualization" Modal

To encourage users to adopt Lens and reduce reliance on Agg-based and TSVB visualizations, we've redesigned the "Create Visualization" modal. The new layout now features two distinct tabs: one highlighting recommended visualizations, and another clearly marking legacy options. This separation ensures users are well-informed about which visualization types are preferred moving forward.

<img width="757" alt="Screenshot 2024-10-15 at 13 15 49" src="https://github.com/user-attachments/assets/fe353504-5511-46ab-aef4-5a340650027b">

![image](https://github.com/user-attachments/assets/86c399fc-e737-453f-84e3-938d85aa22d3)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->