### PR TITLE
[Security Solution] Give entity store permissions to built-in and cloud roles

### DIFF
--- a/packages/kbn-es/src/serverless_resources/project_roles/security/roles.yml
+++ b/packages/kbn-es/src/serverless_resources/project_roles/security/roles.yml
@@ -35,6 +35,7 @@ viewer:
         - '.fleet-actions*'
         - 'risk-score.risk-score-*'
         - '.asset-criticality.asset-criticality-*'
+        - '.entities.v1.latest.security_*'
         - '.ml-anomalies-*'
       privileges:
         - read
@@ -99,6 +100,7 @@ editor:
         - 'maintenance'
     - names:
         - '.asset-criticality.asset-criticality-*'
+        - '.entities.v1.latest.security_*'
       privileges:
         - 'read'
         - 'write'
@@ -162,6 +164,7 @@ t1_analyst:
         - '.fleet-actions*'
         - risk-score.risk-score-*
         - .asset-criticality.asset-criticality-*
+        - .entities.v1.latest.security_*
         - '.ml-anomalies-*'
       privileges:
         - read
@@ -211,6 +214,7 @@ t2_analyst:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - '.ml-anomalies-*'
       privileges:
         - read
@@ -274,6 +278,7 @@ t3_analyst:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - '.ml-anomalies-*'
       privileges:
         - read
@@ -346,6 +351,7 @@ threat_intelligence_analyst:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - '.ml-anomalies-*'
       privileges:
         - read
@@ -406,6 +412,7 @@ rule_author:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - '.ml-anomalies-*'
       privileges:
         - read
@@ -472,6 +479,7 @@ soc_manager:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - '.ml-anomalies-*'
       privileges:
         - read
@@ -543,6 +551,7 @@ detections_admin:
         - all
     - names:
         - .asset-criticality.asset-criticality-*
+        - .entities.v1.latest.security_*
       privileges:
         - read
         - write
@@ -590,6 +599,7 @@ platform_engineer:
         - all
     - names:
         - .asset-criticality.asset-criticality-*
+        - .entities.v1.latest.security_*
       privileges:
         - read
         - write
@@ -648,6 +658,7 @@ endpoint_operations_analyst:
         - .lists*
         - .items*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - '.ml-anomalies-*'
       privileges:
         - read
@@ -717,6 +728,7 @@ endpoint_policy_manager:
         - winlogbeat-*
         - logstash-*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
       privileges:
         - read
     - names:

--- a/packages/kbn-es/src/serverless_resources/security_roles.json
+++ b/packages/kbn-es/src/serverless_resources/security_roles.json
@@ -120,7 +120,12 @@
           "privileges": ["read", "write"]
         },
         {
-          "names": ["metrics-endpoint.metadata_current_*", ".fleet-agents*", ".fleet-actions*", "risk-score.risk-score-*"],
+          "names": [
+            "metrics-endpoint.metadata_current_*",
+            ".fleet-agents*", ".fleet-actions*",
+            "risk-score.risk-score-*",
+            ".entities.v1.latest.security_*"
+          ],
           "privileges": ["read"]
         }
       ],

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/serverless/es_serverless_resources/roles.yml
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/serverless/es_serverless_resources/roles.yml
@@ -25,19 +25,19 @@ viewer:
   cluster: []
   indices:
     - names:
-        - ".siem-signals*"
-        - ".lists-*"
-        - ".items-*"
+        - '.siem-signals*'
+        - '.lists-*'
+        - '.items-*'
       privileges:
-        - "read"
-        - "view_index_metadata"
+        - 'read'
+        - 'view_index_metadata'
       allow_restricted_indices: false
     - names:
-        - ".alerts*"
-        - ".preview.alerts*"
+        - '.alerts*'
+        - '.preview.alerts*'
       privileges:
-        - "read"
-        - "view_index_metadata"
+        - 'read'
+        - 'view_index_metadata'
       allow_restricted_indices: false
     - names:
         - apm-*-transaction*
