### PR TITLE
[EDR Workflows] Enable automated response actions UI in all rules

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/utils.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/utils.ts
@@ -93,16 +93,3 @@ export const isSuppressionRuleConfiguredWithMissingFields = (ruleType: Type) =>
 export const isSuppressionRuleInGA = (ruleType: Type): boolean => {
   return isSuppressibleAlertRule(ruleType) && SUPPRESSIBLE_ALERT_RULES_GA.includes(ruleType);
 };
-export const shouldShowResponseActions = (
-  ruleType: Type | undefined,
-  automatedResponseActionsForAllRulesEnabled: boolean
-) => {
-  return (
-    isQueryRule(ruleType) ||
-    isEsqlRule(ruleType) ||
-    isEqlRule(ruleType) ||
-    isNewTermsRule(ruleType) ||
-    (automatedResponseActionsForAllRulesEnabled &&
-      (isThresholdRule(ruleType) || isThreatMatchRule(ruleType) || isMlRule(ruleType)))
-  );
-};

--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -53,11 +53,6 @@ export const allowedExperimentalValues = Object.freeze({
   automatedProcessActionsEnabled: true,
 
   /**
-   * Temporary feature flag to enable the Response Actions in Rules UI - intermediate release
-   */
-  automatedResponseActionsForAllRulesEnabled: false,
-
-  /**
    * Enables the ability to send Response actions to SentinelOne and persist the results
    * in ES. Adds API changes to support `agentType` and supports `isolate` and `release`
    * response actions in Response Console.

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/step_rule_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/step_rule_actions/index.tsx
@@ -15,9 +15,6 @@ import type {
   ActionVariables,
 } from '@kbn/triggers-actions-ui-plugin/public';
 import { UseArray } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
-import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-import { shouldShowResponseActions } from '../../../../../common/detection_engine/utils';
 import type { RuleObjectId } from '../../../../../common/api/detection_engine/model/rule_schema';
 import { ResponseActionsForm } from '../../../rule_response_actions/response_actions_form';
 import type {
@@ -40,7 +37,6 @@ interface StepRuleActionsProps extends RuleStepProps {
   ruleId?: RuleObjectId; // Rule SO's id (not ruleId)
   actionMessageParams: ActionVariables;
   summaryActionMessageParams: ActionVariables;
-  ruleType?: Type;
   form: FormHook<ActionsStepRule>;
 }
 
@@ -79,15 +75,11 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
   isUpdateView = false,
   actionMessageParams,
   summaryActionMessageParams,
-  ruleType,
   form,
 }) => {
   const {
     services: { application },
   } = useKibana();
-  const automatedResponseActionsForAllRulesEnabled = useIsExperimentalFeatureEnabled(
-    'automatedResponseActionsForAllRulesEnabled'
-  );
   const displayActionsOptions = useMemo(
     () => (
       <>
@@ -105,15 +97,12 @@ const StepRuleActionsComponent: FC<StepRuleActionsProps> = ({
     [actionMessageParams, summaryActionMessageParams]
   );
   const displayResponseActionsOptions = useMemo(() => {
-    if (shouldShowResponseActions(ruleType, automatedResponseActionsForAllRulesEnabled)) {
-      return (
-        <UseArray path="responseActions" initialNumberOfItems={0}>
-          {ResponseActionsForm}
-        </UseArray>
-      );
-    }
-    return null;
-  }, [automatedResponseActionsForAllRulesEnabled, ruleType]);
+    return (
+      <UseArray path="responseActions" initialNumberOfItems={0}>
+        {ResponseActionsForm}
+      </UseArray>
+    );
+  }, []);
   // only display the actions dropdown if the user has "read" privileges for actions
   const displayActionsDropDown = useMemo(() => {
     return application.capabilities.actions.show ? (

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/index.tsx
@@ -789,7 +789,6 @@ const CreateRulePageComponent: React.FC = () => {
             isLoading={isCreateRuleLoading || loading || isStartingJobs}
             actionMessageParams={actionMessageParams}
             summaryActionMessageParams={actionMessageParams}
-            ruleType={ruleType}
             form={actionsStepForm}
           />
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/index.tsx
@@ -840,7 +840,6 @@ const CreateRulePageComponent: React.FC = () => {
       isCreateRuleLoading,
       isStartingJobs,
       loading,
-      ruleType,
       submitRuleDisabled,
       submitRuleEnabled,
     ]

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
@@ -348,7 +348,6 @@ const EditRulePageComponent: FC<{ rule: RuleResponse }> = ({ rule }) => {
                   isUpdateView
                   actionMessageParams={actionMessageParams}
                   summaryActionMessageParams={actionMessageParams}
-                  ruleType={rule?.type}
                   form={actionsStepForm}
                   key="actionsStep"
                 />

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
@@ -361,7 +361,6 @@ const EditRulePageComponent: FC<{ rule: RuleResponse }> = ({ rule }) => {
     [
       rule?.immutable,
       rule?.id,
-      rule?.type,
       activeStep,
       loading,
       isSavedQueryLoading,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/utils/validate.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/utils/validate.ts
@@ -8,7 +8,6 @@
 import type { PartialRule } from '@kbn/alerting-plugin/server';
 import { isEqual, xorWith } from 'lodash';
 import { stringifyZodError } from '@kbn/zod-helpers';
-import { shouldShowResponseActions } from '../../../../../common/detection_engine/utils';
 import {
   type ResponseAction,
   type RuleCreateProps,
@@ -59,16 +58,6 @@ export const validateResponseActionsPermissions = async (
   ruleUpdate: RuleCreateProps | RuleUpdateProps,
   existingRule?: RuleAlertType | null
 ): Promise<void> => {
-  const { experimentalFeatures } = await securitySolution.getConfig();
-  if (
-    !shouldShowResponseActions(
-      ruleUpdate.type,
-      experimentalFeatures.automatedResponseActionsForAllRulesEnabled
-    )
-  ) {
-    return;
-  }
-
   if (
     !rulePayloadContainsResponseActions(ruleUpdate) ||
     (existingRule && !ruleObjectContainsResponseActions(existingRule))


### PR DESCRIPTION
This PR introduces UI changes that remove all checks and the feature flag controlling the visibility of Automated Response Actions in Rules. 
Going forward, response actions will be enabled by default for all rule types.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->