### PR TITLE
[Search] Fix playground crash when adding connector

### DIFF
--- a/x-pack/plugins/search_playground/public/components/summarization_panel/summarization_model.tsx
+++ b/x-pack/plugins/search_playground/public/components/summarization_panel/summarization_model.tsx
@@ -93,7 +93,9 @@ export const SummarizationModel: React.FC<SummarizationModelProps> = ({
 
   useEffect(() => {
     usageTracker?.click(
-      `${AnalyticsEvents.modelSelected}_${selectedModel!.value || selectedModel!.connectorType}`
+      `${AnalyticsEvents.modelSelected}_${
+        selectedModel?.value || selectedModel?.connectorType || 'unknown'
+      }`
     );
   }, [usageTracker, selectedModel]);
 


### PR DESCRIPTION
Fixes an issue where Playground occasionally crashed because a connector model is undefined. 

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->