### PR TITLE
chore(quality-gates): update manual judgement on staging QGs

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-staging.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-staging.yaml
@@ -46,3 +46,4 @@ steps:
         command: "make -C /agent trigger-manual-verification-phase"
         agents:
           image: "docker.elastic.co/ci-agent-images/manual-verification-agent:0.0.6"
+        if: build.env("DEPLOYMENT_SLICES") =~ /.*staging-ds-2.*/


### PR DESCRIPTION
## Summary

  This is a build/promotion system change only, there is no code related
  changes here.

  - Similar to https://github.com/elastic/kibana/pull/195944, but for the non-emergency pipeline in staging
  - For now, only run the staging manual judgement on slice: 'staging-ds-2'
  - Since slices can be grouped as a comma delimited list, we're choosing to be overly cautious with the regex

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

