### PR TITLE
[Security Assistant] Revert open AI Assistant settings in new tab

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
@@ -12,7 +12,6 @@ import {
   EuiContextMenuPanel,
   EuiContextMenuItem,
   EuiConfirmModal,
-  EuiIcon,
   EuiNotificationBadge,
   EuiPopover,
   EuiButtonIcon,
@@ -70,7 +69,6 @@ export const SettingsContextMenu: React.FC<Params> = React.memo(
       () =>
         navigateToApp('management', {
           path: 'kibana/securityAiAssistantManagement',
-          openInNewTab: true,
         }),
       [navigateToApp]
     );
@@ -84,7 +82,6 @@ export const SettingsContextMenu: React.FC<Params> = React.memo(
       () =>
         navigateToApp('management', {
           path: `kibana/securityAiAssistantManagement?tab=${KNOWLEDGE_BASE_TAB}`,
-          openInNewTab: true,
         }),
       [navigateToApp]
     );
@@ -105,13 +102,6 @@ export const SettingsContextMenu: React.FC<Params> = React.memo(
           data-test-subj={'ai-assistant-settings'}
         >
           {i18n.AI_ASSISTANT_SETTINGS}
-          <EuiIcon
-            css={css`
-              margin-left: ${euiThemeVars.euiSizeXS};
-            `}
-            size="s"
-            type="popout"
-          />
         </EuiContextMenuItem>,
         <EuiContextMenuItem
           aria-label={'knowledge-base'}
@@ -120,13 +110,6 @@ export const SettingsContextMenu: React.FC<Params> = React.memo(
           data-test-subj={'knowledge-base'}
         >
           {i18n.KNOWLEDGE_BASE}
-          <EuiIcon
-            css={css`
-              margin-left: ${euiThemeVars.euiSizeXS};
-            `}
-            size="s"
-            type="popout"
-          />
         </EuiContextMenuItem>,
         <EuiContextMenuItem
           aria-label={'anonymization'}


### PR DESCRIPTION
## Summary

Revert changes made in this PR https://github.com/elastic/kibana/pull/197323 to open assistant settings in new tab from context menu. This had unintended consequences, so we are reverting back to opening the assistant settings in the same tab. Below is a recording of the behavior we are moving forward with:

https://github.com/user-attachments/assets/2d3b82b5-c85f-4d82-a2b2-8327095f8b24




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->