### PR TITLE
[8.x] [Entity Analytics] [Entity Store] Show errors on entity store enablement (#198263)

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -39170,6 +39170,8 @@ components:
     Security_Entity_Analytics_API_EngineDescriptor:
       type: object
       properties:
+        error:
+          type: object
         fieldHistoryLength:
           type: integer
         filter:

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/common.gen.ts
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/common.gen.ts
@@ -36,6 +36,7 @@ export const EngineDescriptor = z.object({
   status: EngineStatus,
   filter: z.string().optional(),
   fieldHistoryLength: z.number().int(),
+  error: z.object({}).optional(),
 });
 
 export type InspectQuery = z.infer<typeof InspectQuery>;

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/common.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/entity_store/common.schema.yaml
@@ -30,6 +30,8 @@ components:
           type: string
         fieldHistoryLength:
           type: integer
+        error:
+          type: object
 
     EngineStatus:
       type: string

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -770,6 +770,8 @@ components:
     EngineDescriptor:
       type: object
       properties:
+        error:
+          type: object
         fieldHistoryLength:
           type: integer
         filter:

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -770,6 +770,8 @@ components:
     EngineDescriptor:
       type: object
       properties:
+        error:
+          type: object
         fieldHistoryLength:
           type: integer
         filter:

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_panels.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_panels.tsx
@@ -15,6 +15,7 @@ import {
   EuiLoadingLogo,
   EuiPanel,
   EuiImage,
+  EuiCallOut,
 } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -50,8 +51,24 @@ const EntityStoreDashboardPanelsComponent = () => {
   const entityStore = useEntityEngineStatus();
   const riskEngineStatus = useRiskEngineStatus();
 
-  const { enable: enableStore } = useEntityStoreEnablement();
+  const { enable: enableStore, query } = useEntityStoreEnablement();
+
   const { mutate: initRiskEngine } = useInitRiskEngineMutation();
+
+  const callouts = entityStore.errors.map((err, i) => (
+    <EuiCallOut
+      title={
+        <FormattedMessage
+          id="xpack.securitySolution.entityAnalytics.entityStore.enablement.errors.title"
+          defaultMessage={'An error occurred during entity store resource initialization'}
+        />
+      }
+      color="danger"
+      iconType="error"
+    >
+      <p>{err?.message}</p>
+    </EuiCallOut>
+  ));
 
   const enableEntityStore = (enable: Enablements) => () => {
     setModalState({ visible: false });
@@ -72,6 +89,26 @@ const EntityStoreDashboardPanelsComponent = () => {
       enableStore();
     }
   };
+
+  if (query.error) {
+    return (
+      <>
+        <EuiCallOut
+          title={
+            <FormattedMessage
+              id="xpack.securitySolution.entityAnalytics.entityStore.enablement.errors.queryErrorTitle"
+              defaultMessage={'There was a problem initializing the entity store'}
+            />
+          }
+          color="danger"
+          iconType="error"
+        >
+          <p>{(query.error as { body: { message: string } }).body.message}</p>
+        </EuiCallOut>
+        {callouts}
+      </>
+    );
+  }
 
   if (entityStore.status === 'loading') {
     return (
@@ -109,6 +146,29 @@ const EntityStoreDashboardPanelsComponent = () => {
 
   return (
     <EuiFlexGroup direction="column" data-test-subj="entityStorePanelsGroup">
+      {entityStore.status === 'error' && isRiskScoreAvailable && (
+        <>
+          {callouts}
+          <EuiFlexItem>
+            <EntityAnalyticsRiskScores riskEntity={RiskScoreEntity.user} />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EntityAnalyticsRiskScores riskEntity={RiskScoreEntity.host} />
+          </EuiFlexItem>
+        </>
+      )}
+      {entityStore.status === 'error' && !isRiskScoreAvailable && (
+        <>
+          {callouts}
+          <EuiFlexItem>
+            <EnableEntityStore
+              onEnable={() => setModalState({ visible: true })}
+              loadingRiskEngine={riskEngineInitializing}
+              enablements="riskScore"
+            />
+          </EuiFlexItem>
+        </>
+      )}
       {entityStore.status === 'enabled' && isRiskScoreAvailable && (
         <>
           <EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_engine_status.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_engine_status.ts
@@ -17,6 +17,10 @@ interface Options {
   polling?: UseQueryOptions<ListEntityEnginesResponse>['refetchInterval'];
 }
 
+interface EngineError {
+  message: string;
+}
+
 export const useEntityEngineStatus = (opts: Options = {}) => {
   // QUESTION: Maybe we should have an `EnablementStatus` API route for this?
   const { listEntityEngines } = useEntityStoreRoutes();
@@ -31,6 +35,10 @@ export const useEntityEngineStatus = (opts: Options = {}) => {
   const status = (() => {
     if (data?.count === 0) {
       return 'not_installed';
+    }
+
+    if (data?.engines?.some((engine) => engine.status === 'error')) {
+      return 'error';
     }
 
     if (data?.engines?.every((engine) => engine.status === 'stopped')) {
@@ -52,7 +60,12 @@ export const useEntityEngineStatus = (opts: Options = {}) => {
     return 'enabled';
   })();
 
+  const errors = (data?.engines
+    ?.filter((engine) => engine.status === 'error')
+    .map((engine) => engine.error) ?? []) as EngineError[];
+
   return {
     status,
+    errors,
   };
 };

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
@@ -41,7 +41,7 @@ export const useEntityStoreEnablement = () => {
   });
 
   const { initEntityStore } = useEntityStoreRoutes();
-  const { refetch: initialize } = useQuery({
+  const { refetch: initialize, ...query } = useQuery({
     queryKey: [ENTITY_STORE_ENABLEMENT_INIT],
     queryFn: () => Promise.all([initEntityStore('user'), initEntityStore('host')]),
     enabled: false,
@@ -51,10 +51,10 @@ export const useEntityStoreEnablement = () => {
     telemetry?.reportEntityStoreInit({
       timestamp: new Date().toISOString(),
     });
-    initialize().then(() => setPolling(true));
+    return initialize().then(() => setPolling(true));
   }, [initialize, telemetry]);
 
-  return { enable };
+  return { enable, query };
 };
 
 export const INIT_ENTITY_ENGINE_STATUS_KEY = ['POST', 'INIT_ENTITY_ENGINE'];

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
@@ -280,7 +280,14 @@ export class EntityStoreDataClient {
         error: err.message,
       });
 
-      await this.engineClient.update(entityType, ENGINE_STATUS.ERROR);
+      await this.engineClient.update(entityType, {
+        status: ENGINE_STATUS.ERROR,
+        error: {
+          message: err.message,
+          stack: err.stack,
+          action: 'init',
+        },
+      });
 
       await this.delete(entityType, taskManager, { deleteData: true, deleteEngine: false });
     }
@@ -319,7 +326,7 @@ export class EntityStoreDataClient {
     const fullEntityDefinition = await this.getExistingEntityDefinition(entityType);
     await this.entityClient.startEntityDefinition(fullEntityDefinition);
 
-    return this.engineClient.update(entityType, ENGINE_STATUS.STARTED);
+    return this.engineClient.updateStatus(entityType, ENGINE_STATUS.STARTED);
   }
 
   public async stop(entityType: EntityType) {
@@ -339,7 +346,7 @@ export class EntityStoreDataClient {
     const fullEntityDefinition = await this.getExistingEntityDefinition(entityType);
     await this.entityClient.stopEntityDefinition(fullEntityDefinition);
 
-    return this.engineClient.update(entityType, ENGINE_STATUS.STOPPED);
+    return this.engineClient.updateStatus(entityType, ENGINE_STATUS.STOPPED);
   }
 
   public async get(entityType: EntityType) {
@@ -510,7 +517,7 @@ export class EntityStoreDataClient {
         }
 
         // Update savedObject status
-        await this.engineClient.update(engine.type, ENGINE_STATUS.UPDATING);
+        await this.engineClient.updateStatus(engine.type, ENGINE_STATUS.UPDATING);
 
         try {
           // Update entity manager definition
@@ -523,12 +530,12 @@ export class EntityStoreDataClient {
           });
 
           // Restore the savedObject status and set the new index pattern
-          await this.engineClient.update(engine.type, originalStatus);
+          await this.engineClient.updateStatus(engine.type, originalStatus);
 
           return { type: engine.type, changes: { indexPatterns } };
         } catch (error) {
           // Rollback the engine initial status when the update fails
-          await this.engineClient.update(engine.type, originalStatus);
+          await this.engineClient.updateStatus(engine.type, originalStatus);
 
           throw error;
         }

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/saved_object/engine_descriptor.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/saved_object/engine_descriptor.ts
@@ -78,15 +78,19 @@ export class EngineDescriptorClient {
     return attributes;
   }
 
-  async update(entityType: EntityType, status: EngineStatus) {
+  async update(entityType: EntityType, engine: Partial<EngineDescriptor>) {
     const id = this.getSavedObjectId(entityType);
     const { attributes } = await this.deps.soClient.update<EngineDescriptor>(
       entityEngineDescriptorTypeName,
       id,
-      { status },
+      engine,
       { refresh: 'wait_for' }
     );
     return attributes;
+  }
+
+  async updateStatus(entityType: EntityType, status: EngineStatus) {
+    return this.update(entityType, { status });
   }
 
   async find(entityType: EntityType): Promise<SavedObjectsFindResponse<EngineDescriptor>> {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Entity Analytics] [Entity Store] Show errors on entity store enablement (#198263) (4538481b)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tiago Vila Verde","email":"tiago.vilaverde@elastic.co"},"sourceCommit":{"committedDate":"2024-10-31T03:44:43Z","message":"[Entity Analytics] [Entity Store] Show errors on entity store enablement (#198263)\n\n## Summary\r\n\r\nThis PR adds user feedback for errors that happen when enabling the\r\nentity store.\r\nAny errors during the async setup of store resources will show up as\r\ntoasts, whist initial INIT request failures will appear as an error\r\ncallout.\r\n\r\n![Screenshot 2024-10-29 at 16 48\r\n03](https://github.com/user-attachments/assets/12aa9af3-1e27-44b1-85e5-5053255bd333)\r\n![Screenshot 2024-10-29 at 16 47\r\n19](https://github.com/user-attachments/assets/31790981-599b-4fba-a423-b75e31dbe7be)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"4538481be0c7f519fe716cca611b2ebfa5f89351"},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->