### PR TITLE
[ML] AIOps: Fix and reenable functional tests for log rate analysis

### DIFF
--- a/x-pack/test/functional/apps/aiops/log_rate_analysis.ts
+++ b/x-pack/test/functional/apps/aiops/log_rate_analysis.ts
@@ -315,8 +315,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/176387
-  describe.skip('log rate analysis', function () {
+  describe('log rate analysis', function () {
     for (const testData of logRateAnalysisTestData) {
       describe(`with '${testData.sourceIndexOrSavedSearch}'`, function () {
         before(async () => {

--- a/x-pack/test/functional/apps/aiops/log_rate_analysis/test_data/farequote_data_view_test_data_with_query.ts
+++ b/x-pack/test/functional/apps/aiops/log_rate_analysis/test_data/farequote_data_view_test_data_with_query.ts
@@ -64,128 +64,134 @@ export const farequoteDataViewTestDataWithQuery: TestData = {
         filters: [],
         searchQuery: {
           bool: {
-            filter: [],
-            must_not: [
+            filter: [
               {
                 bool: {
-                  minimum_should_match: 1,
-                  should: [
-                    {
-                      bool: {
-                        minimum_should_match: 1,
-                        should: [
-                          {
-                            term: {
-                              airline: {
-                                value: 'SWR',
+                  must_not: {
+                    bool: {
+                      minimum_should_match: 1,
+                      should: [
+                        {
+                          bool: {
+                            minimum_should_match: 1,
+                            should: [
+                              {
+                                term: {
+                                  airline: {
+                                    value: 'SWR',
+                                  },
+                                },
                               },
-                            },
+                            ],
                           },
-                        ],
-                      },
-                    },
-                    {
-                      bool: {
-                        minimum_should_match: 1,
-                        should: [
-                          {
-                            term: {
-                              airline: {
-                                value: 'ACA',
+                        },
+                        {
+                          bool: {
+                            minimum_should_match: 1,
+                            should: [
+                              {
+                                term: {
+                                  airline: {
+                                    value: 'ACA',
+                                  },
+                                },
                               },
-                            },
+                            ],
                           },
-                        ],
-                      },
-                    },
-                    {
-                      bool: {
-                        minimum_should_match: 1,
-                        should: [
-                          {
-                            term: {
-                              airline: {
-                                value: 'AWE',
+                        },
+                        {
+                          bool: {
+                            minimum_should_match: 1,
+                            should: [
+                              {
+                                term: {
+                                  airline: {
+                                    value: 'AWE',
+                                  },
+                                },
                               },
-                            },
+                            ],
                           },
-                        ],
-                      },
-                    },
-                    {
-                      bool: {
-                        minimum_should_match: 1,
-                        should: [
-                          {
-                            term: {
-                              airline: {
-                                value: 'BAW',
+                        },
+                        {
+                          bool: {
+                            minimum_should_match: 1,
+                            should: [
+                              {
+                                term: {
+                                  airline: {
+                                    value: 'BAW',
+                                  },
+                                },
                               },
-                            },
+                            ],
                           },
-                        ],
-                      },
-                    },
-                    {
-                      bool: {
-                        minimum_should_match: 1,
-                        should: [
-                          {
-                            term: {
-                              airline: {
-                                value: 'JAL',
+                        },
+                        {
+                          bool: {
+                            minimum_should_match: 1,
+                            should: [
+                              {
+                                term: {
+                                  airline: {
+                                    value: 'JAL',
+                                  },
+                                },
                               },
-                            },
+                            ],
                           },
-                        ],
-                      },
-                    },
-                    {
-                      bool: {
-                        minimum_should_match: 1,
-                        should: [
-                          {
-                            term: {
-                              airline: {
-                                value: 'JBU',
+                        },
+                        {
+                          bool: {
+                            minimum_should_match: 1,
+                            should: [
+                              {
+                                term: {
+                                  airline: {
+                                    value: 'JBU',
+                                  },
+                                },
                               },
-                            },
+                            ],
                           },
-                        ],
-                      },
-                    },
-                    {
-                      bool: {
-                        minimum_should_match: 1,
-                        should: [
-                          {
-                            term: {
-                              airline: {
-                                value: 'JZA',
+                        },
+                        {
+                          bool: {
+                            minimum_should_match: 1,
+                            should: [
+                              {
+                                term: {
+                                  airline: {
+                                    value: 'JZA',
+                                  },
+                                },
                               },
-                            },
+                            ],
                           },
-                        ],
-                      },
-                    },
-                    {
-                      bool: {
-                        minimum_should_match: 1,
-                        should: [
-                          {
-                            term: {
-                              airline: {
-                                value: 'KLM',
+                        },
+                        {
+                          bool: {
+                            minimum_should_match: 1,
+                            should: [
+                              {
+                                term: {
+                                  airline: {
+                                    value: 'KLM',
+                                  },
+                                },
                               },
-                            },
+                            ],
                           },
-                        ],
-                      },
+                        },
+                      ],
                     },
-                  ],
+                  },
                 },
               },
             ],
+            must: [],
+            must_not: [],
+            should: [],
           },
         },
         searchQueryLanguage: 'kuery',


### PR DESCRIPTION
## Summary

Follow up to #189863 and #196585.
Related to #176387.

This updates asserting the url state for log rate analysis with a query and reenables the functional tests.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)



<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->