### PR TITLE
[Search][Connectors] Validating connectors name

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
@@ -7,6 +7,7 @@
 
 import React, { ChangeEvent } from 'react';
 
+import { css } from '@emotion/react';
 import { useActions, useValues } from 'kea';
 
 import {
@@ -27,6 +28,7 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import * as Constants from '../../../../shared/constants';
+import { isValidIndexName } from '../../../utils/validate_index_name';
 import { GeneratedConfigFields } from '../../connector_detail/components/generated_config_fields';
 
 import { ConnectorViewLogic } from '../../connector_detail/connector_view_logic';
@@ -71,6 +73,21 @@ export const StartStep: React.FC<StartStepProps> = ({
     setRawName(e.target.value);
   };
 
+  const formError = () => {
+    if (!isValidIndexName(rawName)) {
+      return i18n.translate(
+        'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputHelpText.lineOne',
+        {
+          defaultMessage: '{connectorName} is an invalid index name',
+          values: {
+            connectorName: rawName,
+          },
+        }
+      );
+    }
+    return error;
+  };
+
   return (
     <EuiForm component="form" id="enterprise-search-create-connector">
       <EuiFlexGroup gutterSize="m" direction="column">
@@ -100,6 +117,33 @@ export const StartStep: React.FC<StartStepProps> = ({
                     'xpack.enterpriseSearch.createConnector.startStep.euiFormRow.connectorNameLabel',
                     { defaultMessage: 'Connector name' }
                   )}
+                  helpText={
+                    <>
+                      <EuiText
+                        size="xs"
+                        css={css`
+                          line-break: anywhere;
+                        `}
+                        color="danger"
+                      >
+                        {formError()}
+                      </EuiText>
+                      <EuiText
+                        size="xs"
+                        css={css`
+                          line-break: anywhere;
+                        `}
+                      >
+                        {i18n.translate(
+                          'xpack.enterpriseSearch.startStep.namesShouldBeLowercaseTextLabel',
+                          {
+                            defaultMessage:
+                              'Names should be lowercase and cannot contain spaces or special characters.',
+                          }
+                        )}
+                      </EuiText>
+                    </>
+                  }
                 >
                   <EuiFieldText
                     data-test-subj="enterpriseSearchStartStepFieldText"
@@ -205,9 +249,11 @@ export const StartStep: React.FC<StartStepProps> = ({
               hasShadow={false}
               hasBorder
               paddingSize="l"
-              color={selectedConnector?.name ? 'plain' : 'subdued'}
+              color={selectedConnector?.name && isValidIndexName(rawName) ? 'plain' : 'subdued'}
             >
-              <EuiText color={selectedConnector?.name ? 'default' : 'subdued'}>
+              <EuiText
+                color={selectedConnector?.name && isValidIndexName(rawName) ? 'default' : 'subdued'}
+              >
                 <h3>
                   {i18n.translate(
                     'xpack.enterpriseSearch.createConnector.startStep.h4.deploymentLabel',
@@ -218,7 +264,10 @@ export const StartStep: React.FC<StartStepProps> = ({
                 </h3>
               </EuiText>
               <EuiSpacer size="m" />
-              <EuiText color={selectedConnector?.name ? 'default' : 'subdued'} size="s">
+              <EuiText
+                color={selectedConnector?.name && isValidIndexName(rawName) ? 'default' : 'subdued'}
+                size="s"
+              >
                 <p>
                   {i18n.translate(
                     'xpack.enterpriseSearch.createConnector.startStep.p.youWillStartTheLabel',
@@ -242,7 +291,7 @@ export const StartStep: React.FC<StartStepProps> = ({
                   }
                 }}
                 fill
-                disabled={!canConfigureConnector}
+                disabled={!canConfigureConnector || !isValidIndexName(rawName)}
                 isLoading={isCreateLoading || isGenerateLoading}
               >
                 {Constants.NEXT_BUTTON_LABEL}
@@ -252,12 +301,14 @@ export const StartStep: React.FC<StartStepProps> = ({
         ) : (
           <EuiFlexItem>
             <EuiPanel
-              color={selectedConnector?.name ? 'plain' : 'subdued'}
+              color={selectedConnector?.name && isValidIndexName(rawName) ? 'plain' : 'subdued'}
               hasShadow={false}
               hasBorder
               paddingSize="l"
             >
-              <EuiText color={selectedConnector?.name ? 'default' : 'subdued'}>
+              <EuiText
+                color={selectedConnector?.name && isValidIndexName(rawName) ? 'default' : 'subdued'}
+              >
                 <h3>
                   {i18n.translate(
                     'xpack.enterpriseSearch.createConnector.startStep.h4.configureIndexAndAPILabel',
@@ -268,7 +319,10 @@ export const StartStep: React.FC<StartStepProps> = ({
                 </h3>
               </EuiText>
               <EuiSpacer size="m" />
-              <EuiText color={selectedConnector?.name ? 'default' : 'subdued'} size="s">
+              <EuiText
+                color={selectedConnector?.name && isValidIndexName(rawName) ? 'default' : 'subdued'}
+                size="s"
+              >
                 <p>
                   {i18n.translate(
                     'xpack.enterpriseSearch.createConnector.startStep.p.thisProcessWillCreateLabel',
@@ -309,7 +363,7 @@ export const StartStep: React.FC<StartStepProps> = ({
                     <EuiButton
                       data-test-subj="entSearchContent-connector-configuration-generateConfigButton"
                       data-telemetry-id="entSearchContent-connector-configuration-generateConfigButton"
-                      disabled={!canConfigureConnector}
+                      disabled={!canConfigureConnector || !isValidIndexName(rawName)}
                       fill
                       iconType="sparkles"
                       isLoading={isGenerateLoading || isCreateLoading}
@@ -330,7 +384,12 @@ export const StartStep: React.FC<StartStepProps> = ({
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <ManualConfiguration
-                      isDisabled={isGenerateLoading || isCreateLoading || !canConfigureConnector}
+                      isDisabled={
+                        isGenerateLoading ||
+                        isCreateLoading ||
+                        !canConfigureConnector ||
+                        !isValidIndexName(rawName)
+                      }
                       selfManagePreference={selfManagePreference}
                     />
                   </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
@@ -76,7 +76,7 @@ export const StartStep: React.FC<StartStepProps> = ({
   const formError = () => {
     if (!isValidIndexName(rawName)) {
       return i18n.translate(
-        'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputHelpText.lineOne',
+        'xpack.enterpriseSearch.createConnector.startStep.euiFormRow.nameInputHelpText.lineOne',
         {
           defaultMessage: '{connectorName} is an invalid index name',
           values: {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
@@ -242,10 +242,16 @@ export const StartStep: React.FC<StartStepProps> = ({
               hasShadow={false}
               hasBorder
               paddingSize="l"
-              color={selectedConnector?.name && isValidIndexName(rawName) ? 'plain' : 'subdued'}
+              color={
+                selectedConnector?.name && isValidIndexName(rawName) && !error ? 'plain' : 'subdued'
+              }
             >
               <EuiText
-                color={selectedConnector?.name && isValidIndexName(rawName) ? 'default' : 'subdued'}
+                color={
+                  selectedConnector?.name && isValidIndexName(rawName) && !error
+                    ? 'default'
+                    : 'subdued'
+                }
               >
                 <h3>
                   {i18n.translate(
@@ -284,7 +290,7 @@ export const StartStep: React.FC<StartStepProps> = ({
                   }
                 }}
                 fill
-                disabled={!canConfigureConnector || !isValidIndexName(rawName)}
+                disabled={!canConfigureConnector || !isValidIndexName(rawName) || Boolean(error)}
                 isLoading={isCreateLoading || isGenerateLoading}
               >
                 {Constants.NEXT_BUTTON_LABEL}
@@ -294,13 +300,19 @@ export const StartStep: React.FC<StartStepProps> = ({
         ) : (
           <EuiFlexItem>
             <EuiPanel
-              color={selectedConnector?.name && isValidIndexName(rawName) ? 'plain' : 'subdued'}
+              color={
+                selectedConnector?.name && isValidIndexName(rawName) && !error ? 'plain' : 'subdued'
+              }
               hasShadow={false}
               hasBorder
               paddingSize="l"
             >
               <EuiText
-                color={selectedConnector?.name && isValidIndexName(rawName) ? 'default' : 'subdued'}
+                color={
+                  selectedConnector?.name && isValidIndexName(rawName) && !error
+                    ? 'default'
+                    : 'subdued'
+                }
               >
                 <h3>
                   {i18n.translate(
@@ -313,7 +325,11 @@ export const StartStep: React.FC<StartStepProps> = ({
               </EuiText>
               <EuiSpacer size="m" />
               <EuiText
-                color={selectedConnector?.name && isValidIndexName(rawName) ? 'default' : 'subdued'}
+                color={
+                  selectedConnector?.name && isValidIndexName(rawName) && !error
+                    ? 'default'
+                    : 'subdued'
+                }
                 size="s"
               >
                 <p>
@@ -356,7 +372,9 @@ export const StartStep: React.FC<StartStepProps> = ({
                     <EuiButton
                       data-test-subj="entSearchContent-connector-configuration-generateConfigButton"
                       data-telemetry-id="entSearchContent-connector-configuration-generateConfigButton"
-                      disabled={!canConfigureConnector || !isValidIndexName(rawName)}
+                      disabled={
+                        !canConfigureConnector || !isValidIndexName(rawName) || Boolean(error)
+                      }
                       fill
                       iconType="sparkles"
                       isLoading={isGenerateLoading || isCreateLoading}
@@ -381,7 +399,8 @@ export const StartStep: React.FC<StartStepProps> = ({
                         isGenerateLoading ||
                         isCreateLoading ||
                         !canConfigureConnector ||
-                        !isValidIndexName(rawName)
+                        !isValidIndexName(rawName) ||
+                        Boolean(error)
                       }
                       selfManagePreference={selfManagePreference}
                     />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
@@ -116,26 +116,15 @@ export const StartStep: React.FC<StartStepProps> = ({
                   )}
                   helpText={
                     <>
-                      <EuiText
-                        size="xs"
-                        css={css`
-                          line-break: anywhere;
-                        `}
-                        color="danger"
-                      >
+                      <EuiText size="xs" grow={false} color="danger">
                         {formError}
                       </EuiText>
-                      <EuiText
-                        size="xs"
-                        css={css`
-                          line-break: anywhere;
-                        `}
-                      >
+                      <EuiText size="xs" grow={false}>
                         {i18n.translate(
                           'xpack.enterpriseSearch.startStep.namesShouldBeLowercaseTextLabel',
                           {
                             defaultMessage:
-                              'It should be lowercase and cannot contain spaces or special characters.',
+                              'The connector name should be lowercase and cannot contain spaces or special characters.',
                           }
                         )}
                       </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
@@ -138,7 +138,7 @@ export const StartStep: React.FC<StartStepProps> = ({
                           'xpack.enterpriseSearch.startStep.namesShouldBeLowercaseTextLabel',
                           {
                             defaultMessage:
-                              'Names should be lowercase and cannot contain spaces or special characters.',
+                              'It should be lowercase and cannot contain spaces or special characters.',
                           }
                         )}
                       </EuiText>
@@ -172,6 +172,14 @@ export const StartStep: React.FC<StartStepProps> = ({
                   'xpack.enterpriseSearch.createConnector.startStep.euiFormRow.descriptionLabel',
                   { defaultMessage: 'Description' }
                 )}
+                labelAppend={
+                  <EuiText size="xs">
+                    {i18n.translate(
+                      'xpack.enterpriseSearch.createConnector.startStep.euiFormRow.descriptionLabelAppend',
+                      { defaultMessage: 'Optional' }
+                    )}
+                  </EuiText>
+                }
               >
                 <EuiFieldText
                   data-test-subj="enterpriseSearchStartStepFieldText"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
@@ -73,9 +73,9 @@ export const StartStep: React.FC<StartStepProps> = ({
     setRawName(e.target.value);
   };
 
-  const formError = () => {
-    if (!isValidIndexName(rawName)) {
-      return i18n.translate(
+  const formError = isValidIndexName(rawName)
+    ? error
+    : i18n.translate(
         'xpack.enterpriseSearch.createConnector.startStep.euiFormRow.nameInputHelpText.lineOne',
         {
           defaultMessage: '{connectorName} is an invalid index name',
@@ -84,9 +84,6 @@ export const StartStep: React.FC<StartStepProps> = ({
           },
         }
       );
-    }
-    return error;
-  };
 
   return (
     <EuiForm component="form" id="enterprise-search-create-connector">
@@ -126,7 +123,7 @@ export const StartStep: React.FC<StartStepProps> = ({
                         `}
                         color="danger"
                       >
-                        {formError()}
+                        {formError}
                       </EuiText>
                       <EuiText
                         size="xs"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
@@ -7,7 +7,6 @@
 
 import React, { ChangeEvent } from 'react';
 
-import { css } from '@emotion/react';
 import { useActions, useValues } from 'kea';
 
 import {


### PR DESCRIPTION
## Summary

Validating connectors name field before letting press Generate config or Next.

![CleanShot 2024-10-31 at 10 36 26](https://github.com/user-attachments/assets/3a9a1d93-89a5-425f-a932-666c59a7019c)




<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->