### PR TITLE
Fix wrong date on a header of a report when generated from relative date

### DIFF
--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.test.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.test.tsx
@@ -415,6 +415,21 @@ describe('SharingMetaFields', () => {
     `);
   });
 
+  it('Should convert to absolute correctly', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-10-21T10:19:31.254Z'));
+
+    const from = 'now-1d/d';
+    const to = 'now-1d/d';
+    const component = <SharingMetaFields from={from} to={to} />;
+
+    expect(shallow(component)).toMatchInlineSnapshot(`
+      <div
+        data-shared-timefilter-duration="2024-10-20T00:00:00-04:00 to 2024-10-20T23:59:59-04:00"
+        data-test-subj="dataSharedTimefilterDuration"
+      />
+    `);
+  });
+
   it('Should render the component without data-shared-timefilter-duration if time is not set correctly', () => {
     const component = (
       <SharingMetaFields from="boom" to="now" dateFormat="MMM D, YYYY @ HH:mm:ss.SSS" />

--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.test.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.test.tsx
@@ -420,11 +420,11 @@ describe('SharingMetaFields', () => {
 
     const from = 'now-1d/d';
     const to = 'now-1d/d';
-    const component = <SharingMetaFields from={from} to={to} />;
+    const component = <SharingMetaFields from={from} to={to} dateFormat="MMM D, YYYY @ HH:mm:ss" />;
 
     expect(shallow(component)).toMatchInlineSnapshot(`
       <div
-        data-shared-timefilter-duration="2024-10-20T00:00:00-04:00 to 2024-10-20T23:59:59-04:00"
+        data-shared-timefilter-duration="Oct 20, 2024 @ 00:00:00 to Oct 20, 2024 @ 23:59:59"
         data-test-subj="dataSharedTimefilterDuration"
       />
     `);

--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -209,7 +209,7 @@ export const SharingMetaFields = React.memo(function SharingMetaFields({
   try {
     const dateRangePretty = usePrettyDuration({
       timeFrom: toAbsoluteString(from),
-      timeTo: toAbsoluteString(to),
+      timeTo: toAbsoluteString(to, true),
       quickRanges: [],
       dateFormat,
     });


### PR DESCRIPTION
## Summary

close https://github.com/elastic/kibana/issues/148224

There was an issue when generating a PDF report from a dashboard with relative date with time range display in the header of the report. Note: there data was displayed correctly, the issue was only with the date in the header: 

Dashboard: 

![Screenshot 2024-10-21 at 12 33 21](https://github.com/user-attachments/assets/2bd09099-5375-447a-b829-49671cc3614f)


Report before the fix 👎 

![Screenshot 2024-10-21 at 12 35 19](https://github.com/user-attachments/assets/e114f6f1-ba46-4bec-bf97-f175d18dbcd1)

Report after the fix 👍 


![Screenshot 2024-10-21 at 12 34 17](https://github.com/user-attachments/assets/06fd2b4e-74af-4994-bf48-65903394f91e)








<!--ONMERGE {"backportTargets":["8.15","8.16","8.x"]} ONMERGE-->