### PR TITLE
FTR  SAML Auth - Adjust stateful internal request header

### DIFF
--- a/packages/kbn-ftr-common-functional-services/services/saml_auth/default_request_headers.ts
+++ b/packages/kbn-ftr-common-functional-services/services/saml_auth/default_request_headers.ts
@@ -14,6 +14,7 @@ export const COMMON_REQUEST_HEADERS = {
 // possible change in 9.0 to match serverless
 const STATEFUL_INTERNAL_REQUEST_HEADERS = {
   ...COMMON_REQUEST_HEADERS,
+  'x-elastic-internal-origin': 'kibana',
 };
 
 const SERVERLESS_INTERNAL_REQUEST_HEADERS = {


### PR DESCRIPTION
## Summary

This PR adds the `x-elastic-internal-origin` header to the stateful internal request headers used by FTR.
This fixes an issue that we're seeing when running deployment agnostic tests against ESS on 9.0.0-SNAPSHOT.