### PR TITLE
[8.16] [Enterprise Search] Update Enterprise Search Decommissioning Callout (#197658)

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -252,6 +252,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       gitHub: `${WORKPLACE_SEARCH_DOCS}workplace-search-github-connector.html`,
       gmail: `${WORKPLACE_SEARCH_DOCS}workplace-search-gmail-connector.html`,
       googleDrive: `${WORKPLACE_SEARCH_DOCS}workplace-search-google-drive-connector.html`,
+      guide: `${WORKPLACE_SEARCH_DOCS}index.html`,
       indexingSchedule: `${WORKPLACE_SEARCH_DOCS}workplace-search-customizing-indexing-rules.html#_indexing_schedule`,
       jiraCloud: `${WORKPLACE_SEARCH_DOCS}workplace-search-jira-cloud-connector.html`,
       jiraServer: `${WORKPLACE_SEARCH_DOCS}workplace-search-jira-server-connector.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -215,6 +215,7 @@ export interface DocLinks {
     readonly gettingStarted: string;
     readonly gmail: string;
     readonly googleDrive: string;
+    readonly guide: string;
     readonly indexingSchedule: string;
     readonly jiraCloud: string;
     readonly jiraServer: string;

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engines/components/empty_state.tsx
@@ -13,6 +13,7 @@ import { EuiEmptyPrompt, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { EnterpriseSearchDeprecationCallout } from '../../../../shared/deprecation_callout/deprecation_callout';
+import { docLinks } from '../../../../shared/doc_links';
 import { EuiButtonTo } from '../../../../shared/react_router_helpers';
 import { TelemetryLogic } from '../../../../shared/telemetry';
 import { AppLogic } from '../../../app_logic';
@@ -41,6 +42,7 @@ export const EmptyState: React.FC = () => {
       {showDeprecationCallout ? (
         <EnterpriseSearchDeprecationCallout
           onDismissAction={onDismissDeprecationCallout}
+          learnMoreLinkUrl={docLinks.appSearchGuide}
           restrictWidth
         />
       ) : (

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/layout/page_template.tsx
@@ -12,6 +12,7 @@ import useObservable from 'react-use/lib/useObservable';
 
 import { APP_SEARCH_PLUGIN } from '../../../../../common/constants';
 import { EnterpriseSearchDeprecationCallout } from '../../../shared/deprecation_callout/deprecation_callout';
+import { docLinks } from '../../../shared/doc_links';
 import { KibanaLogic } from '../../../shared/kibana';
 import { SetAppSearchChrome } from '../../../shared/kibana_chrome';
 import { EnterpriseSearchPageTemplateWrapper, PageTemplateProps } from '../../../shared/layout';
@@ -59,7 +60,10 @@ export const AppSearchPageTemplate: React.FC<
     >
       {pageViewTelemetry && <SendAppSearchTelemetry action="viewed" metric={pageViewTelemetry} />}
       {showDeprecationCallout ? (
-        <EnterpriseSearchDeprecationCallout onDismissAction={onDismissDeprecationCallout} />
+        <EnterpriseSearchDeprecationCallout
+          onDismissAction={onDismissDeprecationCallout}
+          learnMoreLinkUrl={docLinks.appSearchGuide}
+        />
       ) : (
         <></>
       )}

--- a/x-pack/plugins/enterprise_search/public/applications/shared/deprecation_callout/deprecation_callout.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/deprecation_callout/deprecation_callout.test.tsx
@@ -14,7 +14,9 @@ import { EnterpriseSearchDeprecationCallout } from './deprecation_callout';
 describe('EnterpriseSearchDeprecationCallout', () => {
   it('renders', () => {
     const dismissFxn = jest.fn();
-    const wrapper = shallow(<EnterpriseSearchDeprecationCallout onDismissAction={dismissFxn} />);
+    const wrapper = shallow(
+      <EnterpriseSearchDeprecationCallout onDismissAction={dismissFxn} learnMoreLinkUrl="#" />
+    );
 
     expect(wrapper.find('EuiCallOut')).toHaveLength(1);
     wrapper.find('EuiCallOut').simulate('dismiss');
@@ -23,7 +25,9 @@ describe('EnterpriseSearchDeprecationCallout', () => {
 
   it('dismisses via the link', () => {
     const dismissFxn = jest.fn();
-    const wrapper = shallow(<EnterpriseSearchDeprecationCallout onDismissAction={dismissFxn} />);
+    const wrapper = shallow(
+      <EnterpriseSearchDeprecationCallout onDismissAction={dismissFxn} learnMoreLinkUrl="#" />
+    );
 
     expect(wrapper.find('EuiLink')).toHaveLength(1);
     wrapper.find('EuiLink').simulate('click');

--- a/x-pack/plugins/enterprise_search/public/applications/shared/deprecation_callout/deprecation_callout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/deprecation_callout/deprecation_callout.tsx
@@ -11,15 +11,15 @@ import { EuiCallOut, EuiButton, EuiLink, EuiFlexItem, EuiFlexGroup, EuiSpacer } 
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { docLinks } from '../doc_links';
-
 interface DeprecationCalloutProps {
   onDismissAction: () => void;
+  learnMoreLinkUrl: string;
   restrictWidth?: boolean;
 }
 
 export const EnterpriseSearchDeprecationCallout: React.FC<DeprecationCalloutProps> = ({
   onDismissAction,
+  learnMoreLinkUrl,
   restrictWidth = false,
 }) => {
   const maxWidth = restrictWidth ? '75%' : '100%';
@@ -43,48 +43,14 @@ export const EnterpriseSearchDeprecationCallout: React.FC<DeprecationCalloutProp
         data-test-subj="EnterpriseSearchDeprecationCallout"
       >
         <FormattedMessage
-          id="xpack.enterpriseSearch.deprecationCallout.first_message"
-          defaultMessage="The standalone Enterprise Search product, including App Search and Workplace Search, remains available in maintenance mode, but are not recommended for new search experiences. Instead, we recommend using our actively developed Elasticsearch-native tools. These tools offer the flexibility and composability of working directly with Elasticsearch indices."
-        />
-        <EuiSpacer size="s" />
-        <FormattedMessage
-          id="xpack.enterpriseSearch.deprecationCallout.second_message"
-          defaultMessage="See this {workplaceSearchBlogUrl} for more information about upgrading your internal knowledge search or this {appSearchBlogUrl} about upgrading your catalog search."
-          values={{
-            workplaceSearchBlogUrl: (
-              <EuiLink
-                data-test-subj="workplaceSearch-deprecationCallout-blog-link"
-                href={docLinks.workplaceSearchEvolutionBlog}
-                target="_blank"
-                data-telemetry-id="workplaceSearch-deprecationCallout-blog-viewLink"
-              >
-                {i18n.translate(
-                  'xpack.enterpriseSearch.deprecationCallout.viewWorkplaceSearchBlog',
-                  {
-                    defaultMessage: 'blog post',
-                  }
-                )}
-              </EuiLink>
-            ),
-            appSearchBlogUrl: (
-              <EuiLink
-                data-test-subj="appSearch-deprecationCallout-blog-link"
-                href={docLinks.appSearchEvolutionBlog}
-                target="_blank"
-                data-telemetry-id="appSearch-deprecationCallout-blog-viewLink"
-              >
-                {i18n.translate('xpack.enterpriseSearch.deprecationCallout.viewAppSearchBlog', {
-                  defaultMessage: 'blog post',
-                })}
-              </EuiLink>
-            ),
-          }}
+          id="xpack.enterpriseSearch.deprecationCallout.message"
+          defaultMessage="The standalone App Search and Workplace Search products remain available in maintenance mode. We recommend using our Elastic Stack tools to build new semantic and AI powered search experiences."
         />
         <EuiSpacer size="s" />
         <EuiFlexGroup direction="row" alignItems="center" justifyContent="flexStart">
           <EuiFlexItem grow={false}>
             <EuiButton
-              href={docLinks.appSearchEvolutionBlog}
+              href={learnMoreLinkUrl}
               color="warning"
               iconType="popout"
               iconSide="right"

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -170,6 +170,7 @@ class DocLinks {
   public workplaceSearchGitHub: string;
   public workplaceSearchGmail: string;
   public workplaceSearchGoogleDrive: string;
+  public workplaceSearchGuide: string;
   public workplaceSearchIndexingSchedule: string;
   public workplaceSearchJiraCloud: string;
   public workplaceSearchJiraServer: string;
@@ -352,6 +353,7 @@ class DocLinks {
     this.workplaceSearchGitHub = '';
     this.workplaceSearchGmail = '';
     this.workplaceSearchGoogleDrive = '';
+    this.workplaceSearchGuide = '';
     this.workplaceSearchIndexingSchedule = '';
     this.workplaceSearchJiraCloud = '';
     this.workplaceSearchJiraServer = '';
@@ -540,6 +542,7 @@ class DocLinks {
     this.workplaceSearchGitHub = docLinks.links.workplaceSearch.gitHub;
     this.workplaceSearchGmail = docLinks.links.workplaceSearch.gmail;
     this.workplaceSearchGoogleDrive = docLinks.links.workplaceSearch.googleDrive;
+    this.workplaceSearchGuide = docLinks.links.workplaceSearch.guide;
     this.workplaceSearchIndexingSchedule = docLinks.links.workplaceSearch.indexingSchedule;
     this.workplaceSearchJiraCloud = docLinks.links.workplaceSearch.jiraCloud;
     this.workplaceSearchJiraServer = docLinks.links.workplaceSearch.jiraServer;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/roles_empty_prompt.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/role_mapping/roles_empty_prompt.tsx
@@ -11,7 +11,9 @@ import { useValues } from 'kea';
 
 import { EuiEmptyPrompt, EuiButton, EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
 
+import { APP_SEARCH_PLUGIN } from '../../../../common/constants';
 import { EnterpriseSearchDeprecationCallout } from '../deprecation_callout/deprecation_callout';
+import { docLinks } from '../doc_links';
 import { KibanaLogic } from '../kibana/kibana_logic';
 import { ProductName } from '../types';
 
@@ -52,11 +54,17 @@ export const RolesEmptyPrompt: React.FC<Props> = ({ onEnable, docsLink, productN
     return null;
   }
 
+  const deprecationLearnMoreLink =
+    productName === APP_SEARCH_PLUGIN.NAME
+      ? docLinks.appSearchGuide
+      : docLinks.workplaceSearchGuide;
+
   return (
     <>
       {showDeprecationCallout ? (
         <EnterpriseSearchDeprecationCallout
           onDismissAction={onDismissDeprecationCallout}
+          learnMoreLinkUrl={deprecationLearnMoreLink}
           restrictWidth
         />
       ) : (

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/views/overview/overview.tsx
@@ -13,6 +13,7 @@ import { EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import { EnterpriseSearchDeprecationCallout } from '../../../shared/deprecation_callout/deprecation_callout';
+import { docLinks } from '../../../shared/doc_links';
 import { AppLogic } from '../../app_logic';
 import { WorkplaceSearchPageTemplate } from '../../components/layout';
 
@@ -77,7 +78,10 @@ export const Overview: React.FC = () => {
       isLoading={dataLoading}
     >
       {showDeprecationCallout ? (
-        <EnterpriseSearchDeprecationCallout onDismissAction={onDismissDeprecationCallout} />
+        <EnterpriseSearchDeprecationCallout
+          onDismissAction={onDismissDeprecationCallout}
+          learnMoreLinkUrl={docLinks.workplaceSearchGuide}
+        />
       ) : (
         <></>
       )}


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.16`:
 - [[Enterprise Search] Update Enterprise Search Decommissioning Callout (#197658)](https://github.com/elastic/kibana/pull/197658)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Mark J. Hoy","email":"mark.hoy@elastic.co"},"sourceCommit":{"committedDate":"2024-10-24T19:10:16Z","message":"[Enterprise Search] Update Enterprise Search Decommissioning Callout (#197658)\n\n## Summary\r\n\r\nUpdates the decommissioning callout text and makes the \"Learn more\"\r\nbutton context aware for App Search and Workplace Search.\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/4871fbb3-61f1-4c39-8af0-d8964a091bca)\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)\r\n- [ ] This will appear in the **Release Notes** and follow the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"20a83d1785eec579f9f37a6337357d8a6eee59cd","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:EnterpriseSearch","v8.16.0","backport:version","v8.17.0"],"number":197658,"url":"https://github.com/elastic/kibana/pull/197658","mergeCommit":{"message":"[Enterprise Search] Update Enterprise Search Decommissioning Callout (#197658)\n\n## Summary\r\n\r\nUpdates the decommissioning callout text and makes the \"Learn more\"\r\nbutton context aware for App Search and Workplace Search.\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/4871fbb3-61f1-4c39-8af0-d8964a091bca)\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)\r\n- [ ] This will appear in the **Release Notes** and follow the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"20a83d1785eec579f9f37a6337357d8a6eee59cd"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->