### PR TITLE
[Lens] fix flaky long running test

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/dimension_panel.test.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/dimension_panel.test.tsx
@@ -373,7 +373,7 @@ describe('FormBasedDimensionEditor', () => {
     // // press arrow up to go back to the beginning
     await userEvent.type(comboBoxInput, '{ArrowUp}{ArrowUp}');
     expect(getVisibleFieldSelectOptions()).toEqual(allOptions.slice(8));
-  });
+  }, 10000); // this test can be long running due to a big tree we're rendering and userEvent.type function that is slow
 
   it('should hide fields that have no data', () => {
     (useExistingFieldsReader as jest.Mock).mockImplementationOnce(() => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/192476
Due the the fact type function is quite slow but irreplaceable here + the DOM tree we're rendering here is very big, I think the best option is to up the timeout limit. On average this test is around 1s long though. (We're setting the limit to 10s)


<!--ONMERGE {"backportTargets":["8.15","8.16","8.x"]} ONMERGE-->