@@ -49,15 +49,16 @@ viewer:
         - packetbeat-*
         - winlogbeat-*
         - metrics-endpoint.metadata_current_*
-        - ".fleet-agents*"
-        - ".fleet-actions*"
-        - "risk-score.risk-score-*"
-        - ".asset-criticality.asset-criticality-*"
-        - ".ml-anomalies-*"
+        - '.fleet-agents*'
+        - '.fleet-actions*'
+        - 'risk-score.risk-score-*'
+        - '.asset-criticality.asset-criticality-*'
+        - '.entities.v1.latest.security_*'
+        - '.ml-anomalies-*'
       privileges:
         - read
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.read
         - feature_siem.read
@@ -75,7 +76,7 @@ viewer:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'
   run_as: []
 
 # modeled after t3_analyst
@@ -83,14 +84,14 @@ editor:
   cluster: []
   indices:
     - names:
-        - ".siem-signals*"
-        - ".lists-*"
-        - ".items-*"
+        - '.siem-signals*'
+        - '.lists-*'
+        - '.items-*'
       privileges:
-        - "read"
-        - "view_index_metadata"
-        - "write"
-        - "maintenance"
+        - 'read'
+        - 'view_index_metadata'
+        - 'write'
+        - 'maintenance'
       allow_restricted_indices: false
     - names:
         - apm-*-transaction*
@@ -105,28 +106,29 @@ editor:
         - read
         - write
     - names:
-        - ".internal.alerts*"
-        - ".alerts*"
-        - ".internal.preview.alerts*"
-        - ".preview.alerts*"
-        - "risk-score.risk-score-*"
+        - '.internal.alerts*'
+        - '.alerts*'
+        - '.internal.preview.alerts*'
+        - '.preview.alerts*'
+        - 'risk-score.risk-score-*'
       privileges:
-        - "read"
-        - "view_index_metadata"
-        - "write"
-        - "maintenance"
+        - 'read'
+        - 'view_index_metadata'
+        - 'write'
+        - 'maintenance'
     - names:
-        - ".asset-criticality.asset-criticality-*"
+        - '.asset-criticality.asset-criticality-*'
+        - .entities.v1.latest.security_*
       privileges:
-        - "read"
-        - "write"
+        - 'read'
+        - 'write'
       allow_restricted_indices: false
     - names:
-        - ".ml-anomalies-*"
+        - '.ml-anomalies-*'
       privileges:
         - read
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -154,15 +156,15 @@ editor:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'
   run_as: []
 
 t1_analyst:
   cluster:
   indices:
     - names:
-        - ".alerts-security*"
-        - ".siem-signals-*"
+        - '.alerts-security*'
+        - '.siem-signals-*'
       privileges:
         - read
         - write
@@ -177,15 +179,16 @@ t1_analyst:
         - packetbeat-*
         - winlogbeat-*
         - metrics-endpoint.metadata_current_*
-        - ".fleet-agents*"
-        - ".fleet-actions*"
+        - '.fleet-agents*'
+        - '.fleet-actions*'
         - risk-score.risk-score-*
         - .asset-criticality.asset-criticality-*
-        - ".ml-anomalies-*"
+        - .entities.v1.latest.security_*
+        - '.ml-anomalies-*'
       privileges:
         - read
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.read
         - feature_siem.read
@@ -204,7 +207,7 @@ t1_analyst:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'
 
 t2_analyst:
   cluster:
@@ -231,7 +234,8 @@ t2_analyst:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
-        - ".ml-anomalies-*"
+        - .entities.v1.latest.security_*
+        - '.ml-anomalies-*'
       privileges:
         - read
     - names:
@@ -240,7 +244,7 @@ t2_analyst:
         - read
         - write
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.read
         - feature_siem.read
@@ -259,7 +263,7 @@ t2_analyst:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'
 
 t3_analyst:
   cluster:
@@ -295,11 +299,12 @@ t3_analyst:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
-        - ".ml-anomalies-*"
+        - .entities.v1.latest.security_*
+        - '.ml-anomalies-*'
       privileges:
         - read
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -328,7 +333,7 @@ t3_analyst:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'
 
 threat_intelligence_analyst:
   cluster:
