### PR TITLE
[Ingest Pipelines] Improve api integration tests

### DIFF
--- a/x-pack/test/api_integration/apis/management/index.js
+++ b/x-pack/test/api_integration/apis/management/index.js
@@ -14,5 +14,6 @@ export default function ({ loadTestFile }) {
     loadTestFile(require.resolve('./index_management'));
     loadTestFile(require.resolve('./index_lifecycle_management'));
     loadTestFile(require.resolve('./snapshot_restore'));
+    loadTestFile(require.resolve('./ingest_pipelines'));
   });
 }

--- a/x-pack/test/api_integration/apis/management/ingest_pipelines/databases.ts
+++ b/x-pack/test/api_integration/apis/management/ingest_pipelines/databases.ts
@@ -13,8 +13,10 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const ingestPipelines = getService('ingestPipelines');
   const url = `/api/ingest_pipelines/databases`;
-  const databaseName = 'GeoIP2-Anonymous-IP';
-  const normalizedDatabaseName = 'geoip2-anonymous-ip';
+  const maxmindDatabaseName = 'GeoIP2-Anonymous-IP';
+  const normalizedMaxmindDatabaseName = 'geoip2-anonymous-ip';
+  const ipinfoDatabaseName = 'asn';
+  const normalizedIpinfoDatabaseName = 'asn';
 
   describe('Manage databases', function () {
     after(async () => {
@@ -22,8 +24,12 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     describe('Create', () => {
-      it('creates a geoip database when using a correct database name', async () => {
-        const database = { maxmind: '123456', databaseName };
+      it('creates a maxmind geoip database when using a correct database name', async () => {
+        const database = {
+          databaseType: 'maxmind',
+          databaseName: maxmindDatabaseName,
+          maxmind: '123456',
+        };
         const { body } = await supertest
           .post(url)
           .set('kbn-xsrf', 'xxx')
@@ -31,13 +37,27 @@ export default function ({ getService }: FtrProviderContext) {
           .expect(200);
 
         expect(body).to.eql({
-          name: databaseName,
-          id: normalizedDatabaseName,
+          name: maxmindDatabaseName,
+          id: normalizedMaxmindDatabaseName,
         });
       });
 
-      it('creates a geoip database when using an incorrect database name', async () => {
-        const database = { maxmind: '123456', databaseName: 'Test' };
+      it('creates an ipinfo geoip database when using a correct database name', async () => {
+        const database = { databaseType: 'ipinfo', databaseName: ipinfoDatabaseName };
+        const { body } = await supertest
+          .post(url)
+          .set('kbn-xsrf', 'xxx')
+          .send(database)
+          .expect(200);
+
+        expect(body).to.eql({
+          name: ipinfoDatabaseName,
+          id: normalizedIpinfoDatabaseName,
+        });
+      });
+
+      it('returns error when creating a geoip database with an incorrect database name', async () => {
+        const database = { databaseType: 'maxmind', databaseName: 'Test', maxmind: '123456' };
         await supertest.post(url).set('kbn-xsrf', 'xxx').send(database).expect(400);
       });
     });
@@ -47,8 +67,13 @@ export default function ({ getService }: FtrProviderContext) {
         const { body } = await supertest.get(url).set('kbn-xsrf', 'xxx').expect(200);
         expect(body).to.eql([
           {
-            id: normalizedDatabaseName,
-            name: databaseName,
+            id: normalizedIpinfoDatabaseName,
+            name: ipinfoDatabaseName,
+            type: 'ipinfo',
+          },
+          {
+            id: normalizedMaxmindDatabaseName,
+            name: maxmindDatabaseName,
             type: 'maxmind',
           },
         ]);
@@ -58,7 +83,12 @@ export default function ({ getService }: FtrProviderContext) {
     describe('Delete', () => {
       it('deletes a geoip database', async () => {
         await supertest
-          .delete(`${url}/${normalizedDatabaseName}`)
+          .delete(`${url}/${normalizedMaxmindDatabaseName}`)
+          .set('kbn-xsrf', 'xxx')
+          .expect(200);
+
+        await supertest
+          .delete(`${url}/${normalizedIpinfoDatabaseName}`)
           .set('kbn-xsrf', 'xxx')
           .expect(200);
       });


### PR DESCRIPTION
Follow-up to https://github.com/elastic/kibana/pull/190830

## Summary

I noticed that the api integration tests that have been added with https://github.com/elastic/kibana/pull/190830 were not actually included to run as part of the Management test suite. This PR adds them and it also adds some test cases for the `ipinfo` database type.



<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->