### PR TITLE
[Saved Objects Tagging] Visually hide tags in Saved Objects Management

### DIFF
--- a/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/__snapshots__/saved_objects_table.test.tsx.snap
@@ -28,6 +28,12 @@ exports[`SavedObjectsTable delete should show a confirm modal 1`] = `
         "name": "search",
         "namespaceType": "single",
       },
+      Object {
+        "displayName": "tag",
+        "hidden": false,
+        "name": "tag",
+        "namespaceType": "single",
+      },
     ]
   }
   isDeleting={false}
@@ -53,7 +59,7 @@ exports[`SavedObjectsTable delete should show a confirm modal 1`] = `
 
 exports[`SavedObjectsTable export should allow the user to choose when exporting all 1`] = `
 <ExportModal
-  filteredItemCount={4}
+  filteredItemCount={5}
   includeReferences={true}
   onCancel={[Function]}
   onExport={[Function]}
@@ -77,6 +83,10 @@ exports[`SavedObjectsTable export should allow the user to choose when exporting
         "id": "search",
         "label": "search (0)",
       },
+      Object {
+        "id": "tag",
+        "label": "tag (0)",
+      },
     ]
   }
   selectedOptions={
@@ -84,6 +94,7 @@ exports[`SavedObjectsTable export should allow the user to choose when exporting
       "dashboard": true,
       "index-pattern": true,
       "search": true,
+      "tag": true,
       "visualization": true,
     }
   }
@@ -93,7 +104,7 @@ exports[`SavedObjectsTable export should allow the user to choose when exporting
 exports[`SavedObjectsTable should render normally 1`] = `
 <div>
   <Header
-    filteredCount={4}
+    filteredCount={5}
     onExportAll={[Function]}
     onImport={[Function]}
     onRefresh={[Function]}
@@ -182,6 +193,12 @@ exports[`SavedObjectsTable should render normally 1`] = `
             "displayName": "search",
             "hidden": false,
             "name": "search",
+            "namespaceType": "single",
+          },
+          Object {
+            "displayName": "tag",
+            "hidden": false,
+            "name": "tag",
             "namespaceType": "single",
           },
         ]
@@ -316,7 +333,7 @@ exports[`SavedObjectsTable should render normally 1`] = `
           "field": "updated_at",
         }
       }
-      totalItemCount={4}
+      totalItemCount={5}
     />
   </RedirectAppLinks>
 </div>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
@@ -51,7 +51,9 @@ const convertType = (type: string): SavedObjectManagementTypeInfo => ({
   namespaceType: 'single',
 });
 
-const allowedTypes = ['index-pattern', 'visualization', 'dashboard', 'search'].map(convertType);
+const allowedTypes = ['index-pattern', 'visualization', 'dashboard', 'search', 'tag'].map(
+  convertType
+);
 
 const allSavedObjects = [
   {
@@ -80,6 +82,13 @@ const allSavedObjects = [
     type: 'visualization',
     attributes: {
       title: `MyViz`,
+    },
+  },
+  {
+    id: '5',
+    type: 'tag',
+    attributes: {
+      title: `HelloWorldTag`,
     },
   },
 ];
@@ -129,6 +138,7 @@ describe('SavedObjectsTable', () => {
       visualization: 0,
       dashboard: 0,
       search: 0,
+      tag: 0,
     });
 
     defaultProps = {
@@ -148,7 +158,7 @@ describe('SavedObjectsTable', () => {
     };
 
     findObjectsMock.mockImplementation(() => ({
-      total: 4,
+      total: 5,
       saved_objects: [
         {
           id: '1',
@@ -197,6 +207,14 @@ describe('SavedObjectsTable', () => {
               path: '/edit/4',
               uiCapabilitiesPath: 'visualize.show',
             },
+          },
+        },
+        {
+          id: '5',
+          type: 'tag',
+          meta: {
+            title: `HelloWorldTag`,
+            icon: 'tag',
           },
         },
       ],
@@ -451,7 +469,7 @@ describe('SavedObjectsTable', () => {
       component.update();
 
       await component.instance().getRelationships('search', '1');
-      const savedObjectTypes = ['index-pattern', 'visualization', 'dashboard', 'search'];
+      const savedObjectTypes = ['index-pattern', 'visualization', 'dashboard', 'search', 'tag'];
       expect(getRelationshipsMock).toHaveBeenCalledWith(http, 'search', '1', savedObjectTypes);
     });
 

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -688,7 +688,10 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
       onSelectionChange: this.onSelectionChanged,
     };
 
-    const filterOptions = allowedTypes.map((type) => ({
+    const filtersWithoutTags = allowedTypes.filter((t) => t.name !== 'tag');
+    const itemsWithoutTags = savedObjects.filter((t) => t.type !== 'tag');
+
+    const filterOptions = filtersWithoutTags.map((type) => ({
       value: type.displayName,
       name: type.displayName,
       view: `${type.displayName} (${savedObjectCounts[type.name] || 0})`,
@@ -733,7 +736,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
             pageIndex={page}
             pageSize={perPage}
             sort={sort}
-            items={savedObjects}
+            items={itemsWithoutTags}
             totalItemCount={filteredItemCount}
             isSearching={isSearching}
             onShowRelationships={this.onShowRelationships}


### PR DESCRIPTION
## Summary

This PR visually hides objects with `tag` type from `Saved Objects Management` table while still allowing them to be exportable.

Closes: #147786