### PR TITLE
Fix issue with short URL not working for dashboard

### DIFF
--- a/src/plugins/dashboard/public/dashboard_app/_dashboard_app_strings.ts
+++ b/src/plugins/dashboard/public/dashboard_app/_dashboard_app_strings.ts
@@ -139,10 +139,15 @@ export const shareModalStrings = {
       defaultMessage:
         'One or more panels on this dashboard have changed. Before you generate a snapshot, save the dashboard.',
     }),
+  getDraftSharePanelChangesWarning: () =>
+    i18n.translate('dashboard.snapshotShare.panelChangesWarning', {
+      defaultMessage:
+        'One or more panels on this dashboard have changed. Before generating a link, save the dashboard.',
+    }),
   getDraftShareWarning: () =>
     i18n.translate('dashboard.snapshotShare.draftWarning', {
       defaultMessage:
-        'One or more panels on this dashboard have changed, save the dashboard to create a permanent link.',
+        'This dashboard has unsaved changes. Consider saving your dashboard before generating the link.',
     }),
 };
 

--- a/src/plugins/dashboard/public/dashboard_app/_dashboard_app_strings.ts
+++ b/src/plugins/dashboard/public/dashboard_app/_dashboard_app_strings.ts
@@ -142,12 +142,18 @@ export const shareModalStrings = {
   getDraftSharePanelChangesWarning: () =>
     i18n.translate('dashboard.snapshotShare.panelChangesWarning', {
       defaultMessage:
-        'One or more panels on this dashboard have changed. Before generating a link, save the dashboard.',
+        'You are about to share a dashboard with unsaved changes, and the link may not work properly. Save the dashboard first to create a permanent link.',
     }),
-  getDraftShareWarning: () =>
+  getEmbedSharePanelChangesWarning: () =>
+    i18n.translate('dashboard.embedShare.draftWarning', {
+      defaultMessage:
+        'You are about to create an embedded dashboard with unsaved changes, and the embed code may not work properly. Save the dashboard first to create a permanent embedded dashboard.',
+    }),
+  getDraftShareWarning: (shareType: 'embed' | 'link') =>
     i18n.translate('dashboard.snapshotShare.draftWarning', {
       defaultMessage:
-        'This dashboard has unsaved changes. Consider saving your dashboard before generating the link.',
+        'This dashboard has unsaved changes. Consider saving your dashboard before generating the {shareType}.',
+      values: { shareType: shareType === 'embed' ? 'embed code' : 'link' },
     }),
 };
 

--- a/src/plugins/dashboard/public/dashboard_app/_dashboard_app_strings.ts
+++ b/src/plugins/dashboard/public/dashboard_app/_dashboard_app_strings.ts
@@ -139,6 +139,11 @@ export const shareModalStrings = {
       defaultMessage:
         'One or more panels on this dashboard have changed. Before you generate a snapshot, save the dashboard.',
     }),
