### PR TITLE
[7.17] [ci] Use es snapshot cache for jest integration tests (#196695)

### DIFF
--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -9,6 +9,7 @@ export KIBANA_DIR
 export XPACK_DIR="$KIBANA_DIR/x-pack"
 
 export CACHE_DIR="$HOME/.kibana"
+export ES_CACHE_DIR="$HOME/.es-snapshot-cache"
 PARENT_DIR="$(cd "$KIBANA_DIR/.."; pwd)"
 export PARENT_DIR
 export WORKSPACE="${WORKSPACE:-$PARENT_DIR}"

--- a/.buildkite/scripts/copy_es_snapshot_cache.sh
+++ b/.buildkite/scripts/copy_es_snapshot_cache.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# If cached snapshots are baked into the agent, copy them into our workspace first
+# We are doing this rather than simply changing the ES base path because many workers
+#   run with the workspace mounted in memory or on a local ssd
+cacheDir="$ES_CACHE_DIR/cache"
+if [[ -d "$cacheDir" ]]; then
+  mkdir -p .es/cache
+  echo "--- Copying ES snapshot cache"
+  echo "Copying cached snapshots from $cacheDir to .es/cache"
+  cp -R "$cacheDir"/* .es/cache/
+fi

--- a/.buildkite/scripts/steps/functional/common.sh
+++ b/.buildkite/scripts/steps/functional/common.sh
@@ -8,5 +8,6 @@ source .buildkite/scripts/common/util.sh
 
 .buildkite/scripts/bootstrap.sh
 .buildkite/scripts/download_build_artifacts.sh
+.buildkite/scripts/copy_es_snapshot_cache.sh
 
 is_test_execution_step

--- a/.buildkite/scripts/steps/test/jest_integration.sh
+++ b/.buildkite/scripts/steps/test/jest_integration.sh
@@ -7,6 +7,7 @@ source .buildkite/scripts/common/util.sh
 is_test_execution_step
 
 .buildkite/scripts/bootstrap.sh
+.buildkite/scripts/copy_es_snapshot_cache.sh
 
 echo '--- Jest Integration Tests'
 checks-reporter-with-killswitch "Jest Integration Tests $((BUILDKITE_PARALLEL_JOB+1))" \


### PR DESCRIPTION
This ended up backporting the whole feature - also includes https://github.com/elastic/kibana/pull/132940 minus the bazel changes.

#196695