### PR TITLE
[ESQL] String escaping fix

### DIFF
--- a/packages/kbn-esql-utils/src/utils/append_to_query.ts
+++ b/packages/kbn-esql-utils/src/utils/append_to_query.ts
@@ -40,7 +40,8 @@ export function appendWhereClauseToESQLQuery(
     default:
       operator = '==';
   }
-  let filterValue = typeof value === 'string' ? `"${value.replace(/\\/g, '\\\\').replace(/\"/g, '\\"')}"` : value;
+  let filterValue =
+    typeof value === 'string' ? `"${value.replace(/\\/g, '\\\\').replace(/\"/g, '\\"')}"` : value;
   // Adding the backticks here are they are needed for special char fields
   let fieldName = `\`${field}\``;
 

--- a/packages/kbn-esql-utils/src/utils/append_to_query.ts
+++ b/packages/kbn-esql-utils/src/utils/append_to_query.ts
@@ -40,7 +40,7 @@ export function appendWhereClauseToESQLQuery(
     default:
       operator = '==';
   }
-  let filterValue = typeof value === 'string' ? `"${value.replace(/\"/g, '\\"')}"` : value;
+  let filterValue = typeof value === 'string' ? `"${value.replace(/\\/g, '\\\\').replace(/\"/g, '\\"')}"` : value;
   // Adding the backticks here are they are needed for special char fields
   let fieldName = `\`${field}\``;
 


### PR DESCRIPTION
## Summary

This PR fixes the problem with string escaping, we need to ensure that backslashes are properly escaped in addition to double quotes.






<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->