### PR TITLE
Update cli-description

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -19,8 +19,8 @@ const program = new Command('bin/kibana');
 program
   .version(pkg.version)
   .description(
-    'Kibana is an open and free, browser ' +
-      'based analytics and search dashboard for Elasticsearch.'
+    'Kibana is an open source (Elastic License 2.0 / AGPL 3.0 / SSPL 1.0),' +
+      ' browser based analytics and search dashboard for Elasticsearch.'
   );
 
 // attach commands

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -19,8 +19,7 @@ const program = new Command('bin/kibana');
 program
   .version(pkg.version)
   .description(
-    'Kibana is an open source (Elastic License 2.0 / AGPL 3.0 / SSPL 1.0),' +
-      ' browser based analytics and search dashboard for Elasticsearch.'
+    'Kibana is an open source, browser based analytics and search dashboard for Elasticsearch.'
   );
 
 // attach commands


### PR DESCRIPTION
Updates the `cli` description text to reflect license change from https://github.com/elastic/kibana/pull/192025.