@@ -363,11 +368,12 @@ threat_intelligence_analyst:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
-        - ".ml-anomalies-*"
+        - .entities.v1.latest.security_*
+        - '.ml-anomalies-*'
       privileges:
         - read
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -385,7 +391,7 @@ threat_intelligence_analyst:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'
 
 rule_author:
   cluster:
@@ -424,11 +430,12 @@ rule_author:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
-        - ".ml-anomalies-*"
+        - .entities.v1.latest.security_*
+        - '.ml-anomalies-*'
       privileges:
         - read
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -453,7 +460,7 @@ rule_author:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'
 
 soc_manager:
   cluster:
@@ -467,7 +474,7 @@ soc_manager:
         - logs-*
         - packetbeat-*
         - winlogbeat-*
-        - .asset-criticality.asset-criticality-*
+        - .entities.v1.latest.security_*
       privileges:
         - read
         - write
@@ -491,11 +498,12 @@ soc_manager:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
-        - ".ml-anomalies-*"
+        - .asset-criticality.asset-criticality-*
+        - '.ml-anomalies-*'
       privileges:
         - read
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -526,10 +534,10 @@ soc_manager:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'
 
 detections_admin:
-  cluster: ["manage_index_templates", "manage_transform"]
+  cluster: ['manage_index_templates', 'manage_transform']
   indices:
     - names:
         - apm-*-transaction*
@@ -554,7 +562,7 @@ detections_admin:
         - metrics-endpoint.metadata_current_*
         - .fleet-agents*
         - .fleet-actions*
-        - ".ml-anomalies-*"
+        - '.ml-anomalies-*'
       privileges:
         - read
     - names:
@@ -563,11 +571,12 @@ detections_admin:
         - all
     - names:
         - .asset-criticality.asset-criticality-*
+        - .entities.v1.latest.security_*
       privileges:
         - read
         - write
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.all
         - feature_siem.all
@@ -585,7 +594,7 @@ detections_admin:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'
 
 platform_engineer:
   cluster:
@@ -611,15 +620,16 @@ platform_engineer:
         - all
     - names:
         - .asset-criticality.asset-criticality-*
+        - .entities.v1.latest.security_*
       privileges:
         - read
         - write
     - names:
-        - ".ml-anomalies-*"
+        - '.ml-anomalies-*'
       privileges:
         - read
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.all
         - feature_siem.all
@@ -647,7 +657,7 @@ platform_engineer:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'
 
 endpoint_operations_analyst:
   cluster:
@@ -670,7 +680,8 @@ endpoint_operations_analyst:
         - .lists*
         - .items*
         - risk-score.risk-score-*
-        - ".ml-anomalies-*"
+        - .entities.v1.latest.security_*
+        - '.ml-anomalies-*'
       privileges:
         - read
     - names:
@@ -688,7 +699,7 @@ endpoint_operations_analyst:
         - read
         - write
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -719,7 +730,7 @@ endpoint_operations_analyst:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'
 
 endpoint_policy_manager:
   cluster:
@@ -740,7 +751,8 @@ endpoint_policy_manager:
         - packetbeat-*
         - winlogbeat-*
         - risk-score.risk-score-*
-        - ".ml-anomalies-*"
+        - .entities.v1.latest.security_*
+        - '.ml-anomalies-*'
       privileges:
         - read
     - names:
@@ -760,7 +772,7 @@ endpoint_policy_manager:
         - write
         - manage
   applications:
-    - application: "kibana-.kibana"
+    - application: 'kibana-.kibana'
       privileges:
         - feature_ml.all
         - feature_siem.all
@@ -786,4 +798,4 @@ endpoint_policy_manager:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: "*"
+      resources: '*'

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/serverless/es_serverless_resources/roles.yml
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/serverless/es_serverless_resources/roles.yml
@@ -25,19 +25,19 @@ viewer:
   cluster: []
   indices:
     - names:
-        - '.siem-signals*'
-        - '.lists-*'
-        - '.items-*'
+        - ".siem-signals*"
+        - ".lists-*"
+        - ".items-*"
       privileges:
