### PR TITLE
[Fleet] unskip flaky test

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/custom_fields/global_data_tags_table.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/custom_fields/global_data_tags_table.test.tsx
@@ -26,8 +26,7 @@ const TEST_IDS = {
   VALUE_INPUT: 'globalDataTagsValueInput',
 };
 
-// Failing: See https://github.com/elastic/kibana/issues/192798
-describe.skip('GlobalDataTagsTable', () => {
+describe('GlobalDataTagsTable', () => {
   let renderResult: RenderResult;
   let mockUpdateAgentPolicy: jest.Mock;
   const globalDataTags: GlobalDataTag[] = [
@@ -49,8 +48,7 @@ describe.skip('GlobalDataTagsTable', () => {
         React.ComponentProps<typeof GlobalDataTagsTable>['updateAgentPolicy']
       >((policy) => {
         mockUpdateAgentPolicy(policy);
-        // @ts-expect-error - TODO: fix this, types do not match
-        _updateAgentPolicy(policy);
+        _updateAgentPolicy({ ...policy, global_data_tags: policy.global_data_tags ?? [] });
       }, []);
 
       return (

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/custom_fields/global_data_tags_table.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/custom_fields/global_data_tags_table.test.tsx
@@ -125,7 +125,7 @@ describe('GlobalDataTagsTable', () => {
         { name: 'newTag2', value: '123 123' },
       ],
     });
-  });
+  }, 10000);
 
   it('should edit an existing tag', async () => {
     renderComponent(globalDataTags);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
@@ -161,7 +161,7 @@ afterAll(() => {
 // FLAKY: https://github.com/elastic/kibana/issues/196467
 // FLAKY: https://github.com/elastic/kibana/issues/196468
 // FLAKY: https://github.com/elastic/kibana/issues/196469
-describe.skip('When on the package policy create page', () => {
+describe('When on the package policy create page', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
@@ -154,13 +154,6 @@ afterAll(() => {
   consoleDebugMock.mockRestore();
 });
 
-// FLAKY: https://github.com/elastic/kibana/issues/196463
-// FLAKY: https://github.com/elastic/kibana/issues/196464
-// FLAKY: https://github.com/elastic/kibana/issues/196465
-// FLAKY: https://github.com/elastic/kibana/issues/196466
-// FLAKY: https://github.com/elastic/kibana/issues/196467
-// FLAKY: https://github.com/elastic/kibana/issues/196468
-// FLAKY: https://github.com/elastic/kibana/issues/196469
 describe('When on the package policy create page', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -212,6 +205,7 @@ describe('When on the package policy create page', () => {
           data_streams: [
             {
               type: 'logs',
+              name: 'access logs',
               dataset: 'nginx.access',
               title: 'Nginx access logs',
               ingest_pipeline: 'default',

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
@@ -300,7 +300,7 @@ describe('When on the package policy create page', () => {
       test('should use custom "cancel" URL', () => {
         expect(cancelLink.href).toBe(expectedRouteState.onCancelUrl);
         expect(cancelButton.href).toBe(expectedRouteState.onCancelUrl);
-      });
+      }, 10000);
     });
   });
 

--- a/x-pack/plugins/fleet/public/components/manage_agent_policies_modal.test.tsx
+++ b/x-pack/plugins/fleet/public/components/manage_agent_policies_modal.test.tsx
@@ -64,8 +64,7 @@ jest.mock('../hooks', () => ({
   }),
 }));
 
-// FLAKY: https://github.com/elastic/kibana/issues/189004
-describe.skip('ManageAgentPoliciesModal', () => {
+describe('ManageAgentPoliciesModal', () => {
   let testRenderer: TestRenderer;
   const mockOnClose = jest.fn();
   const mockPolicies = [{ name: 'Test policy', revision: 2, id: 'policy1' }] as AgentPolicy[];
@@ -115,7 +114,7 @@ describe.skip('ManageAgentPoliciesModal', () => {
     expect(usePackagePolicyWithRelatedData('', {}).savePackagePolicy).toHaveBeenCalledWith({
       policy_ids: ['policy1', 'policy2'],
     });
-  });
+  }, 10000);
 
   it('should keep managed policy when policies are changed', async () => {
     (useGetAgentPolicies as jest.Mock).mockReturnValue({


### PR DESCRIPTION
## Summary

Unskip flaky tests

Couldn't reproduce the failure in a few runs, the flaky test runner doesn't support running Jest tests.

Closes https://github.com/elastic/kibana/issues/196463
Closes https://github.com/elastic/kibana/issues/196464
Closes https://github.com/elastic/kibana/issues/196465
Closes https://github.com/elastic/kibana/issues/196466
Closes https://github.com/elastic/kibana/issues/196467
Closes https://github.com/elastic/kibana/issues/196468
Closes https://github.com/elastic/kibana/issues/196469

Closes https://github.com/elastic/kibana/issues/192798
Closes https://github.com/elastic/kibana/issues/189004

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->