### PR TITLE
[SecuritySolution] Clean up loading state when the timeline import modal closes

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/import_data_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/import_data_modal/index.tsx
@@ -91,6 +91,7 @@ export const ImportDataModalComponent = ({
     setOverwriteExceptions(false);
     setOverwriteActionConnectors(false);
     setActionConnectorsWarnings([]);
+    setIsImporting(false);
   }, [closeModal, setOverwrite, setOverwriteExceptions]);
 
   const onImportComplete = useCallback(


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/183995

The above issue describes an issue where the timeline import modal can get into a broken state after a timeline failed to import. The fix was to synchronize the loading state of the modal.

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->