### PR TITLE
[HTTP/OAS] Enable `x-internal` prop support in bundler's merge utility

### DIFF
--- a/packages/kbn-openapi-bundler/src/bundler/processor_sets.ts
+++ b/packages/kbn-openapi-bundler/src/bundler/processor_sets.ts
@@ -40,6 +40,16 @@ export const DEFAULT_BUNDLING_PROCESSORS: Readonly<DocumentNodeProcessor[]> = [
 ];
 
 /**
+ * Processors which should be applied to documents before merging them together.
+ */
+export const DEFAULT_MERGING_PROCESSORS: Readonly<DocumentNodeProcessor[]> = [
+  // x-internal is quite well known custom property to skip internal API parts.
+  // Enabling it to avoid leaking internal APIs/API parts coming from non processed
+  // by the bundler Kibana domains.
+  createSkipNodeWithInternalPropProcessor(X_INTERNAL),
+];
+
+/**
  * Adds createIncludeLabelsProcessor processor, see createIncludeLabelsProcessor description
  * for more details
  */

--- a/packages/kbn-openapi-bundler/src/openapi_merger.ts
+++ b/packages/kbn-openapi-bundler/src/openapi_merger.ts
@@ -16,7 +16,10 @@ import { ResolvedDocument } from './bundler/ref_resolver/resolved_document';
 import { writeDocuments } from './utils/write_documents';
 import { resolveGlobs } from './utils/resolve_globs';
 import { bundleDocument } from './bundler/bundle_document';
-import { withNamespaceComponentsProcessor } from './bundler/processor_sets';
+import {
+  DEFAULT_MERGING_PROCESSORS,
+  withNamespaceComponentsProcessor,
+} from './bundler/processor_sets';
 import { PrototypeDocument } from './prototype_document';
 import { validatePrototypeDocument } from './validate_prototype_document';
 
@@ -94,7 +97,10 @@ function logSchemas(schemaFilePaths: string[]): void {
 async function bundleDocuments(schemaFilePaths: string[]): Promise<ResolvedDocument[]> {
   return await Promise.all(
     schemaFilePaths.map(async (schemaFilePath) =>
-      bundleDocument(schemaFilePath, withNamespaceComponentsProcessor([], '/info/title'))
+      bundleDocument(
+        schemaFilePath,
+        withNamespaceComponentsProcessor(DEFAULT_MERGING_PROCESSORS, '/info/title')
+      )
     )
   );
 }


### PR DESCRIPTION
## Summary

This PR enables support for `x-internal` property in OpenAPI documents when merging them by OpenAPI Bundler's merge utility. It will help to prevent leaks of internal/WIP parts of OpenAPI bundles which weren't processed by the OpenAPI Bundler at the earlier stages.

## Details

@thomasneirynck brought up a [Slack discussion](https://elastic.slack.com/archives/C5TQ33ND8/p1729860014326159) (internal) regarding using of `x-internal` property in OpenAPI documents for excluding parts of API endpoint definitions. OpenAPI bundler supports it and uses it for bundling Security Solution OpenAPI bundles. This PR enables this functionality for the merge utility used to merge OpenAPI bundles sourced from different parts of Kibana to produce a single Kibana bundle.