### PR TITLE
[Security Solution][Quality Gate Monitoring] Fixed override for monitoring pipeline

### DIFF
--- a/x-pack/plugins/security_solution/scripts/run_cypress/project_handler/cloud_project_handler.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/project_handler/cloud_project_handler.ts
@@ -41,9 +41,15 @@ export class CloudHandler extends ProjectHandler {
     }
 
     // The qualityGate variable has been added here to ensure that when the quality gate runs, there will be
-    // no kibana image override. The tests will be executed against the commit which is already promoted to QA.
+    // no kibana image override unless it is running for the daily monitoring.
+    // The tests will be executed against the commit which is already promoted to QA.
+    const monitoringQualityGate =
+      process.env.KIBANA_MKI_QUALITY_GATE_MONITORING &&
+      process.env.KIBANA_MKI_QUALITY_GATE_MONITORING === '1';
     const qualityGate =
-      process.env.KIBANA_MKI_QUALITY_GATE && process.env.KIBANA_MKI_QUALITY_GATE === '1';
+      process.env.KIBANA_MKI_QUALITY_GATE &&
+      process.env.KIBANA_MKI_QUALITY_GATE === '1' &&
+      !monitoringQualityGate;
     const override = commit && commit !== '' ? commit : process.env.KIBANA_MKI_IMAGE_COMMIT;
     if (override && !qualityGate) {
       const kibanaOverrideImage = `${override?.substring(0, 12)}`;

--- a/x-pack/plugins/security_solution/scripts/run_cypress/project_handler/proxy_project_handler.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/project_handler/proxy_project_handler.ts
@@ -41,9 +41,15 @@ export class ProxyHandler extends ProjectHandler {
     }
 
     // The qualityGate variable has been added here to ensure that when the quality gate runs, there will be
-    // no kibana image override. The tests will be executed against the commit which is already promoted to QA.
+    // no kibana image override unless it is running for the daily monitoring.
+    // The tests will be executed against the commit which is already promoted to QA.
+    const monitoringQualityGate =
+      process.env.KIBANA_MKI_QUALITY_GATE_MONITORING &&
+      process.env.KIBANA_MKI_QUALITY_GATE_MONITORING === '1';
     const qualityGate =
-      process.env.KIBANA_MKI_QUALITY_GATE && process.env.KIBANA_MKI_QUALITY_GATE === '1';
+      process.env.KIBANA_MKI_QUALITY_GATE &&
+      process.env.KIBANA_MKI_QUALITY_GATE === '1' &&
+      !monitoringQualityGate;
     const override = commit && commit !== '' ? commit : process.env.KIBANA_MKI_IMAGE_COMMIT;
     if (override && !qualityGate) {
       const kibanaOverrideImage = `${override?.substring(0, 12)}`;


### PR DESCRIPTION
## Summary

Instead of just quality gate for security, a monitoring pipeline has been introduced which acts like quality gate but is overriding the kibana image with the latest [dev-devenv version](https://github.com/elastic/serverless-gitops/blob/79862d97b1b1d3a97c0d8e2091ea06b9aed43f0c/services/kibana/versions.yaml#L4).

This change addresses the changes needed for this new pipeline taking under consideration the environmental variable `KIBANA_MKI_QUALITY_GATE_MONITORING` which if present, it defines that we do run the set of tests for quality gate but with an override. 


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->