### PR TITLE
[8.16] [Security Solution] Removes outdated rule tour for rule management workflow (#196731)

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/index.tsx
@@ -36,7 +36,6 @@ import { AllRules } from '../../components/rules_table';
 import { RulesTableContextProvider } from '../../components/rules_table/rules_table/rules_table_context';
 import { useInvalidateFetchCoverageOverviewQuery } from '../../../rule_management/api/hooks/use_fetch_coverage_overview_query';
 import { HeaderPage } from '../../../../common/components/header_page';
-import { RuleFeatureTour } from '../../components/rules_table/feature_tour/rules_feature_tour';
 
 const RulesPageComponent: React.FC = () => {
   const [isImportModalVisible, showImportModal, hideImportModal] = useBoolState();
@@ -175,7 +174,6 @@ const RulesPageComponent: React.FC = () => {
             categories={[DEFAULT_APP_CATEGORIES.security.id]}
           />
           <BlogPostDetectionEngineeringCallout />
-          <RuleFeatureTour />
           <AllRules data-test-subj="all-rules" />
         </SecuritySolutionPageWrapper>
       </RulesTableContextProvider>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Security Solution] Removes outdated rule tour for rule management workflow (#196731)](https://github.com/elastic/kibana/pull/196731)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Davis Plumlee","email":"56367316+dplumlee@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-10-21T14:33:26Z","message":"[Security Solution] Removes outdated rule tour for rule management workflow (#196731)\n\n## Summary\r\n\r\nRemoves the tour for rule features implemented in\r\nhttps://github.com/elastic/kibana/pull/176767 as they are no longer new.\r\nKeeps the component and logic to use for future tours, just removes\r\nreference to the specific rules management tour.\r\n\r\n### Steps to test\r\n\r\n1. Make sure the\r\n`securitySolution.rulesManagementPage.newFeaturesTour.v8.13` local\r\nstorage key is cleared from your kibana page (this will make the tour\r\nshow up normally)\r\n2. Notice that navigating to the rule management page does not display\r\nthe rule tour\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3547e154b57adbdbf36abda5c4571452b4ee0b26","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Detections and Resp","Team: SecuritySolution","Feature:Rule Management","Team:Detection Rule Management","v8.16.0","backport:version"],"number":196731,"url":"https://github.com/elastic/kibana/pull/196731","mergeCommit":{"message":"[Security Solution] Removes outdated rule tour for rule management workflow (#196731)\n\n## Summary\r\n\r\nRemoves the tour for rule features implemented in\r\nhttps://github.com/elastic/kibana/pull/176767 as they are no longer new.\r\nKeeps the component and logic to use for future tours, just removes\r\nreference to the specific rules management tour.\r\n\r\n### Steps to test\r\n\r\n1. Make sure the\r\n`securitySolution.rulesManagementPage.newFeaturesTour.v8.13` local\r\nstorage key is cleared from your kibana page (this will make the tour\r\nshow up normally)\r\n2. Notice that navigating to the rule management page does not display\r\nthe rule tour\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3547e154b57adbdbf36abda5c4571452b4ee0b26"}},"sourceBranch":"main","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/196731","number":196731,"mergeCommit":{"message":"[Security Solution] Removes outdated rule tour for rule management workflow (#196731)\n\n## Summary\r\n\r\nRemoves the tour for rule features implemented in\r\nhttps://github.com/elastic/kibana/pull/176767 as they are no longer new.\r\nKeeps the component and logic to use for future tours, just removes\r\nreference to the specific rules management tour.\r\n\r\n### Steps to test\r\n\r\n1. Make sure the\r\n`securitySolution.rulesManagementPage.newFeaturesTour.v8.13` local\r\nstorage key is cleared from your kibana page (this will make the tour\r\nshow up normally)\r\n2. Notice that navigating to the rule management page does not display\r\nthe rule tour\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3547e154b57adbdbf36abda5c4571452b4ee0b26"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->