### PR TITLE
[SecuritySolution][Endpoint] Re-enabled skipped tests

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx
@@ -56,7 +56,7 @@ describe('Users filter', () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, 'usernameX');
+    await userEvent.type(searchInput, 'usernameX', { delay: 10 });
     await userEvent.keyboard('{enter}');
     expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']);
   });
@@ -65,7 +65,7 @@ describe('Users filter', () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, 'usernameX,usernameY,usernameZ');
+    await userEvent.type(searchInput, 'usernameX,usernameY,usernameZ', { delay: 10 });
     await userEvent.keyboard('{enter}');
     expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY', 'usernameZ']);
   });
@@ -74,7 +74,7 @@ describe('Users filter', () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, '   usernameX   ');
+    await userEvent.type(searchInput, '   usernameX   ', { delay: 10 });
     await userEvent.keyboard('{enter}');
     expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']);
   });
@@ -83,7 +83,7 @@ describe('Users filter', () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, '   , usernameX ,usernameY    ,       ');
+    await userEvent.type(searchInput, '   , usernameX ,usernameY    ,       ', { delay: 10 });
     await userEvent.keyboard('{enter}');
     expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY']);
   });

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx
@@ -15,9 +15,7 @@ import {
 import { ActionsLogUsersFilter } from './actions_log_users_filter';
 import { MANAGEMENT_PATH } from '../../../../../common/constants';
 
-// FLAKY: https://github.com/elastic/kibana/issues/193554
-// FLAKY: https://github.com/elastic/kibana/issues/193092
-describe.skip('Users filter', () => {
+describe('Users filter', () => {
   let render: (
     props?: React.ComponentProps<typeof ActionsLogUsersFilter>
   ) => ReturnType<AppContextTestRender['render']>;

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx
@@ -27,7 +27,7 @@ describe('Users filter', () => {
   const filterPrefix = 'users-filter';
   let onChangeUsersFilter: jest.Mock;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     onChangeUsersFilter = jest.fn();
     mockedContext = createAppRootMockRenderer();
     ({ history } = mockedContext);
@@ -57,7 +57,7 @@ describe('Users filter', () => {
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
     await userEvent.type(searchInput, 'usernameX');
-    await userEvent.type(searchInput, '{enter}');
+    await userEvent.keyboard('{enter}');
     expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']);
   });
 
@@ -66,7 +66,7 @@ describe('Users filter', () => {
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
     await userEvent.type(searchInput, 'usernameX,usernameY,usernameZ');
-    await userEvent.type(searchInput, '{enter}');
+    await userEvent.keyboard('{enter}');
     expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY', 'usernameZ']);
   });
 
@@ -75,7 +75,7 @@ describe('Users filter', () => {
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
     await userEvent.type(searchInput, '   usernameX   ');
-    await userEvent.type(searchInput, '{enter}');
+    await userEvent.keyboard('{enter}');
     expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']);
   });
 
@@ -84,7 +84,7 @@ describe('Users filter', () => {
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
     await userEvent.type(searchInput, '   , usernameX ,usernameY    ,       ');
-    await userEvent.type(searchInput, '{enter}');
+    await userEvent.keyboard('{enter}');
     expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY']);
   });
 });


### PR DESCRIPTION
## Summary

This PR attempts to fix tests skipped in elastic/kibana/issues/193092 and elastic/kibana/issues/193554.
The tests seem to be flaky right after an [upgrade to `user-event`](https://github.com/elastic/kibana/pull/189949) dependency on Sep 10th.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->