### PR TITLE
[SecuritySolution] Add text intro to Asset Criticality on upload page

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/pages/entity_store_management_page.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/pages/entity_store_management_page.tsx
@@ -317,6 +317,11 @@ const WhatIsAssetCriticalityPanel: React.FC = () => {
 
   return (
     <EuiPanel hasBorder={true} paddingSize="l" grow={false}>
+      <FormattedMessage
+        id="xpack.securitySolution.entityAnalytics.assetCriticalityUploadPage.information.intro"
+        defaultMessage="As part of importing entities using a text file, you are also able to set Asset Criticality for the imported Entities."
+      />
+      <EuiSpacer size="l" />
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiIcon type="questionInCircle" size="xl" />
         <EuiTitle size="xxs">


### PR DESCRIPTION
## Summary

Add text intro to Asset Criticality on the upload page.
Described here: https://github.com/elastic/kibana/issues/196633#issuecomment-2420541914

![Screenshot 2024-10-23 at 15 21 06](https://github.com/user-attachments/assets/fa984960-6cec-4efa-b009-0044520bb6e6)


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->