### PR TITLE
[Maps] Fix invalid index management link

### DIFF
--- a/x-pack/plugins/file_upload/public/components/__snapshots__/import_complete_view.test.tsx.snap
+++ b/x-pack/plugins/file_upload/public/components/__snapshots__/import_complete_view.test.tsx.snap
@@ -348,7 +348,7 @@ exports[`Should render success 1`] = `
       />
       <a
         data-test-subj="indexManagementNewIndexLink"
-        href="abc/app/management/kibana/dataViews"
+        href="abc/app/management/data/index_management/indices"
         target="_blank"
       >
         <MemoizedFormattedMessage
@@ -525,7 +525,7 @@ exports[`Should render warning when some features failed import 1`] = `
       />
       <a
         data-test-subj="indexManagementNewIndexLink"
-        href="abc/app/management/kibana/dataViews"
+        href="abc/app/management/data/index_management/indices"
         target="_blank"
       >
         <MemoizedFormattedMessage

--- a/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
+++ b/x-pack/plugins/file_upload/public/components/import_complete_view.tsx
@@ -210,7 +210,7 @@ export class ImportCompleteView extends Component<Props, {}> {
           <a
             data-test-subj="indexManagementNewIndexLink"
             target="_blank"
-            href={getHttp().basePath.prepend('/app/management/kibana/dataViews')}
+            href={getHttp().basePath.prepend('/app/management/data/index_management/indices')}
           >
             <FormattedMessage
               id="xpack.fileUpload.importComplete.indexMgmtLink"


### PR DESCRIPTION
## Summary

This PR fixes invalid URL for `To modify the index, go to Index Management.` link.

Closes: #125003


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->