### PR TITLE
[ci] Run on mdx / dev_docs

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -26,7 +26,6 @@
         "\\.md$",
         "^api_docs/.+\\.devdocs\\.json$",
         "^\\.backportrc\\.json$",
-        "^nav-kibana-dev\\.docnav\\.json$",
         "^src/dev/prs/kibana_qa_pr_list\\.json$",
         "^\\.buildkite/pull_requests\\.json$",
         "^\\.devcontainer/"

--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -20,12 +20,10 @@
       "skip_target_branches": ["6.8", "7.11", "7.12"],
       "enable_skippable_commits": true,
       "skip_ci_on_only_changed": [
-        "^dev_docs/",
         "^docs/",
         "^rfcs/",
         "^\\.github/",
         "\\.md$",
-        "\\.mdx$",
         "^api_docs/.+\\.devdocs\\.json$",
         "^\\.backportrc\\.json$",
         "^nav-kibana-dev\\.docnav\\.json$",


### PR DESCRIPTION
Currently CI is not run on pull requests with `dev_docs` only changes.  

This was implemented in https://github.com/elastic/kibana/pull/133087, where at the time we were not running any validation.  Validation was later added in https://github.com/elastic/kibana/pull/149991, but the skip criteria was not updated.

This removes the skip criteria, allowing our validation checks to run on all `dev_docs` changes.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->