### PR TITLE
[8.16] [Ingest Pipelines] Update copy in Manage processors (#196923)

### DIFF
--- a/x-pack/plugins/ingest_pipelines/public/application/sections/manage_processors/add_database_modal.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/manage_processors/add_database_modal.tsx
@@ -137,7 +137,7 @@ export const AddDatabaseModal = ({
             helpText={
               <FormattedMessage
                 id="xpack.ingestPipelines.manageProcessors.geoip.addDatabaseForm.databaseTypeSelectHelpText"
-                defaultMessage="Select which provider you want to use"
+                defaultMessage="Select the provider you want to use."
               />
             }
           >
@@ -156,7 +156,7 @@ export const AddDatabaseModal = ({
                 title={
                   <FormattedMessage
                     id="xpack.ingestPipelines.manageProcessors.geoip.licenseCalloutTitle"
-                    defaultMessage="Add your MaxMind license key to keystore"
+                    defaultMessage="Add your MaxMind license token to the keystore"
                   />
                 }
                 iconType="iInCircle"
@@ -164,7 +164,7 @@ export const AddDatabaseModal = ({
                 <p>
                   <FormattedMessage
                     id="xpack.ingestPipelines.manageProcessors.geoip.licenseCalloutText"
-                    defaultMessage="In order to grant access to your MaxMind account, you must add the license key to the keystore."
+                    defaultMessage="The processor needs the license key to connect to the database."
                   />
                 </p>
               </EuiCallOut>
@@ -178,7 +178,7 @@ export const AddDatabaseModal = ({
                 title={
                   <FormattedMessage
                     id="xpack.ingestPipelines.manageProcessors.geoip.licenseCalloutTitle"
-                    defaultMessage="Add your IP Info license token to keystore"
+                    defaultMessage="Add your IP Info license token to the keystore"
                   />
                 }
                 iconType="iInCircle"
@@ -186,7 +186,7 @@ export const AddDatabaseModal = ({
                 <p>
                   <FormattedMessage
                     id="xpack.ingestPipelines.manageProcessors.geoip.licenseCalloutText"
-                    defaultMessage="In order to grant access to your IP Info account, you must add the license token to the keystore."
+                    defaultMessage="The processor needs the license key to connect to the database."
                   />
                 </p>
               </EuiCallOut>
@@ -246,7 +246,7 @@ export const AddDatabaseModal = ({
               <p>
                 <FormattedMessage
                   id="xpack.ingestPipelines.manageProcessors.geoip.nameExistsErrorText"
-                  defaultMessage="Database cannot be added multiple times."
+                  defaultMessage="A database needs to be added only once in order to be available."
                 />
               </p>
             </EuiCallOut>

--- a/x-pack/plugins/ingest_pipelines/public/application/sections/manage_processors/empty_list.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/manage_processors/empty_list.tsx
@@ -8,6 +8,7 @@
 import { EuiPageTemplate } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
+import { css } from '@emotion/react/dist/emotion-react.cjs';
 
 export const EmptyList = ({ addDatabaseButton }: { addDatabaseButton: JSX.Element }) => {
   return (
@@ -26,11 +27,15 @@ export const EmptyList = ({ addDatabaseButton }: { addDatabaseButton: JSX.Elemen
         <p>
           <FormattedMessage
             id="xpack.ingestPipelines.manageProcessors.geoip.emptyPromptDescription"
-            defaultMessage="Use a custom database when setting up IP Location processor."
+            defaultMessage="Set up a connection to a custom database when setting up IP Location processor."
           />
         </p>
       }
       actions={addDatabaseButton}
+      css={css`
+        width: 450px;
+        padding: 0 20px 0 20px;
+      `}
     />
   );
 };

--- a/x-pack/plugins/ingest_pipelines/public/application/sections/manage_processors/geoip_list.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/manage_processors/geoip_list.tsx
@@ -162,7 +162,7 @@ export const GeoipList: React.FunctionComponent = () => {
               <h2>
                 <FormattedMessage
                   id="xpack.ingestPipelines.manageProcessors.geoip.tableTitle"
-                  defaultMessage="GeoIP"
+                  defaultMessage="IP Location"
                 />
               </h2>
             </EuiTitle>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Ingest Pipelines] Update copy in Manage processors (#196923)](https://github.com/elastic/kibana/pull/196923)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Elena Stoeva","email":"59341489+ElenaStoeva@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-10-22T09:14:42Z","message":"[Ingest Pipelines] Update copy in Manage processors (#196923)\n\n## Summary\r\n\r\nThis PR adds some copy changes to the Manage processors pages.\r\n\r\n1. Empty prompt\r\n- Width and padding of the prompt is adjusted so that \"IP\" in the title\r\nstarts in the 2nd line\r\n- Description is updated\r\n<img width=\"800\" alt=\"Screenshot 2024-10-18 at 17 00 53\"\r\nsrc=\"https://github.com/user-attachments/assets/51aa6cdc-5eb4-4c54-8960-7ee273d82ef5\">\r\n\r\n\r\n2. Add database modal\r\n- Copy in callouts is updated\r\n- The help text of the \"Type\" field is updated\r\n- The text in the \"Database already exists\" error callout is updated\r\n<img width=\"1490\" alt=\"Screenshot 2024-10-21 at 09 34 12\"\r\nsrc=\"https://github.com/user-attachments/assets/ab3c2e21-4457-435f-a4c3-874c6edcb2ce\">\r\n<img width=\"1498\" alt=\"Screenshot 2024-10-18 at 17 24 43\"\r\nsrc=\"https://github.com/user-attachments/assets/a0c15f5d-9360-4ee7-806d-2b5b64b6fd2a\">\r\n\r\n\r\n3. Manage processors page\r\n- The title of the page is changed from \"GeoIP\" to \"IP Location\"\r\n<img width=\"800\" alt=\"Screenshot 2024-10-18 at 17 20 01\"\r\nsrc=\"https://github.com/user-attachments/assets/cde8b070-9664-42df-b71a-723a5356d4a2\">","sha":"996eb73811c665945f8c4425d1e8e89fa9688b40","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","v9.0.0","Feature:Ingest Node Pipelines","backport:prev-minor","v8.16.0","v8.17.0"],"number":196923,"url":"https://github.com/elastic/kibana/pull/196923","mergeCommit":{"message":"[Ingest Pipelines] Update copy in Manage processors (#196923)\n\n## Summary\r\n\r\nThis PR adds some copy changes to the Manage processors pages.\r\n\r\n1. Empty prompt\r\n- Width and padding of the prompt is adjusted so that \"IP\" in the title\r\nstarts in the 2nd line\r\n- Description is updated\r\n<img width=\"800\" alt=\"Screenshot 2024-10-18 at 17 00 53\"\r\nsrc=\"https://github.com/user-attachments/assets/51aa6cdc-5eb4-4c54-8960-7ee273d82ef5\">\r\n\r\n\r\n2. Add database modal\r\n- Copy in callouts is updated\r\n- The help text of the \"Type\" field is updated\r\n- The text in the \"Database already exists\" error callout is updated\r\n<img width=\"1490\" alt=\"Screenshot 2024-10-21 at 09 34 12\"\r\nsrc=\"https://github.com/user-attachments/assets/ab3c2e21-4457-435f-a4c3-874c6edcb2ce\">\r\n<img width=\"1498\" alt=\"Screenshot 2024-10-18 at 17 24 43\"\r\nsrc=\"https://github.com/user-attachments/assets/a0c15f5d-9360-4ee7-806d-2b5b64b6fd2a\">\r\n\r\n\r\n3. Manage processors page\r\n- The title of the page is changed from \"GeoIP\" to \"IP Location\"\r\n<img width=\"800\" alt=\"Screenshot 2024-10-18 at 17 20 01\"\r\nsrc=\"https://github.com/user-attachments/assets/cde8b070-9664-42df-b71a-723a5356d4a2\">","sha":"996eb73811c665945f8c4425d1e8e89fa9688b40"}},"sourceBranch":"main","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/196923","number":196923,"mergeCommit":{"message":"[Ingest Pipelines] Update copy in Manage processors (#196923)\n\n## Summary\r\n\r\nThis PR adds some copy changes to the Manage processors pages.\r\n\r\n1. Empty prompt\r\n- Width and padding of the prompt is adjusted so that \"IP\" in the title\r\nstarts in the 2nd line\r\n- Description is updated\r\n<img width=\"800\" alt=\"Screenshot 2024-10-18 at 17 00 53\"\r\nsrc=\"https://github.com/user-attachments/assets/51aa6cdc-5eb4-4c54-8960-7ee273d82ef5\">\r\n\r\n\r\n2. Add database modal\r\n- Copy in callouts is updated\r\n- The help text of the \"Type\" field is updated\r\n- The text in the \"Database already exists\" error callout is updated\r\n<img width=\"1490\" alt=\"Screenshot 2024-10-21 at 09 34 12\"\r\nsrc=\"https://github.com/user-attachments/assets/ab3c2e21-4457-435f-a4c3-874c6edcb2ce\">\r\n<img width=\"1498\" alt=\"Screenshot 2024-10-18 at 17 24 43\"\r\nsrc=\"https://github.com/user-attachments/assets/a0c15f5d-9360-4ee7-806d-2b5b64b6fd2a\">\r\n\r\n\r\n3. Manage processors page\r\n- The title of the page is changed from \"GeoIP\" to \"IP Location\"\r\n<img width=\"800\" alt=\"Screenshot 2024-10-18 at 17 20 01\"\r\nsrc=\"https://github.com/user-attachments/assets/cde8b070-9664-42df-b71a-723a5356d4a2\">","sha":"996eb73811c665945f8c4425d1e8e89fa9688b40"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/197187","number":197187,"state":"OPEN"}]}] BACKPORT-->