### PR TITLE
Update max supported package version

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -17,7 +17,7 @@ xpack.osquery.enabled: false
 xpack.fleet.enabled: true
 xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 xpack.fleet.internal.registry.spec.min: '3.0'
-xpack.fleet.internal.registry.spec.max: '3.2'
+xpack.fleet.internal.registry.spec.max: '3.3'
 xpack.fleet.packages:
   # fleet_server package installed to publish agent metrics
   - name: fleet_server


### PR DESCRIPTION
Update the max supported package version to 3.3.0. 
Search projects were not updated with the previous PR - https://github.com/elastic/kibana/pull/196551 

Related to https://github.com/elastic/package-spec/pull/818

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->