### PR TITLE
[Infra] Fix anomalies flyout navigation failing test

### DIFF
--- a/x-pack/test/functional/apps/infra/metrics_anomalies.ts
+++ b/x-pack/test/functional/apps/infra/metrics_anomalies.ts
@@ -12,7 +12,13 @@ import { HOSTS_VIEW_PATH, ML_JOB_IDS } from './constants';
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
-  const pageObjects = getPageObjects(['assetDetails', 'common', 'infraHome', 'infraHostsView']);
+  const pageObjects = getPageObjects([
+    'assetDetails',
+    'common',
+    'infraHome',
+    'infraHostsView',
+    'header',
+  ]);
   const infraSourceConfigurationForm = getService('infraSourceConfigurationForm');
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
@@ -144,6 +150,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await pageObjects.infraHome.setAnomaliesDate('Apr 21, 2021 @ 00:00:00.000');
           const hostName = await pageObjects.infraHome.getAnomalyHostName();
           await pageObjects.infraHome.clickShowAffectedHostsButton();
+          await pageObjects.header.waitUntilLoadingHasFinished();
           const currentUrl = await browser.getCurrentUrl();
           expect(currentUrl).to.contain(
             encodeURIComponent(`query:(terms:(host.name:!(${hostName})))`)


### PR DESCRIPTION
Closes #192882 

The issue was that the url was checked too early which resulted in checking the locator url instead of the page url after navigating so I added a check for loading before the URL check and this solved the issue.


https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7284

<!--ONMERGE {"backportTargets":["8.16"]} ONMERGE-->