### PR TITLE
[Security Solution][Notes] - fix incorrect get_notes api for documentIds and savedObjectIds query parameters and adding api integration tests

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/notes/get_notes.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/notes/get_notes.ts
@@ -96,7 +96,7 @@ export const getNotesRoute = (router: SecuritySolutionPluginRouter) => {
               return response.ok({ body });
             }
 
-            // searching for all the notes associated with a specific for saved object id
+            // searching for all the notes associated with a specific saved object id
             const options: SavedObjectsFindOptions = {
               type: noteSavedObjectType,
               hasReference: {

--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/notes/get_notes.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/notes/get_notes.ts
@@ -9,6 +9,8 @@ import type { IKibanaResponse } from '@kbn/core-http-server';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import type { SortOrder } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
+import type { SavedObjectsFindOptions } from '@kbn/core-saved-objects-api-server';
+import { nodeBuilder } from '@kbn/es-query';
 import { timelineSavedObjectType } from '../../saved_object_mappings';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
 import { MAX_UNASSOCIATED_NOTES, NOTE_URL } from '../../../../../common/constants';
@@ -43,78 +45,90 @@ export const getNotesRoute = (router: SecuritySolutionPluginRouter) => {
             uiSettings: { client: uiSettingsClient },
           } = await frameworkRequest.context.core;
           const maxUnassociatedNotes = await uiSettingsClient.get<number>(MAX_UNASSOCIATED_NOTES);
+
+          // if documentIds is provided, we will search for all the notes associated with the documentIds
           const documentIds = queryParams.documentIds ?? null;
-          const savedObjectIds = queryParams.savedObjectIds ?? null;
           if (documentIds != null) {
+            // search for multiple document ids (like retrieving all the notes for all the alerts within a table)
             if (Array.isArray(documentIds)) {
-              const docIdSearchString = documentIds?.join(' | ');
-              const options = {
+              const options: SavedObjectsFindOptions = {
                 type: noteSavedObjectType,
-                search: docIdSearchString,
+                filter: nodeBuilder.or(
+                  documentIds.map((documentId: string) =>
+                    nodeBuilder.is(`${noteSavedObjectType}.attributes.eventId`, documentId)
+                  )
+                ),
                 page: 1,
-                perPage: maxUnassociatedNotes,
-              };
-              const res = await getAllSavedNote(frameworkRequest, options);
-              const body: GetNotesResponse = res ?? {};
-              return response.ok({ body });
-            } else {
-              const options = {
-                type: noteSavedObjectType,
-                search: documentIds,
-                page: 1,
-                perPage: maxUnassociatedNotes,
-              };
-              const res = await getAllSavedNote(frameworkRequest, options);
-              return response.ok({ body: res ?? {} });
-            }
-          } else if (savedObjectIds != null) {
-            if (Array.isArray(savedObjectIds)) {
-              const soIdSearchString = savedObjectIds?.join(' | ');
-              const options = {
-                type: noteSavedObjectType,
-                hasReference: {
-                  type: timelineSavedObjectType,
-                  id: soIdSearchString,
-                },
-                page: 1,
-                perPage: maxUnassociatedNotes,
-              };
-              const res = await getAllSavedNote(frameworkRequest, options);
-              const body: GetNotesResponse = res ?? {};
-              return response.ok({ body });
-            } else {
-              const options = {
-                type: noteSavedObjectType,
-                hasReference: {
-                  type: timelineSavedObjectType,
-                  id: savedObjectIds,
-                },
                 perPage: maxUnassociatedNotes,
               };
               const res = await getAllSavedNote(frameworkRequest, options);
               const body: GetNotesResponse = res ?? {};
               return response.ok({ body });
             }
-          } else {
-            const perPage = queryParams?.perPage ? parseInt(queryParams.perPage, 10) : 10;
-            const page = queryParams?.page ? parseInt(queryParams.page, 10) : 1;
-            const search = queryParams?.search ?? undefined;
-            const sortField = queryParams?.sortField ?? undefined;
-            const sortOrder = (queryParams?.sortOrder as SortOrder) ?? undefined;
-            const filter = queryParams?.filter;
-            const options = {
+
+            // searching for all the notes associated with a specific document id
+            const options: SavedObjectsFindOptions = {
               type: noteSavedObjectType,
-              perPage,
-              page,
-              search,
-              sortField,
-              sortOrder,
-              filter,
+              filter: nodeBuilder.is(`${noteSavedObjectType}.attributes.eventId`, documentIds),
+              page: 1,
+              perPage: maxUnassociatedNotes,
+            };
+            const res = await getAllSavedNote(frameworkRequest, options);
+            return response.ok({ body: res ?? {} });
+          }
+
+          // if savedObjectIds is provided, we will search for all the notes associated with the savedObjectIds
+          const savedObjectIds = queryParams.savedObjectIds ?? null;
+          if (savedObjectIds != null) {
+            // search for multiple saved object ids
+            if (Array.isArray(savedObjectIds)) {
+              const options: SavedObjectsFindOptions = {
+                type: noteSavedObjectType,
+                hasReference: savedObjectIds.map((savedObjectId: string) => ({
+                  type: timelineSavedObjectType,
+                  id: savedObjectId,
+                })),
+                page: 1,
+                perPage: maxUnassociatedNotes,
+              };
+              const res = await getAllSavedNote(frameworkRequest, options);
+              const body: GetNotesResponse = res ?? {};
+              return response.ok({ body });
+            }
+
+            // searching for all the notes associated with a specific for saved object id
+            const options: SavedObjectsFindOptions = {
+              type: noteSavedObjectType,
+              hasReference: {
+                type: timelineSavedObjectType,
+                id: savedObjectIds,
+              },
+              perPage: maxUnassociatedNotes,
             };
             const res = await getAllSavedNote(frameworkRequest, options);
             const body: GetNotesResponse = res ?? {};
             return response.ok({ body });
           }
+
+          // retrieving all the notes following the query parameters
+          const perPage = queryParams?.perPage ? parseInt(queryParams.perPage, 10) : 10;
+          const page = queryParams?.page ? parseInt(queryParams.page, 10) : 1;
+          const search = queryParams?.search ?? undefined;
+          const sortField = queryParams?.sortField ?? undefined;
+          const sortOrder = (queryParams?.sortOrder as SortOrder) ?? undefined;
+          const filter = queryParams?.filter;
+          const options: SavedObjectsFindOptions = {
+            type: noteSavedObjectType,
+            perPage,
+            page,
+            search,
+            sortField,
+            sortOrder,
+            filter,
+          };
+          const res = await getAllSavedNote(frameworkRequest, options);
+          const body: GetNotesResponse = res ?? {};
+          return response.ok({ body });
         } catch (err) {
           const error = transformError(err);
           const siemResponse = buildSiemResponse(response);

--- a/x-pack/test/security_solution_api_integration/test_suites/investigation/saved_objects/trial_license_complete_tier/helpers.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/investigation/saved_objects/trial_license_complete_tier/helpers.ts
@@ -8,6 +8,10 @@
 import type SuperTest from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
 import { TimelineTypeEnum } from '@kbn/security-solution-plugin/common/api/timeline';
+import { NOTE_URL } from '@kbn/security-solution-plugin/common/constants';
+import type { Client } from '@elastic/elasticsearch';
+import { SECURITY_SOLUTION_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import { noteSavedObjectType } from '@kbn/security-solution-plugin/server/lib/timeline/saved_object_mappings';
 
 export const createBasicTimeline = async (supertest: SuperTest.Agent, titleToSaved: string) =>
   await supertest
@@ -36,5 +40,95 @@ export const createBasicTimelineTemplate = async (
         templateTimelineId: uuidv4(),
         templateTimelineVersion: 1,
         timelineType: TimelineTypeEnum.template,
+      },
+    });
+
+export const deleteAllNotes = async (es: Client): Promise<void> => {
+  await es.deleteByQuery({
+    index: SECURITY_SOLUTION_SAVED_OBJECT_INDEX,
+    q: `type:${noteSavedObjectType}`,
+    wait_for_completion: true,
+    refresh: true,
+    body: {},
+  });
+};
+
+export const createNoteAssociatedWithDocumentOnly = async (
+  supertest: SuperTest.Agent,
+  documentId: string,
+  noteText: string
+) =>
+  await supertest
+    .patch(NOTE_URL)
+    .set('kbn-xsrf', 'true')
+    .send({
+      note: {
+        eventId: documentId,
+        timelineId: '',
+        created: Date.now(),
+        createdBy: 'elastic',
+        updated: Date.now(),
+        updatedBy: 'elastic',
+        note: noteText,
+      },
+    });
+
+export const createNoteAssociatedWithSavedObjectOnly = async (
+  supertest: SuperTest.Agent,
+  savedObjectId: string,
+  noteText: string
+) =>
+  await supertest
+    .patch(NOTE_URL)
+    .set('kbn-xsrf', 'true')
+    .send({
+      note: {
+        eventId: '',
+        timelineId: savedObjectId,
+        created: Date.now(),
+        createdBy: 'elastic',
+        updated: Date.now(),
+        updatedBy: 'elastic',
+        note: noteText,
+      },
+    });
+
+export const createNoteAssociatedWithDocumentAndSavedObject = async (
+  supertest: SuperTest.Agent,
+  documentId: string,
+  savedObjectId: string,
+  noteText: string
+) =>
+  await supertest
+    .patch(NOTE_URL)
+    .set('kbn-xsrf', 'true')
+    .send({
+      note: {
+        eventId: documentId,
+        timelineId: savedObjectId,
+        created: Date.now(),
+        createdBy: 'elastic',
+        updated: Date.now(),
+        updatedBy: 'elastic',
+        note: noteText,
+      },
+    });
+
+export const createNoteAssociatedWithNothing = async (
+  supertest: SuperTest.Agent,
+  noteText: string
+) =>
+  await supertest
+    .patch(NOTE_URL)
+    .set('kbn-xsrf', 'true')
+    .send({
+      note: {
+        eventId: '',
+        timelineId: '',
+        created: Date.now(),
+        createdBy: 'elastic',
+        updated: Date.now(),
+        updatedBy: 'elastic',
+        note: noteText,
       },
     });

--- a/x-pack/test/security_solution_api_integration/test_suites/investigation/saved_objects/trial_license_complete_tier/helpers.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/investigation/saved_objects/trial_license_complete_tier/helpers.ts
@@ -7,7 +7,7 @@
 
 import type SuperTest from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
-import { TimelineTypeEnum } from '@kbn/security-solution-plugin/common/api/timeline';
+import { BareNote, TimelineTypeEnum } from '@kbn/security-solution-plugin/common/api/timeline';
 import { NOTE_URL } from '@kbn/security-solution-plugin/common/constants';
 import type { Client } from '@elastic/elasticsearch';
 import { SECURITY_SOLUTION_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
@@ -53,82 +53,26 @@ export const deleteAllNotes = async (es: Client): Promise<void> => {
   });
 };
 
-export const createNoteAssociatedWithDocumentOnly = async (
+export const createNote = async (
   supertest: SuperTest.Agent,
-  documentId: string,
-  noteText: string
+  note: {
+    documentId?: string;
+    savedObjectId?: string;
+    user?: string;
+    text: string;
+  }
 ) =>
   await supertest
     .patch(NOTE_URL)
     .set('kbn-xsrf', 'true')
     .send({
       note: {
-        eventId: documentId,
-        timelineId: '',
+        eventId: note.documentId || '',
+        timelineId: note.savedObjectId || '',
         created: Date.now(),
-        createdBy: 'elastic',
+        createdBy: note.user || 'elastic',
         updated: Date.now(),
-        updatedBy: 'elastic',
-        note: noteText,
-      },
-    });
-
-export const createNoteAssociatedWithSavedObjectOnly = async (
-  supertest: SuperTest.Agent,
-  savedObjectId: string,
-  noteText: string
-) =>
-  await supertest
-    .patch(NOTE_URL)
-    .set('kbn-xsrf', 'true')
-    .send({
-      note: {
-        eventId: '',
-        timelineId: savedObjectId,
-        created: Date.now(),
-        createdBy: 'elastic',
-        updated: Date.now(),
-        updatedBy: 'elastic',
-        note: noteText,
-      },
-    });
-
-export const createNoteAssociatedWithDocumentAndSavedObject = async (
-  supertest: SuperTest.Agent,
-  documentId: string,
-  savedObjectId: string,
-  noteText: string
-) =>
-  await supertest
-    .patch(NOTE_URL)
-    .set('kbn-xsrf', 'true')
-    .send({
-      note: {
-        eventId: documentId,
-        timelineId: savedObjectId,
-        created: Date.now(),
-        createdBy: 'elastic',
-        updated: Date.now(),
-        updatedBy: 'elastic',
-        note: noteText,
-      },
-    });
-
-export const createNoteAssociatedWithNothing = async (
-  supertest: SuperTest.Agent,
-  noteText: string
-) =>
-  await supertest
-    .patch(NOTE_URL)
-    .set('kbn-xsrf', 'true')
-    .send({
-      note: {
-        eventId: '',
-        timelineId: '',
-        created: Date.now(),
-        createdBy: 'elastic',
-        updated: Date.now(),
-        updatedBy: 'elastic',
-        note: noteText,
-      },
+        updatedBy: note.user || 'elastic',
+        note: note.text,
+      } as BareNote,
     });

--- a/x-pack/test/security_solution_api_integration/test_suites/investigation/saved_objects/trial_license_complete_tier/notes.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/investigation/saved_objects/trial_license_complete_tier/notes.ts
@@ -8,13 +8,7 @@
 import expect from '@kbn/expect';
 import { v4 as uuidv4 } from 'uuid';
 import { Note } from '@kbn/security-solution-plugin/common/api/timeline';
-import {
-  createNoteAssociatedWithDocumentAndSavedObject,
-  createNoteAssociatedWithDocumentOnly,
-  createNoteAssociatedWithNothing,
-  createNoteAssociatedWithSavedObjectOnly,
-  deleteAllNotes,
-} from './helpers';
+import { createNote, deleteAllNotes } from './helpers';
 import { FtrProviderContext } from '../../../../../api_integration/ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
@@ -86,49 +80,40 @@ export default function ({ getService }: FtrProviderContext) {
         await deleteAllNotes(es);
       });
 
-      it('should retrieve all the notes for a document id', async () => {
-        const eventId1 = uuidv4();
-        const eventId2 = uuidv4();
-        const timelineId1 = uuidv4();
-        const timelineId2 = uuidv4();
+      const eventId1 = uuidv4();
+      const eventId2 = uuidv4();
+      const eventId3 = uuidv4();
+      const timelineId1 = uuidv4();
+      const timelineId2 = uuidv4();
+      const timelineId3 = uuidv4();
 
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId1,
-          'note associated with event-1 only'
-        );
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId2,
-          'note associated with event-2 only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId1,
-          'note associated with timeline-1 only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId2,
-          'note associated with timeline-2 only'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId1,
-          timelineId1,
-          'note associated with event-1 and timeline-1'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId2,
-          timelineId2,
-          'note associated with event-2 and timeline-2'
-        );
-        await createNoteAssociatedWithNothing(supertest, 'note associated with nothing');
-        await createNoteAssociatedWithNothing(
-          supertest,
-          `another note associated with nothing but has ${eventId1} in the text`
-        );
+      it('should retrieve all the notes for a document id', async () => {
+        await Promise.all([
+          createNote(supertest, { documentId: eventId1, text: 'associated with event-1 only' }),
+          createNote(supertest, { documentId: eventId2, text: 'associated with event-2 only' }),
+          createNote(supertest, {
+            savedObjectId: timelineId1,
+            text: 'associated with timeline-1 only',
+          }),
+          createNote(supertest, {
+            savedObjectId: timelineId2,
+            text: 'associated with timeline-2 only',
+          }),
+          createNote(supertest, {
+            documentId: eventId1,
+            savedObjectId: timelineId1,
+            text: 'associated with event-1 and timeline-1',
+          }),
+          createNote(supertest, {
+            documentId: eventId2,
+            savedObjectId: timelineId2,
+            text: 'associated with event-2 and timeline-2',
+          }),
+          createNote(supertest, { text: 'associated with nothing' }),
+          createNote(supertest, {
+            text: `associated with nothing but has ${eventId1} in the text`,
+          }),
+        ]);
 
         const response = await supertest
           .get(`/api/note?documentIds=${eventId1}`)
@@ -142,74 +127,48 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       it('should retrieve all the notes for multiple document ids', async () => {
-        const eventId1 = uuidv4();
-        const eventId2 = uuidv4();
-        const eventId3 = uuidv4();
-        const timelineId1 = uuidv4();
-        const timelineId2 = uuidv4();
-        const timelineId3 = uuidv4();
-
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId1,
-          'note associated with event-1 only'
-        );
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId2,
-          'note associated with event-2 only'
-        );
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId3,
-          'note associated with event-2 only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId1,
-          'note associated with timeline-1 only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId2,
-          'note associated with timeline-2 only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId3,
-          'note associated with timeline-3 only'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId1,
-          timelineId1,
-          'note associated with event-1 and timeline-1'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId2,
-          timelineId2,
-          'note associated with event-2 and timeline-2'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId3,
-          timelineId3,
-          'note associated with event-3 and timeline-3'
-        );
-        await createNoteAssociatedWithNothing(supertest, 'note associated with nothing');
-        await createNoteAssociatedWithNothing(
-          supertest,
-          `another note associated with nothing but has ${eventId1} in the text`
-        );
-        await createNoteAssociatedWithNothing(
-          supertest,
-          `another note associated with nothing but has ${eventId2} in the text`
-        );
-        await createNoteAssociatedWithNothing(
-          supertest,
-          `another note associated with nothing but has ${eventId3} in the text`
-        );
+        await Promise.all([
+          createNote(supertest, { documentId: eventId1, text: 'associated with event-1 only' }),
+          createNote(supertest, { documentId: eventId2, text: 'associated with event-2 only' }),
+          createNote(supertest, { documentId: eventId3, text: 'associated with event-3 only' }),
+          createNote(supertest, {
+            savedObjectId: timelineId1,
+            text: 'associated with timeline-1 only',
+          }),
+          createNote(supertest, {
+            savedObjectId: timelineId2,
+            text: 'associated with timeline-2 only',
+          }),
+          createNote(supertest, {
+            savedObjectId: timelineId3,
+            text: 'associated with timeline-3 only',
+          }),
+          createNote(supertest, {
+            documentId: eventId1,
+            savedObjectId: timelineId1,
+            text: 'associated with event-1 and timeline-1',
+          }),
+          createNote(supertest, {
+            documentId: eventId2,
+            savedObjectId: timelineId2,
+            text: 'associated with event-2 and timeline-2',
+          }),
+          createNote(supertest, {
+            documentId: eventId3,
+            savedObjectId: timelineId3,
+            text: 'associated with event-3 and timeline-3',
+          }),
+          createNote(supertest, { text: 'associated with nothing' }),
+          createNote(supertest, {
+            text: `associated with nothing but has ${eventId1} in the text`,
+          }),
+          createNote(supertest, {
+            text: `associated with nothing but has ${eventId2} in the text`,
+          }),
+          createNote(supertest, {
+            text: `associated with nothing but has ${eventId3} in the text`,
+          }),
+        ]);
 
         const response = await supertest
           .get(`/api/note?documentIds=${eventId1}&documentIds=${eventId2}`)
@@ -226,48 +185,32 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       it('should retrieve all the notes for a saved object id', async () => {
-        const eventId1 = uuidv4();
-        const eventId2 = uuidv4();
-        const timelineId1 = uuidv4();
-        const timelineId2 = uuidv4();
-
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId1,
-          'note associated with event-1 only'
-        );
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId2,
-          'note associated with event-2 only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId1,
-          'note associated with timeline-1 only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId2,
-          'note associated with timeline-2 only'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId1,
-          timelineId1,
-          'note associated with event-1 and timeline-1'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId2,
-          timelineId2,
-          'note associated with event-2 and timeline-2'
-        );
-        await createNoteAssociatedWithNothing(supertest, 'note associated with nothing');
-        await createNoteAssociatedWithNothing(
-          supertest,
-          `another note associated with nothing but has ${timelineId1} in the text`
-        );
+        await Promise.all([
+          createNote(supertest, { documentId: eventId1, text: 'associated with event-1 only' }),
+          createNote(supertest, { documentId: eventId2, text: 'associated with event-2 only' }),
+          createNote(supertest, {
+            savedObjectId: timelineId1,
+            text: 'associated with timeline-1 only',
+          }),
+          createNote(supertest, {
+            savedObjectId: timelineId2,
+            text: 'associated with timeline-2 only',
+          }),
+          createNote(supertest, {
+            documentId: eventId1,
+            savedObjectId: timelineId1,
+            text: 'associated with event-1 and timeline-1',
+          }),
+          createNote(supertest, {
+            documentId: eventId2,
+            savedObjectId: timelineId2,
+            text: 'associated with event-2 and timeline-2',
+          }),
+          createNote(supertest, { text: 'associated with nothing' }),
+          createNote(supertest, {
+            text: `associated with nothing but has ${timelineId1} in the text`,
+          }),
+        ]);
 
         const response = await supertest
           .get(`/api/note?savedObjectIds=${timelineId1}`)
@@ -281,74 +224,48 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       it('should retrieve all the notes for multiple saved object ids', async () => {
-        const eventId1 = uuidv4();
-        const eventId2 = uuidv4();
-        const eventId3 = uuidv4();
-        const timelineId1 = uuidv4();
-        const timelineId2 = uuidv4();
-        const timelineId3 = uuidv4();
-
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId1,
-          'note associated with event-1 only'
-        );
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId2,
-          'note associated with event-2 only'
-        );
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId3,
-          'note associated with event-3 only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId1,
-          'note associated with timeline-1 only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId2,
-          'note associated with timeline-2 only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId3,
-          'note associated with timeline-3 only'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId1,
-          timelineId1,
-          'note associated with event-1 and timeline-1'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId2,
-          timelineId2,
-          'note associated with event-2 and timeline-2'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId3,
-          timelineId3,
-          'note associated with event-3 and timeline-3'
-        );
-        await createNoteAssociatedWithNothing(supertest, 'note associated with nothing');
-        await createNoteAssociatedWithNothing(
-          supertest,
-          `another note associated with nothing but has ${timelineId1} in the text`
-        );
-        await createNoteAssociatedWithNothing(
-          supertest,
-          `another note associated with nothing but has ${timelineId2} in the text`
-        );
-        await createNoteAssociatedWithNothing(
-          supertest,
-          `another note associated with nothing but has ${timelineId3} in the text`
-        );
+        await Promise.all([
+          createNote(supertest, { documentId: eventId1, text: 'associated with event-1 only' }),
+          createNote(supertest, { documentId: eventId2, text: 'associated with event-2 only' }),
+          createNote(supertest, { documentId: eventId3, text: 'associated with event-3 only' }),
+          createNote(supertest, {
+            savedObjectId: timelineId1,
+            text: 'associated with timeline-1 only',
+          }),
+          createNote(supertest, {
+            savedObjectId: timelineId2,
+            text: 'associated with timeline-2 only',
+          }),
+          createNote(supertest, {
+            savedObjectId: timelineId3,
+            text: 'associated with timeline-3 only',
+          }),
+          createNote(supertest, {
+            documentId: eventId1,
+            savedObjectId: timelineId1,
+            text: 'associated with event-1 and timeline-1',
+          }),
+          createNote(supertest, {
+            documentId: eventId2,
+            savedObjectId: timelineId2,
+            text: 'associated with event-2 and timeline-2',
+          }),
+          createNote(supertest, {
+            documentId: eventId3,
+            savedObjectId: timelineId3,
+            text: 'associated with event-3 and timeline-3',
+          }),
+          createNote(supertest, { text: 'associated with nothing' }),
+          createNote(supertest, {
+            text: `associated with nothing but has ${timelineId1} in the text`,
+          }),
+          createNote(supertest, {
+            text: `associated with nothing but has ${timelineId2} in the text`,
+          }),
+          createNote(supertest, {
+            text: `associated with nothing but has ${timelineId3} in the text`,
+          }),
+        ]);
 
         const response = await supertest
           .get(`/api/note?savedObjectIds=${timelineId1}&savedObjectIds=${timelineId2}`)
@@ -365,26 +282,19 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       it('should retrieve all notes without any query params', async () => {
-        const eventId = uuidv4();
-        const timelineId = uuidv4();
-
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId,
-          'note associated with an event only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId,
-          'note associated with a timeline only'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId,
-          timelineId,
-          'note associated with an event and a timeline'
-        );
-        await createNoteAssociatedWithNothing(supertest, 'note associated with nothing');
+        await Promise.all([
+          createNote(supertest, { documentId: eventId1, text: 'associated with event-1 only' }),
+          createNote(supertest, {
+            savedObjectId: timelineId1,
+            text: 'associated with timeline-1 only',
+          }),
+          createNote(supertest, {
+            documentId: eventId1,
+            savedObjectId: timelineId1,
+            text: 'associated with event-1 and timeline-1',
+          }),
+          createNote(supertest, { text: 'associated with nothing' }),
+        ]);
 
         const response = await supertest
           .get('/api/note')
@@ -397,9 +307,11 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       it('should retrieve notes considering perPage query parameter', async () => {
-        await createNoteAssociatedWithNothing(supertest, 'first note');
-        await createNoteAssociatedWithNothing(supertest, 'second note');
-        await createNoteAssociatedWithNothing(supertest, 'third note');
+        await Promise.all([
+          createNote(supertest, { text: 'first note' }),
+          createNote(supertest, { text: 'second note' }),
+          createNote(supertest, { text: 'third note' }),
+        ]);
 
         const response = await supertest
           .get('/api/note?perPage=1')
@@ -410,13 +322,12 @@ export default function ({ getService }: FtrProviderContext) {
 
         expect(totalCount).to.be(3);
         expect(notes.length).to.be(1);
-        expect(notes[0].note).to.be('first note');
       });
 
       it('should retrieve considering page query parameter', async () => {
-        await createNoteAssociatedWithNothing(supertest, 'first note');
-        await createNoteAssociatedWithNothing(supertest, 'second note');
-        await createNoteAssociatedWithNothing(supertest, 'third note');
+        await createNote(supertest, { text: 'first note' });
+        await createNote(supertest, { text: 'second note' });
+        await createNote(supertest, { text: 'third note' });
 
         const response = await supertest
           .get('/api/note?perPage=1&page=2')
@@ -431,26 +342,19 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       it('should retrieve considering search query parameter', async () => {
-        const eventId = uuidv4();
-        const timelineId = uuidv4();
-
-        await createNoteAssociatedWithDocumentOnly(
-          supertest,
-          eventId,
-          'note associated with an event only'
-        );
-        await createNoteAssociatedWithSavedObjectOnly(
-          supertest,
-          timelineId,
-          'note associated with a timeline only'
-        );
-        await createNoteAssociatedWithDocumentAndSavedObject(
-          supertest,
-          eventId,
-          timelineId,
-          'note associated with an event and a timeline'
-        );
-        await createNoteAssociatedWithNothing(supertest, 'note associated with nothing');
+        await Promise.all([
+          createNote(supertest, { documentId: eventId1, text: 'associated with event-1 only' }),
+          createNote(supertest, {
+            savedObjectId: timelineId1,
+            text: 'associated with timeline-1 only',
+          }),
+          createNote(supertest, {
+            documentId: eventId1,
+            savedObjectId: timelineId1,
+            text: 'associated with event-1 and timeline-1',
+          }),
+          createNote(supertest, { text: 'associated with nothing' }),
+        ]);
 
         const response = await supertest
           .get('/api/note?search=event')
@@ -464,9 +368,11 @@ export default function ({ getService }: FtrProviderContext) {
 
       // TODO why can't we sort on every field? (I tested for the note field (or a random field like abc) and the endpoint crashes)
       it('should retrieve considering sortField query parameters', async () => {
-        await createNoteAssociatedWithDocumentOnly(supertest, '1', 'note 3');
-        await createNoteAssociatedWithDocumentOnly(supertest, '2', 'note 2');
-        await createNoteAssociatedWithDocumentOnly(supertest, '3', 'note 1');
+        await Promise.all([
+          createNote(supertest, { documentId: '1', text: 'note 1' }),
+          createNote(supertest, { documentId: '2', text: 'note 2' }),
+          createNote(supertest, { documentId: '3', text: 'note 3' }),
+        ]);
 
         const response = await supertest
           .get('/api/note?sortField=eventId')
@@ -482,9 +388,11 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       it('should retrieve considering sortOrder query parameters', async () => {
-        await createNoteAssociatedWithDocumentOnly(supertest, '1', 'note 3');
-        await createNoteAssociatedWithDocumentOnly(supertest, '2', 'note 2');
-        await createNoteAssociatedWithDocumentOnly(supertest, '3', 'note 1');
+        await Promise.all([
+          createNote(supertest, { documentId: '1', text: 'note 1' }),
+          createNote(supertest, { documentId: '2', text: 'note 2' }),
+          createNote(supertest, { documentId: '3', text: 'note 3' }),
+        ]);
 
         const response = await supertest
           .get('/api/note?sortField=eventId&sortOrder=desc')


### PR DESCRIPTION
## Summary

While working on adding api integration tests for this [PR](https://github.com/elastic/kibana/pull/195501), I realized that the current logic in the `getNotes` endpoint is not always correct. Here are the issues:

- when retrieving notes for a list of `documentIds` by passing one or multiple `documentIds` query parameters (used for example when the UI wants to retrieve all the notes for all the alerts in the alerts table), we were actually searching for the values of the documentIds in all the fields, instead of just in the `eventId` field. That means that if a user had used the document id value in the note itself (the text part) this value would be returned. The new logic only looks at the `eventId` attributes to return only the necessary notes. I did not do and performance comparison, but I would assume that looking at a specific field vs all the fields would be much more efficient
- the same mistake was done on the `savedObjectIds` query parameter, where we were searching for the values passed within all the fields of the notes objects, instead of just looking for the references to other saved object ids

This PR fixes the 2 issues above and adds a lot of api integration tests to check the above behavior as well as testing other query parameters (like `sortField`, `sortOrder`, `perPage`, `page` and `search`).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->