### PR TITLE
[Reporting] Unskip and optimize tests that generate test reports

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/datastream.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/datastream.ts
@@ -42,6 +42,7 @@ export default function ({ getService }: FtrProviderContext) {
       await esArchiver.load(archives.ecommerce.data);
       await kibanaServer.importExport.load(archives.ecommerce.savedObjects);
 
+      // generate a report that will initialize the Reporting data stream
       const { job, path } = await reportingAPI.createReportJobInternal(
         'csv_searchsource',
         {

--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/datastream.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/datastream.ts
@@ -96,6 +96,7 @@ export default function ({ getService }: FtrProviderContext) {
         internalReqHeader
       );
       await reportingAPI.waitForJobToFinish(path, cookieCredentials, internalReqHeader);
+
       generatedReports.add(job.id);
     });
 

--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/management.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/management.ts
@@ -47,9 +47,45 @@ export default ({ getService }: FtrProviderContext) => {
           browserTimezone: 'UTC',
           objectType: 'search',
           searchSource: {
+            fields: [
+              { field: 'order_date', include_unmapped: true },
+              { field: 'order_id', include_unmapped: true },
+              { field: 'products.product_id', include_unmapped: true },
+            ],
+            filter: [
+              {
+                meta: {
+                  field: 'order_date',
+                  index: '5193f870-d861-11e9-a311-0fa548c5f953',
+                  params: {},
+                },
+                query: {
+                  range: {
+                    order_date: {
+                      format: 'strict_date_optional_time',
+                      gte: '2019-06-20T23:59:44.609Z',
+                      lte: '2019-06-21T00:01:06.957Z',
+                    },
+                  },
+                },
+              },
+              {
+                $state: { store: 'appState' },
+                meta: {
+                  alias: null,
+                  disabled: false,
+                  index: '5193f870-d861-11e9-a311-0fa548c5f953',
+                  key: 'products.product_id',
+                  negate: false,
+                  params: { query: 22599 },
+                  type: 'phrase',
+                },
+                query: { match_phrase: { 'products.product_id': 22599 } },
+              },
+            ],
             index: '5193f870-d861-11e9-a311-0fa548c5f953',
             query: { language: 'kuery', query: '' },
-            version: true,
+            sort: [{ order_date: { format: 'strict_date_optional_time', order: 'desc' } }],
           },
           title: 'Ecommerce Data',
           version: '8.15.0',

--- a/x-pack/test_serverless/functional/test_suites/common/reporting/management.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/reporting/management.ts
@@ -36,9 +36,6 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   };
 
   describe('Reporting Management app', function () {
-    // security_exception: action [indices:admin/create] is unauthorized for user [elastic] with effective roles [superuser] on restricted indices [.reporting-2020.04.19], this action is granted by the index privileges [create_index,manage,all]
-    this.tags('failsOnMKI');
-
     let reportJob: ReportApiJSON;
     let path: string;
 
@@ -56,6 +53,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           params: { savedSearchId: 'ab12e3c0-f231-11e6-9486-733b1ac9221a' },
         },
       ],
+      title: 'report for management app test',
     };
 
     // Kibana CI and MKI use different users

--- a/x-pack/test_serverless/functional/test_suites/common/reporting/management.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/reporting/management.ts
@@ -5,16 +5,12 @@
  * 2.0.
  */
 
-import { DISCOVER_APP_LOCATOR } from '@kbn/discover-plugin/common';
-import {
-  CSV_REPORT_TYPE_V2,
-  type JobParamsCsvFromSavedObject,
-} from '@kbn/reporting-export-types-csv-common';
 import type { CookieCredentials, InternalRequestHeader } from '@kbn/ftr-common-functional-services';
 import { ReportApiJSON } from '@kbn/reporting-common/types';
 import type { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
+  const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const log = getService('log');
   const testSubjects = getService('testSubjects');
@@ -24,6 +20,13 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const samlAuth = getService('samlAuth');
   let cookieCredentials: CookieCredentials;
   let internalReqHeader: InternalRequestHeader;
+
+  const archives: Record<string, { data: string; savedObjects: string }> = {
+    ecommerce: {
+      data: 'x-pack/test/functional/es_archives/reporting/ecommerce',
+      savedObjects: 'x-pack/test/functional/fixtures/kbn_archiver/reporting/ecommerce',
+    },
+  };
 
   const navigateToReportingManagement = async () => {
     log.debug(`navigating to reporting management app`);
@@ -35,54 +38,82 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     });
   };
 
