### PR TITLE
[Cloud Security] Skipping flaky test

### DIFF
--- a/x-pack/test/cloud_security_posture_api/routes/vulnerabilities_dashboard.ts
+++ b/x-pack/test/cloud_security_posture_api/routes/vulnerabilities_dashboard.ts
@@ -119,7 +119,7 @@ export default function (providerContext: FtrProviderContext) {
   const vulnerabilitiesIndex = new EsIndexDataProvider(es, VULNERABILITIES_LATEST_INDEX);
   const scoresIndex = new EsIndexDataProvider(es, BENCHMARK_SCORES_INDEX);
 
-  describe('Vulnerability Dashboard API', async () => {
+  describe.skip('Vulnerability Dashboard API', async () => {
     beforeEach(async () => {
       await vulnerabilitiesIndex.deleteAll();
       await scoresIndex.deleteAll();


### PR DESCRIPTION
## Summary

It fixes #195839

Skipping flaky test, opening a follow-up ticket to  re-enabled test: https://github.com/elastic/kibana/issues/194046


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->