### PR TITLE
[ResponseOps]]MaintenaceWindow] Increase MW table limit to 1k

### DIFF
--- a/x-pack/plugins/alerting/common/routes/maintenance_window/apis/find/schemas/v1.ts
+++ b/x-pack/plugins/alerting/common/routes/maintenance_window/apis/find/schemas/v1.ts
@@ -12,6 +12,7 @@ const MAX_DOCS = 10000;
 
 export const findMaintenanceWindowsRequestQuerySchema = schema.object(
   {
+    // we do not need to use schema.maybe here, because if we do not pass property page, defaultValue will be used
     page: schema.number({
       defaultValue: 1,
       min: 1,
@@ -20,6 +21,7 @@ export const findMaintenanceWindowsRequestQuerySchema = schema.object(
         description: 'The page number to return.',
       },
     }),
+    // we do not need to use schema.maybe here, because if we do not pass property per_page, defaultValue will be used
     per_page: schema.number({
       defaultValue: 1000,
       min: 0,

--- a/x-pack/plugins/alerting/common/routes/maintenance_window/apis/find/schemas/v1.ts
+++ b/x-pack/plugins/alerting/common/routes/maintenance_window/apis/find/schemas/v1.ts
@@ -12,26 +12,22 @@ const MAX_DOCS = 10000;
 
 export const findMaintenanceWindowsRequestQuerySchema = schema.object(
   {
-    page: schema.maybe(
-      schema.number({
-        defaultValue: 1,
-        min: 1,
-        max: MAX_DOCS,
-        meta: {
-          description: 'The page number to return.',
-        },
-      })
-    ),
-    per_page: schema.maybe(
-      schema.number({
-        defaultValue: 20,
-        min: 0,
-        max: 100,
-        meta: {
-          description: 'The number of maintenance windows to return per page.',
-        },
-      })
-    ),
+    page: schema.number({
+      defaultValue: 1,
+      min: 1,
+      max: MAX_DOCS,
+      meta: {
+        description: 'The page number to return.',
+      },
+    }),
+    per_page: schema.number({
+      defaultValue: 1000,
+      min: 0,
+      max: 100,
+      meta: {
+        description: 'The number of maintenance windows to return per page.',
+      },
+    }),
   },
   {
     validate: (params) => {


### PR DESCRIPTION
Here in this PR I am increasing the limit for MW to 1K.
Even I've changed schema for query params(deleted maybe) I did not add additional tests, because we already have one integration test for the case, when we do not have `page` and `per_page` params.



<!--ONMERGE {"backportTargets":["8.15","8.16","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->