### PR TITLE
[ObsUX][APM-Otel] Fix index pattern to accept otel indices, bump up version

### DIFF
--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
@@ -17,7 +17,7 @@ export const builtInServicesFromEcsEntityDefinition: EntityDefinition =
       'This definition extracts service entities from common data streams by looking for the ECS field service.name',
     type: 'service',
     managed: true,
-    indexPatterns: ['logs-*', 'filebeat*', 'traces-apm*'],
+    indexPatterns: ['logs-*', 'filebeat*', 'traces*'],
     latest: {
       timestampField: '@timestamp',
       lookbackPeriod: '10m',

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/services_from_ecs_data.ts
@@ -10,14 +10,14 @@ import { BUILT_IN_ID_PREFIX } from './constants';
 
 export const builtInServicesFromEcsEntityDefinition: EntityDefinition =
   entityDefinitionSchema.parse({
-    version: '0.4.0',
+    version: '0.5.0',
     id: `${BUILT_IN_ID_PREFIX}services_from_ecs_data`,
     name: 'Services from ECS data',
     description:
       'This definition extracts service entities from common data streams by looking for the ECS field service.name',
     type: 'service',
     managed: true,
-    indexPatterns: ['logs-*', 'filebeat*', 'traces*'],
+    indexPatterns: ['logs-*', 'filebeat*', 'traces-*'],
     latest: {
       timestampField: '@timestamp',
       lookbackPeriod: '10m',


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/195653

### The problem
The current service definition used by the transforms uses the`traces-apm*`  indices and service.name as identifier fields, otel has `traces-*.otel-*`

### Solution
Modify the definition of the index patterns to look for `traces*`

We can see now otel service in the entities inventory

<img width="1913" alt="image" src="https://github.com/user-attachments/assets/eab63982-0ab3-4b0f-8557-93e96653630f">

