### PR TITLE
[Cloud Security] Temporarily disabled rule creation for 3P findings

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/detection_rule_counter.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/detection_rule_counter.tsx
@@ -17,6 +17,7 @@ import { METRIC_TYPE } from '@kbn/analytics';
 import { useHistory } from 'react-router-dom';
 import useSessionStorage from 'react-use/lib/useSessionStorage';
 import { useQueryClient } from '@tanstack/react-query';
+import { i18n as kbnI18n } from '@kbn/i18n';
 import { useFetchDetectionRulesAlertsStatus } from '../common/api/use_fetch_detection_rules_alerts_status';
 import { useFetchDetectionRulesByTags } from '../common/api/use_fetch_detection_rules_by_tags';
 import { RuleResponse } from '../common/types';
@@ -67,15 +68,30 @@ export const DetectionRuleCounter = ({ tags, createRuleFn }: DetectionRuleCounte
   }, [history]);
 
   const createDetectionRuleOnClick = useCallback(async () => {
-    uiMetricService.trackUiMetric(METRIC_TYPE.CLICK, CREATE_DETECTION_RULE_FROM_FLYOUT);
     const startServices = { analytics, notifications, i18n, theme };
-    setIsCreateRuleLoading(true);
-    const ruleResponse = await createRuleFn(http);
-    setIsCreateRuleLoading(false);
-    showCreateDetectionRuleSuccessToast(startServices, http, ruleResponse);
-    // Triggering a refetch of rules and alerts to update the UI
-    queryClient.invalidateQueries([DETECTION_ENGINE_RULES_KEY]);
-    queryClient.invalidateQueries([DETECTION_ENGINE_ALERTS_KEY]);
+
+    try {
+      setIsCreateRuleLoading(true);
+      uiMetricService.trackUiMetric(METRIC_TYPE.CLICK, CREATE_DETECTION_RULE_FROM_FLYOUT);
+
+      const ruleResponse = await createRuleFn(http);
+
+      setIsCreateRuleLoading(false);
+      showCreateDetectionRuleSuccessToast(startServices, http, ruleResponse);
+
+      // Triggering a refetch of rules and alerts to update the UI
+      queryClient.invalidateQueries([DETECTION_ENGINE_RULES_KEY]);
+      queryClient.invalidateQueries([DETECTION_ENGINE_ALERTS_KEY]);
+    } catch (e) {
+      setIsCreateRuleLoading(false);
+
+      notifications.toasts.addWarning({
+        title: kbnI18n.translate('xpack.csp.detectionRuleCounter.alerts.createRuleErrorTitle', {
+          defaultMessage: 'Coming Soon',
+        }),
+        text: e.message,
+      });
+    }
   }, [createRuleFn, http, analytics, notifications, i18n, theme, queryClient]);
 
   if (alertsIsError) return <>{'-'}</>;

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/utils/create_detection_rule_from_benchmark.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/utils/create_detection_rule_from_benchmark.ts
@@ -8,8 +8,8 @@
 import { HttpSetup } from '@kbn/core/public';
 import { LATEST_FINDINGS_RETENTION_POLICY } from '@kbn/cloud-security-posture-common';
 import type { CspBenchmarkRule } from '@kbn/cloud-security-posture-common/schema/rules/latest';
+import { i18n } from '@kbn/i18n';
 import { FINDINGS_INDEX_PATTERN } from '../../../../common/constants';
-
 import { createDetectionRule } from '../../../common/api/create_detection_rule';
 import { generateBenchmarkRuleTags } from '../../../../common/utils/detection_rules';
 
