### PR TITLE
[ObsUx][Infra] Processes Tab: Fix failling test

### DIFF
--- a/x-pack/test/functional/apps/infra/node_details.ts
+++ b/x-pack/test/functional/apps/infra/node_details.ts
@@ -404,8 +404,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             await pageObjects.assetDetails.clickProcessesTab();
             const processesTotalValue =
               await pageObjects.assetDetails.getProcessesTabContentTotalValue();
-            const processValue = await processesTotalValue.getVisibleText();
-            expect(processValue).to.eql('N/A');
+            await retry.tryForTime(5000, async () => {
+              expect(await processesTotalValue.getVisibleText()).to.eql('N/A');
+            });
           });
         });
       });
@@ -510,8 +511,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         it('should render processes tab and with Total Value summary', async () => {
           const processesTotalValue =
             await pageObjects.assetDetails.getProcessesTabContentTotalValue();
-          const processValue = await processesTotalValue.getVisibleText();
-          expect(processValue).to.eql('313');
+          await retry.tryForTime(5000, async () => {
+            expect(await processesTotalValue.getVisibleText()).to.eql('313');
+          });
         });
 
         it('should expand processes table row', async () => {


### PR DESCRIPTION
Closes #192891 

## Summary

This PR fixes the processes tab failing test.
I checked locally and it passed.

✅ Flaky test runner (x50): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7264


<!--ONMERGE {"backportTargets":["8.16"]} ONMERGE-->