### PR TITLE
[ftr] use getopts to fetch server args

### DIFF
--- a/packages/kbn-ftr-common-functional-services/services/saml_auth/serverless/auth_provider.ts
+++ b/packages/kbn-ftr-common-functional-services/services/saml_auth/serverless/auth_provider.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import getopts from 'getopts';
 import { ServerlessProjectType, SERVERLESS_ROLES_ROOT_PATH } from '@kbn/es';
 import { type Config } from '@kbn/test';
 import { isServerlessProjectType, readRolesDescriptorsFromResource } from '@kbn/es/src/utils';
@@ -34,30 +35,23 @@ const getDefaultServerlessRole = (projectType: string) => {
   }
 };
 
-const isRoleManagementExplicitlyEnabled = (args: string[]): boolean => {
-  const roleManagementArg = args.find((arg) =>
-    arg.startsWith('--xpack.security.roleManagementEnabled=')
-  );
-
-  // Return true if the value is explicitly set to 'true', otherwise false
-  return roleManagementArg?.split('=')[1] === 'true' || false;
-};
-
 export class ServerlessAuthProvider implements AuthProvider {
   private readonly projectType: string;
   private readonly roleManagementEnabled: boolean;
   private readonly rolesDefinitionPath: string;
 
   constructor(config: Config) {
-    const kbnServerArgs = config.get('kbnTestServer.serverArgs') as string[];
-    this.projectType = kbnServerArgs.reduce((acc, arg) => {
-      const match = arg.match(/--serverless[=\s](\w+)/);
-      return acc + (match ? match[1] : '');
-    }, '') as ServerlessProjectType;
+    const options = getopts(config.get('kbnTestServer.serverArgs'), {
+      boolean: ['xpack.security.roleManagementEnabled'],
+      default: {
+        'xpack.security.roleManagementEnabled': false,
+      },
+    });
+    this.projectType = options.serverless as ServerlessProjectType;
 
     // Indicates whether role management was explicitly enabled using
     // the `--xpack.security.roleManagementEnabled=true` flag.
-    this.roleManagementEnabled = isRoleManagementExplicitlyEnabled(kbnServerArgs);
+    this.roleManagementEnabled = options['xpack.security.roleManagementEnabled'];
 
     if (!isServerlessProjectType(this.projectType)) {
       throw new Error(`Unsupported serverless projectType: ${this.projectType}`);

--- a/packages/kbn-test/src/functional_tests/lib/run_elasticsearch.ts
+++ b/packages/kbn-test/src/functional_tests/lib/run_elasticsearch.ts
@@ -11,6 +11,7 @@ import Url from 'url';
 import { resolve } from 'path';
 import type { ToolingLog } from '@kbn/tooling-log';
 import getPort from 'get-port';
+import getopts from 'getopts';
 import { REPO_ROOT } from '@kbn/repo-info';
 import type { ArtifactLicense, ServerlessProjectType } from '@kbn/es';
 import { isServerlessProjectType, extractAndArchiveLogs } from '@kbn/es/src/utils';
@@ -196,12 +197,8 @@ function getESServerlessOptions(
       (config.get('kbnTestServer.serverArgs') as string[])) ||
     [];
 
-  const projectType = kbnServerArgs
-    .filter((arg) => arg.startsWith('--serverless'))
-    .reduce((acc, arg) => {
-      const match = arg.match(/--serverless[=\s](\w+)/);
-      return acc + (match ? match[1] : '');
-    }, '') as ServerlessProjectType;
+  const options = getopts(kbnServerArgs);
+  const projectType = options.serverless as ServerlessProjectType;
 
   if (!isServerlessProjectType(projectType)) {
     throw new Error(`Unsupported serverless projectType: ${projectType}`);


### PR DESCRIPTION
## Summary

This PR simplifies the code to read server arguments by using `getopts` module as @jbudz suggested. 

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->