### PR TITLE
[Security Solution] [Notes] Enable templated insights with all events, not just alerts

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_details.tsx
@@ -33,6 +33,8 @@ import {
 import { useDocumentDetailsContext } from '../../shared/context';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useWhichFlyout } from '../../shared/hooks/use_which_flyout';
+import { BasicAlertDataContext } from './investigation_guide_view';
+import { useInvestigationGuide } from '../../shared/hooks/use_investigation_guide';
 
 export const FETCH_NOTES_ERROR = i18n.translate(
   'xpack.securitySolution.flyout.left.notes.fetchNotesErrorLabel',
@@ -55,6 +57,10 @@ export const NotesDetails = memo(() => {
   const dispatch = useDispatch();
   const { eventId, dataFormattedForFieldBrowser } = useDocumentDetailsContext();
   const { kibanaSecuritySolutionsPrivileges } = useUserPrivileges();
+  const { basicAlertData: basicData } = useInvestigationGuide({
+    dataFormattedForFieldBrowser,
+  });
+
   const canCreateNotes = kibanaSecuritySolutionsPrivileges.crud;
 
   // will drive the value we send to the AddNote component
@@ -130,7 +136,7 @@ export const NotesDetails = memo(() => {
   );
 
   return (
-    <>
+    <BasicAlertDataContext.Provider value={basicData}>
       {fetchStatus === ReqStatus.Loading && (
         <EuiLoadingElastic data-test-subj={NOTES_LOADING_TEST_ID} size="xxl" />
       )}
@@ -156,7 +162,7 @@ export const NotesDetails = memo(() => {
           </AddNote>
         </>
       )}
-    </>
+    </BasicAlertDataContext.Provider>
   );
 });
 


### PR DESCRIPTION
## Summary

Currently all notes that make use of the markdown based timeline data providers will render as a timeline template if the note is associated with an event, and not an alert. Mostly everything is in place to have everything work for both already, there's just no context that contains the event document in the tree in the notes list component currently. This pr adds that context, and everything else works as expected.

![event_insights](https://github.com/user-attachments/assets/72d25ef2-0c2c-4f82-974f-0f005c9b2d77)


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios







<!--ONMERGE {"backportTargets":["8.16"]} ONMERGE-->