### PR TITLE
[SecuritySolution]  Change Entity Store default transform interval to 30 seconds 

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/constants.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/constants.ts
@@ -9,7 +9,7 @@ import type { EngineStatus } from '../../../../common/api/entity_analytics';
 
 export const DEFAULT_LOOKBACK_PERIOD = '24h';
 
-export const DEFAULT_INTERVAL = '15s';
+export const DEFAULT_INTERVAL = '30s';
 
 export const ENGINE_STATUS: Record<Uppercase<EngineStatus>, EngineStatus> = {
   INSTALLING: 'installing',


### PR DESCRIPTION
## Summary

Change Entity Store default transform interval to 30 seconds 



<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->