### PR TITLE
[8.x] [console] Reenable functional tests aside from font size (#197362)

### DIFF
--- a/test/functional/apps/console/_misc_console_behavior.ts
+++ b/test/functional/apps/console/_misc_console_behavior.ts
@@ -18,8 +18,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
   const PageObjects = getPageObjects(['common', 'console', 'header']);
 
-  // Failing: See https://github.com/elastic/kibana/issues/193868
-  describe.skip('misc console behavior', function testMiscConsoleBehavior() {
+  describe('misc console behavior', function testMiscConsoleBehavior() {
     before(async () => {
       await browser.setWindowSize(1200, 800);
       await PageObjects.common.navigateToApp('console');
@@ -148,8 +147,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.console.toggleKeyboardShortcuts(true);
     });
 
-    describe('customizable font size', () => {
-      // flaky
+    // Failing: See https://github.com/elastic/kibana/issues/193868
+    describe.skip('customizable font size', () => {
       it('should allow the font size to be customized', async () => {
         await PageObjects.console.openConfig();
         await PageObjects.console.setFontSizeSetting(20);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[console] Reenable functional tests aside from font size (#197362)](https://github.com/elastic/kibana/pull/197362)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Matthew Kime","email":"matt@mattki.me"},"sourceCommit":{"committedDate":"2024-10-24T11:38:26Z","message":"[console] Reenable functional tests aside from font size (#197362)\n\n## Summary\r\n\r\nThis is really just a more focused `skip` application so we can get as\r\nmany tests running as quickly as possible.\r\n\r\nPart of: https://github.com/elastic/kibana/issues/193868","sha":"f67bc3287b7b9a3c4bde49151cc4fec035fb7faf","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","v9.0.0","backport:prev-minor"],"number":197362,"url":"https://github.com/elastic/kibana/pull/197362","mergeCommit":{"message":"[console] Reenable functional tests aside from font size (#197362)\n\n## Summary\r\n\r\nThis is really just a more focused `skip` application so we can get as\r\nmany tests running as quickly as possible.\r\n\r\nPart of: https://github.com/elastic/kibana/issues/193868","sha":"f67bc3287b7b9a3c4bde49151cc4fec035fb7faf"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/197362","number":197362,"mergeCommit":{"message":"[console] Reenable functional tests aside from font size (#197362)\n\n## Summary\r\n\r\nThis is really just a more focused `skip` application so we can get as\r\nmany tests running as quickly as possible.\r\n\r\nPart of: https://github.com/elastic/kibana/issues/193868","sha":"f67bc3287b7b9a3c4bde49151cc4fec035fb7faf"}}]}] BACKPORT-->