### PR TITLE
[EDR Workflows] Improve on unavailable shard exception flakiness in cypress

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -77,11 +77,7 @@ export const getCypressBaseConfig = (
         // baseUrl: To override, set Env. variable `CYPRESS_BASE_URL`
         baseUrl: 'http://localhost:5601',
         supportFile: 'public/management/cypress/support/e2e.ts',
-        // temp:
-        // x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
-        // x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
-        specPattern:
-          'public/management/cypress/e2e/artifacts/{event_filters,artifacts_mocked_data}.cy.{js,jsx,ts,tsx}',
+        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,

--- a/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -77,7 +77,11 @@ export const getCypressBaseConfig = (
         // baseUrl: To override, set Env. variable `CYPRESS_BASE_URL`
         baseUrl: 'http://localhost:5601',
         supportFile: 'public/management/cypress/support/e2e.ts',
-        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+        // temp:
+        // x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
+        // x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
+        specPattern:
+          'public/management/cypress/e2e/artifacts/{event_filters,artifacts_mocked_data}.cy.{js,jsx,ts,tsx}',
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
@@ -35,8 +35,7 @@ const loginWithoutAccess = (url: string) => {
   loadPage(url);
 };
 
-// Failing: See https://github.com/elastic/kibana/issues/191914
-describe.skip('Artifacts pages', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
+describe('Artifacts pages', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
   let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
 
   before(() => {

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/event_filters.cy.ts
@@ -41,8 +41,7 @@ describe('Event Filters', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'
     removeAllArtifacts();
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/194135
-  describe.skip('when editing event filter value', () => {
+  describe('when editing event filter value', () => {
     let eventFiltersMock: ArtifactsFixtureType;
     beforeEach(() => {
       login();


### PR DESCRIPTION
## Summary

The cypress task `cy.task('indexEndpointHosts')` sometimes throws `no_shard_available_action_exception`, when transforms are stopped. This looks like a temporary issue, and in other tests it is simply retried.

This PR adds the retry logic for this type of error, and unskips some tests.

closes #194135
closes #191914

### Checklist

Delete any items that are not applicable to this PR.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->