### PR TITLE
[Onboarding][Firehose] Add flag to skip AWS assets installation

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/observability/onboarding/firehose.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/onboarding/firehose.ts
@@ -20,8 +20,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const synthtrace = getService('svlLogsSynthtraceClient');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/193294
-  describe.skip('Onboarding Firehose Quickstart Flow', () => {
+  describe('Onboarding Firehose Quickstart Flow', () => {
     before(async () => {
       await PageObjects.svlCommonPage.loginAsAdmin(); // Onboarding requires admin role
       await PageObjects.common.navigateToUrlWithBrowserHistory(


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/193857
Resolves https://github.com/elastic/kibana/issues/193294

Turns out, dockerized registry is [already being used](https://buildkite.com/elastic/kibana-on-merge/builds/51727#01926d5a-f424-4b8e-b835-0f731c6ddc8d/264-454) for Firehose tests and it's still failing sometimes. So this change adds an explicit flag to skip installation of AWS assets as they are not essential to complete the flow, only the Firehose integration is required.

[Flaky test runner job](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7167).