### PR TITLE
[Dataset Quality] Check if Obs Logs Explorer accessible before linking Logs Explorer

### DIFF
--- a/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_redirect_link.ts
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_redirect_link.ts
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
+import { map } from 'rxjs';
 import { useMemo } from 'react';
+import useObservable from 'react-use/lib/useObservable';
+import { AppStatus } from '@kbn/core-application-browser';
 import {
+  OBSERVABILITY_LOGS_EXPLORER_APP_ID,
   SINGLE_DATASET_LOCATOR_ID,
   SingleDatasetLocatorParams,
 } from '@kbn/deeplinks-observability';
@@ -34,7 +38,7 @@ export const useRedirectLink = <T extends BasicDataStream>({
   sendTelemetry: SendTelemetryFn;
 }) => {
   const {
-    services: { share },
+    services: { share, application },
   } = useKibanaContextForPlugin();
 
   const { from, to } = timeRangeConfig;
@@ -42,12 +46,24 @@ export const useRedirectLink = <T extends BasicDataStream>({
   const logsExplorerLocator =
     share.url.locators.get<SingleDatasetLocatorParams>(SINGLE_DATASET_LOCATOR_ID);
 
+  const isLogsExplorerAppAccessible = useObservable(
+    application.applications$.pipe(
+      map(
+        (apps) =>
+          (apps.get(OBSERVABILITY_LOGS_EXPLORER_APP_ID)?.status ?? AppStatus.inaccessible) ===
+          AppStatus.accessible
+      )
+    ),
+    false
+  );
+
   return useMemo<{
     linkProps: RouterLinkProps;
     navigate: () => void;
     isLogsExplorerAvailable: boolean;
   }>(() => {
-    const isLogsExplorerAvailable = !!logsExplorerLocator && dataStreamStat.type === 'logs';
+    const isLogsExplorerAvailable =
+      isLogsExplorerAppAccessible && !!logsExplorerLocator && dataStreamStat.type === 'logs';
     const config = isLogsExplorerAvailable
       ? buildLogsExplorerConfig({
           locator: logsExplorerLocator,
@@ -95,6 +111,7 @@ export const useRedirectLink = <T extends BasicDataStream>({
     query,
     sendTelemetry,
     share.url.locators,
+    isLogsExplorerAppAccessible,
   ]);
 };
 

--- a/x-pack/plugins/observability_solution/dataset_quality/tsconfig.json
+++ b/x-pack/plugins/observability_solution/dataset_quality/tsconfig.json
@@ -59,7 +59,8 @@
     "@kbn/telemetry-plugin",
     "@kbn/usage-collection-plugin",
     "@kbn/rison",
-    "@kbn/task-manager-plugin"
+    "@kbn/task-manager-plugin",
+    "@kbn/core-application-browser"
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/196506

## Summary

Before linking to Logs Explorer in Dataset Quality, the PR checks if `observability-logs-explorer` is available and accessible before consuming the `SINGLE_DATASET_LOCATOR_ID` locator.

Observability Logs Explorer app is not available in Security and Search solution views. 


After the fix:

https://github.com/user-attachments/assets/ed36806a-0483-4765-a6f1-85936b92d390



There's only one more place, Observability Onboarding, where `SINGLE_DATASET_LOCATOR_ID` is consumed. Which being part of Observability solution view, it can be assumed that Observability Logs Explorer will always be available.

![image](https://github.com/user-attachments/assets/b51bf9b6-a9c4-4fd4-8865-3dda76262a93)

----

The other Observability Logs Explorer locator `ALL_DATASETS_LOCATOR_ID` is only consumed in observability wrapper apps and `apm` and `infra` plugins, all of which are only available under Observability where Observability Logs Explorer is also available.
https://github.com/elastic/kibana/blob/68b3267ca2f76d8de4fedef622608d8685e7eceb/packages/deeplinks/observability/locators/observability_logs_explorer.ts#L24


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->