### PR TITLE
[Security Solution][DQD] Add historical results tour guide

### DIFF
--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/constants.ts
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/constants.ts
@@ -5,5 +5,5 @@
  * 2.0.
  */
 
-export const HISTORICAL_RESULTS_TOUR_IS_ACTIVE_STORAGE_KEY =
-  'securitySolution.dataQualityDashboard.historicalResultsTour.v8.16.isActive';
+export const HISTORICAL_RESULTS_TOUR_IS_DISMISSED_STORAGE_KEY =
+  'securitySolution.dataQualityDashboard.historicalResultsTour.v8.16.isDismissed';

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/constants.ts
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/constants.ts
@@ -5,9 +5,5 @@
  * 2.0.
  */
 
-export const MIN_PAGE_SIZE = 10;
-
-export const HISTORY_TAB_ID = 'history';
-export const LATEST_CHECK_TAB_ID = 'latest_check';
-
-export const HISTORICAL_RESULTS_TOUR_SELECTOR_KEY = 'data-tour-element';
+export const HISTORICAL_RESULTS_TOUR_IS_ACTIVE_STORAGE_KEY =
+  'securitySolution.dataQualityDashboard.historicalResultsTour.v8.16.isActive';

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/hooks/use_is_historical_results_tour_active/index.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/hooks/use_is_historical_results_tour_active/index.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback } from 'react';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+
+import { HISTORICAL_RESULTS_TOUR_IS_DISMISSED_STORAGE_KEY } from '../../constants';
+
+export const useIsHistoricalResultsTourActive = () => {
+  const [isTourDismissed, setIsTourDismissed] = useLocalStorage<boolean>(
+    HISTORICAL_RESULTS_TOUR_IS_DISMISSED_STORAGE_KEY,
+    false
+  );
+
+  const isTourActive = !isTourDismissed;
+  const setIsTourActive = useCallback(
+    (active: boolean) => {
+      setIsTourDismissed(!active);
+    },
+    [setIsTourDismissed]
+  );
+
+  return [isTourActive, setIsTourActive] as const;
+};

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/index.test.tsx
@@ -11,7 +11,10 @@ import React from 'react';
 
 import { EMPTY_STAT } from '../../constants';
 import { alertIndexWithAllResults } from '../../mock/pattern_rollup/mock_alerts_pattern_rollup';
