### PR TITLE
[OAS] Move `deprecated` option on existing fleet routes

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -6409,6 +6409,7 @@
     },
     "/api/fleet/agent-status": {
       "get": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fagent-status#0",
         "parameters": [
           {
@@ -17478,6 +17479,7 @@
         ]
       },
       "put": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fagents%2F%7BagentId%7D%2Freassign#0",
         "parameters": [
           {
@@ -18223,6 +18225,7 @@
         "tags": []
       },
       "post": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fenrollment-api-keys#1",
         "parameters": [
           {
@@ -25047,6 +25050,7 @@
     },
     "/api/fleet/epm/packages/{pkgkey}": {
       "delete": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#3",
         "parameters": [
           {
@@ -25104,6 +25108,7 @@
         "tags": []
       },
       "get": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#0",
         "parameters": [
           {
@@ -25165,6 +25170,7 @@
         "tags": []
       },
       "post": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#2",
         "parameters": [
           {
@@ -25248,6 +25254,7 @@
         "tags": []
       },
       "put": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#1",
         "parameters": [
           {
@@ -40462,6 +40469,7 @@
     },
     "/api/fleet/service-tokens": {
       "post": {
+        "deprecated": true,
         "description": "Create a service token",
         "operationId": "%2Fapi%2Ffleet%2Fservice-tokens#0",
         "parameters": [

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -6409,6 +6409,7 @@
     },
     "/api/fleet/agent-status": {
       "get": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fagent-status#0",
         "parameters": [
           {
@@ -17478,6 +17479,7 @@
         ]
       },
       "put": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fagents%2F%7BagentId%7D%2Freassign#0",
         "parameters": [
           {
@@ -18223,6 +18225,7 @@
         "tags": []
       },
       "post": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fenrollment-api-keys#1",
         "parameters": [
           {
@@ -25047,6 +25050,7 @@
     },
     "/api/fleet/epm/packages/{pkgkey}": {
       "delete": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#3",
         "parameters": [
           {
@@ -25104,6 +25108,7 @@
         "tags": []
       },
       "get": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#0",
         "parameters": [
           {
@@ -25165,6 +25170,7 @@
         "tags": []
       },
       "post": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#2",
         "parameters": [
           {
@@ -25248,6 +25254,7 @@
         "tags": []
       },
       "put": {
+        "deprecated": true,
         "operationId": "%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#1",
         "parameters": [
           {
@@ -40462,6 +40469,7 @@
     },
     "/api/fleet/service-tokens": {
       "post": {
+        "deprecated": true,
         "description": "Create a service token",
         "operationId": "%2Fapi%2Ffleet%2Fservice-tokens#0",
         "parameters": [

--- a/oas_docs/output/kibana.serverless.staging.yaml
+++ b/oas_docs/output/kibana.serverless.staging.yaml
@@ -15066,6 +15066,7 @@ paths:
         - Elastic Agents
   /api/fleet/agent-status:
     get:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fagent-status#0'
       parameters:
         - description: The version of the API to use
@@ -16768,6 +16769,7 @@ paths:
       tags:
         - Elastic Agent actions
     put:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fagents%2F%7BagentId%7D%2Freassign#0'
       parameters:
         - description: The version of the API to use
@@ -18651,6 +18653,7 @@ paths:
       summary: ''
       tags: []
     post:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fenrollment-api-keys#1'
       parameters:
         - description: The version of the API to use
@@ -20428,6 +20431,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgkey}:
     delete:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#3'
       parameters:
         - description: The version of the API to use
@@ -20466,6 +20470,7 @@ paths:
       summary: ''
       tags: []
     get:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#0'
       parameters:
         - description: The version of the API to use
@@ -20506,6 +20511,7 @@ paths:
       summary: ''
       tags: []
     post:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#2'
       parameters:
         - description: The version of the API to use
@@ -20561,6 +20567,7 @@ paths:
       summary: ''
       tags: []
     put:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#1'
       parameters:
         - description: The version of the API to use
@@ -33523,6 +33530,7 @@ paths:
         - Fleet service tokens
   /api/fleet/service-tokens:
     post:
+      deprecated: true
       description: Create a service token
       operationId: '%2Fapi%2Ffleet%2Fservice-tokens#0'
       parameters:

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -15066,6 +15066,7 @@ paths:
         - Elastic Agents
   /api/fleet/agent-status:
     get:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fagent-status#0'
       parameters:
         - description: The version of the API to use
@@ -16768,6 +16769,7 @@ paths:
       tags:
         - Elastic Agent actions
     put:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fagents%2F%7BagentId%7D%2Freassign#0'
       parameters:
         - description: The version of the API to use
@@ -18651,6 +18653,7 @@ paths:
       summary: ''
       tags: []
     post:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fenrollment-api-keys#1'
       parameters:
         - description: The version of the API to use
@@ -20428,6 +20431,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgkey}:
     delete:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#3'
       parameters:
         - description: The version of the API to use
@@ -20466,6 +20470,7 @@ paths:
       summary: ''
       tags: []
     get:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#0'
       parameters:
         - description: The version of the API to use
@@ -20506,6 +20511,7 @@ paths:
       summary: ''
       tags: []
     post:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#2'
       parameters:
         - description: The version of the API to use
@@ -20561,6 +20567,7 @@ paths:
       summary: ''
       tags: []
     put:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#1'
       parameters:
         - description: The version of the API to use
@@ -33523,6 +33530,7 @@ paths:
         - Fleet service tokens
   /api/fleet/service-tokens:
     post:
+      deprecated: true
       description: Create a service token
       operationId: '%2Fapi%2Ffleet%2Fservice-tokens#0'
       parameters:

--- a/oas_docs/output/kibana.staging.yaml
+++ b/oas_docs/output/kibana.staging.yaml
@@ -18495,6 +18495,7 @@ paths:
         - Elastic Agents
   /api/fleet/agent-status:
     get:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fagent-status#0'
       parameters:
         - description: The version of the API to use
@@ -20197,6 +20198,7 @@ paths:
       tags:
         - Elastic Agent actions
     put:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fagents%2F%7BagentId%7D%2Freassign#0'
       parameters:
         - description: The version of the API to use
@@ -22080,6 +22082,7 @@ paths:
       summary: ''
       tags: []
     post:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fenrollment-api-keys#1'
       parameters:
         - description: The version of the API to use
@@ -23857,6 +23860,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgkey}:
     delete:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#3'
       parameters:
         - description: The version of the API to use
@@ -23895,6 +23899,7 @@ paths:
       summary: ''
       tags: []
     get:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#0'
       parameters:
         - description: The version of the API to use
@@ -23935,6 +23940,7 @@ paths:
       summary: ''
       tags: []
     post:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#2'
       parameters:
         - description: The version of the API to use
@@ -23990,6 +23996,7 @@ paths:
       summary: ''
       tags: []
     put:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#1'
       parameters:
         - description: The version of the API to use
@@ -36952,6 +36959,7 @@ paths:
         - Fleet service tokens
   /api/fleet/service-tokens:
     post:
+      deprecated: true
       description: Create a service token
       operationId: '%2Fapi%2Ffleet%2Fservice-tokens#0'
       parameters:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -18495,6 +18495,7 @@ paths:
         - Elastic Agents
   /api/fleet/agent-status:
     get:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fagent-status#0'
       parameters:
         - description: The version of the API to use
@@ -20197,6 +20198,7 @@ paths:
       tags:
         - Elastic Agent actions
     put:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fagents%2F%7BagentId%7D%2Freassign#0'
       parameters:
         - description: The version of the API to use
@@ -22080,6 +22082,7 @@ paths:
       summary: ''
       tags: []
     post:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fenrollment-api-keys#1'
       parameters:
         - description: The version of the API to use
@@ -23857,6 +23860,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgkey}:
     delete:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#3'
       parameters:
         - description: The version of the API to use
@@ -23895,6 +23899,7 @@ paths:
       summary: ''
       tags: []
     get:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#0'
       parameters:
         - description: The version of the API to use
@@ -23935,6 +23940,7 @@ paths:
       summary: ''
       tags: []
     post:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#2'
       parameters:
         - description: The version of the API to use
@@ -23990,6 +23996,7 @@ paths:
       summary: ''
       tags: []
     put:
+      deprecated: true
       operationId: '%2Fapi%2Ffleet%2Fepm%2Fpackages%2F%7Bpkgkey%7D#1'
       parameters:
         - description: The version of the API to use
@@ -36952,6 +36959,7 @@ paths:
         - Fleet service tokens
   /api/fleet/service-tokens:
     post:
+      deprecated: true
       description: Create a service token
       operationId: '%2Fapi%2Ffleet%2Fservice-tokens#0'
       parameters:

--- a/x-pack/plugins/fleet/server/routes/agent/index.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/index.ts
@@ -107,6 +107,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetOneAgentRequestSchema,
           response: {
@@ -137,6 +143,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: UpdateAgentRequestSchema,
           response: {
@@ -167,6 +179,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostBulkUpdateAgentTagsRequestSchema,
           response: {
@@ -197,6 +215,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: DeleteAgentRequestSchema,
           response: {
@@ -228,6 +252,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetAgentsRequestSchema,
           response: {
@@ -258,6 +288,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetTagsRequestSchema,
           response: {
@@ -288,6 +324,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostNewAgentActionRequestSchema,
           response: {
@@ -322,6 +364,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostCancelActionRequestSchema,
           response: {
@@ -357,6 +405,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostRetrieveAgentsByActionsRequestSchema,
           response: {
@@ -386,6 +440,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: { request: PostAgentUnenrollRequestSchema, response: {} },
       },
       postAgentUnenrollHandler
@@ -397,13 +457,21 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
-      deprecated: true,
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: { request: PutAgentReassignRequestSchemaDeprecated },
+        options: {
+          // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
+          deprecated: true,
+        },
       },
       putAgentsReassignHandlerDeprecated
     );
@@ -422,6 +490,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostAgentReassignRequestSchema,
           response: {
@@ -451,6 +525,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostRequestDiagnosticsActionRequestSchema,
           response: {
@@ -480,6 +560,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostBulkRequestDiagnosticsActionRequestSchema,
           response: {
@@ -509,6 +595,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: ListAgentUploadsRequestSchema,
           response: {
@@ -538,6 +630,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetAgentUploadFileRequestSchema,
           response: {
@@ -567,6 +665,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: DeleteAgentUploadFileRequestSchema,
           response: {
@@ -599,6 +703,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetAgentStatusRequestSchema,
           response: {
@@ -619,13 +729,21 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
-      deprecated: true,
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: { request: GetAgentStatusRequestSchema },
+        options: {
+          // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
+          deprecated: true,
+        },
       },
       getAgentStatusForAgentPolicyHandler
     );
@@ -644,6 +762,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetAgentDataRequestSchema,
           response: {
@@ -674,6 +798,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostAgentUpgradeRequestSchema,
           response: {
@@ -703,6 +833,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostBulkAgentUpgradeRequestSchema,
           response: {
@@ -733,6 +869,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetActionStatusRequestSchema,
           response: {
@@ -763,6 +905,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostBulkAgentReassignRequestSchema,
           response: {
@@ -793,6 +941,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostBulkAgentUnenrollRequestSchema,
           response: {
@@ -823,6 +977,12 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: {},
           response: {

--- a/x-pack/plugins/fleet/server/routes/app/index.ts
+++ b/x-pack/plugins/fleet/server/routes/app/index.ts
@@ -210,6 +210,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       .addVersion(
         {
           version: API_VERSIONS.internal.v1,
+          security: {
+            authz: {
+              enabled: false,
+              reason: 'This route is opted out from authorization',
+            },
+          },
           validate: {},
         },
         postEnableSpaceAwarenessHandler
@@ -226,6 +232,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: CheckPermissionsRequestSchema,
           response: {
@@ -252,6 +264,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.internal.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {},
       },
       getAgentPoliciesSpacesHandler
@@ -271,6 +289,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GenerateServiceTokenRequestSchema,
           response: {
@@ -293,13 +317,21 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
         fleet: { allAgents: true },
       },
       description: `Create a service token`,
-      // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
-      deprecated: true,
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {},
+        options: {
+          // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
+          deprecated: true,
+        },
       },
       generateServiceTokenHandler
     );

--- a/x-pack/plugins/fleet/server/routes/enrollment_api_key/index.ts
+++ b/x-pack/plugins/fleet/server/routes/enrollment_api_key/index.ts
@@ -47,6 +47,12 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetOneEnrollmentAPIKeyRequestSchema,
           response: {
@@ -76,6 +82,12 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: DeleteEnrollmentAPIKeyRequestSchema,
           response: {
@@ -105,6 +117,12 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetEnrollmentAPIKeysRequestSchema,
           response: {
@@ -137,6 +155,12 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: PostEnrollmentAPIKeyRequestSchema,
           response: {
@@ -167,6 +191,12 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: { request: GetOneEnrollmentAPIKeyRequestSchema },
       },
       getOneEnrollmentApiKeyHandler
@@ -184,6 +214,12 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: { request: DeleteEnrollmentAPIKeyRequestSchema },
       },
       deleteEnrollmentApiKeyHandler
@@ -201,6 +237,12 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: { request: GetEnrollmentAPIKeysRequestSchema },
       },
       getEnrollmentApiKeysHandler
@@ -212,13 +254,21 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
-      deprecated: true,
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: { request: PostEnrollmentAPIKeyRequestSchema },
+        options: {
+          // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
+          deprecated: true,
+        },
       },
       postEnrollmentApiKeyHandler
     );

--- a/x-pack/plugins/fleet/server/routes/epm/index.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/index.ts
@@ -124,6 +124,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetCategoriesRequestSchema,
           response: {
@@ -151,6 +157,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetPackagesRequestSchema,
           response: {
@@ -178,6 +190,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetInstalledPackagesRequestSchema,
           response: {
@@ -205,6 +223,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: {},
           response: {
@@ -232,6 +256,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetStatsRequestSchema,
           response: {
@@ -259,6 +289,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetInputsRequestSchema,
           response: {
@@ -286,6 +322,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetFileRequestSchema,
           response: {
@@ -315,6 +357,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetInfoRequestSchema,
           response: {
@@ -344,6 +392,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: UpdatePackageRequestSchema,
           response: {
@@ -371,6 +425,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: InstallPackageFromRegistryRequestSchema,
           response: {
@@ -401,6 +461,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       .addVersion(
         {
           version: API_VERSIONS.public.v1,
+          security: {
+            authz: {
+              enabled: false,
+              reason: 'This route is opted out from authorization',
+            },
+          },
           validate: {
             request: InstallKibanaAssetsRequestSchema,
             response: {
@@ -430,6 +496,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       .addVersion(
         {
           version: API_VERSIONS.public.v1,
+          security: {
+            authz: {
+              enabled: false,
+              reason: 'This route is opted out from authorization',
+            },
+          },
           validate: {
             request: DeleteKibanaAssetsRequestSchema,
             response: {
@@ -460,6 +532,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: BulkInstallPackagesFromRegistryRequestSchema,
           response: {
@@ -495,6 +573,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: InstallPackageByUploadRequestSchema,
           response: {
@@ -522,6 +606,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: CreateCustomIntegrationRequestSchema,
           response: {
@@ -551,6 +641,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: DeletePackageRequestSchema,
           response: {
@@ -579,6 +675,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: {},
           response: {
@@ -606,6 +708,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetDataStreamsRequestSchema,
           response: {
@@ -633,6 +741,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: GetBulkAssetsRequestSchema,
           response: {
@@ -659,13 +773,21 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
           fleetAuthz,
           getRouteRequiredAuthz('get', EPM_API_ROUTES.INFO_PATTERN_DEPRECATED)
         ).granted,
-      // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
-      deprecated: true,
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: { request: GetInfoRequestSchemaDeprecated },
+        options: {
+          // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
+          deprecated: true,
+        },
       },
       async (context, request, response) => {
         const newRequest = { ...request, params: splitPkgKey(request.params.pkgkey) } as any;
@@ -688,13 +810,21 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       fleetAuthz: {
         integrations: { writePackageSettings: true },
       },
-      // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
-      deprecated: true,
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: { request: UpdatePackageRequestSchemaDeprecated },
+        options: {
+          // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
+          deprecated: true,
+        },
       },
       async (context, request, response) => {
         const newRequest = { ...request, params: splitPkgKey(request.params.pkgkey) } as any;
@@ -715,13 +845,21 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .post({
       path: EPM_API_ROUTES.INSTALL_FROM_REGISTRY_PATTERN_DEPRECATED,
       fleetAuthz: INSTALL_PACKAGES_AUTHZ,
-      // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
-      deprecated: true,
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: { request: InstallPackageFromRegistryRequestSchemaDeprecated },
+        options: {
+          // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
+          deprecated: true,
+        },
       },
       async (context, request, response) => {
         const newRequest = {
@@ -744,13 +882,21 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       fleetAuthz: {
         integrations: { removePackages: true },
       },
-      // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
-      deprecated: true,
     })
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: { request: DeletePackageRequestSchemaDeprecated },
+        options: {
+          // @ts-expect-error TODO(https://github.com/elastic/kibana/issues/196095): Replace {RouteDeprecationInfo}
+          deprecated: true,
+        },
       },
       async (context, request, response) => {
         const newRequest = { ...request, params: splitPkgKey(request.params.pkgkey) } as any;
@@ -791,6 +937,12 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .addVersion(
       {
         version: API_VERSIONS.public.v1,
+        security: {
+          authz: {
+            enabled: false,
+            reason: 'This route is opted out from authorization',
+          },
+        },
         validate: {
           request: ReauthorizeTransformRequestSchema,
           response: {


### PR DESCRIPTION
## Summary

Temporary fix to reinstate the deprecated status for the fleet endpoints in OAS