### PR TITLE
Skips serverless org members nav card test on MKI

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/platform_security/navigation/management_nav_cards.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/platform_security/navigation/management_nav_cards.ts
@@ -61,7 +61,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       describe('organization members', function () {
         // Observability will not support custom roles
         // Cannot test cloud link on MKI (will redirect to login)
-        this.tags(['skipSvlOblt', 'failsOnMKI']);
+        this.tags(['skipSvlOblt', 'skipMKI']);
 
         it('displays the Organization members management card, and will navigate to the cloud organization URL', async () => {
           await pageObjects.svlManagementPage.assertOrgMembersManagementCardExists();
@@ -109,7 +109,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       describe('Organization members', function () {
         // Observability will not support custom roles
         // Cannot test cloud link on MKI (will redirect to login)
-        this.tags(['skipSvlOblt', 'failsOnMKI']);
+        this.tags(['skipSvlOblt', 'skipMKI']);
 
         it('displays the organization members management card, and will navigate to the cloud organization URL', async () => {
           // The org members nav card is always visible because there is no way to check if a user has approprite privileges

--- a/x-pack/test_serverless/functional/test_suites/common/platform_security/navigation/management_nav_cards.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/platform_security/navigation/management_nav_cards.ts
@@ -56,13 +56,18 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           const url = await browser.getCurrentUrl();
           expect(url).to.contain('/management/security/roles');
         });
+      });
+
+      describe('organization members', function () {
+        // Observability will not support custom roles
+        // Cannot test cloud link on MKI (will redirect to login)
+        this.tags(['skipSvlOblt', 'failsOnMKI']);
 
         it('displays the Organization members management card, and will navigate to the cloud organization URL', async () => {
           await pageObjects.svlManagementPage.assertOrgMembersManagementCardExists();
           await pageObjects.svlManagementPage.clickOrgMembersManagementCard();
 
           const url = await browser.getCurrentUrl();
-          // `--xpack.cloud.organization_url: '/account/members'`,
           expect(url).to.contain('/account/members');
         });
       });

--- a/x-pack/test_serverless/functional/test_suites/common/platform_security/navigation/management_nav_cards.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/platform_security/navigation/management_nav_cards.ts
@@ -107,7 +107,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       describe('Organization members', function () {
-        this.tags('skipSvlOblt'); // Observability will not support custom roles
+        // Observability will not support custom roles
+        // Cannot test cloud link on MKI (will redirect to login)
+        this.tags(['skipSvlOblt', 'failsOnMKI']);
+
         it('displays the organization members management card, and will navigate to the cloud organization URL', async () => {
           // The org members nav card is always visible because there is no way to check if a user has approprite privileges
           await pageObjects.svlManagementPage.assertOrgMembersManagementCardExists();


### PR DESCRIPTION
## Summary

Skips the functional test for the org members management nav card on MKI. The test attempts to confirm a link to the cloud org members page, but on MKI it will redirect to cloud login.