### PR TITLE
[Security Solution][Notes] - fix the notes link that is shown twice in the search bar

### DIFF
--- a/x-pack/plugins/security_solution/public/management/links.ts
+++ b/x-pack/plugins/security_solution/public/management/links.ts
@@ -230,6 +230,7 @@ export const links: LinkItem = {
       skipUrlState: true,
       hideTimeline: true,
       hideWhenExperimentalKey: 'securitySolutionNotesDisabled',
+      globalSearchDisabled: true,
     },
   ],
 };


### PR DESCRIPTION
## Summary

This PR fixes a minor inconvenience where the Kibana search bar was showing 2 entries for the new Notes management page.

| Before fix | After fix |
| ------------- | ------------- |
| ![Screenshot 2024-10-29 at 11 53 44 AM](https://github.com/user-attachments/assets/77bd4b5a-d8d4-4f4f-8378-6aff1ec1b00b) | ![Screenshot 2024-10-29 at 11 53 19 AM](https://github.com/user-attachments/assets/d138e307-b4ea-473b-9102-eb7e7b540bff) |

Notes: this fix does not fix an issue happening in the space-specific search, where Notes, Timelines and maybe other entries are appearing twice. That issue seems to be related to the way we are removing then adding back links to work with the new navigation. I looked into it but could not find a way to fix yet, so this will be part of a follow up PR

https://github.com/elastic/kibana/issues/197694

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->