### PR TITLE
[Cases] Adapt breadcrumbs to new stateful navigation

### DIFF
--- a/x-pack/plugins/cases/public/components/use_breadcrumbs/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/use_breadcrumbs/index.test.tsx
@@ -54,10 +54,10 @@ describe('useCasesBreadcrumbs', () => {
   describe('set all_cases breadcrumbs', () => {
     it('call setBreadcrumbs with all items', async () => {
       renderHook(() => useCasesBreadcrumbs(CasesDeepLinkId.cases), { wrapper });
-      expect(mockSetBreadcrumbs).toHaveBeenCalledWith([
-        { href: '/test', onClick: expect.any(Function), text: 'Test' },
-        { text: 'Cases' },
-      ]);
+      expect(mockSetBreadcrumbs).toHaveBeenCalledWith(
+        [{ href: '/test', onClick: expect.any(Function), text: 'Test' }, { text: 'Cases' }],
+        { project: { value: [] } }
+      );
       expect(mockSetServerlessBreadcrumbs).toHaveBeenCalledWith([]);
     });
 
@@ -76,11 +76,14 @@ describe('useCasesBreadcrumbs', () => {
   describe('set create_case breadcrumbs', () => {
     it('call setBreadcrumbs with all items', () => {
       renderHook(() => useCasesBreadcrumbs(CasesDeepLinkId.casesCreate), { wrapper });
-      expect(mockSetBreadcrumbs).toHaveBeenCalledWith([
-        { href: '/test', onClick: expect.any(Function), text: 'Test' },
-        { href: CasesDeepLinkId.cases, onClick: expect.any(Function), text: 'Cases' },
-        { text: 'Create' },
-      ]);
+      expect(mockSetBreadcrumbs).toHaveBeenCalledWith(
+        [
+          { href: '/test', onClick: expect.any(Function), text: 'Test' },
+          { href: CasesDeepLinkId.cases, onClick: expect.any(Function), text: 'Cases' },
+          { text: 'Create' },
+        ],
+        { project: { value: [] } }
+      );
       expect(mockSetServerlessBreadcrumbs).toHaveBeenCalledWith([]);
     });
 
@@ -100,11 +103,14 @@ describe('useCasesBreadcrumbs', () => {
     const title = 'Fake Title';
     it('call setBreadcrumbs with title', () => {
       renderHook(() => useCasesTitleBreadcrumbs(title), { wrapper });
-      expect(mockSetBreadcrumbs).toHaveBeenCalledWith([
-        { href: '/test', onClick: expect.any(Function), text: 'Test' },
-        { href: CasesDeepLinkId.cases, onClick: expect.any(Function), text: 'Cases' },
-        { text: title },
-      ]);
+      expect(mockSetBreadcrumbs).toHaveBeenCalledWith(
+        [
+          { href: '/test', onClick: expect.any(Function), text: 'Test' },
+          { href: CasesDeepLinkId.cases, onClick: expect.any(Function), text: 'Cases' },
+          { text: title },
+        ],
+        { project: { value: [{ text: title }] } }
+      );
       expect(mockSetServerlessBreadcrumbs).toHaveBeenCalledWith([{ text: title }]);
     });
 
@@ -123,11 +129,14 @@ describe('useCasesBreadcrumbs', () => {
   describe('set settings breadcrumbs', () => {
     it('call setBreadcrumbs with all items', () => {
       renderHook(() => useCasesBreadcrumbs(CasesDeepLinkId.casesConfigure), { wrapper });
-      expect(mockSetBreadcrumbs).toHaveBeenCalledWith([
-        { href: '/test', onClick: expect.any(Function), text: 'Test' },
-        { href: CasesDeepLinkId.cases, onClick: expect.any(Function), text: 'Cases' },
-        { text: 'Settings' },
-      ]);
+      expect(mockSetBreadcrumbs).toHaveBeenCalledWith(
+        [
+          { href: '/test', onClick: expect.any(Function), text: 'Test' },
+          { href: CasesDeepLinkId.cases, onClick: expect.any(Function), text: 'Cases' },
+          { text: 'Settings' },
+        ],
+        { project: { value: [] } }
+      );
       expect(mockSetServerlessBreadcrumbs).toHaveBeenCalledWith([]);
     });
 


### PR DESCRIPTION
## Summary

Continuation of: https://github.com/elastic/kibana/pull/196169

Adapted the Cases breadcrumbs to the new navigation for stateful (ESS) environments.

Using the same `chrome.setBreadcrumbs` API, the case title breadcrumb now needs to be passed separately, inside the second _param_ object with `{ project: { value }}`.

### Screenshots

Before
<img width="776" alt="before" src="https://github.com/user-attachments/assets/29df8b36-71b3-4cf8-9c77-a72848ff91fc">


After
<img width="776" alt="after" src="https://github.com/user-attachments/assets/bfa0bf06-9e94-454e-ace0-be63f13f9bc7">



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->