### PR TITLE
chore(o11y): add missing access options to routes

### DIFF
--- a/x-pack/plugins/observability_solution/observability/server/lib/annotations/register_annotation_apis.ts
+++ b/x-pack/plugins/observability_solution/observability/server/lib/annotations/register_annotation_apis.ts
@@ -98,6 +98,9 @@ export function registerAnnotationAPIs({
       validate: {
         body: unknowns,
       },
+      options: {
+        access: 'public',
+      },
     },
     wrapRouteHandler(t.type({ body: createAnnotationRt }), ({ data, client }) => {
       return client.create(data.body);
@@ -109,6 +112,9 @@ export function registerAnnotationAPIs({
       path: '/api/observability/annotation/{id}',
       validate: {
         body: unknowns,
+      },
+      options: {
+        access: 'public',
       },
     },
     wrapRouteHandler(t.type({ body: updateAnnotationRt }), ({ data, client }) => {
@@ -122,6 +128,9 @@ export function registerAnnotationAPIs({
       validate: {
         params: unknowns,
       },
+      options: {
+        access: 'public',
+      },
     },
     wrapRouteHandler(t.type({ params: deleteAnnotationRt }), ({ data, client }) => {
       return client.delete(data.params);
@@ -133,6 +142,9 @@ export function registerAnnotationAPIs({
       path: '/api/observability/annotation/{id}',
       validate: {
         params: unknowns,
+      },
+      options: {
+        access: 'public',
       },
     },
     wrapRouteHandler(t.type({ params: getAnnotationByIdRt }), ({ data, client }) => {
@@ -146,6 +158,9 @@ export function registerAnnotationAPIs({
       validate: {
         query: unknowns,
       },
+      options: {
+        access: 'public',
+      },
     },
     wrapRouteHandler(t.type({ query: findAnnotationRt }), ({ data, client }) => {
       return client.find(data.query);
@@ -157,6 +172,9 @@ export function registerAnnotationAPIs({
       path: '/api/observability/annotation/permissions',
       validate: {
         query: unknowns,
+      },
+      options: {
+        access: 'public',
       },
     },
     wrapRouteHandler(t.type({}), ({ client }) => {

--- a/x-pack/plugins/observability_solution/observability/server/routes/assistant/route.ts
+++ b/x-pack/plugins/observability_solution/observability/server/routes/assistant/route.ts
@@ -13,6 +13,7 @@ const getObservabilityAlertDetailsContextRoute = createObservabilityServerRoute(
   endpoint: 'GET /internal/observability/assistant/alert_details_contextual_insights',
   options: {
     tags: [],
+    access: 'internal',
   },
   params: t.type({
     query: alertDetailsContextRt,

--- a/x-pack/plugins/observability_solution/observability/server/routes/rules/route.ts
+++ b/x-pack/plugins/observability_solution/observability/server/routes/rules/route.ts
@@ -13,6 +13,7 @@ const alertsDynamicIndexPatternRoute = createObservabilityServerRoute({
   endpoint: 'GET /api/observability/rules/alerts/dynamic_index_pattern 2023-10-31',
   options: {
     tags: [],
+    access: 'public',
   },
   params: t.type({
     query: t.type({


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/192730


### 🧀 Summary

This PR adds the missing access option in some o11y routes.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->