-  describe('Reporting Management app', function () {
-    let reportJob: ReportApiJSON;
+  describe('Reporting Management app', () => {
+    let job: ReportApiJSON;
     let path: string;
 
-    const savedObjectsArchive = 'test/functional/fixtures/kbn_archiver/discover';
-
-    const job: JobParamsCsvFromSavedObject = {
-      browserTimezone: 'UTC',
-      objectType: 'search',
-      version: '8.10.0',
-      locatorParams: [
-        {
-          id: DISCOVER_APP_LOCATOR,
-          version: 'reporting',
-          // the create job API requires a valid savedSearchId
-          params: { savedSearchId: 'ab12e3c0-f231-11e6-9486-733b1ac9221a' },
-        },
-      ],
-      title: 'report for management app test',
-    };
-
-    // Kibana CI and MKI use different users
     before('initialize saved object archive', async () => {
       cookieCredentials = await samlAuth.getM2MApiCookieCredentialsWithRoleScope('admin');
       internalReqHeader = samlAuth.getInternalRequestHeader();
-      // add test saved search object
-      await kibanaServer.importExport.load(savedObjectsArchive);
 
-      // generate a report that can be tested to show in the listing
-      const result = await reportingAPI.createReportJobInternal(
-        CSV_REPORT_TYPE_V2,
-        job,
+      // add test saved search object
+      await esArchiver.load(archives.ecommerce.data);
+      await kibanaServer.importExport.load(archives.ecommerce.savedObjects);
+
+      // generate a test report to ensure the user is able to see it in the listing
+      ({ job, path } = await reportingAPI.createReportJobInternal(
+        'csv_searchsource',
+        {
+          browserTimezone: 'UTC',
+          objectType: 'search',
+          searchSource: {
+            fields: [
+              { field: 'order_date', include_unmapped: true },
+              { field: 'order_id', include_unmapped: true },
+              { field: 'products.product_id', include_unmapped: true },
+            ],
+            filter: [
+              {
+                meta: {
+                  field: 'order_date',
+                  index: '5193f870-d861-11e9-a311-0fa548c5f953',
+                  params: {},
+                },
+                query: {
+                  range: {
+                    order_date: {
+                      format: 'strict_date_optional_time',
+                      gte: '2019-06-20T23:59:44.609Z',
+                      lte: '2019-06-21T00:01:06.957Z',
+                    },
+                  },
+                },
+              },
+              {
+                $state: { store: 'appState' },
+                meta: {
+                  alias: null,
+                  disabled: false,
+                  index: '5193f870-d861-11e9-a311-0fa548c5f953',
+                  key: 'products.product_id',
+                  negate: false,
+                  params: { query: 22599 },
+                  type: 'phrase',
+                },
+                query: { match_phrase: { 'products.product_id': 22599 } },
+              },
+            ],
+            index: '5193f870-d861-11e9-a311-0fa548c5f953',
+            query: { language: 'kuery', query: '' },
+            sort: [{ order_date: { format: 'strict_date_optional_time', order: 'desc' } }],
+          },
+          title: 'Ecommerce Data',
+          version: '8.15.0',
+        },
         cookieCredentials,
         internalReqHeader
-      );
-
-      path = result.path;
-      reportJob = result.job;
+      ));
     });
 
     after('clean up archives', async () => {
-      await kibanaServer.importExport.unload(savedObjectsArchive);
       await reportingAPI.waitForJobToFinish(path, cookieCredentials, internalReqHeader);
+      await esArchiver.unload(archives.ecommerce.data);
+      await kibanaServer.importExport.unload(archives.ecommerce.savedObjects);
     });
 
     it(`user sees a job they've created`, async () => {
       await navigateToReportingManagement();
-      await testSubjects.existOrFail(`viewReportingLink-${reportJob.id}`);
+      await testSubjects.existOrFail(`viewReportingLink-${job.id}`);
     });
   });
 };


### PR DESCRIPTION
## Summary

This PR re-enables test reports that have been consistently failing in the serverless test environment. Investigation shows the reason for flakiness _may_ be due to the fact that the reports are exporting a large amount of data, which causes timeouts, including authentication tokens to time out.

To speed up the tests, date range filters and field selections have been added to the report job parameters, which leads to a lower amount of data being exported. The tests that are updated in this PR now generate an export with 2 documents, where previously they were exporting up to 4675 documents.