### PR TITLE
[8.x] Hide assistant's knowledge base UI when `assistantKnowledgeBaseByDefault` feature flag is disabled (#196762)

### DIFF
--- a/x-pack/packages/security-solution/features/src/assistant/index.ts
+++ b/x-pack/packages/security-solution/features/src/assistant/index.ts
@@ -9,11 +9,13 @@ import type { ProductFeatureParams } from '../types';
 import { getAssistantBaseKibanaFeature } from './kibana_features';
 import {
   getAssistantBaseKibanaSubFeatureIds,
-  assistantSubFeaturesMap,
+  getAssistantSubFeaturesMap,
 } from './kibana_sub_features';
 
-export const getAssistantFeature = (): ProductFeatureParams<AssistantSubFeatureId> => ({
+export const getAssistantFeature = (
+  experimentalFeatures: Record<string, boolean>
+): ProductFeatureParams<AssistantSubFeatureId> => ({
   baseKibanaFeature: getAssistantBaseKibanaFeature(),
   baseKibanaSubFeatureIds: getAssistantBaseKibanaSubFeatureIds(),
-  subFeaturesMap: assistantSubFeaturesMap,
+  subFeaturesMap: getAssistantSubFeaturesMap(experimentalFeatures),
 });

--- a/x-pack/packages/security-solution/features/src/assistant/kibana_sub_features.ts
+++ b/x-pack/packages/security-solution/features/src/assistant/kibana_sub_features.ts
@@ -102,9 +102,28 @@ export const getAssistantBaseKibanaSubFeatureIds = (): AssistantSubFeatureId[] =
  * Defines all the Security Assistant subFeatures available.
  * The order of the subFeatures is the order they will be displayed
  */
-export const assistantSubFeaturesMap = Object.freeze(
-  new Map<AssistantSubFeatureId, SubFeatureConfig>([
+export const getAssistantSubFeaturesMap = (
+  experimentalFeatures: Record<string, boolean>
+): Map<AssistantSubFeatureId, SubFeatureConfig> => {
+  const assistantSubFeaturesList: Array<[AssistantSubFeatureId, SubFeatureConfig]> = [
     [AssistantSubFeatureId.updateAnonymization, updateAnonymizationSubFeature],
-    [AssistantSubFeatureId.manageGlobalKnowledgeBase, manageGlobalKnowledgeBaseSubFeature],
-  ])
-);
+  ];
+
+  // Use the following code to add feature based on feature flag
+  // if (experimentalFeatures.featureFlagName) {
+  //   assistantSubFeaturesList.push([AssistantSubFeatureId.featureId, featureSubFeature]);
+  // }
+
+  if (experimentalFeatures.assistantKnowledgeBaseByDefault) {
+    assistantSubFeaturesList.push([
+      AssistantSubFeatureId.manageGlobalKnowledgeBase,
+      manageGlobalKnowledgeBaseSubFeature,
+    ]);
+  }
+
+  const assistantSubFeaturesMap = new Map<AssistantSubFeatureId, SubFeatureConfig>(
+    assistantSubFeaturesList
+  );
+
+  return Object.freeze(assistantSubFeaturesMap);
+};

--- a/x-pack/plugins/security_solution/server/lib/product_features_service/product_features_service.ts
+++ b/x-pack/plugins/security_solution/server/lib/product_features_service/product_features_service.ts
@@ -62,7 +62,7 @@ export class ProductFeaturesService {
       casesFeature.baseKibanaSubFeatureIds
     );
 
-    const assistantFeature = getAssistantFeature();
+    const assistantFeature = getAssistantFeature(this.experimentalFeatures);
     this.securityAssistantProductFeatures = new ProductFeatures(
       this.logger,
       assistantFeature.subFeaturesMap,

--- a/x-pack/test/api_integration/config.ts
+++ b/x-pack/test/api_integration/config.ts
@@ -30,6 +30,9 @@ export async function getApiIntegrationConfig({ readConfigFile }: FtrConfigProvi
         '--xpack.ruleRegistry.write.enabled=true',
         '--xpack.ruleRegistry.write.enabled=true',
         '--xpack.ruleRegistry.write.cache.enabled=false',
+        `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+          'assistantKnowledgeBaseByDefault',
+        ])}`,
         '--monitoring_collection.opentelemetry.metrics.prometheus.enabled=true',
       ],
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Hide assistant's knowledge base UI when `assistantKnowledgeBaseByDefault` feature flag is disabled (#196762)](https://github.com/elastic/kibana/pull/196762)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2024-10-18T11:35:04Z","message":"Hide assistant's knowledge base UI when `assistantKnowledgeBaseByDefault` feature flag is disabled (#196762)\n\n## Summary\r\n\r\nThis is the followup to https://github.com/elastic/kibana/pull/195733\r\nwhere we implemented the RBAC to allow managing Global Knowledge Base\r\ndocs. With those changes we introduced a bug where we do not hide the\r\nRBAC configuration setting when `assistantKnowledgeBaseByDefault`\r\nfeature flag is disabled. It means that in Serverless users will see\r\nthis setting but it will do nothing for them.\r\n\r\n### Screenshots of the fixed behaviour\r\n\r\n* `assistantKnowledgeBaseByDefault = true`\r\n\r\n\r\n![Capture-2024-10-17-204859](https://github.com/user-attachments/assets/ca4489b1-8ad9-4e57-824f-455ddb74da6c)\r\n\r\n* `assistantKnowledgeBaseByDefault = false`\r\n\r\n\r\n![Capture-2024-10-17-204752](https://github.com/user-attachments/assets/fbd2511f-4e09-4ef9-8403-6578366728e4)","sha":"f6e8065dd75116ddf596b77f75a8468804008323","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Feature:Security Assistant","Team:Security Generative AI","v8.16.0","backport:version"],"number":196762,"url":"https://github.com/elastic/kibana/pull/196762","mergeCommit":{"message":"Hide assistant's knowledge base UI when `assistantKnowledgeBaseByDefault` feature flag is disabled (#196762)\n\n## Summary\r\n\r\nThis is the followup to https://github.com/elastic/kibana/pull/195733\r\nwhere we implemented the RBAC to allow managing Global Knowledge Base\r\ndocs. With those changes we introduced a bug where we do not hide the\r\nRBAC configuration setting when `assistantKnowledgeBaseByDefault`\r\nfeature flag is disabled. It means that in Serverless users will see\r\nthis setting but it will do nothing for them.\r\n\r\n### Screenshots of the fixed behaviour\r\n\r\n* `assistantKnowledgeBaseByDefault = true`\r\n\r\n\r\n![Capture-2024-10-17-204859](https://github.com/user-attachments/assets/ca4489b1-8ad9-4e57-824f-455ddb74da6c)\r\n\r\n* `assistantKnowledgeBaseByDefault = false`\r\n\r\n\r\n![Capture-2024-10-17-204752](https://github.com/user-attachments/assets/fbd2511f-4e09-4ef9-8403-6578366728e4)","sha":"f6e8065dd75116ddf596b77f75a8468804008323"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/196762","number":196762,"mergeCommit":{"message":"Hide assistant's knowledge base UI when `assistantKnowledgeBaseByDefault` feature flag is disabled (#196762)\n\n## Summary\r\n\r\nThis is the followup to https://github.com/elastic/kibana/pull/195733\r\nwhere we implemented the RBAC to allow managing Global Knowledge Base\r\ndocs. With those changes we introduced a bug where we do not hide the\r\nRBAC configuration setting when `assistantKnowledgeBaseByDefault`\r\nfeature flag is disabled. It means that in Serverless users will see\r\nthis setting but it will do nothing for them.\r\n\r\n### Screenshots of the fixed behaviour\r\n\r\n* `assistantKnowledgeBaseByDefault = true`\r\n\r\n\r\n![Capture-2024-10-17-204859](https://github.com/user-attachments/assets/ca4489b1-8ad9-4e57-824f-455ddb74da6c)\r\n\r\n* `assistantKnowledgeBaseByDefault = false`\r\n\r\n\r\n![Capture-2024-10-17-204752](https://github.com/user-attachments/assets/fbd2511f-4e09-4ef9-8403-6578366728e4)","sha":"f6e8065dd75116ddf596b77f75a8468804008323"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/196857","number":196857,"state":"MERGED","mergeCommit":{"sha":"8094dd6d7791a5fd6e8ead925a1ba42b6bb7acfa","message":"[8.16] Hide assistant&#x27;s knowledge base UI when &#x60;assistantKnowledgeBaseByDefault&#x60; feature flag is disabled (#196762) (#196857)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.16`:\n- [Hide assistant&#x27;s knowledge base UI when\n&#x60;assistantKnowledgeBaseByDefault&#x60; feature flag is disabled\n(#196762)](https://github.com/elastic/kibana/pull/196762)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Ievgen\nSorokopud\",\"email\":\"ievgen.sorokopud@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-10-18T11:35:04Z\",\"message\":\"Hide\nassistant's knowledge base UI when `assistantKnowledgeBaseByDefault`\nfeature flag is disabled (#196762)\\n\\n## Summary\\r\\n\\r\\nThis is the\nfollowup to https://github.com/elastic/kibana/pull/195733\\r\\nwhere we\nimplemented the RBAC to allow managing Global Knowledge Base\\r\\ndocs.\nWith those changes we introduced a bug where we do not hide the\\r\\nRBAC\nconfiguration setting when `assistantKnowledgeBaseByDefault`\\r\\nfeature\nflag is disabled. It means that in Serverless users will see\\r\\nthis\nsetting but it will do nothing for them.\\r\\n\\r\\n### Screenshots of the\nfixed behaviour\\r\\n\\r\\n* `assistantKnowledgeBaseByDefault =\ntrue`\\r\\n\\r\\n\\r\\n![Capture-2024-10-17-204859](https://github.com/user-attachments/assets/ca4489b1-8ad9-4e57-824f-455ddb74da6c)\\r\\n\\r\\n*\n`assistantKnowledgeBaseByDefault =\nfalse`\\r\\n\\r\\n\\r\\n![Capture-2024-10-17-204752](https://github.com/user-attachments/assets/fbd2511f-4e09-4ef9-8403-6578366728e4)\",\"sha\":\"f6e8065dd75116ddf596b77f75a8468804008323\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"Feature:Security\nAssistant\",\"Team:Security Generative\nAI\",\"v8.16.0\",\"backport:version\"],\"title\":\"Hide assistant's knowledge\nbase UI when `assistantKnowledgeBaseByDefault` feature flag is\ndisabled\",\"number\":196762,\"url\":\"https://github.com/elastic/kibana/pull/196762\",\"mergeCommit\":{\"message\":\"Hide\nassistant's knowledge base UI when `assistantKnowledgeBaseByDefault`\nfeature flag is disabled (#196762)\\n\\n## Summary\\r\\n\\r\\nThis is the\nfollowup to https://github.com/elastic/kibana/pull/195733\\r\\nwhere we\nimplemented the RBAC to allow managing Global Knowledge Base\\r\\ndocs.\nWith those changes we introduced a bug where we do not hide the\\r\\nRBAC\nconfiguration setting when `assistantKnowledgeBaseByDefault`\\r\\nfeature\nflag is disabled. It means that in Serverless users will see\\r\\nthis\nsetting but it will do nothing for them.\\r\\n\\r\\n### Screenshots of the\nfixed behaviour\\r\\n\\r\\n* `assistantKnowledgeBaseByDefault =\ntrue`\\r\\n\\r\\n\\r\\n![Capture-2024-10-17-204859](https://github.com/user-attachments/assets/ca4489b1-8ad9-4e57-824f-455ddb74da6c)\\r\\n\\r\\n*\n`assistantKnowledgeBaseByDefault =\nfalse`\\r\\n\\r\\n\\r\\n![Capture-2024-10-17-204752](https://github.com/user-attachments/assets/fbd2511f-4e09-4ef9-8403-6578366728e4)\",\"sha\":\"f6e8065dd75116ddf596b77f75a8468804008323\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.16\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/196762\",\"number\":196762,\"mergeCommit\":{\"message\":\"Hide\nassistant's knowledge base UI when `assistantKnowledgeBaseByDefault`\nfeature flag is disabled (#196762)\\n\\n## Summary\\r\\n\\r\\nThis is the\nfollowup to https://github.com/elastic/kibana/pull/195733\\r\\nwhere we\nimplemented the RBAC to allow managing Global Knowledge Base\\r\\ndocs.\nWith those changes we introduced a bug where we do not hide the\\r\\nRBAC\nconfiguration setting when `assistantKnowledgeBaseByDefault`\\r\\nfeature\nflag is disabled. It means that in Serverless users will see\\r\\nthis\nsetting but it will do nothing for them.\\r\\n\\r\\n### Screenshots of the\nfixed behaviour\\r\\n\\r\\n* `assistantKnowledgeBaseByDefault =\ntrue`\\r\\n\\r\\n\\r\\n![Capture-2024-10-17-204859](https://github.com/user-attachments/assets/ca4489b1-8ad9-4e57-824f-455ddb74da6c)\\r\\n\\r\\n*\n`assistantKnowledgeBaseByDefault =\nfalse`\\r\\n\\r\\n\\r\\n![Capture-2024-10-17-204752](https://github.com/user-attachments/assets/fbd2511f-4e09-4ef9-8403-6578366728e4)\",\"sha\":\"f6e8065dd75116ddf596b77f75a8468804008323\"}},{\"branch\":\"8.16\",\"label\":\"v8.16.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Ievgen Sorokopud <ievgen.sorokopud@elastic.co>"}}]}] BACKPORT-->