### PR TITLE
[SecuritySolution] Fix EntitiesList 'name' column sorting

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.test.tsx
@@ -106,7 +106,7 @@ describe('EntitiesList', () => {
     fireEvent.click(columnHeader);
     expect(mockUseEntitiesListQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        sortField: 'entity.displayName.keyword',
+        sortField: 'entity.name.text',
         sortOrder: 'asc',
       })
     );

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_columns.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entities_list_columns.tsx
@@ -79,7 +79,7 @@ export const useEntitiesListColumns = (): EntitiesListColumns => {
       width: '5%',
     },
     {
-      field: 'entity.displayName.keyword',
+      field: 'entity.name.text',
       name: (
         <FormattedMessage
           id="xpack.securitySolution.entityAnalytics.entityStore.entitiesList.nameColumn.title"


### PR DESCRIPTION
## Summary

Fix EntitiesList 'name' column sorting.


https://github.com/user-attachments/assets/04a745d8-bae0-4c33-8ff2-f37e8caf4108






<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->