### PR TITLE
[Reporting] Use uniquely identifying string to associate user with their report

### DIFF
--- a/docs/user/reporting/script-example.asciidoc
+++ b/docs/user/reporting/script-example.asciidoc
@@ -22,15 +22,17 @@ An example response for a successfully queued report:
 [source,js]
 ---------------------------------------------------------
 {
-  "path": "/api/reporting/jobs/download/jxzaofkc0ykpf4062305t068", <1>
+  "path": "/api/reporting/jobs/download/eb154ed4-6767-4acb-b239-d4baab0f65f2",
   "job": {
-    "id": "jxzaofkc0ykpf4062305t068",
-    "index": ".reporting-2018.11.11",
-    "jobtype": "csv",
-    "created_by": "elastic",
-    "payload": ..., <2>
-    "timeout": 120000,
-    "max_attempts": 3
+    "id": "eb154ed4-6767-4acb-b239-d4baab0f65f2",
+    "index": ".ds-.kibana-reporting-2024.10.23-000001",
+    "jobtype": "csv_v2",
+    "created_at": "2024-10-24T21:04:56.213Z",
+    "created_by": "reporting_user:native:default_native",
+    "status": "pending",
+    "attempts": 0,
+    "migration_version": "7.14.0",
+    "payload": ...,
   }
 }
 ---------------------------------------------------------

