### PR TITLE
[SecuritySolution] Fix schedule risk engine callout when engine is installed but disabled

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/asset_criticality_file_uploader/components/schedule_risk_engine_callout.test.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/asset_criticality_file_uploader/components/schedule_risk_engine_callout.test.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { TestProviders } from '../../../../common/mock';
 import { ScheduleRiskEngineCallout } from './schedule_risk_engine_callout';
+import { RiskEngineStatusEnum } from '../../../../../common/api/entity_analytics';
 
 const oneHourFromNow = () => {
   const date = new Date();
@@ -48,7 +49,7 @@ describe('ScheduleRiskEngineCallout', () => {
     mockUseRiskEngineStatus.mockReturnValue({
       data: {
         isNewRiskScoreModuleInstalled: true,
-
+        risk_engine_status: RiskEngineStatusEnum.ENABLED,
         risk_engine_task_status: {
           status: 'idle',
           runAt: oneHourFromNow().toISOString(),
@@ -70,7 +71,7 @@ describe('ScheduleRiskEngineCallout', () => {
     mockUseRiskEngineStatus.mockReturnValue({
       data: {
         isNewRiskScoreModuleInstalled: true,
-
+        risk_engine_status: RiskEngineStatusEnum.ENABLED,
         risk_engine_task_status: {
           status: 'running',
           runAt: oneHourFromNow().toISOString(),
@@ -89,7 +90,7 @@ describe('ScheduleRiskEngineCallout', () => {
     mockUseRiskEngineStatus.mockReturnValue({
       data: {
         isNewRiskScoreModuleInstalled: true,
-
+        risk_engine_status: RiskEngineStatusEnum.ENABLED,
         risk_engine_task_status: {
           status: 'idle',
           runAt: new Date().toISOString(), // past date
@@ -110,7 +111,7 @@ describe('ScheduleRiskEngineCallout', () => {
     mockUseRiskEngineStatus.mockReturnValueOnce({
       data: {
         isNewRiskScoreModuleInstalled: true,
-
+        risk_engine_status: RiskEngineStatusEnum.ENABLED,
         risk_engine_task_status: {
           status: 'idle',
           runAt: oneHourFromNow(),
@@ -127,7 +128,7 @@ describe('ScheduleRiskEngineCallout', () => {
     mockUseRiskEngineStatus.mockReturnValueOnce({
       data: {
         isNewRiskScoreModuleInstalled: true,
-
+        risk_engine_status: RiskEngineStatusEnum.ENABLED,
         risk_engine_task_status: {
           status: 'idle',
           runAt: thirtyMinutesFromNow(),
@@ -143,7 +144,7 @@ describe('ScheduleRiskEngineCallout', () => {
     mockUseRiskEngineStatus.mockReturnValue({
       data: {
         isNewRiskScoreModuleInstalled: true,
-
+        risk_engine_status: RiskEngineStatusEnum.ENABLED,
         risk_engine_task_status: {
           status: 'idle',
           runAt: new Date().toISOString(), // past date
@@ -164,6 +165,21 @@ describe('ScheduleRiskEngineCallout', () => {
     mockUseRiskEngineStatus.mockReturnValue({
       data: {
         isNewRiskScoreModuleInstalled: false,
+      },
+    });
+
+    const { queryByTestId } = render(<ScheduleRiskEngineCallout />, {
+      wrapper: TestProviders,
+    });
+
+    expect(queryByTestId('risk-engine-callout')).toBeNull();
+  });
+
+  it('should not show the callout if the risk engine is disabled', () => {
+    mockUseRiskEngineStatus.mockReturnValue({
+      data: {
+        isNewRiskScoreModuleInstalled: true,
+        risk_engine_status: RiskEngineStatusEnum.DISABLED,
       },
     });
 

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/asset_criticality_file_uploader/components/schedule_risk_engine_callout.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/asset_criticality_file_uploader/components/schedule_risk_engine_callout.tsx
@@ -16,6 +16,7 @@ import React, { useCallback, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { i18n } from '@kbn/i18n';
+import { RiskEngineStatusEnum } from '../../../../../common/api/entity_analytics';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { formatTimeFromNow } from '../helpers';
 import { useScheduleNowRiskEngineMutation } from '../../../api/hooks/use_schedule_now_risk_engine_mutation';
@@ -76,7 +77,10 @@ export const ScheduleRiskEngineCallout: React.FC = () => {
     scheduleRiskEngineMutation();
   }, [scheduleRiskEngineMutation]);
 
-  if (!riskEngineStatus?.isNewRiskScoreModuleInstalled) {
+  if (
+    !riskEngineStatus?.isNewRiskScoreModuleInstalled ||
+    riskEngineStatus?.risk_engine_status !== RiskEngineStatusEnum.ENABLED
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Fix the visibility of the Schedule Risk Engine Callout inside the asset criticality bulk upload when the risk engine is disabled.
The callout should not be displayed when the risk engine is installed but disabled.


### How to test it?
* Open Kibana - Security Solution
* Navigate to the risk engine page and install the risk engine
* On the same page, disable the risk engine
* Navigate to the asset criticality page
* Successfully upload a document 
* You should see a "success" but no risk engine callout.

![Screenshot 2024-10-16 at 10 41 39](https://github.com/user-attachments/assets/5c8f078e-4588-434e-8c76-03d72b1c5a16)



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.15","8.x"]} ONMERGE-->