### PR TITLE
[Search][FTR] Fix / Improve tests

### DIFF
--- a/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_search_elasticsearch_start_page.ts
@@ -85,8 +85,8 @@ export function SvlSearchElasticsearchStartPageProvider({ getService }: FtrProvi
     },
     async expectO11yTrialLink() {
       await testSubjects.existOrFail('startO11yTrialBtn');
-      expect(await testSubjects.getAttribute('startO11yTrialBtn', 'href')).equal(
-        'https://fake-cloud.elastic.co/projects/create/observability/start'
+      expect(await testSubjects.getAttribute('startO11yTrialBtn', 'href')).match(
+        /^https?\:\/\/.*\/projects\/create\/observability\/start/
       );
       expect(await testSubjects.getAttribute('startO11yTrialBtn', 'target')).equal('_blank');
     },

--- a/x-pack/test_serverless/functional/page_objects/svl_search_index_detail_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_search_index_detail_page.ts
@@ -27,8 +27,8 @@ export function SvlSearchIndexDetailPageProvider({ getService }: FtrProviderCont
     },
     async expectConnectionDetails() {
       await testSubjects.existOrFail('connectionDetailsEndpoint', { timeout: 2000 });
-      expect(await (await testSubjects.find('connectionDetailsEndpoint')).getVisibleText()).to.be(
-        'https://fakeprojectid.es.fake-domain.cld.elstc.co:443'
+      expect(await (await testSubjects.find('connectionDetailsEndpoint')).getVisibleText()).match(
+        /^https?\:\/\/.*(\:\d+)?/
       );
     },
     async expectQuickStats() {

--- a/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/elasticsearch_start.ts
@@ -27,9 +27,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   };
 
   describe('Elasticsearch Start [Onboarding Empty State]', function () {
-    // fails on MKI, see https://github.com/elastic/kibana/issues/196981
-    this.tags(['failsOnMKI']);
-
     describe('developer', function () {
       before(async () => {
         await pageObjects.svlCommonPage.loginWithRole('developer');

--- a/x-pack/test_serverless/functional/test_suites/search/getting_started.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/getting_started.ts
@@ -15,7 +15,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('getting started', function () {
     before(async () => {
-      await pageObjects.svlCommonPage.loginAsAdmin();
+      await pageObjects.svlCommonPage.loginWithRole('developer');
     });
 
     it('has serverless side nav', async () => {

--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -130,21 +130,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
         deepLinkId: 'dashboards',
       });
-      // check Other tools
-      // > Maps
-      await solutionNavigation.sidenav.clickLink({
-        deepLinkId: 'maps',
-      });
-      await solutionNavigation.sidenav.expectLinkActive({
-        deepLinkId: 'maps',
-      });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Other tools' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-        text: 'Maps',
-      });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-        deepLinkId: 'maps',
-      });
 
       // check Getting Started
       await solutionNavigation.sidenav.clickLink({

--- a/x-pack/test_serverless/functional/test_suites/search/search_index_detail.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/search_index_detail.ts
@@ -25,9 +25,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const indexName = 'test-my-index';
 
   describe('Search index detail page', function () {
-    // fails on MKI, see https://github.com/elastic/kibana/issues/196981
-    this.tags(['failsOnMKI']);
-
     before(async () => {
       await pageObjects.svlCommonPage.loginWithRole('developer');
       await pageObjects.svlApiKeys.deleteAPIKeys();
@@ -120,15 +117,15 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           });
           await svlSearchNavigation.navigateToIndexDetailPage(indexName);
         });
+        it('should have index documents', async () => {
+          await pageObjects.svlSearchIndexDetailPage.expectHasIndexDocuments();
+        });
         it('menu action item should be replaced with playground', async () => {
           await pageObjects.svlSearchIndexDetailPage.expectActionItemReplacedWhenHasDocs();
         });
         it('should have link to API reference doc link in options menu', async () => {
           await pageObjects.svlSearchIndexDetailPage.clickMoreOptionsActionsButton();
           await pageObjects.svlSearchIndexDetailPage.expectAPIReferenceDocLinkExistsInMoreOptions();
-        });
-        it('should have index documents', async () => {
-          await pageObjects.svlSearchIndexDetailPage.expectHasIndexDocuments();
         });
         it('should have one document in quick stats', async () => {
           await pageObjects.svlSearchIndexDetailPage.expectQuickStatsToHaveDocumentCount(1);


### PR DESCRIPTION
## Summary

Closes #196981

- Updated Search Index Details with data test suite to check for index documents first, this should help reduce flakey tests in MKI since we will ensure the documents are available before moving forward
- Updated URL checks to use regex instead `.equal` with the mocked value. This should ensure the tests can pass in MKI and with integration testing
- Removed the navigation check for the Maps page, this was causing intermittent failures due to a modal on the page.
- Updated the getting started test suite to use `developer` role instead of `admin`

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