-        - 'read'
-        - 'view_index_metadata'
+        - "read"
+        - "view_index_metadata"
       allow_restricted_indices: false
     - names:
-        - '.alerts*'
-        - '.preview.alerts*'
+        - ".alerts*"
+        - ".preview.alerts*"
       privileges:
-        - 'read'
-        - 'view_index_metadata'
+        - "read"
+        - "view_index_metadata"
       allow_restricted_indices: false
     - names:
         - apm-*-transaction*
@@ -49,16 +49,16 @@ viewer:
         - packetbeat-*
         - winlogbeat-*
         - metrics-endpoint.metadata_current_*
-        - '.fleet-agents*'
-        - '.fleet-actions*'
-        - 'risk-score.risk-score-*'
-        - '.asset-criticality.asset-criticality-*'
-        - '.entities.v1.latest.security_*'
-        - '.ml-anomalies-*'
+        - ".fleet-agents*"
+        - ".fleet-actions*"
+        - "risk-score.risk-score-*"
+        - ".asset-criticality.asset-criticality-*"
+        - ".entities.v1.latest.security_*"
+        - ".ml-anomalies-*"
       privileges:
         - read
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.read
         - feature_siem.read
@@ -76,7 +76,7 @@ viewer:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"
   run_as: []
 
 # modeled after t3_analyst
@@ -84,14 +84,14 @@ editor:
   cluster: []
   indices:
     - names:
-        - '.siem-signals*'
-        - '.lists-*'
-        - '.items-*'
+        - ".siem-signals*"
+        - ".lists-*"
+        - ".items-*"
       privileges:
-        - 'read'
-        - 'view_index_metadata'
-        - 'write'
-        - 'maintenance'
+        - "read"
+        - "view_index_metadata"
+        - "write"
+        - "maintenance"
       allow_restricted_indices: false
     - names:
         - apm-*-transaction*
@@ -106,29 +106,29 @@ editor:
         - read
         - write
     - names:
-        - '.internal.alerts*'
-        - '.alerts*'
-        - '.internal.preview.alerts*'
-        - '.preview.alerts*'
-        - 'risk-score.risk-score-*'
+        - ".internal.alerts*"
+        - ".alerts*"
+        - ".internal.preview.alerts*"
+        - ".preview.alerts*"
+        - "risk-score.risk-score-*"
       privileges:
-        - 'read'
-        - 'view_index_metadata'
-        - 'write'
-        - 'maintenance'
+        - "read"
+        - "view_index_metadata"
+        - "write"
+        - "maintenance"
     - names:
-        - '.asset-criticality.asset-criticality-*'
+        - ".asset-criticality.asset-criticality-*"
         - .entities.v1.latest.security_*
       privileges:
-        - 'read'
-        - 'write'
+        - "read"
+        - "write"
       allow_restricted_indices: false
     - names:
-        - '.ml-anomalies-*'
+        - ".ml-anomalies-*"
       privileges:
         - read
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -156,15 +156,15 @@ editor:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"
   run_as: []
 
 t1_analyst:
   cluster:
   indices:
     - names:
-        - '.alerts-security*'
-        - '.siem-signals-*'
+        - ".alerts-security*"
+        - ".siem-signals-*"
       privileges:
         - read
         - write
@@ -179,16 +179,16 @@ t1_analyst:
         - packetbeat-*
         - winlogbeat-*
         - metrics-endpoint.metadata_current_*
-        - '.fleet-agents*'
-        - '.fleet-actions*'
+        - ".fleet-agents*"
+        - ".fleet-actions*"
         - risk-score.risk-score-*
         - .asset-criticality.asset-criticality-*
         - .entities.v1.latest.security_*
-        - '.ml-anomalies-*'
+        - ".ml-anomalies-*"
       privileges:
         - read
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.read
         - feature_siem.read
@@ -207,7 +207,7 @@ t1_analyst:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"
 
 t2_analyst:
   cluster:
