### PR TITLE
Revert "[Synthetics] Revert 8.15 public API responses (#195295)"

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/server/routes/monitor_cruds/formatters/saved_object_to_monitor.test.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/routes/monitor_cruds/formatters/saved_object_to_monitor.test.ts
@@ -70,6 +70,9 @@ describe('mergeSourceMonitor', () => {
     const result = mapSavedObjectToMonitor({ monitor: { attributes: testMonitor } } as any);
 
     expect(result).toEqual({
+      __ui: {
+        is_tls_enabled: false,
+      },
       alert: {
         status: {
           enabled: true,
@@ -78,6 +81,8 @@ describe('mergeSourceMonitor', () => {
           enabled: true,
         },
       },
+      'check.request.method': 'GET',
+      'check.response.status': ['404'],
       config_id: 'ae88f0aa-9c7d-4a5f-96dc-89d65a0ca947',
       custom_heartbeat_id: 'todos-lightweight-test-projects-default',
       enabled: true,
@@ -95,45 +100,29 @@ describe('mergeSourceMonitor', () => {
           label: 'North America - US Central',
         },
       ],
-      max_redirects: 0,
+      max_attempts: 2,
+      max_redirects: '0',
       mode: 'any',
       name: 'Todos Lightweight',
       namespace: 'default',
+      origin: 'project',
       original_space: 'default',
-      proxy_url: '',
+      project_id: 'test-projects',
+      'response.include_body': 'on_error',
+      'response.include_body_max_bytes': '1024',
+      'response.include_headers': true,
       retest_on_failure: true,
       revision: 21,
       schedule: {
         number: '3',
         unit: 'm',
       },
-      'service.name': '',
-      tags: [],
+      'ssl.key': 'test-key',
+      'ssl.supported_protocols': ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
+      'ssl.verification_mode': 'full',
       timeout: '16',
       type: 'http',
       url: '${devUrl}',
-      'url.port': null,
-      ssl: {
-        certificate: '',
-        certificate_authorities: '',
-        supported_protocols: ['TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
-        verification_mode: 'full',
-        key: 'test-key',
-      },
-      response: {
-        include_body: 'on_error',
-        include_body_max_bytes: '1024',
-        include_headers: true,
-      },
-      check: {
-        request: {
-          method: 'GET',
-        },
-        response: {
-          status: ['404'],
-        },
-      },
-      params: {},
     });
   });
 

--- a/x-pack/plugins/observability_solution/synthetics/server/routes/monitor_cruds/formatters/saved_object_to_monitor.test.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/routes/monitor_cruds/formatters/saved_object_to_monitor.test.ts
@@ -84,8 +84,17 @@ describe('mergeSourceMonitor', () => {
       id: 'todos-lightweight-test-projects-default',
       ipv4: true,
       ipv6: true,
-      locations: ['us_central', 'us_east'],
-      private_locations: ['pvt_us_east'],
+      locations: [
+        {
+          geo: {
+            lat: 41.25,
+            lon: -95.86,
+          },
+          id: 'us_central',
+          isServiceManaged: true,
+          label: 'North America - US Central',
+        },
+      ],
       max_redirects: 0,
       mode: 'any',
       name: 'Todos Lightweight',
@@ -157,30 +166,12 @@ describe('mergeSourceMonitor', () => {
       locations: [
         {
           geo: {
-            lon: -95.86,
             lat: 41.25,
+            lon: -95.86,
           },
-          isServiceManaged: true,
           id: 'us_central',
-          label: 'North America - US Central',
-        },
-        {
-          geo: {
-            lon: -95.86,
-            lat: 41.25,
-          },
           isServiceManaged: true,
-          id: 'us-east4-a',
-          label: 'US East',
-        },
-        {
-          geo: {
-            lon: -95.86,
-            lat: 41.25,
-          },
-          isServiceManaged: false,
-          id: 'pvt_us_east',
-          label: 'US East (Private)',
+          label: 'North America - US Central',
         },
       ],
       max_redirects: '0',
@@ -248,24 +239,6 @@ const testMonitor = {
       isServiceManaged: true,
       id: 'us_central',
       label: 'North America - US Central',
-    },
-    {
-      geo: {
-        lon: -95.86,
-        lat: 41.25,
-      },
-      isServiceManaged: true,
-      id: 'us-east4-a',
-      label: 'US East',
-    },
-    {
-      geo: {
-        lon: -95.86,
-        lat: 41.25,
-      },
-      isServiceManaged: false,
-      id: 'pvt_us_east',
-      label: 'US East (Private)',
     },
   ],
   namespace: 'default',

--- a/x-pack/plugins/observability_solution/synthetics/server/routes/monitor_cruds/formatters/saved_object_to_monitor.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/routes/monitor_cruds/formatters/saved_object_to_monitor.ts
@@ -7,7 +7,6 @@
 
 import { SavedObject } from '@kbn/core/server';
 import { mergeWith, omit, omitBy } from 'lodash';
-import { LocationsMap } from '../../../synthetics_service/project_monitor/normalizers/common_fields';
 import {
   ConfigKey,
   EncryptedSyntheticsMonitor,
@@ -39,14 +38,11 @@ type Result = MonitorFieldsResult & {
   ssl: Record<string, any>;
   response: Record<string, any>;
   check: Record<string, any>;
-  locations: string[];
-  private_locations: string[];
 };
 
 export const transformPublicKeys = (result: Result) => {
   let formattedResult = {
     ...result,
-    ...formatLocations(result),
     [ConfigKey.PARAMS]: formatParams(result),
     retest_on_failure: (result[ConfigKey.MAX_ATTEMPTS] ?? 1) > 1,
     ...(result[ConfigKey.HOSTS] && { host: result[ConfigKey.HOSTS] }),
@@ -70,7 +66,8 @@ export const transformPublicKeys = (result: Result) => {
 
   return omitBy(
     res,
-    (_, key) => key.startsWith('response.') || key.startsWith('ssl.') || key.startsWith('check.')
+    (value, key) =>
+      key.startsWith('response.') || key.startsWith('ssl.') || key.startsWith('check.')
   );
 };
 
@@ -106,24 +103,6 @@ const customizer = (destVal: any, srcValue: any, key: string) => {
   if (key !== ConfigKey.METADATA) {
     return srcValue;
   }
-};
-
-const formatLocations = (config: MonitorFields) => {
-  const locMap = Object.entries(LocationsMap);
-  const locations = config[ConfigKey.LOCATIONS]
-    ?.filter((location) => location.isServiceManaged)
-    .map((location) => {
-      return locMap.find(([_key, value]) => value === location.id)?.[0] ?? location.id;
-    });
-
-  const privateLocations = config[ConfigKey.LOCATIONS]
-    ?.filter((location) => !location.isServiceManaged)
-    .map((location) => location.id);
-
-  return {
-    ...(locations && { locations }),
-    ...(privateLocations && { private_locations: privateLocations }),
-  };
 };
 
 const formatParams = (config: MonitorFields) => {

--- a/x-pack/test/api_integration/apis/synthetics/add_monitor.ts
+++ b/x-pack/test/api_integration/apis/synthetics/add_monitor.ts
@@ -8,7 +8,7 @@ import expect from '@kbn/expect';
 import epct from 'expect';
 import moment from 'moment/moment';
 import { v4 as uuidv4 } from 'uuid';
-import { omit } from 'lodash';
+import { omit, omitBy } from 'lodash';
 import {
   ConfigKey,
   MonitorTypeEnum,
@@ -23,7 +23,10 @@ import { format as formatUrl } from 'url';
 import supertest from 'supertest';
 import { getServiceApiKeyPrivileges } from '@kbn/synthetics-plugin/server/synthetics_service/get_api_key';
 import { syntheticsMonitorType } from '@kbn/synthetics-plugin/common/types/saved_objects';
-import { transformPublicKeys } from '@kbn/synthetics-plugin/server/routes/monitor_cruds/formatters/saved_object_to_monitor';
+import {
+  removeMonitorEmptyValues,
+  transformPublicKeys,
+} from '@kbn/synthetics-plugin/server/routes/monitor_cruds/formatters/saved_object_to_monitor';
 import { FtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helper/get_fixture_json';
 import { SyntheticsMonitorTestService } from './services/synthetics_monitor_test_service';
@@ -61,7 +64,7 @@ export const keyToOmitList = [
 ];
 
 export const omitMonitorKeys = (monitor: any) => {
-  return omit(transformPublicKeys(monitor), keyToOmitList);
+  return omitBy(omit(transformPublicKeys(monitor), keyToOmitList), removeMonitorEmptyValues);
 };
 
 export default function ({ getService }: FtrProviderContext) {

--- a/x-pack/test/api_integration/apis/synthetics/get_monitor.ts
+++ b/x-pack/test/api_integration/apis/synthetics/get_monitor.ts
@@ -242,7 +242,6 @@ export default function ({ getService }: FtrProviderContext) {
             revision: 1,
             locations: [LOCAL_LOCATION],
             name: 'Test HTTP Monitor 044',
-            labels: {},
           })
         );
       });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/198518
This reverts commit d21495bbce07ed39fdcf077c9170d012adab74a4 and 


## Testing

Create few HTTP, ICMP, TCP and Browser monitors via API in 8.15 and in this PR

Compared JSOn diffs to make sure responses are same




<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->