### PR TITLE
Enable ES dot prefix validation in serverless tests

### DIFF
--- a/x-pack/test_serverless/shared/config.base.ts
+++ b/x-pack/test_serverless/shared/config.base.ts
@@ -94,6 +94,7 @@ export default async () => {
         'xpack.security.authc.realms.jwt.jwt1.order=-98',
         `xpack.security.authc.realms.jwt.jwt1.pkc_jwkset_path=${getDockerFileMountPath(jwksPath)}`,
         `xpack.security.authc.realms.jwt.jwt1.token_type=access_token`,
+        'serverless.indices.validate_dot_prefixes=true',
       ],
       ssl: true, // SSL is required for SAML realm
     },


### PR DESCRIPTION
DO NOT MERGE

Enable dot prefix ES validation to reproduce failure against release branch.