### PR TITLE
search: move getting started to footer

### DIFF
--- a/x-pack/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/plugins/serverless_search/public/navigation_tree.ts
@@ -130,18 +130,19 @@ export const navigationTree = (): NavigationTreeDefinition => ({
           spaceBefore: 'm',
           children: [{ link: 'maps' }],
         },
-        {
-          id: 'gettingStarted',
-          title: i18n.translate('xpack.serverlessSearch.nav.gettingStarted', {
-            defaultMessage: 'Getting Started',
-          }),
-          link: 'serverlessElasticsearch',
-          spaceBefore: 'm',
-        },
       ],
     },
   ],
   footer: [
+    {
+      id: 'gettingStarted',
+      type: 'navItem',
+      title: i18n.translate('xpack.serverlessSearch.nav.gettingStarted', {
+        defaultMessage: 'Getting Started',
+      }),
+      link: 'serverlessElasticsearch',
+      icon: 'launch',
+    },
     {
       type: 'navGroup',
       id: 'project_settings_project_nav',


### PR DESCRIPTION
## Summary

Moved the `Getting Started` link to the footer

![image](https://github.com/user-attachments/assets/4d388fba-c6a4-4a72-b9f1-5ea839e435fe)


