### PR TITLE
[Automatic Import] Cel template fixes

### DIFF
--- a/x-pack/plugins/integration_assistant/server/templates/agent/cel.yml.hbs
+++ b/x-pack/plugins/integration_assistant/server/templates/agent/cel.yml.hbs
@@ -147,17 +147,3 @@ resource.rate_limit.burst: {{resource_rate_limit_burst}}
 resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"
 resource.tracer.maxbackups: 5
 {{/if}}
-
-{{#if tags}}
-tags:
-{{#each tags as |tag|}}
-  - {{tag}}
-{{/each}}
-{{/if}}
-{{#contains "forwarded" tags}}
-publisher_pipeline.disable_host: true
-{{/contains}}
-{{#if processors}}
-processors:
-{{processors}}
-{{/if}}

--- a/x-pack/plugins/integration_assistant/server/templates/manifest/cel_manifest.yml.njk
+++ b/x-pack/plugins/integration_assistant/server/templates/manifest/cel_manifest.yml.njk
@@ -1,4 +1,5 @@
 - input: cel
+  template_path: cel.yml.hbs
   title: |
     {{ data_stream_title }}
   description: |
@@ -308,21 +309,6 @@
       show_user: false
       multi: false
       required: false
-    - name: processors
-      type: yaml
-      title: Processors
-      multi: false
-      required: false
-      show_user: false
-      description: >
-        Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-    - name: tags
-      type: text
-      title: Tags
-      multi: true
-      show_user: false
-      default:
-        - forwarded
     - name: enable_request_tracer
       type: bool
       title: Enable request tracing


### PR DESCRIPTION
## Summary

This PR corrects the CEL template so that it can successfully complete package policy installation. The fixes are 1) adding a template path, and 2) removing the common template values from the cel templates. 

Tested and verified with and without the CEL generation FF enabled.




<!--ONMERGE {"backportTargets":["8.16"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->