### PR TITLE
[ci] More resources for check oas snapshot

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -474,7 +474,7 @@ steps:
       image: family/kibana-ubuntu-2004
       imageProject: elastic-images-prod
       provider: gcp
-      machineType: n2-standard-2
+      machineType: n2-standard-4
       preemptible: true
     timeout_in_minutes: 60
     retry:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -114,7 +114,7 @@ steps:
   - command: .buildkite/scripts/steps/checks/capture_oas_snapshot.sh
     label: 'Check OAS Snapshot'
     agents:
-      machineType: n2-standard-2
+      machineType: n2-standard-4
       preemptible: true
     timeout_in_minutes: 60
     retry:


### PR DESCRIPTION
This step doesn't have enough CPU/memory for the number of processes running.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->