### PR TITLE
[React@18] Use `fireEvent` and `userEvent` for interactions where tests start failing with React@18

### DIFF
--- a/packages/kbn-expandable-flyout/src/components/settings_menu.test.tsx
+++ b/packages/kbn-expandable-flyout/src/components/settings_menu.test.tsx
@@ -8,6 +8,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 
 import { SettingsMenu } from './settings_menu';
@@ -41,7 +42,8 @@ describe('SettingsMenu', () => {
   });
 
   describe('push vs overlay', () => {
-    it('should render the flyout type button group', () => {
+    it('should render the flyout type button group', async () => {
+      const user = userEvent.setup();
       const flyoutCustomProps = {
         hideSettings: false,
         pushVsOverlay: {
@@ -56,7 +58,7 @@ describe('SettingsMenu', () => {
         </TestProvider>
       );
 
-      getByTestId(SETTINGS_MENU_BUTTON_TEST_ID).click();
+      await user.click(getByTestId(SETTINGS_MENU_BUTTON_TEST_ID));
 
       expect(getByTestId(SETTINGS_MENU_FLYOUT_TYPE_TITLE_TEST_ID)).toBeInTheDocument();
       expect(
@@ -65,7 +67,8 @@ describe('SettingsMenu', () => {
       expect(getByTestId(SETTINGS_MENU_FLYOUT_TYPE_BUTTON_GROUP_TEST_ID)).toBeInTheDocument();
     });
 
-    it('should have the type selected if option is enabled', () => {
+    it('should have the type selected if option is enabled', async () => {
+      const user = userEvent.setup();
       const state = {
         panels: initialPanelsState,
         ui: {
@@ -87,7 +90,7 @@ describe('SettingsMenu', () => {
         </TestProvider>
       );
 
-      getByTestId(SETTINGS_MENU_BUTTON_TEST_ID).click();
+      await user.click(getByTestId(SETTINGS_MENU_BUTTON_TEST_ID));
 
       expect(getByTestId(SETTINGS_MENU_FLYOUT_TYPE_BUTTON_GROUP_PUSH_TEST_ID)).toHaveClass(
         'euiButtonGroupButton-isSelected'
@@ -97,7 +100,8 @@ describe('SettingsMenu', () => {
       );
     });
 
-    it('should select correct the flyout type', () => {
+    it('should select correct the flyout type', async () => {
+      const user = userEvent.setup();
       const flyoutCustomProps = {
         hideSettings: false,
         pushVsOverlay: {
@@ -114,8 +118,8 @@ describe('SettingsMenu', () => {
 
       expect(localStorage.getItem(EXPANDABLE_FLYOUT_LOCAL_STORAGE)).toEqual(null);
 
-      getByTestId(SETTINGS_MENU_BUTTON_TEST_ID).click();
-      getByTestId(SETTINGS_MENU_FLYOUT_TYPE_BUTTON_GROUP_PUSH_TEST_ID).click();
+      await user.click(getByTestId(SETTINGS_MENU_BUTTON_TEST_ID));
+      await user.click(getByTestId(SETTINGS_MENU_FLYOUT_TYPE_BUTTON_GROUP_PUSH_TEST_ID));
 
       expect(localStorage.getItem(EXPANDABLE_FLYOUT_LOCAL_STORAGE)).toEqual(
         JSON.stringify({ [PUSH_VS_OVERLAY_LOCAL_STORAGE]: 'push' })
@@ -128,7 +132,8 @@ describe('SettingsMenu', () => {
       );
     });
 
-    it('should render the the flyout type button group disabled', () => {
+    it('should render the the flyout type button group disabled', async () => {
+      const user = userEvent.setup();
       const flyoutCustomProps = {
         hideSettings: false,
         pushVsOverlay: {
@@ -145,7 +150,7 @@ describe('SettingsMenu', () => {
 
       expect(localStorage.getItem(EXPANDABLE_FLYOUT_LOCAL_STORAGE)).toEqual(null);
 
-      getByTestId(SETTINGS_MENU_BUTTON_TEST_ID).click();
+      await user.click(getByTestId(SETTINGS_MENU_BUTTON_TEST_ID));
       expect(getByTestId(SETTINGS_MENU_FLYOUT_TYPE_BUTTON_GROUP_TEST_ID)).toHaveAttribute(
         'disabled'
       );
@@ -164,7 +169,8 @@ describe('SettingsMenu', () => {
       expect(localStorage.getItem(EXPANDABLE_FLYOUT_LOCAL_STORAGE)).toEqual(null);
     });
 
-    it('should not render the information icon if the tooltip is empty', () => {
+    it('should not render the information icon if the tooltip is empty', async () => {
+      const user = userEvent.setup();
       const flyoutCustomProps = {
         hideSettings: false,
         pushVsOverlay: {
@@ -179,7 +185,7 @@ describe('SettingsMenu', () => {
         </TestProvider>
       );
 
-      getByTestId(SETTINGS_MENU_BUTTON_TEST_ID).click();
+      await user.click(getByTestId(SETTINGS_MENU_BUTTON_TEST_ID));
 
       expect(
         queryByTestId(SETTINGS_MENU_FLYOUT_TYPE_INFORMATION_ICON_TEST_ID)
@@ -188,7 +194,8 @@ describe('SettingsMenu', () => {
   });
 
   describe('resize', () => {
-    it('should render the flyout resize button', () => {
+    it('should render the flyout resize button', async () => {
+      const user = userEvent.setup();
       const flyoutCustomProps = {
         hideSettings: false,
         resize: {
@@ -202,7 +209,7 @@ describe('SettingsMenu', () => {
         </TestProvider>
       );
 
-      getByTestId(SETTINGS_MENU_BUTTON_TEST_ID).click();
+      await user.click(getByTestId(SETTINGS_MENU_BUTTON_TEST_ID));
 
       expect(getByTestId(SETTINGS_MENU_FLYOUT_RESIZE_TITLE_TEST_ID)).toBeInTheDocument();
       expect(
@@ -211,7 +218,8 @@ describe('SettingsMenu', () => {
       expect(getByTestId(SETTINGS_MENU_FLYOUT_RESIZE_BUTTON_TEST_ID)).toBeInTheDocument();
     });
 
-    it('should reset correctly when clicked', () => {
+    it('should reset correctly when clicked', async () => {
+      const user = userEvent.setup();
       const flyoutCustomProps = {
         hideSettings: false,
         resize: {
@@ -235,8 +243,8 @@ describe('SettingsMenu', () => {
         </TestProvider>
       );
 
-      getByTestId(SETTINGS_MENU_BUTTON_TEST_ID).click();
-      getByTestId(SETTINGS_MENU_FLYOUT_RESIZE_BUTTON_TEST_ID).click();
+      await user.click(getByTestId(SETTINGS_MENU_BUTTON_TEST_ID));
+      await user.click(getByTestId(SETTINGS_MENU_FLYOUT_RESIZE_BUTTON_TEST_ID));
 
       const expandableFlyout = localStorage.getItem(EXPANDABLE_FLYOUT_LOCAL_STORAGE);
       expect(expandableFlyout).not.toBe(null);
@@ -246,7 +254,8 @@ describe('SettingsMenu', () => {
       expect(expandableFlyout).not.toHaveProperty(USER_SECTION_WIDTHS_LOCAL_STORAGE);
     });
 
-    it('should render the the flyout resize button disabled', () => {
+    it('should render the the flyout resize button disabled', async () => {
+      const user = userEvent.setup();
       const flyoutCustomProps = {
         hideSettings: false,
         resize: {
@@ -261,12 +270,13 @@ describe('SettingsMenu', () => {
         </TestProvider>
       );
 
-      getByTestId(SETTINGS_MENU_BUTTON_TEST_ID).click();
+      await user.click(getByTestId(SETTINGS_MENU_BUTTON_TEST_ID));
       expect(getByTestId(SETTINGS_MENU_FLYOUT_RESIZE_BUTTON_TEST_ID)).toHaveAttribute('disabled');
       expect(getByTestId(SETTINGS_MENU_FLYOUT_RESIZE_INFORMATION_ICON_TEST_ID)).toBeInTheDocument();
     });
 
-    it('should not render the information icon if the tooltip is empty', () => {
+    it('should not render the information icon if the tooltip is empty', async () => {
+      const user = userEvent.setup();
       const flyoutCustomProps = {
         hideSettings: false,
         resize: {
@@ -281,7 +291,7 @@ describe('SettingsMenu', () => {
         </TestProvider>
       );
 
-      getByTestId(SETTINGS_MENU_BUTTON_TEST_ID).click();
+      await user.click(getByTestId(SETTINGS_MENU_BUTTON_TEST_ID));
       expect(
         queryByTestId(SETTINGS_MENU_FLYOUT_RESIZE_INFORMATION_ICON_TEST_ID)
       ).not.toBeInTheDocument();

--- a/packages/kbn-field-utils/src/components/field_description/field_description.test.tsx
+++ b/packages/kbn-field-utils/src/components/field_description/field_description.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { FieldDescription } from './field_description';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import { SHOULD_TRUNCATE_FIELD_DESCRIPTION_LOCALSTORAGE_KEY } from './field_description';
 
@@ -51,12 +51,12 @@ describe('FieldDescription', () => {
     const customDescription = 'test this long desc '.repeat(8).trim();
     render(<FieldDescription field={{ name: 'bytes', type: 'number', customDescription }} />);
     expect(screen.queryByTestId('fieldDescription-bytes')).toHaveTextContent(customDescription);
-    screen.queryByTestId('toggleFieldDescription-bytes')?.click();
+    fireEvent.click(screen.queryByTestId('toggleFieldDescription-bytes'));
     expect(screen.queryByTestId('fieldDescription-bytes')).toHaveTextContent(
       `${customDescription}View less`
     );
     expect(mockSetLocalStorage).toHaveBeenCalledWith(false);
-    screen.queryByTestId('toggleFieldDescription-bytes')?.click();
+    fireEvent.click(screen.queryByTestId('toggleFieldDescription-bytes'));
     expect(screen.queryByTestId('fieldDescription-bytes')).toHaveTextContent(customDescription);
     expect(mockSetLocalStorage).toHaveBeenCalledWith(true);
   });

--- a/packages/kbn-field-utils/src/components/field_description/field_description.test.tsx
+++ b/packages/kbn-field-utils/src/components/field_description/field_description.test.tsx
@@ -51,12 +51,12 @@ describe('FieldDescription', () => {
     const customDescription = 'test this long desc '.repeat(8).trim();
     render(<FieldDescription field={{ name: 'bytes', type: 'number', customDescription }} />);
     expect(screen.queryByTestId('fieldDescription-bytes')).toHaveTextContent(customDescription);
-    fireEvent.click(screen.queryByTestId('toggleFieldDescription-bytes'));
+    fireEvent.click(screen.getByTestId('toggleFieldDescription-bytes'));
     expect(screen.queryByTestId('fieldDescription-bytes')).toHaveTextContent(
       `${customDescription}View less`
     );
     expect(mockSetLocalStorage).toHaveBeenCalledWith(false);
-    fireEvent.click(screen.queryByTestId('toggleFieldDescription-bytes'));
+    fireEvent.click(screen.getByTestId('toggleFieldDescription-bytes'));
     expect(screen.queryByTestId('fieldDescription-bytes')).toHaveTextContent(customDescription);
     expect(mockSetLocalStorage).toHaveBeenCalledWith(true);
   });
@@ -69,7 +69,7 @@ describe('FieldDescription', () => {
       `${customDescription}View less`
     );
     expect(mockSetLocalStorage).not.toHaveBeenCalled();
-    screen.queryByTestId('toggleFieldDescription-bytes')?.click();
+    fireEvent.click(screen.getByTestId('toggleFieldDescription-bytes'));
     expect(screen.queryByTestId('fieldDescription-bytes')).toHaveTextContent(customDescription);
     expect(mockSetLocalStorage).toHaveBeenCalledWith(true);
   });

--- a/packages/kbn-unified-data-table/src/components/custom_control_columns/additional_row_control/row_menu_control_column.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/custom_control_columns/additional_row_control/row_menu_control_column.test.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import type { EuiDataGridCellValueElementProps } from '@elastic/eui';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { getRowMenuControlColumn } from './row_menu_control_column';
 import { dataTableContextMock } from '../../../../__mocks__/table_context';
@@ -20,7 +21,8 @@ describe('getRowMenuControlColumn', () => {
     ...dataTableContextMock,
   };
 
-  it('should render the component', () => {
+  it('should render the component', async () => {
+    const user = userEvent.setup();
     const mockClick = jest.fn();
     const props = {
       id: 'test_row_menu_control',
@@ -57,7 +59,7 @@ describe('getRowMenuControlColumn', () => {
     const menuButton = screen.getByTestId('unifiedDataTable_test_row_menu_control');
     expect(menuButton).toBeInTheDocument();
 
-    menuButton.click();
+    await user.click(menuButton);
 
     expect(screen.getByTestId('exampleRowControl-visBarVerticalStacked')).toBeInTheDocument();
     expect(screen.getByTestId('exampleRowControl-heart')).toBeInTheDocument();
@@ -65,7 +67,7 @@ describe('getRowMenuControlColumn', () => {
     const button = screen.getByTestId('unifiedDataTable_rowMenu_test_row_menu_control');
     expect(button).toBeInTheDocument();
 
-    button.click();
+    await user.click(button);
     expect(mockClick).toHaveBeenCalledWith({ record: contextMock.getRowByIndex(1), rowIndex: 1 });
   });
 });

--- a/packages/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -1256,8 +1256,10 @@ describe('UnifiedDataTable', () => {
   describe('columns', () => {
     // Default column width in EUI is hardcoded to 100px for Jest envs
     const EUI_DEFAULT_COLUMN_WIDTH = '100px';
-    const getColumnHeader = (name: string) => screen.getByRole('columnheader', { name });
-    const queryColumnHeader = (name: string) => screen.queryByRole('columnheader', { name });
+    const getColumnHeader = (name: string) =>
+      screen.getByRole('columnheader', { name: (content) => content.startsWith(name) });
+    const queryColumnHeader = (name: string) =>
+      screen.queryByRole('columnheader', { name: (content) => content.startsWith(name) });
     const openColumnActions = async (name: string) => {
       const actionsButton = screen.getByTestId(`dataGridHeaderCellActionButton-${name}`);
       await userEvent.click(actionsButton);

--- a/packages/kbn-unified-data-table/src/components/data_table_document_selection.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_document_selection.test.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../__mocks__/table_context';
 import { UnifiedDataTableContext } from '../table_context';
 import { getDocId } from '@kbn/discover-utils';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { servicesMock } from '../../__mocks__/services';
@@ -408,8 +409,9 @@ describe('document selection', () => {
       );
       return {
         getButton: async () => {
+          const user = userEvent.setup();
           const menuButton = await screen.findByTestId('unifiedDataTableSelectionBtn');
-          menuButton.click();
+          await user.click(menuButton);
           return screen.queryByRole('button', { name: /Compare/ });
         },
       };
@@ -425,19 +427,20 @@ describe('document selection', () => {
       const { getButton } = renderCompareBtn({ setIsCompareActive });
       const button = await getButton();
       expect(button).toBeInTheDocument();
-      expect(button?.getAttribute('disabled')).toBeNull();
-      button?.click();
+      expect(button!.getAttribute('disabled')).toBeNull();
+      await userEvent.click(button!);
       expect(setIsCompareActive).toHaveBeenCalledWith(true);
     });
 
     it('should disable the button if limit is reached', async () => {
+      const user = userEvent.setup();
       const selectedDocIds = Array.from({ length: 500 }, (_, i) => i.toString());
       const setIsCompareActive = jest.fn();
       const { getButton } = renderCompareBtn({ selectedDocIds, setIsCompareActive });
       const button = await getButton();
       expect(button).toBeInTheDocument();
-      expect(button?.getAttribute('disabled')).toBe('');
-      button?.click();
+      expect(button!.getAttribute('disabled')).toBe('');
+      await user.click(button!);
       expect(setIsCompareActive).not.toHaveBeenCalled();
     });
   });

--- a/packages/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
+++ b/packages/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.test.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { findTestSubject } from '@elastic/eui/lib/test';
 import { buildDataTableRecord } from '@kbn/discover-utils';
@@ -78,7 +79,8 @@ describe('<DocViewer />', () => {
     expect(errorMsgComponent.text()).toMatch(new RegExp(`${errorMsg}`));
   });
 
-  test('should save active tab to local storage', () => {
+  test('should save active tab to local storage', async () => {
+    const user = userEvent.setup();
     const registry = new DocViewsRegistry();
     registry.add({ id: 'test1', order: 10, title: 'Render function', render: jest.fn() });
     registry.add({ id: 'test2', order: 20, title: 'Render function', render: jest.fn() });
@@ -88,13 +90,13 @@ describe('<DocViewer />', () => {
     expect(screen.getByTestId('docViewerTab-test1').getAttribute('aria-selected')).toBe('true');
     expect(screen.getByTestId('docViewerTab-test2').getAttribute('aria-selected')).toBe('false');
 
-    screen.getByTestId('docViewerTab-test2').click();
+    await user.click(screen.getByTestId('docViewerTab-test2'));
 
     expect(screen.getByTestId('docViewerTab-test1').getAttribute('aria-selected')).toBe('false');
     expect(screen.getByTestId('docViewerTab-test2').getAttribute('aria-selected')).toBe('true');
     expect(mockSetLocalStorage).toHaveBeenCalledWith('kbn_doc_viewer_tab_test2');
 
-    screen.getByTestId('docViewerTab-test1').click();
+    await user.click(screen.getByTestId('docViewerTab-test1'));
 
     expect(screen.getByTestId('docViewerTab-test1').getAttribute('aria-selected')).toBe('true');
     expect(screen.getByTestId('docViewerTab-test2').getAttribute('aria-selected')).toBe('false');

--- a/packages/shared-ux/error_boundary/src/services/error_boundary_services.test.tsx
+++ b/packages/shared-ux/error_boundary/src/services/error_boundary_services.test.tsx
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import userEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 import React from 'react';
 
@@ -23,6 +24,7 @@ describe('<KibanaErrorBoundaryProvider>', () => {
   });
 
   it('creates a context of services for KibanaErrorBoundary', async () => {
+    const user = userEvent.setup();
     const reportEventSpy = jest.spyOn(analytics!, 'reportEvent');
 
     const { findByTestId } = render(
@@ -32,7 +34,8 @@ describe('<KibanaErrorBoundaryProvider>', () => {
         </KibanaErrorBoundary>
       </KibanaErrorBoundaryProvider>
     );
-    (await findByTestId('clickForErrorBtn')).click();
+
+    await user.click(await findByTestId('clickForErrorBtn'));
 
     expect(reportEventSpy).toBeCalledWith('fatal-error-react', {
       component_name: 'BadComponent',
@@ -43,6 +46,7 @@ describe('<KibanaErrorBoundaryProvider>', () => {
   });
 
   it('uses higher-level context if available', async () => {
+    const user = userEvent.setup();
     const reportEventSpy1 = jest.spyOn(analytics!, 'reportEvent');
 
     const analytics2 = analyticsServiceMock.createAnalyticsServiceStart();
@@ -60,7 +64,8 @@ describe('<KibanaErrorBoundaryProvider>', () => {
         </KibanaErrorBoundary>
       </KibanaErrorBoundaryProvider>
     );
-    (await findByTestId('clickForErrorBtn')).click();
+
+    await user.click(await findByTestId('clickForErrorBtn'));
 
     expect(reportEventSpy2).not.toBeCalled();
     expect(reportEventSpy1).toBeCalledWith('fatal-error-react', {

--- a/packages/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
+++ b/packages/shared-ux/error_boundary/src/ui/error_boundary.test.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import React, { FC, PropsWithChildren } from 'react';
 
 import { KibanaErrorBoundary } from '../..';
@@ -46,12 +46,12 @@ describe('<KibanaErrorBoundary>', () => {
         <ChunkLoadErrorComponent />
       </Template>
     );
-    (await findByTestId('clickForErrorBtn')).click();
+    fireEvent.click(await findByTestId('clickForErrorBtn'));
 
     expect(await findByText(strings.recoverable.callout.title())).toBeVisible();
     expect(await findByText(strings.recoverable.callout.pageReloadButton())).toBeVisible();
 
-    (await findByTestId('errorBoundaryRecoverablePromptReloadBtn')).click();
+    fireEvent.click(await findByTestId('errorBoundaryRecoverablePromptReloadBtn'));
 
     expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
@@ -64,14 +64,14 @@ describe('<KibanaErrorBoundary>', () => {
         <BadComponent />
       </Template>
     );
-    (await findByTestId('clickForErrorBtn')).click();
+    fireEvent.click(await findByTestId('clickForErrorBtn'));
 
     expect(await findByText(strings.fatal.callout.title())).toBeVisible();
     expect(await findByText(strings.fatal.callout.body())).toBeVisible();
     expect(await findByText(strings.fatal.callout.showDetailsButton())).toBeVisible();
     expect(await findByText(strings.fatal.callout.pageReloadButton())).toBeVisible();
 
-    (await findByTestId('errorBoundaryFatalPromptReloadBtn')).click();
+    fireEvent.click(await findByTestId('errorBoundaryFatalPromptReloadBtn'));
 
     expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
@@ -87,7 +87,7 @@ describe('<KibanaErrorBoundary>', () => {
         <BadComponent />
       </Template>
     );
-    (await findByTestId('clickForErrorBtn')).click();
+    fireEvent.click(await findByTestId('clickForErrorBtn'));
 
     expect(mockDeps.analytics.reportEvent.mock.calls[0][0]).toBe('fatal-error-react');
     expect(mockDeps.analytics.reportEvent.mock.calls[0][1]).toMatchObject({
@@ -107,7 +107,8 @@ describe('<KibanaErrorBoundary>', () => {
         <BadComponent />
       </Template>
     );
-    (await findByTestId('clickForErrorBtn')).click();
+
+    fireEvent.click(await findByTestId('clickForErrorBtn'));
 
     expect(
       mockDeps.analytics.reportEvent.mock.calls[0][1].component_stack.includes('at BadComponent')

--- a/src/plugins/discover/public/embeddable/get_search_embeddable_factory.test.tsx
+++ b/src/plugins/discover/public/embeddable/get_search_embeddable_factory.test.tsx
@@ -18,7 +18,7 @@ import { BuildReactEmbeddableApiRegistration } from '@kbn/embeddable-plugin/publ
 import { PresentationContainer } from '@kbn/presentation-containers';
 import { PhaseEvent, PublishesUnifiedSearch, StateComparators } from '@kbn/presentation-publishing';
 import { VIEW_MODE } from '@kbn/saved-search-plugin/common';
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 
 import { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
 import { createDataViewDataSource } from '../../common/data_sources';
@@ -143,8 +143,10 @@ describe('saved search embeddable', () => {
       expect(api.dataLoading.getValue()).toBe(false);
 
       expect(discoverComponent.queryByTestId('embeddedSavedSearchDocTable')).toBeInTheDocument();
-      expect(discoverComponent.getByTestId('embeddedSavedSearchDocTable').textContent).toEqual(
-        'No results found'
+      await waitFor(() =>
+        expect(discoverComponent.getByTestId('embeddedSavedSearchDocTable').textContent).toEqual(
+          'No results found'
+        )
       );
     });
 

--- a/src/plugins/unified_search/public/saved_query_management/saved_query_management_list.test.tsx
+++ b/src/plugins/unified_search/public/saved_query_management/saved_query_management_list.test.tsx
@@ -155,8 +155,10 @@ describe('Saved query management list component', () => {
 
   it('should render the saved queries on the selectable component', async () => {
     render(wrapSavedQueriesListComponentInContext(props));
-    expect(await screen.findAllByRole('option')).toHaveLength(1);
-    expect(screen.getByRole('option', { name: 'Test' })).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryAllByRole('option')).toHaveLength(1));
+    expect(
+      screen.getByRole('option', { name: (content) => content.startsWith('Test') })
+    ).toBeInTheDocument();
   });
 
   it('should display the total and selected count', async () => {
@@ -173,7 +175,9 @@ describe('Saved query management list component', () => {
     render(wrapSavedQueriesListComponentInContext(newProps));
     expect(await screen.findByText('6 queries')).toBeInTheDocument();
     expect(screen.queryByText('6 queries | 1 selected')).not.toBeInTheDocument();
-    await userEvent.click(screen.getByRole('option', { name: 'Test 0' }));
+    await userEvent.click(
+      screen.getByRole('option', { name: (content) => content.startsWith('Test 0') })
+    );
     expect(screen.queryByText('6 queries')).not.toBeInTheDocument();
     expect(screen.getByText('6 queries | 1 selected')).toBeInTheDocument();
   });
@@ -213,7 +217,9 @@ describe('Saved query management list component', () => {
     render(wrapSavedQueriesListComponentInContext(newProps));
     expect(await screen.findByLabelText('Load query')).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Delete query' })).toBeDisabled();
-    await userEvent.click(screen.getByRole('option', { name: 'Test' }));
+    await userEvent.click(
+      screen.getByRole('option', { name: (content) => content.startsWith('Test') })
+    );
     expect(screen.getByLabelText('Load query')).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Delete query' })).toBeEnabled();
     await userEvent.click(screen.getByLabelText('Load query'));
@@ -240,7 +246,9 @@ describe('Saved query management list component', () => {
 
   it('should render the modal on delete', async () => {
     render(wrapSavedQueriesListComponentInContext(props));
-    await userEvent.click(await screen.findByRole('option', { name: 'Test' }));
+    await userEvent.click(
+      await screen.findByRole('option', { name: (content) => content.startsWith('Test') })
+    );
     await userEvent.click(screen.getByRole('button', { name: 'Delete query' }));
     expect(screen.getByRole('heading', { name: 'Delete "Test"?' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
@@ -261,7 +269,9 @@ describe('Saved query management list component', () => {
       },
     };
     render(wrapSavedQueriesListComponentInContext(newProps));
-    await userEvent.click(await screen.findByRole('option', { name: 'Test' }));
+    await userEvent.click(
+      await screen.findByRole('option', { name: (content) => content.startsWith('Test') })
+    );
     await userEvent.click(screen.getByRole('button', { name: 'Delete query' }));
     expect(screen.getByRole('heading', { name: 'Delete "Test"?' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
@@ -378,9 +388,18 @@ describe('Saved query management list component', () => {
     await waitFor(() => {
       expect(findSavedQueriesSpy).toHaveBeenLastCalledWith(undefined, 5, 1);
     });
-    expect(screen.getByRole('option', { name: 'Test 0', checked: false })).toBeInTheDocument();
-    await userEvent.click(screen.getByRole('option', { name: 'Test 0' }));
-    expect(screen.getByRole('option', { name: 'Test 0', checked: true })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {
+        name: (content) => content.startsWith('Test 0'),
+        checked: false,
+      })
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('option', { name: (content) => content.startsWith('Test 0') })
+    );
+    expect(
+      screen.getByRole('option', { name: (content) => content.startsWith('Test 0'), checked: true })
+    ).toBeInTheDocument();
     findSavedQueriesSpy.mockResolvedValue({
       total: 6,
       queries: generateSavedQueries(1),
@@ -397,7 +416,9 @@ describe('Saved query management list component', () => {
     await waitFor(() => {
       expect(findSavedQueriesSpy).toHaveBeenLastCalledWith(undefined, 5, 1);
     });
-    expect(screen.getByRole('option', { name: 'Test 0', checked: true })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: (content) => content.startsWith('Test 0'), checked: true })
+    ).toBeInTheDocument();
   });
 
   it('should allow providing a search term', async () => {

--- a/x-pack/packages/security-solution/side_nav/src/solution_side_nav.test.tsx
+++ b/x-pack/packages/security-solution/side_nav/src/solution_side_nav.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 import { SolutionSideNav, type SolutionSideNavProps } from './solution_side_nav';
 import type { SolutionSideNavItem } from './types';
@@ -62,7 +63,8 @@ describe('SolutionSideNav', () => {
       );
     });
 
-    it('should call onClick callback if link clicked', () => {
+    it('should call onClick callback if link clicked', async () => {
+      const user = userEvent.setup();
       const mockOnClick = jest.fn((ev) => {
         ev.preventDefault();
       });
@@ -76,11 +78,12 @@ describe('SolutionSideNav', () => {
         },
       ];
       const result = renderNav({ items });
-      result.getByTestId(`solutionSideNavItemLink-${'exploreLanding'}`).click();
+      await user.click(result.getByTestId(`solutionSideNavItemLink-${'exploreLanding'}`));
       expect(mockOnClick).toHaveBeenCalled();
     });
 
-    it('should send telemetry if link clicked', () => {
+    it('should send telemetry if link clicked', async () => {
+      const user = userEvent.setup();
       const items = [
         ...mockItems,
         {
@@ -90,7 +93,7 @@ describe('SolutionSideNav', () => {
         },
       ];
       const result = renderNav({ items });
-      result.getByTestId(`solutionSideNavItemLink-${'exploreLanding'}`).click();
+      await user.click(result.getByTestId(`solutionSideNavItemLink-${'exploreLanding'}`));
       expect(mockTrack).toHaveBeenCalledWith(
         METRIC_TYPE.CLICK,
         `${TELEMETRY_EVENT.NAVIGATION}${'exploreLanding'}`
@@ -107,32 +110,35 @@ describe('SolutionSideNav', () => {
       expect(result.queryByTestId(`solutionSideNavItemButton-${'alerts'}`)).not.toBeInTheDocument();
     });
 
-    it('should render the panel when button is clicked', () => {
+    it('should render the panel when button is clicked', async () => {
+      const user = userEvent.setup();
       const result = renderNav();
       expect(result.queryByTestId('solutionSideNavPanel')).not.toBeInTheDocument();
 
-      result.getByTestId(`solutionSideNavItemButton-${'dashboardsLanding'}`).click();
+      await user.click(result.getByTestId(`solutionSideNavItemButton-${'dashboardsLanding'}`));
       expect(result.getByTestId('solutionSideNavPanel')).toBeInTheDocument();
       expect(result.getByText('Overview')).toBeInTheDocument();
     });
 
-    it('should telemetry when button is clicked', () => {
+    it('should telemetry when button is clicked', async () => {
+      const user = userEvent.setup();
       const result = renderNav();
       expect(result.queryByTestId('solutionSideNavPanel')).not.toBeInTheDocument();
 
-      result.getByTestId(`solutionSideNavItemButton-${'dashboardsLanding'}`).click();
+      await user.click(result.getByTestId(`solutionSideNavItemButton-${'dashboardsLanding'}`));
       expect(mockTrack).toHaveBeenCalledWith(
         METRIC_TYPE.CLICK,
         `${TELEMETRY_EVENT.PANEL_NAVIGATION_TOGGLE}${'dashboardsLanding'}`
       );
     });
 
-    it('should close the panel when the same button is clicked', () => {
+    it('should close the panel when the same button is clicked', async () => {
+      const user = userEvent.setup();
       const result = renderNav();
-      result.getByTestId(`solutionSideNavItemButton-${'dashboardsLanding'}`).click();
+      await user.click(result.getByTestId(`solutionSideNavItemButton-${'dashboardsLanding'}`));
       expect(result.getByTestId('solutionSideNavPanel')).toBeInTheDocument();
 
-      result.getByTestId(`solutionSideNavItemButton-${'dashboardsLanding'}`).click();
+      await user.click(result.getByTestId(`solutionSideNavItemButton-${'dashboardsLanding'}`));
 
       // add check at the end of the event loop to ensure the panel is removed
       setTimeout(() => {
@@ -140,7 +146,8 @@ describe('SolutionSideNav', () => {
       });
     });
 
-    it('should open other panel when other button is clicked while open', () => {
+    it('should open other panel when other button is clicked while open', async () => {
+      const user = userEvent.setup();
       const items = [
         ...mockItems,
         {
@@ -159,11 +166,11 @@ describe('SolutionSideNav', () => {
       ];
       const result = renderNav({ items });
 
-      result.getByTestId(`solutionSideNavItemButton-${'dashboardsLanding'}`).click();
+      await user.click(result.getByTestId(`solutionSideNavItemButton-${'dashboardsLanding'}`));
       expect(result.getByTestId('solutionSideNavPanel')).toBeInTheDocument();
       expect(result.getByText('Overview')).toBeInTheDocument();
 
-      result.getByTestId(`solutionSideNavItemButton-${'exploreLanding'}`).click();
+      await user.click(result.getByTestId(`solutionSideNavItemButton-${'exploreLanding'}`));
       expect(result.queryByTestId('solutionSideNavPanel')).toBeInTheDocument();
       expect(result.getByText('Users')).toBeInTheDocument();
     });

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -963,7 +963,9 @@ describe('AllCasesListGeneric', () => {
         // Deactivates assignees filter
         await userEvent.click(await screen.findByRole('button', { name: 'More' }));
         await waitForEuiPopoverOpen();
-        await userEvent.click(await screen.findByRole('option', { name: 'Assignees' }));
+        await userEvent.click(
+          await screen.findByRole('option', { name: (context) => context.startsWith('Assignees') })
+        );
 
         expect(useGetCasesMock).toHaveBeenLastCalledWith({
           filterOptions: {
@@ -974,7 +976,9 @@ describe('AllCasesListGeneric', () => {
         });
 
         // Reopens assignees filter
-        await userEvent.click(await screen.findByRole('option', { name: 'Assignees' }));
+        await userEvent.click(
+          await screen.findByRole('option', { name: (context) => context.startsWith('Assignees') })
+        );
         // Opens the assignees popup
         await userEvent.click(assigneesButton);
         expect(await screen.findByLabelText('click to filter assignees')).toBeInTheDocument();

--- a/x-pack/plugins/cases/public/components/all_cases/status_filter.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/status_filter.test.tsx
@@ -55,7 +55,9 @@ describe('StatusFilter', () => {
 
     await userEvent.click(await screen.findByTestId('options-filter-popover-button-status'));
     await waitForEuiPopoverOpen();
-    await userEvent.click(await screen.findByRole('option', { name: LABELS.open }));
+    await userEvent.click(
+      await screen.findByRole('option', { name: (context) => context.startsWith(LABELS.open) })
+    );
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith({

--- a/x-pack/plugins/cases/public/components/all_cases/table_filters.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table_filters.test.tsx
@@ -339,7 +339,9 @@ describe('CasesTableFilters ', () => {
 
       await userEvent.click(screen.getByRole('button', { name: 'More' }));
       await waitForEuiPopoverOpen();
-      await userEvent.click(screen.getByRole('option', { name: 'Solution' }));
+      await userEvent.click(
+        screen.getByRole('option', { name: (content) => content.startsWith('Solution') })
+      );
 
       expect(onFilterChanged).toHaveBeenCalledWith({
         ...DEFAULT_FILTER_OPTIONS,
@@ -417,7 +419,9 @@ describe('CasesTableFilters ', () => {
       // deactivate the assignees filter
       await userEvent.click(screen.getByRole('button', { name: 'More' }));
       await waitForEuiPopoverOpen();
-      await userEvent.click(screen.getByRole('option', { name: 'Assignees' }));
+      await userEvent.click(
+        screen.getByRole('option', { name: (context) => context.startsWith('Assignees') })
+      );
 
       expect(onFilterChanged).toHaveBeenCalledWith({
         ...DEFAULT_FILTER_OPTIONS,
@@ -589,7 +593,9 @@ describe('CasesTableFilters ', () => {
       appMockRender.render(<CasesTableFilters {...customProps} />);
 
       await userEvent.click(await screen.findByTestId('options-filter-popover-button-filters'));
-      await userEvent.click(await screen.findByRole('option', { name: 'Toggle' }));
+      await userEvent.click(
+        await screen.findByRole('option', { name: (context) => context.startsWith('Toggle') })
+      );
 
       expect(onFilterChanged).toHaveBeenCalledWith({
         ...DEFAULT_FILTER_OPTIONS,
@@ -654,7 +660,9 @@ describe('CasesTableFilters ', () => {
       await userEvent.click(screen.getByRole('button', { name: 'More' }));
       await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(5));
 
-      await userEvent.click(screen.getByRole('option', { name: 'Toggle' }));
+      await userEvent.click(
+        screen.getByRole('option', { name: (context) => context.startsWith('Toggle') })
+      );
 
       const filterBar = await screen.findByTestId('cases-table-filters');
       const allFilters = within(filterBar).getAllByRole('button');
@@ -670,7 +678,9 @@ describe('CasesTableFilters ', () => {
       await userEvent.click(screen.getByRole('button', { name: 'More' }));
       await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(5));
 
-      await userEvent.click(screen.getByRole('option', { name: 'Toggle' }));
+      await userEvent.click(
+        screen.getByRole('option', { name: (context) => context.startsWith('Toggle') })
+      );
       const storedFilterState = localStorage.getItem(
         'securitySolution.cases.list.tableFiltersConfig'
       );
@@ -708,7 +718,9 @@ describe('CasesTableFilters ', () => {
       await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(5));
 
       expect(await screen.findByTestId('options-filter-popover-button-status')).toBeInTheDocument();
-      await userEvent.click(screen.getByRole('option', { name: 'Status' }));
+      await userEvent.click(
+        screen.getByRole('option', { name: (context) => context.startsWith('Status') })
+      );
 
       const filterBar = await screen.findByTestId('cases-table-filters');
       const allFilters = within(filterBar).getAllByRole('button');
@@ -729,7 +741,9 @@ describe('CasesTableFilters ', () => {
       appMockRender.render(<CasesTableFilters {...customProps} />);
 
       await userEvent.click(await screen.findByRole('button', { name: 'More' }));
-      await userEvent.click(await screen.findByRole('option', { name: 'Status' }));
+      await userEvent.click(
+        await screen.findByRole('option', { name: (context) => context.startsWith('Status') })
+      );
 
       expect(onFilterChanged).toHaveBeenCalledWith({
         ...DEFAULT_FILTER_OPTIONS,
@@ -749,7 +763,9 @@ describe('CasesTableFilters ', () => {
       await userEvent.click(screen.getByRole('button', { name: 'More' }));
       await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(5));
 
-      await userEvent.click(screen.getByRole('option', { name: 'Status' }));
+      await userEvent.click(
+        screen.getByRole('option', { name: (context) => context.startsWith('Status') })
+      );
 
       const storedFilterState = localStorage.getItem(
         'securitySolution.cases.list.tableFiltersConfig'
@@ -894,10 +910,14 @@ describe('CasesTableFilters ', () => {
 
       expect(await screen.findByTestId('options-filter-popover-button-status')).toBeInTheDocument();
       await userEvent.click(await screen.findByTestId('options-filter-popover-button-filters'));
-      await userEvent.click(await screen.findByRole('option', { name: 'Status' }));
+      await userEvent.click(
+        await screen.findByRole('option', { name: (context) => context.startsWith('Status') })
+      );
 
       await userEvent.click(await screen.findByTestId('options-filter-popover-button-filters'));
-      await userEvent.click(await screen.findByRole('option', { name: 'Status' }));
+      await userEvent.click(
+        await screen.findByRole('option', { name: (context) => context.startsWith('Status') })
+      );
 
       allFilters = within(filterBar).getAllByRole('button');
       orderedFilterLabels = ['Severity', 'Tags', 'Categories', 'Status', 'More'];
@@ -959,7 +979,9 @@ describe('CasesTableFilters ', () => {
 
       await userEvent.click(screen.getByRole('button', { name: 'More' }));
       // we need any user action to trigger the filter config update
-      await userEvent.click(await screen.findByRole('option', { name: 'Toggle' }));
+      await userEvent.click(
+        await screen.findByRole('option', { name: (context) => context.startsWith('Toggle') })
+      );
 
       const storedFilterState = localStorage.getItem(
         'securitySolution.cases.list.tableFiltersConfig'

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.test.tsx
@@ -647,7 +647,7 @@ describe('<ComplianceDashboard />', () => {
 
     renderComplianceDashboardPage(cloudPosturePages.kspm_dashboard.path);
 
-    screen.getByTestId(CLOUD_DASHBOARD_TAB).click();
+    fireEvent.click(screen.getByTestId(CLOUD_DASHBOARD_TAB));
 
     expectIdsInDoc({
       be: [CSPM_INTEGRATION_NOT_INSTALLED_TEST_SUBJECT],
@@ -689,7 +689,7 @@ describe('<ComplianceDashboard />', () => {
 
     renderComplianceDashboardPage();
 
-    screen.getByTestId(KUBERNETES_DASHBOARD_TAB).click();
+    fireEvent.click(screen.getByTestId(KUBERNETES_DASHBOARD_TAB));
 
     expectIdsInDoc({
       be: [KSPM_INTEGRATION_NOT_INSTALLED_TEST_SUBJECT],

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import { coreMock } from '@kbn/core/public/mocks';
 import type { BaseCspSetupStatus, CspStatusCode } from '@kbn/cloud-security-posture-common';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { TestProvider } from '../../test/test_provider';
 import { ComplianceDashboard, getDefaultTab } from '.';
@@ -619,7 +620,9 @@ describe('<ComplianceDashboard />', () => {
     });
   });
 
-  it('Show CSPM installation prompt if CSPM is not installed and KSPM is installed ,NO AGENT', () => {
+  it('Show CSPM installation prompt if CSPM is not installed and KSPM is installed ,NO AGENT', async () => {
+    const user = userEvent.setup();
+
     (useCspSetupStatusApi as jest.Mock).mockImplementation(() =>
       createReactQueryResponse({
         status: 'success',
@@ -647,7 +650,7 @@ describe('<ComplianceDashboard />', () => {
 
     renderComplianceDashboardPage(cloudPosturePages.kspm_dashboard.path);
 
-    fireEvent.click(screen.getByTestId(CLOUD_DASHBOARD_TAB));
+    await user.click(screen.getByTestId(CLOUD_DASHBOARD_TAB));
 
     expectIdsInDoc({
       be: [CSPM_INTEGRATION_NOT_INSTALLED_TEST_SUBJECT],
@@ -661,7 +664,9 @@ describe('<ComplianceDashboard />', () => {
     });
   });
 
-  it('Show KSPM installation prompt if KSPM is not installed and CSPM is installed , NO AGENT', () => {
+  it('Show KSPM installation prompt if KSPM is not installed and CSPM is installed , NO AGENT', async () => {
+    const user = userEvent.setup();
+
     (useCspSetupStatusApi as jest.Mock).mockImplementation(() =>
       createReactQueryResponse({
         status: 'success',
@@ -676,6 +681,7 @@ describe('<ComplianceDashboard />', () => {
         },
       })
     );
+
     (useCspmStatsApi as jest.Mock).mockImplementation(() => ({
       isSuccess: true,
       isLoading: false,
@@ -689,7 +695,7 @@ describe('<ComplianceDashboard />', () => {
 
     renderComplianceDashboardPage();
 
-    fireEvent.click(screen.getByTestId(KUBERNETES_DASHBOARD_TAB));
+    await user.click(screen.getByTestId(KUBERNETES_DASHBOARD_TAB));
 
     expectIdsInDoc({
       be: [KSPM_INTEGRATION_NOT_INSTALLED_TEST_SUBJECT],

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_dataset.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_dataset.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { render, act, fireEvent } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 
@@ -49,12 +49,11 @@ describe('DatasetFilter', () => {
     onToggleDataset: () => {},
   });
 
-  it('Renders all statuses', () => {
-    act(() => {
-      fireEvent.click(getByRole('button'));
-    });
+  it('Renders all statuses', async () => {
+    fireEvent.click(getByRole('button'));
 
-    expect(getByText('elastic_agent')).toBeInTheDocument();
+    await waitFor(() => expect(getByText('elastic_agent')).toBeInTheDocument());
+
     expect(getByText('elastic_agent.filebeat')).toBeInTheDocument();
     expect(getByText('elastic_agent.fleet_server')).toBeInTheDocument();
     expect(getByText('elastic_agent.metricbeat')).toBeInTheDocument();

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_dataset.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_logs/filter_dataset.test.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 import React from 'react';
-import { render, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, waitFor } from '@testing-library/react';
 
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 
@@ -50,7 +51,9 @@ describe('DatasetFilter', () => {
   });
 
   it('Renders all statuses', async () => {
-    fireEvent.click(getByRole('button'));
+    const user = userEvent.setup();
+
+    await user.click(getByRole('button'));
 
     await waitFor(() => expect(getByText('elastic_agent')).toBeInTheDocument());
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/filter_bar/tags_filter.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/filter_bar/tags_filter.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 
 import { createFleetTestRendererMock } from '../../../../../../../mock';
 
@@ -19,6 +20,7 @@ describe('TagsFilter', () => {
   }
 
   it('should remove one tag on clicking selected tag', async () => {
+    const user = userEvent.setup();
     const tags = ['tag1', 'tag2', 'tag3'];
     const selectedTags = ['tag1', 'tag2', 'tag3'];
     const onSelectedTagsChange = jest.fn();
@@ -29,9 +31,9 @@ describe('TagsFilter', () => {
     };
     const { getByText, getByTestId } = render(props);
     const filterButton = getByTestId('agentList.tagsFilter');
-    filterButton.click();
+    await user.click(filterButton);
     const tag = getByText('tag1');
-    tag.click();
+    await user.click(tag);
     expect(onSelectedTagsChange).toHaveBeenCalledWith(['tag2', 'tag3']);
   });
 });

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/review_step/review_step.test.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/review_step/review_step.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, act, type RenderResult, fireEvent, waitFor } from '@testing-library/react';
+import { render, type RenderResult, fireEvent, waitFor } from '@testing-library/react';
 import { TestProvider } from '../../../../../mocks/test_provider';
 import { ReviewStep } from './review_step';
 import { ActionsProvider } from '../../state';
@@ -70,9 +70,7 @@ describe('ReviewStep', () => {
 
   describe('when edit pipeline button is clicked', () => {
     beforeEach(() => {
-      act(() => {
-        result.getByTestId('editPipelineButton').click();
-      });
+      fireEvent.click(result.getByTestId('editPipelineButton'));
     });
 
     it('should open pipeline editor', () => {
@@ -81,9 +79,7 @@ describe('ReviewStep', () => {
 
     describe('when saving pipeline without changes', () => {
       beforeEach(() => {
-        act(() => {
-          result.getByTestId('savePipelineButton').click();
-        });
+        fireEvent.click(result.getByTestId('savePipelineButton'));
       });
 
       it('should call setResults', () => {
@@ -93,19 +89,15 @@ describe('ReviewStep', () => {
 
     describe('when saving pipeline with changes', () => {
       beforeEach(async () => {
-        act(() => {
-          fireEvent.change(result.getByTestId('mockCodeEditor'), {
-            target: { value: JSON.stringify(customPipeline) },
-          });
+        fireEvent.change(result.getByTestId('mockCodeEditor'), {
+          target: { value: JSON.stringify(customPipeline) },
         });
       });
 
       describe('when check pipeline is successful', () => {
         beforeEach(async () => {
-          await act(async () => {
-            result.getByTestId('savePipelineButton').click();
-            await waitFor(() => expect(mockActions.setIsGenerating).toHaveBeenCalledWith(false));
-          });
+          fireEvent.click(result.getByTestId('savePipelineButton'));
+          await waitFor(() => expect(mockActions.setIsGenerating).toHaveBeenCalledWith(false));
         });
 
         it('should call setIsGenerating', () => {
@@ -129,10 +121,8 @@ describe('ReviewStep', () => {
           mockRunCheckPipelineResults.mockImplementationOnce(() => {
             throw new Error('test error');
           });
-          await act(async () => {
-            result.getByTestId('savePipelineButton').click();
-            await waitFor(() => expect(mockActions.setIsGenerating).toHaveBeenCalledWith(false));
-          });
+          fireEvent.click(result.getByTestId('savePipelineButton'));
+          await waitFor(() => expect(mockActions.setIsGenerating).toHaveBeenCalledWith(false));
         });
 
         it('should check pipeline', () => {
@@ -153,10 +143,8 @@ describe('ReviewStep', () => {
           mockRunCheckPipelineResults.mockReturnValueOnce({
             results: { ...mockResults, docs: [] },
           });
-          await act(async () => {
-            result.getByTestId('savePipelineButton').click();
-            await waitFor(() => expect(mockActions.setIsGenerating).toHaveBeenCalledWith(false));
-          });
+          fireEvent.click(result.getByTestId('savePipelineButton'));
+          await waitFor(() => expect(mockActions.setIsGenerating).toHaveBeenCalledWith(false));
         });
 
         it('should check pipeline', () => {

--- a/x-pack/plugins/kubernetes_security/public/components/tree_view_container/tree_nav/index.test.tsx
+++ b/x-pack/plugins/kubernetes_security/public/components/tree_view_container/tree_nav/index.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { AppContextTestRender, createAppRootMockRenderer } from '../../../test';
 import { clusterResponseMock } from '../mocks';
 import { TreeNav } from '.';
@@ -45,6 +46,7 @@ describe('TreeNav component', () => {
   });
 
   it('shows the tree path according with the selected view type', async () => {
+    const user = userEvent.setup();
     renderResult = mockedContext.render(<TreeNavContainer />);
 
     const logicalViewPath = 'cluster / namespace / pod / container image';
@@ -55,25 +57,28 @@ describe('TreeNav component', () => {
     const infraStructureViewRadio = renderResult.getByTestId(
       'treeNavType_generated-idinfrastructure'
     );
-    infraStructureViewRadio.click();
 
+    await user.click(infraStructureViewRadio);
     expect(renderResult.getByText('cluster / node / pod / container image')).toBeInTheDocument();
 
-    logicViewButton.click();
+    await user.click(logicViewButton);
+
     expect(renderResult.getByText(logicalViewPath)).toBeInTheDocument();
   });
 
   it('collapses / expands the tree nav when clicking on collapse button', async () => {
+    const user = userEvent.setup();
+
     renderResult = mockedContext.render(<TreeNavContainer />);
 
     expect(renderResult.getByText(/cluster/i)).toBeVisible();
 
     const collapseButton = await renderResult.getByLabelText(/collapse/i);
-    collapseButton.click();
+    await user.click(collapseButton);
     expect(renderResult.getByText(/cluster/i)).not.toBeVisible();
 
     const expandButton = await renderResult.getByLabelText(/expand/i);
-    expandButton.click();
+    await user.click(expandButton);
     expect(renderResult.getByText(/cluster/i)).toBeVisible();
   });
 });

--- a/x-pack/plugins/lens/public/visualizations/metric/toolbar/titles_and_text_popover.test.tsx
+++ b/x-pack/plugins/lens/public/visualizations/metric/toolbar/titles_and_text_popover.test.tsx
@@ -75,7 +75,7 @@ describe('TitlesAndTextPopover', () => {
       breakdownByAccessor: undefined,
     });
     const labelOptionsButton = screen.getByTestId('lnsTextOptionsButton');
-    labelOptionsButton.click();
+    fireEvent.click(labelOptionsButton);
 
     const newSubtitle = 'new subtitle hey';
     const subtitleField = screen.getByDisplayValue('subtitle');
@@ -109,7 +109,7 @@ describe('TitlesAndTextPopover', () => {
   it('should set titlesTextAlign', async () => {
     renderToolbarOptions({ ...fullState });
     const textOptionsButton = screen.getByTestId('lnsTextOptionsButton');
-    textOptionsButton.click();
+    fireEvent.click(textOptionsButton);
 
     const titlesAlignBtnGroup = new EuiButtonGroupTestHarness('lens-titles-alignment-btn');
 
@@ -127,7 +127,7 @@ describe('TitlesAndTextPopover', () => {
   it('should set valuesTextAlign', async () => {
     renderToolbarOptions({ ...fullState });
     const textOptionsButton = screen.getByTestId('lnsTextOptionsButton');
-    textOptionsButton.click();
+    fireEvent.click(textOptionsButton);
 
     const valueAlignBtnGroup = new EuiButtonGroupTestHarness('lens-values-alignment-btn');
 
@@ -145,7 +145,7 @@ describe('TitlesAndTextPopover', () => {
   it('should set valueFontMode', async () => {
     renderToolbarOptions({ ...fullState });
     const textOptionsButton = screen.getByTestId('lnsTextOptionsButton');
-    textOptionsButton.click();
+    fireEvent.click(textOptionsButton);
 
     const modeBtnGroup = new EuiButtonGroupTestHarness('lens-value-font-mode-btn');
 
@@ -160,7 +160,7 @@ describe('TitlesAndTextPopover', () => {
   it('should set iconAlign', async () => {
     renderToolbarOptions({ ...fullState, icon: 'sortUp' });
     const textOptionsButton = screen.getByTestId('lnsTextOptionsButton');
-    textOptionsButton.click();
+    fireEvent.click(textOptionsButton);
 
     const iconAlignBtnGroup = new EuiButtonGroupTestHarness('lens-icon-alignment-btn');
 
@@ -175,7 +175,7 @@ describe('TitlesAndTextPopover', () => {
   it.each([undefined, 'empty'])('should hide iconAlign option when icon is %j', async (icon) => {
     renderToolbarOptions({ ...fullState, icon });
     const textOptionsButton = screen.getByTestId('lnsTextOptionsButton');
-    textOptionsButton.click();
+    fireEvent.click(textOptionsButton);
 
     expect(screen.queryByTestId('lens-icon-alignment-btn')).not.toBeInTheDocument();
   });

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_container.test.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_container.test.tsx
@@ -6,7 +6,8 @@
  */
 
 import { composeStories } from '@storybook/testing-react';
-import { render, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { disableConsoleWarning } from '../../../../../utils/test_helpers';
 import * as stories from './waterfall_container.stories';
@@ -25,12 +26,14 @@ describe('WaterfallContainer', () => {
   });
 
   it('expands and contracts the accordion', async () => {
+    const user = userEvent.setup();
+
     const { getAllByRole } = render(<Example />);
     const buttons = await waitFor(() => getAllByRole('button'));
     const parentItem = buttons[1];
     const childItem = buttons[2];
 
-    fireEvent.click(parentItem);
+    await user.click(parentItem);
 
     expect(parentItem).toHaveAttribute('aria-expanded', 'false');
     expect(childItem).toHaveAttribute('aria-expanded', 'true');

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_container.test.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_container.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { composeStories } from '@storybook/testing-react';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { disableConsoleWarning } from '../../../../../utils/test_helpers';
 import * as stories from './waterfall_container.stories';
@@ -30,7 +30,7 @@ describe('WaterfallContainer', () => {
     const parentItem = buttons[1];
     const childItem = buttons[2];
 
-    parentItem.click();
+    fireEvent.click(parentItem);
 
     expect(parentItem).toHaveAttribute('aria-expanded', 'false');
     expect(childItem).toHaveAttribute('aria-expanded', 'true');

--- a/x-pack/plugins/observability_solution/exploratory_view/public/components/shared/exploratory_view/exploratory_view.test.tsx
+++ b/x-pack/plugins/observability_solution/exploratory_view/public/components/shared/exploratory_view/exploratory_view.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import { render, mockAppDataView } from './rtl_helpers';
 import { ExploratoryView } from './exploratory_view';
 import * as obsvDataViews from '../../../utils/observability_data_views/observability_data_views';
@@ -87,7 +87,7 @@ describe('ExploratoryView', () => {
     const toggleButton = await screen.findByText('Hide chart');
     expect(toggleButton).toBeInTheDocument();
 
-    toggleButton.click();
+    fireEvent.click(toggleButton);
 
     expect(toggleButton.textContent).toBe('Show chart');
     expect(screen.queryByText('Refresh')).toBeNull();

--- a/x-pack/plugins/observability_solution/observability/public/pages/alert_details/alert_details.test.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/pages/alert_details/alert_details.test.tsx
@@ -12,6 +12,7 @@ import { observabilityAIAssistantPluginMock } from '@kbn/observability-ai-assist
 import { useBreadcrumbs, TagsList } from '@kbn/observability-shared-plugin/public';
 import { RuleTypeModel, ValidationResult } from '@kbn/triggers-actions-ui-plugin/public';
 import { ruleTypeRegistryMock } from '@kbn/triggers-actions-ui-plugin/public/application/rule_type_registry.mock';
+import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/react';
 import { Chance } from 'chance';
 import React, { Fragment } from 'react';
@@ -175,6 +176,7 @@ describe('Alert details', () => {
   });
 
   it('should show Metadata tab', async () => {
+    const user = userEvent.setup();
     useFetchAlertDetailMock.mockReturnValue([false, alertDetail]);
 
     const alertDetails = renderComponent();
@@ -184,7 +186,7 @@ describe('Alert details', () => {
     expect(alertDetails.queryByTestId('alertDetailsTabbedContent')?.textContent).toContain(
       'Metadata'
     );
-    alertDetails.getByText('Metadata').click();
+    await user.click(alertDetails.getByText('Metadata'));
     expect(alertDetails.queryByTestId('metadataTabPanel')).toBeTruthy();
     expect(alertDetails.queryByTestId('metadataTabPanel')?.textContent).toContain(
       'kibana.alert.status'

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/functions/visualize_esql.test.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/public/functions/visualize_esql.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
@@ -180,11 +180,9 @@ describe('VisualizeESQL', () => {
 
     renderComponent({}, lensService);
 
-    await act(async () => {
-      await userEvent.click(
-        await screen.findByTestId('observabilityAiAssistantLensESQLDisplayTableButton')
-      );
-    });
+    await userEvent.click(
+      await screen.findByTestId('observabilityAiAssistantLensESQLDisplayTableButton')
+    );
 
     expect(await screen.findByTestId('observabilityAiAssistantESQLDataGrid')).toBeInTheDocument();
   });

--- a/x-pack/plugins/observability_solution/slo/public/pages/slos/slos.test.tsx
+++ b/x-pack/plugins/observability_solution/slo/public/pages/slos/slos.test.tsx
@@ -11,7 +11,8 @@ import { usePerformanceContext } from '@kbn/ebt-tools';
 import { observabilityAIAssistantPluginMock } from '@kbn/observability-ai-assistant-plugin/public/mock';
 import { HeaderMenuPortal, TagsList } from '@kbn/observability-shared-plugin/public';
 import { encode } from '@kbn/rison';
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import Router from 'react-router-dom';
 import { paths } from '../../../common/locators/paths';
@@ -251,6 +252,7 @@ describe('SLOs Page', () => {
 
     describe('when API has returned results', () => {
       it('renders the SLO list with SLO items', async () => {
+        const user = userEvent.setup();
         useFetchSloListMock.mockReturnValue({ isLoading: false, data: sloList });
 
         useFetchHistoricalSummaryMock.mockReturnValue({
@@ -263,7 +265,7 @@ describe('SLOs Page', () => {
         });
         expect(await screen.findByTestId('sloListViewButton')).toBeTruthy();
 
-        fireEvent.click(screen.getByTestId('sloListViewButton'));
+        await user.click(screen.getByTestId('sloListViewButton'));
 
         expect(screen.queryByTestId('slosPage')).toBeTruthy();
         expect(screen.queryByTestId('sloList')).toBeTruthy();
@@ -272,6 +274,7 @@ describe('SLOs Page', () => {
       });
 
       it('allows editing an SLO', async () => {
+        const user = userEvent.setup();
         useFetchSloListMock.mockReturnValue({ isLoading: false, data: sloList });
 
         useFetchHistoricalSummaryMock.mockReturnValue({
@@ -283,9 +286,9 @@ describe('SLOs Page', () => {
           render(<SlosPage />);
         });
         expect(await screen.findByTestId('compactView')).toBeTruthy();
-        fireEvent.click(screen.getByTestId('compactView'));
+        await user.click(screen.getByTestId('compactView'));
 
-        (await screen.findByLabelText('All actions, row 1')).click();
+        await user.click(await screen.findByLabelText('All actions, row 1'));
 
         await waitForEuiPopoverOpen();
 
@@ -293,12 +296,13 @@ describe('SLOs Page', () => {
 
         expect(button).toBeTruthy();
 
-        button.click();
+        await user.click(button);
 
         expect(mockNavigate).toBeCalledWith(`${paths.sloEdit(sloList.results.at(0)?.id || '')}`);
       });
 
       it('allows creating a new rule for an SLO', async () => {
+        const user = userEvent.setup();
         useFetchSloListMock.mockReturnValue({ isLoading: false, data: sloList });
 
         useFetchHistoricalSummaryMock.mockReturnValue({
@@ -310,8 +314,9 @@ describe('SLOs Page', () => {
           render(<SlosPage />);
         });
         expect(await screen.findByTestId('compactView')).toBeTruthy();
-        fireEvent.click(screen.getByTestId('compactView'));
-        screen.getByLabelText('All actions, row 1').click();
+        await user.click(screen.getByTestId('compactView'));
+        expect(screen.getByLabelText('All actions, row 1')).toBeTruthy();
+        await user.click(screen.getByLabelText('All actions, row 1')!);
 
         await waitForEuiPopoverOpen();
 
@@ -319,12 +324,13 @@ describe('SLOs Page', () => {
 
         expect(button).toBeTruthy();
 
-        button.click();
+        await user.click(button);
 
         expect(mockGetAddRuleFlyout).toBeCalled();
       });
 
       it('allows managing rules for an SLO', async () => {
+        const user = userEvent.setup();
         useFetchSloListMock.mockReturnValue({ isLoading: false, data: sloList });
 
         useFetchHistoricalSummaryMock.mockReturnValue({
@@ -336,8 +342,9 @@ describe('SLOs Page', () => {
           render(<SlosPage />);
         });
         expect(await screen.findByTestId('compactView')).toBeTruthy();
-        fireEvent.click(screen.getByTestId('compactView'));
-        screen.getByLabelText('All actions, row 1').click();
+        await user.click(screen.getByTestId('compactView'));
+        expect(screen.getByLabelText('All actions, row 1')).toBeTruthy();
+        await user.click(screen.getByLabelText('All actions, row 1')!);
 
         await waitForEuiPopoverOpen();
 
@@ -345,12 +352,13 @@ describe('SLOs Page', () => {
 
         expect(button).toBeTruthy();
 
-        button.click();
+        await user.click(button);
 
         expect(mockLocator).toBeCalled();
       });
 
       it('allows deleting an SLO', async () => {
+        const user = userEvent.setup();
         useFetchSloListMock.mockReturnValue({ isLoading: false, data: sloList });
 
         useFetchHistoricalSummaryMock.mockReturnValue({
@@ -363,8 +371,9 @@ describe('SLOs Page', () => {
         });
 
         expect(await screen.findByTestId('compactView')).toBeTruthy();
-        fireEvent.click(screen.getByTestId('compactView'));
-        screen.getByLabelText('All actions, row 1').click();
+        await user.click(screen.getByTestId('compactView'));
+        expect(screen.getByLabelText('All actions, row 1')).toBeTruthy();
+        await user.click(screen.getByLabelText('All actions, row 1')!);
 
         await waitForEuiPopoverOpen();
 
@@ -372,9 +381,9 @@ describe('SLOs Page', () => {
 
         expect(button).toBeTruthy();
 
-        button.click();
+        await user.click(button);
 
-        screen.getByTestId('observabilitySolutionSloDeleteModalConfirmButton').click();
+        await user.click(screen.getByTestId('observabilitySolutionSloDeleteModalConfirmButton'));
 
         expect(mockDeleteSlo).toBeCalledWith({
           id: sloList.results.at(0)?.id,
@@ -383,6 +392,7 @@ describe('SLOs Page', () => {
       });
 
       it('allows cloning an SLO', async () => {
+        const user = userEvent.setup();
         useFetchSloListMock.mockReturnValue({ isLoading: false, data: sloList });
 
         useFetchHistoricalSummaryMock.mockReturnValue({
@@ -395,8 +405,9 @@ describe('SLOs Page', () => {
         });
 
         expect(await screen.findByTestId('compactView')).toBeTruthy();
-        fireEvent.click(screen.getByTestId('compactView'));
-        screen.getByLabelText('All actions, row 1').click();
+        await user.click(screen.getByTestId('compactView'));
+        expect(screen.getByLabelText('All actions, row 1')).toBeTruthy();
+        await user.click(screen.getByLabelText('All actions, row 1')!);
 
         await waitForEuiPopoverOpen();
 
@@ -404,11 +415,12 @@ describe('SLOs Page', () => {
 
         expect(button).toBeTruthy();
 
-        button.click();
+        await user.click(button);
+
+        const slo = sloList.results.at(0);
 
         await waitFor(() => {
-          const slo = sloList.results.at(0);
-          expect(mockNavigate).toBeCalledWith(
+          return expect(mockNavigate).toBeCalledWith(
             paths.sloCreateWithEncodedForm(
               encode({ ...slo, name: `[Copy] ${slo!.name}`, id: undefined })
             )

--- a/x-pack/plugins/security_solution/public/common/components/assignees/assignees_apply_panel.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/assignees/assignees_apply_panel.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 import { ASSIGNEES_APPLY_BUTTON_TEST_ID, ASSIGNEES_APPLY_PANEL_TEST_ID } from './test_ids';
 import { AssigneesApplyPanel } from './assignees_apply_panel';
@@ -75,9 +75,9 @@ describe('<AssigneesApplyPanel />', () => {
     });
 
     expect(getByTestId(ASSIGNEES_APPLY_BUTTON_TEST_ID)).toBeDisabled();
-    getByText(mockUserProfiles[1].user.full_name).click();
+    fireEvent.click(getByText(mockUserProfiles[1].user.full_name));
     expect(getByTestId(ASSIGNEES_APPLY_BUTTON_TEST_ID)).not.toBeDisabled();
-    getByTestId(ASSIGNEES_APPLY_BUTTON_TEST_ID).click();
+    fireEvent.click(getByTestId(ASSIGNEES_APPLY_BUTTON_TEST_ID));
 
     expect(mockedOnApply).toHaveBeenCalledWith({
       add: ['user-id-2'],

--- a/x-pack/plugins/security_solution/public/common/components/assignees/assignees_selectable.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/assignees/assignees_selectable.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 
 import { AssigneesSelectable } from './assignees_selectable';
@@ -81,7 +82,9 @@ describe('<AssigneesSelectable />', () => {
     expect(assigneesList).toHaveTextContent(i18n.ASSIGNEES_NO_ASSIGNEES);
   });
 
-  it('should call `onSelectionChange` on user selection', () => {
+  it('should call `onSelectionChange` on user selection', async () => {
+    const user = userEvent.setup();
+
     (useBulkGetUserProfiles as jest.Mock).mockReturnValue({
       isLoading: false,
       data: [],
@@ -93,12 +96,12 @@ describe('<AssigneesSelectable />', () => {
       onSelectionChange: onSelectionChangeMock,
     });
 
-    getByText('User 1').click();
-    getByText('User 2').click();
-    getByText('User 3').click();
-    getByText('User 3').click();
-    getByText('User 2').click();
-    getByText('User 1').click();
+    await user.click(getByText('User 1'));
+    await user.click(getByText('User 2'));
+    await user.click(getByText('User 3'));
+    await user.click(getByText('User 3'));
+    await user.click(getByText('User 2'));
+    await user.click(getByText('User 1'));
 
     expect(onSelectionChangeMock).toHaveBeenCalledTimes(6);
     expect(onSelectionChangeMock.mock.calls).toEqual([

--- a/x-pack/plugins/security_solution/public/common/components/events_tab/events_query_tab_body.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_tab/events_query_tab_body.test.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import userEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TableId, dataTableActions } from '@kbn/securitysolution-data-table';
@@ -153,14 +154,15 @@ describe('EventsQueryTabBody', () => {
     );
   });
 
-  it('renders the matrix histogram stacked by alerts default value', () => {
+  it('renders the matrix histogram stacked by alerts default value', async () => {
+    const user = userEvent.setup();
     const result = render(
       <TestProviders>
         <EventsQueryTabBody {...commonProps} />
       </TestProviders>
     );
 
-    result.getByTestId('showExternalAlertsCheckbox').click();
+    await user.click(result.getByTestId('showExternalAlertsCheckbox'));
 
     expect(result.getByTestId('header-section-supplements').querySelector('select')?.value).toEqual(
       'event.module'

--- a/x-pack/plugins/security_solution/public/common/components/filter_by_assignees_popover/filter_by_assignees_popover.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/filter_by_assignees_popover/filter_by_assignees_popover.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 import { FilterByAssigneesPopover } from './filter_by_assignees_popover';
 import { TestProviders } from '../../mock';
@@ -88,14 +88,14 @@ describe('<FilterByAssigneesPopover />', () => {
   it('should render opened popover component', () => {
     const { getByTestId } = renderFilterByAssigneesPopover();
 
-    getByTestId(FILTER_BY_ASSIGNEES_BUTTON).click();
+    fireEvent.click(getByTestId(FILTER_BY_ASSIGNEES_BUTTON));
     expect(getByTestId('euiSelectableList')).toBeInTheDocument();
   });
 
   it('should render assignees', () => {
     const { getByTestId } = renderFilterByAssigneesPopover();
 
-    getByTestId(FILTER_BY_ASSIGNEES_BUTTON).click();
+    fireEvent.click(getByTestId(FILTER_BY_ASSIGNEES_BUTTON));
 
     const assigneesList = getByTestId('euiSelectableList');
     expect(assigneesList).toHaveTextContent('User 1');
@@ -110,14 +110,14 @@ describe('<FilterByAssigneesPopover />', () => {
     const onUsersChangeMock = jest.fn();
     const { getByTestId, getByText } = renderFilterByAssigneesPopover([], onUsersChangeMock);
 
-    getByTestId(FILTER_BY_ASSIGNEES_BUTTON).click();
+    fireEvent.click(getByTestId(FILTER_BY_ASSIGNEES_BUTTON));
 
-    getByText('User 1').click();
-    getByText('User 2').click();
-    getByText('User 3').click();
-    getByText('User 3').click();
-    getByText('User 2').click();
-    getByText('User 1').click();
+    fireEvent.click(getByText('User 1'));
+    fireEvent.click(getByText('User 2'));
+    fireEvent.click(getByText('User 3'));
+    fireEvent.click(getByText('User 3'));
+    fireEvent.click(getByText('User 2'));
+    fireEvent.click(getByText('User 1'));
 
     expect(onUsersChangeMock).toHaveBeenCalledTimes(6);
     expect(onUsersChangeMock.mock.calls).toEqual([

--- a/x-pack/plugins/security_solution/public/common/components/guided_onboarding_tour/cases_tour_steps.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/guided_onboarding_tour/cases_tour_steps.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { CasesTourSteps } from './cases_tour_steps';
 import { AlertsCasesTourSteps } from './tour_config';
 import { TestProviders } from '../../mock';
@@ -27,7 +27,7 @@ describe('cases tour steps', () => {
   });
   it('On click next, AlertsCasesTourSteps.submitCase step active', () => {
     const { getByTestId, queryByTestId } = render(<CasesTourSteps />, { wrapper: TestProviders });
-    getByTestId(`step-${AlertsCasesTourSteps.createCase}`).click();
+    fireEvent.click(getByTestId(`step-${AlertsCasesTourSteps.createCase}`));
     expect(getByTestId(`step-${AlertsCasesTourSteps.submitCase}`)).toBeInTheDocument();
     expect(queryByTestId(`step-${AlertsCasesTourSteps.createCase}`)).not.toBeInTheDocument();
   });

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/related_integrations.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/related_integrations.test.tsx
@@ -732,18 +732,16 @@ function showEuiComboBoxOptions(comboBoxToggleButton: HTMLElement): Promise<void
   });
 }
 
-function selectEuiComboBoxOption({
+async function selectEuiComboBoxOption({
   comboBoxToggleButton,
   optionIndex,
 }: {
   comboBoxToggleButton: HTMLElement;
   optionIndex: number;
-}): Promise<void> {
-  return act(async () => {
-    await showEuiComboBoxOptions(comboBoxToggleButton);
+}) {
+  await showEuiComboBoxOptions(comboBoxToggleButton);
 
-    fireEvent.click(screen.getAllByRole('option')[optionIndex]);
-  });
+  fireEvent.click(screen.getAllByRole('option')[optionIndex]);
 }
 
 function clearEuiComboBoxSelection({ clearButton }: { clearButton: HTMLElement }): Promise<void> {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/required_fields/required_fields.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/required_fields/required_fields.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { I18nProvider } from '@kbn/i18n-react';
-import { screen, render, act, fireEvent, waitFor } from '@testing-library/react';
+import { screen, render, fireEvent, waitFor } from '@testing-library/react';
 import { Form, useForm } from '../../../../shared_imports';
 
 import type { DataViewFieldBase } from '@kbn/es-query';
@@ -586,8 +586,7 @@ function showEuiComboBoxOptions(comboBoxToggleButton: HTMLElement): Promise<void
   return waitFor(() => {
     const listWithOptionsElement = document.querySelector('[role="listbox"]');
     const emptyListElement = document.querySelector('.euiComboBoxOptionsList__empty');
-
-    expect(listWithOptionsElement || emptyListElement).toBeInTheDocument();
+    return expect(listWithOptionsElement || emptyListElement).toBeInTheDocument();
   });
 }
 
@@ -639,19 +638,17 @@ function selectFirstEuiComboBoxOption({
   return selectEuiComboBoxOption({ comboBoxToggleButton, optionIndex: 0 });
 }
 
-function typeInCustomComboBoxOption({
+async function typeInCustomComboBoxOption({
   comboBoxToggleButton,
   optionText,
 }: {
   comboBoxToggleButton: HTMLElement;
   optionText: string;
 }) {
-  return act(async () => {
-    await showEuiComboBoxOptions(comboBoxToggleButton);
+  await showEuiComboBoxOptions(comboBoxToggleButton);
 
-    fireEvent.change(document.activeElement as HTMLInputElement, { target: { value: optionText } });
-    fireEvent.keyDown(document.activeElement as HTMLInputElement, { key: 'Enter' });
-  });
+  fireEvent.change(document.activeElement as HTMLInputElement, { target: { value: optionText } });
+  fireEvent.keyDown(document.activeElement as HTMLInputElement, { key: 'Enter' });
 }
 
 function getLastSelectToggleButtonForName(): HTMLElement {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/required_fields/required_fields.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/required_fields/required_fields.test.tsx
@@ -46,7 +46,8 @@ describe('RequiredFields form part', () => {
 
     render(<TestForm indexPatternFields={indexPatternFields} />);
 
-    await addRequiredFieldRow();
+    addRequiredFieldRow();
+
     await selectFirstEuiComboBoxOption({
       comboBoxToggleButton: getSelectToggleButtonForName('empty'),
     });
@@ -64,7 +65,7 @@ describe('RequiredFields form part', () => {
 
     render(<TestForm initialState={initialState} indexPatternFields={indexPatternFields} />);
 
-    await addRequiredFieldRow();
+    addRequiredFieldRow();
 
     await selectFirstEuiComboBoxOption({
       comboBoxToggleButton: getSelectToggleButtonForName('empty'),
@@ -82,7 +83,7 @@ describe('RequiredFields form part', () => {
 
     render(<TestForm indexPatternFields={indexPatternFields} />);
 
-    await addRequiredFieldRow();
+    addRequiredFieldRow();
 
     await selectEuiComboBoxOption({
       comboBoxToggleButton: getSelectToggleButtonForName('empty'),
@@ -92,7 +93,7 @@ describe('RequiredFields form part', () => {
     expect(screen.getByDisplayValue('field1')).toBeVisible();
     expect(screen.getByDisplayValue('string')).toBeVisible();
 
-    await addRequiredFieldRow();
+    addRequiredFieldRow();
 
     await selectEuiComboBoxOption({
       comboBoxToggleButton: getSelectToggleButtonForName('empty'),
@@ -106,7 +107,7 @@ describe('RequiredFields form part', () => {
   it('user can add his own custom field name and type', async () => {
     render(<TestForm indexPatternFields={[]} />);
 
-    await addRequiredFieldRow();
+    addRequiredFieldRow();
 
     await typeInCustomComboBoxOption({
       comboBoxToggleButton: getSelectToggleButtonForName('empty'),
@@ -150,9 +151,7 @@ describe('RequiredFields form part', () => {
 
     render(<TestForm initialState={initialState} indexPatternFields={indexPatternFields} />);
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('removeRequiredFieldButton-field1'));
-    });
+    fireEvent.click(screen.getByTestId('removeRequiredFieldButton-field1'));
 
     expect(screen.queryByDisplayValue('field1')).toBeNull();
   });
@@ -168,7 +167,7 @@ describe('RequiredFields form part', () => {
 
     render(<TestForm initialState={initialState} indexPatternFields={indexPatternFields} />);
 
-    await addRequiredFieldRow();
+    addRequiredFieldRow();
 
     const emptyRowOptions = await getDropdownOptions(getSelectToggleButtonForName('empty'));
     expect(emptyRowOptions).toEqual(['field2', 'field3']);
@@ -197,7 +196,7 @@ describe('RequiredFields form part', () => {
 
     expect(screen.getByTestId(ADD_REQUIRED_FIELD_BUTTON_TEST_ID)).toBeEnabled();
 
-    await addRequiredFieldRow();
+    addRequiredFieldRow();
 
     expect(screen.getByTestId(ADD_REQUIRED_FIELD_BUTTON_TEST_ID)).toBeDisabled();
   });
@@ -305,7 +304,7 @@ describe('RequiredFields form part', () => {
 
       render(<TestForm indexPatternFields={indexPatternFields} />);
 
-      await addRequiredFieldRow();
+      addRequiredFieldRow();
 
       expect(screen.queryByTestId(REQUIRED_FIELDS_GENERAL_WARNING_TEST_ID)).toBeNull();
     });
@@ -313,7 +312,7 @@ describe('RequiredFields form part', () => {
     it(`doesn't display a warning when field is invalid`, async () => {
       render(<TestForm />);
 
-      await addRequiredFieldRow();
+      addRequiredFieldRow();
 
       await typeInCustomComboBoxOption({
         comboBoxToggleButton: getSelectToggleButtonForName('empty'),
@@ -330,7 +329,7 @@ describe('RequiredFields form part', () => {
     it('form is invalid when only field name is empty', async () => {
       render(<TestForm />);
 
-      await addRequiredFieldRow();
+      addRequiredFieldRow();
 
       await typeInCustomComboBoxOption({
         comboBoxToggleButton: getSelectToggleButtonForType('empty'),
@@ -350,7 +349,7 @@ describe('RequiredFields form part', () => {
     it('form is invalid when only field type is empty', async () => {
       render(<TestForm />);
 
-      await addRequiredFieldRow();
+      addRequiredFieldRow();
 
       await typeInCustomComboBoxOption({
         comboBoxToggleButton: getSelectToggleButtonForName('empty'),
@@ -377,7 +376,7 @@ describe('RequiredFields form part', () => {
 
       render(<TestForm initialState={initialState} indexPatternFields={indexPatternFields} />);
 
-      await addRequiredFieldRow();
+      addRequiredFieldRow();
 
       await typeInCustomComboBoxOption({
         comboBoxToggleButton: getSelectToggleButtonForName('empty'),
@@ -399,9 +398,9 @@ describe('RequiredFields form part', () => {
 
       render(<TestForm onSubmit={handleSubmit} />);
 
-      await addRequiredFieldRow();
+      addRequiredFieldRow();
 
-      await submitForm();
+      submitForm();
 
       expect(handleSubmit).toHaveBeenCalledWith({
         data: [{ name: '', type: '' }],
@@ -416,7 +415,7 @@ describe('RequiredFields form part', () => {
 
       render(<TestForm onSubmit={handleSubmit} />);
 
-      await submitForm();
+      submitForm();
 
       await waitFor(() => {
         expect(handleSubmit).toHaveBeenCalledWith({
@@ -433,11 +432,9 @@ describe('RequiredFields form part', () => {
 
       render(<TestForm initialState={initialState} onSubmit={handleSubmit} />);
 
-      await act(async () => {
-        fireEvent.click(screen.getByTestId('removeRequiredFieldButton-field1'));
-      });
+      fireEvent.click(screen.getByTestId('removeRequiredFieldButton-field1'));
 
-      await submitForm();
+      submitForm();
 
       await waitFor(() => {
         expect(handleSubmit).toHaveBeenCalledWith({
@@ -456,13 +453,13 @@ describe('RequiredFields form part', () => {
 
       render(<TestForm indexPatternFields={indexPatternFields} onSubmit={handleSubmit} />);
 
-      await addRequiredFieldRow();
+      addRequiredFieldRow();
 
       await selectFirstEuiComboBoxOption({
         comboBoxToggleButton: getSelectToggleButtonForName('empty'),
       });
 
-      await submitForm();
+      submitForm();
 
       expect(handleSubmit).toHaveBeenCalledWith({
         data: [{ name: 'field1', type: 'string' }],
@@ -487,7 +484,7 @@ describe('RequiredFields form part', () => {
         />
       );
 
-      await submitForm();
+      submitForm();
 
       expect(handleSubmit).toHaveBeenCalledWith({
         data: [{ name: 'field1', type: 'string' }],
@@ -523,7 +520,7 @@ describe('RequiredFields form part', () => {
         optionText: 'date',
       });
 
-      await submitForm();
+      submitForm();
 
       expect(handleSubmit).toHaveBeenCalledWith({
         data: [{ name: 'field2', type: 'date' }],
@@ -550,7 +547,7 @@ describe('RequiredFields form part', () => {
 
       expect(screen.queryByTestId(REQUIRED_FIELDS_GENERAL_WARNING_TEST_ID)).toBeVisible();
 
-      await submitForm();
+      submitForm();
 
       expect(handleSubmit).toHaveBeenCalledWith({
         data: [{ name: 'name-that-does-not-exist', type: 'type-that-does-not-exist' }],
@@ -579,10 +576,8 @@ async function getDropdownOptions(dropdownToggleButton: HTMLElement): Promise<st
   return options;
 }
 
-export function addRequiredFieldRow(): Promise<void> {
-  return act(async () => {
-    fireEvent.click(screen.getByText('Add required field'));
-  });
+export function addRequiredFieldRow() {
+  fireEvent.click(screen.getByText('Add required field'));
 }
 
 function showEuiComboBoxOptions(comboBoxToggleButton: HTMLElement): Promise<void> {
@@ -608,34 +603,32 @@ type SelectEuiComboBoxOptionParameters =
       optionIndex?: undefined;
     };
 
-function selectEuiComboBoxOption({
+async function selectEuiComboBoxOption({
   comboBoxToggleButton,
   optionIndex,
   optionText,
 }: SelectEuiComboBoxOptionParameters): Promise<void> {
-  return act(async () => {
-    await showEuiComboBoxOptions(comboBoxToggleButton);
+  await showEuiComboBoxOptions(comboBoxToggleButton);
 
-    const options = Array.from(
-      document.querySelectorAll('[data-test-subj*="comboBoxOptionsList"] [role="option"]')
-    );
+  const options = Array.from(
+    document.querySelectorAll('[data-test-subj*="comboBoxOptionsList"] [role="option"]')
+  );
 
-    if (typeof optionText === 'string') {
-      const optionToSelect = options.find((option) => option.textContent === optionText);
+  if (typeof optionText === 'string') {
+    const optionToSelect = options.find((option) => option.textContent === optionText);
 
-      if (!optionToSelect) {
-        throw new Error(
-          `Could not find option with text "${optionText}". Available options: ${options
-            .map((option) => option.textContent)
-            .join(', ')}`
-        );
-      }
-
-      fireEvent.click(optionToSelect);
-    } else {
-      fireEvent.click(options[optionIndex]);
+    if (!optionToSelect) {
+      throw new Error(
+        `Could not find option with text "${optionText}". Available options: ${options
+          .map((option) => option.textContent)
+          .join(', ')}`
+      );
     }
-  });
+
+    fireEvent.click(optionToSelect);
+  } else {
+    fireEvent.click(options[optionIndex]);
+  }
 }
 
 function selectFirstEuiComboBoxOption({
@@ -680,10 +673,8 @@ function getSelectToggleButtonForType(value: string): HTMLElement {
     .querySelector('[data-test-subj="comboBoxToggleListButton"]') as HTMLElement;
 }
 
-function submitForm(): Promise<void> {
-  return act(async () => {
-    fireEvent.click(screen.getByText('Submit'));
-  });
+function submitForm() {
+  fireEvent.click(screen.getByText('Submit'));
 }
 
 interface TestFormProps {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/eql_query_bar/eql_query_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/eql_query_bar/eql_query_bar.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
 
 import { mockIndexPattern, TestProviders, useFormFieldMock } from '../../../../common/mock';
 import { mockQueryBar } from '../../../rule_management_ui/components/rules_table/__mocks__/mock';
@@ -140,9 +140,11 @@ describe('EqlQueryBar', () => {
       // open options popover
       fireEvent.click(getByTestId('eql-settings-trigger'));
       // display combobox options
-      within(getByTestId(`eql-timestamp-field`)).getByRole('combobox').focus();
+      act(() => {
+        within(getByTestId(`eql-timestamp-field`)).getByRole('combobox').focus();
+      });
       // select timestamp
-      getByText('timestamp').click();
+      fireEvent.click(getByText('timestamp'));
 
       expect(onOptionsChangeMock).toHaveBeenCalledWith('timestampField', 'timestamp');
     });

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/index.test.tsx
@@ -688,34 +688,32 @@ type SelectEuiComboBoxOptionParameters =
       optionIndex?: undefined;
     };
 
-function selectEuiComboBoxOption({
+async function selectEuiComboBoxOption({
   comboBoxToggleButton,
   optionIndex,
   optionText,
 }: SelectEuiComboBoxOptionParameters): Promise<void> {
-  return act(async () => {
-    await showEuiComboBoxOptions(comboBoxToggleButton);
+  await showEuiComboBoxOptions(comboBoxToggleButton);
 
-    const options = Array.from(
-      document.querySelectorAll('[data-test-subj*="comboBoxOptionsList"] [role="option"]')
-    );
+  const options = Array.from(
+    document.querySelectorAll('[data-test-subj*="comboBoxOptionsList"] [role="option"]')
+  );
 
-    if (typeof optionText === 'string') {
-      const optionToSelect = options.find((option) => option.textContent === optionText);
+  if (typeof optionText === 'string') {
+    const optionToSelect = options.find((option) => option.textContent === optionText);
 
-      if (optionToSelect) {
-        fireEvent.click(optionToSelect);
-      } else {
-        throw new Error(
-          `Could not find option with text "${optionText}". Available options: ${options
-            .map((option) => option.textContent)
-            .join(', ')}`
-        );
-      }
+    if (optionToSelect) {
+      fireEvent.click(optionToSelect);
     } else {
-      fireEvent.click(options[optionIndex]);
+      throw new Error(
+        `Could not find option with text "${optionText}". Available options: ${options
+          .map((option) => option.textContent)
+          .join(', ')}`
+      );
     }
-  });
+  } else {
+    fireEvent.click(options[optionIndex]);
+  }
 }
 
 function selectFirstEuiComboBoxOption({

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/filter_panel.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/coverage_overview/filter_panel.test.tsx
@@ -54,22 +54,26 @@ describe('CoverageOverviewFiltersPanel', () => {
   test('it correctly populates rule activity filter state', () => {
     const wrapper = renderFiltersPanel();
 
-    wrapper.getByTestId('coverageOverviewRuleActivityFilterButton').click();
+    fireEvent.click(wrapper.getByTestId('coverageOverviewRuleActivityFilterButton'));
 
-    within(wrapper.getByTestId('coverageOverviewFilterList'))
-      .getByText(ruleActivityFilterLabelMap[ruleActivityFilterDefaultOptions[0].label])
-      .click();
+    fireEvent.click(
+      within(wrapper.getByTestId('coverageOverviewFilterList')).getByText(
+        ruleActivityFilterLabelMap[ruleActivityFilterDefaultOptions[0].label]
+      )
+    );
     expect(setRuleActivityFilter).toHaveBeenCalledWith([ruleActivityFilterDefaultOptions[0].label]);
   });
 
   test('it correctly populates rule source filter state', () => {
     const wrapper = renderFiltersPanel();
 
-    wrapper.getByTestId('coverageOverviewRuleSourceFilterButton').click();
+    fireEvent.click(wrapper.getByTestId('coverageOverviewRuleSourceFilterButton'));
 
-    within(wrapper.getByTestId('coverageOverviewFilterList'))
-      .getByText(ruleSourceFilterLabelMap[ruleSourceFilterDefaultOptions[0].label])
-      .click();
+    fireEvent.click(
+      within(wrapper.getByTestId('coverageOverviewFilterList')).getByText(
+        ruleSourceFilterLabelMap[ruleSourceFilterDefaultOptions[0].label]
+      )
+    );
     expect(setRuleSourceFilter).toHaveBeenCalledWith([ruleSourceFilterDefaultOptions[0].label]);
   });
 

--- a/x-pack/plugins/security_solution/public/flyout/shared/components/expandable_panel.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/shared/components/expandable_panel.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 import {
   EXPANDABLE_PANEL_HEADER_LEFT_SECTION_TEST_ID,
@@ -133,7 +134,8 @@ describe('<ExpandablePanel />', () => {
       expect(queryByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(TEST_ID))).not.toBeInTheDocument();
     });
 
-    it('click toggle button should expand the panel', () => {
+    it('click toggle button should expand the panel', async () => {
+      const user = userEvent.setup();
       const { getByTestId } = render(
         <ThemeProvider theme={mockTheme}>
           <ExpandablePanel {...expandableDefaultProps}>{children}</ExpandablePanel>
@@ -142,7 +144,7 @@ describe('<ExpandablePanel />', () => {
 
       const toggle = getByTestId(EXPANDABLE_PANEL_TOGGLE_ICON_TEST_ID(TEST_ID));
       expect(toggle.firstChild).toHaveAttribute('data-euiicon-type', 'arrowRight');
-      toggle.click();
+      await user.click(toggle);
 
       expect(getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(TEST_ID))).toHaveTextContent(
         'test content'
@@ -182,7 +184,8 @@ describe('<ExpandablePanel />', () => {
       expect(getByTestId(EXPANDABLE_PANEL_TOGGLE_ICON_TEST_ID(TEST_ID))).toBeInTheDocument();
     });
 
-    it('click toggle button should collapse the panel', () => {
+    it('click toggle button should collapse the panel', async () => {
+      const user = userEvent.setup();
       const { getByTestId, queryByTestId } = render(
         <ThemeProvider theme={mockTheme}>
           <ExpandablePanel {...expandedDefaultProps}>{children}</ExpandablePanel>
@@ -193,7 +196,7 @@ describe('<ExpandablePanel />', () => {
       expect(toggle.firstChild).toHaveAttribute('data-euiicon-type', 'arrowDown');
       expect(getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(TEST_ID))).toBeInTheDocument();
 
-      toggle.click();
+      await user.click(toggle);
       expect(toggle.firstChild).toHaveAttribute('data-euiicon-type', 'arrowRight');
       expect(queryByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(TEST_ID))).not.toBeInTheDocument();
     });

--- a/x-pack/plugins/security_solution/public/management/components/console/components/command_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/command_list.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { ConsoleTestSetup, HelpSidePanelSelectorsAndActions } from '../mocks';
+import userEvent from '@testing-library/user-event';
 import {
   getCommandListMock,
   getConsoleTestSetup,
@@ -119,9 +120,10 @@ describe('When rendering the command list (help output)', () => {
       expect(renderResult.getByTestId('test-commandList-group1-cmd1-addToInput')).toBeDisabled();
     });
 
-    it('should add command to console input when [+] button is clicked', () => {
+    it('should add command to console input when [+] button is clicked', async () => {
+      const user = userEvent.setup();
       renderAndOpenHelpPanel();
-      renderResult.getByTestId('test-commandList-group1-cmd6-addToInput').click();
+      await user.click(renderResult.getByTestId('test-commandList-group1-cmd6-addToInput'));
       expect(consoleSelectors.getInputText()).toEqual('cmd6 --foo ');
     });
 

--- a/x-pack/plugins/security_solution/public/management/components/console/components/console_header.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/components/console_header.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import type { ConsoleProps } from '..';
 import type { AppContextTestRender } from '../../../../common/mock/endpoint';
 import { getConsoleTestSetup } from '../mocks';
@@ -41,9 +42,10 @@ describe('Console header area', () => {
     );
   });
 
-  it('should open the side panel when help button is clicked', () => {
+  it('should open the side panel when help button is clicked', async () => {
+    const user = userEvent.setup();
     render();
-    renderResult.getByTestId('test-header-helpButton').click();
+    await user.click(renderResult.getByTestId('test-header-helpButton'));
 
     expect(renderResult.getByTestId('test-sidePanel')).toBeTruthy();
   });

--- a/x-pack/plugins/security_solution/public/management/components/console/mocks.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/console/mocks.tsx
@@ -88,16 +88,16 @@ export const getConsoleSelectorsAndActionMock = (
 
   const openHelpPanel: ConsoleSelectorsAndActionsMock['openHelpPanel'] = () => {
     if (!isHelpPanelOpen()) {
-      renderResult.getByTestId(`${dataTestSubj}-header-helpButton`).click();
+      fireEvent.click(renderResult.getByTestId(`${dataTestSubj}-header-helpButton`));
     }
   };
   const closeHelpPanel: ConsoleSelectorsAndActionsMock['closeHelpPanel'] = () => {
     if (isHelpPanelOpen()) {
-      renderResult.getByTestId(`${dataTestSubj}-sidePanel-headerCloseButton`).click();
+      fireEvent.click(renderResult.getByTestId(`${dataTestSubj}-sidePanel-headerCloseButton`));
     }
   };
   const submitCommand: ConsoleSelectorsAndActionsMock['submitCommand'] = () => {
-    renderResult.getByTestId(`${dataTestSubj}-inputTextSubmitButton`).click();
+    fireEvent.click(renderResult.getByTestId(`${dataTestSubj}-inputTextSubmitButton`));
   };
   const enterCommand: ConsoleSelectorsAndActionsMock['enterCommand'] = async (
     cmd,

--- a/x-pack/plugins/security_solution/public/management/components/context_menu_with_router_support/context_menu_with_router_support.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/context_menu_with_router_support/context_menu_with_router_support.test.tsx
@@ -23,9 +23,7 @@ describe('When using the ContextMenuWithRouterSupport component', () => {
   let items: ContextMenuWithRouterSupportProps['items'];
 
   const clickMenuTriggerButton = () => {
-    act(() => {
-      fireEvent.click(renderResult.getByTestId('testMenu-triggerButton'));
-    });
+    fireEvent.click(renderResult.getByTestId('testMenu-triggerButton'));
   };
 
   const getContextMenuPanel = () => renderResult.queryByTestId('testMenu-popoverPanel');
@@ -99,11 +97,9 @@ describe('When using the ContextMenuWithRouterSupport component', () => {
   it('should close menu when a menu item is clicked and call menu item onclick callback', async () => {
     render();
     clickMenuTriggerButton();
-    await act(async () => {
-      const menuPanelRemoval = waitForElementToBeRemoved(getContextMenuPanel());
-      fireEvent.click(renderResult.getByTestId('menu-item-one'));
-      await menuPanelRemoval;
-    });
+    const menuPanelRemoval = waitForElementToBeRemoved(getContextMenuPanel());
+    fireEvent.click(renderResult.getByTestId('menu-item-one'));
+    await menuPanelRemoval;
 
     expect(getContextMenuPanel()).toBeNull();
   });

--- a/x-pack/plugins/security_solution/public/timelines/components/bottom_bar/add_timeline_button.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/bottom_bar/add_timeline_button.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { AddTimelineButton } from './add_timeline_button';
 import { useCreateTimeline } from '../../hooks/use_create_timeline';
 
@@ -25,7 +25,7 @@ describe('AddTimelineButton', () => {
 
     expect(plusButton).toBeInTheDocument();
 
-    plusButton.click();
+    fireEvent.click(plusButton);
 
     expect(getByTestId('timeline-bottom-bar-create-new-timeline')).toBeInTheDocument();
     expect(getByTestId('timeline-bottom-bar-create-new-timeline')).toHaveTextContent(

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/actions/attach_to_case_button.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/actions/attach_to_case_button.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 import { useKibana } from '../../../../common/lib/kibana';
 import { mockTimelineModel, TestProviders } from '../../../../common/mock';
@@ -57,7 +57,7 @@ describe('AttachToCaseButton', () => {
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent('Attach to case');
 
-    button.click();
+    fireEvent.click(button);
 
     expect(getByTestId('timeline-modal-attach-timeline-to-new-case')).toBeInTheDocument();
     expect(getByTestId('timeline-modal-attach-timeline-to-new-case')).toHaveTextContent(
@@ -81,11 +81,11 @@ describe('AttachToCaseButton', () => {
 
     const { getByTestId } = renderAttachToCaseButton();
 
-    getByTestId('timeline-modal-attach-to-case-dropdown-button').click();
+    fireEvent.click(getByTestId('timeline-modal-attach-to-case-dropdown-button'));
 
     await waitForEuiPopoverOpen();
 
-    getByTestId('timeline-modal-attach-timeline-to-existing-case').click();
+    fireEvent.click(getByTestId('timeline-modal-attach-timeline-to-existing-case'));
 
     expect(navigateToApp).toHaveBeenCalledWith('securitySolutionUI', {
       path: '/create',
@@ -103,11 +103,11 @@ describe('AttachToCaseButton', () => {
 
     const { getByTestId } = renderAttachToCaseButton();
 
-    getByTestId('timeline-modal-attach-to-case-dropdown-button').click();
+    fireEvent.click(getByTestId('timeline-modal-attach-to-case-dropdown-button'));
 
     await waitForEuiPopoverOpen();
 
-    getByTestId('timeline-modal-attach-timeline-to-existing-case').click();
+    fireEvent.click(getByTestId('timeline-modal-attach-timeline-to-existing-case'));
 
     expect(navigateToApp).toHaveBeenCalledWith('securitySolutionUI', {
       path: '/case-id',

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/actions/new_timeline_button.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/actions/new_timeline_button.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { NewTimelineButton } from './new_timeline_button';
 import { TimelineId } from '../../../../../common/types';
@@ -40,7 +40,7 @@ describe('NewTimelineButton', () => {
     expect(button).toBeInTheDocument();
     expect(getByText('New')).toBeInTheDocument();
 
-    button.click();
+    fireEvent.click(button);
 
     expect(getByTestId('timeline-modal-new-timeline')).toBeInTheDocument();
     expect(getByTestId('timeline-modal-new-timeline')).toHaveTextContent('New Timeline');
@@ -59,8 +59,8 @@ describe('NewTimelineButton', () => {
 
     const { getByTestId } = renderNewTimelineButton();
 
-    getByTestId('timeline-modal-new-timeline-dropdown-button').click();
-    getByTestId('timeline-modal-new-timeline').click();
+    fireEvent.click(getByTestId('timeline-modal-new-timeline-dropdown-button'));
+    fireEvent.click(getByTestId('timeline-modal-new-timeline'));
 
     await waitFor(() => {
       expect(spy).toHaveBeenCalledWith({

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/actions/open_timeline_button.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/actions/open_timeline_button.test.tsx
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { OpenTimelineButton } from './open_timeline_button';
 import { TestProviders } from '../../../../common/mock/test_providers';
 import { useParams } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import { TimelineTypeEnum } from '../../../../../common/api/timeline';
 import { useStartTransaction } from '../../../../common/lib/apm/use_start_transaction';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
@@ -60,6 +61,7 @@ describe('OpenTimelineButton', () => {
   });
 
   it('should open the modal after clicking on the button', async () => {
+    (useDispatch as jest.Mock).mockReturnValue(jest.fn());
     (useParams as jest.Mock).mockReturnValue({ tabName: TimelineTypeEnum.template });
     (useStartTransaction as jest.Mock).mockReturnValue({ startTransaction: jest.fn() });
     (useSourcererDataView as jest.Mock).mockReturnValue({
@@ -75,7 +77,7 @@ describe('OpenTimelineButton', () => {
 
     const { getByTestId } = renderOpenTimelineButton();
 
-    getByTestId('timeline-modal-open-timeline-button').click();
+    fireEvent.click(getByTestId('timeline-modal-open-timeline-button'));
 
     await waitFor(() => {
       expect(getByTestId('open-timeline-modal')).toBeInTheDocument();

--- a/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_metadata_tab/index.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import { AppContextTestRender, createAppRootMockRenderer } from '../../test';
 import type {
   ProcessEventHost,
@@ -122,6 +123,7 @@ describe('DetailPanelMetadataTab component', () => {
 
   describe('When DetailPanelMetadataTab is mounted', () => {
     it('renders DetailPanelMetadataTab correctly (non cloud environment)', async () => {
+      const user = userEvent.setup();
       renderResult = mockedContext.render(<DetailPanelMetadataTab processHost={TEST_HOST} />);
 
       expect(renderResult.queryByText('hostname')).toBeVisible();
@@ -136,7 +138,7 @@ describe('DetailPanelMetadataTab component', () => {
       expect(renderResult.queryByText(TEST_NAME)).toBeVisible();
 
       // expand host os accordion
-      renderResult.queryByText('OS')?.click();
+      await user.click(renderResult.getByText('OS'));
       expect(renderResult.queryByText('architecture')).toBeVisible();
       expect(renderResult.queryByText('os.family')).toBeVisible();
       expect(renderResult.queryByText('os.full')).toBeVisible();
@@ -159,6 +161,8 @@ describe('DetailPanelMetadataTab component', () => {
     });
 
     it('renders DetailPanelMetadataTab correctly (cloud environment)', async () => {
+      const user = userEvent.setup();
+
       renderResult = mockedContext.render(
         <DetailPanelMetadataTab
           processHost={TEST_HOST}
@@ -182,7 +186,7 @@ describe('DetailPanelMetadataTab component', () => {
       expect(renderResult.queryAllByText('name').length).toBe(2);
 
       // expand host os accordion
-      renderResult.queryByText('OS')?.click();
+      await user.click(renderResult.getByText('OS'));
       expect(renderResult.queryByText('architecture')).toBeVisible();
       expect(renderResult.queryByText('os.family')).toBeVisible();
       expect(renderResult.queryByText('os.full')).toBeVisible();
@@ -199,7 +203,7 @@ describe('DetailPanelMetadataTab component', () => {
       expect(renderResult.queryByText(TEST_OS_VERSION)).toBeVisible();
 
       // expand Container Accordion
-      renderResult.queryByText('Container')?.click();
+      await user.click(renderResult.getByText('Container'));
       expect(renderResult.queryByText('image.name')).toBeVisible();
       expect(renderResult.queryByText('image.tag')).toBeVisible();
       expect(renderResult.queryByText('image.hash.all')).toBeVisible();
@@ -210,7 +214,7 @@ describe('DetailPanelMetadataTab component', () => {
       expect(renderResult.queryByText(TEST_CONTAINER_IMAGE_HASH_ALL)).toBeVisible();
 
       // expand Orchestrator Accordion
-      renderResult.queryByText('Orchestrator')?.click();
+      await user.click(renderResult.getByText('Orchestrator'));
       expect(renderResult.queryByText('resource.name')).toBeVisible();
       expect(renderResult.queryByText('resource.type')).toBeVisible();
       expect(renderResult.queryByText('resource.ip')).toBeVisible();
@@ -227,7 +231,7 @@ describe('DetailPanelMetadataTab component', () => {
       expect(renderResult.queryByText(TEST_ORCHESTRATOR_CLUSTER_NAME)).toBeVisible();
 
       // expand Cloud Accordion
-      renderResult.queryByText('Cloud')?.click();
+      await user.click(renderResult.getByText('Cloud'));
       expect(renderResult.queryByText('instance.name')).toBeVisible();
       expect(renderResult.queryByText('provider')).toBeVisible();
       expect(renderResult.queryByText('region')).toBeVisible();

--- a/x-pack/plugins/session_view/public/components/process_tree_alerts_filter/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_alerts_filter/index.test.tsx
@@ -10,6 +10,7 @@ import { mockAlertTypeCounts } from '../../../common/mocks/constants/session_vie
 import { AppContextTestRender, createAppRootMockRenderer } from '../../test';
 import { ProcessTreeAlertsFilter, ProcessTreeAlertsFilterDeps } from '.';
 import userEvent from '@testing-library/user-event';
+import { fireEvent } from '@testing-library/react';
 import { DEFAULT_ALERT_FILTER_VALUE } from '../../../common/constants';
 
 describe('ProcessTreeAlertsFiltersFilter component', () => {
@@ -112,13 +113,15 @@ describe('ProcessTreeAlertsFiltersFilter component', () => {
       });
 
       it('should open filter menu popover', async () => {
+        const user = userEvent.setup();
+
         renderResult = mockedContext.render(<ProcessTreeAlertsFilter {...props} />);
 
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
         );
 
-        await userEvent.click(filterButton);
+        await user.click(filterButton);
 
         const filterMenu = renderResult.queryByTestId(
           'sessionView:sessionViewAlertDetailsFilterSelectorContainerMenu'
@@ -130,13 +133,15 @@ describe('ProcessTreeAlertsFiltersFilter component', () => {
 
     describe('EuiContextMenuItem filter when two alert categories exists', () => {
       it('should display network option in filter menu', async () => {
+        const user = userEvent.setup();
+
         renderResult = mockedContext.render(<ProcessTreeAlertsFilter {...props} />);
 
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
         );
 
-        await userEvent.click(filterButton);
+        await user.click(filterButton);
 
         const filterMenuItem = renderResult.queryByTestId(
           'sessionView:sessionViewAlertDetailsFilterItem-network'
@@ -147,13 +152,15 @@ describe('ProcessTreeAlertsFiltersFilter component', () => {
       });
 
       it('should display process option in filter menu', async () => {
+        const user = userEvent.setup();
+
         renderResult = mockedContext.render(<ProcessTreeAlertsFilter {...props} />);
 
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
         );
 
-        await userEvent.click(filterButton);
+        await user.click(filterButton);
 
         const filterMenuItem = renderResult.queryByTestId(
           'sessionView:sessionViewAlertDetailsFilterItem-process'
@@ -164,13 +171,15 @@ describe('ProcessTreeAlertsFiltersFilter component', () => {
       });
 
       it('should not display file option in filter menu', async () => {
+        const user = userEvent.setup();
+
         renderResult = mockedContext.render(<ProcessTreeAlertsFilter {...props} />);
 
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
         );
 
-        await userEvent.click(filterButton);
+        await user.click(filterButton);
 
         const filterMenuItem = renderResult.queryByTestId(
           'sessionView:sessionViewAlertDetailsFilterItem-file'
@@ -192,11 +201,12 @@ describe('ProcessTreeAlertsFiltersFilter component', () => {
       });
 
       it('should display network option in filter menu', async () => {
+        const user = userEvent.setup();
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
         );
 
-        await userEvent.click(filterButton);
+        await user.click(filterButton);
 
         const filterMenuItem = renderResult.queryByTestId(
           'sessionView:sessionViewAlertDetailsFilterItem-network'
@@ -207,11 +217,12 @@ describe('ProcessTreeAlertsFiltersFilter component', () => {
       });
 
       it('should display process option in filter menu', async () => {
+        const user = userEvent.setup();
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
         );
 
-        await userEvent.click(filterButton);
+        await user.click(filterButton);
 
         const filterMenuItem = renderResult.queryByTestId(
           'sessionView:sessionViewAlertDetailsFilterItem-process'
@@ -222,11 +233,12 @@ describe('ProcessTreeAlertsFiltersFilter component', () => {
       });
 
       it('should display file option in filter menu', async () => {
+        const user = userEvent.setup();
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
         );
 
-        await userEvent.click(filterButton);
+        await user.click(filterButton);
 
         const filterMenuItem = renderResult.queryByTestId(
           'sessionView:sessionViewAlertDetailsFilterItem-file'
@@ -248,6 +260,7 @@ describe('ProcessTreeAlertsFiltersFilter component', () => {
           <ProcessTreeAlertsFilter {...props} alertTypeCounts={alertTypeCountsUpdated} />
         );
       });
+
       it('should set the EmptyFilterButton text content to  display "View: all alerts"  by default ', () => {
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
@@ -256,45 +269,61 @@ describe('ProcessTreeAlertsFiltersFilter component', () => {
       });
 
       it('should set the EmptyFilterButton text content to  display "View: file alerts"  when file alert option is clicked', async () => {
+        const user = userEvent.setup();
+
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
         );
-        await userEvent.click(filterButton);
+        await user.click(filterButton);
 
-        renderResult.getByTestId('sessionView:sessionViewAlertDetailsFilterItem-file').click();
+        fireEvent.click(
+          renderResult.getByTestId('sessionView:sessionViewAlertDetailsFilterItem-file')
+        );
 
         expect(filterButton).toHaveTextContent('View: file alerts');
       });
 
       it('should set the EmptyFilterButton text content to  display "View: all alerts"  when default filter option is clicked', async () => {
+        const user = userEvent.setup();
+
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
         );
-        await userEvent.click(filterButton);
+        await user.click(filterButton);
 
-        renderResult.getByTestId('sessionView:sessionViewAlertDetailsFilterItem-default').click();
+        fireEvent.click(
+          renderResult.getByTestId('sessionView:sessionViewAlertDetailsFilterItem-default')
+        );
 
         expect(filterButton).toHaveTextContent(`View: ${DEFAULT_ALERT_FILTER_VALUE} alerts`);
       });
 
       it('should set the EmptyFilterButton text content to  display "View: process alerts"  when process alert option is clicked', async () => {
+        const user = userEvent.setup();
+
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
         );
-        await userEvent.click(filterButton);
+        await user.click(filterButton);
 
-        renderResult.getByTestId('sessionView:sessionViewAlertDetailsFilterItem-process').click();
+        fireEvent.click(
+          renderResult.getByTestId('sessionView:sessionViewAlertDetailsFilterItem-process')
+        );
 
         expect(filterButton).toHaveTextContent('View: process alerts');
       });
 
       it('should set the EmptyFilterButton text content to  display "View: network alerts"  when network alert option is clicked', async () => {
+        const user = userEvent.setup();
+
         const filterButton = renderResult.getByTestId(
           'sessionView:sessionViewAlertDetailsEmptyFilterButton'
         );
-        await userEvent.click(filterButton);
+        await user.click(filterButton);
 
-        renderResult.getByTestId('sessionView:sessionViewAlertDetailsFilterItem-network').click();
+        fireEvent.click(
+          renderResult.getByTestId('sessionView:sessionViewAlertDetailsFilterItem-network')
+        );
 
         expect(filterButton).toHaveTextContent('View: network alerts');
       });

--- a/x-pack/plugins/session_view/public/components/session_view_detail_panel/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view_detail_panel/index.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import userEvent from '@testing-library/user-event';
 import {
   mockAlerts,
   sessionViewBasicProcessMock,
@@ -57,22 +58,25 @@ describe('SessionView component', () => {
     });
 
     it('can switch tabs to show host details', async () => {
+      const user = userEvent.setup();
       renderResult = mockedContext.render(<SessionViewDetailPanel {...props} />);
-      renderResult.queryByText('Metadata')?.click();
+      await user.click(renderResult.getByText('Metadata'));
       expect(renderResult.queryByText('hostname')).toBeVisible();
       expect(renderResult.queryAllByText('james-fleet-714-2')).toHaveLength(2);
     });
 
     it('can switch tabs to show alert details', async () => {
+      const user = userEvent.setup();
       renderResult = mockedContext.render(
         <SessionViewDetailPanel {...props} alerts={mockAlerts} alertsCount={mockAlerts.length} />
       );
-      renderResult.queryByText('Alerts')?.click();
+      await user.click(renderResult.getByText('Alerts'));
       expect(renderResult.queryByText('List view')).toBeVisible();
     });
     it('alert tab disabled when no alerts', async () => {
+      const user = userEvent.setup();
       renderResult = mockedContext.render(<SessionViewDetailPanel {...props} />);
-      renderResult.queryByText('Alerts')?.click();
+      await user.click(renderResult.getByText('Alerts'));
       expect(renderResult.queryByText('List view')).toBeFalsy();
     });
   });

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/update_connector.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/update_connector.test.tsx
@@ -11,7 +11,7 @@ import userEvent from '@testing-library/user-event';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
 import { Props, UpdateConnector } from './update_connector';
 import { act } from 'react-dom/test-utils';
-import { render, act as reactAct, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 jest.mock('@kbn/triggers-actions-ui-plugin/public/common/lib/kibana');
 
@@ -235,16 +235,14 @@ describe('UpdateConnector renders', () => {
 
     expect(onConfirm).not.toHaveBeenCalled();
 
-    await reactAct(async () => {
-      const urlInput = getByTestId('credentialsApiUrlFromInput');
-      const usernameInput = getByTestId('connector-servicenow-username-form-input');
-      const passwordInput = getByTestId('connector-servicenow-password-form-input');
+    const urlInput = getByTestId('credentialsApiUrlFromInput');
+    const usernameInput = getByTestId('connector-servicenow-username-form-input');
+    const passwordInput = getByTestId('connector-servicenow-password-form-input');
 
-      await userEvent.type(urlInput, 'https://example.com', { delay: 100 });
-      await userEvent.type(usernameInput, 'user', { delay: 100 });
-      await userEvent.type(passwordInput, 'pass', { delay: 100 });
-      await userEvent.click(getByTestId('snUpdateInstallationSubmit'));
-    });
+    await userEvent.type(urlInput, 'https://example.com', { delay: 100 });
+    await userEvent.type(usernameInput, 'user', { delay: 100 });
+    await userEvent.type(passwordInput, 'pass', { delay: 100 });
+    await userEvent.click(getByTestId('snUpdateInstallationSubmit'));
 
     // Wait for click event to be processed
     await waitFor(() => expect(onConfirm).toHaveBeenCalled(), { timeout: 3000 });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_form.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_form.test.tsx
@@ -19,7 +19,7 @@ import {
 import { act } from 'react-dom/test-utils';
 import { EuiFieldText } from '@elastic/eui';
 import { I18nProvider, __IntlProvider as IntlProvider } from '@kbn/i18n-react';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 import { DEFAULT_FREQUENCY } from '../../../common/constants';
 import { RuleNotifyWhen, SanitizedRuleAction } from '@kbn/alerting-plugin/common';
 import { AlertConsumers } from '@kbn/rule-data-utils';
@@ -376,7 +376,9 @@ describe('action_type_form', () => {
     jest.useFakeTimers({ legacyFakeTimers: true });
     wrapper.find('[data-test-subj="action-group-error-icon"]').first().simulate('mouseOver');
     // Run the timers so the EuiTooltip will be visible
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     wrapper.update();
     expect(wrapper.find('.euiToolTipPopover').last().text()).toBe('Action contains errors.');
     // Clearing all mocks will also reset fake timers.
@@ -428,10 +430,10 @@ describe('action_type_form', () => {
     expect(summaryOrPerRuleSelect).toBeTruthy();
 
     const button = wrapper.getByText('For each alert');
-    button.click();
-    await act(async () => {
-      wrapper.getByText('Summary of alerts').click();
-    });
+
+    fireEvent.click(button);
+
+    fireEvent.click(wrapper.getByText('Summary of alerts'));
 
     expect(mockTransformActionVariables.mock.calls).toEqual([
       [
@@ -512,9 +514,8 @@ describe('action_type_form', () => {
 
     expect(wrapper.getByTestId('mustacheAutocompleteSwitch')).toBeTruthy();
 
-    await act(async () => {
-      wrapper.getByTestId('mustacheAutocompleteSwitch').click();
-    });
+    fireEvent.click(wrapper.getByTestId('mustacheAutocompleteSwitch'));
+
     expect(setActionParamsProperty).toHaveBeenCalledWith('dedupKey', '', 1);
   });
 
@@ -557,7 +558,8 @@ describe('action_type_form', () => {
         </IntlProvider>
       );
 
-      wrapper.getByTestId('notifyWhenSelect').click();
+      fireEvent.click(wrapper.getByTestId('notifyWhenSelect'));
+
       await act(async () => {
         expect(wrapper.queryByText('On status changes')).not.toBeTruthy();
         expect(wrapper.queryByText('On check intervals')).not.toBeTruthy();
@@ -610,7 +612,8 @@ describe('action_type_form', () => {
         </IntlProvider>
       );
 
-      wrapper.getByTestId('notifyWhenSelect').click();
+      fireEvent.click(wrapper.getByTestId('notifyWhenSelect'));
+
       await act(async () => {
         expect(wrapper.queryByText('On status changes')).not.toBeTruthy();
         expect(wrapper.queryByText('On check intervals')).not.toBeTruthy();


### PR DESCRIPTION
## Summary

[We're working on upgrading Kibana to React@18 packages](https://github.com/elastic/kibana-team/issues/1016). For this we will also need to update testing-library to 13+ 
This PR cherry-picks some of the changes needed for [testing-library upgrade](https://github.com/elastic/kibana/pull/192354/files), mainly about using provided utils from `@testing-library/react` and `@testing-library/user-event`, `fireEvent` and `userEvent` respectively to trigger UI actions as opposed to explicitly triggering methods on returned elements. The difference is that those methods automatically wrap actions in `act()` This often needed in these places due to changes in how React handles batching and concurrent rendering. 

To run the tests locally with React@18 packages, use the following:

```
"react:":"~18.2.0",
"react-dom:":"~18.2.0",
"@testing-library/dom": "^10.4.0",
"@testing-library/react": "^16.0.1",
```

