### PR TITLE
[Security Solution][Notes] - fix an issue that breaks the notes management page, an enum value was missing from the api

### DIFF
--- a/oas_docs/output/kibana.serverless.staging.yaml
+++ b/oas_docs/output/kibana.serverless.staging.yaml
@@ -3,7 +3,7 @@ info:
   contact:
     name: Kibana Team
   description: >
-    **Technical preview**
+    **Technical preview**  
 
     This functionality is in technical preview and may be changed or removed in
     a future release.
@@ -170,7 +170,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -269,7 +269,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -361,7 +361,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -447,7 +447,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -569,7 +569,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -665,7 +665,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -757,7 +757,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -845,7 +845,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-

--- a/oas_docs/output/kibana.serverless.staging.yaml
+++ b/oas_docs/output/kibana.serverless.staging.yaml
@@ -3,7 +3,7 @@ info:
   contact:
     name: Kibana Team
   description: >
-    **Technical preview**  
+    **Technical preview**
 
     This functionality is in technical preview and may be changed or removed in
     a future release.
@@ -170,7 +170,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -269,7 +269,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -361,7 +361,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -447,7 +447,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -569,7 +569,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -665,7 +665,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -757,7 +757,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -845,7 +845,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -49426,6 +49426,7 @@ components:
     Security_Timeline_API_AssociatedFilterType:
       description: Filter notes based on their association with a document or saved object.
       enum:
+        - all
         - document_only
         - saved_object_only
         - document_and_saved_object

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -3,7 +3,7 @@ info:
   contact:
     name: Kibana Team
   description: >
-    **Technical preview**
+    **Technical preview**  
 
     This functionality is in technical preview and may be changed or removed in
     a future release.
@@ -170,7 +170,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -269,7 +269,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -361,7 +361,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -447,7 +447,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -569,7 +569,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -665,7 +665,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -757,7 +757,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -845,7 +845,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -3,7 +3,7 @@ info:
   contact:
     name: Kibana Team
   description: >
-    **Technical preview**  
+    **Technical preview**
 
     This functionality is in technical preview and may be changed or removed in
     a future release.
@@ -170,7 +170,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -269,7 +269,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -361,7 +361,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -447,7 +447,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -569,7 +569,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -665,7 +665,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -757,7 +757,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -845,7 +845,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -49426,6 +49426,7 @@ components:
     Security_Timeline_API_AssociatedFilterType:
       description: Filter notes based on their association with a document or saved object.
       enum:
+        - all
         - document_only
         - saved_object_only
         - document_and_saved_object

--- a/oas_docs/output/kibana.staging.yaml
+++ b/oas_docs/output/kibana.staging.yaml
@@ -163,7 +163,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -262,7 +262,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -354,7 +354,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -440,7 +440,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -562,7 +562,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -658,7 +658,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -750,7 +750,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -838,7 +838,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -6975,7 +6975,7 @@ paths:
         - cases
     patch:
       description: >
-        You must have `all` privileges for the **Cases** feature in the 
+        You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the
         Kibana  feature privileges, depending on the owner of the case you're
         updating.
@@ -39355,7 +39355,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded.  Errors pertaining to individual
-            objects will be returned in the response body. 
+            objects will be returned in the response body.
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -39389,7 +39389,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded. Errors pertaining to individual
-            objects will be returned in the response body. 
+            objects will be returned in the response body.
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -46086,7 +46086,7 @@ components:
           description: >
             The scaling factor to use when encoding values. This property is
             applicable when `type` is `scaled_float`. Values will be multiplied
-            by this factor at index time and rounded to the closest long value. 
+            by this factor at index time and rounded to the closest long value.
           type: integer
         type:
           description: Specifies the data type for the field.
@@ -58192,6 +58192,7 @@ components:
     Security_Timeline_API_AssociatedFilterType:
       description: Filter notes based on their association with a document or saved object.
       enum:
+        - all
         - document_only
         - saved_object_only
         - document_and_saved_object

--- a/oas_docs/output/kibana.staging.yaml
+++ b/oas_docs/output/kibana.staging.yaml
@@ -163,7 +163,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -262,7 +262,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -354,7 +354,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -440,7 +440,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -562,7 +562,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -658,7 +658,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -750,7 +750,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -838,7 +838,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -6975,7 +6975,7 @@ paths:
         - cases
     patch:
       description: >
-        You must have `all` privileges for the **Cases** feature in the
+        You must have `all` privileges for the **Cases** feature in the 
         **Management**, **Observability**, or **Security** section of the
         Kibana  feature privileges, depending on the owner of the case you're
         updating.
@@ -39355,7 +39355,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded.  Errors pertaining to individual
-            objects will be returned in the response body.
+            objects will be returned in the response body. 
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -39389,7 +39389,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded. Errors pertaining to individual
-            objects will be returned in the response body.
+            objects will be returned in the response body. 
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -46086,7 +46086,7 @@ components:
           description: >
             The scaling factor to use when encoding values. This property is
             applicable when `type` is `scaled_float`. Values will be multiplied
