### PR TITLE
[Entity Analytics] Bug: update timestamp on criticality soft delete

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
@@ -342,6 +342,7 @@ export class AssetCriticalityDataClient {
           asset: {
             criticality: CRITICALITY_VALUES.DELETED,
           },
+          '@timestamp': new Date().toISOString(),
           ...getImplicitEntityFields({
             ...idParts,
             criticalityLevel: CRITICALITY_VALUES.DELETED,


### PR DESCRIPTION
## Summary

This fixes a bug with asset criticality where "soft delete" does not update the `@timestamp` field

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->