### PR TITLE
[Synthetics] For lens embeddable apply styling workaround for panel border !!

### DIFF
--- a/x-pack/plugins/observability_solution/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.tsx
+++ b/x-pack/plugins/observability_solution/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.tsx
@@ -288,5 +288,8 @@ const Wrapper = styled.div<{
       right: 50%;
       transform: translate(50%, -50%);
     }
+    .embPanel {
+      outline: none;
+    }
   }
 `;


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/198273

For lens embeddable apply styling workaround for panel border !!

<img width="1726" alt="image" src="https://github.com/user-attachments/assets/df2bcc4c-d069-44a7-99c3-59696566a6b3">


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->