### PR TITLE
[Search][Onboarding] Auto-collapse side on Global Empty State

### DIFF
--- a/x-pack/plugins/search_indices/public/components/start/hooks/use_init_side_nav.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/hooks/use_init_side_nav.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useState } from 'react';
+import useObservable from 'react-use/lib/useObservable';
+
+import type { IndicesStatusResponse } from '../../../../common';
+
+import { useKibana } from '../../../hooks/use_kibana';
+
+/* useInitSideNav Hook checks if the sidenav is collapsed, and collapses it if
+ * we're going to show the empty state. */
+export const useInitSideNav = (indicesStatus?: IndicesStatusResponse) => {
+  const [collapsedSideNav, setCollapsedSideNav] = useState<boolean>(false);
+  const {
+    chrome: { sideNav },
+  } = useKibana().services;
+  const isSideNavCollapsed = useObservable(sideNav.getIsCollapsed$());
+  useEffect(() => {
+    if (!collapsedSideNav && isSideNavCollapsed === true) {
+      // if the side nav is collapsed, but we haven't auto-collapsed, flip our
+      // flag anyway to allow user to un-collapse on first click.
+      setCollapsedSideNav(true);
+      return;
+    }
+    if (
+      isSideNavCollapsed ||
+      collapsedSideNav ||
+      !indicesStatus ||
+      indicesStatus.indexNames.length > 0
+    ) {
+      return;
+    }
+    sideNav.setIsCollapsed(true);
+    // track if we've auto-collapsed the side nav so that this doesn't
+    // keep collapsing the side-nav
+    setCollapsedSideNav(true);
+  }, [collapsedSideNav, indicesStatus, isSideNavCollapsed, sideNav]);
+};

--- a/x-pack/plugins/search_indices/public/components/start/start_page.tsx
+++ b/x-pack/plugins/search_indices/public/components/start/start_page.tsx
@@ -17,6 +17,7 @@ import { useUserPrivilegesQuery } from '../../hooks/api/use_user_permissions';
 import { useIndicesRedirect } from './hooks/use_indices_redirect';
 import { ElasticsearchStart } from './elasticsearch_start';
 import { StartPageError } from './status_error';
+import { useInitSideNav } from './hooks/use_init_side_nav';
 
 export const ElasticsearchStartPage = () => {
   const { console: consolePlugin } = useKibana().services;
@@ -32,6 +33,7 @@ export const ElasticsearchStartPage = () => {
     () => (consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null),
     [consolePlugin]
   );
+  useInitSideNav(indicesData);
   useIndicesRedirect(indicesData);
 
   return (

--- a/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
@@ -109,5 +109,16 @@ export function SvlSearchElasticsearchStartPageProvider({ getService }: FtrProvi
       await testSubjects.missingOrFail('apiKeyHasNotBeenGenerated');
       await testSubjects.missingOrFail('apiKeyHasBeenGenerated');
     },
+
+    async expectSearchSideNavIsOpen() {
+      await testSubjects.existOrFail('*nav-item-search_project_nav.home');
+    },
+    async expectSearchSideNavIsCollapsed() {
+      await testSubjects.missingOrFail('*nav-item-search_project_nav.home');
+    },
+    async clickSideNavCollapseButton() {
+      await testSubjects.existOrFail('euiCollapsibleNavButton');
+      await testSubjects.click('euiCollapsibleNavButton');
+    },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
@@ -76,11 +76,18 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await es.indices.create({ index: 'test-my-index-002' });
         await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnIndexListPage();
       });
+      it('should start with side nav collapsed', async () => {
+        await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnStartPage();
+        await pageObjects.svlSearchElasticsearchStartPage.expectSearchSideNavIsCollapsed();
+        await pageObjects.svlSearchElasticsearchStartPage.clickSideNavCollapseButton();
+        await pageObjects.svlSearchElasticsearchStartPage.expectSearchSideNavIsOpen();
+      });
       it('should redirect to indices list if single index exist on page load', async () => {
         await svlSearchNavigation.navigateToGettingStartedPage();
         await es.indices.create({ index: 'test-my-index-001' });
         await svlSearchNavigation.navigateToElasticsearchStartPage(true);
         await pageObjects.svlSearchElasticsearchStartPage.expectToBeOnIndexListPage();
+        await pageObjects.svlSearchElasticsearchStartPage.expectSearchSideNavIsOpen();
       });
 
       it('should support switching between UI and Code Views', async () => {


### PR DESCRIPTION
## Summary

Updates the global empty state to auto-collapse the side nav. This will happen if the global empty state is rendered with 0 indices on the start page.

### Screenshots

<img width="1111" alt="image" src="https://github.com/user-attachments/assets/96cd9d96-81ec-4fad-84e3-b4d8bf6a68e0">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
