### PR TITLE
[Lens] escape backslash characters in the formula input

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/generate.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/formula/generate.ts
@@ -79,7 +79,7 @@ export function generateFormula(
     }
     previousFormula +=
       (previousColumn.filter.language === 'kuery' ? 'kql=' : 'lucene=') +
-      `'${previousColumn.filter.query.replace(/'/g, `\\'`)}'`; // replace all
+      `'${previousColumn.filter.query.replace(/\\/g, '\\\\').replace(/'/g, `\\'`)}'`; // replace all
   }
   if (previousColumn.timeShift) {
     if (


### PR DESCRIPTION
## Summary

Ensures that backslashes are properly escaped in addition to single quotes in formula



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->