### PR TITLE
[ES|QL] Fixes inline casting wrong validation

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/helpers.ts
@@ -46,7 +46,7 @@ import {
 } from '../definitions/types';
 import type { ESQLRealField, ESQLVariable, ReferenceMaps } from '../validation/types';
 import { removeMarkerArgFromArgsList } from './context';
-import { isNumericDecimalType } from './esql_types';
+import { compareTypesWithLiterals, isNumericDecimalType } from './esql_types';
 import type { ReasonTypes } from './types';
 import { DOUBLE_TICKS_REGEX, EDITOR_MARKER, SINGLE_BACKTICK } from './constants';
 import type { EditorContext } from '../autocomplete/types';
@@ -473,7 +473,7 @@ export function checkFunctionArgMatchesDefinition(
     const lowerArgType = argType?.toLowerCase();
     const lowerArgCastType = arg.castType?.toLowerCase();
     return (
-      lowerArgType === lowerArgCastType ||
+      compareTypesWithLiterals(lowerArgCastType, lowerArgType) ||
       // for valid shorthand casts like 321.12::int or "false"::bool
       (['int', 'bool'].includes(lowerArgCastType) && argType.startsWith(lowerArgCastType))
     );

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -9547,6 +9547,11 @@
       "warning": []
     },
     {
+      "query": "from a_index | where 1::string==\"keyword\"",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | eval trim(\"23\"::double)",
       "error": [
         "Argument of [trim] must be [keyword], found value [\"23\"::double] type [double]"

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -1636,6 +1636,8 @@ describe('validation logic', () => {
       // accepts casting with multiple types
       testErrorsAndWarnings('from a_index | eval 1::keyword::long::double', []);
 
+      testErrorsAndWarnings('from a_index | where 1::string=="keyword"', []);
+
       // takes into account casting in function arguments
       testErrorsAndWarnings('from a_index | eval trim("23"::double)', [
         'Argument of [trim] must be [keyword], found value ["23"::double] type [double]',


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/192255

Fixes the wrong client side validation error for inline casting cases. For example

```
FROM logstash-*
| WHERE `clientip`::string=="126.217.11.66"
```

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->