### PR TITLE
[SecuritySolution][Alert Details] - fix missing key console log error

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/header.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/header.tsx
@@ -64,6 +64,7 @@ export const PanelHeader: FC<PanelHeaderProps> = memo(
           isTourAnchor={isAlert}
           step={AlertsCasesTourSteps.reviewAlertDetailsFlyout}
           tourId={SecurityStepId.alertsCases}
+          key={index}
         >
           <EuiTab
             onClick={() => onSelectedTabChanged(tab.id)}


### PR DESCRIPTION
## Summary

This PR fixes a very minor inconvenience, with a missing `key` that throws an error in the console when opening the alert details flyout in the Overview tab

https://github.com/user-attachments/assets/b9d876e0-e166-4e9c-b6bb-07ac9d88170d
