### PR TITLE
Delete data when clearing security entity store

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/api/entity_store.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/api/entity_store.ts
@@ -43,11 +43,14 @@ export const useEntityStoreRoutes = () => {
       });
     };
 
-    const deleteEntityEngine = async (entityType: EntityType) => {
-      return http.fetch<DeleteEntityEngineResponse>(`/api/entity_store/engines/${entityType}`, {
-        method: 'DELETE',
-        version: API_VERSIONS.public.v1,
-      });
+    const deleteEntityEngine = async (entityType: EntityType, deleteData: boolean) => {
+      return http.fetch<DeleteEntityEngineResponse>(
+        `/api/entity_store/engines/${entityType}?data=${deleteData}`,
+        {
+          method: 'DELETE',
+          version: API_VERSIONS.public.v1,
+        }
+      );
     };
 
     const listEntityEngines = async () => {

--- a/x-pack/plugins/security_solution/public/entity_analytics/api/entity_store.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/api/entity_store.ts
@@ -44,13 +44,11 @@ export const useEntityStoreRoutes = () => {
     };
 
     const deleteEntityEngine = async (entityType: EntityType, deleteData: boolean) => {
-      return http.fetch<DeleteEntityEngineResponse>(
-        `/api/entity_store/engines/${entityType}?data=${deleteData}`,
-        {
-          method: 'DELETE',
-          version: API_VERSIONS.public.v1,
-        }
-      );
+      return http.fetch<DeleteEntityEngineResponse>(`/api/entity_store/engines/${entityType}`, {
+        method: 'DELETE',
+        query: { data: deleteData },
+        version: API_VERSIONS.public.v1,
+      });
     };
 
     const listEntityEngines = async () => {

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
@@ -110,7 +110,7 @@ export const useDeleteEntityEngineMutation = (options?: UseMutationOptions<{}>) 
   const invalidateEntityEngineStatusQuery = useInvalidateEntityEngineStatusQuery();
   const { deleteEntityEngine } = useEntityStoreRoutes();
   return useMutation<DeleteEntityEngineResponse[]>(
-    () => Promise.all([deleteEntityEngine('user'), deleteEntityEngine('host')]),
+    () => Promise.all([deleteEntityEngine('user', true), deleteEntityEngine('host', true)]),
     {
       ...options,
       mutationKey: DELETE_ENTITY_ENGINE_STATUS_KEY,


### PR DESCRIPTION
## Summary

Fixed a bug where the "Clear all entities" button in the security entity store didn't delete data due to a missing query parameter.

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->