### PR TITLE
[Stateful sidenav] Fix dashboard listing breadcrumbs

### DIFF
--- a/src/plugins/dashboard/public/dashboard_app/listing_page/dashboard_listing_page.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/listing_page/dashboard_listing_page.tsx
@@ -50,11 +50,16 @@ export const DashboardListingPage = ({
   }, []);
 
   useEffect(() => {
-    coreServices.chrome.setBreadcrumbs([
+    coreServices.chrome.setBreadcrumbs(
+      [
+        {
+          text: getDashboardBreadcrumb(),
+        },
+      ],
       {
-        text: getDashboardBreadcrumb(),
-      },
-    ]);
+        project: { value: [] },
+      }
+    );
 
     if (serverlessService) {
       // if serverless breadcrumbs available,


### PR DESCRIPTION
In this PR I've fixed an issue with the breadcrumbs of the dashboards listing page.

The breadcrumb was not reset when navigating from editing the dashboard back to the listing page.

## Issue fixed

<img width="1529" alt="Screenshot 2024-10-28 at 12 32 24" src="https://github.com/user-attachments/assets/ae1ee677-87e2-4c90-9de1-ff90f2f2b6c4">


<!--ONMERGE {"backportTargets":["8.15","8.16","8.x"]} ONMERGE-->