### PR TITLE
[fix] Fix lint error error  'react-use' import is restricted from being used

### DIFF
--- a/x-pack/plugins/security_solution/public/attack_discovery/pages/header/settings_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/attack_discovery/pages/header/settings_modal/index.tsx
@@ -24,7 +24,7 @@ import {
   SHOW_SETTINGS_TOUR_LOCAL_STORAGE_KEY,
 } from '@kbn/elastic-assistant';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useLocalStorage } from 'react-use';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
 
 import { AlertsSettings } from './alerts_settings';
 import { useSpaceId } from '../../../../common/hooks/use_space_id';


### PR DESCRIPTION
## Summary 
Merged in https://github.com/elastic/kibana/pull/195669 - it passed the lint stage on the PR, but fails in the quick-check and lint stages of `on-merge` jobs.

The rule was added in https://github.com/elastic/kibana/pull/195456 - but the offending PR was last verified several hours before that.