### PR TITLE
[ML] Transforms: Pagination in the source documents data grid fix

### DIFF
--- a/x-pack/plugins/transform/public/app/hooks/use_index_data.ts
+++ b/x-pack/plugins/transform/public/app/hooks/use_index_data.ts
@@ -196,7 +196,7 @@ export const useIndexData = (options: UseIndexDataOptions): UseIndexDataReturnTy
       setStatus(INDEX_STATUS.LOADED);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataGridDataError, dataGridDataIsError, dataGridDataIsLoading]);
+  }, [dataGridDataError, dataGridDataIsError, dataGridDataIsLoading, dataGridData]);
 
   const allDataViewFieldNames = new Set(dataView.fields.map((f) => f.name));
   const { error: histogramsForFieldsError, data: histogramsForFieldsData } =


### PR DESCRIPTION
## Summary

Fix for: [#195881](https://github.com/elastic/kibana/issues/195881)

After:
It's hardly visible in the recording, but if you look at the `@timestamp` column, you can see that the values are changing correctly while navigating to a previous page, which was not the case before the fix.

https://github.com/user-attachments/assets/33be9e8c-e558-4f48-994a-562c4e3788de



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.15","8.16"]} ONMERGE-->