### PR TITLE
[Cloud Security] Remove failsOnMKI tag from the Agentless agent tests in Serverless Quality Gates

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
@@ -25,9 +25,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const AWS_SINGLE_ACCOUNT_TEST_ID = 'awsSingleTestId';
 
   describe('Agentless API Serverless', function () {
-    // fails on MKI, see https://github.com/elastic/kibana/issues/196245
-    this.tags(['failsOnMKI']);
-
     let mockApiServer: http.Server;
     let cisIntegration: typeof pageObjects.cisAddIntegration;
 


### PR DESCRIPTION
## Summary

Enabling the Serverless Quality Gate test for the Agentless Agent now that the Agentless API downtime is completed

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->