### PR TITLE
[EDR Workflows] Download multiple agent versions

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/agent_downloader_cli/agent_downloader.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/agent_downloader_cli/agent_downloader.ts
@@ -45,7 +45,7 @@ const downloadAndStoreElasticAgent = async (
 ): Promise<void> => {
   const versionsToDownload = getVersionsToDownload(version);
 
-  // Although we have a list of versions to try downloading, we only need to download one, and will return as soon as it succeeds.
+  // Download all the versions in the list
   for (const versionToDownload of versionsToDownload) {
     try {
       const { url } = await getAgentDownloadUrl(versionToDownload, closestMatch, log);
@@ -53,13 +53,10 @@ const downloadAndStoreElasticAgent = async (
 
       await downloadAndStoreAgent(url, fileName);
       log.info(`Successfully downloaded and stored version ${versionToDownload}`);
-      return; // Exit once successful
     } catch (error) {
       log.error(`Failed to download or store version ${versionToDownload}: ${error.message}`);
     }
   }
-
-  log.error(`Failed to download agent for any available version: ${versionsToDownload.join(', ')}`);
 };
 
 export const agentDownloaderRunner: RunFn = async (cliContext) => {

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/agent_downloads_service.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/agent_downloads_service.ts
@@ -113,8 +113,14 @@ class AgentDownloadStorage extends SettingsStorage<AgentDownloadStorageSettings>
 
           await handleProcessInterruptions(
             async () => {
-              const { body } = await nodeFetch(agentDownloadUrl);
-              await finished(body.pipe(outputStream));
+              try {
+                const { body } = await nodeFetch(agentDownloadUrl);
+                await finished(body.pipe(outputStream));
+              } catch (error) {
+                this.log.error(`Error during download attempt ${attempt}: ${error.message}`);
+                // Ensure any errors here propagate and trigger retry
+                throw error;
+              }
             },
             () => fs.unlinkSync(newDownloadInfo.fullFilePath) // Clean up on interruption
           );


### PR DESCRIPTION
The behavior now is that we cache 8.15.4, but our tests are expecting 8.15.3.
Talked to @jbudz  who reported this disconnection - and we agreed to download and store both new (8.15.4) and last (8.15.3 ) versions.

Additionally, it includes a catch for any errors that occur while fetching the agent and initiates a retry if such an error happens.

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->