### PR TITLE
[Security Solution] Clean up external link text in a general way

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
@@ -138,7 +138,7 @@ export const TIMELINE_FIELD = (field: string) => {
   return `[data-test-subj="formatted-field-${field}"]`;
 };
 
-export const removeExternalLinkText = (str: string) => str.replace(/\(external[^)]*\)/g, '');
+export const removeExternalLinkText = (str: string) => str.replace(/\([^)]+\)/g, '');
 
 export const DEFINE_RULE_PANEL_PROGRESS =
   '[data-test-subj="defineRule"] [data-test-subj="stepPanelProgress"]';

--- a/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
@@ -138,7 +138,8 @@ export const TIMELINE_FIELD = (field: string) => {
   return `[data-test-subj="formatted-field-${field}"]`;
 };
 
-export const removeExternalLinkText = (str: string) => str.replace(/\([^)]+\)/g, '');
+export const removeExternalLinkText = (str: string) =>
+  str.replace(/\([^)]*(opens in a new tab or window)[^)]*\)/g, '');
 
 export const DEFINE_RULE_PANEL_PROGRESS =
   '[data-test-subj="defineRule"] [data-test-subj="stepPanelProgress"]';


### PR DESCRIPTION
## Summary

This PR generalizes external link text cleanup in `removeExternalLinkText`. 

## Details

Recent Rule Management [periodic pipeline failure](https://buildkite.com/elastic/security-serverless-quality-gate-kibana-periodic/builds/1209#job-01928e56-28f3-4b45-8f9f-7158b324c115) was caused by merging back https://github.com/elastic/kibana/pull/195525. Despite EUI changes were [addressed](https://github.com/elastic/kibana/pull/195525/files#diff-8d47b006a91beb2c5074560dbcd42eecef96173e03ffeec7c726dd322425f760) in our test utility it wasn't properly picked up. The problem is fixed in a more general way.

<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->