### PR TITLE
[EDR Workflows] Skip Osquery test in MKI

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/all/ecs_mappings.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/ecs_mappings.cy.ts
@@ -18,7 +18,7 @@ import {
   typeInOsqueryFieldInput,
 } from '../../tasks/live_query';
 
-describe('EcsMapping', { tags: ['@ess', '@serverless'] }, () => {
+describe('EcsMapping', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
   beforeEach(() => {
     initializeDataViews();
   });


### PR DESCRIPTION
This test has been recently unskipped after a long time - we'll have to take a closer look at it. 
Skipping on MKI for now.

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->