### PR TITLE
[8.16] [SecuritySolution]  Fix Pagination should reset when a new filter is applied to the entity table (#198129)

### DIFF
--- a/x-pack/plugins/entity_manager/server/lib/entity_client.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entity_client.ts
@@ -106,9 +106,7 @@ export class EntityClient {
     });
 
     if (!definition) {
-      const message = `Unable to find entity definition with [${id}]`;
-      this.options.logger.error(message);
-      throw new EntityDefinitionNotFound(message);
+      throw new EntityDefinitionNotFound(`Unable to find entity definition with [${id}]`);
     }
 
     await uninstallEntityDefinition({

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.test.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { EntitiesList } from './entities_list';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { useQueryToggle } from '../../../common/containers/query_toggle';
@@ -15,6 +15,7 @@ import { useErrorToast } from '../../../common/hooks/use_error_toast';
 import type { ListEntitiesResponse } from '../../../../common/api/entity_analytics/entity_store/entities/list_entities.gen';
 import { useGlobalFilterQuery } from '../../../common/hooks/use_global_filter_query';
 import { TestProviders } from '../../../common/mock';
+import { times } from 'lodash/fp';
 
 jest.mock('../../../common/containers/use_global_time');
 jest.mock('../../../common/containers/query_toggle');
@@ -22,21 +23,23 @@ jest.mock('./hooks/use_entities_list_query');
 jest.mock('../../../common/hooks/use_error_toast');
 jest.mock('../../../common/hooks/use_global_filter_query');
 
-const entityName = 'Entity Name';
+const secondPageTestId = 'pagination-button-1';
+const entityName = 'Entity Name 1';
 const responseData: ListEntitiesResponse = {
   page: 1,
   per_page: 10,
-  total: 1,
-  records: [
-    {
+  total: 20,
+  records: times(
+    (index) => ({
       '@timestamp': '2021-08-02T14:00:00.000Z',
-      user: { name: entityName },
+      user: { name: `Entity Name ${index}` },
       entity: {
-        name: entityName,
+        name: `Entity Name ${index}`,
         source: 'test-index',
       },
-    },
-  ],
+    }),
+    10
+  ),
   inspect: undefined,
 };
 
@@ -81,7 +84,7 @@ describe('EntitiesList', () => {
 
   it('displays the correct number of rows', () => {
     render(<EntitiesList />, { wrapper: TestProviders });
-    expect(screen.getAllByRole('row')).toHaveLength(2);
+    expect(screen.getAllByRole('row')).toHaveLength(10 + 1);
   });
 
   it('calls refetch on time range change', () => {
@@ -110,6 +113,21 @@ describe('EntitiesList', () => {
         sortOrder: 'asc',
       })
     );
+  });
+
+  it('should reset the page when sort order changes ', async () => {
+    render(<EntitiesList />, { wrapper: TestProviders });
+
+    const secondPageButton = screen.getByTestId(secondPageTestId);
+    fireEvent.click(secondPageButton);
+
+    const columnHeader = screen.getByText('Name');
+    fireEvent.click(columnHeader);
+
+    await waitFor(() => {
+      const firstPageButton = screen.getByTestId('pagination-button-0');
+      expect(firstPageButton).toHaveAttribute('aria-current', 'true');
+    });
   });
 
   it('displays error toast when there is an error', () => {

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.tsx
@@ -94,6 +94,11 @@ export const EntitiesList: React.FC = () => {
     inspect: data?.inspect ?? null,
   });
 
+  // Reset the active page when the search criteria changes
+  useEffect(() => {
+    setActivePage(0);
+  }, [sorting, limit, filter]);
+
   const columns = useEntitiesListColumns();
 
   // Force a refetch when "refresh" button is clicked.
@@ -112,7 +117,7 @@ export const EntitiesList: React.FC = () => {
   return (
     <PaginatedTable
       id={ENTITIES_LIST_TABLE_ID}
-      activePage={(data?.page ?? 1) - 1}
+      activePage={activePage}
       columns={columns}
       headerCount={data?.total ?? 0}
       titleSize="s"

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
@@ -346,7 +346,7 @@ export class EntityStoreDataClient {
           deleteData,
         });
       } catch (e) {
-        logger.error(`Error deleting entity definition for ${entityType}: ${e.message}`);
+        logger.warn(`Error deleting entity definition for ${entityType}: ${e.message}`);
       }
       await deleteEntityIndexComponentTemplate({
         unitedDefinition,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[SecuritySolution]  Fix Pagination should reset when a new filter is applied to the entity table (#198129)](https://github.com/elastic/kibana/pull/198129)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2024-10-30T12:28:10Z","message":"[SecuritySolution]  Fix Pagination should reset when a new filter is applied to the entity table (#198129)\n\n## Summary\r\n\r\nFix \"Pagination should reset when a new filter is applied to the entity\r\ntable\"\r\n* Extra changes: I demoted some error logs to warning as part of\r\nhttps://github.com/elastic/security-team/issues/10951\r\n\r\n\r\nhttps://github.com/user-attachments/assets/16357db1-5e77-4c7f-ae94-9371d71c4970\r\n\r\n\r\n### How to test it?\r\n* Start kibana with data\r\n* Navigate to the security solution / entity analytics dashboard\r\n* Start the entity store\r\n* Navigate between pages and change the filter, sorting, and query.","sha":"40edfe1496348997d4f4a48654882fd0dc1d1a85","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","v9.0.0","Team: SecuritySolution","Theme: entity_analytics","Feature:Entity Analytics","Team:Entity Analytics","v8.16.0","backport:version","v8.17.0"],"number":198129,"url":"https://github.com/elastic/kibana/pull/198129","mergeCommit":{"message":"[SecuritySolution]  Fix Pagination should reset when a new filter is applied to the entity table (#198129)\n\n## Summary\r\n\r\nFix \"Pagination should reset when a new filter is applied to the entity\r\ntable\"\r\n* Extra changes: I demoted some error logs to warning as part of\r\nhttps://github.com/elastic/security-team/issues/10951\r\n\r\n\r\nhttps://github.com/user-attachments/assets/16357db1-5e77-4c7f-ae94-9371d71c4970\r\n\r\n\r\n### How to test it?\r\n* Start kibana with data\r\n* Navigate to the security solution / entity analytics dashboard\r\n* Start the entity store\r\n* Navigate between pages and change the filter, sorting, and query.","sha":"40edfe1496348997d4f4a48654882fd0dc1d1a85"}},"sourceBranch":"main","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/198129","number":198129,"mergeCommit":{"message":"[SecuritySolution]  Fix Pagination should reset when a new filter is applied to the entity table (#198129)\n\n## Summary\r\n\r\nFix \"Pagination should reset when a new filter is applied to the entity\r\ntable\"\r\n* Extra changes: I demoted some error logs to warning as part of\r\nhttps://github.com/elastic/security-team/issues/10951\r\n\r\n\r\nhttps://github.com/user-attachments/assets/16357db1-5e77-4c7f-ae94-9371d71c4970\r\n\r\n\r\n### How to test it?\r\n* Start kibana with data\r\n* Navigate to the security solution / entity analytics dashboard\r\n* Start the entity store\r\n* Navigate between pages and change the filter, sorting, and query.","sha":"40edfe1496348997d4f4a48654882fd0dc1d1a85"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/198315","number":198315,"state":"OPEN"}]}] BACKPORT-->