### PR TITLE
[Security solution] Data stream resource initialization helper

### DIFF
--- a/x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/create_conversation.ts
+++ b/x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/create_conversation.ts
@@ -43,6 +43,7 @@ export const createConversation = async ({
       refresh: 'wait_for',
     });
 
+    console.log('===> response', response);
     const createdConversation = await getConversation({
       esClient,
       conversationIndex,
@@ -50,6 +51,7 @@ export const createConversation = async ({
       logger,
       user,
     });
+    console.log('===> getConversation', getConversation);
     return createdConversation;
   } catch (err) {
     logger.error(`Error creating conversation: ${err} with title: ${conversation.title}`);

--- a/x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/create_conversation.ts
+++ b/x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/create_conversation.ts
@@ -43,7 +43,6 @@ export const createConversation = async ({
       refresh: 'wait_for',
     });
 
-    console.log('===> response', response);
     const createdConversation = await getConversation({
       esClient,
       conversationIndex,
@@ -51,7 +50,6 @@ export const createConversation = async ({
       logger,
       user,
     });
-    console.log('===> getConversation', getConversation);
     return createdConversation;
   } catch (err) {
     logger.error(`Error creating conversation: ${err} with title: ${conversation.title}`);

--- a/x-pack/plugins/elastic_assistant/server/ai_assistant_service/create_resource_installation_helper.test.ts
+++ b/x-pack/plugins/elastic_assistant/server/ai_assistant_service/create_resource_installation_helper.test.ts
@@ -11,7 +11,7 @@ import { loggingSystemMock } from '@kbn/core/server/mocks';
 import {
   createResourceInstallationHelper,
   errorResult,
-  InitializationPromise,
+  InitializationState,
   ResourceInstallationHelper,
   successResult,
   calculateDelay,
@@ -54,7 +54,7 @@ const getCommonInitPromise = async (
   resolution: boolean,
   timeoutMs: number = 1,
   customLogString: string = ''
-): Promise<InitializationPromise> => {
+): Promise<InitializationState> => {
   if (timeoutMs < 0) {
     throw new Error('fail');
   }

--- a/x-pack/plugins/elastic_assistant/server/ai_assistant_service/create_resource_installation_helper.ts
+++ b/x-pack/plugins/elastic_assistant/server/ai_assistant_service/create_resource_installation_helper.ts
@@ -57,18 +57,15 @@ export function createResourceInstallationHelper(
       const { result: commonInitResult, error: commonInitError } = await commonInitPromise;
       if (commonInitResult) {
         await installFn(namespace, timeoutMs);
-        console.log('===> installer case 1');
         return successResult();
       } else {
         logger.warn(
           `Common resources were not initialized, cannot initialize resources for ${namespace}`
         );
-        console.log('===> installer case 2');
         return errorResult(commonInitError);
       }
     } catch (err) {
       logger.error(`Error initializing resources ${namespace} - ${err.message}`);
-      console.log('===> installer case 3');
       return errorResult(err.message);
     }
   };
@@ -119,7 +116,6 @@ export function createResourceInstallationHelper(
           return errorResult(`Unrecognized spaceId ${key}`);
         }
         const initializationState = await initializedResources.get(key);
-        console.log('===> initializationState promise', initializationState);
         return initializationState ?? errorResult(`Initialize state returned undefined`);
       } catch (e) {
         return errorResult(`Initialize resources encountered an error: ${e.message}`);

--- a/x-pack/plugins/elastic_assistant/server/ai_assistant_service/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/ai_assistant_service/index.ts
@@ -171,6 +171,7 @@ export class AIAssistantService {
   private async initializeResources(): Promise<InitializationPromise> {
     this.isInitializing = true;
     try {
+      console.trace('===> initializeResources');
       this.options.logger.debug(`Initializing resources for AIAssistantService`);
       const esClient = await this.options.elasticsearchClientPromise;
 
@@ -286,6 +287,7 @@ export class AIAssistantService {
     const { result: initialized, error } = await this.getSpaceResourcesInitializationPromise(
       opts.spaceId
     );
+    console.log('===> checkResourcesInstallation', { initialized, error });
 
     // If space level resources initialization failed, retry
     if (!initialized && error) {
@@ -331,6 +333,7 @@ export class AIAssistantService {
     opts: CreateAIAssistantClientParams
   ): Promise<AIAssistantConversationsDataClient | null> {
     const res = await this.checkResourcesInstallation(opts);
+    console.log('===> conversations data client resources check', res);
 
     if (res === null) {
       return null;
@@ -419,6 +422,7 @@ export class AIAssistantService {
     opts: CreateAIAssistantClientParams
   ): Promise<AIAssistantDataClient | null> {
     const res = await this.checkResourcesInstallation(opts);
+    console.log('===> res createAIAssistantPromptsDataClient', res);
 
     if (res === null) {
       return null;
@@ -459,6 +463,7 @@ export class AIAssistantService {
     const result = await this.resourceInitializationHelper.getInitializedResources(spaceId);
     // If the spaceId is unrecognized and spaceId is not the default, we
     // need to kick off resource installation and return the promise
+    console.log('===> getSpaceResourcesInitializationPromise', result);
     if (
       result.error &&
       result.error.includes(`Unrecognized spaceId`) &&

--- a/x-pack/plugins/elastic_assistant/server/ai_assistant_service/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/ai_assistant_service/index.ts
@@ -16,7 +16,7 @@ import { getDefaultAnonymizationFields } from '../../common/anonymization';
 import { AssistantResourceNames, GetElser } from '../types';
 import { AIAssistantConversationsDataClient } from '../ai_assistant_data_clients/conversations';
 import {
-  InitializationPromise,
+  InitializationState,
   ResourceInstallationHelper,
   createResourceInstallationHelper,
   errorResult,
@@ -80,7 +80,7 @@ export class AIAssistantService {
   private anonymizationFieldsDataStream: DataStreamSpacesAdapter;
   private attackDiscoveryDataStream: DataStreamSpacesAdapter;
   private resourceInitializationHelper: ResourceInstallationHelper;
-  private initPromise: Promise<InitializationPromise>;
+  private initPromise: Promise<InitializationState>;
   private isKBSetupInProgress: boolean = false;
   // Temporary 'feature flag' to determine if we should initialize the new kb mappings, toggled when accessing kbDataClient
   private v2KnowledgeBaseEnabled: boolean = false;
@@ -168,7 +168,7 @@ export class AIAssistantService {
     return newDataStream;
   };
 
-  private async initializeResources(): Promise<InitializationPromise> {
+  private async initializeResources(): Promise<InitializationState> {
     this.isInitializing = true;
     try {
       this.options.logger.debug(`Initializing resources for AIAssistantService`);
@@ -283,13 +283,13 @@ export class AIAssistantService {
 
   private async checkResourcesInstallation(opts: CreateAIAssistantClientParams) {
     // Check if resources installation has succeeded
-    const { result: initialized, error } = await this.getSpaceResourcesInitializationPromise(
+    const { result: initialized, error } = await this.getSpaceResourcesInitializationState(
       opts.spaceId
     );
 
     // If space level resources initialization failed, retry
     if (!initialized && error) {
-      let initRetryPromise: Promise<InitializationPromise> | undefined;
+      let initRetryPromise: Promise<InitializationState> | undefined;
 
       // If !this.initialized, we know that resource initialization failed
       // and we need to retry this before retrying the spaceId specific resources
@@ -453,9 +453,9 @@ export class AIAssistantService {
     });
   }
 
-  public async getSpaceResourcesInitializationPromise(
+  public async getSpaceResourcesInitializationState(
     spaceId: string | undefined = DEFAULT_NAMESPACE_STRING
-  ): Promise<InitializationPromise> {
+  ): Promise<InitializationState> {
     const result = await this.resourceInitializationHelper.getInitializedResources(spaceId);
     // If the spaceId is unrecognized and spaceId is not the default, we
     // need to kick off resource installation and return the promise

--- a/x-pack/plugins/elastic_assistant/server/ai_assistant_service/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/ai_assistant_service/index.ts
@@ -171,7 +171,6 @@ export class AIAssistantService {
   private async initializeResources(): Promise<InitializationPromise> {
     this.isInitializing = true;
     try {
-      console.trace('===> initializeResources');
       this.options.logger.debug(`Initializing resources for AIAssistantService`);
       const esClient = await this.options.elasticsearchClientPromise;
 
@@ -287,7 +286,6 @@ export class AIAssistantService {
     const { result: initialized, error } = await this.getSpaceResourcesInitializationPromise(
       opts.spaceId
     );
-    console.log('===> checkResourcesInstallation', { initialized, error });
 
     // If space level resources initialization failed, retry
     if (!initialized && error) {
@@ -333,7 +331,6 @@ export class AIAssistantService {
     opts: CreateAIAssistantClientParams
   ): Promise<AIAssistantConversationsDataClient | null> {
     const res = await this.checkResourcesInstallation(opts);
-    console.log('===> conversations data client resources check', res);
 
     if (res === null) {
       return null;
@@ -422,7 +419,6 @@ export class AIAssistantService {
     opts: CreateAIAssistantClientParams
   ): Promise<AIAssistantDataClient | null> {
     const res = await this.checkResourcesInstallation(opts);
-    console.log('===> res createAIAssistantPromptsDataClient', res);
 
     if (res === null) {
       return null;
@@ -463,7 +459,6 @@ export class AIAssistantService {
     const result = await this.resourceInitializationHelper.getInitializedResources(spaceId);
     // If the spaceId is unrecognized and spaceId is not the default, we
     // need to kick off resource installation and return the promise
-    console.log('===> getSpaceResourcesInitializationPromise', result);
     if (
       result.error &&
       result.error.includes(`Unrecognized spaceId`) &&

--- a/x-pack/plugins/elastic_assistant/server/routes/helpers.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/helpers.ts
@@ -594,7 +594,6 @@ export const performChecks = ({
   const assistantResponse = buildResponse(response);
 
   if (license) {
-    console.log('===> create license', context.licensing.license);
     if (!hasAIAssistantLicense(context.licensing.license)) {
       return response.forbidden({
         body: {
@@ -605,7 +604,6 @@ export const performChecks = ({
   }
 
   if (authenticatedUser) {
-    console.log('===> getCurrentUser', context.elasticAssistant.getCurrentUser());
     if (context.elasticAssistant.getCurrentUser() == null) {
       return assistantResponse.error({
         body: `Authenticated user not found`,

--- a/x-pack/plugins/elastic_assistant/server/routes/helpers.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/helpers.ts
@@ -594,6 +594,7 @@ export const performChecks = ({
   const assistantResponse = buildResponse(response);
 
   if (license) {
+    console.log('===> create license', context.licensing.license);
     if (!hasAIAssistantLicense(context.licensing.license)) {
       return response.forbidden({
         body: {
@@ -604,6 +605,7 @@ export const performChecks = ({
   }
 
   if (authenticatedUser) {
+    console.log('===> getCurrentUser', context.elasticAssistant.getCurrentUser());
     if (context.elasticAssistant.getCurrentUser() == null) {
       return assistantResponse.error({
         body: `Authenticated user not found`,

--- a/x-pack/plugins/elastic_assistant/server/routes/prompts/bulk_actions_route.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/prompts/bulk_actions_route.ts
@@ -157,7 +157,6 @@ export const bulkPromptsRoute = (router: ElasticAssistantPluginRouter, logger: L
         try {
           const ctx = await context.resolve(['core', 'elasticAssistant', 'licensing']);
           const license = ctx.licensing.license;
-          console.log('===> bulk license', license);
           if (!hasAIAssistantLicense(license)) {
             return response.forbidden({
               body: {
@@ -174,7 +173,6 @@ export const bulkPromptsRoute = (router: ElasticAssistantPluginRouter, logger: L
             });
           }
           const dataClient = await ctx.elasticAssistant.getAIAssistantPromptsDataClient();
-          console.log('===> bulk dataClient', dataClient);
 
           if (body.create && body.create.length > 0) {
             const result = await dataClient?.findDocuments<EsPromptsSchema>({
@@ -196,7 +194,6 @@ export const bulkPromptsRoute = (router: ElasticAssistantPluginRouter, logger: L
           }
 
           const writer = await dataClient?.getWriter();
-          console.log('===> writer', writer);
           const changedAt = new Date().toISOString();
           const {
             errors,

--- a/x-pack/plugins/elastic_assistant/server/routes/prompts/bulk_actions_route.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/prompts/bulk_actions_route.ts
@@ -157,6 +157,7 @@ export const bulkPromptsRoute = (router: ElasticAssistantPluginRouter, logger: L
         try {
           const ctx = await context.resolve(['core', 'elasticAssistant', 'licensing']);
           const license = ctx.licensing.license;
+          console.log('===> bulk license', license);
           if (!hasAIAssistantLicense(license)) {
             return response.forbidden({
               body: {
@@ -173,6 +174,7 @@ export const bulkPromptsRoute = (router: ElasticAssistantPluginRouter, logger: L
             });
           }
           const dataClient = await ctx.elasticAssistant.getAIAssistantPromptsDataClient();
+          console.log('===> bulk dataClient', dataClient);
 
           if (body.create && body.create.length > 0) {
             const result = await dataClient?.findDocuments<EsPromptsSchema>({
@@ -194,6 +196,7 @@ export const bulkPromptsRoute = (router: ElasticAssistantPluginRouter, logger: L
           }
 
           const writer = await dataClient?.getWriter();
+          console.log('===> writer', writer);
           const changedAt = new Date().toISOString();
           const {
             errors,

--- a/x-pack/plugins/elastic_assistant/server/routes/user_conversations/create_route.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/user_conversations/create_route.ts
@@ -50,10 +50,12 @@ export const createConversationRoute = (router: ElasticAssistantPluginRouter): v
             request,
             response,
           });
+          console.log('===> checkResponse', checkResponse);
           if (checkResponse) {
             return checkResponse;
           }
           const dataClient = await ctx.elasticAssistant.getAIAssistantConversationsDataClient();
+          console.log('===> create dataClient', dataClient);
 
           const createdConversation = await dataClient?.createConversation({
             conversation: request.body,

--- a/x-pack/plugins/elastic_assistant/server/routes/user_conversations/create_route.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/user_conversations/create_route.ts
@@ -50,12 +50,11 @@ export const createConversationRoute = (router: ElasticAssistantPluginRouter): v
             request,
             response,
           });
-          console.log('===> checkResponse', checkResponse);
+
           if (checkResponse) {
             return checkResponse;
           }
           const dataClient = await ctx.elasticAssistant.getAIAssistantConversationsDataClient();
-          console.log('===> create dataClient', dataClient);
 
           const createdConversation = await dataClient?.createConversation({
             conversation: request.body,

--- a/x-pack/plugins/elastic_assistant/server/routes/user_conversations/create_route.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/user_conversations/create_route.ts
@@ -50,7 +50,6 @@ export const createConversationRoute = (router: ElasticAssistantPluginRouter): v
             request,
             response,
           });
-
           if (checkResponse) {
             return checkResponse;
           }

--- a/x-pack/plugins/security_solution/public/assistant/provider.tsx
+++ b/x-pack/plugins/security_solution/public/assistant/provider.tsx
@@ -153,6 +153,10 @@ export const AssistantProvider: FC<PropsWithChildren<unknown>> = ({ children }) 
   const hasEnterpriseLicence = licenseService.isEnterprise();
   useEffect(() => {
     const migrateConversationsFromLocalStorage = once(async () => {
+      console.log('conversations useEffect', {
+        hasEnterpriseLicence,
+        assistantAvailability,
+      });
       if (
         hasEnterpriseLicence &&
         assistantAvailability.isAssistantEnabled &&
@@ -178,6 +182,10 @@ export const AssistantProvider: FC<PropsWithChildren<unknown>> = ({ children }) 
 
   useEffect(() => {
     const createSecurityPrompts = once(async () => {
+      console.log('prompts useEffect', {
+        hasEnterpriseLicence,
+        assistantAvailability,
+      });
       if (
         hasEnterpriseLicence &&
         assistantAvailability.isAssistantEnabled &&

--- a/x-pack/plugins/security_solution/public/assistant/provider.tsx
+++ b/x-pack/plugins/security_solution/public/assistant/provider.tsx
@@ -153,10 +153,6 @@ export const AssistantProvider: FC<PropsWithChildren<unknown>> = ({ children }) 
   const hasEnterpriseLicence = licenseService.isEnterprise();
   useEffect(() => {
     const migrateConversationsFromLocalStorage = once(async () => {
-      console.log('conversations useEffect', {
-        hasEnterpriseLicence,
-        assistantAvailability,
-      });
       if (
         hasEnterpriseLicence &&
         assistantAvailability.isAssistantEnabled &&
@@ -182,10 +178,6 @@ export const AssistantProvider: FC<PropsWithChildren<unknown>> = ({ children }) 
 
   useEffect(() => {
     const createSecurityPrompts = once(async () => {
-      console.log('prompts useEffect', {
-        hasEnterpriseLicence,
-        assistantAvailability,
-      });
       if (
         hasEnterpriseLicence &&
         assistantAvailability.isAssistantEnabled &&


### PR DESCRIPTION
## Summary

Fixes a bug with the resource initialization helper by awaiting the `getter` promise, ensuring resource installation happens once license has updated.

Steps to reproduce
1. Start es with a basic license
2. Start kibana
3. Visit the assistant
4. Click Manage license. License settings will open in a new tab. Start a trial
5. Return to the open tab with Assistant

### Previous Behavior
Error messages shown for create conversation and update prompt
![e2](https://github.com/user-attachments/assets/cef0b1e8-c7b5-4392-b469-e0655babd709)

### New Behavior
Conversations and quick prompts are created without issue

## Still to do

Need to go through and make `dataClient` required in our APIs, and add error handling for when it is `undefined`