### PR TITLE
[ES|QL] Catch internal parsing errors

### DIFF
--- a/packages/kbn-esql-ast/src/parser/__tests__/columns.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/columns.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getAstAndSyntaxErrors as parse } from '..';
+import { parse } from '..';
 
 describe('Column Identifier Expressions', () => {
   it('can parse un-quoted identifiers', () => {

--- a/packages/kbn-esql-ast/src/parser/__tests__/commands.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/commands.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getAstAndSyntaxErrors as parse } from '..';
+import { parse } from '..';
 
 describe('commands', () => {
   describe('correctly formatted, basic usage', () => {

--- a/packages/kbn-esql-ast/src/parser/__tests__/from.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/from.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getAstAndSyntaxErrors as parse } from '..';
+import { parse } from '..';
 
 describe('FROM', () => {
   describe('correctly formatted', () => {

--- a/packages/kbn-esql-ast/src/parser/__tests__/function.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/function.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getAstAndSyntaxErrors as parse } from '..';
+import { parse } from '..';
 import { Walker } from '../../walker';
 
 describe('function AST nodes', () => {

--- a/packages/kbn-esql-ast/src/parser/__tests__/inlinecast.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/inlinecast.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getAstAndSyntaxErrors as parse } from '..';
+import { parse } from '..';
 import { ESQLFunction, ESQLInlineCast, ESQLSingleAstItem } from '../../types';
 
 describe('Inline cast (::)', () => {

--- a/packages/kbn-esql-ast/src/parser/__tests__/literal.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/literal.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getAstAndSyntaxErrors as parse } from '..';
+import { parse } from '..';
 import { ESQLLiteral } from '../../types';
 
 describe('literal expression', () => {

--- a/packages/kbn-esql-ast/src/parser/__tests__/metrics.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/metrics.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getAstAndSyntaxErrors as parse } from '..';
+import { parse } from '..';
 
 describe('METRICS', () => {
   describe('correctly formatted', () => {

--- a/packages/kbn-esql-ast/src/parser/__tests__/params.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/params.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getAstAndSyntaxErrors as parse } from '..';
+import { parse } from '..';
 import { Walker } from '../../walker';
 
 /**

--- a/packages/kbn-esql-ast/src/parser/__tests__/rename.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/rename.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getAstAndSyntaxErrors as parse } from '..';
+import { parse } from '..';
 
 describe('RENAME', () => {
   /**

--- a/packages/kbn-esql-ast/src/parser/__tests__/sort.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/sort.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getAstAndSyntaxErrors as parse } from '..';
+import { parse } from '..';
 
 describe('SORT', () => {
   describe('correctly formatted', () => {

--- a/packages/kbn-esql-ast/src/parser/__tests__/where.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/where.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getAstAndSyntaxErrors as parse } from '..';
+import { parse } from '..';
 
 describe('WHERE', () => {
   describe('correctly formatted', () => {

--- a/packages/kbn-esql-ast/src/parser/parser.ts
+++ b/packages/kbn-esql-ast/src/parser/parser.ts
@@ -100,33 +100,66 @@ export interface ParseResult {
 }
 
 export const parse = (text: string | undefined, options: ParseOptions = {}): ParseResult => {
-  if (text == null) {
-    const commands: ESQLAstQueryExpression['commands'] = [];
-    return { ast: commands, root: Builder.expression.query(commands), errors: [], tokens: [] };
+  try {
+    if (text == null) {
+      const commands: ESQLAstQueryExpression['commands'] = [];
+      return { ast: commands, root: Builder.expression.query(commands), errors: [], tokens: [] };
+    }
+    const errorListener = new ESQLErrorListener();
+    const parseListener = new ESQLAstBuilderListener();
+    const { tokens, parser } = getParser(
+      CharStreams.fromString(text),
+      errorListener,
+      parseListener
+    );
+
+    parser[GRAMMAR_ROOT_RULE]();
+
+    const errors = errorListener.getErrors().filter((error) => {
+      return !SYNTAX_ERRORS_TO_IGNORE.includes(error.message);
+    });
+    const { ast: commands } = parseListener.getAst();
+    const root = Builder.expression.query(commands, {
+      location: {
+        min: 0,
+        max: text.length - 1,
+      },
+    });
+
+    if (options.withFormatting) {
+      const decorations = collectDecorations(tokens);
+      attachDecorations(root, tokens.tokens, decorations.lines);
+    }
+
+    return { root, ast: commands, errors, tokens: tokens.tokens };
+  } catch (error) {
+    /**
+     * Parsing should never fail, meaning this branch should never execute. But
+     * if it does fail, we want to log the error message for easier debugging.
+     */
+    // eslint-disable-next-line no-console
+    console.error(error);
+
+    const root = Builder.expression.query();
+
+    return {
+      root,
+      ast: root.commands,
+      errors: [
+        {
+          startLineNumber: 0,
+          endLineNumber: 0,
+          startColumn: 0,
+          endColumn: 0,
+          message:
+            'Parsing internal error: ' +
+            (!!error && typeof error === 'object' ? String(error.message) : String(error)),
+          severity: 'error',
+        },
+      ],
+      tokens: [],
+    };
   }
-  const errorListener = new ESQLErrorListener();
-  const parseListener = new ESQLAstBuilderListener();
-  const { tokens, parser } = getParser(CharStreams.fromString(text), errorListener, parseListener);
-
-  parser[GRAMMAR_ROOT_RULE]();
-
-  const errors = errorListener.getErrors().filter((error) => {
-    return !SYNTAX_ERRORS_TO_IGNORE.includes(error.message);
-  });
-  const { ast: commands } = parseListener.getAst();
-  const root = Builder.expression.query(commands, {
-    location: {
-      min: 0,
-      max: text.length - 1,
-    },
-  });
-
-  if (options.withFormatting) {
-    const decorations = collectDecorations(tokens);
-    attachDecorations(root, tokens.tokens, decorations.lines);
-  }
-
-  return { root, ast: commands, errors, tokens: tokens.tokens };
 };
 
 export const parseErrors = (text: string) => {


### PR DESCRIPTION
## Summary

Addresses this comment https://github.com/elastic/kibana/issues/191683#issuecomment-2338181503

Catches parser internal errors, and reports them the same as the regular parsing errors.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->