### PR TITLE
[8.16] [Entity Analytics] Bug: update timestamp on criticality soft delete (#196722)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
@@ -342,6 +342,7 @@ export class AssetCriticalityDataClient {
           asset: {
             criticality: CRITICALITY_VALUES.DELETED,
           },
+          '@timestamp': new Date().toISOString(),
           ...getImplicitEntityFields({
             ...idParts,
             criticalityLevel: CRITICALITY_VALUES.DELETED,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Entity Analytics] Bug: update timestamp on criticality soft delete (#196722)](https://github.com/elastic/kibana/pull/196722)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tiago Vila Verde","email":"tiago.vilaverde@elastic.co"},"sourceCommit":{"committedDate":"2024-10-18T08:07:32Z","message":"[Entity Analytics] Bug: update timestamp on criticality soft delete (#196722)\n\n## Summary\r\n\r\nThis fixes a bug with asset criticality where \"soft delete\" does not\r\nupdate the `@timestamp` field","sha":"07fc8753604a27b9cc2c7c396e85f9bd9dc40674","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","v9.0.0","backport:prev-minor","Team:Entity Analytics","v8.17.0"],"number":196722,"url":"https://github.com/elastic/kibana/pull/196722","mergeCommit":{"message":"[Entity Analytics] Bug: update timestamp on criticality soft delete (#196722)\n\n## Summary\r\n\r\nThis fixes a bug with asset criticality where \"soft delete\" does not\r\nupdate the `@timestamp` field","sha":"07fc8753604a27b9cc2c7c396e85f9bd9dc40674"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/196722","number":196722,"mergeCommit":{"message":"[Entity Analytics] Bug: update timestamp on criticality soft delete (#196722)\n\n## Summary\r\n\r\nThis fixes a bug with asset criticality where \"soft delete\" does not\r\nupdate the `@timestamp` field","sha":"07fc8753604a27b9cc2c7c396e85f9bd9dc40674"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/196810","number":196810,"state":"MERGED","mergeCommit":{"sha":"7a8f79d4a3c777b10a470dc4e7f458f8b2c7176b","message":"[8.x] [Entity Analytics] Bug: update timestamp on criticality soft delete (#196722) (#196810)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Entity Analytics] Bug: update timestamp on criticality soft delete\n(#196722)](https://github.com/elastic/kibana/pull/196722)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Tiago Vila\nVerde\",\"email\":\"tiago.vilaverde@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-10-18T08:07:32Z\",\"message\":\"[Entity\nAnalytics] Bug: update timestamp on criticality soft delete\n(#196722)\\n\\n## Summary\\r\\n\\r\\nThis fixes a bug with asset criticality\nwhere \\\"soft delete\\\" does not\\r\\nupdate the `@timestamp`\nfield\",\"sha\":\"07fc8753604a27b9cc2c7c396e85f9bd9dc40674\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"release_note:fix\",\"v9.0.0\",\"backport:prev-minor\",\"Team:Entity\nAnalytics\"],\"title\":\"[Entity Analytics] Bug: update timestamp on\ncriticality soft\ndelete\",\"number\":196722,\"url\":\"https://github.com/elastic/kibana/pull/196722\",\"mergeCommit\":{\"message\":\"[Entity\nAnalytics] Bug: update timestamp on criticality soft delete\n(#196722)\\n\\n## Summary\\r\\n\\r\\nThis fixes a bug with asset criticality\nwhere \\\"soft delete\\\" does not\\r\\nupdate the `@timestamp`\nfield\",\"sha\":\"07fc8753604a27b9cc2c7c396e85f9bd9dc40674\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/196722\",\"number\":196722,\"mergeCommit\":{\"message\":\"[Entity\nAnalytics] Bug: update timestamp on criticality soft delete\n(#196722)\\n\\n## Summary\\r\\n\\r\\nThis fixes a bug with asset criticality\nwhere \\\"soft delete\\\" does not\\r\\nupdate the `@timestamp`\nfield\",\"sha\":\"07fc8753604a27b9cc2c7c396e85f9bd9dc40674\"}}]}] BACKPORT-->\n\nCo-authored-by: Tiago Vila Verde <tiago.vilaverde@elastic.co>"}}]}] BACKPORT-->