### PR TITLE
[Security Solution][Hotfix] Avoid blocking prebuilt rule upgrade upon conflicts with disabled feature flag

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_prebuilt_rules_upgrade_state.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_prebuilt_rules_upgrade_state.ts
@@ -6,6 +6,7 @@
  */
 
 import { useCallback, useMemo, useState } from 'react';
+import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import type {
   RulesUpgradeState,
   FieldsUpgradeState,
@@ -32,6 +33,9 @@ interface UseRulesUpgradeStateResult {
 export function usePrebuiltRulesUpgradeState(
   ruleUpgradeInfos: RuleUpgradeInfoForReview[]
 ): UseRulesUpgradeStateResult {
+  const isPrebuiltRulesCustomizationEnabled = useIsExperimentalFeatureEnabled(
+    'prebuiltRulesCustomizationEnabled'
+  );
   const [rulesResolvedConflicts, setRulesResolvedConflicts] = useState<RulesResolvedConflicts>({});
 
   const setRuleFieldResolvedValue = useCallback(
@@ -61,16 +65,17 @@ export function usePrebuiltRulesUpgradeState(
           ruleUpgradeInfo.diff.fields,
           rulesResolvedConflicts[ruleUpgradeInfo.rule_id] ?? {}
         ),
-        hasUnresolvedConflicts:
-          getUnacceptedConflictsCount(
-            ruleUpgradeInfo.diff.fields,
-            rulesResolvedConflicts[ruleUpgradeInfo.rule_id] ?? {}
-          ) > 0,
+        hasUnresolvedConflicts: isPrebuiltRulesCustomizationEnabled
+          ? getUnacceptedConflictsCount(
+              ruleUpgradeInfo.diff.fields,
+              rulesResolvedConflicts[ruleUpgradeInfo.rule_id] ?? {}
+            ) > 0
+          : false,
       };
     }
 
     return state;
-  }, [ruleUpgradeInfos, rulesResolvedConflicts]);
+  }, [ruleUpgradeInfos, rulesResolvedConflicts, isPrebuiltRulesCustomizationEnabled]);
 
   return {
     rulesUpgradeState,


### PR DESCRIPTION
## Summary

It turned out some of the update rule buttons are disabled. This is a side effect of the functionality not fully hidden under a feature flag. This PR hides prebuilt rule customisation functionality disabling update rule buttons under `prebuiltRulesCustomizationEnabled` feature flag.

## Before

![image](https://github.com/user-attachments/assets/b7ca5ff8-be37-47a7-ad7e-b85386909f38)

## After

<img width="1719" alt="image" src="https://github.com/user-attachments/assets/349223dc-dda5-46fb-832f-d7097a81580e">

<img width="1721" alt="image" src="https://github.com/user-attachments/assets/a28512f6-e605-460e-884d-571ab408a7d9">




<!--ONMERGE {"backportTargets":["8.15","8.16","8.x"]} ONMERGE-->