### PR TITLE
[8.x] Flipped Security Entity Store flag to being a "disable" flag (#195818)

### DIFF
--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -118,3 +118,8 @@ xpack.ml.compatibleModuleType: 'security'
 
 # Disable the embedded Dev Console
 console.ui.embeddedEnabled: false
+
+# Experimental Security Solution features
+
+# This feature is disabled in Serverless until fully performance tested within a Serverless environment
+xpack.securitySolution.enableExperimental: ['entityStoreDisabled']

--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -236,9 +236,10 @@ export const allowedExperimentalValues = Object.freeze({
   dataIngestionHubEnabled: false,
 
   /**
-   * Enables the new Entity Store engine routes
+   * Disables Security's Entity Store engine routes. The Entity Store feature is available by default, but
+   * can be disabled if necessary in a given environment.
    */
-  entityStoreEnabled: false,
+  entityStoreDisabled: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/security_solution/public/entity_analytics/pages/entity_analytics_dashboard.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/pages/entity_analytics_dashboard.tsx
@@ -32,7 +32,7 @@ const EntityAnalyticsComponent = () => {
   const { indicesExist, loading: isSourcererLoading, sourcererDataView } = useSourcererDataView();
   const isRiskScoreModuleLicenseAvailable = useHasSecurityCapability('entity-analytics');
 
-  const isEntityStoreEnabled = useIsExperimentalFeatureEnabled('entityStoreEnabled');
+  const isEntityStoreDisabled = useIsExperimentalFeatureEnabled('entityStoreDisabled');
 
   return (
     <>
@@ -71,7 +71,7 @@ const EntityAnalyticsComponent = () => {
                   <EntityAnalyticsAnomalies />
                 </EuiFlexItem>
 
-                {isEntityStoreEnabled ? (
+                {!isEntityStoreDisabled ? (
                   <EuiFlexItem>
                     <EntitiesList />
                   </EuiFlexItem>

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/register_entity_analytics_routes.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/register_entity_analytics_routes.ts
@@ -15,7 +15,7 @@ export const registerEntityAnalyticsRoutes = (routeDeps: EntityAnalyticsRoutesDe
   registerAssetCriticalityRoutes(routeDeps);
   registerRiskScoreRoutes(routeDeps);
   registerRiskEngineRoutes(routeDeps);
-  if (routeDeps.config.experimentalFeatures.entityStoreEnabled) {
+  if (!routeDeps.config.experimentalFeatures.entityStoreDisabled) {
     registerEntityStoreRoutes(routeDeps);
   }
 };

--- a/x-pack/plugins/security_solution/server/plugin.ts
+++ b/x-pack/plugins/security_solution/server/plugin.ts
@@ -221,7 +221,7 @@ export class Plugin implements ISecuritySolutionPlugin {
       logger.error(`Error scheduling entity analytics migration: ${err}`);
     });
 
-    if (experimentalFeatures.entityStoreEnabled) {
+    if (!experimentalFeatures.entityStoreDisabled) {
       registerEntityStoreFieldRetentionEnrichTask({
         getStartServices: core.getStartServices,
         logger: this.logger,

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -138,6 +138,7 @@ export default function ({ getService }: FtrProviderContext) {
         'endpoint:complete-external-response-actions',
         'endpoint:metadata-check-transforms-task',
         'endpoint:user-artifact-packager',
+        'entity_store:field_retention:enrichment',
         'fleet:check-deleted-files-task',
         'fleet:delete-unenrolled-agents-task',
         'fleet:deploy_agent_policies',

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/configs/ess.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/configs/ess.config.ts
@@ -15,10 +15,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     ...functionalConfig.getAll(),
     kbnTestServer: {
       ...functionalConfig.get('kbnTestServer'),
-      serverArgs: [
-        ...functionalConfig.get('kbnTestServer.serverArgs'),
-        `--xpack.securitySolution.enableExperimental=${JSON.stringify(['entityStoreEnabled'])}`,
-      ],
+      serverArgs: [...functionalConfig.get('kbnTestServer.serverArgs')],
     },
     testFiles: [require.resolve('..')],
     junit: {

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/configs/serverless.config.ts
@@ -9,7 +9,6 @@ import { createTestConfig } from '../../../../../config/serverless/config.base';
 
 export default createTestConfig({
   kbnTestServerArgs: [
-    `--xpack.securitySolution.enableExperimental=${JSON.stringify(['entityStoreEnabled'])}`,
     `--xpack.securitySolutionServerless.productTypes=${JSON.stringify([
       { product_line: 'security', product_tier: 'complete' },
       { product_line: 'endpoint', product_tier: 'complete' },

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/engine.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/engine.ts
@@ -22,6 +22,7 @@ export default ({ getService }: FtrProviderContext) => {
   } = elasticAssetCheckerFactory(getService);
 
   const utils = EntityStoreUtils(getService);
+
   // TODO: unskip once permissions issue is resolved
   describe.skip('@ess @serverless @skipInServerlessMKI Entity Store Engine APIs', () => {
     before(async () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/entities_list.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/entities_list.ts
@@ -10,8 +10,9 @@ import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default ({ getService }: FtrProviderContext) => {
   const securitySolutionApi = getService('securitySolutionApi');
+
   // TODO: unskip once permissions issue is resolved
-  describe.skip('@ess @serverless @skipInServerlessMKI Entity store - Entities list API', () => {
+  describe.skip('@ess Entity store - Entities list API', () => {
     describe('when the entity store is disable', () => {
       it("should return response with success status when the index doesn't exist", async () => {
         const { body } = await securitySolutionApi.listEntities({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Flipped Security Entity Store flag to being a "disable" flag (#195818)](https://github.com/elastic/kibana/pull/195818)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jared Burgett","email":"147995946+jaredburgettelastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-10-15T04:56:08Z","message":"Flipped Security Entity Store flag to being a \"disable\" flag (#195818)\n\n## Summary\r\n\r\nThe Security Solution Entity Store feature will now be available by\r\ndefault. However, there will be a flag that can be switched on, if\r\ndesired, to **disable** that feature entirely.\r\n\r\nRegardless of whether this flag is enabled or not, Security's Entity\r\nStore is still only fully enabled through an enablement workflow. In\r\nother words, a Security Solution customer must turn on the feature\r\nthrough an onboarding workflow in order to enable its features.\r\n\r\nAdditionally, we are disabling this feature in Serverless at first, to\r\nperform proper Serverless load/performance testing. (We do not expect it\r\nto be significantly different than ESS/ECH, but are doing so out of an\r\nabundance of caution).\r\n\r\n---------\r\n\r\nCo-authored-by: Pablo Machado <pablo.nevesmachado@elastic.co>","sha":"ea582dc65029f5537d6093c3fadb8b90b7768f91","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor"],"number":195818,"url":"https://github.com/elastic/kibana/pull/195818","mergeCommit":{"message":"Flipped Security Entity Store flag to being a \"disable\" flag (#195818)\n\n## Summary\r\n\r\nThe Security Solution Entity Store feature will now be available by\r\ndefault. However, there will be a flag that can be switched on, if\r\ndesired, to **disable** that feature entirely.\r\n\r\nRegardless of whether this flag is enabled or not, Security's Entity\r\nStore is still only fully enabled through an enablement workflow. In\r\nother words, a Security Solution customer must turn on the feature\r\nthrough an onboarding workflow in order to enable its features.\r\n\r\nAdditionally, we are disabling this feature in Serverless at first, to\r\nperform proper Serverless load/performance testing. (We do not expect it\r\nto be significantly different than ESS/ECH, but are doing so out of an\r\nabundance of caution).\r\n\r\n---------\r\n\r\nCo-authored-by: Pablo Machado <pablo.nevesmachado@elastic.co>","sha":"ea582dc65029f5537d6093c3fadb8b90b7768f91"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/195818","number":195818,"mergeCommit":{"message":"Flipped Security Entity Store flag to being a \"disable\" flag (#195818)\n\n## Summary\r\n\r\nThe Security Solution Entity Store feature will now be available by\r\ndefault. However, there will be a flag that can be switched on, if\r\ndesired, to **disable** that feature entirely.\r\n\r\nRegardless of whether this flag is enabled or not, Security's Entity\r\nStore is still only fully enabled through an enablement workflow. In\r\nother words, a Security Solution customer must turn on the feature\r\nthrough an onboarding workflow in order to enable its features.\r\n\r\nAdditionally, we are disabling this feature in Serverless at first, to\r\nperform proper Serverless load/performance testing. (We do not expect it\r\nto be significantly different than ESS/ECH, but are doing so out of an\r\nabundance of caution).\r\n\r\n---------\r\n\r\nCo-authored-by: Pablo Machado <pablo.nevesmachado@elastic.co>","sha":"ea582dc65029f5537d6093c3fadb8b90b7768f91"}}]}] BACKPORT-->