### PR TITLE
[8.16] [EEM] Replace hashed ID with human readable ID (#193652)

### DIFF
--- a/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/ci_checks/saved_objects/check_registered_types.test.ts
@@ -91,7 +91,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "endpoint:unified-user-artifact-manifest": "71c7fcb52c658b21ea2800a6b6a76972ae1c776e",
         "endpoint:user-artifact-manifest": "1c3533161811a58772e30cdc77bac4631da3ef2b",
         "enterprise_search_telemetry": "9ac912e1417fc8681e0cd383775382117c9e3d3d",
-        "entity-definition": "e3811fd5fbb878d170067c0d6897a2e63010af36",
+        "entity-definition": "1c6bff35c423d5dc5650bc806cf2899e4706a0bc",
         "entity-discovery-api-key": "c267a65c69171d1804362155c1378365f5acef88",
         "entity-engine-status": "8cb7dcb13f5e2ea8f2e08dd4af72c110e2051120",
         "epm-packages": "8042d4a1522f6c4e6f5486e791b3ffe3a22f88fd",

--- a/x-pack/packages/kbn-entities-schema/src/schema/common.ts
+++ b/x-pack/packages/kbn-entities-schema/src/schema/common.ts
@@ -145,7 +145,7 @@ export type MetadataField = z.infer<typeof metadataSchema>;
 export const identityFieldsSchema = z
   .object({
     field: z.string(),
-    optional: z.boolean(),
+    optional: z.literal(false),
   })
   .or(z.string().transform((value) => ({ field: value, optional: false })));
 

--- a/x-pack/plugins/entity_manager/server/lib/entities/helpers/fixtures/builtin_entity_definition.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/helpers/fixtures/builtin_entity_definition.ts
@@ -16,8 +16,8 @@ export const builtInEntityDefinition = entityDefinitionSchema.parse({
   latest: {
     timestampField: '@timestamp',
   },
-  identityFields: ['log.logger', { field: 'event.category', optional: true }],
-  displayNameTemplate: '{{log.logger}}{{#event.category}}:{{.}}{{/event.category}}',
+  identityFields: ['log.logger'],
+  displayNameTemplate: '{{log.logger}}',
   metadata: ['tags', 'host.name', 'host.os.name', { source: '_index', destination: 'sourceIndex' }],
   metrics: [],
 });

--- a/x-pack/plugins/entity_manager/server/lib/entities/helpers/fixtures/entity_definition.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/helpers/fixtures/entity_definition.ts
@@ -20,8 +20,8 @@ export const rawEntityDefinition = {
       syncDelay: '10s',
     },
   },