-import { auditbeatWithAllResults } from '../../mock/pattern_rollup/mock_auditbeat_pattern_rollup';
+import {
+  auditbeatWithAllResults,
+  emptyAuditbeatPatternRollup,
+} from '../../mock/pattern_rollup/mock_auditbeat_pattern_rollup';
 import { packetbeatNoResults } from '../../mock/pattern_rollup/mock_packetbeat_pattern_rollup';
 import {
   TestDataQualityProviders,
@@ -31,15 +34,22 @@ const formatNumber = (value: number | undefined) =>
   value != null ? numeral(value).format(defaultNumberFormat) : EMPTY_STAT;
 
 const ilmPhases = ['hot', 'warm', 'unmanaged'];
-const patterns = ['.alerts-security.alerts-default', 'auditbeat-*', 'packetbeat-*'];
+const patterns = [
+  'test-empty-pattern-*',
+  '.alerts-security.alerts-default',
+  'auditbeat-*',
+  'packetbeat-*',
+];
 
 const patternRollups: Record<string, PatternRollup> = {
+  'test-empty-pattern-*': { ...emptyAuditbeatPatternRollup, pattern: 'test-empty-pattern-*' },
   '.alerts-security.alerts-default': alertIndexWithAllResults,
   'auditbeat-*': auditbeatWithAllResults,
   'packetbeat-*': packetbeatNoResults,
 };
 
 const patternIndexNames: Record<string, string[]> = {
+  'test-empty-pattern-*': [],
   'auditbeat-*': [
     '.ds-auditbeat-8.6.1-2023.02.07-000001',
     'auditbeat-custom-empty-index-1',
@@ -83,11 +93,11 @@ describe('IndicesDetails', () => {
   });
 
   describe('tour', () => {
-    test('it renders the tour wrapping view history button of first row of first pattern', async () => {
+    test('it renders the tour wrapping view history button of first row of first non-empty pattern', async () => {
       const wrapper = await screen.findByTestId('historicalResultsTour');
       const button = within(wrapper).getByRole('button', { name: 'View history' });
       expect(button).toBeInTheDocument();
-      expect(button).toHaveAttribute('data-tour-element', patterns[0]);
+      expect(button).toHaveAttribute('data-tour-element', patterns[1]);
 
       expect(
         screen.getByRole('dialog', { name: 'Introducing data quality history' })
@@ -113,23 +123,23 @@ describe('IndicesDetails', () => {
     });
 
     describe('when the first pattern is toggled', () => {
-      test('it renders the tour wrapping view history button of first row of second pattern', async () => {
-        const firstPatternAccordionWrapper = await screen.findByTestId(
-          `${patterns[0]}PatternPanel`
+      test('it renders the tour wrapping view history button of first row of second non-empty pattern', async () => {
+        const firstNonEmptyPatternAccordionWrapper = await screen.findByTestId(
+          `${patterns[1]}PatternPanel`
         );
-        const accordionToggle = within(firstPatternAccordionWrapper).getByRole('button', {
+        const accordionToggle = within(firstNonEmptyPatternAccordionWrapper).getByRole('button', {
           name: /Pass/,
         });
         await userEvent.click(accordionToggle);
 
-        const secondPatternAccordionWrapper = screen.getByTestId(`${patterns[1]}PatternPanel`);
+        const secondPatternAccordionWrapper = screen.getByTestId(`${patterns[2]}PatternPanel`);
         const historicalResultsWrapper = await within(secondPatternAccordionWrapper).findByTestId(
           'historicalResultsTour'
         );
         const button = within(historicalResultsWrapper).getByRole('button', {
           name: 'View history',
         });
-        expect(button).toHaveAttribute('data-tour-element', patterns[1]);
+        expect(button).toHaveAttribute('data-tour-element', patterns[2]);
 
         expect(
           screen.getByRole('dialog', { name: 'Introducing data quality history' })

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/index.test.tsx
@@ -117,7 +117,7 @@ describe('IndicesDetails', () => {
         await waitFor(() => expect(screen.queryByTestId('historicalResultsTour')).toBeNull());
 
         expect(localStorage.getItem(HISTORICAL_RESULTS_TOUR_IS_DISMISSED_STORAGE_KEY)).toEqual(
-          'false'
+          'true'
         );
       });
     });

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/index.test.tsx
@@ -23,7 +23,7 @@ import {
 import { PatternRollup } from '../../types';
 import { Props, IndicesDetails } from '.';
 import userEvent from '@testing-library/user-event';
-import { HISTORICAL_RESULTS_TOUR_IS_ACTIVE_STORAGE_KEY } from './constants';
+import { HISTORICAL_RESULTS_TOUR_IS_DISMISSED_STORAGE_KEY } from './constants';
 
 const defaultBytesFormat = '0,0.[0]b';
 const formatBytes = (value: number | undefined) =>
@@ -70,7 +70,7 @@ const defaultProps: Props = {
 describe('IndicesDetails', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
-    localStorage.removeItem(HISTORICAL_RESULTS_TOUR_IS_ACTIVE_STORAGE_KEY);
+    localStorage.removeItem(HISTORICAL_RESULTS_TOUR_IS_DISMISSED_STORAGE_KEY);
 
     render(
       <TestExternalProviders>
@@ -116,7 +116,7 @@ describe('IndicesDetails', () => {
 
         await waitFor(() => expect(screen.queryByTestId('historicalResultsTour')).toBeNull());
 
-        expect(localStorage.getItem(HISTORICAL_RESULTS_TOUR_IS_ACTIVE_STORAGE_KEY)).toEqual(
+        expect(localStorage.getItem(HISTORICAL_RESULTS_TOUR_IS_DISMISSED_STORAGE_KEY)).toEqual(
           'false'
         );
       });

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/historical_results_tour/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/historical_results_tour/index.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { HISTORICAL_RESULTS_TOUR_SELECTOR_KEY } from '../constants';
+import { HistoricalResultsTour } from '.';
+import { INTRODUCING_DATA_QUALITY_HISTORY, VIEW_PAST_RESULTS } from './translations';
+
+const anchorSelectorValue = 'test-anchor';
+
+describe('HistoricalResultsTour', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('given no anchor element', () => {
+    it('does not render the tour step', () => {
+      render(
+        <HistoricalResultsTour
+          anchorSelectorValue={anchorSelectorValue}
+          onTryIt={jest.fn()}
+          isOpen={true}
+          onDismissTour={jest.fn()}
+        />
+      );
+
+      expect(screen.queryByText(INTRODUCING_DATA_QUALITY_HISTORY)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('given an anchor element', () => {
+    beforeEach(() => {
+      // eslint-disable-next-line no-unsanitized/property
+      document.body.innerHTML = `<div ${HISTORICAL_RESULTS_TOUR_SELECTOR_KEY}="${anchorSelectorValue}"></div>`;
+    });
+
+    describe('when isOpen is true', () => {
+      const onTryIt = jest.fn();
+      const onDismissTour = jest.fn();
+      beforeEach(() => {
+        render(
+          <HistoricalResultsTour
+            anchorSelectorValue={anchorSelectorValue}
+            onTryIt={onTryIt}
+            isOpen={true}
+            onDismissTour={onDismissTour}
+          />
+        );
+      });
+      it('renders the tour step', async () => {
+        expect(
+          await screen.findByRole('dialog', { name: INTRODUCING_DATA_QUALITY_HISTORY })
+        ).toBeInTheDocument();
+        expect(screen.getByText(INTRODUCING_DATA_QUALITY_HISTORY)).toBeInTheDocument();
+        expect(screen.getByText(VIEW_PAST_RESULTS)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Close/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Try It/i })).toBeInTheDocument();
+
+        const historicalResultsTour = screen.getByTestId('historicalResultsTour');
+        expect(historicalResultsTour.querySelector('[data-tour-element]')).toHaveAttribute(
+          'data-tour-element',
+          anchorSelectorValue
+        );
+      });
+
+      describe('when the close button is clicked', () => {
+        it('calls dismissTour', async () => {
+          await userEvent.click(await screen.findByRole('button', { name: /Close/i }));
+          expect(onDismissTour).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('when the try it button is clicked', () => {
+        it('calls onTryIt', async () => {
+          await userEvent.click(await screen.findByRole('button', { name: /Try It/i }));
+          expect(onTryIt).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe('when isOpen is false', () => {
+      it('does not render the tour step', async () => {
+        render(
+          <HistoricalResultsTour
+            anchorSelectorValue={anchorSelectorValue}
+            onTryIt={jest.fn()}
+            isOpen={false}
+            onDismissTour={jest.fn()}
+          />
+        );
+
+        await waitFor(() =>
+          expect(screen.queryByText(INTRODUCING_DATA_QUALITY_HISTORY)).not.toBeInTheDocument()
+        );
+      });
+    });
+  });
+});

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/historical_results_tour/index.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/historical_results_tour/index.tsx
@@ -12,22 +12,24 @@ import styled from 'styled-components';
 import { HISTORICAL_RESULTS_TOUR_SELECTOR_KEY } from '../constants';
 import { CLOSE, INTRODUCING_DATA_QUALITY_HISTORY, TRY_IT, VIEW_PAST_RESULTS } from './translations';
 
-interface HistoricalResultsTourProps {
+export interface Props {
   anchorSelectorValue: string;
   isOpen: boolean;
   onTryIt: () => void;
   onDismissTour: () => void;
+  zIndex?: number;
 }
 
 const StyledText = styled(EuiText)`
   margin-block-start: -10px;
 `;
 
-export const HistoricalResultsTour: FC<HistoricalResultsTourProps> = ({
+export const HistoricalResultsTour: FC<Props> = ({
   anchorSelectorValue,
   onTryIt,
   isOpen,
   onDismissTour,
+  zIndex,
 }) => {
   const [anchorElement, setAnchorElement] = useState<HTMLElement>();
 
@@ -64,6 +66,7 @@ export const HistoricalResultsTour: FC<HistoricalResultsTourProps> = ({
       anchorPosition="rightUp"
       repositionOnScroll
       anchor={anchorElement}
+      zIndex={zIndex}
       footerAction={[
         <EuiButtonEmpty size="xs" color="text" onClick={onDismissTour}>
           {CLOSE}

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/historical_results_tour/index.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/historical_results_tour/index.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC, useEffect, useState } from 'react';
+import { EuiButton, EuiButtonEmpty, EuiText, EuiTourStep } from '@elastic/eui';
+import styled from 'styled-components';
+
+import { HISTORICAL_RESULTS_TOUR_SELECTOR_KEY } from '../constants';
+import { CLOSE, INTRODUCING_DATA_QUALITY_HISTORY, TRY_IT, VIEW_PAST_RESULTS } from './translations';
+
+interface HistoricalResultsTourProps {
+  anchorSelectorValue: string;
+  isOpen: boolean;
+  onTryIt: () => void;
+  onDismissTour: () => void;
+}
+
+const StyledText = styled(EuiText)`
+  margin-block-start: -10px;
+`;
+
+export const HistoricalResultsTour: FC<HistoricalResultsTourProps> = ({
+  anchorSelectorValue,
+  onTryIt,
+  isOpen,
+  onDismissTour,
+}) => {
+  const [anchorElement, setAnchorElement] = useState<HTMLElement>();
+
+  useEffect(() => {
+    const element = document.querySelector<HTMLElement>(
+      `[${HISTORICAL_RESULTS_TOUR_SELECTOR_KEY}="${anchorSelectorValue}"]`
+    );
+
+    if (!element) {
+      return;
+    }
+
+    setAnchorElement(element);
+  }, [anchorSelectorValue]);
+
+  if (!isOpen || !anchorElement) {
+    return null;
+  }
+
+  return (
+    <EuiTourStep
+      content={
+        <StyledText size="s">
+          <p>{VIEW_PAST_RESULTS}</p>
+        </StyledText>
+      }
+      data-test-subj="historicalResultsTour"
+      isStepOpen={isOpen}
+      minWidth={283}
+      onFinish={onDismissTour}
+      step={1}
+      stepsTotal={1}
+      title={INTRODUCING_DATA_QUALITY_HISTORY}
+      anchorPosition="rightUp"
+      repositionOnScroll
+      anchor={anchorElement}
+      footerAction={[
+        <EuiButtonEmpty size="xs" color="text" onClick={onDismissTour}>
+          {CLOSE}
+        </EuiButtonEmpty>,
+        <EuiButton color="success" size="s" onClick={onTryIt}>
+          {TRY_IT}
+        </EuiButton>,
+      ]}
+    />
+  );
+};

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/historical_results_tour/translations.ts
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/historical_results_tour/translations.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const CLOSE = i18n.translate('securitySolutionPackages.ecsDataQualityDashboard.close', {
+  defaultMessage: 'Close',
+});
+
+export const TRY_IT = i18n.translate('securitySolutionPackages.ecsDataQualityDashboard.tryIt', {
+  defaultMessage: 'Try it',
+});
+
+export const INTRODUCING_DATA_QUALITY_HISTORY = i18n.translate(
+  'securitySolutionPackages.ecsDataQualityDashboard.introducingDataQualityHistory',
+  {
+    defaultMessage: 'Introducing data quality history',
+  }
+);
+
+export const VIEW_PAST_RESULTS = i18n.translate(
+  'securitySolutionPackages.ecsDataQualityDashboard.viewPastResults',
+  {
+    defaultMessage: 'View past results',
+  }
+);

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { act, render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 
 import {
   TestDataQualityProviders,
@@ -19,6 +19,7 @@ import { useStats } from './hooks/use_stats';
 import { ERROR_LOADING_METADATA_TITLE, LOADING_STATS } from './translations';
 import { useHistoricalResults } from './hooks/use_historical_results';
 import { getHistoricalResultStub } from '../../../stub/get_historical_result_stub';
+import userEvent from '@testing-library/user-event';
 
 const pattern = 'auditbeat-*';
 
@@ -81,6 +82,10 @@ describe('pattern', () => {
             setChartSelectedIndex={jest.fn()}
             indexNames={Object.keys(auditbeatWithAllResults.stats!)}
             pattern={pattern}
+            isTourActive={false}
+            onDismissTour={jest.fn()}
+            isFirstOpenPattern={false}
+            onAccordionToggle={jest.fn()}
           />
         </TestDataQualityProviders>
       </TestExternalProviders>
@@ -107,6 +112,10 @@ describe('pattern', () => {
                 setChartSelectedIndex={jest.fn()}
                 indexNames={undefined}
                 pattern={'remote:*'}
+                isTourActive={false}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={false}
+                onAccordionToggle={jest.fn()}
               />
             </TestDataQualityProviders>
           </TestExternalProviders>
@@ -127,6 +136,10 @@ describe('pattern', () => {
                 setChartSelectedIndex={jest.fn()}
                 indexNames={undefined}
                 pattern={pattern}
+                isTourActive={false}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={false}
+                onAccordionToggle={jest.fn()}
               />
             </TestDataQualityProviders>
           </TestExternalProviders>
@@ -155,6 +168,10 @@ describe('pattern', () => {
                 setChartSelectedIndex={jest.fn()}
                 indexNames={Object.keys(auditbeatWithAllResults.stats!)}
                 pattern={pattern}
+                isTourActive={false}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={false}
+                onAccordionToggle={jest.fn()}
               />
             </TestDataQualityProviders>
           </TestExternalProviders>
@@ -182,6 +199,10 @@ describe('pattern', () => {
                 setChartSelectedIndex={jest.fn()}
                 indexNames={Object.keys(auditbeatWithAllResults.stats!)}
                 pattern={pattern}
+                isTourActive={false}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={false}
+                onAccordionToggle={jest.fn()}
               />
             </TestDataQualityProviders>
           </TestExternalProviders>
@@ -215,6 +236,10 @@ describe('pattern', () => {
                 setChartSelectedIndex={jest.fn()}
                 indexNames={Object.keys(auditbeatWithAllResults.stats!)}
                 pattern={pattern}
+                isTourActive={false}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={false}
+                onAccordionToggle={jest.fn()}
               />
             </TestDataQualityProviders>
           </TestExternalProviders>
@@ -248,6 +273,10 @@ describe('pattern', () => {
                 setChartSelectedIndex={jest.fn()}
                 indexNames={Object.keys(auditbeatWithAllResults.stats!)}
                 pattern={pattern}
+                isTourActive={false}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={false}
+                onAccordionToggle={jest.fn()}
               />
             </TestDataQualityProviders>
           </TestExternalProviders>
@@ -292,6 +321,10 @@ describe('pattern', () => {
                 setChartSelectedIndex={jest.fn()}
                 indexNames={Object.keys(auditbeatWithAllResults.stats!)}
                 pattern={pattern}
+                isTourActive={false}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={false}
+                onAccordionToggle={jest.fn()}
               />
             </TestDataQualityProviders>
           </TestExternalProviders>
@@ -306,7 +339,7 @@ describe('pattern', () => {
           name: 'Check now',
         });
 
-        await act(async () => checkNowButton.click());
+        await userEvent.click(checkNowButton);
 
         // assert
         expect(checkIndex).toHaveBeenCalledTimes(1);
@@ -370,6 +403,10 @@ describe('pattern', () => {
                 setChartSelectedIndex={jest.fn()}
                 indexNames={Object.keys(auditbeatWithAllResults.stats!)}
                 pattern={pattern}
+                isTourActive={false}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={false}
+                onAccordionToggle={jest.fn()}
               />
             </TestDataQualityProviders>
           </TestExternalProviders>
@@ -384,7 +421,7 @@ describe('pattern', () => {
           name: 'View history',
         });
 
-        await act(async () => viewHistoryButton.click());
+        await userEvent.click(viewHistoryButton);
 
         // assert
         expect(fetchHistoricalResults).toHaveBeenCalledTimes(1);
@@ -444,6 +481,10 @@ describe('pattern', () => {
                 setChartSelectedIndex={jest.fn()}
                 indexNames={Object.keys(auditbeatWithAllResults.stats!)}
                 pattern={pattern}
+                isTourActive={false}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={false}
+                onAccordionToggle={jest.fn()}
               />
             </TestDataQualityProviders>
           </TestExternalProviders>
@@ -458,11 +499,11 @@ describe('pattern', () => {
           name: 'View history',
         });
 
-        await act(async () => viewHistoryButton.click());
+        await userEvent.click(viewHistoryButton);
 
         const closeButton = screen.getByRole('button', { name: 'Close this dialog' });
 
-        await act(async () => closeButton.click());
+        await userEvent.click(closeButton);
 
         // assert
         expect(screen.queryByTestId('indexCheckFlyout')).not.toBeInTheDocument();
@@ -504,6 +545,10 @@ describe('pattern', () => {
                 setChartSelectedIndex={jest.fn()}
                 indexNames={Object.keys(auditbeatWithAllResults.stats!)}
                 pattern={pattern}
+                isTourActive={false}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={false}
+                onAccordionToggle={jest.fn()}
               />
             </TestDataQualityProviders>
           </TestExternalProviders>
@@ -530,6 +575,344 @@ describe('pattern', () => {
         );
         expect(screen.getByTestId('latestResults')).toBeInTheDocument();
         expect(screen.queryByTestId('historicalResults')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Tour', () => {
+    describe('when isTourActive and isFirstOpenPattern', () => {
+      it('renders the tour near the first row history view button', async () => {
+        (useIlmExplain as jest.Mock).mockReturnValue({
+          error: null,
+          ilmExplain: auditbeatWithAllResults.ilmExplain,
+          loading: false,
+        });
+
+        (useStats as jest.Mock).mockReturnValue({
+          stats: auditbeatWithAllResults.stats,
+          error: null,
+          loading: false,
+        });
+
+        render(
+          <TestExternalProviders>
+            <TestDataQualityProviders>
+              <Pattern
+                patternRollup={auditbeatWithAllResults}
+                chartSelectedIndex={null}
+                setChartSelectedIndex={jest.fn()}
+                indexNames={Object.keys(auditbeatWithAllResults.stats!)}
+                pattern={pattern}
+                isTourActive={true}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={true}
+                onAccordionToggle={jest.fn()}
+              />
+            </TestDataQualityProviders>
+          </TestExternalProviders>
+        );
+
+        const rows = screen.getAllByRole('row');
+        // skipping the first row which is the header
+        const firstBodyRow = within(rows[1]);
+
+        const tourWrapper = await firstBodyRow.findByTestId('historicalResultsTour');
+
+        expect(
+          within(tourWrapper).getByRole('button', { name: 'View history' })
+        ).toBeInTheDocument();
+
+        expect(
+          screen.getByRole('dialog', { name: 'Introducing data quality history' })
+        ).toBeInTheDocument();
+      });
+
+      describe('when accordion is collapsed', () => {
+        it('hides the tour', async () => {
+          (useIlmExplain as jest.Mock).mockReturnValue({
+            error: null,
+            ilmExplain: auditbeatWithAllResults.ilmExplain,
+            loading: false,
+          });
+
+          (useStats as jest.Mock).mockReturnValue({
+            stats: auditbeatWithAllResults.stats,
+            error: null,
+            loading: false,
+          });
+
+          render(
+            <TestExternalProviders>
+              <TestDataQualityProviders>
+                <Pattern
+                  patternRollup={auditbeatWithAllResults}
+                  chartSelectedIndex={null}
+                  setChartSelectedIndex={jest.fn()}
+                  indexNames={Object.keys(auditbeatWithAllResults.stats!)}
+                  pattern={pattern}
+                  isTourActive={true}
+                  onDismissTour={jest.fn()}
+                  isFirstOpenPattern={true}
+                  onAccordionToggle={jest.fn()}
+                />
+              </TestDataQualityProviders>
+            </TestExternalProviders>
+          );
+
+          expect(await screen.findByTestId('historicalResultsTour')).toBeInTheDocument();
+
+          const accordionToggle = screen.getByRole('button', {
+            name: 'Fail auditbeat-* hot (1) unmanaged (2) Incompatible fields 4 Indices checked 3 Indices 3 Size 17.9MB Docs 19,127',
+          });
+
+          await userEvent.click(accordionToggle);
+
+          expect(screen.queryByTestId('historicalResultsTour')).not.toBeInTheDocument();
+        });
+      });
+
+      describe('when the tour close button is clicked', () => {
+        it('invokes onDismissTour', async () => {
+          (useIlmExplain as jest.Mock).mockReturnValue({
+            error: null,
+            ilmExplain: auditbeatWithAllResults.ilmExplain,
+            loading: false,
+          });
+
+          (useStats as jest.Mock).mockReturnValue({
+            stats: auditbeatWithAllResults.stats,
+            error: null,
+            loading: false,
+          });
+
+          const onDismissTour = jest.fn();
+
+          render(
+            <TestExternalProviders>
+              <TestDataQualityProviders>
+                <Pattern
+                  patternRollup={auditbeatWithAllResults}
+                  chartSelectedIndex={null}
+                  setChartSelectedIndex={jest.fn()}
+                  indexNames={Object.keys(auditbeatWithAllResults.stats!)}
+                  pattern={pattern}
+                  isTourActive={true}
+                  onDismissTour={onDismissTour}
+                  isFirstOpenPattern={true}
+                  onAccordionToggle={jest.fn()}
+                />
+              </TestDataQualityProviders>
+            </TestExternalProviders>
+          );
+
+          const tourDialog = await screen.findByRole('dialog', {
+            name: 'Introducing data quality history',
+          });
+
+          const closeButton = within(tourDialog).getByRole('button', { name: 'Close' });
+
+          await userEvent.click(closeButton);
+
+          expect(onDismissTour).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('when the tour tryIt action is clicked', () => {
+        it('opens the flyout with history tab and invokes onDismissTour', async () => {
+          (useIlmExplain as jest.Mock).mockReturnValue({
+            error: null,
+            ilmExplain: auditbeatWithAllResults.ilmExplain,
+            loading: false,
+          });
+
+          (useStats as jest.Mock).mockReturnValue({
+            stats: auditbeatWithAllResults.stats,
+            error: null,
+            loading: false,
+          });
+
+          const onDismissTour = jest.fn();
+
+          render(
+            <TestExternalProviders>
+              <TestDataQualityProviders>
+                <Pattern
+                  patternRollup={auditbeatWithAllResults}
+                  chartSelectedIndex={null}
+                  setChartSelectedIndex={jest.fn()}
+                  indexNames={Object.keys(auditbeatWithAllResults.stats!)}
+                  pattern={pattern}
+                  isTourActive={true}
+                  onDismissTour={onDismissTour}
+                  isFirstOpenPattern={true}
+                  onAccordionToggle={jest.fn()}
+                />
+              </TestDataQualityProviders>
+            </TestExternalProviders>
+          );
+
+          const tourDialog = await screen.findByRole('dialog', {
+            name: 'Introducing data quality history',
+          });
+
+          const tryItButton = within(tourDialog).getByRole('button', { name: 'Try it' });
+
+          await userEvent.click(tryItButton);
+
+          expect(onDismissTour).toHaveBeenCalledTimes(1);
+          expect(screen.getByTestId('indexCheckFlyout')).toBeInTheDocument();
+          expect(screen.getByRole('tab', { name: 'Latest Check' })).toHaveAttribute(
+            'aria-selected',
+            'false'
+          );
+          expect(screen.getByRole('tab', { name: 'History' })).toHaveAttribute(
+            'aria-selected',
+            'true'
+          );
+        });
+      });
+
+      describe('when latest latest check flyout tab is opened', () => {
+        it('hides the tour in listview and shows in flyout', async () => {
+          (useIlmExplain as jest.Mock).mockReturnValue({
+            error: null,
+            ilmExplain: auditbeatWithAllResults.ilmExplain,
+            loading: false,
+          });
+
+          (useStats as jest.Mock).mockReturnValue({
+            stats: auditbeatWithAllResults.stats,
+            error: null,
+            loading: false,
+          });
+
+          const onDismissTour = jest.fn();
+
+          render(
+            <TestExternalProviders>
+              <TestDataQualityProviders>
+                <Pattern
+                  patternRollup={auditbeatWithAllResults}
+                  chartSelectedIndex={null}
+                  setChartSelectedIndex={jest.fn()}
+                  indexNames={Object.keys(auditbeatWithAllResults.stats!)}
+                  pattern={pattern}
+                  isTourActive={true}
+                  onDismissTour={onDismissTour}
+                  isFirstOpenPattern={true}
+                  onAccordionToggle={jest.fn()}
+                />
+              </TestDataQualityProviders>
+            </TestExternalProviders>
+          );
+
+          const rows = screen.getAllByRole('row');
+          // skipping the first row which is the header
+          const firstBodyRow = within(rows[1]);
+
+          expect(await firstBodyRow.findByTestId('historicalResultsTour')).toBeInTheDocument();
+          expect(
+            screen.getByRole('dialog', { name: 'Introducing data quality history' })
+          ).toBeInTheDocument();
+
+          const checkNowButton = firstBodyRow.getByRole('button', {
+            name: 'Check now',
+          });
+          await userEvent.click(checkNowButton);
+
+          expect(screen.getByTestId('indexCheckFlyout')).toBeInTheDocument();
+          expect(screen.getByRole('tab', { name: 'Latest Check' })).toHaveAttribute(
+            'aria-selected',
+            'true'
+          );
+          expect(screen.getByRole('tab', { name: 'History' })).toHaveAttribute(
+            'aria-selected',
+            'false'
+          );
+
+          expect(firstBodyRow.queryByTestId('historicalResultsTour')).not.toBeInTheDocument();
+
+          const tabWrapper = await screen.findByRole('tab', { name: 'History' });
+          await waitFor(() =>
+            expect(
+              tabWrapper.closest('[data-test-subj="historicalResultsTour"]')
+            ).toBeInTheDocument()
+          );
+
+          expect(onDismissTour).not.toHaveBeenCalled();
+        }, 10000);
+      });
+    });
+
+    describe('when not isFirstOpenPattern', () => {
+      it('does not render the tour', async () => {
+        (useIlmExplain as jest.Mock).mockReturnValue({
+          error: null,
+          ilmExplain: auditbeatWithAllResults.ilmExplain,
+          loading: false,
+        });
+
+        (useStats as jest.Mock).mockReturnValue({
+          stats: auditbeatWithAllResults.stats,
+          error: null,
+          loading: false,
+        });
+
+        render(
+          <TestExternalProviders>
+            <TestDataQualityProviders>
+              <Pattern
+                patternRollup={auditbeatWithAllResults}
+                chartSelectedIndex={null}
+                setChartSelectedIndex={jest.fn()}
+                indexNames={Object.keys(auditbeatWithAllResults.stats!)}
+                pattern={pattern}
+                isTourActive={true}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={false}
+                onAccordionToggle={jest.fn()}
+              />
+            </TestDataQualityProviders>
+          </TestExternalProviders>
+        );
+
+        expect(screen.queryByTestId('historicalResultsTour')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when not isTourActive', () => {
+      it('does not render the tour', async () => {
+        (useIlmExplain as jest.Mock).mockReturnValue({
+          error: null,
+          ilmExplain: auditbeatWithAllResults.ilmExplain,
+          loading: false,
+        });
+
+        (useStats as jest.Mock).mockReturnValue({
+          stats: auditbeatWithAllResults.stats,
+          error: null,
+          loading: false,
+        });
+
+        render(
+          <TestExternalProviders>
+            <TestDataQualityProviders>
+              <Pattern
+                patternRollup={auditbeatWithAllResults}
+                chartSelectedIndex={null}
+                setChartSelectedIndex={jest.fn()}
+                indexNames={Object.keys(auditbeatWithAllResults.stats!)}
+                pattern={pattern}
+                isTourActive={false}
+                onDismissTour={jest.fn()}
+                isFirstOpenPattern={true}
+                onAccordionToggle={jest.fn()}
+              />
+            </TestDataQualityProviders>
+          </TestExternalProviders>
+        );
+
+        expect(screen.queryByTestId('historicalResultsTour')).not.toBeInTheDocument();
       });
     });
   });

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index.tsx
@@ -377,6 +377,15 @@ const PatternComponent: React.FC<Props> = ({
                     isAccordionOpen
                   }
                   onDismissTour={onDismissTour}
+                  // Only set zIndex when the tour is in list view (not in flyout)
+                  //
+                  // 1 less than the z-index of the left navigation
+                  // 5 less than the z-index of the timeline
+                  //
+                  //
+                  // TODO this hack should be removed when we properly set z-indexes
+                  // in the timeline and left navigation
+                  zIndex={998}
                 />
                 <SummaryTable
                   getTableColumns={getSummaryTableColumns}
@@ -390,7 +399,6 @@ const PatternComponent: React.FC<Props> = ({
                   onCheckNowAction={handleFlyoutCheckNowAndExpandAction}
                   onViewHistoryAction={handleFlyoutViewCheckHistoryAction}
                   sorting={sorting}
-                  firstIndexName={items[0]?.indexName}
                 />
               </div>
             )}

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index_check_flyout/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/index_check_flyout/index.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { IndexCheckFlyout } from '.';
@@ -41,6 +41,8 @@ describe('IndexCheckFlyout', () => {
                 pattern="auditbeat-*"
                 patternRollup={auditbeatWithAllResults}
                 stats={mockStats}
+                onDismissTour={jest.fn()}
+                isTourActive={false}
               />
             </TestHistoricalResultsProvider>
           </TestDataQualityProviders>
@@ -97,6 +99,8 @@ describe('IndexCheckFlyout', () => {
                 patternRollup={auditbeatWithAllResults}
                 stats={mockStats}
                 initialSelectedTabId="latest_check"
+                isTourActive={false}
+                onDismissTour={jest.fn()}
               />
             </TestHistoricalResultsProvider>
           </TestDataQualityProviders>
@@ -129,6 +133,8 @@ describe('IndexCheckFlyout', () => {
                 patternRollup={auditbeatWithAllResults}
                 stats={mockStats}
                 initialSelectedTabId="latest_check"
+                isTourActive={false}
+                onDismissTour={jest.fn()}
               />
             </TestHistoricalResultsProvider>
           </TestDataQualityProviders>
@@ -175,6 +181,8 @@ describe('IndexCheckFlyout', () => {
                 patternRollup={auditbeatWithAllResults}
                 stats={mockStats}
                 initialSelectedTabId="latest_check"
+                onDismissTour={jest.fn()}
+                isTourActive={false}
               />
             </TestHistoricalResultsProvider>
           </TestDataQualityProviders>
@@ -205,6 +213,181 @@ describe('IndexCheckFlyout', () => {
       );
 
       expect(screen.getByTestId('historicalResults')).toBeInTheDocument();
+    });
+  });
+
+  describe('Tour guide', () => {
+    describe('when in Latest Check tab and isTourActive', () => {
+      it('should render the tour guide near history tab with proper data-tour-element attribute', async () => {
+        const pattern = 'auditbeat-*';
+        render(
+          <TestExternalProviders>
+            <TestDataQualityProviders>
+              <TestHistoricalResultsProvider>
+                <IndexCheckFlyout
+                  ilmExplain={mockIlmExplain}
+                  indexName="auditbeat-custom-index-1"
+                  onClose={jest.fn()}
+                  pattern={pattern}
+                  patternRollup={auditbeatWithAllResults}
+                  stats={mockStats}
+                  initialSelectedTabId="latest_check"
+                  onDismissTour={jest.fn()}
+                  isTourActive={true}
+                />
+              </TestHistoricalResultsProvider>
+            </TestDataQualityProviders>
+          </TestExternalProviders>
+        );
+
+        const historyTab = screen.getByRole('tab', { name: 'History' });
+        const latestCheckTab = screen.getByRole('tab', { name: 'Latest Check' });
+
+        expect(historyTab).toHaveAttribute('data-tour-element', `${pattern}-history-tab`);
+        expect(latestCheckTab).not.toHaveAttribute('data-tour-element', `${pattern}-history-tab`);
+        await waitFor(() =>
+          expect(historyTab.closest('[data-test-subj="historicalResultsTour"]')).toBeInTheDocument()
+        );
+        expect(
+          screen.getByRole('dialog', { name: 'Introducing data quality history' })
+        ).toBeInTheDocument();
+      });
+
+      describe('when the tour close button is clicked', () => {
+        it('should invoke the dismiss tour callback', async () => {
+          const onDismissTour = jest.fn();
+          render(
+            <TestExternalProviders>
+              <TestDataQualityProviders>
+                <TestHistoricalResultsProvider>
+                  <IndexCheckFlyout
+                    ilmExplain={mockIlmExplain}
+                    indexName="auditbeat-custom-index-1"
+                    onClose={jest.fn()}
+                    pattern="auditbeat-*"
+                    patternRollup={auditbeatWithAllResults}
+                    stats={mockStats}
+                    initialSelectedTabId="latest_check"
+                    onDismissTour={onDismissTour}
+                    isTourActive={true}
+                  />
+                </TestHistoricalResultsProvider>
+              </TestDataQualityProviders>
+            </TestExternalProviders>
+          );
+
+          const dialogWrapper = await screen.findByRole('dialog', {
+            name: 'Introducing data quality history',
+          });
+
+          const closeButton = within(dialogWrapper).getByRole('button', { name: 'Close' });
+          await userEvent.click(closeButton);
+
+          expect(onDismissTour).toHaveBeenCalled();
+        });
+      });
+
+      describe('when the tour TryIt button is clicked', () => {
+        it('should switch to history tab and invoke onDismissTour', async () => {
+          const onDismissTour = jest.fn();
+          render(
+            <TestExternalProviders>
+              <TestDataQualityProviders>
+                <TestHistoricalResultsProvider>
+                  <IndexCheckFlyout
+                    ilmExplain={mockIlmExplain}
+                    indexName="auditbeat-custom-index-1"
+                    onClose={jest.fn()}
+                    pattern="auditbeat-*"
+                    patternRollup={auditbeatWithAllResults}
+                    stats={mockStats}
+                    initialSelectedTabId="latest_check"
+                    onDismissTour={onDismissTour}
+                    isTourActive={true}
+                  />
+                </TestHistoricalResultsProvider>
+              </TestDataQualityProviders>
+            </TestExternalProviders>
+          );
+
+          const dialogWrapper = await screen.findByRole('dialog', {
+            name: 'Introducing data quality history',
+          });
+
+          const tryItButton = within(dialogWrapper).getByRole('button', { name: 'Try it' });
+          await userEvent.click(tryItButton);
+
+          expect(onDismissTour).toHaveBeenCalled();
+          expect(screen.getByRole('tab', { name: 'History' })).toHaveAttribute(
+            'aria-selected',
+            'true'
+          );
+
+          expect(onDismissTour).toHaveBeenCalled();
+        });
+      });
+
+      describe('when manually switching to history tab', () => {
+        it('should invoke onDismissTour', async () => {
+          const onDismissTour = jest.fn();
+          render(
+            <TestExternalProviders>
+              <TestDataQualityProviders>
+                <TestHistoricalResultsProvider>
+                  <IndexCheckFlyout
+                    ilmExplain={mockIlmExplain}
+                    indexName="auditbeat-custom-index-1"
+                    onClose={jest.fn()}
+                    pattern="auditbeat-*"
+                    patternRollup={auditbeatWithAllResults}
+                    stats={mockStats}
+                    initialSelectedTabId="latest_check"
+                    onDismissTour={onDismissTour}
+                    isTourActive={true}
+                  />
+                </TestHistoricalResultsProvider>
+              </TestDataQualityProviders>
+            </TestExternalProviders>
+          );
+
+          const historyTab = screen.getByRole('tab', { name: 'History' });
+          await userEvent.click(historyTab);
+
+          expect(onDismissTour).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when not isTourActive', () => {
+      it('should not render the tour guide', async () => {
+        render(
+          <TestExternalProviders>
+            <TestDataQualityProviders>
+              <TestHistoricalResultsProvider>
+                <IndexCheckFlyout
+                  ilmExplain={mockIlmExplain}
+                  indexName="auditbeat-custom-index-1"
+                  onClose={jest.fn()}
+                  pattern="auditbeat-*"
+                  patternRollup={auditbeatWithAllResults}
+                  stats={mockStats}
+                  initialSelectedTabId="latest_check"
+                  onDismissTour={jest.fn()}
+                  isTourActive={false}
+                />
+              </TestHistoricalResultsProvider>
+            </TestDataQualityProviders>
+          </TestExternalProviders>
+        );
+
+        await waitFor(() =>
+          expect(screen.queryByTestId('historicalResultsTour')).not.toBeInTheDocument()
+        );
+
+        expect(
+          screen.queryByRole('dialog', { name: 'Introducing data quality history' })
+        ).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/summary_table/index.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/summary_table/index.tsx
@@ -30,6 +30,7 @@ export interface Props {
     pattern: string;
     onCheckNowAction: (indexName: string) => void;
     onViewHistoryAction: (indexName: string) => void;
+    firstIndexName?: string;
   }) => Array<EuiBasicTableColumn<IndexSummaryTableItem>>;
   items: IndexSummaryTableItem[];
   pageIndex: number;
@@ -41,6 +42,7 @@ export interface Props {
   sorting: SortConfig;
   onCheckNowAction: (indexName: string) => void;
   onViewHistoryAction: (indexName: string) => void;
+  firstIndexName?: string;
 }
 
 const SummaryTableComponent: React.FC<Props> = ({
@@ -55,6 +57,7 @@ const SummaryTableComponent: React.FC<Props> = ({
   sorting,
   onCheckNowAction,
   onViewHistoryAction,
+  firstIndexName,
 }) => {
   const { isILMAvailable, formatBytes, formatNumber } = useDataQualityContext();
   const columns = useMemo(
@@ -66,6 +69,7 @@ const SummaryTableComponent: React.FC<Props> = ({
         pattern,
         onCheckNowAction,
         onViewHistoryAction,
+        firstIndexName,
       }),
     [
       getTableColumns,
@@ -75,6 +79,7 @@ const SummaryTableComponent: React.FC<Props> = ({
       pattern,
       onCheckNowAction,
       onViewHistoryAction,
+      firstIndexName,
     ]
   );
   const getItemId = useCallback((item: IndexSummaryTableItem) => item.indexName, []);

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/summary_table/index.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/summary_table/index.tsx
@@ -42,7 +42,6 @@ export interface Props {
   sorting: SortConfig;
   onCheckNowAction: (indexName: string) => void;
   onViewHistoryAction: (indexName: string) => void;
-  firstIndexName?: string;
 }
 
 const SummaryTableComponent: React.FC<Props> = ({
@@ -57,7 +56,6 @@ const SummaryTableComponent: React.FC<Props> = ({
   sorting,
   onCheckNowAction,
   onViewHistoryAction,
-  firstIndexName,
 }) => {
   const { isILMAvailable, formatBytes, formatNumber } = useDataQualityContext();
   const columns = useMemo(
@@ -69,7 +67,7 @@ const SummaryTableComponent: React.FC<Props> = ({
         pattern,
         onCheckNowAction,
         onViewHistoryAction,
-        firstIndexName,
+        firstIndexName: items[0]?.indexName,
       }),
     [
       getTableColumns,
@@ -79,7 +77,7 @@ const SummaryTableComponent: React.FC<Props> = ({
       pattern,
       onCheckNowAction,
       onViewHistoryAction,
-      firstIndexName,
+      items,
     ]
   );
   const getItemId = useCallback((item: IndexSummaryTableItem) => item.indexName, []);

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/summary_table/utils/columns.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/summary_table/utils/columns.test.tsx
@@ -197,6 +197,60 @@ describe('helpers', () => {
 
         expect(onViewHistoryAction).toBeCalledWith(indexSummaryTableItem.indexName);
       });
+
+      test('adds data-tour-element attribute to the first view history button', () => {
+        const pattern = 'auditbeat-*';
+        const columns = getSummaryTableColumns({
+          formatBytes,
+          formatNumber,
+          isILMAvailable,
+          pattern,
+          onCheckNowAction: jest.fn(),
+          onViewHistoryAction: jest.fn(),
+          firstIndexName: indexName,
+        });
+
+        const expandActionRender = (
+          (columns[0] as EuiTableActionsColumnType<IndexSummaryTableItem>)
+            .actions[1] as CustomItemAction<IndexSummaryTableItem>
+        ).render;
+
+        render(
+          <TestExternalProviders>
+            {expandActionRender != null && expandActionRender(indexSummaryTableItem, true)}
+          </TestExternalProviders>
+        );
+
+        const button = screen.getByLabelText(VIEW_HISTORY);
+        expect(button).toHaveAttribute('data-tour-element', pattern);
+      });
+
+      test('doesn`t add data-tour-element attribute to non-first view history buttons', () => {
+        const pattern = 'auditbeat-*';
+        const columns = getSummaryTableColumns({
+          formatBytes,
+          formatNumber,
+          isILMAvailable,
+          pattern,
+          onCheckNowAction: jest.fn(),
+          onViewHistoryAction: jest.fn(),
+          firstIndexName: 'another-index',
+        });
+
+        const expandActionRender = (
+          (columns[0] as EuiTableActionsColumnType<IndexSummaryTableItem>)
+            .actions[1] as CustomItemAction<IndexSummaryTableItem>
+        ).render;
+
+        render(
+          <TestExternalProviders>
+            {expandActionRender != null && expandActionRender(indexSummaryTableItem, true)}
+          </TestExternalProviders>
+        );
+
+        const button = screen.getByLabelText(VIEW_HISTORY);
+        expect(button).not.toHaveAttribute('data-tour-element');
+      });
     });
 
     describe('incompatible render()', () => {

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/summary_table/utils/columns.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/summary_table/utils/columns.tsx
@@ -37,6 +37,7 @@ import { IndexResultBadge } from '../../index_result_badge';
 import { Stat } from '../../../../../stat';
 import { getIndexResultToolTip } from '../../utils/get_index_result_tooltip';
 import { CHECK_NOW } from '../../translations';
+import { HISTORICAL_RESULTS_TOUR_SELECTOR_KEY } from '../../constants';
 
 const ProgressContainer = styled.div`
   width: 150px;
@@ -102,6 +103,7 @@ export const getSummaryTableColumns = ({
   pattern,
   onCheckNowAction,
   onViewHistoryAction,
+  firstIndexName,
 }: {
   formatBytes: (value: number | undefined) => string;
   formatNumber: (value: number | undefined) => string;
@@ -109,6 +111,7 @@ export const getSummaryTableColumns = ({
   pattern: string;
   onCheckNowAction: (indexName: string) => void;
   onViewHistoryAction: (indexName: string) => void;
+  firstIndexName?: string;
 }): Array<EuiBasicTableColumn<IndexSummaryTableItem>> => [
   {
     name: i18n.ACTIONS,
@@ -132,12 +135,16 @@ export const getSummaryTableColumns = ({
       {
         name: i18n.VIEW_HISTORY,
         render: (item) => {
+          const isFirstIndexName = firstIndexName === item.indexName;
           return (
             <EuiToolTip content={i18n.VIEW_HISTORY}>
               <EuiButtonIcon
                 iconType="clockCounter"
                 aria-label={i18n.VIEW_HISTORY}
                 onClick={() => onViewHistoryAction(item.indexName)}
+                {...(isFirstIndexName && {
+                  [HISTORICAL_RESULTS_TOUR_SELECTOR_KEY]: pattern,
+                })}
               />
             </EuiToolTip>
           );

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/mock/pattern_rollup/mock_auditbeat_pattern_rollup.ts
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/mock/pattern_rollup/mock_auditbeat_pattern_rollup.ts
@@ -166,3 +166,21 @@ export const auditbeatWithAllResults: PatternRollup = {
     },
   },
 };
+
+export const emptyAuditbeatPatternRollup: PatternRollup = {
+  docsCount: 0,
+  error: null,
+  ilmExplain: {},
+  ilmExplainPhaseCounts: {
+    hot: 0,
+    warm: 0,
+    cold: 0,
+    frozen: 0,
+    unmanaged: 0,
+  },
+  indices: 0,
+  pattern: 'auditbeat-*',
+  results: {},
+  sizeInBytes: 0,
+  stats: {},
+};


### PR DESCRIPTION
addresses #195971

This PR adds missing new historical results feature tour guide.

## Tour guide features:
- ability to maintain visual presence while collapsing accordions in list-view
- move from list-view to flyout view and back
- seamlessly integrates with existing opening flyout and history tab functionality

## PR decisions with explanation:
- data-tour-element has been introduced on select elements (like first actions of each first row) to avoid polluting every single element with data-test-subj. This way it's imho specific and semantically more clear what the elements are for.
- early on I tried to control the anchoring with refs but some eui elements don't allow passing refs like EuiTab, so instead a more simpler and straightforward approach with dom selectors has been chosen
- localStorage key name has been picked in accordance with other instances of usage `securitySolution.dataQualityDashboard.historicalResultsTour.v8.16.isActive` the name includes the full domain + the version when it's introduced. And since this tour step is a single step there is no need to stringify an object with `isTourActive` in and it's much simpler to just bake the activity state into the name and make the value just a boolean.

## UI Demo

### Anchor reposition demo (listview + flyout)
https://github.com/user-attachments/assets/0f961c51-0e36-48ca-aab4-bef3b0d1269e

### List view tour guide try it + reload demo
https://github.com/user-attachments/assets/ca1f5fda-ee02-4a48-827c-91df757a8ddf

### FlyOut Try It + reload demo
https://github.com/user-attachments/assets/d0801ac3-1ed1-4e64-9d6b-3140b8402bdf

### Manual history tab selection path + reload demo
https://github.com/user-attachments/assets/34dbb447-2fd6-4dc0-a4f5-682c9c65cc8b

### Manual open history view path + reload demo
https://github.com/user-attachments/assets/945dd042-fc12-476e-8d23-f48c9ded9f65

### Dismiss list view tour guide + reload demo
https://github.com/user-attachments/assets/d20d1416-827f-46f2-9161-a3c0a8cbd932

### Dismiss FlyOut tour guide + reload demo
https://github.com/user-attachments/assets/8f085f59-20a9-49f0-b5b3-959c4719f5cb

### Serverless empty pattern handling + reposition demo
https://github.com/user-attachments/assets/4af5939e-663c-4439-a3fc-deff2d4de7e4



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->