### PR TITLE
[Security Assistant] Knowledge base settings author column fix 

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/translations.ts
+++ b/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/translations.ts
@@ -168,20 +168,6 @@ export const ENTRY_NAME_INPUT_PLACEHOLDER = i18n.translate(
   }
 );
 
-export const ENTRY_SPACE_INPUT_LABEL = i18n.translate(
-  'xpack.elasticAssistant.assistant.settings.knowledgeBaseSettingsManagement.entrySpaceInputLabel',
-  {
-    defaultMessage: 'Space',
-  }
-);
-
-export const ENTRY_SPACE_INPUT_PLACEHOLDER = i18n.translate(
-  'xpack.elasticAssistant.assistant.settings.knowledgeBaseSettingsManagement.entrySpaceInputPlaceholder',
-  {
-    defaultMessage: 'Select',
-  }
-);
-
 export const SHARING_PRIVATE_OPTION_LABEL = i18n.translate(
   'xpack.elasticAssistant.assistant.settings.knowledgeBaseSettingsManagement.sharingPrivateOptionLabel',
   {
@@ -272,7 +258,8 @@ export const ENTRY_DESCRIPTION_HELP_LABEL = i18n.translate(
 export const ENTRY_DESCRIPTION_PLACEHOLDER = i18n.translate(
   'xpack.elasticAssistant.assistant.settings.knowledgeBaseSettingsManagement.entryDescriptionPlaceholder',
   {
-    defaultMessage: 'Use this index to answer any question related to asset information.',
+    defaultMessage:
+      'Example: "Use this index to answer any question related to asset information."',
   }
 );
 
@@ -295,7 +282,7 @@ export const ENTRY_QUERY_DESCRIPTION_PLACEHOLDER = i18n.translate(
   'xpack.elasticAssistant.assistant.settings.knowledgeBaseSettingsManagement.entryQueryDescriptionPlaceholder',
   {
     defaultMessage:
-      'Key terms to retrieve asset related information, like host names, IP Addresses or cloud objects.',
+      'Example: "Key terms to retrieve asset related information, like host names, IP Addresses or cloud objects."',
   }
 );
 

--- a/x-pack/packages/kbn-elastic-assistant/tsconfig.json
+++ b/x-pack/packages/kbn-elastic-assistant/tsconfig.json
@@ -31,5 +31,6 @@
     "@kbn/core",
     "@kbn/zod",
     "@kbn/data-views-plugin",
+    "@kbn/user-profile-components",
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the bug with the author column in the knowledge base settings table by properly fetching the user avatar and correctly plumbing in the `createdBy` value.

### Translation change

I also made a translation change to add the word "Example" to placeholder examples and I deleted unused translations.

## Testing fix

Have multiple users and create multiple private and global KB entries with each. Assure that each entry appears correctly for each author with the proper author and avatar

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->