### PR TITLE
[ci] Set disk size for artifact builds

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -6,6 +6,7 @@ steps:
       imageProject: elastic-images-prod
       provider: gcp
       machineType: c2-standard-16
+      diskSizeGb: 125
     timeout_in_minutes: 120
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -12,6 +12,7 @@ steps:
     agents:
       machineType: n2-standard-8
       preemptible: true
+      diskSizeGb: 125
     key: build
     if: "build.env('KIBANA_BUILD_ID') == null || build.env('KIBANA_BUILD_ID') == ''"
     timeout_in_minutes: 90


### PR DESCRIPTION
Defines disk size for artifact builds.  This will be a no-op - the boot disk size is >= the definitions in this PR.

A test run with the smaller boot disk can be seen in https://buildkite.com/elastic/kibana-pull-request/builds/248242.  I plan on making further adjustments after the boot disk has been promoted.

<!--ONMERGE {"backportTargets":["7.17","8.15","8.16","8.17","8.x"]} ONMERGE-->