### PR TITLE
[Fleet] Use FIPS compliant password hashing algorithm in output preconfiguration

### DIFF
--- a/x-pack/plugins/fleet/server/services/preconfiguration/outputs.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration/outputs.ts
@@ -5,11 +5,14 @@
  * 2.0.
  */
 
-import crypto from 'crypto';
+import crypto from 'node:crypto';
+import utils from 'node:util';
 
 import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
 import { isEqual } from 'lodash';
 import { dump } from 'js-yaml';
+
+const pbkdf2Async = utils.promisify(crypto.pbkdf2);
 
 import type {
   PreconfiguredOutput,
@@ -142,32 +145,23 @@ export async function createOrUpdatePreconfiguredOutputs(
 // Values recommended by NodeJS documentation
 const keyLength = 64;
 const saltLength = 16;
-
-// N=2^14 (16 MiB), r=8 (1024 bytes), p=5
-const scryptParams = {
-  cost: 16384,
-  blockSize: 8,
-  parallelization: 5,
-};
+const maxIteration = 100000;
 
 export async function hashSecret(secret: string) {
-  return new Promise((resolve, reject) => {
-    const salt = crypto.randomBytes(saltLength).toString('hex');
-    crypto.scrypt(secret, salt, keyLength, scryptParams, (err, derivedKey) => {
-      if (err) reject(err);
-      resolve(`${salt}:${derivedKey.toString('hex')}`);
-    });
-  });
+  const salt = crypto.randomBytes(saltLength).toString('hex');
+  const derivedKey = await pbkdf2Async(secret, salt, maxIteration, keyLength, 'sha512');
+
+  return `${salt}:${derivedKey.toString('hex')}`;
 }
 
 async function verifySecret(hash: string, secret: string) {
-  return new Promise((resolve, reject) => {
-    const [salt, key] = hash.split(':');
-    crypto.scrypt(secret, salt, keyLength, scryptParams, (err, derivedKey) => {
-      if (err) reject(err);
-      resolve(crypto.timingSafeEqual(Buffer.from(key, 'hex'), derivedKey));
-    });
-  });
+  const [salt, key] = hash.split(':');
+  const derivedKey = await pbkdf2Async(secret, salt, maxIteration, keyLength, 'sha512');
+  const keyBuffer = Buffer.from(key, 'hex');
+  if (keyBuffer.length !== derivedKey.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(Buffer.from(key, 'hex'), derivedKey);
 }
 
 async function hashSecrets(output: PreconfiguredOutput) {


### PR DESCRIPTION
## Description 

Resolve #194944

Use FIPS compliant password hashing algorithm instead of `crypto.scrypt`.

This will result output to be updated when upgrading Kibana version.

## Tests

I added some unit test to check we currently upgrade output if hashing method changed.

You can test this is working with the following config, with kibana from main then switching to that PR.
```
xpack.fleet.internal.fleetServerStandalone: true # to enable secrets
xpack.fleet.outputs:
  - name: 'Test output'
    is_default: true
    is_default_monitoring: true
    type: 'logstash'
    id: 'output-123'
    hosts: ['elasticsearch:9200']
    allow_edit: []
    ssl:
      certificate: 'replace2'
    secrets:
      ssl:
        key: 'replace3'
```

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->