### PR TITLE
[Observability Onboarding] Fix EDOT collector permissions

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/server/lib/api_key/create_shipper_api_key.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/lib/api_key/create_shipper_api_key.ts
@@ -6,7 +6,11 @@
  */
 
 import { ElasticsearchClient } from '@kbn/core/server';
-import { MONITOR_CLUSTER, INDEX_LOGS_AND_METRICS, WRITE_APM_EVENTS } from './privileges';
+import {
+  MONITOR_CLUSTER,
+  INDEX_LOGS_AND_METRICS,
+  INDEX_LOGS_METRICS_AND_TRACES,
+} from './privileges';
 
 export function createShipperApiKey(esClient: ElasticsearchClient, name: string, withAPM = false) {
   // Based on https://www.elastic.co/guide/en/fleet/master/grant-access-to-elasticsearch.html#create-api-key-standalone-agent
@@ -20,8 +24,7 @@ export function createShipperApiKey(esClient: ElasticsearchClient, name: string,
       role_descriptors: {
         standalone_agent: {
           cluster: [MONITOR_CLUSTER],
-          indices: [INDEX_LOGS_AND_METRICS],
-          applications: withAPM ? [WRITE_APM_EVENTS] : undefined,
+          indices: [withAPM ? INDEX_LOGS_METRICS_AND_TRACES : INDEX_LOGS_AND_METRICS],
         },
       },
     },

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/lib/api_key/has_log_monitoring_privileges.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/lib/api_key/has_log_monitoring_privileges.ts
@@ -6,14 +6,17 @@
  */
 
 import { ElasticsearchClient } from '@kbn/core/server';
-import { MONITOR_CLUSTER, INDEX_LOGS_AND_METRICS, WRITE_APM_EVENTS } from './privileges';
+import {
+  MONITOR_CLUSTER,
+  INDEX_LOGS_AND_METRICS,
+  INDEX_LOGS_METRICS_AND_TRACES,
+} from './privileges';
 
 export async function hasLogMonitoringPrivileges(esClient: ElasticsearchClient, withAPM = false) {
   const res = await esClient.security.hasPrivileges({
     body: {
       cluster: [MONITOR_CLUSTER, 'manage_own_api_key'],
-      index: [INDEX_LOGS_AND_METRICS],
-      application: withAPM ? [WRITE_APM_EVENTS] : undefined,
+      index: [withAPM ? INDEX_LOGS_METRICS_AND_TRACES : INDEX_LOGS_AND_METRICS],
     },
   });
 

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/lib/api_key/privileges.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/lib/api_key/privileges.ts
@@ -18,9 +18,8 @@ export const INDEX_LOGS_AND_METRICS: estypes.SecurityIndicesPrivileges = {
   privileges: ['auto_configure', 'create_doc'],
 };
 
-// https://www.elastic.co/guide/en/observability/master/apm-api-key.html#apm-create-api-key-workflow-es
-export const WRITE_APM_EVENTS: estypes.SecurityApplicationPrivileges = {
-  application: 'apm',
-  privileges: ['event:write', 'config_agent:read'],
-  resources: ['*'],
+// https://www.elastic.co/guide/en/fleet/master/grant-access-to-elasticsearch.html#create-api-key-standalone-agent
+export const INDEX_LOGS_METRICS_AND_TRACES: estypes.SecurityIndicesPrivileges = {
+  names: ['logs-*-*', 'metrics-*-*', 'traces-*-*'],
+  privileges: ['auto_configure', 'create_doc'],
 };


### PR DESCRIPTION
## Summary

Fix EDOT collector permissions.

## Details

Adds `traces-*-*` index privilege and removed unnecessary `apm` application privileges:

```json
{
  "standalone_agent": {
    "cluster": [
      "monitor"
    ],
    "indices": [
      {
        "names": [
          "logs-*-*",
          "metrics-*-*",
          "traces-*-*"
        ],
        "privileges": [
          "auto_configure",
          "create_doc"
        ],
        "allow_restricted_indices": false
      }
    ],
    "applications": []
  }
}
```

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->