### PR TITLE
Code owners check - match files and directories

### DIFF
--- a/packages/kbn-code-owners/src/file_code_owner.ts
+++ b/packages/kbn-code-owners/src/file_code_owner.ts
@@ -43,11 +43,12 @@ export function getPathsWithOwnersReversed(): PathWithOwners[] {
 
   const pathsWithOwners: PathWithOwners[] = codeowners.map((c) => {
     const [path, ...ghTeams] = c.split(/\s+/);
+    const cleanedPath = path.replace(/\/$/, ''); // remove trailing slash
     return {
-      path,
+      path: cleanedPath,
       teams: ghTeams.map((t) => t.replace('@', '')).join(),
       // register CODEOWNERS entries with the `ignores` lib for later path matching
-      ignorePattern: ignore().add([path]),
+      ignorePattern: ignore().add([cleanedPath]),
     };
   });
 


### PR DESCRIPTION
## Summary

This PR modifies the code owners check to allow "file" matches for "directory" entries.

### Details

Taking the code owner entry `/x-pack/test_serverless/**/test_suites/**/ml/ @elastic/ml-ui` as an example. Note the trailing slash in the path, indicating a directory.
Before this PR, if we asked the script for the code owner of `x-pack/test_serverless/functional/test_suites/security/ml`, it would not match, because this requested path doesn't have the trailing slash, thus asking for the file `ml` and not the directory. While this is technically correct, it's just too easy to overlook this detail and get a false negative as a result.
This PR is removing trailing slashes from the code owners entries when adding them to the lookup table, so they now match both, directory and file requests (and requests for everything within the directory). So going back to the example, all these owner requests would be matched and return `@elastic/ml-ui` as the owner:
* `x-pack/test_serverless/functional/test_suites/security/ml`
* `x-pack/test_serverless/functional/test_suites/security/ml/`
* `x-pack/test_serverless/functional/test_suites/security/ml/index.ts`

