### PR TITLE
[Search] test(es3): ensure index management index details shown

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/search/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/index.ts
@@ -15,6 +15,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./navigation'));
     loadTestFile(require.resolve('./connectors/connectors_overview'));
     loadTestFile(require.resolve('./default_dataview'));
+    loadTestFile(require.resolve('./index_management'));
     loadTestFile(require.resolve('./pipelines'));
     loadTestFile(require.resolve('./cases/attachment_framework'));
     loadTestFile(require.resolve('./dashboards/build_dashboard'));

--- a/x-pack/test_serverless/functional/test_suites/search/index_management.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/index_management.ts
@@ -18,7 +18,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     'indexManagement',
   ]);
   const security = getService('security');
+  const esDeleteAllIndices = getService('esDeleteAllIndices');
 
+  const testIndexName = `test-index-ftr-${Math.random()}`;
   describe('index management', function () {
     before(async () => {
       await security.testUser.setRoles(['index_management_user']);
@@ -29,9 +31,24 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await pageObjects.indexManagement.changeTabs('indicesTab');
       await pageObjects.header.waitUntilLoadingHasFinished();
     });
+    after(async () => {
+      await esDeleteAllIndices(testIndexName);
+    });
 
     it('has embedded dev console', async () => {
       await testHasEmbeddedConsole(pageObjects);
+    });
+
+    it('can create an index', async () => {
+      await pageObjects.indexManagement.clickCreateIndexButton();
+      await pageObjects.indexManagement.setCreateIndexName(testIndexName);
+      await pageObjects.indexManagement.clickCreateIndexSaveButton();
+      await pageObjects.indexManagement.expectIndexToExist(testIndexName);
+    });
+
+    it('can view index details - index with no documents', async () => {
+      await pageObjects.indexManagement.indexDetailsPage.openIndexDetailsPage(0);
+      await pageObjects.indexManagement.indexDetailsPage.expectIndexDetailsPageIsLoaded();
     });
   });
 }


### PR DESCRIPTION
## Summary

Re-added the serverless search specific index management tests so that we can ensure the index details page is rendered correctly when the search indices plugin feature flag is disabled.

This test will be replaced by index_details tests when the feature flag is enabled, but until that is the default behavior this test ensure we have full coverage for the user experience.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
