### PR TITLE
[8.x] [EDR Workflows] Skip Osquery test in MKI (#198117)

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/all/ecs_mappings.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/ecs_mappings.cy.ts
@@ -18,7 +18,7 @@ import {
   typeInOsqueryFieldInput,
 } from '../../tasks/live_query';
 
-describe('EcsMapping', { tags: ['@ess', '@serverless'] }, () => {
+describe('EcsMapping', { tags: ['@ess', '@serverless', '@skipInServerlessMKI'] }, () => {
   beforeEach(() => {
     initializeDataViews();
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [EDR Workflows] Skip Osquery test in MKI (#198117) (e5eb58a5)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2024-10-29T10:35:07Z","message":"[EDR Workflows] Skip Osquery test in MKI (#198117)","sha":"e5eb58a533ec34e1484340f4e11a0a61083b1572"},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->