### PR TITLE
[Lens] Fix switchVisualizationType to use it without layerId

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.test.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.test.tsx
@@ -4214,4 +4214,30 @@ describe('xy_visualization', () => {
       `);
     });
   });
+  describe('switchVisualizationType', () => {
+    it('should switch all the layers to the new visualization type if layerId is not specified (AI assistant case)', () => {
+      const state = exampleState();
+      state.layers[1] = state.layers[0];
+      state.layers[1].layerId = 'second';
+      state.layers[2] = state.layers[0];
+      state.layers[2].layerId = 'third';
+      const newType = 'bar';
+      const newState = xyVisualization.switchVisualizationType!(newType, state);
+      expect((newState.layers[0] as XYDataLayerConfig).seriesType).toEqual(newType);
+      expect((newState.layers[1] as XYDataLayerConfig).seriesType).toEqual(newType);
+      expect((newState.layers[2] as XYDataLayerConfig).seriesType).toEqual(newType);
+    });
+    it('should switch only the second layer to the new visualization type if layerId is specified (chart switch case)', () => {
+      const state = exampleState();
+      state.layers[1] = { ...state.layers[0] };
+      state.layers[1].layerId = 'second';
+      state.layers[2] = { ...state.layers[0] };
+      state.layers[2].layerId = 'third';
+      const newType = 'bar';
+      const newState = xyVisualization.switchVisualizationType!(newType, state, 'first');
+      expect((newState.layers[0] as XYDataLayerConfig).seriesType).toEqual(newType);
+      expect((newState.layers[1] as XYDataLayerConfig).seriesType).toEqual('area');
+      expect((newState.layers[2] as XYDataLayerConfig).seriesType).toEqual('area');
+    });
+  });
 });

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
@@ -263,14 +263,13 @@ export const getXyVisualization = ({
   getDescription,
 
   switchVisualizationType(seriesType: string, state: State, layerId?: string) {
-    const dataLayer = state.layers.find((l) => l.layerId === layerId);
+    const dataLayer = state.layers.find((l) => l.layerId === layerId) ?? state.layers[0];
     if (dataLayer && !isDataLayer(dataLayer)) {
       throw new Error('Cannot switch series type for non-data layer');
     }
     if (!dataLayer) {
       return state;
     }
-    // todo: test how they switch between percentage etc
     const currentStackingType = stackingTypes.find(({ subtypes }) =>
       subtypes.includes(dataLayer.seriesType)
     );

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
@@ -263,7 +263,9 @@ export const getXyVisualization = ({
   getDescription,
 
   switchVisualizationType(seriesType: string, state: State, layerId?: string) {
-    const dataLayer = state.layers.find((l) => l.layerId === layerId) ?? state.layers[0];
+    const dataLayer = layerId
+      ? state.layers.find((l) => l.layerId === layerId)
+      : state.layers.at(0);
     if (dataLayer && !isDataLayer(dataLayer)) {
       throw new Error('Cannot switch series type for non-data layer');
     }


### PR DESCRIPTION
With [PR #187475](https://github.com/elastic/kibana/pull/187475/files) we introduced a bug, affecting the AI assistant's suggestions API when switching between different chart types (e.g., from bar to line chart). This feature relies on the switchVisualizationType method, which was changed to require a `layerId`. However, the suggestions API does not provide `layerId`, causing the chart type to not switch as expected.

Solution:
The bug can be resolved by modifying the logic in the `switchVisualizationType` method. We changed:

```ts
const dataLayer = state.layers.find((l) => l.layerId === layerId);
```

to:

```ts
const dataLayer = state.layers.find((l) => l.layerId === layerId) ?? state.layers[0];
```

This ensures that the suggestions API falls back to the first layer if no specific layerId is provided.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->