### PR TITLE
[Dataset quality] Add missing `breakdownField` while hydrating the Dataset Quality Details state.

### DIFF
--- a/x-pack/plugins/observability_solution/dataset_quality/public/controller/dataset_quality_details/public_state.ts
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/controller/dataset_quality_details/public_state.ts
@@ -51,6 +51,7 @@ export const getContextFromPublicState = (
     },
   },
   dataStream: publicState.dataStream,
+  breakdownField: publicState.breakdownField,
   expandedDegradedField: publicState.expandedDegradedField,
   showCurrentQualityIssues:
     publicState.showCurrentQualityIssues ?? DEFAULT_CONTEXT.showCurrentQualityIssues,


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/196775.

## Summary

The PR simply adds the missing `breakdownField` while hydrating the context state from public state (e.g. from URL state).

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->