### PR TITLE
[Cloud Security] Remove Cursor pointer when hovering over Distribution Bar

### DIFF
--- a/x-pack/packages/security-solution/distribution_bar/src/distribution_bar.tsx
+++ b/x-pack/packages/security-solution/distribution_bar/src/distribution_bar.tsx
@@ -57,7 +57,6 @@ const useStyles = () => {
         &:hover {
           height: 7px;
           border-radius: 3px;
-          cursor: pointer;
 
           .euiBadge {
             cursor: unset;


### PR DESCRIPTION
## Summary

Currently since clicking on Distribution Bar on Alerts Flyout or Contextual Flyout doesn't do anything (like filtering), showing pointer cursor when user hovers over the Distribution is a bit misleading. As such this PR removes that cursor pointer when hovering over the bar. Once we have the filter functionality, we will add it back



<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->