### PR TITLE
feat: disable buttons to try sample data or upload a file for a read-only user

### DIFF
--- a/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -1,5 +1,144 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AddData disable sample data and upload buttons for a read-only user 1`] = `
+<_EuiPageSection
+  aria-labelledby="homDataAdd__title"
+  bottomBorder={true}
+  className="homDataAdd"
+  paddingSize="xl"
+>
+  <EuiFlexGroup
+    alignItems="flexEnd"
+  >
+    <EuiFlexItem>
+      <EuiTitle
+        size="s"
+      >
+        <h2
+          id="homDataAdd__title"
+        >
+          <MemoizedFormattedMessage
+            defaultMessage="Get started by adding integrations"
+            id="home.addData.sectionTitle"
+          />
+        </h2>
+      </EuiTitle>
+      <EuiSpacer />
+      <EuiText>
+        <p>
+          <MemoizedFormattedMessage
+            defaultMessage="To start working with your data, use one of our many ingest options. Collect data from an app or service, or upload a file. If you're not ready to use your own data, play with a sample data set."
+            id="home.addData.text"
+          />
+        </p>
+      </EuiText>
+      <EuiSpacer />
+      <EuiFlexGroup
+        gutterSize="m"
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <RedirectAppLinks
+            coreStart={
+              Object {
+                "application": Object {
+                  "capabilities": Object {
+                    "navLinks": Object {
+                      "integrations": true,
+                    },
+                    "rulesSettings": Object {
+                      "writeFlappingSettingsUI": false,
+                    },
+                  },
+                },
+              }
+            }
+          >
+            <EuiButton
+              data-test-subj="homeAddData"
+              fill={true}
+              fullWidth={true}
+              href="/app/integrations/browse"
+              iconType="plusInCircle"
+              onClick={[Function]}
+            >
+              <MemoizedFormattedMessage
+                defaultMessage="Add integrations"
+                id="home.addData.addDataButtonLabel"
+              />
+            </EuiButton>
+          </RedirectAppLinks>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={false}
+        >
+          <EuiButtonEmpty
+            data-test-subj="addSampleData"
+            disabled={true}
+            href="#/tutorial_directory/sampleData"
+            iconType="documents"
+          >
+            <MemoizedFormattedMessage
+              defaultMessage="Try sample data"
+              id="home.addData.sampleDataButtonLabel"
+            />
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={false}
+        >
+          <EuiButtonEmpty
+            data-test-subj="uploadFile"
+            disabled={true}
+            href="#/tutorial_directory/fileDataViz"
+            iconType="importAction"
+          >
+            <MemoizedFormattedMessage
+              defaultMessage="Upload a file"
+              id="home.addData.uploadFileButtonLabel"
+            />
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+    <EuiFlexItem>
+      <MoveData
+        addBasePath={
+          [MockFunction] {
+            "calls": Array [
+              Array [
+                "/app/integrations/browse",
+              ],
+              Array [
+                "#/tutorial_directory/sampleData",
+              ],
+              Array [
+                "#/tutorial_directory/fileDataViz",
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": "/app/integrations/browse",
+              },
+              Object {
+                "type": "return",
+                "value": "#/tutorial_directory/sampleData",
+              },
+              Object {
+                "type": "return",
+                "value": "#/tutorial_directory/fileDataViz",
+              },
+            ],
+          }
+        }
+      />
+    </EuiFlexItem>
+  </EuiFlexGroup>
+</_EuiPageSection>
+`;
+
 exports[`AddData render 1`] = `
 <_EuiPageSection
   aria-labelledby="homDataAdd__title"
@@ -47,6 +186,9 @@ exports[`AddData render 1`] = `
                     "navLinks": Object {
                       "integrations": true,
                     },
+                    "rulesSettings": Object {
+                      "writeFlappingSettingsUI": true,
+                    },
                   },
                 },
               }
@@ -72,6 +214,7 @@ exports[`AddData render 1`] = `
         >
           <EuiButtonEmpty
             data-test-subj="addSampleData"
+            disabled={false}
             href="#/tutorial_directory/sampleData"
             iconType="documents"
           >
@@ -86,6 +229,7 @@ exports[`AddData render 1`] = `
         >
           <EuiButtonEmpty
             data-test-subj="uploadFile"
+            disabled={false}
             href="#/tutorial_directory/fileDataViz"
             iconType="importAction"
           >

--- a/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -47,8 +47,8 @@ exports[`AddData disable sample data and upload buttons for a read-only user 1`]
                     "navLinks": Object {
                       "integrations": true,
                     },
-                    "roles": Object {
-                      "save": false,
+                    "savedObjectsManagement": Object {
+                      "edit": false,
                     },
                   },
                 },
@@ -186,8 +186,8 @@ exports[`AddData render 1`] = `
                     "navLinks": Object {
                       "integrations": true,
                     },
-                    "roles": Object {
-                      "save": true,
+                    "savedObjectsManagement": Object {
+                      "edit": true,
                     },
                   },
                 },

--- a/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
+++ b/src/plugins/home/public/application/components/add_data/__snapshots__/add_data.test.tsx.snap
@@ -47,8 +47,8 @@ exports[`AddData disable sample data and upload buttons for a read-only user 1`]
                     "navLinks": Object {
                       "integrations": true,
                     },
-                    "rulesSettings": Object {
-                      "writeFlappingSettingsUI": false,
+                    "roles": Object {
+                      "save": false,
                     },
                   },
                 },
