### PR TITLE
[8.16] [Entity Analytics] [Entity Store] Run init requests sequentially to prevent resource exists error (#198268)

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_panels.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_panels.tsx
@@ -66,6 +66,7 @@ const EntityStoreDashboardPanelsComponent = () => {
       };
       setRiskEngineInitializing(true);
       initRiskEngine(undefined, options);
+      return;
     }
 
     if (enable.entityStore) {

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
@@ -43,7 +43,8 @@ export const useEntityStoreEnablement = () => {
   const { initEntityStore } = useEntityStoreRoutes();
   const { refetch: initialize } = useQuery({
     queryKey: [ENTITY_STORE_ENABLEMENT_INIT],
-    queryFn: () => Promise.all([initEntityStore('user'), initEntityStore('host')]),
+    queryFn: async () =>
+      initEntityStore('user').then((usr) => initEntityStore('host').then((host) => [usr, host])),
     enabled: false,
   });
 
@@ -79,7 +80,9 @@ export const useInitEntityEngineMutation = (options?: UseMutationOptions<{}>) =>
         timestamp: new Date().toISOString(),
         action: 'start',
       });
-      return Promise.all([initEntityStore('user'), initEntityStore('host')]);
+      return initEntityStore('user').then((usr) =>
+        initEntityStore('host').then((host) => [usr, host])
+      );
     },
     {
       ...options,
@@ -107,7 +110,9 @@ export const useStopEntityEngineMutation = (options?: UseMutationOptions<{}>) =>
         timestamp: new Date().toISOString(),
         action: 'stop',
       });
