### PR TITLE
[8.16] Kibana space scoped component-template for risk engine (#197170)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/configurations.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/configurations.ts
@@ -129,6 +129,9 @@ export const riskScoreFieldMap: FieldMap = {
 } as const;
 
 export const mappingComponentName = '.risk-score-mappings';
+export const nameSpaceAwareMappingsComponentName = (namespace: string): string => {
+  return `${mappingComponentName}-${namespace}`;
+};
 export const totalFieldsLimit = 1000;
 
 export const getIndexPatternDataStream = (namespace: string): IIndexPatternString => ({

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/init_and_status_apis.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/init_and_status_apis.ts
@@ -27,19 +27,30 @@ export default ({ getService }: FtrProviderContext) => {
   const es = getService('es');
   const supertest = getService('supertest');
   const kibanaServer = getService('kibanaServer');
+  const spaces = getService('spaces');
+  const customSpaceName = 'ea-customspace-it';
   const riskEngineRoutes = riskEngineRouteHelpersFactory(supertest);
+  const riskEngineRoutesWithNamespace = riskEngineRouteHelpersFactory(supertest, customSpaceName);
   const log = getService('log');
 
-  // Failing: See https://github.com/elastic/kibana/issues/191637
-  describe.skip('@ess @serverless @serverlessQA init_and_status_apis', () => {
+  describe('@ess @serverless @serverlessQA init_and_status_apis', () => {
     before(async () => {
+      await spaces.create({
+        id: customSpaceName,
+        name: customSpaceName,
+        description: 'Space for ${customSpaceName}',
+        disabledFeatures: [],
+      });
       await riskEngineRoutes.cleanUp();
+      await riskEngineRoutesWithNamespace.cleanUp();
     });
 
     afterEach(async () => {
       await riskEngineRoutes.cleanUp();
+      await riskEngineRoutesWithNamespace.cleanUp();
       await clearLegacyTransforms({ es, log });
       await clearLegacyDashboards({ supertest, log });
+      await spaces.delete(customSpaceName);
     });
 
     describe('init api', () => {
@@ -54,10 +65,21 @@ export default ({ getService }: FtrProviderContext) => {
             risk_engine_resources_installed: true,
           },
         });
+
+        const customNamespaceResponse = await riskEngineRoutesWithNamespace.init();
+        expect(customNamespaceResponse.body).to.eql({
+          result: {
+            errors: [],
+            legacy_risk_engine_disabled: true,
+            risk_engine_configuration_created: true,
+            risk_engine_enabled: true,
+            risk_engine_resources_installed: true,
+          },
+        });
       });
 
-      it('should install resources on init call', async () => {
-        const componentTemplateName = '.risk-score-mappings';
+      it('should install resources on init call in the default namespace', async () => {
+        const componentTemplateName = '.risk-score-mappings-default';
         const indexTemplateName = '.risk-score.risk-score-default-index-template';
         const dataStreamName = 'risk-score.risk-score-default';
         const latestIndexName = 'risk-score.risk-score-latest-default';
@@ -210,7 +232,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(indexTemplate.index_template.index_patterns).to.eql([
           'risk-score.risk-score-default',
         ]);
-        expect(indexTemplate.index_template.composed_of).to.eql(['.risk-score-mappings']);
+        expect(indexTemplate.index_template.composed_of).to.eql(['.risk-score-mappings-default']);
         expect(indexTemplate.index_template.template!.mappings?.dynamic).to.eql(false);
         expect(indexTemplate.index_template.template!.mappings?._meta?.managed).to.eql(true);
         expect(indexTemplate.index_template.template!.mappings?._meta?.namespace).to.eql('default');
@@ -242,6 +264,221 @@ export default ({ getService }: FtrProviderContext) => {
 
         expect(dataStream?.mappings?._meta?.managed).to.eql(true);
         expect(dataStream?.mappings?._meta?.namespace).to.eql('default');
+        expect(dataStream?.mappings?._meta?.kibana?.version).to.be.a('string');
+        expect(dataStream?.mappings?.dynamic).to.eql('false');
+
+        expect(dataStream?.settings?.index?.mapping).to.eql({
+          total_fields: {
+            limit: '1000',
+          },
+        });
+
+        expect(dataStream?.settings?.index?.hidden).to.eql('true');
+        expect(dataStream?.settings?.index?.number_of_shards).to.eql(1);
+
+        const indexExist = await es.indices.exists({
+          index: latestIndexName,
+        });
+
+        expect(indexExist).to.eql(true);
+
+        const transformStats = await es.transform.getTransformStats({
+          transform_id: transformId,
+        });
+
+        expect(transformStats.transforms[0].state).to.eql('stopped');
+      });
+
+      it('should install resources on init call in the custom namespace', async () => {
+        const componentTemplateName = `.risk-score-mappings-${customSpaceName}`;
+        const indexTemplateName = `.risk-score.risk-score-${customSpaceName}-index-template`;
+        const dataStreamName = `risk-score.risk-score-${customSpaceName}`;
+        const latestIndexName = `risk-score.risk-score-latest-${customSpaceName}`;
+        const transformId = `risk_score_latest_transform_${customSpaceName}`;
+
+        await riskEngineRoutesWithNamespace.init();
+
+        const { component_templates: componentTemplates1 } = await es.cluster.getComponentTemplate({
+          name: componentTemplateName,
+        });
+
+        expect(componentTemplates1.length).to.eql(1);
+        const componentTemplate = componentTemplates1[0];
+
+        expect(componentTemplate.name).to.eql(componentTemplateName);
+        expect(componentTemplate.component_template.template.mappings).to.eql({
+          dynamic: 'strict',
+          properties: {
+            '@timestamp': {
+              ignore_malformed: false,
+              type: 'date',
+            },
+            host: {
+              properties: {
+                name: {
+                  type: 'keyword',
+                },
+                risk: {
+                  properties: {
+                    calculated_level: {
+                      type: 'keyword',
+                    },
+                    calculated_score: {
+                      type: 'float',
+                    },
+                    calculated_score_norm: {
+                      type: 'float',
+                    },
+                    category_1_count: {
+                      type: 'long',
+                    },
+                    category_1_score: {
+                      type: 'float',
+                    },
+                    id_field: {
+                      type: 'keyword',
+                    },
+                    id_value: {
+                      type: 'keyword',
+                    },
+                    notes: {
+                      type: 'keyword',
+                    },
+                    inputs: {
+                      properties: {
+                        id: {
+                          type: 'keyword',
+                        },
+                        index: {
+                          type: 'keyword',
+                        },
+                        category: {
+                          type: 'keyword',
+                        },
+                        description: {
+                          type: 'keyword',
+                        },
+                        risk_score: {
+                          type: 'float',
+                        },
+                        timestamp: {
+                          type: 'date',
+                        },
+                      },
+                      type: 'object',
+                    },
+                  },
+                  type: 'object',
+                },
+              },
+            },
+            user: {
+              properties: {
+                name: {
+                  type: 'keyword',
+                },
+                risk: {
+                  properties: {
+                    calculated_level: {
+                      type: 'keyword',
+                    },
+                    calculated_score: {
+                      type: 'float',
+                    },
+                    calculated_score_norm: {
+                      type: 'float',
+                    },
+                    category_1_count: {
+                      type: 'long',
+                    },
+                    category_1_score: {
+                      type: 'float',
+                    },
+                    id_field: {
+                      type: 'keyword',
+                    },
+                    id_value: {
+                      type: 'keyword',
+                    },
+                    notes: {
+                      type: 'keyword',
+                    },
+                    inputs: {
+                      properties: {
+                        id: {
+                          type: 'keyword',
+                        },
+                        index: {
+                          type: 'keyword',
+                        },
+                        category: {
+                          type: 'keyword',
+                        },
+                        description: {
+                          type: 'keyword',
+                        },
+                        risk_score: {
+                          type: 'float',
+                        },
+                        timestamp: {
+                          type: 'date',
+                        },
+                      },
+                      type: 'object',
+                    },
+                  },
+                  type: 'object',
+                },
+              },
+            },
+          },
+        });
+
+        const { index_templates: indexTemplates } = await es.indices.getIndexTemplate({
+          name: indexTemplateName,
+        });
+        expect(indexTemplates.length).to.eql(1);
+        const indexTemplate = indexTemplates[0];
+        expect(indexTemplate.name).to.eql(indexTemplateName);
+        expect(indexTemplate.index_template.index_patterns).to.eql([
+          `risk-score.risk-score-${customSpaceName}`,
+        ]);
+        expect(indexTemplate.index_template.composed_of).to.eql([
+          `.risk-score-mappings-${customSpaceName}`,
+        ]);
+        expect(indexTemplate.index_template.template!.mappings?.dynamic).to.eql(false);
+        expect(indexTemplate.index_template.template!.mappings?._meta?.managed).to.eql(true);
+        expect(indexTemplate.index_template.template!.mappings?._meta?.namespace).to.eql(
+          customSpaceName
+        );
+        expect(indexTemplate.index_template.template!.mappings?._meta?.kibana?.version).to.be.a(
+          'string'
+        );
+
+        expect(indexTemplate.index_template.template!.settings).to.eql({
+          index: {
+            mapping: {
+              total_fields: {
+                limit: '1000',
+              },
+            },
+          },
+        });
+
+        expect(indexTemplate.index_template.template!.lifecycle).to.eql({
+          enabled: true,
+        });
+
+        const dsResponse = await es.indices.get({
+          index: dataStreamName,
+        });
+
+        const dataStream = Object.values(dsResponse).find(
+          (ds) => ds.data_stream === dataStreamName
+        );
+
+        expect(dataStream?.mappings?._meta?.managed).to.eql(true);
+        expect(dataStream?.mappings?._meta?.namespace).to.eql(customSpaceName);
         expect(dataStream?.mappings?._meta?.kibana?.version).to.be.a('string');
         expect(dataStream?.mappings?.dynamic).to.eql('false');
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Kibana space scoped component-template for risk engine (#197170)](https://github.com/elastic/kibana/pull/197170)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Abhishek Bhatia","email":"117628830+abhishekbhatia1710@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-10-22T15:45:52Z","message":"Kibana space scoped component-template for risk engine (#197170)\n\n## Summary\r\n\r\nThe component template used when enabling the risk engine is not Kibana\r\nspace-agnostic, as the component template in every space is named\r\n`.risk-score-mappings`. This caused issues during the cleanup process,\r\nwhere it attempted to delete the same component template from each space\r\nbut failed because other spaces' index templates were still referencing\r\nit.\r\n\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)\r\n- [ ] This will appear in the **Release Notes** and follow the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b562288289f326084511c68759db84e20cee2791","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","v9.0.0","Team:Entity Analytics","backport:version"],"number":197170,"url":"https://github.com/elastic/kibana/pull/197170","mergeCommit":{"message":"Kibana space scoped component-template for risk engine (#197170)\n\n## Summary\r\n\r\nThe component template used when enabling the risk engine is not Kibana\r\nspace-agnostic, as the component template in every space is named\r\n`.risk-score-mappings`. This caused issues during the cleanup process,\r\nwhere it attempted to delete the same component template from each space\r\nbut failed because other spaces' index templates were still referencing\r\nit.\r\n\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)\r\n- [ ] This will appear in the **Release Notes** and follow the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b562288289f326084511c68759db84e20cee2791"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/197170","number":197170,"mergeCommit":{"message":"Kibana space scoped component-template for risk engine (#197170)\n\n## Summary\r\n\r\nThe component template used when enabling the risk engine is not Kibana\r\nspace-agnostic, as the component template in every space is named\r\n`.risk-score-mappings`. This caused issues during the cleanup process,\r\nwhere it attempted to delete the same component template from each space\r\nbut failed because other spaces' index templates were still referencing\r\nit.\r\n\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)\r\n- [ ] This will appear in the **Release Notes** and follow the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"b562288289f326084511c68759db84e20cee2791"}}]}] BACKPORT-->