### PR TITLE
[Synthetics] URL validation softens to allow vars usage !!

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.test.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.test.ts
@@ -21,6 +21,14 @@ describe('isValidUrl', () => {
   it('returns true for valid URL', () => {
     expect(isValidURL('https://elastic.co')).toBeTruthy();
   });
+
+  it('returns skips validation vars', () => {
+    expect(isValidURL('${urlParam}')).toBeTruthy();
+  });
+
+  it('returns skips validation vars with http', () => {
+    expect(isValidURL('http://${urlParam}')).toBeTruthy();
+  });
 });
 
 describe('getUrlsField', () => {

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.ts
@@ -8,6 +8,7 @@
 import { omit, uniqBy } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { isValidNamespace } from '@kbn/fleet-plugin/common';
+import { hasNoParams } from '../../formatters/formatting_utils';
 import { formatLocation } from '../../../../common/utils/location_formatter';
 import {
   BrowserFields,
@@ -408,6 +409,10 @@ export const getOptionalListField = (value?: string[] | string): string[] => {
  * @returns `true` if `new URL` does not throw an error, `false` otherwise
  */
 export const isValidURL = (url: string): boolean => {
+  if (!hasNoParams(url)) {
+    // this is done to avoid parsing urls with variables
+    return true;
+  }
   try {
     new URL(url);
     return true;


### PR DESCRIPTION
## Summary

URL validation softens to allow vars usage !!

For example 

` should urls: "${url}" interpolate --params '{"url": "my-url"}'`

<!--ONMERGE {"backportTargets":["8.15","8.16","8.x"]} ONMERGE-->