### PR TITLE
[Onboarding] Add tech preview badge to the OTel k8s flow

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
@@ -191,6 +191,7 @@ export function useCustomCardsForCategory(
           version: '',
           integration: '',
           isQuickstart: true,
+          release: 'preview',
         },
       ];
 

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/pages/otel_kubernetes.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/pages/otel_kubernetes.tsx
@@ -28,6 +28,7 @@ export const OtelKubernetesPage = () => (
             defaultMessage: 'Unified Kubernetes observability with the OpenTelemetry Operator',
           }
         )}
+        isTechnicalPreview={true}
       />
     }
   >


### PR DESCRIPTION
Adds Tech Preview badges for the k8s OTel flow.

### Quickstart tile
<img width="405" alt="image" src="https://github.com/user-attachments/assets/1425c39d-a3a8-44c1-9e05-b8ad0c7757ee">

### Onboarding page
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/4a8b73f0-1eb1-4361-bb69-3ad62c463446">




<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->