@@ -235,7 +235,7 @@ t2_analyst:
         - .fleet-actions*
         - risk-score.risk-score-*
         - .entities.v1.latest.security_*
-        - '.ml-anomalies-*'
+        - ".ml-anomalies-*"
       privileges:
         - read
     - names:
@@ -244,7 +244,7 @@ t2_analyst:
         - read
         - write
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.read
         - feature_siem.read
@@ -263,7 +263,7 @@ t2_analyst:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"
 
 t3_analyst:
   cluster:
@@ -300,11 +300,11 @@ t3_analyst:
         - .fleet-actions*
         - risk-score.risk-score-*
         - .entities.v1.latest.security_*
-        - '.ml-anomalies-*'
+        - ".ml-anomalies-*"
       privileges:
         - read
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -333,7 +333,7 @@ t3_analyst:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"
 
 threat_intelligence_analyst:
   cluster:
@@ -369,11 +369,11 @@ threat_intelligence_analyst:
         - .fleet-actions*
         - risk-score.risk-score-*
         - .entities.v1.latest.security_*
-        - '.ml-anomalies-*'
+        - ".ml-anomalies-*"
       privileges:
         - read
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -391,7 +391,7 @@ threat_intelligence_analyst:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"
 
 rule_author:
   cluster:
@@ -431,11 +431,11 @@ rule_author:
         - .fleet-actions*
         - risk-score.risk-score-*
         - .entities.v1.latest.security_*
-        - '.ml-anomalies-*'
+        - ".ml-anomalies-*"
       privileges:
         - read
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -460,7 +460,7 @@ rule_author:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"
 
 soc_manager:
   cluster:
@@ -474,6 +474,7 @@ soc_manager:
         - logs-*
         - packetbeat-*
         - winlogbeat-*
+        - .asset-criticality.asset-criticality-*
         - .entities.v1.latest.security_*
       privileges:
         - read
@@ -499,11 +500,11 @@ soc_manager:
         - .fleet-actions*
         - risk-score.risk-score-*
         - .asset-criticality.asset-criticality-*
-        - '.ml-anomalies-*'
+        - ".ml-anomalies-*"
       privileges:
         - read
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -534,10 +535,10 @@ soc_manager:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"
 
 detections_admin:
-  cluster: ['manage_index_templates', 'manage_transform']
+  cluster: ["manage_index_templates", "manage_transform"]
   indices:
     - names:
         - apm-*-transaction*
@@ -562,7 +563,7 @@ detections_admin:
         - metrics-endpoint.metadata_current_*
         - .fleet-agents*
         - .fleet-actions*
-        - '.ml-anomalies-*'
+        - ".ml-anomalies-*"
       privileges:
         - read
     - names:
@@ -576,7 +577,7 @@ detections_admin:
         - read
         - write
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.all
         - feature_siem.all
@@ -594,7 +595,7 @@ detections_admin:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"
 
 platform_engineer:
   cluster:
@@ -625,11 +626,11 @@ platform_engineer:
         - read
         - write
     - names:
-        - '.ml-anomalies-*'
+        - ".ml-anomalies-*"
       privileges:
         - read
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.all
         - feature_siem.all
@@ -657,7 +658,7 @@ platform_engineer:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"
 
 endpoint_operations_analyst:
   cluster:
@@ -681,7 +682,7 @@ endpoint_operations_analyst:
         - .items*
         - risk-score.risk-score-*
         - .entities.v1.latest.security_*
-        - '.ml-anomalies-*'
+        - ".ml-anomalies-*"
       privileges:
         - read
     - names:
@@ -699,7 +700,7 @@ endpoint_operations_analyst:
         - read
         - write
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.read
         - feature_siem.all
@@ -730,7 +731,7 @@ endpoint_operations_analyst:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"
 
 endpoint_policy_manager:
   cluster:
@@ -752,7 +753,7 @@ endpoint_policy_manager:
         - winlogbeat-*
         - risk-score.risk-score-*
         - .entities.v1.latest.security_*
-        - '.ml-anomalies-*'
+        - ".ml-anomalies-*"
       privileges:
         - read
     - names:
