### PR TITLE
Skip serverless search start_elasticsearch and search_index_details suites for MKI

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
@@ -27,6 +27,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   };
 
   describe('Elasticsearch Start [Onboarding Empty State]', function () {
+    // fails on MKI, see https://github.com/elastic/kibana/issues/196981
+    this.tags(['failsOnMKI']);
+
     describe('developer', function () {
       before(async () => {
         await pageObjects.svlCommonPage.loginWithRole('developer');

--- a/x-pack/test_serverless/functional/test_suites/search/search_index_detail.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/search_index_detail.ts
@@ -24,7 +24,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const esDeleteAllIndices = getService('esDeleteAllIndices');
   const indexName = 'test-my-index';
 
-  describe('Search index detail page', () => {
+  describe('Search index detail page', function () {
+    // fails on MKI, see https://github.com/elastic/kibana/issues/196981
+    this.tags(['failsOnMKI']);
+
     before(async () => {
       await pageObjects.svlCommonPage.loginWithRole('developer');
       await pageObjects.svlApiKeys.deleteAPIKeys();


### PR DESCRIPTION
## Summary

This PR skips the serverless search test suites `start_elasticsearch` and `search_index_details` in MKI runs.
See #196981