### PR TITLE
[Security assistant] Fix `AlertsRange` for Assistant

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/alerts_settings/alerts_settings.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/alerts_settings/alerts_settings.tsx
@@ -13,9 +13,9 @@ import { KnowledgeBaseConfig } from '../../types';
 import { AlertsRange } from '../../../knowledge_base/alerts_range';
 import * as i18n from '../../../knowledge_base/translations';
 
-export const MIN_LATEST_ALERTS = 10;
-export const MAX_LATEST_ALERTS = 100;
-export const TICK_INTERVAL = 10;
+export const MIN_LATEST_ALERTS = 50;
+export const MAX_LATEST_ALERTS = 500;
+export const TICK_INTERVAL = 50;
 export const RANGE_CONTAINER_WIDTH = 600; // px
 const LABEL_WRAPPER_MIN_WIDTH = 95; // px
 


### PR DESCRIPTION
## Summary

I did a [bad job on a merge conflict](https://github.com/elastic/kibana/pull/195733/commits/df14f67743ae22d486ad9862c0904a73eb1526ae) last night, bringing back the updates to the `AlertsRange` min/max/interval.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->