### PR TITLE
[EDR Workflows] Rename Osquery Serverless tests job name

### DIFF
--- a/.buildkite/pipelines/chrome_forward_testing.yml
+++ b/.buildkite/pipelines/chrome_forward_testing.yml
@@ -300,7 +300,7 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
-    label: 'Serverless Osquery Cypress Tests'
+    label: 'Osquery Cypress Tests on Serverless'
     agents:
       machineType: n2-standard-4
       preemptible: true

--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -218,7 +218,7 @@ steps:
               limit: 1
 
       - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
-        label: "Serverless Osquery Cypress Tests"
+        label: "Osquery Cypress Tests on Serverless"
         if: "build.env('SKIP_CYPRESS') != '1' && build.env('SKIP_CYPRESS') != 'true'"
         agents:
           image: family/kibana-ubuntu-2004

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -405,7 +405,7 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
-    label: 'Serverless Osquery Cypress Tests'
+    label: 'Osquery Cypress Tests on Serverless'
     agents:
       image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/pointer_compression.yml
+++ b/.buildkite/pipelines/pointer_compression.yml
@@ -339,7 +339,7 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
-    label: 'Serverless Osquery Cypress Tests'
+    label: 'Osquery Cypress Tests on Serverless'
     agents:
       image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod

--- a/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/osquery_cypress.yml
@@ -15,7 +15,7 @@ steps:
           limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
-    label: 'Serverless Osquery Cypress Tests'
+    label: 'Osquery Cypress Tests on Serverless'
     agents:
       machineType: n2-standard-4
       preemptible: true


### PR DESCRIPTION
I noticed that Osquery serverless is not following the pattern of other tests (eg. Defend Workflows). This change will help keep them in proper order.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->