### PR TITLE
[Fleet] Prevent hosted policies space change

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
@@ -328,7 +328,7 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
           }
         >
           <SpaceSelector
-            isDisabled={disabled}
+            isDisabled={disabled || agentPolicy.is_managed === true}
             value={
               'space_ids' in agentPolicy && agentPolicy.space_ids
                 ? agentPolicy.space_ids

--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -343,6 +343,7 @@ export const createAgentPolicyHandler: FleetRequestHandler<
         currentSpaceId: spaceId,
         newSpaceIds: spaceIds,
         authorizedSpaces,
+        options: { force },
       });
     }
 
@@ -385,6 +386,7 @@ export const updateAgentPolicyHandler: FleetRequestHandler<
         currentSpaceId: spaceId,
         newSpaceIds: spaceIds,
         authorizedSpaces,
+        options: { force },
       });
 
       spaceId = spaceIds[0];

--- a/x-pack/plugins/fleet/server/services/spaces/agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/spaces/agent_policy.test.ts
@@ -112,6 +112,23 @@ describe('updateAgentPolicySpaces', () => {
     );
   });
 
+  it('throw when trying to change a managed policies space', async () => {
+    jest.mocked(agentPolicyService.get).mockResolvedValue({
+      id: 'policy1',
+      space_ids: ['default'],
+      is_managed: true,
+    } as any);
+    jest.mocked(packagePolicyService.findAllForAgentPolicy).mockResolvedValue([] as any);
+    await expect(
+      updateAgentPolicySpaces({
+        agentPolicyId: 'policy1',
+        currentSpaceId: 'default',
+        newSpaceIds: ['test'],
+        authorizedSpaces: ['test', 'default'],
+      })
+    ).rejects.toThrowError(/Cannot update hosted agent policy policy1 space/);
+  });
+
   it('throw when trying to add a space with missing permissions', async () => {
     await expect(
       updateAgentPolicySpaces({

--- a/x-pack/plugins/fleet/server/services/spaces/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/spaces/agent_policy.ts
@@ -19,7 +19,7 @@ import { appContextService } from '../app_context';
 import { agentPolicyService } from '../agent_policy';
 import { ENROLLMENT_API_KEYS_INDEX } from '../../constants';
 import { packagePolicyService } from '../package_policy';
-import { FleetError } from '../../errors';
+import { FleetError, HostedAgentPolicyRestrictionRelatedError } from '../../errors';
 
 import { isSpaceAwarenessEnabled } from './helpers';
 
@@ -28,11 +28,13 @@ export async function updateAgentPolicySpaces({
   currentSpaceId,
   newSpaceIds,
   authorizedSpaces,
+  options,
 }: {
   agentPolicyId: string;
   currentSpaceId: string;
   newSpaceIds: string[];
   authorizedSpaces: string[];
+  options?: { force?: boolean };
 }) {
   const useSpaceAwareness = await isSpaceAwarenessEnabled();
   if (!useSpaceAwareness || !newSpaceIds || newSpaceIds.length === 0) {
@@ -49,6 +51,16 @@ export async function updateAgentPolicySpaces({
     currentSpaceSoClient,
     agentPolicyId
   );
+
+  if (!existingPolicy) {
+    return;
+  }
+
+  if (existingPolicy.is_managed && !options?.force) {
+    throw new HostedAgentPolicyRestrictionRelatedError(
+      `Cannot update hosted agent policy ${existingPolicy.id} space `
+    );
+  }
 
   if (deepEqual(existingPolicy?.space_ids?.sort() ?? [DEFAULT_SPACE_ID], newSpaceIds.sort())) {
     return;


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/kibana/issues/192546

Fleet is becoming space aware, we should not allow hosted policies space to be changed through the API, that PR does that by preventing hosted policies (cloud) spaces to be changed unless the force flag is passed (as for other managed policies fields).

## UI Change

The space selector field is now also disabled in the UI for managed policy

<img width="1269" alt="Screenshot 2024-10-28 at 2 10 33 PM" src="https://github.com/user-attachments/assets/e407f3b4-587d-43d6-b9ff-6b61e57819f8">


## Tests

I added a unit test to cover that change.



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->