### PR TITLE
[Canvas] Fix unescaped backslashes

### DIFF
--- a/x-pack/plugins/canvas/common/lib/autocomplete.ts
+++ b/x-pack/plugins/canvas/common/lib/autocomplete.ts
@@ -484,7 +484,7 @@ function maybeQuote(value: any) {
     if (value.match(/^\{.*\}$/)) {
       return value;
     }
-    return `"${value.replace(/"/g, '\\"')}"`;
+    return `"${value.replace(/[\\"]/g, '\\$&')}"`;
   }
   return value;
 }


### PR DESCRIPTION
Fixes unescaped backslashes in Canvas autocomplete
