### PR TITLE
[EDR Workflows] Enable Blocklist CY in MKI

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/blocklist.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/blocklist.cy.ts
@@ -41,7 +41,7 @@ const {
 describe(
   'Blocklist',
   {
-    tags: ['@ess', '@serverless', '@skipInServerlessMKI'], // @skipInServerlessMKI until kibana is rebuilt after merge
+    tags: ['@ess', '@serverless'],
   },
   () => {
     let indexedPolicy: IndexedFleetEndpointPolicyResponse;


### PR DESCRIPTION
Since adding this test file was tied to changes in Kibana, we initially couldn’t enable it in the MKI. The MKI relies on a Kibana image built from the main branch, and at that time, the necessary changes for these tests to pass hadn’t yet been merged. Now that these updates are included in the main branch, the Kibana image used in MKI has the required changes, so we can proceed with enabling the tests. 

Manual MKI run - https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-defend-workflows/builds/1545

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->