### PR TITLE
Fix flaky connector adapters test

### DIFF
--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/alerts.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/alerts.ts
@@ -1901,7 +1901,7 @@ instanceStateValue: true
          */
         const response = await alertUtils.createAlwaysFiringSystemAction({
           reference,
-          overwrites: { schedule: { interval: '1s' } },
+          overwrites: { schedule: { interval: '1m' } },
         });
 
         expect(response.status).to.eql(200);


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/198388

In this PR, I'm increasing the rule frequency to avoid rule actions running multiple times when asserting for the action to only have ran once.

Flaky test runner:
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7307

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->