### PR TITLE
[8.x] [SecuritySolution][Threat Intelligence] - re-enable Cypress test skipped because of removal of bsearch (#195826)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/indicators.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/indicators.cy.ts
@@ -298,7 +298,7 @@ describe('Multiple indicators', { tags: ['@ess'] }, () => {
 
       cy.log('should reload the data when refresh button is pressed');
 
-      cy.intercept(/bsearch/).as('search');
+      cy.intercept('POST', '/internal/search/threatIntelligenceSearchStrategy').as('search');
       cy.get(REFRESH_BUTTON).should('exist').click();
       cy.wait('@search');
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[SecuritySolution][Threat Intelligence] - re-enable Cypress test skipped because of removal of bsearch (#195826)](https://github.com/elastic/kibana/pull/195826)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2024-10-11T01:51:44Z","message":"[SecuritySolution][Threat Intelligence] - re-enable Cypress test skipped because of removal of bsearch (#195826)","sha":"edd8f08e1b1e213bbe67c9f5ce9de5326ca94877","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","Team:Threat Hunting:Investigations"],"number":195826,"url":"https://github.com/elastic/kibana/pull/195826","mergeCommit":{"message":"[SecuritySolution][Threat Intelligence] - re-enable Cypress test skipped because of removal of bsearch (#195826)","sha":"edd8f08e1b1e213bbe67c9f5ce9de5326ca94877"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/195826","number":195826,"mergeCommit":{"message":"[SecuritySolution][Threat Intelligence] - re-enable Cypress test skipped because of removal of bsearch (#195826)","sha":"edd8f08e1b1e213bbe67c9f5ce9de5326ca94877"}}]}] BACKPORT-->