### PR TITLE
[Side navigation] bring back getIsActive to o11y solution navigation

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/navigation_tree.ts
+++ b/x-pack/plugins/observability_solution/observability/public/navigation_tree.ts
@@ -86,9 +86,25 @@ export function createNavTree(pluginsStart: ObservabilityPublicPluginsStart) {
             children: [
               {
                 children: [
-                  { link: 'apm:services' },
-                  { link: 'apm:traces' },
-                  { link: 'apm:dependencies' },
+                  {
+                    link: 'apm:services',
+                    getIsActive: ({ pathNameSerialized }) => {
+                      const regex = /app\/apm\/.*service.*/;
+                      return regex.test(pathNameSerialized);
+                    },
+                  },
+                  {
+                    link: 'apm:traces',
+                    getIsActive: ({ pathNameSerialized, prepend }) => {
+                      return pathNameSerialized.startsWith(prepend('/app/apm/traces'));
+                    },
+                  },
+                  {
+                    link: 'apm:dependencies',
+                    getIsActive: ({ pathNameSerialized, prepend }) => {
+                      return pathNameSerialized.startsWith(prepend('/app/apm/dependencies'));
+                    },
+                  },
                   {
                     link: 'ux',
                     title: i18n.translate('xpack.observability.obltNav.apm.ux', {
@@ -136,8 +152,16 @@ export function createNavTree(pluginsStart: ObservabilityPublicPluginsStart) {
                     title: i18n.translate('xpack.observability.infrastructure.inventory', {
                       defaultMessage: 'Infrastructure inventory',
                     }),
+                    getIsActive: ({ pathNameSerialized, prepend }) => {
+                      return pathNameSerialized.startsWith(prepend('/app/metrics/inventory'));
+                    },
                   },
-                  { link: 'metrics:hosts' },
+                  {
+                    link: 'metrics:hosts',
+                    getIsActive: ({ pathNameSerialized, prepend }) => {
+                      return pathNameSerialized.startsWith(prepend('/app/metrics/hosts'));
+                    },
+                  },
                   {
                     link: 'metrics:metrics-explorer',
                     title: i18n.translate(


### PR DESCRIPTION
## Summary

I realized that as part of this [PR](https://github.com/elastic/kibana/pull/192805/files#diff-8f26b8327cc9fc31bef2b22bb53b82256edc9cf05cfc9c766d746a7aa4532437L144), `getIsActive` method was accidentally removed from `Applications` and `Infrastructure` menus. This PR brings `getIsActive` back. I didn't find any bug with the absence of `getIsActive`. Purpose of this PR is to not remove something that was there before.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->