### PR TITLE
[Search][Fix] Index Details: poll mappings

### DIFF
--- a/x-pack/plugins/search_indices/public/constants.ts
+++ b/x-pack/plugins/search_indices/public/constants.ts
@@ -7,6 +7,7 @@
 
 export enum QueryKeys {
   FetchIndex = 'fetchIndex',
+  FetchMapping = 'fetchMapping',
   FetchSearchIndicesStatus = 'fetchSearchIndicesStatus',
   FetchUserStartPrivileges = 'fetchUserStartPrivileges',
   SearchDocuments = 'searchDocuments',

--- a/x-pack/plugins/search_indices/public/hooks/api/use_index_mappings.ts
+++ b/x-pack/plugins/search_indices/public/hooks/api/use_index_mappings.ts
@@ -8,12 +8,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { useKibana } from '../use_kibana';
 import { Mappings } from '../../types';
+import { QueryKeys } from '../../constants';
 
+const POLLING_INTERVAL = 15 * 1000;
 export const useIndexMapping = (indexName: string) => {
   const { http } = useKibana().services;
-  const queryKey = ['fetchMapping', indexName];
+  const queryKey = [QueryKeys.FetchMapping, indexName];
   const result = useQuery<Mappings, { body: { message: string; error: string } }>({
     queryKey,
+    refetchInterval: POLLING_INTERVAL,
+    refetchIntervalInBackground: true,
     refetchOnWindowFocus: 'always',
     queryFn: () =>
       http.fetch<Mappings>(`/api/index_management/mapping/${encodeURIComponent(indexName)}`),


### PR DESCRIPTION
## Summary

Updated the mappings call to poll like the index call does so that the UI will refresh when the user adds mappings with the dev console or somewhere else with the window still in focus.

Additionally updated the query key for the fetch to save the `fetchMapping` key to the constants so we can track all query keys in one place.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->