### PR TITLE
[Observability Onboarding] Improve wording in auto-detect description

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
@@ -172,7 +172,7 @@ export function useCustomCardsForCategory(
             'xpack.observability_onboarding.useCustomCardsForCategory.kubernetesOtelDescription',
             {
               defaultMessage:
-                'Unified Kubernetes observability with the OpenTelemetry Operator and Elastic Distributions of OpenTelemetry (EDOT)',
+                'Unified Kubernetes observability with Elastic Distro for OTel Collector',
             }
           ),
           release: 'preview',

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
@@ -57,7 +57,7 @@ export function useCustomCardsForCategory(
           description: i18n.translate(
             'xpack.observability_onboarding.useCustomCardsForCategory.autoDetectDescription',
             {
-              defaultMessage: 'Scan your host for log and metric files, auto-install integrations',
+              defaultMessage: 'Scan your host for log files, metrics, auto-install integrations',
             }
           ),
           extraLabelsBadges: [
@@ -165,16 +165,17 @@ export function useCustomCardsForCategory(
           title: i18n.translate(
             'xpack.observability_onboarding.useCustomCardsForCategory.kubernetesOtelTitle',
             {
-              defaultMessage: 'Kubernetes monitoring with EDOT Collector',
+              defaultMessage: 'Kubernetes monitoring with EDOT',
             }
           ),
           description: i18n.translate(
             'xpack.observability_onboarding.useCustomCardsForCategory.kubernetesOtelDescription',
             {
               defaultMessage:
-                'Unified Kubernetes observability with Elastic Distro for OTel Collector',
+                'Unified Kubernetes observability with the OpenTelemetry Operator and Elastic Distributions of OpenTelemetry (EDOT)',
             }
           ),
+          release: 'preview',
           extraLabelsBadges: [
             <ExtraLabelBadgeWrapper>
               <LogoIcon logo="kubernetes" size="m" />

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
@@ -165,7 +165,7 @@ export function useCustomCardsForCategory(
           title: i18n.translate(
             'xpack.observability_onboarding.useCustomCardsForCategory.kubernetesOtelTitle',
             {
-              defaultMessage: 'Kubernetes monitoring with EDOT',
+              defaultMessage: 'Kubernetes monitoring with EDOT Collector',
             }
           ),
           description: i18n.translate(

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
@@ -175,7 +175,6 @@ export function useCustomCardsForCategory(
                 'Unified Kubernetes observability with Elastic Distro for OTel Collector',
             }
           ),
-          release: 'preview',
           extraLabelsBadges: [
             <ExtraLabelBadgeWrapper>
               <LogoIcon logo="kubernetes" size="m" />
@@ -192,7 +191,7 @@ export function useCustomCardsForCategory(
           version: '',
           integration: '',
           isQuickstart: true,
-          release: 'preview',
+          releddase: 'preview',
         },
       ];
 

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/onboarding_flow_form/use_custom_cards_for_category.tsx
@@ -191,7 +191,7 @@ export function useCustomCardsForCategory(
           version: '',
           integration: '',
           isQuickstart: true,
-          releddase: 'preview',
+          release: 'preview',
         },
       ];
 


### PR DESCRIPTION
Metrics are not stored in files, slightly adjusting the wording

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->