### PR TITLE
[8.x] [Security Solution] [Notes] Enable templated insights with all events, not just alerts (#197164)

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/notes_details.tsx
@@ -33,6 +33,8 @@ import {
 import { useDocumentDetailsContext } from '../../shared/context';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useWhichFlyout } from '../../shared/hooks/use_which_flyout';
+import { BasicAlertDataContext } from './investigation_guide_view';
+import { useInvestigationGuide } from '../../shared/hooks/use_investigation_guide';
 
 export const FETCH_NOTES_ERROR = i18n.translate(
   'xpack.securitySolution.flyout.left.notes.fetchNotesErrorLabel',
@@ -55,6 +57,10 @@ export const NotesDetails = memo(() => {
   const dispatch = useDispatch();
   const { eventId, dataFormattedForFieldBrowser } = useDocumentDetailsContext();
   const { kibanaSecuritySolutionsPrivileges } = useUserPrivileges();
+  const { basicAlertData: basicData } = useInvestigationGuide({
+    dataFormattedForFieldBrowser,
+  });
+
   const canCreateNotes = kibanaSecuritySolutionsPrivileges.crud;
 
   // will drive the value we send to the AddNote component
@@ -130,7 +136,7 @@ export const NotesDetails = memo(() => {
   );
 
   return (
-    <>
+    <BasicAlertDataContext.Provider value={basicData}>
       {fetchStatus === ReqStatus.Loading && (
         <EuiLoadingElastic data-test-subj={NOTES_LOADING_TEST_ID} size="xxl" />
       )}
@@ -156,7 +162,7 @@ export const NotesDetails = memo(() => {
           </AddNote>
         </>
       )}
-    </>
+    </BasicAlertDataContext.Provider>
   );
 });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution] [Notes] Enable templated insights with all events, not just alerts (#197164)](https://github.com/elastic/kibana/pull/197164)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Qualters","email":"56408403+kqualters-elastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-10-22T14:34:12Z","message":"[Security Solution] [Notes] Enable templated insights with all events, not just alerts (#197164)\n\n## Summary\r\n\r\nCurrently all notes that make use of the markdown based timeline data\r\nproviders will render as a timeline template if the note is associated\r\nwith an event, and not an alert. Mostly everything is in place to have\r\neverything work for both already, there's just no context that contains\r\nthe event document in the tree in the notes list component currently.\r\nThis pr adds that context, and everything else works as expected.\r\n\r\n\r\n![event_insights](https://github.com/user-attachments/assets/72d25ef2-0c2c-4f82-974f-0f005c9b2d77)\r\n\r\n\r\n### Checklist\r\n\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"fe79c85ddde0dd7f2bb978286ecb56a71950fb39","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Threat Hunting:Investigations","Feature:Investigation Guides","v8.16.0","backport:version"],"number":197164,"url":"https://github.com/elastic/kibana/pull/197164","mergeCommit":{"message":"[Security Solution] [Notes] Enable templated insights with all events, not just alerts (#197164)\n\n## Summary\r\n\r\nCurrently all notes that make use of the markdown based timeline data\r\nproviders will render as a timeline template if the note is associated\r\nwith an event, and not an alert. Mostly everything is in place to have\r\neverything work for both already, there's just no context that contains\r\nthe event document in the tree in the notes list component currently.\r\nThis pr adds that context, and everything else works as expected.\r\n\r\n\r\n![event_insights](https://github.com/user-attachments/assets/72d25ef2-0c2c-4f82-974f-0f005c9b2d77)\r\n\r\n\r\n### Checklist\r\n\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"fe79c85ddde0dd7f2bb978286ecb56a71950fb39"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/197164","number":197164,"mergeCommit":{"message":"[Security Solution] [Notes] Enable templated insights with all events, not just alerts (#197164)\n\n## Summary\r\n\r\nCurrently all notes that make use of the markdown based timeline data\r\nproviders will render as a timeline template if the note is associated\r\nwith an event, and not an alert. Mostly everything is in place to have\r\neverything work for both already, there's just no context that contains\r\nthe event document in the tree in the notes list component currently.\r\nThis pr adds that context, and everything else works as expected.\r\n\r\n\r\n![event_insights](https://github.com/user-attachments/assets/72d25ef2-0c2c-4f82-974f-0f005c9b2d77)\r\n\r\n\r\n### Checklist\r\n\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"fe79c85ddde0dd7f2bb978286ecb56a71950fb39"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/197254","number":197254,"state":"MERGED","mergeCommit":{"sha":"61679b7fc044565f47a3e762434863c535e7e544","message":"[8.16] [Security Solution] [Notes] Enable templated insights with all events, not just alerts (#197164) (#197254)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.16`:\n- [[Security Solution] [Notes] Enable templated insights with all\nevents, not just alerts\n(#197164)](https://github.com/elastic/kibana/pull/197164)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Kevin\nQualters\",\"email\":\"56408403+kqualters-elastic@users.noreply.github.com\"},\"sourceCommit\":{\"committedDate\":\"2024-10-22T14:34:12Z\",\"message\":\"[Security\nSolution] [Notes] Enable templated insights with all events, not just\nalerts (#197164)\\n\\n## Summary\\r\\n\\r\\nCurrently all notes that make use\nof the markdown based timeline data\\r\\nproviders will render as a\ntimeline template if the note is associated\\r\\nwith an event, and not an\nalert. Mostly everything is in place to have\\r\\neverything work for both\nalready, there's just no context that contains\\r\\nthe event document in\nthe tree in the notes list component currently.\\r\\nThis pr adds that\ncontext, and everything else works as\nexpected.\\r\\n\\r\\n\\r\\n![event_insights](https://github.com/user-attachments/assets/72d25ef2-0c2c-4f82-974f-0f005c9b2d77)\\r\\n\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"fe79c85ddde0dd7f2bb978286ecb56a71950fb39\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"Team:Threat\nHunting:Investigations\",\"Feature:Investigation\nGuides\",\"v8.16.0\",\"backport:version\"],\"title\":\"[Security Solution]\n[Notes] Enable templated insights with all events, not just\nalerts\",\"number\":197164,\"url\":\"https://github.com/elastic/kibana/pull/197164\",\"mergeCommit\":{\"message\":\"[Security\nSolution] [Notes] Enable templated insights with all events, not just\nalerts (#197164)\\n\\n## Summary\\r\\n\\r\\nCurrently all notes that make use\nof the markdown based timeline data\\r\\nproviders will render as a\ntimeline template if the note is associated\\r\\nwith an event, and not an\nalert. Mostly everything is in place to have\\r\\neverything work for both\nalready, there's just no context that contains\\r\\nthe event document in\nthe tree in the notes list component currently.\\r\\nThis pr adds that\ncontext, and everything else works as\nexpected.\\r\\n\\r\\n\\r\\n![event_insights](https://github.com/user-attachments/assets/72d25ef2-0c2c-4f82-974f-0f005c9b2d77)\\r\\n\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"fe79c85ddde0dd7f2bb978286ecb56a71950fb39\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.16\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/197164\",\"number\":197164,\"mergeCommit\":{\"message\":\"[Security\nSolution] [Notes] Enable templated insights with all events, not just\nalerts (#197164)\\n\\n## Summary\\r\\n\\r\\nCurrently all notes that make use\nof the markdown based timeline data\\r\\nproviders will render as a\ntimeline template if the note is associated\\r\\nwith an event, and not an\nalert. Mostly everything is in place to have\\r\\neverything work for both\nalready, there's just no context that contains\\r\\nthe event document in\nthe tree in the notes list component currently.\\r\\nThis pr adds that\ncontext, and everything else works as\nexpected.\\r\\n\\r\\n\\r\\n![event_insights](https://github.com/user-attachments/assets/72d25ef2-0c2c-4f82-974f-0f005c9b2d77)\\r\\n\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"fe79c85ddde0dd7f2bb978286ecb56a71950fb39\"}},{\"branch\":\"8.16\",\"label\":\"v8.16.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Kevin Qualters <56408403+kqualters-elastic@users.noreply.github.com>"}}]}] BACKPORT-->