### PR TITLE
[Fleet] Default new agentless-only integration setup technology to agentless

### DIFF
--- a/x-pack/plugins/fleet/README.md
+++ b/x-pack/plugins/fleet/README.md
@@ -32,6 +32,7 @@ In addition, it is typically needed to set up a Fleet Server and enroll Elastic 
 - [Running a local Fleet Server and enrolling Elastic Agents](dev_docs/local_setup/enrolling_agents.md) for developing Kibana in stateful (not serverless) mode
 - [Developing Kibana in serverless mode](dev_docs/local_setup/developing_kibana_in_serverless.md) for developing Kibana in serverless mode
 - [Developing Kibana and Fleet Server simultaneously](dev_docs/local_setup/developing_kibana_and_fleet_server.md) for doing simultaneous Kibana and Fleet Server development
+- [Testing agentless integrations](dev_docs/local_setup/agentless.md)
 
 ### Running Fleet locally in stateful mode
 

--- a/x-pack/plugins/fleet/dev_docs/local_setup/agentless.md
+++ b/x-pack/plugins/fleet/dev_docs/local_setup/agentless.md
@@ -1,0 +1,28 @@
+# Testing agentless integrations
+
+Integrations have two possible deployment modes:
+* on user-managed agents (most cases)
+* on internally managed agents: these are called agentless
+
+## Kibana config
+
+Agentless integrations are available in ESS and Serverless, so in order to test or develop these in a local environment, the config should emulate either of these.
+
+At the time of writing, this can be achieved by adding the following to your `kibana.dev.yml`:
+```
+# Emulate cloud
+xpack.cloud.id: "123456789"
+
+# Enable agentless experimental feature flag in Fleet
+xpack.fleet.enableExperimental: ['agentless']
+# Agentless Fleet config
+xpack.fleet.agentless.enabled: true
+xpack.fleet.agentless.api.url: 'https://api.agentless.url/api/v1/ess'
+xpack.fleet.agentless.api.tls.certificate: './config/node.crt'
+xpack.fleet.agentless.api.tls.key: './config/node.key'
+xpack.fleet.agentless.api.tls.ca: './config/ca.crt'
+```
+
+## Which integrations to test with?
+
+At the time of writing, the Elastic Connectors integration is [agentless only](https://github.com/elastic/integrations/blob/2ebdf0cada6faed352e71a82cf71487672f27bf2/packages/elastic_connectors/manifest.yml#L35-L39) and the Cloud Security Posture Management (CSPM) integration offers both agent-based and agentless deployment modes. These are still in technical preview, so "Display beta integrations" should be checked.

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
@@ -227,6 +227,74 @@ describe('useSetupTechnology', () => {
     expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
   });
 
+  it('should set the default selected setup technology to agent-based when creating a non agentless-only package policy', async () => {
+    (useConfig as MockFn).mockReturnValue({
+      agentless: {
+        enabled: true,
+        api: {
+          url: 'https://agentless.api.url',
+        },
+      },
+    } as any);
+    (useStartServices as MockFn).mockReturnValue({
+      cloud: {
+        isCloudEnabled: true,
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useSetupTechnology({
+        setNewAgentPolicy,
+        newAgentPolicy: newAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
+        setSelectedPolicyTab: setSelectedPolicyTabMock,
+        packageInfo: packageInfoMock,
+        packagePolicy: packagePolicyMock,
+      })
+    );
+
+    expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
+  });
+
+  it('should set the default selected setup technology to agentless when creating an agentless-only package policy', async () => {
+    (useConfig as MockFn).mockReturnValue({
+      agentless: {
+        enabled: true,
+        api: {
+          url: 'https://agentless.api.url',
+        },
+      },
+    } as any);
+    (useStartServices as MockFn).mockReturnValue({
+      cloud: {
+        isCloudEnabled: true,
+      },
+    });
+    const agentlessOnlyPackageInfoMock = {
+      policy_templates: [
+        {
+          deployment_modes: {
+            default: { enabled: false },
+            agentless: { enabled: true },
+          },
+        },
+      ],
+    } as PackageInfo;
+
+    const { result } = renderHook(() =>
+      useSetupTechnology({
+        setNewAgentPolicy,
+        newAgentPolicy: newAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
+        setSelectedPolicyTab: setSelectedPolicyTabMock,
+        packageInfo: agentlessOnlyPackageInfoMock,
+        packagePolicy: packagePolicyMock,
+      })
+    );
+
+    expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENTLESS);
+  });
+
   it('should fetch agentless policy if agentless feature is enabled and isServerless is true', async () => {
     const { waitForNextUpdate } = renderHook(() =>
       useSetupTechnology({
@@ -336,7 +404,11 @@ describe('useSetupTechnology', () => {
       })
     );
 
+    await rerender();
+
     expect(generateNewAgentPolicyWithDefaults).toHaveBeenCalled();
+
+    expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
 
     act(() => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useConfig } from '../../../../../hooks';
 import { ExperimentalFeaturesService } from '../../../../../services';
@@ -28,6 +28,7 @@ import {
 import {
   isAgentlessIntegration as isAgentlessIntegrationFn,
   getAgentlessAgentPolicyNameFromPackagePolicyName,
+  isOnlyAgentlessIntegration,
 } from '../../../../../../../../common/services/agentless_policy_helper';
 
 export const useAgentless = () => {
@@ -97,9 +98,13 @@ export function useSetupTechnology({
 
   // this is a placeholder for the new agent-BASED policy that will be used when the user switches from agentless to agent-based and back
   const newAgentBasedPolicy = useRef<NewAgentPolicy>(newAgentPolicy);
-  const [selectedSetupTechnology, setSelectedSetupTechnology] = useState<SetupTechnology>(
-    SetupTechnology.AGENT_BASED
-  );
+  const defaultSetupTechnology = useMemo(() => {
+    return isOnlyAgentlessIntegration(packageInfo)
+      ? SetupTechnology.AGENTLESS
+      : SetupTechnology.AGENT_BASED;
+  }, [packageInfo]);
+  const [selectedSetupTechnology, setSelectedSetupTechnology] =
+    useState<SetupTechnology>(defaultSetupTechnology);
   const [newAgentlessPolicy, setNewAgentlessPolicy] = useState<AgentPolicy | NewAgentPolicy>(() => {
     const agentless = generateNewAgentPolicyWithDefaults({
       inactivity_timeout: 3600,
@@ -153,6 +158,13 @@ export function useSetupTechnology({
       fetchAgentlessPolicy();
     }
   }, [isDefaultAgentlessPolicyEnabled]);
+
+  useEffect(() => {
+    if (isEditPage) {
+      return;
+    }
+    setSelectedSetupTechnology(defaultSetupTechnology);
+  }, [packageInfo, defaultSetupTechnology, isEditPage]);
 
   const handleSetupTechnologyChange = useCallback(
     (setupTechnology: SetupTechnology, policyTemplateName?: string) => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/193007

This change ensures that when installing agentless-only integrations in the UI, the "Setup technology" dropdown menu defaults to "Agentless".

I also added a quick dev doc to capture the local setup needed to test agentless.

### How to test

1\. Add the following to `kibana.dev.yml`:
```yml
# Emulate cloud
xpack.cloud.id: "123456789"

# Enable agentless experimental feature flag in Fleet
xpack.fleet.enableExperimental: ['agentless']
# Agentless Fleet config
xpack.fleet.agentless.enabled: true
xpack.fleet.agentless.api.url: 'https://api.agentless.url/api/v1/ess'
xpack.fleet.agentless.api.tls.certificate: './config/node.crt'
xpack.fleet.agentless.api.tls.key: './config/node.key'
xpack.fleet.agentless.api.tls.ca: './config/ca.crt'
```

2\. Go to the integrations catalog, tick "Display beta integrations" and add the "Add Elastic Connectors" integration. The "Setup technology" dropdown menu should default to "Agentless". It should still be possible to select "Agent-based".

![Screenshot 2024-10-24 at 12 18 12](https://github.com/user-attachments/assets/33244e5b-4393-4204-84fe-748557453d29)

3\. Add the "Cloud Security Posture Management (CSPM)" integration. The "Setup technology" dropdown menu (under "Advanced options") should default to "Agent-based". It should still be possible to select "Agentless".

![Screenshot 2024-10-24 at 12 18 42](https://github.com/user-attachments/assets/75b41f3a-9c80-4751-a44a-e2bd0e0b4c5a)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->