-  identityFields: ['log.logger', { field: 'event.category', optional: true }],
-  displayNameTemplate: '{{log.logger}}{{#event.category}}:{{.}}{{/event.category}}',
+  identityFields: ['log.logger'],
+  displayNameTemplate: '{{log.logger}}',
   metadata: ['tags', 'host.name', 'host.os.name', { source: '_index', destination: 'sourceIndex' }],
   metrics: [
     {

--- a/x-pack/plugins/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_latest_processors.test.ts.snap
+++ b/x-pack/plugins/entity_manager/server/lib/entities/ingest_pipeline/__snapshots__/generate_latest_processors.test.ts.snap
@@ -37,52 +37,13 @@ Array [
       "field": "entity.identityFields",
       "value": Array [
         "log.logger",
-        "event.category",
       ],
     },
   },
   Object {
-    "script": Object {
-      "description": "Generated the entity.id field",
-      "source": "// This function will recursively collect all the values of a HashMap of HashMaps
-Collection collectValues(HashMap subject) {
-  Collection values = new ArrayList();
-  // Iterate through the values
-  for(Object value: subject.values()) {
-    // If the value is a HashMap, recurse
-    if (value instanceof HashMap) {
-      values.addAll(collectValues((HashMap) value));
-    } else {
-      values.add(String.valueOf(value));
-    }
-  }
-  return values;
-}
-// Create the string builder
-StringBuilder entityId = new StringBuilder();
-if (ctx[\\"entity\\"][\\"identity\\"] != null) {
-  // Get the values as a collection
-  Collection values = collectValues(ctx[\\"entity\\"][\\"identity\\"]);
-  // Convert to a list and sort
-  List sortedValues = new ArrayList(values);
-  Collections.sort(sortedValues);
-  // Create comma delimited string
-  for(String instanceValue: sortedValues) {
-    entityId.append(instanceValue);
-    entityId.append(\\":\\");
-  }
-  // Assign the entity.id
-  ctx[\\"entity\\"][\\"id\\"] = entityId.length() > 0 ? entityId.substring(0, entityId.length() - 1) : \\"unknown\\";
-}",
-    },
-  },
-  Object {
-    "fingerprint": Object {
-      "fields": Array [
-        "entity.id",
-      ],
-      "method": "MurmurHash3",
-      "target_field": "entity.id",
+    "set": Object {
+      "field": "entity.id",
+      "value": "{{{entity.identity.log.logger}}}",
     },
   },
   Object {
@@ -124,13 +85,6 @@ if (ctx.entity?.metadata?.sourceIndex?.data != null) {
     },
   },
   Object {
-    "set": Object {
-      "field": "event.category",
-      "if": "ctx.entity?.identity?.event?.category != null",
-      "value": "{{entity.identity.event.category}}",
-    },
-  },
-  Object {
     "remove": Object {
       "field": "entity.identity",
       "ignore_missing": true,
@@ -139,7 +93,7 @@ if (ctx.entity?.metadata?.sourceIndex?.data != null) {
   Object {
     "set": Object {
       "field": "entity.displayName",
-      "value": "{{log.logger}}{{#event.category}}:{{.}}{{/event.category}}",
+      "value": "{{log.logger}}",
     },
   },
   Object {
@@ -188,52 +142,13 @@ Array [
       "field": "entity.identityFields",
       "value": Array [
         "log.logger",
-        "event.category",
       ],
     },
   },
   Object {
-    "script": Object {
-      "description": "Generated the entity.id field",
-      "source": "// This function will recursively collect all the values of a HashMap of HashMaps
-Collection collectValues(HashMap subject) {
-  Collection values = new ArrayList();
-  // Iterate through the values
-  for(Object value: subject.values()) {
-    // If the value is a HashMap, recurse
-    if (value instanceof HashMap) {
-      values.addAll(collectValues((HashMap) value));
-    } else {
-      values.add(String.valueOf(value));
-    }
-  }
-  return values;
-}
-// Create the string builder
-StringBuilder entityId = new StringBuilder();
-if (ctx[\\"entity\\"][\\"identity\\"] != null) {
-  // Get the values as a collection
-  Collection values = collectValues(ctx[\\"entity\\"][\\"identity\\"]);
-  // Convert to a list and sort
-  List sortedValues = new ArrayList(values);
-  Collections.sort(sortedValues);
-  // Create comma delimited string
-  for(String instanceValue: sortedValues) {
-    entityId.append(instanceValue);
-    entityId.append(\\":\\");
-  }
-  // Assign the entity.id
-  ctx[\\"entity\\"][\\"id\\"] = entityId.length() > 0 ? entityId.substring(0, entityId.length() - 1) : \\"unknown\\";
-}",
-    },
-  },
-  Object {
-    "fingerprint": Object {
-      "fields": Array [
-        "entity.id",
-      ],
-      "method": "MurmurHash3",
-      "target_field": "entity.id",
+    "set": Object {
+      "field": "entity.id",
+      "value": "{{{entity.identity.log.logger}}}",
     },
   },
   Object {
@@ -275,13 +190,6 @@ if (ctx.entity?.metadata?.sourceIndex?.data != null) {
     },
   },
   Object {
-    "set": Object {
-      "field": "event.category",
-      "if": "ctx.entity?.identity?.event?.category != null",
-      "value": "{{entity.identity.event.category}}",
-    },
-  },
-  Object {
     "remove": Object {
       "field": "entity.identity",
       "ignore_missing": true,
@@ -290,7 +198,7 @@ if (ctx.entity?.metadata?.sourceIndex?.data != null) {
   Object {
     "set": Object {
       "field": "entity.displayName",
-      "value": "{{log.logger}}{{#event.category}}:{{.}}{{/event.category}}",
+      "value": "{{log.logger}}",
     },
   },
   Object {

--- a/x-pack/plugins/entity_manager/server/lib/entities/ingest_pipeline/generate_latest_processors.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/ingest_pipeline/generate_latest_processors.ts
@@ -140,52 +140,13 @@ export function generateLatestProcessors(definition: EntityDefinition) {
       },
     },
     {
-      script: {
-        description: 'Generated the entity.id field',
-        source: cleanScript(`
-        // This function will recursively collect all the values of a HashMap of HashMaps
-        Collection collectValues(HashMap subject) {
-          Collection values = new ArrayList();
-          // Iterate through the values
-          for(Object value: subject.values()) {
-            // If the value is a HashMap, recurse
-            if (value instanceof HashMap) {
-              values.addAll(collectValues((HashMap) value));
-            } else {
-              values.add(String.valueOf(value));
-            }
-          }
-          return values;
-        }
-
-        // Create the string builder
-        StringBuilder entityId = new StringBuilder();
-
-        if (ctx["entity"]["identity"] != null) {
-          // Get the values as a collection
-          Collection values = collectValues(ctx["entity"]["identity"]);
-
-          // Convert to a list and sort
-          List sortedValues = new ArrayList(values);
-          Collections.sort(sortedValues);
-
-          // Create comma delimited string
-          for(String instanceValue: sortedValues) {
-            entityId.append(instanceValue);
-            entityId.append(":");
-          }
-
-            // Assign the entity.id
-          ctx["entity"]["id"] = entityId.length() > 0 ? entityId.substring(0, entityId.length() - 1) : "unknown";
-        }
-       `),
-      },
-    },
-    {
-      fingerprint: {
-        fields: ['entity.id'],
-        target_field: 'entity.id',
-        method: 'MurmurHash3',
+      set: {
+        field: 'entity.id',
+        value: definition.identityFields
+          .map((identityField) => identityField.field)
+          .sort()
+          .map((identityField) => `{{{entity.identity.${identityField}}}}`)
+          .join('-'),
       },
     },
     ...(definition.staticFields != null

--- a/x-pack/plugins/entity_manager/server/lib/entities/transform/__snapshots__/generate_latest_transform.test.ts.snap
+++ b/x-pack/plugins/entity_manager/server/lib/entities/transform/__snapshots__/generate_latest_transform.test.ts.snap
@@ -139,16 +139,9 @@ Object {
       },
     },
     "group_by": Object {
-      "entity.identity.event.category": Object {
-        "terms": Object {
-          "field": "event.category",
-          "missing_bucket": true,
-        },
-      },
       "entity.identity.log.logger": Object {
         "terms": Object {
           "field": "log.logger",
-          "missing_bucket": false,
         },
       },
     },

--- a/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_latest_transform.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/transform/generate_latest_transform.ts
@@ -32,13 +32,9 @@ export function generateLatestTransform(
     filter.push(getElasticsearchQueryOrThrow(definition.filter));
   }
 
-  if (definition.identityFields.some(({ optional }) => !optional)) {
-    definition.identityFields
-      .filter(({ optional }) => !optional)
-      .forEach(({ field }) => {
-        filter.push({ exists: { field } });
-      });
-  }
+  definition.identityFields.forEach(({ field }) => {
+    filter.push({ exists: { field } });
+  });
 
   filter.push({
     range: {
@@ -108,7 +104,7 @@ const generateTransformPutRequest = ({
           (acc, id) => ({
             ...acc,
             [`entity.identity.${id.field}`]: {
-              terms: { field: id.field, missing_bucket: id.optional },
+              terms: { field: id.field },
             },
           }),
           {}

--- a/x-pack/test/api_integration/apis/entity_manager/definitions.ts
+++ b/x-pack/test/api_integration/apis/entity_manager/definitions.ts
@@ -170,6 +170,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         const parsedSample = entityLatestSchema.safeParse(sample.hits.hits[0]._source);
         expect(parsedSample.success).to.be(true);
+        expect(parsedSample.data?.entity.id).to.be('admin-console');
       });
     });
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [EEM] Replace hashed ID with human readable ID (#193652) (ae2c6ad3)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Milton Hultgren","email":"milton.hultgren@elastic.co"},"sourceCommit":{"committedDate":"2024-10-18T14:42:38Z","message":"[EEM] Replace hashed ID with human readable ID (#193652)\n\nThis PR turns the `entity.id` field format from a hashed value to a\r\nhuman readable string of the **values** found in the identity fields,\r\nsuch as `my_host-my_cloud_zone` for the identity fields `[host.name,\r\ncloud.availability_zone]`.\r\nThe order of the values is based on the order in the identity fields\r\nlist.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ae2c6ad321f2b4318d4114c1309b4420861bcd29"},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->