### PR TITLE
Support Kibana URL parts with stripped default port

### DIFF
--- a/packages/kbn-test/kbn_test_config.ts
+++ b/packages/kbn-test/kbn_test_config.ts
@@ -54,4 +54,21 @@ export const kbnTestConfig = new (class KbnTestConfig {
       password,
     };
   }
+
+  /**
+   * Use to get `port:undefined` for assertions if the port is default for the
+   * used protocol and thus would be stripped by the browser
+   */
+  getUrlPartsWithStrippedDefaultPort(user: UserAuth = kibanaTestUser): UrlParts {
+    const urlParts = this.getUrlParts(user);
+
+    if (
+      (urlParts.protocol === 'http' && urlParts.port === 80) ||
+      (urlParts.protocol === 'https' && urlParts.port === 443)
+    ) {
+      urlParts.port = undefined;
+    }
+
+    return urlParts;
+  }
 })();


### PR DESCRIPTION
## Summary

This PR adds support for getting Kibana URL parts with stripped default port.

### Details

* Adds method `getUrlPartsWithStrippedDefaultPort` to `kbnTestConfig`
* Can be used when asserting URLs where the browser strips the default port


<!--ONMERGE {"backportTargets":["8.16"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->