@@ -186,8 +186,8 @@ exports[`AddData render 1`] = `
                     "navLinks": Object {
                       "integrations": true,
                     },
-                    "rulesSettings": Object {
-                      "writeFlappingSettingsUI": true,
+                    "roles": Object {
+                      "save": true,
                     },
                   },
                 },

--- a/src/plugins/home/public/application/components/add_data/add_data.test.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.test.tsx
@@ -29,7 +29,17 @@ beforeEach(() => {
 });
 
 const applicationStartMock = {
-  capabilities: { navLinks: { integrations: true } },
+  capabilities: {
+    navLinks: { integrations: true },
+    rulesSettings: { writeFlappingSettingsUI: true },
+  },
+} as unknown as ApplicationStart;
+
+const applicationStartMockRestricted = {
+  capabilities: {
+    navLinks: { integrations: true },
+    rulesSettings: { writeFlappingSettingsUI: false },
+  },
 } as unknown as ApplicationStart;
 
 const addBasePathMock = jest.fn((path: string) => (path ? path : 'path'));
@@ -40,6 +50,17 @@ describe('AddData', () => {
       <AddData
         addBasePath={addBasePathMock}
         application={applicationStartMock}
+        isDarkMode={false}
+        isCloudEnabled={false}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+  test('disable sample data and upload buttons for a read-only user', () => {
+    const component = shallowWithIntl(
+      <AddData
+        addBasePath={addBasePathMock}
+        application={applicationStartMockRestricted}
         isDarkMode={false}
         isCloudEnabled={false}
       />

--- a/src/plugins/home/public/application/components/add_data/add_data.test.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.test.tsx
@@ -31,14 +31,14 @@ beforeEach(() => {
 const applicationStartMock = {
   capabilities: {
     navLinks: { integrations: true },
-    roles: { save: true },
+    savedObjectsManagement: { edit: true },
   },
 } as unknown as ApplicationStart;
 
 const applicationStartMockRestricted = {
   capabilities: {
     navLinks: { integrations: true },
-    roles: { save: false },
+    savedObjectsManagement: { edit: false },
   },
 } as unknown as ApplicationStart;
 

--- a/src/plugins/home/public/application/components/add_data/add_data.test.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.test.tsx
@@ -31,14 +31,14 @@ beforeEach(() => {
 const applicationStartMock = {
   capabilities: {
     navLinks: { integrations: true },
-    rulesSettings: { writeFlappingSettingsUI: true },
+    roles: { save: true },
   },
 } as unknown as ApplicationStart;
 
 const applicationStartMockRestricted = {
   capabilities: {
     navLinks: { integrations: true },
-    rulesSettings: { writeFlappingSettingsUI: false },
+    roles: { save: false },
   },
 } as unknown as ApplicationStart;
 

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -38,7 +38,7 @@ interface Props {
 export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isCloudEnabled }) => {
   const { trackUiMetric, guidedOnboardingService } = getServices();
   const canAccessIntegrations = application.capabilities.navLinks.integrations;
-  const onlyReadAccess = !application.capabilities.rulesSettings.writeFlappingSettingsUI;
+  const onlyReadAccess = !application.capabilities.roles.save;
 
   if (canAccessIntegrations) {
     return (

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -38,7 +38,7 @@ interface Props {
 export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isCloudEnabled }) => {
   const { trackUiMetric, guidedOnboardingService } = getServices();
   const canAccessIntegrations = application.capabilities.navLinks.integrations;
-  const onlyReadAccess = !application.capabilities.roles.save;
+  const onlyReadAccess = !application.capabilities.savedObjectsManagement.edit;
 
   if (canAccessIntegrations) {
     return (

--- a/src/plugins/home/public/application/components/add_data/add_data.tsx
+++ b/src/plugins/home/public/application/components/add_data/add_data.tsx
@@ -38,6 +38,8 @@ interface Props {
 export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isCloudEnabled }) => {
   const { trackUiMetric, guidedOnboardingService } = getServices();
   const canAccessIntegrations = application.capabilities.navLinks.integrations;
+  const onlyReadAccess = !application.capabilities.rulesSettings.writeFlappingSettingsUI;
+
   if (canAccessIntegrations) {
     return (
       <KibanaPageTemplate.Section
@@ -122,6 +124,7 @@ export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isClo
                   data-test-subj="addSampleData"
                   href={addBasePath('#/tutorial_directory/sampleData')}
                   iconType="documents"
+                  disabled={onlyReadAccess}
                 >
                   <FormattedMessage
                     id="home.addData.sampleDataButtonLabel"
@@ -135,6 +138,7 @@ export const AddData: FC<Props> = ({ addBasePath, application, isDarkMode, isClo
                   data-test-subj="uploadFile"
                   href={addBasePath('#/tutorial_directory/fileDataViz')}
                   iconType="importAction"
+                  disabled={onlyReadAccess}
                 >
                   <FormattedMessage
                     id="home.addData.uploadFileButtonLabel"


### PR DESCRIPTION
## Summary

This PR fixes [[Home] Disable sample data actions for non-privileged users](https://github.com/elastic/kibana/issues/138547) issue and updates corresponding tests.

Currently a user with read-only privileges sees the Home screen like this

![Screenshot 2024-10-28 at 13 59 08](https://github.com/user-attachments/assets/3979fd95-5a6c-4751-bf7f-32f3ead7152c)


This PR suggests for a user with read-only privileges to see the Home screen like this

![Screenshot 2024-10-28 at 13 40 30](https://github.com/user-attachments/assets/e5e0bab1-12ff-4226-8ead-c06e9047b83b)
