### PR TITLE
Update `kea` Library from v2.6.0 to v3.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1157,7 +1157,7 @@
     "json-stringify-safe": "5.0.1",
     "jsonwebtoken": "^9.0.2",
     "jsts": "^1.6.2",
-    "kea": "^2.6.0",
+    "kea": "^3.1.6",
     "langchain": "^0.2.11",
     "langsmith": "^0.1.55",
     "launchdarkly-js-client-sdk": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22055,10 +22055,14 @@ kdbush@^4.0.2:
   resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-4.0.2.tgz#2f7b7246328b4657dd122b6c7f025fbc2c868e39"
   integrity sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==
 
-kea@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/kea/-/kea-2.6.0.tgz#774a82188e0fb52cdb18b72843a875ee857f3807"
-  integrity sha512-+yaLyZx8h2v96aL01XIRZjqA8Qk4fIUziznSKnkjDItUU8YnH75xER6+vMHT5EHC3MJeSScxIx5UuqZl30DBdg==
+kea@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/kea/-/kea-3.1.6.tgz#382f52a9b50ab3ca4f64e18eabdd47e974bc4303"
+  integrity sha512-EftYkqGyI8hdC8Eo9r6jGtUSxdykNe1L+Cpu+7t/SEWc9f3OPFtNFPF+hdxdYBeZp2Je3EY6BAEQfWhP4mbUPA==
+  dependencies:
+    redux "^4.2.0"
+    reselect "^4.1.5"
+    use-sync-external-store "^1.2.0"
 
 keyv@^4.0.0:
   version "4.5.4"
@@ -27381,7 +27385,7 @@ redux-thunks@^1.0.0:
   resolved "https://registry.yarnpkg.com/redux-thunks/-/redux-thunks-1.0.0.tgz#56e03b86d281a2664c884ab05c543d9ab1673658"
   integrity sha1-VuA7htKBomZMiEqwXFQ9mrFnNlg=
 
-redux@^4.0.0, redux@^4.0.4, redux@^4.2.1:
+redux@^4.0.0, redux@^4.0.4, redux@^4.2.0, redux@^4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz"
   integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
@@ -27800,7 +27804,7 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-reselect@^4.0.0, reselect@^4.1.8:
+reselect@^4.0.0, reselect@^4.1.5, reselect@^4.1.8:
   version "4.1.8"
   resolved "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz"
   integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==


### PR DESCRIPTION
## Summary
This PR upgrades the `kea` library from version `^2.6.0` to `^3.1.6`. 

## References
https://github.com/keajs/kea/blob/master/CHANGELOG.md