### PR TITLE
[tests] skip SyncAlertsToggle tests

### DIFF
--- a/x-pack/plugins/cases/public/components/case_form_fields/sync_alerts_toggle.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_form_fields/sync_alerts_toggle.test.tsx
@@ -14,7 +14,8 @@ import { FormTestComponent } from '../../common/test_utils';
 import type { AppMockRenderer } from '../../common/mock';
 import { createAppMockRenderer } from '../../common/mock';
 
-describe('SyncAlertsToggle', () => {
+// Failing: https://github.com/elastic/kibana/issues/190270
+describe.skip('SyncAlertsToggle', () => {
   let appMockRender: AppMockRenderer;
   const onSubmit = jest.fn();
   const defaultFormProps = {

--- a/x-pack/plugins/cases/public/components/case_settings/sync_alerts_switch.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_settings/sync_alerts_switch.test.tsx
@@ -14,7 +14,6 @@ import { createAppMockRenderer } from '../../common/mock';
 import { SyncAlertsSwitch } from './sync_alerts_switch';
 
 // Failing: See https://github.com/elastic/kibana/issues/192997
-// Failing: See https://github.com/elastic/kibana/issues/190270
 describe.skip('SyncAlertsSwitch', () => {
   let appMockRender: AppMockRenderer;
 


### PR DESCRIPTION
## Summary
It seems the flaky unit-tests cases from https://github.com/elastic/kibana/issues/190270 were skipped in the wrong file with a similar component name.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->