### PR TITLE
Skip serverless security agentless tests for MKI

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
@@ -25,6 +25,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const AWS_SINGLE_ACCOUNT_TEST_ID = 'awsSingleTestId';
 
   describe('Agentless API Serverless', function () {
+    // fails on MKI, see https://github.com/elastic/kibana/issues/196245
+    this.tags(['failsOnMKI']);
+
     let mockApiServer: http.Server;
     let cisIntegration: typeof pageObjects.cisAddIntegration;
 


### PR DESCRIPTION
## Summary

This PR skips the serverless security agentless test suite for MKI runs. Details in #196245