### PR TITLE
[Security Solution] Disable deprecated rules bulk CRUD API endpoints in Serverless and 9.0

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
@@ -11,10 +11,6 @@ import type { SetupPlugins } from '../../../../plugin_contract';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
 
 import { performBulkActionRoute } from './rules/bulk_actions/route';
-import { bulkCreateRulesRoute } from './rules/bulk_create_rules/route';
-import { bulkDeleteRulesRoute } from './rules/bulk_delete_rules/route';
-import { bulkPatchRulesRoute } from './rules/bulk_patch_rules/route';
-import { bulkUpdateRulesRoute } from './rules/bulk_update_rules/route';
 import { createRuleRoute } from './rules/create_rule/route';
 import { deleteRuleRoute } from './rules/delete_rule/route';
 import { exportRulesRoute } from './rules/export_rules/route';
@@ -39,12 +35,6 @@ export const registerRuleManagementRoutes = (
   updateRuleRoute(router);
   patchRuleRoute(router);
   deleteRuleRoute(router);
-
-  // Rules bulk CRUD
-  bulkCreateRulesRoute(router, logger);
-  bulkUpdateRulesRoute(router, logger);
-  bulkPatchRulesRoute(router, logger);
-  bulkDeleteRulesRoute(router, logger);
 
   // Rules bulk actions
   performBulkActionRoute(router, config, ml, logger);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
@@ -31,6 +31,8 @@ import { getDeprecatedBulkEndpointHeader, logDeprecatedBulkEndpoint } from '../.
 
 /**
  * @deprecated since version 8.2.0. Use the detection_engine/rules/_bulk_action API instead
+ *
+ * TODO: https://github.com/elastic/kibana/issues/193184 Delete this route and clean up the code
  */
 export const bulkCreateRulesRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
   router.versioned

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
@@ -45,6 +45,8 @@ type Handler = RequestHandler<
 
 /**
  * @deprecated since version 8.2.0. Use the detection_engine/rules/_bulk_action API instead
+ *
+ * TODO: https://github.com/elastic/kibana/issues/193184 Delete this route and clean up the code
  */
 export const bulkDeleteRulesRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
   const handler: Handler = async (

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
@@ -25,6 +25,8 @@ import { RULE_MANAGEMENT_BULK_ACTION_SOCKET_TIMEOUT_MS } from '../../timeouts';
 
 /**
  * @deprecated since version 8.2.0. Use the detection_engine/rules/_bulk_action API instead
+ *
+ * TODO: https://github.com/elastic/kibana/issues/193184 Delete this route and clean up the code
  */
 export const bulkPatchRulesRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
   router.versioned

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
@@ -29,6 +29,8 @@ import { RULE_MANAGEMENT_BULK_ACTION_SOCKET_TIMEOUT_MS } from '../../timeouts';
 
 /**
  * @deprecated since version 8.2.0. Use the detection_engine/rules/_bulk_action API instead
+ *
+ * TODO: https://github.com/elastic/kibana/issues/193184 Delete this route and clean up the code
  */
 export const bulkUpdateRulesRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
   router.versioned

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/prebuilt_rule_customization/trial_license_complete_tier/rules_export.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/prebuilt_rule_customization/trial_license_complete_tier/rules_export.ts
@@ -46,14 +46,14 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     it('exports a set of custom installed rules via the _export API', async () => {
-      await securitySolutionApi
-        .bulkCreateRules({
-          body: [
-            getCustomQueryRuleParams({ rule_id: 'rule-id-1' }),
-            getCustomQueryRuleParams({ rule_id: 'rule-id-2' }),
-          ],
-        })
-        .expect(200);
+      await Promise.all([
+        securitySolutionApi
+          .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-1' }) })
+          .expect(200),
+        securitySolutionApi
+          .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-2' }) })
+          .expect(200),
+      ]);
 
       const { body: exportResult } = await securitySolutionApi
         .exportRules({ query: {}, body: null })
@@ -182,14 +182,14 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('exports a set of custom and prebuilt installed rules via the _export API', async () => {
-        await securitySolutionApi
-          .bulkCreateRules({
-            body: [
-              getCustomQueryRuleParams({ rule_id: 'rule-id-1' }),
-              getCustomQueryRuleParams({ rule_id: 'rule-id-2' }),
-            ],
-          })
-          .expect(200);
+        await Promise.all([
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-1' }) })
+            .expect(200),
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-2' }) })
+            .expect(200),
+        ]);
 
         const { body: exportResult } = await securitySolutionApi
           .exportRules({ query: {}, body: null })
@@ -232,14 +232,14 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('exports both custom and prebuilt rules when rule_ids are specified via the _export API', async () => {
-        await securitySolutionApi
-          .bulkCreateRules({
-            body: [
-              getCustomQueryRuleParams({ rule_id: 'rule-id-1' }),
-              getCustomQueryRuleParams({ rule_id: 'rule-id-2' }),
-            ],
-          })
-          .expect(200);
+        await Promise.all([
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-1' }) })
+            .expect(200),
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-2' }) })
+            .expect(200),
+        ]);
 
         const { body: exportResult } = await securitySolutionApi
           .exportRules({
@@ -277,14 +277,14 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('exports a set of custom and prebuilt installed rules via the bulk_actions API', async () => {
-        await securitySolutionApi
-          .bulkCreateRules({
-            body: [
-              getCustomQueryRuleParams({ rule_id: 'rule-id-1' }),
-              getCustomQueryRuleParams({ rule_id: 'rule-id-2' }),
-            ],
-          })
-          .expect(200);
+        await Promise.all([
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-1' }) })
+            .expect(200),
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-2' }) })
+            .expect(200),
+        ]);
 
         const { body: exportResult } = await securitySolutionApi
           .performRulesBulkAction({

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/basic_license_essentials_tier/create_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/basic_license_essentials_tier/create_rules_bulk.ts
@@ -38,7 +38,8 @@ export default ({ getService }: FtrProviderContext): void => {
   const auditbeatPath = dataPathBuilder.getPath('auditbeat/hosts');
   const utils = getService('securitySolutionUtils');
 
-  describe('@ess @serverless @skipInServerlessMKI create_rules_bulk', () => {
+  // TODO: https://github.com/elastic/kibana/issues/193184 Delete this file and clean up the code
+  describe.skip('@ess @serverless @skipInServerlessMKI create_rules_bulk', () => {
     describe('creating rules in bulk', () => {
       before(async () => {
         await esArchiver.load(auditbeatPath);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/basic_license_essentials_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/basic_license_essentials_tier/index.ts
@@ -9,7 +9,6 @@ import { FtrProviderContext } from '../../../../../ftr_provider_context';
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Rules Management  - Rule Creation APIs', function () {
     loadTestFile(require.resolve('./create_rules'));
-    loadTestFile(require.resolve('./create_rules_bulk'));
     loadTestFile(require.resolve('./create_ml_rules_privileges'));
   });
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/create_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_creation/trial_license_complete_tier/create_rules_bulk.ts
@@ -44,8 +44,8 @@ export default ({ getService }: FtrProviderContext): void => {
   const log = getService('log');
   const es = getService('es');
 
-  // See https://github.com/elastic/kibana/issues/130963 for discussion on deprecation
-  describe('@ess @skipInServerless create_rules_bulk', () => {
+  // TODO: https://github.com/elastic/kibana/issues/193184 Delete this file and clean up the code
+  describe.skip('@ess @skipInServerless create_rules_bulk', () => {
     describe('deprecations', () => {
       afterEach(async () => {
         await deleteAllRules(supertest, log);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/basic_license_essentials_tier/delete_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/basic_license_essentials_tier/delete_rules_bulk.ts
@@ -32,7 +32,8 @@ export default ({ getService }: FtrProviderContext): void => {
   const es = getService('es');
   const utils = getService('securitySolutionUtils');
 
-  describe('@ess @serverless @skipInServerlessMKI delete_rules_bulk', () => {
+  // TODO: https://github.com/elastic/kibana/issues/193184 Unskip and rewrite using the _bulk_action API endpoint
+  describe.skip('@ess @serverless @skipInServerlessMKI delete_rules_bulk', () => {
     describe('deleting rules bulk using DELETE', () => {
       beforeEach(async () => {
         await createAlertsIndex(supertest, log);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk.ts
@@ -37,8 +37,8 @@ export default ({ getService }: FtrProviderContext): void => {
   const es = getService('es');
   const utils = getService('securitySolutionUtils');
 
-  // See https://github.com/elastic/kibana/issues/130963 for discussion on deprecation
-  describe('@ess @skipInServerlesMKI delete_rules_bulk', () => {
+  // TODO: https://github.com/elastic/kibana/issues/193184 Unskip and rewrite using the _bulk_action API endpoint
+  describe.skip('@ess @skipInServerlesMKI delete_rules_bulk', () => {
     describe('deprecations', () => {
       it('should return a warning header', async () => {
         await createRule(supertest, log, getSimpleRule());

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk_legacy.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk_legacy.ts
@@ -28,7 +28,8 @@ export default ({ getService }: FtrProviderContext): void => {
   const log = getService('log');
   const es = getService('es');
 
-  describe('@ess delete_rules_bulk_legacy', () => {
+  // TODO: https://github.com/elastic/kibana/issues/193184 Unskip and rewrite using the _bulk_action API endpoint
+  describe.skip('@ess delete_rules_bulk_legacy', () => {
     describe('deleting rules bulk using POST', () => {
       beforeEach(async () => {
         await createAlertsIndex(supertest, log);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/index.ts
@@ -9,7 +9,6 @@ import { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Rules Management - Rule Patch APIs', function () {
-    loadTestFile(require.resolve('./patch_rules_bulk'));
     loadTestFile(require.resolve('./patch_rules'));
   });
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules_bulk.ts
@@ -34,7 +34,8 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
   const utils = getService('securitySolutionUtils');
 
-  describe('@ess @serverless @skipInServerlessMKI patch_rules_bulk', () => {
+  // TODO: https://github.com/elastic/kibana/issues/193184 Delete this file and clean up the code
+  describe.skip('@ess @serverless @skipInServerlessMKI patch_rules_bulk', () => {
     describe('patch rules bulk', () => {
       beforeEach(async () => {
         await createAlertsIndex(supertest, log);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/index.ts
@@ -9,7 +9,6 @@ import { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Rules Management - Rule Patch APIs', function () {
-    loadTestFile(require.resolve('./patch_rules_bulk'));
     loadTestFile(require.resolve('./patch_rules'));
     loadTestFile(require.resolve('./patch_rules_ess'));
   });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/patch_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/trial_license_complete_tier/patch_rules_bulk.ts
@@ -41,8 +41,8 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
   const utils = getService('securitySolutionUtils');
 
-  // See https://github.com/elastic/kibana/issues/130963 for discussion on deprecation
-  describe('@ess @skipInServerless patch_rules_bulk', () => {
+  // TODO: https://github.com/elastic/kibana/issues/193184 Delete this file and clean up the code
+  describe.skip('@ess @skipInServerless patch_rules_bulk', () => {
     describe('deprecations', () => {
       afterEach(async () => {
         await deleteAllRules(supertest, log);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/index.ts
@@ -9,7 +9,6 @@ import { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Rules Management - Rule Update APIs', function () {
-    loadTestFile(require.resolve('./update_rules_bulk'));
     loadTestFile(require.resolve('./update_rules'));
   });
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/basic_license_essentials_tier/update_rules_bulk.ts
@@ -35,7 +35,8 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
   const utils = getService('securitySolutionUtils');
 
-  describe('@ess @serverless @skipInServerlessMKI update_rules_bulk', () => {
+  // TODO: https://github.com/elastic/kibana/issues/193184 Delete this file and clean up the code
+  describe.skip('@ess @serverless @skipInServerlessMKI update_rules_bulk', () => {
     describe('update rules bulk', () => {
       beforeEach(async () => {
         await createAlertsIndex(supertest, log);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/index.ts
@@ -9,7 +9,6 @@ import { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Rules Management - Rule Update APIs', function () {
-    loadTestFile(require.resolve('./update_rules_bulk'));
     loadTestFile(require.resolve('./update_rules'));
     loadTestFile(require.resolve('./update_rules_ess'));
   });

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/update_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_update/trial_license_complete_tier/update_rules_bulk.ts
@@ -52,8 +52,8 @@ export default ({ getService }: FtrProviderContext) => {
   const utils = getService('securitySolutionUtils');
   let username: string;
 
-  // See https://github.com/elastic/kibana/issues/130963 for discussion on deprecation
-  describe('@ess update_rules_bulk', () => {
+  // TODO: https://github.com/elastic/kibana/issues/193184 Delete this file and clean up the code
+  describe.skip('@ess update_rules_bulk', () => {
     before(async () => {
       username = await utils.getUsername();
     });


### PR DESCRIPTION
**Partially addresses:** https://github.com/elastic/kibana/issues/193184
**Breaking change proposal:** https://github.com/elastic/dev/issues/2772 (internal)

## Summary

This PR disables the following deprecated [bulk API endpoints for creating, updating and deleting detection rules](https://www.elastic.co/guide/en/security/current/bulk-actions-rules-api.html) from [Elastic Security APIs](https://www.elastic.co/guide/en/security/current/security-apis.html) in Serverless and upcoming `v9.0.0`:

| Method | Endpoint |
| ------ | ------------------------------------------------------- |
| POST   | /api/detection_engine/rules/\_bulk_create               |
| PUT    | /api/detection_engine/rules/\_bulk_update               |
| PATCH  | /api/detection_engine/rules/\_bulk_update               |
| DELETE | /api/detection_engine/rules/\_bulk_delete               |
| POST   | /api/detection_engine/rules/\_bulk_delete               |

Specifically, as a first step we remove the endpoints from the route registrations. Once https://github.com/elastic/dev/issues/2772 is approved, we will merge this PR and remove the corresponding endpoint handlers and associated code in a follow-up PR.


### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
  - [x] https://github.com/elastic/security-docs/issues/5981
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [x] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

