### PR TITLE
Use internal user to create list 

### DIFF
--- a/x-pack/plugins/lists/server/plugin.ts
+++ b/x-pack/plugins/lists/server/plugin.ts
@@ -103,7 +103,7 @@ export class ListPlugin implements Plugin<ListPluginSetup, ListsPluginStart, {},
         security,
         savedObjects: { client: savedObjectsClient },
         elasticsearch: {
-          client: { asCurrentUser: esClient },
+          client: { asCurrentUser: esClient, asInternalUser: internalEsClient },
         },
       } = await context.core;
       if (config == null) {
@@ -121,6 +121,13 @@ export class ListPlugin implements Plugin<ListPluginSetup, ListsPluginStart, {},
             }),
           getExtensionPointClient: (): ExtensionPointStorageClientInterface =>
             extensionPoints.getClient(),
+          getInternalListClient: (): ListClient =>
+            new ListClient({
+              config,
+              esClient: internalEsClient,
+              spaceId,
+              user,
+            }),
           getListClient: (): ListClient =>
             new ListClient({
               config,

--- a/x-pack/plugins/lists/server/routes/list_index/create_list_index_route.ts
+++ b/x-pack/plugins/lists/server/routes/list_index/create_list_index_route.ts
@@ -11,7 +11,7 @@ import { CreateListIndexResponse } from '@kbn/securitysolution-lists-common/api'
 
 import type { ListsPluginRouter } from '../../types';
 import { buildSiemResponse } from '../utils';
-import { getListClient } from '..';
+import { getInternalListClient } from '..';
 
 export const createListIndexRoute = (router: ListsPluginRouter): void => {
   router.versioned
@@ -26,7 +26,7 @@ export const createListIndexRoute = (router: ListsPluginRouter): void => {
       const siemResponse = buildSiemResponse(response);
 
       try {
-        const lists = await getListClient(context);
+        const lists = await getInternalListClient(context);
 
         const listDataStreamExists = await lists.getListDataStreamExists();
         const listItemDataStreamExists = await lists.getListItemDataStreamExists();

--- a/x-pack/plugins/lists/server/routes/utils/get_internal_list_client.ts
+++ b/x-pack/plugins/lists/server/routes/utils/get_internal_list_client.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ListClient } from '../../services/lists/list_client';
+import { ErrorWithStatusCode } from '../../error_with_status_code';
+import type { ListsRequestHandlerContext } from '../../types';
+
+export const getInternalListClient = async (
+  context: ListsRequestHandlerContext
+): Promise<ListClient> => {
+  const lists = (await context.lists)?.getInternalListClient();
+  if (lists == null) {
+    throw new ErrorWithStatusCode('Lists is not found as a plugin', 404);
+  } else {
+    return lists;
+  }
+};

--- a/x-pack/plugins/lists/server/routes/utils/index.ts
+++ b/x-pack/plugins/lists/server/routes/utils/index.ts
@@ -8,6 +8,7 @@
 export * from './get_error_message_exception_list_item';
 export * from './get_error_message_exception_list';
 export * from './get_list_client';
+export * from './get_internal_list_client';
 export * from './get_exception_list_client';
 export * from './route_validation';
 export * from './build_siem_response';

--- a/x-pack/plugins/lists/server/types.ts
+++ b/x-pack/plugins/lists/server/types.ts
@@ -53,6 +53,7 @@ export interface ListPluginSetup {
  * @public
  */
 export interface ListsApiRequestHandlerContext {
+  getInternalListClient: () => ListClient;
   getListClient: () => ListClient;
   getExceptionListClient: () => ExceptionListClient;
   getExtensionPointClient: () => ExtensionPointStorageClientInterface;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
@@ -107,6 +107,7 @@ const createRequestContextMock = (
       getListClient: jest.fn(() => clients.lists.listClient),
       getExceptionListClient: jest.fn(() => clients.lists.exceptionListClient),
       getExtensionPointClient: jest.fn(),
+      getInternalListClient: jest.fn(),
     },
   };
 };


### PR DESCRIPTION
Recently there was changes which restrict creation of dot notation indices for not operator user in serverless.

We created `.list-${space}` from the current user, by making API request from UI which is failing right now


This is quick fix, which use internal user to create lists.


Currently this check available only on serverless QA, but there is a plan to ship it to prod. Which will block the serverless release, as all tests failed.

We checked on QA env, that with main branch we can't create those indices, but with this PR deployed, it fix it.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->