### PR TITLE
[8.x] [EDR Workflows] Fix Cypress tests failing on Alerts step (#197384)

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/all/ecs_mappings.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/ecs_mappings.cy.ts
@@ -18,8 +18,7 @@ import {
   typeInOsqueryFieldInput,
 } from '../../tasks/live_query';
 
-// Failing: See https://github.com/elastic/kibana/issues/192128
-describe.skip('EcsMapping', { tags: ['@ess', '@serverless'] }, () => {
+describe('EcsMapping', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     initializeDataViews();
   });

--- a/x-pack/plugins/osquery/cypress/tasks/api_fixtures.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/api_fixtures.ts
@@ -231,7 +231,7 @@ export const loadRule = (includeResponseActions = false) => {
       tags: [],
       license: '',
       interval: '1m',
-      from: 'now-120s',
+      from: 'now-360s',
       to: 'now',
       meta: { from: '1m', kibana_siem_app_url: 'http://localhost:5620/app/security' },
       actions: [],

--- a/x-pack/plugins/osquery/cypress/tasks/live_query.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/live_query.ts
@@ -58,7 +58,7 @@ export const verifyQueryTimeout = (timeout: string) => {
 
 // sometimes the results get stuck in the tests, this is a workaround
 export const checkResults = () => {
-  cy.getBySel('osqueryResultsTable').then(($table) => {
+  cy.getBySel('osqueryResultsTable', { timeout: 120000 }).then(($table) => {
     if ($table.find('div .euiDataGridRow').length > 0) {
       cy.getBySel('dataGridRowCell', { timeout: 120000 }).should('have.lengthOf.above', 0);
     } else {
@@ -158,6 +158,7 @@ export const checkActionItemsInResults = ({
   cases: boolean;
   timeline: boolean;
 }) => {
+  checkResults();
   cy.contains('View in Discover').should(discover ? 'exist' : 'not.exist');
   cy.contains('View in Lens').should(lens ? 'exist' : 'not.exist');
   cy.contains('Add to Case').should(cases ? 'exist' : 'not.exist');

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/automated_response_actions.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/automated_response_actions.cy.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
+import { waitForAlertsToPopulate } from '@kbn/test-suites-xpack/security_solution_cypress/cypress/tasks/create_new_rule';
+import { login } from '../../tasks/login';
+import { waitForEndpointListPageToBeLoaded } from '../../tasks/response_console';
 import type { PolicyData } from '../../../../../common/endpoint/types';
-import { APP_ENDPOINTS_PATH } from '../../../../../common/constants';
 import { closeAllToasts } from '../../tasks/toasts';
 import { toggleRuleOffAndOn, visitRuleAlerts } from '../../tasks/isolate';
 import { cleanupRule, loadRule } from '../../tasks/api_fixtures';
-import { login } from '../../tasks/login';
-import { loadPage } from '../../tasks/common';
 import type { IndexedFleetEndpointPolicyResponse } from '../../../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
 import { createAgentPolicyTask, getEndpointIntegrationVersion } from '../../tasks/fleet';
 import { changeAlertsFilter } from '../../tasks/alerts';
@@ -38,21 +38,33 @@ describe(
     let indexedPolicy: IndexedFleetEndpointPolicyResponse;
     let policy: PolicyData;
     let createdHost: CreateAndEnrollEndpointHostResponse;
+    let ruleId: string;
+    let ruleName: string;
+    beforeEach(() => {
+      login();
+    });
 
     before(() => {
-      getEndpointIntegrationVersion().then((version) =>
-        createAgentPolicyTask(version, 'automated_response_actions').then((data) => {
-          indexedPolicy = data;
-          policy = indexedPolicy.integrationPolicies[0];
+      getEndpointIntegrationVersion()
+        .then((version) =>
+          createAgentPolicyTask(version, 'automated_response_actions').then((data) => {
+            indexedPolicy = data;
+            policy = indexedPolicy.integrationPolicies[0];
 
-          return enableAllPolicyProtections(policy.id).then(() => {
-            // Create and enroll a new Endpoint host
-            return createEndpointHost(policy.policy_ids[0]).then((host) => {
-              createdHost = host as CreateAndEnrollEndpointHostResponse;
+            return enableAllPolicyProtections(policy.id).then(() => {
+              // Create and enroll a new Endpoint host
+              return createEndpointHost(policy.policy_ids[0]).then((host) => {
+                createdHost = host as CreateAndEnrollEndpointHostResponse;
+              });
             });
+          })
+        )
+        .then(() => {
+          loadRule().then((data) => {
+            ruleId = data.id;
+            ruleName = data.name;
           });
-        })
-      );
+        });
     });
 
     after(() => {
@@ -67,47 +79,29 @@ describe(
       if (createdHost) {
         deleteAllLoadedEndpointData({ endpointAgentIds: [createdHost.agentId] });
       }
+
+      if (ruleId) {
+        cleanupRule(ruleId);
+      }
     });
 
-    beforeEach(() => {
-      login();
-    });
+    it('should have been called against a created host', () => {
+      waitForEndpointListPageToBeLoaded(createdHost.hostname);
+      toggleRuleOffAndOn(ruleName);
 
-    describe('From alerts', () => {
-      let ruleId: string;
-      let ruleName: string;
+      visitRuleAlerts(ruleName);
+      closeAllToasts();
 
-      before(() => {
-        loadRule().then((data) => {
-          ruleId = data.id;
-          ruleName = data.name;
-        });
-      });
+      changeAlertsFilter(`process.name: "agentbeat" and agent.id: "${createdHost.agentId}"`);
+      waitForAlertsToPopulate();
 
-      after(() => {
-        if (ruleId) {
-          cleanupRule(ruleId);
-        }
-      });
+      cy.getByTestSubj('expand-event').first().click();
+      cy.getByTestSubj('securitySolutionFlyoutNavigationExpandDetailButton').click();
+      cy.getByTestSubj('securitySolutionFlyoutResponseTab').click();
 
-      it('should have generated endpoint and rule', () => {
-        loadPage(APP_ENDPOINTS_PATH);
-        cy.contains(createdHost.hostname).should('exist');
-
-        toggleRuleOffAndOn(ruleName);
-
-        visitRuleAlerts(ruleName);
-        closeAllToasts();
-
-        changeAlertsFilter(`process.name: "agentbeat" and agent.id: "${createdHost.agentId}"`);
-        cy.getByTestSubj('expand-event').first().click();
-        cy.getByTestSubj('securitySolutionFlyoutNavigationExpandDetailButton').click();
-        cy.getByTestSubj('securitySolutionFlyoutResponseTab').click();
-
-        cy.contains(/isolate is pending|isolate completed successfully/g);
-        cy.contains(/kill-process is pending|kill-process completed successfully/g);
-        cy.contains('The action was called with a non-existing event field name: entity_id');
-      });
+      cy.contains(/isolate is pending|isolate completed successfully/g);
+      cy.contains(/kill-process is pending|kill-process completed successfully/g);
+      cy.contains('The action was called with a non-existing event field name: entity_id');
     });
   }
 );

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/api_fixtures.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/api_fixtures.ts
@@ -55,7 +55,7 @@ export const loadRule = (body = {}, includeResponseActions = true) =>
       tags: [],
       license: '',
       interval: '1m',
-      from: 'now-120s',
+      from: 'now-360s',
       to: 'now',
       meta: { from: '1m', kibana_siem_app_url: 'http://localhost:5620/app/security' },
       actions: [],

--- a/x-pack/plugins/security_solution/public/management/cypress/tsconfig.json
+++ b/x-pack/plugins/security_solution/public/management/cypress/tsconfig.json
@@ -34,5 +34,6 @@
     "@kbn/security-solution-serverless",
     "@kbn/dev-utils",
     "@kbn/spaces-plugin",
+    "@kbn/test-suites-xpack/security_solution_cypress/cypress",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[EDR Workflows] Fix Cypress tests failing on Alerts step (#197384)](https://github.com/elastic/kibana/pull/197384)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2024-10-28T14:44:29Z","message":"[EDR Workflows] Fix Cypress tests failing on Alerts step (#197384)","sha":"962f73130b96df919473de79b6a9b0067652e607","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Defend Workflows","v8.16.0","backport:version","v8.17.0"],"number":197384,"url":"https://github.com/elastic/kibana/pull/197384","mergeCommit":{"message":"[EDR Workflows] Fix Cypress tests failing on Alerts step (#197384)","sha":"962f73130b96df919473de79b6a9b0067652e607"}},"sourceBranch":"main","suggestedTargetBranches":["8.16","8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/197384","number":197384,"mergeCommit":{"message":"[EDR Workflows] Fix Cypress tests failing on Alerts step (#197384)","sha":"962f73130b96df919473de79b6a9b0067652e607"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->