### PR TITLE
[Console] Update autocomplete definitions for 8.16

### DIFF
--- a/src/plugins/console/server/lib/spec_definitions/json/generated/capabilities.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/capabilities.json
@@ -6,7 +6,7 @@
     "patterns": [
       "_capabilities"
     ],
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/capabilities.html",
+    "documentation": "https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc#require-or-skip-api-capabilities",
     "availability": {
       "stack": false,
       "serverless": false

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.stats.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/cluster.stats.json
@@ -5,7 +5,7 @@
       "filter_path": [],
       "human": "__flag__",
       "pretty": "__flag__",
-      "flat_settings": "__flag__",
+      "include_remotes": "__flag__",
       "timeout": [
         "-1",
         "0"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/connector.last_sync.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/connector.last_sync.json
@@ -14,8 +14,8 @@
     ],
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-connector-last-sync-api.html",
     "availability": {
-      "stack": true,
-      "serverless": true
+      "stack": false,
+      "serverless": false
     }
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/enrich.stats.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/enrich.stats.json
@@ -15,7 +15,7 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-stats-api.html",
     "availability": {
       "stack": true,
-      "serverless": true
+      "serverless": false
     }
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/esql.query.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/esql.query.json
@@ -15,7 +15,8 @@
         "smile",
         "arrow"
       ],
-      "delimiter": ""
+      "delimiter": "",
+      "drop_null_columns": "__flag__"
     },
     "methods": [
       "POST"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.create_data_stream.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.create_data_stream.json
@@ -4,7 +4,17 @@
       "error_trace": "__flag__",
       "filter_path": [],
       "human": "__flag__",
-      "pretty": "__flag__"
+      "pretty": "__flag__",
+      "master_timeout": [
+        "30s",
+        "-1",
+        "0"
+      ],
+      "timeout": [
+        "30s",
+        "-1",
+        "0"
+      ]
     },
     "methods": [
       "PUT"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.data_streams_stats.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.data_streams_stats.json
@@ -23,7 +23,7 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
     "availability": {
       "stack": true,
-      "serverless": true
+      "serverless": false
     }
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.delete_data_lifecycle.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.delete_data_lifecycle.json
@@ -30,7 +30,7 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html",
     "availability": {
       "stack": true,
-      "serverless": true
+      "serverless": false
     }
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.delete_data_stream.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.delete_data_stream.json
@@ -5,6 +5,11 @@
       "filter_path": [],
       "human": "__flag__",
       "pretty": "__flag__",
+      "master_timeout": [
+        "30s",
+        "-1",
+        "0"
+      ],
       "expand_wildcards": [
         "all",
         "open",

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get_data_lifecycle.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get_data_lifecycle.json
@@ -12,7 +12,12 @@
         "hidden",
         "none"
       ],
-      "include_defaults": "__flag__"
+      "include_defaults": "__flag__",
+      "master_timeout": [
+        "30s",
+        "-1",
+        "0"
+      ]
     },
     "methods": [
       "GET"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get_data_stream.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.get_data_stream.json
@@ -12,7 +12,13 @@
         "hidden",
         "none"
       ],
