### PR TITLE
[7.17] Fix AggConfig backslash escaping (#193932)

### DIFF
--- a/src/plugins/data/common/search/aggs/metrics/lib/get_response_agg_config_class.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/get_response_agg_config_class.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getResponseAggId } from './get_response_agg_config_class';
+
+describe('getResponseAggConfigClass', () => {
+  describe('getResponseAggId', () => {
+    it('should generate a dot-separated ID from parent/key', () => {
+      const id = getResponseAggId('parent', 'child');
+      expect(id).toBe('parent.child');
+    });
+
+    it('should use brackets/quotes if the value includes a dot', () => {
+      const id = getResponseAggId('parent', 'foo.bar');
+      expect(id).toBe(`parent['foo.bar']`);
+    });
+
+    it('should escape quotes', () => {
+      const id = getResponseAggId('parent', `foo.b'ar`);
+      expect(id).toBe(`parent['foo.b\\'ar']`);
+    });
+
+    it('should escape backslashes', () => {
+      const id = getResponseAggId('parent', `f\\oo.b'ar`);
+      expect(id).toBe(`parent['f\\\\oo.b\\'ar']`);
+    });
+  });
+});

--- a/src/plugins/data/common/search/aggs/metrics/lib/get_response_agg_config_class.test.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/get_response_agg_config_class.test.ts
@@ -1,10 +1,9 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
  */
 
 import { getResponseAggId } from './get_response_agg_config_class';

--- a/src/plugins/data/common/search/aggs/metrics/lib/get_response_agg_config_class.ts
+++ b/src/plugins/data/common/search/aggs/metrics/lib/get_response_agg_config_class.ts
@@ -30,6 +30,15 @@ export interface IResponseAggConfig extends IMetricAggConfig {
   parentId: IMetricAggConfig['id'];
 }
 
+export function getResponseAggId(parentId: string, key: string) {
+  const subId = String(key);
+  if (subId.indexOf('.') > -1) {
+    return parentId + "['" + subId.replace(/[\\']/g, '\\$&') + "']"; // $& means the whole matched string
+  } else {
+    return parentId + '.' + subId;
+  }
+}
+
 export const create = (parentAgg: IMetricAggConfig, props: Partial<IMetricAggConfig>) => {
   /**
    * AggConfig "wrapper" for multi-value metric aggs which
@@ -40,17 +49,7 @@ export const create = (parentAgg: IMetricAggConfig, props: Partial<IMetricAggCon
    */
   function ResponseAggConfig(this: IResponseAggConfig, key: string) {
     const parentId = parentAgg.id;
-    let id;
-
-    const subId = String(key);
-
-    if (subId.indexOf('.') > -1) {
-      id = parentId + "['" + subId.replace(/'/g, "\\'") + "']";
-    } else {
-      id = parentId + '.' + subId;
-    }
-
-    this.id = id;
+    this.id = getResponseAggId(parentId, key);
     this.key = key;
     this.parentId = parentId;
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix AggConfig backslash escaping (#193932)](https://github.com/elastic/kibana/pull/193932)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lukas Olson","email":"lukas@elastic.co"},"sourceCommit":{"committedDate":"2024-09-27T15:56:48Z","message":"Fix AggConfig backslash escaping (#193932)\n\n## Summary\r\n\r\nFixes `AggConfig` handling to properly escape backslash as well as the\r\nsingle quote it already escapes.\r\n\r\n(I believe this has been around ever since\r\nhttps://github.com/elastic/kibana/pull/2486.)","sha":"9916dd0137a87ee9969b3a8d42bbf40cb753dae5","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Aggregations","release_note:skip","v9.0.0","Team:DataDiscovery","backport:prev-minor","backport:prev-major","v8.16.0","v8.15.4"],"number":193932,"url":"https://github.com/elastic/kibana/pull/193932","mergeCommit":{"message":"Fix AggConfig backslash escaping (#193932)\n\n## Summary\r\n\r\nFixes `AggConfig` handling to properly escape backslash as well as the\r\nsingle quote it already escapes.\r\n\r\n(I believe this has been around ever since\r\nhttps://github.com/elastic/kibana/pull/2486.)","sha":"9916dd0137a87ee9969b3a8d42bbf40cb753dae5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/193932","number":193932,"mergeCommit":{"message":"Fix AggConfig backslash escaping (#193932)\n\n## Summary\r\n\r\nFixes `AggConfig` handling to properly escape backslash as well as the\r\nsingle quote it already escapes.\r\n\r\n(I believe this has been around ever since\r\nhttps://github.com/elastic/kibana/pull/2486.)","sha":"9916dd0137a87ee9969b3a8d42bbf40cb753dae5"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/194324","number":194324,"state":"MERGED","mergeCommit":{"sha":"6040c6ed836f3a0a62545198119af20b2502301e","message":"[8.x] Fix AggConfig backslash escaping (#193932) (#194324)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [Fix AggConfig backslash escaping\n(#193932)](https://github.com/elastic/kibana/pull/193932)\n\n<!--- Backport version: 9.4.3 -->