+  getDraftShareWarning: () =>
+    i18n.translate('dashboard.snapshotShare.draftWarning', {
+      defaultMessage:
+        'One or more panels on this dashboard have changed, save the dashboard to create a permanent link.',
+    }),
 };
 
 /*

--- a/src/plugins/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
@@ -225,7 +225,25 @@ export function ShowShareModal({
             >
               {Boolean(unsavedDashboardState?.panels)
                 ? shareModalStrings.getDraftSharePanelChangesWarning()
-                : shareModalStrings.getDraftShareWarning()}
+                : shareModalStrings.getDraftShareWarning('link')}
+            </EuiCallOut>
+          ),
+        },
+        embed: {
+          draftModeCallOut: (
+            <EuiCallOut
+              color="warning"
+              data-test-subj="DashboardDraftModeEmbedCallOut"
+              title={
+                <FormattedMessage
+                  id="dashboard.share.shareModal.draftModeCallout.title"
+                  defaultMessage="Unsaved changes"
+                />
+              }
+            >
+              {Boolean(unsavedDashboardState?.panels)
+                ? shareModalStrings.getEmbedSharePanelChangesWarning()
+                : shareModalStrings.getDraftShareWarning('embed')}
             </EuiCallOut>
           ),
         },

--- a/src/plugins/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
@@ -11,7 +11,7 @@ import { omit } from 'lodash';
 import moment from 'moment';
 import React, { ReactElement, useState } from 'react';
 
-import { EuiCheckboxGroup } from '@elastic/eui';
+import { EuiCallOut, EuiCheckboxGroup } from '@elastic/eui';
 import type { Capabilities } from '@kbn/core/public';
 import { QueryState } from '@kbn/data-plugin/common';
 import { DASHBOARD_APP_LOCATOR } from '@kbn/deeplinks-analytics';
@@ -19,6 +19,7 @@ import { ViewMode } from '@kbn/embeddable-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { getStateFromKbnUrl, setStateToKbnUrl, unhashUrl } from '@kbn/kibana-utils-plugin/public';
 
+import { FormattedMessage } from '@kbn/i18n-react';
 import { convertPanelMapToPanelsArray, DashboardPanelMap } from '../../../../common';
 import { DashboardLocatorParams } from '../../../dashboard_container';
 import {
@@ -195,11 +196,13 @@ export function ShowShareModal({
     unhashUrl(baseUrl)
   );
 
+  const allowShortUrl = getDashboardCapabilities().createShortUrl;
+
   shareService.toggleShareContextMenu({
     isDirty,
     anchorElement,
     allowEmbed: true,
-    allowShortUrl: getDashboardCapabilities().createShortUrl,
+    allowShortUrl,
     shareableUrl,
     objectId: savedObjectId,
     objectType: 'dashboard',
@@ -207,6 +210,24 @@ export function ShowShareModal({
       title: i18n.translate('dashboard.share.shareModal.title', {
         defaultMessage: 'Share this dashboard',
       }),
+      config: {
+        link: {
+          draftModeCallOut: allowShortUrl ? (
+            <EuiCallOut
+              color="warning"
+              data-test-subj="DashboardDraftModeCopyLinkCallOut"
+              title={
+                <FormattedMessage
+                  id="dashboard.share.shareModal.draftModeCallout.title"
+                  defaultMessage="Unsaved changes"
+                />
+              }
+            >
+              {shareModalStrings.getDraftShareWarning()}
+            </EuiCallOut>
+          ) : null,
+        },
+      },
     },
     sharingData: {
       title:

--- a/src/plugins/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
@@ -123,7 +123,7 @@ export function ShowShareModal({
   const allUnsavedPanels = (() => {
     if (
       Object.keys(unsavedDashboardState?.panels ?? {}).length === 0 &&
-      Object.keys(panelModifications ?? {}).length === 0
+      Object.keys(omit(panelModifications ?? {}, PANELS_CONTROL_GROUP_KEY)).length === 0
     ) {
       // if this dashboard has no modifications or unsaved panels return early. No overrides needed.
       return;
@@ -212,7 +212,7 @@ export function ShowShareModal({
       }),
       config: {
         link: {
-          draftModeCallOut: allowShortUrl ? (
+          draftModeCallOut: (
             <EuiCallOut
               color="warning"
               data-test-subj="DashboardDraftModeCopyLinkCallOut"
@@ -223,9 +223,11 @@ export function ShowShareModal({
                 />
               }
             >
-              {shareModalStrings.getDraftShareWarning()}
+              {Boolean(unsavedDashboardState?.panels)
+                ? shareModalStrings.getDraftSharePanelChangesWarning()
+                : shareModalStrings.getDraftShareWarning()}
             </EuiCallOut>
-          ) : null,
+          ),
         },
       },
     },

--- a/src/plugins/share/public/components/context/index.tsx
+++ b/src/plugins/share/public/components/context/index.tsx
@@ -19,7 +19,7 @@ import type {
   ShareContext,
 } from '../../types';
 
-export type { ShareMenuItemV2 } from '../../types';
+export type { ShareMenuItemV2, ShareContextObjectTypeConfig } from '../../types';
 
 export interface IShareContext extends ShareContext {
   allowEmbed: boolean;

--- a/src/plugins/share/public/components/tabs/embed/embed_content.test.tsx
+++ b/src/plugins/share/public/components/tabs/embed/embed_content.test.tsx
@@ -19,6 +19,7 @@ describe('Share modal embed content tab', () => {
     beforeEach(() => {
       component = mountWithIntl(
         <EmbedContent
+          isDirty={false}
           objectType="dashboard"
           setIsNotSaved={() => jest.fn()}
           shareableUrl="/home#/"

--- a/src/plugins/share/public/components/tabs/embed/embed_content.tsx
+++ b/src/plugins/share/public/components/tabs/embed/embed_content.tsx
@@ -23,7 +23,7 @@ import useMountedState from 'react-use/lib/useMountedState';
 import { format as formatUrl, parse as parseUrl } from 'url';
 import { AnonymousAccessState } from '../../../../common';
 
-import { type IShareContext } from '../../context';
+import type { IShareContext, ShareContextObjectTypeConfig } from '../../context';
 
 type EmbedProps = Pick<
   IShareContext,
@@ -32,8 +32,10 @@ type EmbedProps = Pick<
   | 'shareableUrl'
   | 'embedUrlParamExtensions'
   | 'objectType'
+  | 'isDirty'
 > & {
   setIsNotSaved: () => void;
+  objectConfig?: ShareContextObjectTypeConfig;
 };
 
 interface UrlParams {
@@ -52,7 +54,9 @@ export const EmbedContent = ({
   shareableUrlForSavedObject,
   shareableUrl,
   objectType,
+  objectConfig = {},
   setIsNotSaved,
+  isDirty,
 }: EmbedProps) => {
   const isMounted = useMountedState();
   const [urlParams, setUrlParams] = useState<UrlParams | undefined>(undefined);
@@ -252,12 +256,20 @@ export const EmbedContent = ({
       />
     );
 
+  const { draftModeCallOut: DraftModeCallout } = objectConfig;
+
   return (
     <>
       <EuiForm>
         <EuiText size="s">{helpText}</EuiText>
         <EuiSpacer />
         {renderUrlParamExtensions()}
+        {isDirty && DraftModeCallout && (
+          <>
+            <EuiSpacer size="m" />
+            {DraftModeCallout}
+          </>
+        )}
         <EuiSpacer />
       </EuiForm>
       <EuiFlexGroup justifyContent="flexEnd" responsive={false}>

--- a/src/plugins/share/public/components/tabs/embed/index.tsx
+++ b/src/plugins/share/public/components/tabs/embed/index.tsx
@@ -38,8 +38,14 @@ const embedTabReducer: IEmbedTab['reducer'] = (state = { url: '', isNotSaved: fa
 };
 
 const EmbedTabContent: NonNullable<IEmbedTab['content']> = ({ state, dispatch }) => {
-  const { embedUrlParamExtensions, shareableUrlForSavedObject, shareableUrl, objectType, isDirty } =
-    useShareTabsContext()!;
+  const {
+    embedUrlParamExtensions,
+    shareableUrlForSavedObject,
+    shareableUrl,
+    objectType,
+    objectTypeMeta,
+    isDirty,
+  } = useShareTabsContext()!;
 
   const setIsNotSaved = useCallback(() => {
     dispatch({
@@ -55,8 +61,10 @@ const EmbedTabContent: NonNullable<IEmbedTab['content']> = ({ state, dispatch })
         shareableUrlForSavedObject,
         shareableUrl,
         objectType,
+        objectConfig: objectTypeMeta?.config?.embed,
         isNotSaved: state?.isNotSaved,
         setIsNotSaved,
+        isDirty,
       }}
     />
   );

--- a/src/plugins/share/public/components/tabs/link/index.tsx
+++ b/src/plugins/share/public/components/tabs/link/index.tsx
@@ -51,6 +51,7 @@ const linkTabReducer: ILinkTab['reducer'] = (
 const LinkTabContent: ILinkTab['content'] = ({ state, dispatch }) => {
   const {
     objectType,
+    objectTypeMeta,
     objectId,
     isDirty,
     shareableUrl,
@@ -86,6 +87,7 @@ const LinkTabContent: ILinkTab['content'] = ({ state, dispatch }) => {
     <LinkContent
       {...{
         objectType,
+        objectConfig: objectTypeMeta?.config?.link,
         objectId,
         isDirty,
         shareableUrl,

--- a/src/plugins/share/public/components/tabs/link/link_content.tsx
+++ b/src/plugins/share/public/components/tabs/link/link_content.tsx
@@ -10,7 +10,6 @@
 import {
   copyToClipboard,
   EuiButton,
-  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
@@ -21,7 +20,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useState, useRef, useEffect } from 'react';
-import type { IShareContext } from '../../context';
+import type { IShareContext, ShareContextObjectTypeConfig } from '../../context';
 
 type LinkProps = Pick<
   IShareContext,
@@ -33,7 +32,7 @@ type LinkProps = Pick<
   | 'delegatedShareUrlHandler'
   | 'shareableUrlLocatorParams'
   | 'allowShortUrl'
->;
+> & { objectConfig?: ShareContextObjectTypeConfig };
 
 interface UrlParams {
   [extensionName: string]: {
@@ -44,6 +43,7 @@ interface UrlParams {
 export const LinkContent = ({
   isDirty,
   objectType,
+  objectConfig = {},
   shareableUrl,
   urlService,
   shareableUrlLocatorParams,
@@ -116,6 +116,8 @@ export const LinkContent = ({
     setIsLoading(false);
   }, [snapshotUrl, delegatedShareUrlHandler, allowShortUrl, createShortUrl]);
 
+  const { draftModeCallOut: DraftModeCallout } = objectConfig;
+
   return (
     <>
       <EuiForm>
@@ -126,21 +128,10 @@ export const LinkContent = ({
             values={{ objectType }}
           />
         </EuiText>
-        {isDirty && objectType === 'lens' && (
+        {isDirty && DraftModeCallout && (
           <>
             <EuiSpacer size="m" />
-            <EuiCallOut
-              color="warning"
-              iconType="warning"
-              title={
-                <FormattedMessage id="share.link.warning.title" defaultMessage="Unsaved changes" />
-              }
-            >
-              <FormattedMessage
-                id="share.link.warning.lens"
-                defaultMessage="Copy the link to get a temporary link. Save the lens visualization to create a permanent link."
-              />
-            </EuiCallOut>
+            {DraftModeCallout}
           </>
         )}
         <EuiSpacer size="l" />

--- a/src/plugins/share/public/types.ts
+++ b/src/plugins/share/public/types.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ComponentType, ReactElement } from 'react';
+import type { ComponentType, ReactElement, ReactNode } from 'react';
 import type { InjectedIntl } from '@kbn/i18n-react';
 import { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiContextMenuPanelItemDescriptorEntry } from '@elastic/eui/src/components/context_menu/context_menu';
@@ -20,6 +20,10 @@ export type BrowserUrlService = UrlService<
   BrowserShortUrlClientFactoryCreateParams,
   BrowserShortUrlClient
 >;
+
+export interface ShareContextObjectTypeConfig {
+  draftModeCallOut?: ReactNode;
+}
 
 /**
  * @public
@@ -37,6 +41,7 @@ export interface ShareContext {
    */
   objectTypeMeta: {
     title: string;
+    config?: Partial<Record<'link' | 'export' | 'embed', ShareContextObjectTypeConfig>>;
   };
   objectId?: string;
   /**

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -17,6 +17,8 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { DataViewPickerProps } from '@kbn/unified-search-plugin/public';
 import { getManagedContentBadge } from '@kbn/managed-content-badge';
 import moment from 'moment';
+import { EuiCallOut } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { LENS_APP_LOCATOR } from '../../common/locator/locator';
 import { LENS_APP_NAME } from '../../common/constants';
 import { LensAppServices, LensTopNavActions, LensTopNavMenuProps } from './types';
@@ -641,6 +643,26 @@ export const LensTopNavMenu = ({
                 title: i18n.translate('xpack.lens.app.shareModal.title', {
                   defaultMessage: 'Share this Lens visualization',
                 }),
+                config: {
+                  link: {
+                    draftModeCallOut: (
+                      <EuiCallOut
+                        color="warning"
+                        title={
+                          <FormattedMessage
+                            id="xpack.lens.app.shareModal.draftModeCallout.title"
+                            defaultMessage="Unsaved changes"
+                          />
+                        }
+                      >
+                        <FormattedMessage
+                          id="xpack.lens.app.shareModal.draftModeCallout.link.warning"
+                          defaultMessage="Copy the link to get a temporary link. Save the lens visualization to create a permanent link."
+                        />
+                      </EuiCallOut>
+                    ),
+                  },
+                },
               },
               sharingData,
               // only want to know about changes when savedObjectURL.href

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -657,7 +657,7 @@ export const LensTopNavMenu = ({
                       >
                         <FormattedMessage
                           id="xpack.lens.app.shareModal.draftModeCallout.link.warning"
-                          defaultMessage="The link will only work temporarily. Save the Lens visualization first to create a permanent link."
+                          defaultMessage="The copied link resolves to the current state of this visualization. To get a permanent link, make sure to save your Lens visualization first."
                         />
                       </EuiCallOut>
                     ),

--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -657,7 +657,7 @@ export const LensTopNavMenu = ({
                       >
                         <FormattedMessage
                           id="xpack.lens.app.shareModal.draftModeCallout.link.warning"
-                          defaultMessage="Copy the link to get a temporary link. Save the lens visualization to create a permanent link."
+                          defaultMessage="The link will only work temporarily. Save the Lens visualization first to create a permanent link."
                         />
                       </EuiCallOut>
                     ),


### PR DESCRIPTION
## Summary


This PR  Resolves https://github.com/elastic/kibana/issues/191090

In addition, it adds implementation to allow consumers pass in their callout message of choice for handling the message displayed to users on attempting to copy a url especially that when short urls are allowed, in draft mode the URL copied will not point to the same configuration once the change has been persisted.

For lens the message that was displayed previously when presented with the option to copy a link remains the same, however for dashboard a new message is being added. See screenshot below;


<img width="540" alt="Screenshot 2024-10-23 at 22 58 46" src="https://github.com/user-attachments/assets/90d584b5-d48c-4521-b75c-2c7827ddf444">


### Checklist
<!-- 
Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials -->
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
<!--
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

-->

<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.x"]} ONMERGE-->