-      "include_defaults": "__flag__"
+      "include_defaults": "__flag__",
+      "master_timeout": [
+        "30s",
+        "-1",
+        "0"
+      ],
+      "verbose": "__flag__"
     },
     "methods": [
       "GET"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.migrate_to_data_stream.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.migrate_to_data_stream.json
@@ -4,7 +4,17 @@
       "error_trace": "__flag__",
       "filter_path": [],
       "human": "__flag__",
-      "pretty": "__flag__"
+      "pretty": "__flag__",
+      "master_timeout": [
+        "30s",
+        "-1",
+        "0"
+      ],
+      "timeout": [
+        "30s",
+        "-1",
+        "0"
+      ]
     },
     "methods": [
       "POST"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.promote_data_stream.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.promote_data_stream.json
@@ -4,7 +4,12 @@
       "error_trace": "__flag__",
       "filter_path": [],
       "human": "__flag__",
-      "pretty": "__flag__"
+      "pretty": "__flag__",
+      "master_timeout": [
+        "30s",
+        "-1",
+        "0"
+      ]
     },
     "methods": [
       "POST"

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/indices.put_template.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/indices.put_template.json
@@ -24,7 +24,7 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html",
     "availability": {
       "stack": true,
-      "serverless": true
+      "serverless": false
     }
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/inference.stream_inference.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/inference.stream_inference.json
@@ -1,0 +1,16 @@
+{
+  "inference.stream_inference": {
+    "methods": [
+      "POST"
+    ],
+    "patterns": [
+      "_inference/{inference_id}/_stream",
+      "_inference/{task_type}/{inference_id}/_stream"
+    ],
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/post-stream-inference-api.html",
+    "availability": {
+      "stack": true,
+      "serverless": false
+    }
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/security.delete_role.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/security.delete_role.json
@@ -20,7 +20,7 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html",
     "availability": {
       "stack": true,
-      "serverless": false
+      "serverless": true
     }
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/security.get_builtin_privileges.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/security.get_builtin_privileges.json
@@ -15,7 +15,7 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html",
     "availability": {
       "stack": true,
-      "serverless": false
+      "serverless": true
     }
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/security.get_role.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/security.get_role.json
@@ -16,7 +16,7 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html",
     "availability": {
       "stack": true,
-      "serverless": false
+      "serverless": true
     }
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/security.put_role.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/security.put_role.json
@@ -21,7 +21,7 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html",
     "availability": {
       "stack": true,
-      "serverless": false
+      "serverless": true
     }
   }
 }

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.repository_verify_integrity.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/snapshot.repository_verify_integrity.json
@@ -1,0 +1,29 @@
+{
+  "snapshot.repository_verify_integrity": {
+    "url_params": {
+      "error_trace": "__flag__",
+      "filter_path": [],
+      "human": "__flag__",
+      "pretty": "__flag__",
+      "meta_thread_pool_concurrency": "",
+      "blob_thread_pool_concurrency": "",
+      "snapshot_verification_concurrency": "",
+      "index_verification_concurrency": "",
+      "index_snapshot_verification_concurrency": "",
+      "max_failed_shard_snapshots": "",
+      "verify_blob_contents": "__flag__",
+      "max_bytes_per_sec": ""
+    },
+    "methods": [
+      "POST"
+    ],
+    "patterns": [
+      "_snapshot/{repository}/_verify_integrity"
+    ],
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+    "availability": {
+      "stack": false,
+      "serverless": false
+    }
+  }
+}

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/sql.query.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/sql.query.json
@@ -5,7 +5,15 @@
       "filter_path": [],
       "human": "__flag__",
       "pretty": "__flag__",
-      "format": ""
+      "format": [
+        "csv",
+        "json",
+        "tsv",
+        "txt",
+        "yaml",
+        "cbor",
+        "smile"
+      ]
     },
     "methods": [
       "POST",

--- a/src/plugins/console/server/lib/spec_definitions/json/generated/xpack.info.json
+++ b/src/plugins/console/server/lib/spec_definitions/json/generated/xpack.info.json
@@ -5,7 +5,11 @@
       "filter_path": [],
       "human": "__flag__",
       "pretty": "__flag__",
-      "categories": "",
+      "categories": [
+        "build",
+        "features",
+        "license"
+      ],
       "accept_enterprise": "__flag__"
     },
     "methods": [


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/194601

## Summary

This PR updates the script-generated Console autocomplete definitions for 8.16.


### Testing
We currently don't have automated tests for all autocomplete definition endpoints, so we should test the changes manually. We do this by running Kibana and verifying in Console that the changed endpoints are suggested correctly. It's important that we also test in serverless and make sure that the changed endpoints are only available in the specified offerings, based on the `availability` property. For example, if an autocompletion definition has the following `availability` property:
```
    "availability": {
      "stack": true,
      "serverless": false
    }
```
this means that the endpoint should be suggested in stateful Kibana, but not in serverless.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->