### PR TITLE
[Observability Onboarding] Update the title and description of the OTel flow for K8s

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
@@ -165,14 +165,14 @@ export function useCustomCardsForCategory(
           title: i18n.translate(
             'xpack.observability_onboarding.useCustomCardsForCategory.kubernetesOtelTitle',
             {
-              defaultMessage: 'Kubernetes monitoring with EDOT Collector',
+              defaultMessage: 'Unified Kubernetes monitoring with OpenTelemetry',
             }
           ),
           description: i18n.translate(
             'xpack.observability_onboarding.useCustomCardsForCategory.kubernetesOtelDescription',
             {
               defaultMessage:
-                'Unified Kubernetes observability with Elastic Distro for OTel Collector',
+                'Monitor Kubernetes Infrastructure and auto-instrument Applications with OpenTelemetry',
             }
           ),
           extraLabelsBadges: [


### PR DESCRIPTION
Update the title and description of the tile for the OpenTelemetry flow for Kubernetes.

### Before
<img width="789" alt="image" src="https://github.com/user-attachments/assets/e000251b-08a3-428e-b1a2-7c1dc2d2d873">


### After
![image (3)](https://github.com/user-attachments/assets/51db07e0-cb77-4a74-9759-e69f4861408a)

Closes https://github.com/elastic/kibana/issues/197289