@@ -772,7 +773,7 @@ endpoint_policy_manager:
         - write
         - manage
   applications:
-    - application: 'kibana-.kibana'
+    - application: "kibana-.kibana"
       privileges:
         - feature_ml.all
         - feature_siem.all
@@ -798,4 +799,4 @@ endpoint_policy_manager:
         - feature_graph.all
         - feature_maps.all
         - feature_visualize.all
-      resources: '*'
+      resources: "*"

--- a/x-pack/test_serverless/shared/lib/security/kibana_roles/project_controller_security_roles.yml
+++ b/x-pack/test_serverless/shared/lib/security/kibana_roles/project_controller_security_roles.yml
@@ -34,6 +34,7 @@ viewer:
         - ".fleet-actions*"
         - "risk-score.risk-score-*"
         - ".asset-criticality.asset-criticality-*"
+        - ".entities.v1.latest.security_*"
         - ".ml-anomalies-*"
       privileges:
         - read
@@ -98,6 +99,7 @@ editor:
         - "maintenance"
     - names:
         - ".asset-criticality.asset-criticality-*"
+        - ".entities.v1.latest.security_*"
       privileges:
         - "read"
         - "write"
@@ -162,6 +164,7 @@ t1_analyst:
         - ".fleet-actions*"
         - risk-score.risk-score-*
         - .asset-criticality.asset-criticality-*
+        - .entities.v1.latest.security_*
         - ".ml-anomalies-*"
       privileges:
         - read
@@ -212,6 +215,7 @@ t2_analyst:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - ".ml-anomalies-*"
       privileges:
         - read
@@ -276,6 +280,7 @@ t3_analyst:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - ".ml-anomalies-*"
       privileges:
         - read
@@ -344,6 +349,7 @@ threat_intelligence_analyst:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - ".ml-anomalies-*"
       privileges:
         - read
@@ -405,6 +411,7 @@ rule_author:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - ".ml-anomalies-*"
       privileges:
         - read
@@ -448,7 +455,7 @@ soc_manager:
         - logs-*
         - packetbeat-*
         - winlogbeat-*
-        - .asset-criticality.asset-criticality-*
+        - .entities.v1.latest.security_*
       privileges:
         - read
         - write
@@ -472,6 +479,7 @@ soc_manager:
         - .fleet-agents*
         - .fleet-actions*
         - risk-score.risk-score-*
+        - .asset-criticality.asset-criticality-*
         - ".ml-anomalies-*"
       privileges:
         - read
@@ -544,6 +552,7 @@ detections_admin:
         - all
     - names:
         - .asset-criticality.asset-criticality-*
+        - .entities.v1.latest.security_*
       privileges:
         - read
         - write
@@ -592,6 +601,7 @@ platform_engineer:
         - all
     - names:
         - .asset-criticality.asset-criticality-*
+        - .entities.v1.latest.security_*
       privileges:
         - read
         - write
@@ -651,6 +661,7 @@ endpoint_operations_analyst:
         - .lists*
         - .items*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - ".ml-anomalies-*"
       privileges:
         - read
@@ -721,6 +732,7 @@ endpoint_policy_manager:
         - packetbeat-*
         - winlogbeat-*
         - risk-score.risk-score-*
+        - .entities.v1.latest.security_*
         - ".ml-anomalies-*"
       privileges:
         - read

--- a/x-pack/test_serverless/shared/lib/security/kibana_roles/project_controller_security_roles.yml
+++ b/x-pack/test_serverless/shared/lib/security/kibana_roles/project_controller_security_roles.yml
@@ -455,6 +455,7 @@ soc_manager:
         - logs-*
         - packetbeat-*
         - winlogbeat-*
+        - .asset-criticality.asset-criticality-*
         - .entities.v1.latest.security_*
       privileges:
         - read


### PR DESCRIPTION
## Summary

Give entity store permissions to built-in and cloud roles.
The entity store should be available where the RiskEngine is.

ES controller PR https://github.com/elastic/elasticsearch-controller/pull/753


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->