### PR TITLE
[Onboarding] only update the index details page when plugin is enabled

### DIFF
--- a/x-pack/plugins/search_indices/public/plugin.ts
+++ b/x-pack/plugins/search_indices/public/plugin.ts
@@ -87,11 +87,13 @@ export class SearchIndicesPlugin
   ): SearchIndicesPluginStart {
     const { indexManagement } = deps;
     docLinks.setDocLinks(core.docLinks.links);
-    indexManagement?.extensionsService.setIndexDetailsPageRoute({
-      renderRoute: (indexName) => {
-        return `/app/elasticsearch/indices/index_details/${indexName}`;
-      },
-    });
+    if (this.pluginEnabled) {
+      indexManagement?.extensionsService.setIndexDetailsPageRoute({
+        renderRoute: (indexName) => {
+          return `/app/elasticsearch/indices/index_details/${indexName}`;
+        },
+      });
+    }
     return {
       enabled: this.pluginEnabled,
       startAppId: START_APP_ID,


### PR DESCRIPTION
## Summary

The index details page is always updated even when the plugin is disabled. Using the pluginEnabled conditional to only update when enabled.  

### How to replicate
1. disable uisetting for search indices plugin
2. go to index management and click on a index detail

Expected: see the old index detail page
actual: goes to the new index detail url but does not render the search detail page (as plugin disabled)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->