### PR TITLE
Fix documentation for session lifespan default

### DIFF
--- a/docs/settings/security-settings.asciidoc
+++ b/docs/settings/security-settings.asciidoc
@@ -201,7 +201,7 @@ NOTE: Use a string of `<count>[ms\|s\|m\|h\|d\|w\|M\|Y]` (e.g. '20m', '24h', '7d
 
 [[xpack-session-lifespan]] xpack.security.session.lifespan {ess-icon}::
 Ensures that user sessions will expire after the defined time period. This behavior is also known as an "absolute timeout". If this is set to `0`, user sessions could stay active indefinitely. This and <<xpack-session-idleTimeout, `xpack.security.session.idleTimeout`>> are both highly
-recommended. You can also specify this setting for <<xpack-security-provider-session-lifespan, every provider separately>>. By default, this value is 30 days.
+recommended. You can also specify this setting for <<xpack-security-provider-session-lifespan, every provider separately>>. By default, this value is 30 days for on-prem installations, and 24 hours for Elastic Cloud installations.
 +
 TIP: Use a string of `<count>[ms\|s\|m\|h\|d\|w\|M\|Y]` (e.g. '20m', '24h', '7d', '1w').
 


### PR DESCRIPTION
This pull request includes an update to the `docs/settings/security-settings.asciidoc` file to clarify the default session lifespan settings for different installation environments.

Documentation update:

* [`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204): Clarified that the default session lifespan is 30 days for on-prem installations and 24 hours for Elastic Cloud installations.

<!--ONMERGE {"backportTargets":["7.17","8.15","8.16","8.x"]} ONMERGE-->