### PR TITLE
[Cloud Security] add sideEffects: false to shared csp packages

### DIFF
--- a/x-pack/packages/kbn-cloud-security-posture/common/package.json
+++ b/x-pack/packages/kbn-cloud-security-posture/common/package.json
@@ -3,5 +3,6 @@
     "private": true,
     "version": "1.0.0",
     "license": "Elastic License 2.0",
-    "description": "Shared components for cloud security posture, both client and server side"
+    "description": "Shared components for cloud security posture, both client and server side",
+    "sideEffects": false
   }

--- a/x-pack/packages/kbn-cloud-security-posture/public/package.json
+++ b/x-pack/packages/kbn-cloud-security-posture/public/package.json
@@ -3,5 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "license": "Elastic License 2.0",
-  "description": "Shared components for cloud security posture, client side"
+  "description": "Shared components for cloud security posture, client side",
+  "sideEffects": false
 }


### PR DESCRIPTION
## Summary

add `sideEffects: false` to shared packages for better tree shaking, see [docs](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) and [related discussion](https://elastic.slack.com/archives/C5TQ33ND8/p1724317421954709?thread_ts=1724314732.061379&cid=C5TQ33ND8)




<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->