### PR TITLE
[ES|QL] Supports _index_mode in the metadata options

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -1123,7 +1123,7 @@ describe('autocomplete', () => {
           { filterText: '_source', text: '_source, ', command: TRIGGER_SUGGESTION_COMMAND },
         ]);
         // no comma if there are no more fields
-        testSuggestions('FROM a METADATA _id, _ignored, _index, _source, _version/', [
+        testSuggestions('FROM a METADATA _id, _ignored, _index, _source, _index_mode, _version/', [
           { filterText: '_version', text: '_version | ', command: TRIGGER_SUGGESTION_COMMAND },
         ]);
       });

--- a/packages/kbn-esql-validation-autocomplete/src/shared/constants.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/shared/constants.ts
@@ -15,4 +15,4 @@ export const SINGLE_TICK_REGEX = /`/g;
 export const DOUBLE_BACKTICK = '``';
 export const SINGLE_BACKTICK = '`';
 
-export const METADATA_FIELDS = ['_version', '_id', '_index', '_source', '_ignored'];
+export const METADATA_FIELDS = ['_version', '_id', '_index', '_source', '_ignored', '_index_mode'];


### PR DESCRIPTION
## Summary

Adds support for _index_mode in the matadata options

<img width="880" alt="image" src="https://github.com/user-attachments/assets/3de63f67-0235-4bf9-9c2e-ad0657df82a5">



<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->