### PR TITLE
[8.12] Revert "Deprecate search session documentation"

### DIFF
--- a/docs/discover/search-sessions.asciidoc
+++ b/docs/discover/search-sessions.asciidoc
@@ -1,8 +1,6 @@
 [[search-sessions]]
 == Run a search session in the background
 
-deprecated::[8.15.0,Search Sessions are deprecated and will be removed in a future version.]
-
 Sometimes you might need to search through large amounts of data, no matter
 how long the search takes.
 Consider a threat hunting scenario, where you need to search through years of data.

--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -509,8 +509,8 @@ Includes {ref}/frozen-indices.html[frozen indices] in results. Searching through
 frozen indices might increase the search time. This setting is off by default.
 Users must opt-in to include frozen indices.
 
-[[search-timeout]]`search:timeout`:: Change the maximum timeout, in milliseconds (ms), for search requests. To disable
-the timeout and allow queries to run to completion, set to 0. The default is `600000`, or 10 minutes.
+[[search-timeout]]`search:timeout`:: Change the maximum timeout, in milliseconds (ms), for a search
+session. To disable the timeout and allow queries to run to completion, set to 0. The default is 600,000 ms, or 10 minutes.
 
 [float]
 [[kibana-siem-settings]]

--- a/docs/settings/search-sessions-settings.asciidoc
+++ b/docs/settings/search-sessions-settings.asciidoc
@@ -5,20 +5,18 @@
 <titleabbrev>Search sessions settings</titleabbrev>
 ++++
 
-deprecated::[8.15.0,Search Sessions are deprecated and will be removed in a future version.]
-
 Configure the search session settings in your `kibana.yml` configuration file.
 
-deprecated:[8.15.0] `data.search.sessions.enabled` {ess-icon}::
+`data.search.sessions.enabled` {ess-icon}::
 Set to `true` (default) to enable search sessions.
 
-deprecated:[8.15.0] `data.search.sessions.notTouchedTimeout` {ess-icon}::
+`data.search.sessions.notTouchedTimeout` {ess-icon}::
 How long {kib} stores search results from unsaved sessions,
 after the last search in the session completes. The default is `5m`.
 
-deprecated:[8.15.0] `data.search.sessions.maxUpdateRetries` {ess-icon}::
+`data.search.sessions.maxUpdateRetries` {ess-icon}::
 How many retries {kib} can perform while attempting to save a search session. The default is `10`.
 
-deprecated:[8.15.0] `data.search.sessions.defaultExpiration` {ess-icon}::
+`data.search.sessions.defaultExpiration` {ess-icon}::
 How long search session results are stored before they are deleted.
 Extending a search session resets the expiration by the same value. The default is `7d`.


### PR DESCRIPTION
## Summary

Reverts https://github.com/elastic/kibana/pull/192224 for 8.12 as it references 8.15 but was accidentally backported to 8.12.