@@ -63,6 +63,14 @@ export const createDetectionRuleFromBenchmarkRule = async (
   http: HttpSetup,
   benchmarkRule: CspBenchmarkRule['metadata']
 ) => {
+  if (!benchmarkRule.benchmark?.posture_type) {
+    throw new Error(
+      i18n.translate('xpack.csp.createDetectionRuleFromBenchmarkRule.createRuleErrorMessage', {
+        defaultMessage: 'Rule creation is currently only available for Elastic findings',
+      })
+    );
+  }
+
   return await createDetectionRule({
     http,
     rule: {

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/utils/create_detection_rule_from_vulnerability.test.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/utils/create_detection_rule_from_vulnerability.test.ts
@@ -18,7 +18,7 @@ jest.mock('../../../common/utils/is_native_csp_finding', () => ({
   isNativeCspFinding: jest.fn(),
 }));
 
-describe('CreateDetectionRuleFromVulnerability', () => {
+describe.skip('CreateDetectionRuleFromVulnerability', () => {
   describe('getVulnerabilityTags', () => {
     it('should return tags with CSP_RULE_TAG and vulnerability id', () => {
       const mockVulnerability = {

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/utils/create_detection_rule_from_vulnerability.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/utils/create_detection_rule_from_vulnerability.ts
@@ -13,6 +13,7 @@ import {
   VULNERABILITIES_SEVERITY,
 } from '@kbn/cloud-security-posture-common';
 import type { Vulnerability } from '@kbn/cloud-security-posture-common/schema/vulnerabilities/latest';
+import { CSP_VULN_DATASET } from '../../../common/utils/get_vendor_name';
 import { isNativeCspFinding } from '../../../common/utils/is_native_csp_finding';
 import { VULNERABILITIES_INDEX_PATTERN } from '../../../../common/constants';
 import { createDetectionRule } from '../../../common/api/create_detection_rule';
@@ -87,6 +88,15 @@ export const createDetectionRuleFromVulnerabilityFinding = async (
   http: HttpSetup,
   vulnerabilityFinding: CspVulnerabilityFinding
 ) => {
+  if (!vulnerabilityFinding.data_stream?.dataset !== CSP_VULN_DATASET) {
+    throw new Error(
+      i18n.translate(
+        'xpack.csp.createDetectionRuleFromVulnerabilityFinding.createRuleErrorMessage',
+        { defaultMessage: 'Rule creation is currently only available for Elastic findings' }
+      )
+    );
+  }
+
   const tags = getVulnerabilityTags(vulnerabilityFinding);
   const vulnerability = vulnerabilityFinding.vulnerability;
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/utils/create_detection_rule_from_vulnerability.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/utils/create_detection_rule_from_vulnerability.ts
@@ -88,7 +88,7 @@ export const createDetectionRuleFromVulnerabilityFinding = async (
   http: HttpSetup,
   vulnerabilityFinding: CspVulnerabilityFinding
 ) => {
-  if (!vulnerabilityFinding.data_stream?.dataset !== CSP_VULN_DATASET) {
+  if (vulnerabilityFinding.data_stream?.dataset !== CSP_VULN_DATASET) {
     throw new Error(
       i18n.translate(
         'xpack.csp.createDetectionRuleFromVulnerabilityFinding.createRuleErrorMessage',


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/security-team/issues/10797

This PR is meant to be temporary and easy to revert. There are many "rough" areas but we should be able to re-enable rule creation for 8.17 and remove everything that is being add in this PR.

**Why not disable the buttons?**

There are 3 buttons for each findings type - from the kebab menu, from the action menu, and directly from the flyout alert section. Disabling all of them would also require to add a lot of tooltips, and bypass a lot of tests. deemed not worth for the small time period that we plan to have this situation

**Why the errors are different?**

Using the `notifications` service from `useKibana` requires the `createDetection` functions to be react hooks. this requires a larger refactor to all consumers of those functions and its not worth the effort

The alerts field's `detection rule creation counter` for some reason does not handle errors which means the throwed error does not pop up a toaster. Instead i've used the notification service from outside the creation function logic and passed a custom toaster which is better verbally.

**Why misconfig shows `-` while vulns has the counter component?**

Vulns were fixed and already are supporting 3P rule creation. but due to recent changes we had to make regarding the [retention policy for 3P](https://github.com/elastic/security-team/issues/10683), we are still not sure how the rule creation will function and thus disabling the entire thing until we will feel more confident.

There is a separate ticket to [support rule creation for misconfigs](https://github.com/elastic/kibana/issues/190971) as well, but its been pushed to 8.17 because we disable everything anyways for 8.16. 

While this is not the prettiest solution, its just the easiest to come back to in the near future without overdoing on temporary changes

**Why skip the tests?**

The change is fundamental to the logic of how we determine which type of rule to create, throwing an error basically disables all logic that we have to decide which tags to create a rule with and its not worth to refactor or write new tests for this temporary solution.

**In the video:**

Creation works for native csp findings, does not work for all mentioned buttons for wiz misconfig + wiz vuln


https://github.com/user-attachments/assets/305ee80f-973d-41cd-ac1b-c860113b3f9e



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->