### PR TITLE
[deploy-fix@1728886420] [Onboarding] only update the index details page when plugin is enabled (#196077)

### DIFF
--- a/x-pack/plugins/search_indices/public/plugin.ts
+++ b/x-pack/plugins/search_indices/public/plugin.ts
@@ -87,11 +87,13 @@ export class SearchIndicesPlugin
   ): SearchIndicesPluginStart {
     const { indexManagement } = deps;
     docLinks.setDocLinks(core.docLinks.links);
-    indexManagement?.extensionsService.setIndexDetailsPageRoute({
-      renderRoute: (indexName) => {
-        return `/app/elasticsearch/indices/index_details/${indexName}`;
-      },
-    });
+    if (this.pluginEnabled) {
+      indexManagement?.extensionsService.setIndexDetailsPageRoute({
+        renderRoute: (indexName) => {
+          return `/app/elasticsearch/indices/index_details/${indexName}`;
+        },
+      });
+    }
     return {
       enabled: this.pluginEnabled,
       startAppId: START_APP_ID,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `deploy-fix@1728886420`:
 - [[Onboarding] only update the index details page when plugin is enabled (#196077)](https://github.com/elastic/kibana/pull/196077)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Joe McElroy","email":"joseph.mcelroy@elastic.co"},"sourceCommit":{"committedDate":"2024-10-14T11:53:25Z","message":"[Onboarding] only update the index details page when plugin is enabled (#196077)\n\n## Summary\r\n\r\nThe index details page is always updated even when the plugin is\r\ndisabled. Using the pluginEnabled conditional to only update when\r\nenabled.\r\n\r\n### How to replicate\r\n1. disable uisetting for search indices plugin\r\n2. go to index management and click on a index detail\r\n\r\nExpected: see the old index detail page\r\nactual: goes to the new index detail url but does not render the search\r\ndetail page (as plugin disabled)\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed","sha":"efab00b36ede744916f924c6a7965dd93624493b","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor"],"number":196077,"url":"https://github.com/elastic/kibana/pull/196077","mergeCommit":{"message":"[Onboarding] only update the index details page when plugin is enabled (#196077)\n\n## Summary\r\n\r\nThe index details page is always updated even when the plugin is\r\ndisabled. Using the pluginEnabled conditional to only update when\r\nenabled.\r\n\r\n### How to replicate\r\n1. disable uisetting for search indices plugin\r\n2. go to index management and click on a index detail\r\n\r\nExpected: see the old index detail page\r\nactual: goes to the new index detail url but does not render the search\r\ndetail page (as plugin disabled)\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed","sha":"efab00b36ede744916f924c6a7965dd93624493b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/196077","number":196077,"mergeCommit":{"message":"[Onboarding] only update the index details page when plugin is enabled (#196077)\n\n## Summary\r\n\r\nThe index details page is always updated even when the plugin is\r\ndisabled. Using the pluginEnabled conditional to only update when\r\nenabled.\r\n\r\n### How to replicate\r\n1. disable uisetting for search indices plugin\r\n2. go to index management and click on a index detail\r\n\r\nExpected: see the old index detail page\r\nactual: goes to the new index detail url but does not render the search\r\ndetail page (as plugin disabled)\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed","sha":"efab00b36ede744916f924c6a7965dd93624493b"}},{"url":"https://github.com/elastic/kibana/pull/196121","number":196121,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->