### PR TITLE
[8.x] [ftr] update svl shared config with cluster settings (#196336)

### DIFF
--- a/x-pack/test_serverless/shared/config.base.ts
+++ b/x-pack/test_serverless/shared/config.base.ts
@@ -94,6 +94,10 @@ export default async () => {
         'xpack.security.authc.realms.jwt.jwt1.order=-98',
         `xpack.security.authc.realms.jwt.jwt1.pkc_jwkset_path=${getDockerFileMountPath(jwksPath)}`,
         `xpack.security.authc.realms.jwt.jwt1.token_type=access_token`,
+        // controller cluster-settings
+        `cluster.service.slow_task_logging_threshold=15s`,
+        `cluster.service.slow_task_thread_dump_timeout=5s`,
+        `serverless.search.enable_replicas_for_instant_failover=true`,
       ],
       ssl: true, // SSL is required for SAML realm
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [ftr] update svl shared config with cluster settings (#196336) (05efaaaa)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2024-10-30T10:55:22Z","message":"[ftr] update svl shared config with cluster settings (#196336)\n\n## Summary\r\n\r\nAdding Elasticsearch cluster settings to replicate MKI cluster setup for\r\nFTR.","sha":"05efaaaab7fe1ea386833627df5a24956cc26530"},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->