### PR TITLE
chore(): do not cancel ld-code-references jobs

### DIFF
--- a/.github/workflows/launchdarkly-code-references.yml
+++ b/.github/workflows/launchdarkly-code-references.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - 'main'
 
-# cancel in-flight workflow run if another push was triggered
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   launchDarklyCodeReferences:
     name: LaunchDarkly Code References


### PR DESCRIPTION
## Summary

We've seen a few cancellations happening from time to time. Given that the runtime is around 1 minute, it's not a big deal if it runs multiple times. Also, the chances of getting outdated data seem very low since our repo gets plenty of commits each day.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [x] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

