### PR TITLE
[SecuritySoltuon] fix unnecessary requests from the alert flyout

### DIFF
--- a/x-pack/plugins/cases/public/client/ui/get_all_cases_selector_modal.tsx
+++ b/x-pack/plugins/cases/public/client/ui/get_all_cases_selector_modal.tsx
@@ -31,6 +31,7 @@ export const getAllCasesSelectorModalLazy = ({
   hiddenStatuses,
   onRowClick,
   onClose,
+  queryClient,
 }: GetAllCasesSelectorModalPropsInternal) => (
   <CasesProvider
     value={{
@@ -39,6 +40,7 @@ export const getAllCasesSelectorModalLazy = ({
       getFilesClient,
       owner,
       permissions,
+      queryClient,
     }}
   >
     <Suspense fallback={<EuiLoadingSpinner />}>

--- a/x-pack/plugins/cases/public/client/ui/get_cases.tsx
+++ b/x-pack/plugins/cases/public/client/ui/get_cases.tsx
@@ -37,6 +37,7 @@ export const getCasesLazy = ({
   timelineIntegration,
   features,
   releasePhase,
+  queryClient,
 }: GetCasesPropsInternal) => (
   <CasesProvider
     value={{
@@ -48,6 +49,7 @@ export const getCasesLazy = ({
       basePath,
       features,
       releasePhase,
+      queryClient,
     }}
   >
     <Suspense fallback={<EuiLoadingSpinner />}>

--- a/x-pack/plugins/cases/public/client/ui/get_cases_context.tsx
+++ b/x-pack/plugins/cases/public/client/ui/get_cases_context.tsx
@@ -32,6 +32,7 @@ const CasesProviderLazyWrapper = ({
   children,
   releasePhase,
   getFilesClient,
+  queryClient,
 }: GetCasesContextPropsInternal & { children: ReactNode }) => (
   <Suspense fallback={<EuiLoadingSpinner />}>
     <CasesProviderLazy
@@ -43,6 +44,7 @@ const CasesProviderLazyWrapper = ({
         features,
         releasePhase,
         getFilesClient,
+        queryClient,
       }}
     >
       {children}

--- a/x-pack/plugins/cases/public/client/ui/get_create_case_flyout.tsx
+++ b/x-pack/plugins/cases/public/client/ui/get_create_case_flyout.tsx
@@ -33,6 +33,7 @@ export const getCreateCaseFlyoutLazy = ({
   onClose,
   onSuccess,
   attachments,
+  queryClient,
 }: GetCreateCaseFlyoutPropsInternal) => (
   <CasesProvider
     value={{
@@ -42,6 +43,7 @@ export const getCreateCaseFlyoutLazy = ({
       owner,
       permissions,
       features,
+      queryClient,
     }}
   >
     <Suspense fallback={<EuiLoadingSpinner />}>

--- a/x-pack/plugins/cases/public/client/ui/get_recent_cases.tsx
+++ b/x-pack/plugins/cases/public/client/ui/get_recent_cases.tsx
@@ -29,6 +29,7 @@ export const getRecentCasesLazy = ({
   owner,
   permissions,
   maxCasesToShow,
+  queryClient,
 }: GetRecentCasesPropsInternal) => (
   <CasesProvider
     value={{
@@ -37,6 +38,7 @@ export const getRecentCasesLazy = ({
       getFilesClient,
       owner,
       permissions,
+      queryClient,
     }}
   >
     <Suspense fallback={<EuiLoadingSpinner />}>

--- a/x-pack/plugins/cases/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/cases/public/common/mock/test_providers.tsx
@@ -102,8 +102,8 @@ const TestProvidersComponent: React.FC<TestProviderProps> = ({
               owner,
               permissions,
               getFilesClient,
+              queryClient,
             }}
-            queryClient={queryClient}
           >
             <FilesContext client={createMockFilesClient()}>{children}</FilesContext>
           </CasesProvider>
@@ -184,8 +184,8 @@ export const createAppMockRenderer = ({
               permissions,
               releasePhase,
               getFilesClient,
+              queryClient,
             }}
-            queryClient={queryClient}
           >
             {children}
           </CasesProvider>

--- a/x-pack/plugins/cases/public/components/cases_context/index.tsx
+++ b/x-pack/plugins/cases/public/components/cases_context/index.tsx
@@ -45,6 +45,7 @@ export interface CasesContextValue {
   features: CasesFeaturesAllRequired;
   releasePhase: ReleasePhase;
   dispatch: CasesContextValueDispatch;
+  queryClient?: QueryClient;
 }
 
 export interface CasesContextProps
@@ -54,6 +55,7 @@ export interface CasesContextProps
     | 'permissions'
     | 'externalReferenceAttachmentTypeRegistry'
     | 'persistableStateAttachmentTypeRegistry'
+    | 'queryClient'
   > {
   basePath?: string;
   features?: CasesFeatures;
@@ -66,7 +68,6 @@ export const CasesContext = React.createContext<CasesContextValue | undefined>(u
 export const CasesProvider: FC<
   PropsWithChildren<{
     value: CasesContextProps;
-    queryClient?: QueryClient;
   }>
 > = ({
   children,
@@ -79,11 +80,10 @@ export const CasesProvider: FC<
     features = {},
     releasePhase = 'ga',
     getFilesClient,
+    queryClient,
   },
-  queryClient = casesQueryClient,
 }) => {
   const [state, dispatch] = useReducer(casesContextReducer, getInitialCasesContextState());
-
   const value: CasesContextValue = useMemo(
     () => ({
       externalReferenceAttachmentTypeRegistry,
@@ -111,6 +111,7 @@ export const CasesProvider: FC<
       ),
       releasePhase,
       dispatch,
+      queryClient,
     }),
     /**
      * We want to trigger a rerender only when the permissions will change.
@@ -152,7 +153,7 @@ export const CasesProvider: FC<
   );
 
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={value.queryClient || casesQueryClient}>
       <CasesStateContext.Provider value={state}>
         <CasesContext.Provider value={value}>
           {applyFilesContext(

--- a/x-pack/plugins/security_solution/public/app/routes.tsx
+++ b/x-pack/plugins/security_solution/public/app/routes.tsx
@@ -10,6 +10,7 @@ import type { FC } from 'react';
 import React, { memo, useEffect } from 'react';
 import { Router, Routes, Route } from '@kbn/shared-ux-router';
 import { useDispatch } from 'react-redux';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { APP_ID } from '../../common/constants';
 import { RouteCapture } from '../common/components/endpoint/route_capture';
@@ -30,6 +31,7 @@ const PageRouterComponent: FC<RouterProps> = ({ children, history }) => {
   const { cases } = useKibana().services;
   const CasesContext = cases.ui.getCasesContext();
   const userCasesPermissions = cases.helpers.canUseCases(ownerApp);
+  const queryClient = useQueryClient();
   const dispatch = useDispatch<(action: AppAction) => void>();
   useEffect(() => {
     return () => {
@@ -48,7 +50,11 @@ const PageRouterComponent: FC<RouterProps> = ({ children, history }) => {
         <RouteCapture>
           <Routes>
             <Route path="/">
-              <CasesContext owner={ownerApp} permissions={userCasesPermissions}>
+              <CasesContext
+                owner={ownerApp}
+                permissions={userCasesPermissions}
+                queryClient={queryClient}
+              >
                 <HomePage>{children}</HomePage>
               </CasesContext>
             </Route>

--- a/x-pack/plugins/security_solution/public/app/routes.tsx
+++ b/x-pack/plugins/security_solution/public/app/routes.tsx
@@ -24,10 +24,12 @@ interface RouterProps {
   history: History;
 }
 
+const ownerApp = [APP_ID];
+
 const PageRouterComponent: FC<RouterProps> = ({ children, history }) => {
   const { cases } = useKibana().services;
   const CasesContext = cases.ui.getCasesContext();
-  const userCasesPermissions = cases.helpers.canUseCases([APP_ID]);
+  const userCasesPermissions = cases.helpers.canUseCases(ownerApp);
   const dispatch = useDispatch<(action: AppAction) => void>();
   useEffect(() => {
     return () => {
@@ -46,7 +48,7 @@ const PageRouterComponent: FC<RouterProps> = ({ children, history }) => {
         <RouteCapture>
           <Routes>
             <Route path="/">
-              <CasesContext owner={[APP_ID]} permissions={userCasesPermissions}>
+              <CasesContext owner={ownerApp} permissions={userCasesPermissions}>
                 <HomePage>{children}</HomePage>
               </CasesContext>
             </Route>


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/195607

As described in the issue above, whenever a click was registered in the alert flyout, some logic in Kibana would trigger 5 HTTP requests. 

After some debugging, it became apparent that it was caused by a misconfigured `ReactQuery` client stemming from the cases plugin. The cases client does not specify a behaviour for focus changes which was causing the extra HTTP requests.

Security solution's `ReactQuery` client comes with some defaults that make sure that unnecessary requests due to focus changes don't occur. However, since the cases context was overriding the `QueryClientProvider`, these defaults were overwritten.

```jsx
<SecuritySolutionApp>
  <...>
  <QueryClientProvider>
     <...>
     <CasesContext>
       <QueryClientProvider>
         <!-- the actual components -->
       </QueryClientProvider>
     </CasesContext>
  </QueryClientProvider>
</SecuritySolutionApp>
```

The fix was to add `queryClient` to the `CaseContext`'s `value`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
