### PR TITLE
[Reporting] Add searchSourceStart.create error handling

### DIFF
--- a/packages/kbn-generate-csv/src/generate_csv.ts
+++ b/packages/kbn-generate-csv/src/generate_csv.ts
@@ -26,10 +26,12 @@ import {
   byteSizeValueToNumber,
   CancellationToken,
   ReportingError,
+  ReportingSavedObjectNotFoundError,
 } from '@kbn/reporting-common';
 import type { TaskInstanceFields, TaskRunResult } from '@kbn/reporting-common/types';
 import type { ReportingConfigType } from '@kbn/reporting-server';
 
+import { TaskErrorSource, createTaskRunError } from '@kbn/task-manager-plugin/server';
 import { CONTENT_TYPE_CSV } from '../constants';
 import type { JobParamsCSV } from '../types';
 import { getExportSettings, type CsvExportSettings } from './lib/get_export_settings';
@@ -235,6 +237,21 @@ export class CsvGenerator {
 
   public async generateData(): Promise<TaskRunResult> {
     const logger = this.logger;
+
+    const createSearchSource = async () => {
+      try {
+        const source = await this.dependencies.searchSourceStart.create(this.job.searchSource);
+        return source;
+      } catch (err) {
+        // Saved object not found
+        if (err?.output?.statusCode === 404) {
+          const reportingError = new ReportingSavedObjectNotFoundError(err);
+          throw createTaskRunError(reportingError, TaskErrorSource.USER);
+        }
+        throw new Error(err);
+      }
+    };
+
     const [settings, searchSource] = await Promise.all([
       getExportSettings(
         this.clients.uiSettings,
@@ -243,7 +260,7 @@ export class CsvGenerator {
         this.job.browserTimezone,
         logger
       ),
-      this.dependencies.searchSourceStart.create(this.job.searchSource),
+      createSearchSource(),
     ]);
 
     const { startedAt, retryAt } = this.taskInstanceFields;

--- a/packages/kbn-generate-csv/src/generate_csv.ts
+++ b/packages/kbn-generate-csv/src/generate_csv.ts
@@ -248,7 +248,7 @@ export class CsvGenerator {
           const reportingError = new ReportingSavedObjectNotFoundError(err);
           throw createTaskRunError(reportingError, TaskErrorSource.USER);
         }
-        throw new Error(err);
+        throw err;
       }
     };
 

--- a/packages/kbn-generate-csv/tsconfig.json
+++ b/packages/kbn-generate-csv/tsconfig.json
@@ -30,5 +30,6 @@
     "@kbn/es-types",
     "@kbn/data-views-plugin",
     "@kbn/search-types",
+    "@kbn/task-manager-plugin",
   ]
 }

--- a/packages/kbn-reporting/common/errors.ts
+++ b/packages/kbn-reporting/common/errors.ts
@@ -152,3 +152,10 @@ export class VisualReportingSoftDisabledError extends ReportingError {
     });
   }
 }
+
+export class ReportingSavedObjectNotFoundError extends ReportingError {
+  static code = 'reporting_saved_object_not_found' as const;
+  public get code(): string {
+    return ReportingSavedObjectNotFoundError.code;
+  }
+}

--- a/packages/kbn-reporting/common/errors.ts
+++ b/packages/kbn-reporting/common/errors.ts
@@ -154,7 +154,7 @@ export class VisualReportingSoftDisabledError extends ReportingError {
 }
 
 export class ReportingSavedObjectNotFoundError extends ReportingError {
-  static code = 'reporting_saved_object_not_found' as const;
+  static code = 'reporting_saved_object_not_found_error' as const;
   public get code(): string {
     return ReportingSavedObjectNotFoundError.code;
   }


### PR DESCRIPTION
## Summary

This PR adds a new type of error (`ReportingSavedObjectNotFoundError`) which gets thrown when passed in saved object doesn't exist.

This produces a log like this:
```
[2024-10-22T15:09:26.768+02:00][ERROR][plugins.reporting.runTask] Error: ReportingError(code: reporting_saved_object_not_found) "Error: Saved object [index-pattern/ff959d40-b880-11e8-a6d9-e546fe2bba5f] not found"
```

Closes: #191548
Closes: #196620
