### PR TITLE
[ES|QL] Introduce unary expressions

### DIFF
--- a/packages/kbn-esql-ast/src/builder/builder.ts
+++ b/packages/kbn-esql-ast/src/builder/builder.ts
@@ -16,11 +16,14 @@ import {
   ESQLCommand,
   ESQLCommandOption,
   ESQLDecimalLiteral,
+  ESQLFunction,
   ESQLInlineCast,
   ESQLIntegerLiteral,
   ESQLList,
   ESQLLocation,
+  ESQLSingleAstItem,
   ESQLSource,
+  ESQLUnaryExpression,
 } from '../types';
 import { AstNodeParserFields, AstNodeTemplate, PartialFields } from './types';
 
@@ -128,6 +131,35 @@ export namespace Builder {
         name: template.parts.join('.'),
         type: 'column',
       };
+    };
+
+    export const func = (
+      template: AstNodeTemplate<ESQLFunction>,
+      fromParser?: Partial<AstNodeParserFields>
+    ): ESQLFunction => {
+      return {
+        ...template,
+        ...Builder.parserFields(fromParser),
+        name: template.name.toLocaleLowerCase(),
+        type: 'function',
+      };
+    };
+
+    export const unary = (
+      operator: string,
+      operand: ESQLSingleAstItem,
+      template: Omit<AstNodeTemplate<ESQLUnaryExpression>, 'subtype' | 'name' | 'args'>,
+      fromParser?: Partial<AstNodeParserFields>
+    ): ESQLUnaryExpression => {
+      return Builder.expression.func(
+        {
+          ...template,
+          name: operator,
+          args: [operand],
+          subtype: 'unary-expression',
+        },
+        fromParser
+      ) as ESQLUnaryExpression;
     };
 
     export const inlineCast = (

--- a/packages/kbn-esql-ast/src/parser/__tests__/columns.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/columns.test.ts
@@ -90,4 +90,28 @@ describe('Column Identifier Expressions', () => {
       },
     ]);
   });
+
+  it('column inside a unary expression', () => {
+    const text = 'ROW -col';
+    const { ast } = parse(text);
+
+    expect(ast).toMatchObject([
+      {
+        type: 'command',
+        args: [
+          {
+            type: 'function',
+            subtype: 'unary-expression',
+            name: '-',
+            args: [
+              {
+                type: 'column',
+                parts: ['col'],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/kbn-esql-ast/src/parser/__tests__/literal.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/literal.test.ts
@@ -13,8 +13,8 @@ import { ESQLLiteral } from '../../types';
 describe('literal expression', () => {
   it('numeric expression captures "value", and "name" fields', () => {
     const text = 'ROW 1';
-    const { ast } = parse(text);
-    const literal = ast[0].args[0] as ESQLLiteral;
+    const { root } = parse(text);
+    const literal = root.commands[0].args[0] as ESQLLiteral;
 
     expect(literal).toMatchObject({
       type: 'literal',
@@ -26,9 +26,9 @@ describe('literal expression', () => {
 
   it('decimals vs integers', () => {
     const text = 'ROW a(1.0, 1)';
-    const { ast } = parse(text);
+    const { root } = parse(text);
 
-    expect(ast[0]).toMatchObject({
+    expect(root.commands[0]).toMatchObject({
       type: 'command',
       args: [
         {
@@ -41,6 +41,89 @@ describe('literal expression', () => {
             {
               type: 'literal',
               literalType: 'integer',
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('negative number', () => {
+    const text = 'ROW -1';
+    const { root } = parse(text);
+
+    expect(root.commands[0]).toMatchObject({
+      type: 'command',
+      args: [
+        {
+          type: 'literal',
+          literalType: 'integer',
+          value: -1,
+        },
+      ],
+    });
+  });
+
+  it('chained negation expression', () => {
+    const text = 'ROW -(-1)';
+    const { root } = parse(text);
+
+    expect(root.commands[0]).toMatchObject({
+      type: 'command',
+      args: [
+        {
+          type: 'function',
+          subtype: 'unary-expression',
+          name: '-',
+          args: [
+            {
+              type: 'literal',
+              literalType: 'integer',
+              value: -1,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('many chained unary expressions', () => {
+    const text = 'ROW -(+(-(+(-1))))';
+    const { root } = parse(text);
+
+    expect(root.commands[0]).toMatchObject({
+      type: 'command',
+      args: [
+        {
+          type: 'function',
+          subtype: 'unary-expression',
+          name: '-',
+          args: [
+            {
+              type: 'function',
+              subtype: 'unary-expression',
+              name: '+',
+              args: [
+                {
+                  type: 'function',
+                  subtype: 'unary-expression',
+                  name: '-',
+                  args: [
+                    {
+                      type: 'function',
+                      subtype: 'unary-expression',
+                      name: '+',
+                      args: [
+                        {
+                          type: 'literal',
+                          literalType: 'integer',
+                          value: -1,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
             },
           ],
         },

--- a/packages/kbn-esql-ast/src/parser/factories.ts
+++ b/packages/kbn-esql-ast/src/parser/factories.ts
@@ -41,6 +41,8 @@ import type {
   FunctionSubtype,
   ESQLNumericLiteral,
   ESQLOrderExpression,
+  ESQLUnaryExpression,
+  ESQLSingleAstItem,
 } from '../types';
 import { parseIdentifier, getPosition } from './helpers';
 import { Builder, type AstNodeParserFields } from '../builder';
@@ -87,21 +89,6 @@ export const createNumericLiteral = (
     { value: Number(ctx.getText()), literalType },
     createParserFields(ctx)
   );
-
-export function createFakeMultiplyLiteral(
-  ctx: ArithmeticUnaryContext,
-  literalType: ESQLNumericLiteralType
-): ESQLLiteral {
-  return {
-    type: 'literal',
-    literalType,
-    text: ctx.getText(),
-    name: ctx.getText(),
-    value: ctx.PLUS() ? 1 : -1,
-    location: getPosition(ctx.start, ctx.stop),
-    incomplete: Boolean(ctx.exception),
-  };
-}
 
 export function createLiteralString(token: Token): ESQLLiteral {
   const text = token.text!;
@@ -198,6 +185,14 @@ export function createFunction<Subtype extends FunctionSubtype>(
     node.subtype = subtype;
   }
   return node;
+}
+
+export function createUnaryExpression(
+  ctx: ArithmeticUnaryContext,
+  operand: ESQLSingleAstItem
+): ESQLUnaryExpression {
+  const operator = ctx.PLUS() ? '+' : ctx.MINUS() ? '-' : 'unknown';
+  return Builder.expression.unary(operator, operand, {}, createParserFields(ctx));
 }
 
 export const createOrderExpression = (

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.ts
@@ -344,6 +344,14 @@ function validateFunction(
   if (astFunction.incomplete) {
     return messages;
   }
+
+  if (astFunction.subtype === 'unary-expression') {
+    const name = astFunction.name;
+    if (name === '+' || name === '-') {
+      return messages;
+    }
+  }
+
   const fnDefinition = getFunctionDefinition(astFunction.name)!;
 
   const isFnSupported = isSupportedFunction(astFunction.name, parentCommand, parentOption);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/189258


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

