### PR TITLE
[React@18 failing tests] Dataset quality handles user privileges

### DIFF
--- a/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_redirect_link.ts
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_redirect_link.ts
@@ -47,12 +47,16 @@ export const useRedirectLink = <T extends BasicDataStream>({
     share.url.locators.get<SingleDatasetLocatorParams>(SINGLE_DATASET_LOCATOR_ID);
 
   const isLogsExplorerAppAccessible = useObservable(
-    application.applications$.pipe(
-      map(
-        (apps) =>
-          (apps.get(OBSERVABILITY_LOGS_EXPLORER_APP_ID)?.status ?? AppStatus.inaccessible) ===
-          AppStatus.accessible
-      )
+    useMemo(
+      () =>
+        application.applications$.pipe(
+          map(
+            (apps) =>
+              (apps.get(OBSERVABILITY_LOGS_EXPLORER_APP_ID)?.status ?? AppStatus.inaccessible) ===
+              AppStatus.accessible
+          )
+        ),
+      [application.applications$]
     ),
     false
   );


### PR DESCRIPTION
## Summary

Similar to https://github.com/elastic/kibana/pull/196384 another test on dataset quality page [started failing ](https://buildkite.com/elastic/kibana-pull-request/builds/245171#0192ba1a-034f-40d9-a256-57c7973ef8b1) with React@18. 

Looks like the failure is similar as there is inifite re-render now with React@18, but not with React@17.  I, unfortunatly, can't explain why it breaks :( 






<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->