### PR TITLE
[ci] Fix cloud deployments

### DIFF
--- a/.buildkite/scripts/steps/cloud/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/cloud/build_and_deploy.sh
@@ -19,7 +19,7 @@ download_artifact "kibana-$VERSION-linux-x86_64.tar.gz" ./target --build "${KIBA
 echo "--- Build Cloud Distribution"
 ELASTICSEARCH_MANIFEST_URL="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/$(jq -r '.version' package.json)/manifest-latest-verified.json"
 ELASTICSEARCH_SHA=$(curl -s $ELASTICSEARCH_MANIFEST_URL | jq -r '.sha')
-ELASTICSEARCH_CLOUD_IMAGE="docker.elastic.co/kibana-ci/elasticsearch-cloud:$VERSION-$ELASTICSEARCH_SHA"
+ELASTICSEARCH_CLOUD_IMAGE="docker.elastic.co/kibana-ci/elasticsearch-cloud-ess:$VERSION-$ELASTICSEARCH_SHA"
 
 KIBANA_CLOUD_IMAGE="docker.elastic.co/kibana-ci/kibana-cloud:$VERSION-$GIT_COMMIT"
 CLOUD_DEPLOYMENT_NAME="kibana-pr-$BUILDKITE_PULL_REQUEST"

--- a/.buildkite/scripts/steps/es_snapshots/build.sh
+++ b/.buildkite/scripts/steps/es_snapshots/build.sh
@@ -86,10 +86,10 @@ echo "--- Create kibana-ci docker cloud image archives"
 # block the rest of the snapshot promotion process
 set +e
 ./gradlew :distribution:docker:cloud-ess-docker-export:assemble && {
-  ES_CLOUD_ID=$(docker images "docker.elastic.co/elasticsearch-ci/elasticsearch-cloud" --format "{{.ID}}")
-  ES_CLOUD_VERSION=$(docker images "docker.elastic.co/elasticsearch-ci/elasticsearch-cloud" --format "{{.Tag}}")
+  ES_CLOUD_ID=$(docker images "docker.elastic.co/elasticsearch/elasticsearch-cloud-ess" --format "{{.ID}}")
+  ES_CLOUD_VERSION=$(docker images "docker.elastic.co/elasticsearch/elasticsearch-cloud-ess" --format "{{.Tag}}")
   KIBANA_ES_CLOUD_VERSION="$ES_CLOUD_VERSION-$ELASTICSEARCH_GIT_COMMIT"
-  KIBANA_ES_CLOUD_IMAGE="docker.elastic.co/kibana-ci/elasticsearch-cloud:$KIBANA_ES_CLOUD_VERSION"
+  KIBANA_ES_CLOUD_IMAGE="docker.elastic.co/kibana-ci/elasticsearch-cloud-ess:$KIBANA_ES_CLOUD_VERSION"
   echo $ES_CLOUD_ID $ES_CLOUD_VERSION $KIBANA_ES_CLOUD_VERSION $KIBANA_ES_CLOUD_IMAGE
   docker tag "$ES_CLOUD_ID" "$KIBANA_ES_CLOUD_IMAGE"
 

--- a/.buildkite/scripts/steps/es_snapshots/build.sh
+++ b/.buildkite/scripts/steps/es_snapshots/build.sh
@@ -85,7 +85,7 @@ echo "--- Create kibana-ci docker cloud image archives"
 # When we bump versions, these dependencies may not exist yet, but we don't want to
 # block the rest of the snapshot promotion process
 set +e
-./gradlew :distribution:docker:cloud-docker-export:assemble && {
+./gradlew :distribution:docker:cloud-ess-docker-export:assemble && {
   ES_CLOUD_ID=$(docker images "docker.elastic.co/elasticsearch-ci/elasticsearch-cloud" --format "{{.ID}}")
   ES_CLOUD_VERSION=$(docker images "docker.elastic.co/elasticsearch-ci/elasticsearch-cloud" --format "{{.Tag}}")
   KIBANA_ES_CLOUD_VERSION="$ES_CLOUD_VERSION-$ELASTICSEARCH_GIT_COMMIT"


### PR DESCRIPTION
Our build scripts are relying on a step that was removed in https://github.com/elastic/elasticsearch/pull/115357.  The image that was produced by this script is eventually consumed by cloud deployments from pull requests. 

This updates our scripts to use the cloud-ess variant instead.  There should not be any functional difference.  


We'll need the image to go through our promotion pipeline to be tested via label.
https://buildkite.com/elastic/kibana-elasticsearch-snapshot-build/builds/4673

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->