### PR TITLE
[Canvas] Fix unescaped backslashes

### DIFF
--- a/src/plugins/presentation_util/public/components/expression_input/autocomplete.ts
+++ b/src/plugins/presentation_util/public/components/expression_input/autocomplete.ts
@@ -439,7 +439,7 @@ function maybeQuote(value: any) {
     if (value.match(/^\{.*\}$/)) {
       return value;
     }
-    return `"${value.replace(/"/g, '\\"')}"`;
+    return `"${value.replace(/[\\"]/g, '\\$&')}"`;
   }
   return value;
 }


### PR DESCRIPTION
Fixes unescaped backslashes in Canvas autocomplete

<!--ONMERGE {"backportTargets":["7.17","8.15","8.x"]} ONMERGE-->