### PR TITLE
[Share] Add loading state to link_content

### DIFF
--- a/src/plugins/share/public/components/tabs/link/link_content.tsx
+++ b/src/plugins/share/public/components/tabs/link/link_content.tsx
@@ -54,6 +54,7 @@ export const LinkContent = ({
   const [urlParams] = useState<UrlParams | undefined>(undefined);
   const [isTextCopied, setTextCopied] = useState(false);
   const [shortUrlCache, setShortUrlCache] = useState<string | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
 
   const getUrlWithUpdatedParams = useCallback(
     (tempUrl: string): string => {
@@ -99,6 +100,7 @@ export const LinkContent = ({
   }, [shareableUrlLocatorParams, urlService.shortUrls, getSnapshotUrl, setShortUrlCache]);
 
   const copyUrlHelper = useCallback(async () => {
+    setIsLoading(true);
     let urlToCopy = url;
 
     if (!urlToCopy || delegatedShareUrlHandler) {
@@ -112,6 +114,7 @@ export const LinkContent = ({
     copyToClipboard(urlToCopy);
     setUrl(urlToCopy);
     setTextCopied(true);
+    setIsLoading(false);
     return urlToCopy;
   }, [url, delegatedShareUrlHandler, allowShortUrl, createShortUrl, getSnapshotUrl]);
 
@@ -164,6 +167,7 @@ export const LinkContent = ({
               onBlur={() => (objectType === 'lens' && isDirty ? null : setTextCopied(false))}
               onClick={copyUrlHelper}
               color={objectType === 'lens' && isDirty ? 'warning' : 'primary'}
+              isLoading={isLoading}
             >
               <FormattedMessage id="share.link.copyLinkButton" defaultMessage="Copy link" />
             </EuiButton>


### PR DESCRIPTION
## Summary

This PR adds a loading state to `Copy Link` button in share modal.

Fixes: #194641



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->