### PR TITLE
[SO finder] Increase type column width

### DIFF
--- a/src/plugins/saved_objects_finder/public/finder/saved_object_finder.tsx
+++ b/src/plugins/saved_objects_finder/public/finder/saved_object_finder.tsx
@@ -231,7 +231,7 @@ export class SavedObjectFinderUi extends React.Component<
             name: i18n.translate('savedObjectsFinder.typeName', {
               defaultMessage: 'Type',
             }),
-            width: '50px',
+            width: '75px',
             align: 'center',
             description: i18n.translate('savedObjectsFinder.typeDescription', {
               defaultMessage: 'Type of the saved object',


### PR DESCRIPTION
In this PR I've increased the width of the "type" column of the saved object finder table.

Fixes https://github.com/elastic/kibana/issues/193750