-      return Promise.all([stopEntityStore('user'), stopEntityStore('host')]);
+      return stopEntityStore('user').then((usr) =>
+        stopEntityStore('host').then((host) => [usr, host])
+      );
     },
     {
       ...options,
@@ -129,7 +134,10 @@ export const useDeleteEntityEngineMutation = (options?: UseMutationOptions<{}>) 
   const invalidateEntityEngineStatusQuery = useInvalidateEntityEngineStatusQuery();
   const { deleteEntityEngine } = useEntityStoreRoutes();
   return useMutation<DeleteEntityEngineResponse[]>(
-    () => Promise.all([deleteEntityEngine('user', true), deleteEntityEngine('host', true)]),
+    () =>
+      deleteEntityEngine('user', true).then((usr) =>
+        deleteEntityEngine('host', true).then((host) => [usr, host])
+      ),
     {
       ...options,
       mutationKey: DELETE_ENTITY_ENGINE_STATUS_KEY,

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/elasticsearch_assets/ingest_pipeline.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/elasticsearch_assets/ingest_pipeline.ts
@@ -125,7 +125,7 @@ export const createPlatformPipeline = async ({
         managed_by: 'entity_store',
         managed: true,
       },
-      description: `Ingest pipeline for entity defiinition ${entityManagerDefinition.id}`,
+      description: `Ingest pipeline for entity definition ${entityManagerDefinition.id}`,
       processors: buildIngestPipeline({
         namespace: unitedDefinition.namespace,
         version: unitedDefinition.version,

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
@@ -143,7 +143,7 @@ export class EntityStoreDataClient {
       );
     }
     logger.info(
-      `In namespace ${this.options.namespace}: Initializing entity store for ${entityType}`
+      `[Entity Store] In namespace ${this.options.namespace}: Initializing entity store for ${entityType}`
     );
 
     const descriptor = await this.engineClient.init(entityType, {
@@ -151,7 +151,7 @@ export class EntityStoreDataClient {
       fieldHistoryLength,
       indexPattern,
     });
-    logger.debug(`Initialized engine for ${entityType}`);
+    logger.debug(`[Entity Store] Initialized saved object for ${entityType}`);
     // first create the entity definition without starting it
     // so that the index template is created which we can add a component template to
 
@@ -164,7 +164,9 @@ export class EntityStoreDataClient {
       config,
       pipelineDebugMode
     ).catch((error) => {
-      logger.error(`There was an error during async setup of the Entity Store: ${error.message}`);
+      logger.error(
+        `[Entity Store] There was an error during async setup of the Entity Store: ${error.message}`
+      );
     });
 
     return descriptor;
@@ -259,7 +261,7 @@ export class EntityStoreDataClient {
         logger,
         taskManager,
       });
-      logger.info(`Entity store initialized for ${entityType}`);
+      debugLog(`Entity store initialized`);
 
       const setupEndTime = moment().utc().toISOString();
       const duration = moment(setupEndTime).diff(moment(setupStartTime), 'seconds');
@@ -270,7 +272,7 @@ export class EntityStoreDataClient {
       return updated;
     } catch (err) {
       this.options.logger.error(
-        `Error initializing entity store for ${entityType}: ${err.message}`
+        `[Entity Store] Error initializing entity store for ${entityType}: ${err.message}`
       );
 
       this.options.telemetry?.reportEvent(ENTITY_ENGINE_RESOURCE_INIT_FAILURE_EVENT.eventType, {
@@ -367,7 +369,9 @@ export class EntityStoreDataClient {
       frequency: `${config.frequency.asSeconds()}s`,
     });
     const { entityManagerDefinition } = unitedDefinition;
-    logger.info(`In namespace ${namespace}: Deleting entity store for ${entityType}`);
+    logger.info(
+      `[Entity Store] In namespace ${namespace}: Deleting entity store for ${entityType}`
+    );
     try {
       try {
         await this.entityClient.deleteEntityDefinition({
@@ -414,6 +418,7 @@ export class EntityStoreDataClient {
         });
       }
 
+      logger.info(`[Entity Store] In namespace ${namespace}: Deleted store for ${entityType}`);
       return { deleted: true };
     } catch (e) {
       logger.error(`Error deleting entity store for ${entityType}: ${e.message}`);

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/task/field_retention_enrichment_task.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/task/field_retention_enrichment_task.ts
@@ -36,12 +36,12 @@ import {
 const logFactory =
   (logger: Logger, taskId: string) =>
   (message: string): void =>
-    logger.info(`[task ${taskId}]: ${message}`);
+    logger.info(`[Entity Store] [task ${taskId}]: ${message}`);
 
 const debugLogFactory =
   (logger: Logger, taskId: string) =>
   (message: string): void =>
-    logger.debug(`[task ${taskId}]: ${message}`);
+    logger.debug(`[Entity Store] [task ${taskId}]: ${message}`);
 
 const getTaskName = (): string => TYPE;
 
@@ -65,7 +65,9 @@ export const registerEntityStoreFieldRetentionEnrichTask = ({
   taskManager: TaskManagerSetupContract | undefined;
 }): void => {
   if (!taskManager) {
-    logger.info('Task Manager is unavailable; skipping entity store enrich policy registration.');
+    logger.info(
+      '[Entity Store]  Task Manager is unavailable; skipping entity store enrich policy registration.'
+    );
     return;
   }
 
@@ -134,7 +136,7 @@ export const startEntityStoreFieldRetentionEnrichTask = async ({
       params: { version: VERSION },
     });
   } catch (e) {
-    logger.warn(`[task ${taskId}]: error scheduling task, received ${e.message}`);
+    logger.warn(`[Entity Store]  [task ${taskId}]: error scheduling task, received ${e.message}`);
     throw e;
   }
 };
@@ -150,9 +152,14 @@ export const removeEntityStoreFieldRetentionEnrichTask = async ({
 }) => {
   try {
     await taskManager.remove(getTaskId(namespace));
+    logger.info(
+      `[Entity Store]  Removed entity store enrich policy task for namespace ${namespace}`
+    );
   } catch (err) {
     if (!SavedObjectsErrorHelpers.isNotFoundError(err)) {
-      logger.error(`Failed to remove  entity store enrich policy task: ${err.message}`);
+      logger.error(
+        `[Entity Store]  Failed to remove  entity store enrich policy task: ${err.message}`
+      );
       throw err;
     }
   }
@@ -233,7 +240,7 @@ export const runTask = async ({
       state: updatedState,
     };
   } catch (e) {
-    logger.error(`[task ${taskId}]: error running task, received ${e.message}`);
+    logger.error(`[Entity Store] [task ${taskId}]: error running task, received ${e.message}`);
     throw e;
   }
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Entity Analytics] [Entity Store] Run init requests sequentially to prevent resource exists error (#198268) (6a50066e)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tiago Vila Verde","email":"tiago.vilaverde@elastic.co"},"sourceCommit":{"committedDate":"2024-10-30T16:03:07Z","message":"[Entity Analytics] [Entity Store] Run init requests sequentially to prevent resource exists error (#198268)\n\n## Summary\r\n\r\nThis PR fixes an issue where running init for both `user` and `host`\r\nentity engines in parallel would cause a race condition while enabling\r\nthe risk engine, resulting in a `Resource already exists` error.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"6a50066e00ae38a64c5365fd66b4dc32857ba1fc"},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->