### PR TITLE
[ML] Data Drift: Update brush positions on window resize fix

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/data_drift/document_count_chart_single_brush/single_brush.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/data_drift/document_count_chart_single_brush/single_brush.tsx
@@ -311,7 +311,7 @@ export const SingleBrush: FC<SingleBrushProps> = (props) => {
         mlBrushSelection.exit().remove();
       }
 
-      function updateBrushes() {
+      function updateBrush() {
         const mlBrushSelection = gBrushes
           .selectAll('.brush')
           .data<SingleBrush>(brushes.current, (d) => (d as SingleBrush).id);
@@ -346,7 +346,7 @@ export const SingleBrush: FC<SingleBrushProps> = (props) => {
         minRef.current = min;
         maxRef.current = max;
         snapTimestampsRef.current = snapTimestamps;
-        updateBrushes();
+        updateBrush();
       }
 
       drawBrushes();

--- a/x-pack/plugins/data_visualizer/public/application/data_drift/document_count_chart_single_brush/single_brush.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/data_drift/document_count_chart_single_brush/single_brush.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { isEqual } from 'lodash';
 import React, { useEffect, useRef, type FC } from 'react';
 
 import * as d3Brush from 'd3-brush';
@@ -310,9 +311,42 @@ export const SingleBrush: FC<SingleBrushProps> = (props) => {
         mlBrushSelection.exit().remove();
       }
 
+      function updateBrushes() {
+        const mlBrushSelection = gBrushes
+          .selectAll('.brush')
+          .data<SingleBrush>(brushes.current, (d) => (d as SingleBrush).id);
+
+        mlBrushSelection.each(function (brushObject, i, n) {
+          const x = d3
+            .scaleLinear()
+            .domain([minRef.current, maxRef.current])
+            .rangeRound([0, widthRef.current]);
+          brushObject.brush.extent([
+            [0, BRUSH_MARGIN],
+            [widthRef.current, BRUSH_HEIGHT - BRUSH_MARGIN],
+          ]);
+
+          brushObject.brush(d3.select(n[i] as SVGGElement));
+          const xStart = x(brushObject.start) ?? 0;
+          const xEnd = x(brushObject.end) ?? 0;
+          brushObject.brush.move(d3.select(n[i] as SVGGElement), [xStart, xEnd]);
+        });
+      }
+
       if (brushes.current.length !== 1) {
         widthRef.current = width;
         newBrush(`${brushId}`, baselineMin, baselineMax);
+      } else if (
+        widthRef.current !== width ||
+        minRef.current !== min ||
+        maxRef.current !== max ||
+        !isEqual(snapTimestampsRef.current, snapTimestamps)
+      ) {
+        widthRef.current = width;
+        minRef.current = min;
+        maxRef.current = max;
+        snapTimestampsRef.current = snapTimestamps;
+        updateBrushes();
       }
 
       drawBrushes();


### PR DESCRIPTION
## Summary

Fix for: [#188738](https://github.com/elastic/kibana/issues/188738).
The brush positions weren't being updated on window resize, as is done in e.g. `Log Rate Analysis`.

After fix:


https://github.com/user-attachments/assets/fd424c19-744f-4d20-8076-25cf8e0c8ecb



<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->