### PR TITLE
Fixing CTA content for web crawler

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/ingestion_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/ingestion_selector.tsx
@@ -89,8 +89,7 @@ export const IngestionSelector: React.FC = () => {
                   : i18n.translate(
                       'xpack.enterpriseSearch.ingestSelector.method.crawler.description',
                       {
-                        defaultMessage:
-                          'Discover, extract, and index searchable content from websites and knowledge bases.',
+                        defaultMessage: 'Crawl URL',
                       }
                     )
               }


### PR DESCRIPTION
## Summary

Small bug fix for this web crawler CTA button content:
![CleanShot 2024-10-18 at 13 31 42@2x](https://github.com/user-attachments/assets/edc5f341-30d5-4a90-96bd-3eda2836bbfe)
That should say just _Crawl URL_



<!--ONMERGE {"backportTargets":["8.15","8.16","8.x"]} ONMERGE-->