### PR TITLE
[CLOUD] add the term search for es in kibana

### DIFF
--- a/x-pack/plugins/cloud/common/parse_onboarding_default_solution.test.ts
+++ b/x-pack/plugins/cloud/common/parse_onboarding_default_solution.test.ts
@@ -16,6 +16,8 @@ describe('parseOnboardingSolution', () => {
     [
       ['elasticsearch', 'es'],
       ['Elasticsearch', 'es'],
+      ['search', 'es'],
+      ['Search', 'es'],
       ['observability', 'oblt'],
       ['Observability', 'oblt'],
       ['security', 'security'],

--- a/x-pack/plugins/cloud/common/parse_onboarding_default_solution.ts
+++ b/x-pack/plugins/cloud/common/parse_onboarding_default_solution.ts
@@ -18,9 +18,13 @@ export function parseOnboardingSolution(value?: string): OnBoardingDefaultSoluti
   if (!value) return;
 
   const solutions: Array<{
-    cloudValue: 'elasticsearch' | 'observability' | 'security';
+    cloudValue: 'search' | 'elasticsearch' | 'observability' | 'security';
     kibanaValue: OnBoardingDefaultSolution;
   }> = [
+    {
+      cloudValue: 'search',
+      kibanaValue: 'es',
+    },
     {
       cloudValue: 'elasticsearch',
       kibanaValue: 'es',

--- a/x-pack/plugins/spaces/server/routes/lib/parse_cloud_solution.test.ts
+++ b/x-pack/plugins/spaces/server/routes/lib/parse_cloud_solution.test.ts
@@ -13,6 +13,10 @@ describe('parseCloudSolution', () => {
     expect(parseCloudSolution('elasticsearch')).toBe('es');
   });
 
+  it('should return "es" for "search"', () => {
+    expect(parseCloudSolution('search')).toBe('es');
+  });
+
   it('should return "oblt" for "observability"', () => {
     expect(parseCloudSolution('observability')).toBe('oblt');
   });
@@ -24,6 +28,10 @@ describe('parseCloudSolution', () => {
   // Test case insensitivity
   it('should return "es" for "ELASTICSEARCH"', () => {
     expect(parseCloudSolution('ELASTICSEARCH')).toBe('es');
+  });
+
+  it('should return "es" for "SEARCH"', () => {
+    expect(parseCloudSolution('SEARCH')).toBe('es');
   });
 
   it('should return "oblt" for "OBSERVABILITY"', () => {

--- a/x-pack/plugins/spaces/server/routes/lib/parse_cloud_solution.ts
+++ b/x-pack/plugins/spaces/server/routes/lib/parse_cloud_solution.ts
@@ -8,6 +8,7 @@
 import type { SolutionView } from '../../../common';
 
 const CLOUD_TO_KIBANA_SOLUTION_MAP = new Map<string, SolutionView>([
+  ['search', 'es'],
   ['elasticsearch', 'es'],
   ['observability', 'oblt'],
   ['security', 'security'],


### PR DESCRIPTION
## Summary

The cloud can pass the term `search` for the solution type. It will be ideal to only have one term but for now let's merge this fix and I will check with CP that we only pass one term for `search` and `elasticsearch`.


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->