### PR TITLE
[7.17] Fix documentation for session lifespan default (#198065)

### DIFF
--- a/docs/settings/security-settings.asciidoc
+++ b/docs/settings/security-settings.asciidoc
@@ -289,7 +289,7 @@ Use a string of `<count>[ms\|s\|m\|h\|d\|w\|M\|Y]` (e.g. '20m', '24h', '7d', '1w
 |[[xpack-session-lifespan]] `xpack.security.session.lifespan` {ess-icon}
   | Ensures that user sessions will expire after the defined time period. This behavior is also known as an "absolute timeout". If
 this is _not_ set or set to `0`, user sessions could stay active indefinitely. This and <<xpack-session-idleTimeout, `xpack.security.session.idleTimeout`>> are both highly
-recommended. You can also specify this setting for <<xpack-security-provider-session-lifespan, every provider separately>>. By default, this setting is not set.
+recommended. You can also specify this setting for <<xpack-security-provider-session-lifespan, every provider separately>>. By default, this setting is not set for on-prem, and is set to 24 hours on Elastic Cloud.
 
 2+a|
 [TIP]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix documentation for session lifespan default (#198065)](https://github.com/elastic/kibana/pull/198065)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2024-10-28T18:01:56Z","message":"Fix documentation for session lifespan default (#198065)\n\nThis pull request includes an update to the\r\n`docs/settings/security-settings.asciidoc` file to clarify the default\r\nsession lifespan settings for different installation environments.\r\n\r\nDocumentation update:\r\n\r\n*\r\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\r\nClarified that the default session lifespan is 30 days for on-prem\r\ninstallations and 24 hours for Elastic Cloud installations.","sha":"7ab51231e38a6d074d08cd92606988c591c24017","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","v9.0.0","docs","backport:all-open","v8.16.0","v8.17.0","v8.15.4"],"number":198065,"url":"https://github.com/elastic/kibana/pull/198065","mergeCommit":{"message":"Fix documentation for session lifespan default (#198065)\n\nThis pull request includes an update to the\r\n`docs/settings/security-settings.asciidoc` file to clarify the default\r\nsession lifespan settings for different installation environments.\r\n\r\nDocumentation update:\r\n\r\n*\r\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\r\nClarified that the default session lifespan is 30 days for on-prem\r\ninstallations and 24 hours for Elastic Cloud installations.","sha":"7ab51231e38a6d074d08cd92606988c591c24017"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/198065","number":198065,"mergeCommit":{"message":"Fix documentation for session lifespan default (#198065)\n\nThis pull request includes an update to the\r\n`docs/settings/security-settings.asciidoc` file to clarify the default\r\nsession lifespan settings for different installation environments.\r\n\r\nDocumentation update:\r\n\r\n*\r\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\r\nClarified that the default session lifespan is 30 days for on-prem\r\ninstallations and 24 hours for Elastic Cloud installations.","sha":"7ab51231e38a6d074d08cd92606988c591c24017"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/198069","number":198069,"state":"MERGED","mergeCommit":{"sha":"8c36e4a484b5c9879d3b7d173c38cb953e9b4b08","message":"[8.16] Fix documentation for session lifespan default (#198065) (#198069)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.16`:\n- [Fix documentation for session lifespan default\n(#198065)](https://github.com/elastic/kibana/pull/198065)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Larry\nGregory\",\"email\":\"larry.gregory@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-10-28T18:01:56Z\",\"message\":\"Fix\ndocumentation for session lifespan default (#198065)\\n\\nThis pull\nrequest includes an update to\nthe\\r\\n`docs/settings/security-settings.asciidoc` file to clarify the\ndefault\\r\\nsession lifespan settings for different installation\nenvironments.\\r\\n\\r\\nDocumentation\nupdate:\\r\\n\\r\\n*\\r\\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\\r\\nClarified\nthat the default session lifespan is 30 days for\non-prem\\r\\ninstallations and 24 hours for Elastic Cloud\ninstallations.\",\"sha\":\"7ab51231e38a6d074d08cd92606988c591c24017\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Team:Security\",\"release_note:skip\",\"v9.0.0\",\"docs\",\"backport:all-open\"],\"title\":\"Fix\ndocumentation for session lifespan\ndefault\",\"number\":198065,\"url\":\"https://github.com/elastic/kibana/pull/198065\",\"mergeCommit\":{\"message\":\"Fix\ndocumentation for session lifespan default (#198065)\\n\\nThis pull\nrequest includes an update to\nthe\\r\\n`docs/settings/security-settings.asciidoc` file to clarify the\ndefault\\r\\nsession lifespan settings for different installation\nenvironments.\\r\\n\\r\\nDocumentation\nupdate:\\r\\n\\r\\n*\\r\\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\\r\\nClarified\nthat the default session lifespan is 30 days for\non-prem\\r\\ninstallations and 24 hours for Elastic Cloud\ninstallations.\",\"sha\":\"7ab51231e38a6d074d08cd92606988c591c24017\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/198065\",\"number\":198065,\"mergeCommit\":{\"message\":\"Fix\ndocumentation for session lifespan default (#198065)\\n\\nThis pull\nrequest includes an update to\nthe\\r\\n`docs/settings/security-settings.asciidoc` file to clarify the\ndefault\\r\\nsession lifespan settings for different installation\nenvironments.\\r\\n\\r\\nDocumentation\nupdate:\\r\\n\\r\\n*\\r\\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\\r\\nClarified\nthat the default session lifespan is 30 days for\non-prem\\r\\ninstallations and 24 hours for Elastic Cloud\ninstallations.\",\"sha\":\"7ab51231e38a6d074d08cd92606988c591c24017\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/198070","number":198070,"state":"MERGED","mergeCommit":{"sha":"25795fe2ab5df586fd781642ee9dbfc59c198e9e","message":"[8.x] Fix documentation for session lifespan default (#198065) (#198070)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [Fix documentation for session lifespan default\n(#198065)](https://github.com/elastic/kibana/pull/198065)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Larry\nGregory\",\"email\":\"larry.gregory@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-10-28T18:01:56Z\",\"message\":\"Fix\ndocumentation for session lifespan default (#198065)\\n\\nThis pull\nrequest includes an update to\nthe\\r\\n`docs/settings/security-settings.asciidoc` file to clarify the\ndefault\\r\\nsession lifespan settings for different installation\nenvironments.\\r\\n\\r\\nDocumentation\nupdate:\\r\\n\\r\\n*\\r\\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\\r\\nClarified\nthat the default session lifespan is 30 days for\non-prem\\r\\ninstallations and 24 hours for Elastic Cloud\ninstallations.\",\"sha\":\"7ab51231e38a6d074d08cd92606988c591c24017\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Team:Security\",\"release_note:skip\",\"v9.0.0\",\"docs\",\"backport:all-open\"],\"title\":\"Fix\ndocumentation for session lifespan\ndefault\",\"number\":198065,\"url\":\"https://github.com/elastic/kibana/pull/198065\",\"mergeCommit\":{\"message\":\"Fix\ndocumentation for session lifespan default (#198065)\\n\\nThis pull\nrequest includes an update to\nthe\\r\\n`docs/settings/security-settings.asciidoc` file to clarify the\ndefault\\r\\nsession lifespan settings for different installation\nenvironments.\\r\\n\\r\\nDocumentation\nupdate:\\r\\n\\r\\n*\\r\\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\\r\\nClarified\nthat the default session lifespan is 30 days for\non-prem\\r\\ninstallations and 24 hours for Elastic Cloud\ninstallations.\",\"sha\":\"7ab51231e38a6d074d08cd92606988c591c24017\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/198065\",\"number\":198065,\"mergeCommit\":{\"message\":\"Fix\ndocumentation for session lifespan default (#198065)\\n\\nThis pull\nrequest includes an update to\nthe\\r\\n`docs/settings/security-settings.asciidoc` file to clarify the\ndefault\\r\\nsession lifespan settings for different installation\nenvironments.\\r\\n\\r\\nDocumentation\nupdate:\\r\\n\\r\\n*\\r\\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\\r\\nClarified\nthat the default session lifespan is 30 days for\non-prem\\r\\ninstallations and 24 hours for Elastic Cloud\ninstallations.\",\"sha\":\"7ab51231e38a6d074d08cd92606988c591c24017\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>"}},{"branch":"8.15","label":"v8.15.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/198068","number":198068,"state":"MERGED","mergeCommit":{"sha":"76dfd876288f32f3b984de6c8c9d44f95737fa18","message":"[8.15] Fix documentation for session lifespan default (#198065) (#198068)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.15`:\n- [Fix documentation for session lifespan default\n(#198065)](https://github.com/elastic/kibana/pull/198065)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Larry\nGregory\",\"email\":\"larry.gregory@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-10-28T18:01:56Z\",\"message\":\"Fix\ndocumentation for session lifespan default (#198065)\\n\\nThis pull\nrequest includes an update to\nthe\\r\\n`docs/settings/security-settings.asciidoc` file to clarify the\ndefault\\r\\nsession lifespan settings for different installation\nenvironments.\\r\\n\\r\\nDocumentation\nupdate:\\r\\n\\r\\n*\\r\\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\\r\\nClarified\nthat the default session lifespan is 30 days for\non-prem\\r\\ninstallations and 24 hours for Elastic Cloud\ninstallations.\",\"sha\":\"7ab51231e38a6d074d08cd92606988c591c24017\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Team:Security\",\"release_note:skip\",\"v9.0.0\",\"docs\",\"backport:all-open\"],\"title\":\"Fix\ndocumentation for session lifespan\ndefault\",\"number\":198065,\"url\":\"https://github.com/elastic/kibana/pull/198065\",\"mergeCommit\":{\"message\":\"Fix\ndocumentation for session lifespan default (#198065)\\n\\nThis pull\nrequest includes an update to\nthe\\r\\n`docs/settings/security-settings.asciidoc` file to clarify the\ndefault\\r\\nsession lifespan settings for different installation\nenvironments.\\r\\n\\r\\nDocumentation\nupdate:\\r\\n\\r\\n*\\r\\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\\r\\nClarified\nthat the default session lifespan is 30 days for\non-prem\\r\\ninstallations and 24 hours for Elastic Cloud\ninstallations.\",\"sha\":\"7ab51231e38a6d074d08cd92606988c591c24017\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/198065\",\"number\":198065,\"mergeCommit\":{\"message\":\"Fix\ndocumentation for session lifespan default (#198065)\\n\\nThis pull\nrequest includes an update to\nthe\\r\\n`docs/settings/security-settings.asciidoc` file to clarify the\ndefault\\r\\nsession lifespan settings for different installation\nenvironments.\\r\\n\\r\\nDocumentation\nupdate:\\r\\n\\r\\n*\\r\\n[`docs/settings/security-settings.asciidoc`](diffhunk://#diff-97a4c4e3696b33b246f55ddd794608530b693f0a7a66ae1361a32b67c7461523L204-R204):\\r\\nClarified\nthat the default session lifespan is 30 days for\non-prem\\r\\ninstallations and 24 hours for Elastic Cloud\ninstallations.\",\"sha\":\"7ab51231e38a6d074d08cd92606988c591c24017\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Larry Gregory <larry.gregory@elastic.co>"}}]}] BACKPORT-->