-            by this factor at index time and rounded to the closest long value.
+            by this factor at index time and rounded to the closest long value. 
           type: integer
         type:
           description: Specifies the data type for the field.

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -163,7 +163,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -262,7 +262,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -354,7 +354,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -440,7 +440,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -562,7 +562,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -658,7 +658,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -750,7 +750,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -838,7 +838,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -6975,7 +6975,7 @@ paths:
         - cases
     patch:
       description: >
-        You must have `all` privileges for the **Cases** feature in the 
+        You must have `all` privileges for the **Cases** feature in the
         **Management**, **Observability**, or **Security** section of the
         Kibana  feature privileges, depending on the owner of the case you're
         updating.
@@ -39355,7 +39355,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded.  Errors pertaining to individual
-            objects will be returned in the response body. 
+            objects will be returned in the response body.
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -39389,7 +39389,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded. Errors pertaining to individual
-            objects will be returned in the response body. 
+            objects will be returned in the response body.
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -46086,7 +46086,7 @@ components:
           description: >
             The scaling factor to use when encoding values. This property is
             applicable when `type` is `scaled_float`. Values will be multiplied
-            by this factor at index time and rounded to the closest long value. 
+            by this factor at index time and rounded to the closest long value.
           type: integer
         type:
           description: Specifies the data type for the field.
@@ -58192,6 +58192,7 @@ components:
     Security_Timeline_API_AssociatedFilterType:
       description: Filter notes based on their association with a document or saved object.
       enum:
+        - all
         - document_only
         - saved_object_only
         - document_and_saved_object

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -163,7 +163,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -262,7 +262,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -354,7 +354,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -440,7 +440,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -562,7 +562,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -658,7 +658,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -750,7 +750,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -838,7 +838,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -6975,7 +6975,7 @@ paths:
         - cases
     patch:
       description: >
-        You must have `all` privileges for the **Cases** feature in the
+        You must have `all` privileges for the **Cases** feature in the 
         **Management**, **Observability**, or **Security** section of the
         Kibana  feature privileges, depending on the owner of the case you're
         updating.
@@ -39355,7 +39355,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded.  Errors pertaining to individual
-            objects will be returned in the response body.
+            objects will be returned in the response body. 
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -39389,7 +39389,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded. Errors pertaining to individual
-            objects will be returned in the response body.
+            objects will be returned in the response body. 
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -46086,7 +46086,7 @@ components:
           description: >
             The scaling factor to use when encoding values. This property is
             applicable when `type` is `scaled_float`. Values will be multiplied
-            by this factor at index time and rounded to the closest long value.
+            by this factor at index time and rounded to the closest long value. 
           type: integer
         type:
           description: Specifies the data type for the field.

--- a/x-pack/plugins/security_solution/common/api/timeline/get_notes/get_notes_route.gen.ts
+++ b/x-pack/plugins/security_solution/common/api/timeline/get_notes/get_notes_route.gen.ts
@@ -23,6 +23,7 @@ import { Note } from '../model/components.gen';
  */
 export type AssociatedFilterType = z.infer<typeof AssociatedFilterType>;
 export const AssociatedFilterType = z.enum([
+  'all',
   'document_only',
   'saved_object_only',
   'document_and_saved_object',

--- a/x-pack/plugins/security_solution/common/api/timeline/get_notes/get_notes_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/timeline/get_notes/get_notes_route.schema.yaml
@@ -75,10 +75,11 @@ components:
     AssociatedFilterType:
         type: string
         enum:
-            - document_only
-            - saved_object_only
-            - document_and_saved_object
-            - orphan
+          - all
+          - document_only
+          - saved_object_only
+          - document_and_saved_object
+          - orphan
         description: Filter notes based on their association with a document or saved object.
     DocumentIds:
       oneOf:

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
@@ -928,6 +928,7 @@ components:
     AssociatedFilterType:
       description: Filter notes based on their association with a document or saved object.
       enum:
+        - all
         - document_only
         - saved_object_only
         - document_and_saved_object

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_timeline_api_2023_10_31.bundled.schema.yaml
@@ -928,6 +928,7 @@ components:
     AssociatedFilterType:
       description: Filter notes based on their association with a document or saved object.
       enum:
+        - all
         - document_only
         - saved_object_only
         - document_and_saved_object


### PR DESCRIPTION
## Summary

_**Notes: please ignore the spaces introduced in the first commit, Webstorm is trying to be smart... CI should take care of fixing that in a second commit shortly**_

This PR fixes a small issue that prevents the notes management page to load. The issue comes from the fact that one of the enum values passed to filter notes was missing from the open api spec. This issue was introduced in this recent [PR](https://github.com/elastic/kibana/pull/195501).

Current notes management borken page
![Screenshot 2024-10-18 at 10 30 13 AM](https://github.com/user-attachments/assets/4926a62f-1ebf-4698-8a13-bf761d77f4ba)

This is the error in the network tab
![Screenshot 2024-10-18 at 10 30 29 AM](https://github.com/user-attachments/assets/90b56246-c116-4050-bcfa-2c6668274e74)

This PR fixes the issue
![Screenshot 2024-10-18 at 10 27 01 AM](https://github.com/user-attachments/assets/7d3338ce-ad73-4be5-b94c-15bcf0234680)



<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->