--- a/packages/kbn-reporting/common/types.ts
+++ b/packages/kbn-reporting/common/types.ts
@@ -133,7 +133,7 @@ export interface ReportSource {
    * generate the report
    */
   jobtype: string; // refers to `ExportTypeDefinition.jobType`
-  created_by: string | false; // username or `false` if security is disabled. Used for ensuring users can only access the reports they've created.
+  created_by: string | false; // uses the `username:realm-type:realm-name` triple format, or `false` if security is disabled. Used for ensuring users can only access the reports they've created.
   payload: BasePayload;
   meta: {
     // for telemetry

--- a/x-pack/plugins/reporting/server/routes/common/generate/request_handler.test.ts
+++ b/x-pack/plugins/reporting/server/routes/common/generate/request_handler.test.ts
@@ -10,7 +10,12 @@ jest.mock('uuid', () => ({ v4: () => 'mock-report-id' }));
 import rison from '@kbn/rison';
 
 import { KibanaRequest, KibanaResponseFactory } from '@kbn/core/server';
-import { coreMock, httpServerMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import {
+  coreMock,
+  httpServerMock,
+  loggingSystemMock,
+  securityServiceMock,
+} from '@kbn/core/server/mocks';
 import { JobParamsPDFV2, TaskPayloadPDFV2 } from '@kbn/reporting-export-types-pdf-common';
 import { createMockConfigSchema } from '@kbn/reporting-mocks-server';
 
@@ -91,9 +96,11 @@ describe('Handle request to generate', () => {
     mockContext = getMockContext();
     mockContext.reporting = Promise.resolve({} as ReportingSetup);
 
+    const mockUser = securityServiceMock.createMockAuthenticatedUser({ username: 'testymcgee' });
+
     requestHandler = new RequestHandler(
       reportingCore,
-      { username: 'testymcgee' },
+      mockUser,
       mockContext,
       '/api/reporting/test/generate/pdf',
       mockRequest,
@@ -114,7 +121,7 @@ describe('Handle request to generate', () => {
           "_seq_no": undefined,
           "attempts": 0,
           "completed_at": undefined,
-          "created_by": "testymcgee",
+          "created_by": "testymcgee:native:native1",
           "error": undefined,
           "execution_time_ms": undefined,
           "jobtype": "printable_pdf_v2",

--- a/x-pack/plugins/reporting/server/routes/common/generate/request_handler.ts
+++ b/x-pack/plugins/reporting/server/routes/common/generate/request_handler.ts
@@ -25,6 +25,7 @@ import type {
   ReportingRequestHandlerContext,
   ReportingUser,
 } from '../../../types';
+import { getUserTriple } from '../get_user';
 
 export const handleUnavailable = (res: KibanaResponseFactory) => {
   return res.custom({ statusCode: 503, body: 'Not Available' });
@@ -99,7 +100,7 @@ export class RequestHandler {
     const report = await store.addReport(
       new Report({
         jobtype: exportType.jobType,
-        created_by: user ? user.username : false,
+        created_by: user ? getUserTriple(user) : false,
         payload,
         migration_version: jobParams.version,
         meta: {

--- a/x-pack/plugins/reporting/server/routes/common/get_user.ts
+++ b/x-pack/plugins/reporting/server/routes/common/get_user.ts
@@ -6,7 +6,32 @@
  */
 
 import { KibanaRequest, SecurityServiceStart } from '@kbn/core/server';
+import { ReportingUser } from '../../types';
 
+/**
+ * Returns an AuthenticatedUser object, or `false` in the case where Security is disabled
+ */
 export function getUser(request: KibanaRequest, securityService: SecurityServiceStart) {
   return securityService.authc.getCurrentUser(request) ?? false;
+}
+
+/**
+ * Pre 9.0, reports are associated with the user by the username field
+ */
+export function getUsername(user: ReportingUser) {
+  return user ? user.username : false;
+}
+
+/**
+ * In 9.0 and higher, reports are associated with the user using a triple that uniquely identifies the user
+ */
+export function getUserTriple(user: ReportingUser) {
+  if (user) {
+    return [
+      user.username, // can not use user.profile_uid as sometimes it is undefined
+      user.authentication_realm.type,
+      user.authentication_realm.name,
+    ].join(':');
+  }
+  return false;
 }

--- a/x-pack/plugins/reporting/server/routes/common/jobs/job_management_pre_routing.test.ts
+++ b/x-pack/plugins/reporting/server/routes/common/jobs/job_management_pre_routing.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { httpServerMock } from '@kbn/core/server/mocks';
+import { httpServerMock, securityServiceMock } from '@kbn/core/server/mocks';
 import { createMockConfigSchema } from '@kbn/reporting-mocks-server';
 import { ReportingCore } from '../../..';
 import { ReportingInternalSetup, ReportingInternalStart } from '../../../core';
@@ -30,7 +30,11 @@ const mockCounters = {
   usageCounter: jest.fn(),
   errorCounter: jest.fn(),
 };
-const mockUser = { username: 'joeuser' };
+const mockUser = securityServiceMock.createMockAuthenticatedUser({
+  roles: ['superuser'],
+  profile_uid: 'tom-riddle',
+  username: 'Tom Riddle',
+});
 const options = { isInternal: false };
 
 beforeEach(async () => {
@@ -42,7 +46,7 @@ beforeEach(async () => {
     {
       securityService: {
         authc: {
-          getCurrentUser: () => ({ id: '123', roles: ['superuser'], username: 'Tom Riddle' }),
+          getCurrentUser: () => mockUser,
         },
       },
     },

--- a/x-pack/plugins/reporting/server/routes/internal/generate/integration_tests/generation_from_jobparams.test.ts
+++ b/x-pack/plugins/reporting/server/routes/internal/generate/integration_tests/generation_from_jobparams.test.ts
@@ -10,7 +10,7 @@ import { BehaviorSubject } from 'rxjs';
 import supertest from 'supertest';
 
 import { setupServer } from '@kbn/core-test-helpers-test-utils';
-import { coreMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { coreMock, loggingSystemMock, securityServiceMock } from '@kbn/core/server/mocks';
 import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
 import { INTERNAL_ROUTES } from '@kbn/reporting-common';
 import { PdfExportType } from '@kbn/reporting-export-types-pdf';
@@ -79,7 +79,12 @@ describe(`POST ${INTERNAL_ROUTES.GENERATE_PREFIX}`, () => {
         },
         securityService: {
           authc: {
-            getCurrentUser: () => ({ id: '123', roles: ['superuser'], username: 'Tom Riddle' }),
+            getCurrentUser: () =>
+              securityServiceMock.createMockAuthenticatedUser({
+                roles: ['superuser'],
+                profile_uid: 'tom-riddle',
+                username: 'Tom Riddle',
+              }),
           },
         },
       },
@@ -212,7 +217,7 @@ describe(`POST ${INTERNAL_ROUTES.GENERATE_PREFIX}`, () => {
         expect(body).toMatchObject({
           job: {
             attempts: 0,
-            created_by: 'Tom Riddle',
+            created_by: 'Tom Riddle:native:native1',
             id: 'foo',
             index: 'foo-index',
             jobtype: 'printable_pdf_v2',

--- a/x-pack/plugins/reporting/server/routes/internal/management/integration_tests/jobs.test.ts
+++ b/x-pack/plugins/reporting/server/routes/internal/management/integration_tests/jobs.test.ts
@@ -15,7 +15,7 @@ jest.mock('../../../../lib/content_stream', () => ({
 
 import { estypes } from '@elastic/elasticsearch';
 import { setupServer } from '@kbn/core-test-helpers-test-utils';
-import { ElasticsearchClientMock, coreMock } from '@kbn/core/server/mocks';
+import { ElasticsearchClientMock, coreMock, securityServiceMock } from '@kbn/core/server/mocks';
 import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
 import { INTERNAL_ROUTES } from '@kbn/reporting-common';
 import { createMockConfigSchema } from '@kbn/reporting-mocks-server';
@@ -101,7 +101,12 @@ describe(`Reporting Job Management Routes: Internal`, () => {
         },
         securityService: {
           authc: {
-            getCurrentUser: () => ({ id: '123', roles: ['superuser'], username: 'Tom Riddle' }),
+            getCurrentUser: () =>
+              securityServiceMock.createMockAuthenticatedUser({
+                roles: ['superuser'],
+                profile_uid: 'tom-riddle',
+                username: 'Tom Riddle',
+              }),
           },
         },
       },

--- a/x-pack/plugins/reporting/server/routes/public/integration_tests/generation_from_jobparams.test.ts
+++ b/x-pack/plugins/reporting/server/routes/public/integration_tests/generation_from_jobparams.test.ts
@@ -10,7 +10,7 @@ import { BehaviorSubject } from 'rxjs';
 import supertest from 'supertest';
 
 import { setupServer } from '@kbn/core-test-helpers-test-utils';
-import { coreMock, loggingSystemMock } from '@kbn/core/server/mocks';
+import { coreMock, loggingSystemMock, securityServiceMock } from '@kbn/core/server/mocks';
 import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
 import { PUBLIC_ROUTES } from '@kbn/reporting-common';
 import { PdfExportType } from '@kbn/reporting-export-types-pdf';
@@ -78,7 +78,12 @@ describe(`POST ${PUBLIC_ROUTES.GENERATE_PREFIX}`, () => {
         },
         securityService: {
           authc: {
-            getCurrentUser: () => ({ id: '123', roles: ['superuser'], username: 'Tom Riddle' }),
+            getCurrentUser: () =>
+              securityServiceMock.createMockAuthenticatedUser({
+                roles: ['superuser'],
+                profile_uid: 'tom-riddle',
+                username: 'Tom Riddle',
+              }),
           },
         },
       },
@@ -211,7 +216,7 @@ describe(`POST ${PUBLIC_ROUTES.GENERATE_PREFIX}`, () => {
         expect(body).toMatchObject({
           job: {
             attempts: 0,
-            created_by: 'Tom Riddle',
+            created_by: 'Tom Riddle:native:native1',
             id: 'foo',
             index: 'foo-index',
             jobtype: 'printable_pdf_v2',
@@ -252,7 +257,7 @@ describe(`POST ${PUBLIC_ROUTES.GENERATE_PREFIX}`, () => {
         expect(body).toMatchObject({
           job: {
             attempts: 0,
-            created_by: 'Tom Riddle',
+            created_by: 'Tom Riddle:native:native1',
             id: 'foo',
             index: 'foo-index',
             jobtype: 'printable_pdf',

--- a/x-pack/plugins/reporting/server/routes/public/integration_tests/jobs.test.ts
+++ b/x-pack/plugins/reporting/server/routes/public/integration_tests/jobs.test.ts
@@ -15,7 +15,11 @@ import supertest from 'supertest';
 
 import { estypes } from '@elastic/elasticsearch';
 import { setupServer } from '@kbn/core-test-helpers-test-utils';
-import { coreMock, type ElasticsearchClientMock } from '@kbn/core/server/mocks';
+import {
+  coreMock,
+  securityServiceMock,
+  type ElasticsearchClientMock,
+} from '@kbn/core/server/mocks';
 import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
 import { PUBLIC_ROUTES } from '@kbn/reporting-common';
 import { ExportTypesRegistry } from '@kbn/reporting-server/export_types_registry';
@@ -97,7 +101,12 @@ describe(`Reporting Job Management Routes: Public`, () => {
         },
         securityService: {
           authc: {
-            getCurrentUser: () => ({ id: '123', roles: ['superuser'], username: 'Tom Riddle' }),
+            getCurrentUser: () =>
+              securityServiceMock.createMockAuthenticatedUser({
+                roles: ['superuser'],
+                profile_uid: 'tom-riddle',
+                username: 'Tom Riddle',
+              }),
           },
         },
       },

--- a/x-pack/plugins/reporting/server/types.ts
+++ b/x-pack/plugins/reporting/server/types.ts
@@ -47,7 +47,7 @@ export interface ReportingSetup {
  * Plugin Start Contract
  */
 export type ReportingStart = ReportingSetup;
-export type ReportingUser = { username: AuthenticatedUser['username'] } | false;
+export type ReportingUser = AuthenticatedUser | false;
 
 export type ScrollConfig = ReportingConfigType['csv']['scroll'];
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/dev/issues/2891

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Users might lose access to older reports | Low | High | Integration tests will verify that users will be able to view older reports alongside new reports. |
| Users might gain access to reports belonging to another user | Medium | High | Integration tests will verify that all users can see their own reports, but not the reports of other users. |

