### PR TITLE
[Visualize] remove never executing functional tests code

### DIFF
--- a/test/functional/apps/getting_started/_shakespeare.ts
+++ b/test/functional/apps/getting_started/_shakespeare.ts
@@ -81,7 +81,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       // Remove refresh click when vislib is removed
       // https://github.com/elastic/kibana/issues/56143
-      await PageObjects.visualize.clickRefresh(true);
+      await PageObjects.visualize.clickRefresh();
 
       const expectedChartValues = [111396];
       await retry.try(async () => {

--- a/test/functional/apps/visualize/group2/_gauge_chart.ts
+++ b/test/functional/apps/visualize/group2/_gauge_chart.ts
@@ -62,7 +62,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.click('gaugePercentageMode');
       await testSubjects.setValue('gaugePercentageModeFormatPattern', '0.0%');
       await visChart.waitForVisualizationRenderingStabilized();
-      await visEditor.clickGo(false);
+      await visEditor.clickGo(true);
 
       await retry.try(async function tryingForTime() {
         const expectedTexts = ['57.3%', 'Average bytes'];
@@ -82,7 +82,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectField('machine.os.raw');
         log.debug('Size = 4');
         await visEditor.setSize(4);
-        await visEditor.clickGo(false);
+        await visEditor.clickGo(true);
       });
 
       it('should show Split Gauges', async () => {
@@ -118,7 +118,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.clickBucket('Metric', 'metrics');
         await visEditor.selectAggregation('Min', 'metrics');
         await visEditor.selectField('bytes', 'metrics');
-        await visEditor.clickGo(false);
+        await visEditor.clickGo(true);
 
         await retry.try(async function tryingForTime() {
           const metricValue = await visChart.getGaugeValue();

--- a/test/functional/apps/visualize/group2/_heatmap_chart.ts
+++ b/test/functional/apps/visualize/group2/_heatmap_chart.ts
@@ -29,7 +29,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       isNewChartsLibraryEnabled = await visChart.isNewChartsLibraryEnabled(
         'visualization:visualize:legacyHeatmapChartsLibrary'
       );
-      await visualize.initTests(isNewChartsLibraryEnabled);
+      await visualize.initTests(!isNewChartsLibraryEnabled);
       log.debug('navigateToApp visualize');
       await visualize.navigateToNewAggBasedVisualization();
       log.debug('clickHeatmapChart');

--- a/test/functional/apps/visualize/group2/_heatmap_chart.ts
+++ b/test/functional/apps/visualize/group2/_heatmap_chart.ts
@@ -43,7 +43,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       log.debug('Field = @timestamp');
       await visEditor.selectField('@timestamp');
       // leaving Interval set to Auto
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo(!isNewChartsLibraryEnabled);
     });
 
     it('should save and load', async function () {
@@ -102,7 +102,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     it('should show 6 color ranges if changed on options', async function () {
       await visEditor.clickOptionsTab();
       await visEditor.changeHeatmapColorNumbers(6);
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo(!isNewChartsLibraryEnabled);
       await visChart.waitForVisualizationRenderingStabilized();
 
       const legends = await visChart.getLegendEntries();
@@ -143,7 +143,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       log.debug('customize 2 last ranges');
       await visEditor.setCustomRangeByIndex(6, '650', '720');
       await visEditor.setCustomRangeByIndex(7, '800', '905');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo(!isNewChartsLibraryEnabled);
 
       await visChart.waitForVisualizationRenderingStabilized();
       const legends = await visChart.getLegendEntries();

--- a/test/functional/apps/visualize/group3/_pie_chart.ts
+++ b/test/functional/apps/visualize/group3/_pie_chart.ts
@@ -49,7 +49,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       log.debug('setNumericInterval 4000');
       await visEditor.setInterval('40000', { type: 'numeric' });
       log.debug('clickGo');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
     });
 
     after(async () => {
@@ -107,8 +107,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.toggleOtherBucket(2);
         await visEditor.toggleMissingBucket(2);
         log.debug('clickGo');
-        await visEditor.clickGo(isNewChartsLibraryEnabled);
         await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
+        await visEditor.clickGo();
       });
 
       it('should apply correct filter on other bucket', async () => {
@@ -185,8 +185,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.toggleOtherBucket(3);
         await visEditor.toggleMissingBucket(3);
         log.debug('clickGo');
-        await visEditor.clickGo(isNewChartsLibraryEnabled);
         await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
+        await visEditor.clickGo();
       });
     });
 
@@ -203,7 +203,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectAggregation('Terms');
         await visEditor.selectField('machine.os.raw');
         await visEditor.toggleDisabledAgg(2);
-        await visEditor.clickGo(isNewChartsLibraryEnabled);
+        await visEditor.clickGo();
 
         await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
       });
@@ -220,7 +220,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show correct result when agg is re-enabled', async () => {
         await visEditor.toggleDisabledAgg(2);
-        await visEditor.clickGo(isNewChartsLibraryEnabled);
+        await visEditor.clickGo();
 
         const expectedTableData = [
           '0',
@@ -305,7 +305,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.addNewFilterAggregation();
         log.debug('Set the 2nd filter value');
         await visEditor.setFilterAggregationValue('geo.dest:"CN"', 1);
-        await visEditor.clickGo(isNewChartsLibraryEnabled);
+        await visEditor.clickGo();
         const emptyFromTime = 'Sep 19, 2016 @ 06:31:44.000';
         const emptyToTime = 'Sep 23, 2016 @ 18:31:44.000';
         log.debug(
@@ -339,7 +339,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.clickBucket('Split slices');
         await visEditor.selectAggregation('Terms');
         await visEditor.selectField('geo.dest');
-        await visEditor.clickGo(isNewChartsLibraryEnabled);
+        await visEditor.clickGo();
       });
 
       it('should show correct chart', async () => {
@@ -428,13 +428,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           '360,000',
           'CN',
         ].sort();
-        if (isNewChartsLibraryEnabled) {
-          await visEditor.clickOptionsTab();
-          await visEditor.togglePieLegend();
-          await visEditor.togglePieNestedLegend();
-          await visEditor.clickDataTab();
-          await visEditor.clickGo(isNewChartsLibraryEnabled);
-        }
+
+        await visEditor.clickOptionsTab();
+        await visEditor.togglePieLegend();
+        await visEditor.togglePieNestedLegend();
+        await visEditor.clickDataTab();
+        await visEditor.clickGo();
+
         await visChart.filterLegend('CN');
         await visChart.waitForVisualization();
         await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
@@ -466,7 +466,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectAggregation('Filters');
         log.debug('Set the 1st filter value of the aggregation id 3');
         await visEditor.setFilterAggregationValue('geo.dest:"UX"', 0, 3);
-        await visEditor.clickGo(isNewChartsLibraryEnabled);
+        await visEditor.clickGo();
         const legends = await visChart.getLegendEntries();
         const expectedLegends = ['geo.dest:"US"', 'geo.dest:"UX"'];
         expect(legends).to.eql(expectedLegends);
@@ -487,7 +487,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.clickBucket('Split slices');
         await visEditor.selectAggregation('Terms');
         await visEditor.selectField('geo.src');
-        await visEditor.clickGo(isNewChartsLibraryEnabled);
+        await visEditor.clickGo();
       });
 
       it('shows correct split chart', async () => {

--- a/test/functional/apps/visualize/group3/_pie_chart.ts
+++ b/test/functional/apps/visualize/group3/_pie_chart.ts
@@ -68,7 +68,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should show 10 slices in pie chart', async function () {
-      await pieChart.expectPieSliceCount(10, isNewChartsLibraryEnabled);
+      await pieChart.expectPieSliceCount(10);
     });
 
     it('should show correct data', async function () {
@@ -107,8 +107,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.toggleOtherBucket(2);
         await visEditor.toggleMissingBucket(2);
         log.debug('clickGo');
-        await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
         await visEditor.clickGo();
+        await pieChart.expectPieChartLabels(expectedTableData);
       });
 
       it('should apply correct filter on other bucket', async () => {
@@ -116,7 +116,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await pieChart.filterOnPieSlice('Other');
         await visChart.waitForVisualization();
-        await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
+        await pieChart.expectPieChartLabels(expectedTableData);
         await filterBar.removeFilter('machine.os.raw');
         await visChart.waitForVisualization();
       });
@@ -126,7 +126,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await visChart.filterLegend('Other');
         await visChart.waitForVisualization();
-        await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
+        await pieChart.expectPieChartLabels(expectedTableData);
         await filterBar.removeFilter('machine.os.raw');
         await visChart.waitForVisualization();
       });
@@ -185,8 +185,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.toggleOtherBucket(3);
         await visEditor.toggleMissingBucket(3);
         log.debug('clickGo');
-        await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
         await visEditor.clickGo();
+        await pieChart.expectPieChartLabels(expectedTableData);
       });
     });
 
@@ -205,7 +205,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.toggleDisabledAgg(2);
         await visEditor.clickGo();
 
-        await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
+        await pieChart.expectPieChartLabels(expectedTableData);
       });
 
       it('should correctly save disabled agg', async () => {
@@ -215,7 +215,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visChart.waitForRenderingCount();
 
         const expectedTableData = ['ios', 'osx', 'win 7', 'win 8', 'win xp'];
-        await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
+        await pieChart.expectPieChartLabels(expectedTableData);
       });
 
       it('should show correct result when agg is re-enabled', async () => {
@@ -285,7 +285,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           'osx',
         ].sort();
 
-        await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
+        await pieChart.expectPieChartLabels(expectedTableData);
       });
     });
 
@@ -313,7 +313,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         );
         await timePicker.setAbsoluteRange(emptyFromTime, emptyToTime);
         await visChart.waitForVisualization();
-        await visChart.expectError();
       });
     });
     describe('multi series slice', () => {
@@ -396,7 +395,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           ['360,000', '47', 'BR', '2'],
         ].map((row) =>
           // the count of records is not shown for every split level in the new charting library
-          isNewChartsLibraryEnabled ? [row[0], ...row.slice(2)] : row
+          [row[0], ...row.slice(2)]
         );
 
         await inspector.open();
@@ -437,17 +436,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await visChart.filterLegend('CN');
         await visChart.waitForVisualization();
-        await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
+        await pieChart.expectPieChartLabels(expectedTableData);
         await filterBar.removeFilter('geo.dest');
         await visChart.waitForVisualization();
       });
 
-      it('should still showing pie chart when a subseries have zero data', async function () {
-        if (isNewChartsLibraryEnabled) {
-          // TODO: it seems that adding a filter agg which has no results to a pie chart breaks it and instead it shows "no data"
-          return;
-        }
-
+      // TODO: it seems that adding a filter agg which has no results to a pie chart breaks it and instead it shows "no data"
+      it.skip('should still showing pie chart when a subseries have zero data', async function () {
         await visualize.navigateToNewAggBasedVisualization();
         log.debug('clickPieChart');
         await visualize.clickPieChart();
@@ -519,7 +514,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           ['osx', '1,322', 'BR', '30'],
         ].map((row) =>
           // the count of records is not shown for every split level in the new charting library
-          isNewChartsLibraryEnabled ? [row[0], ...row.slice(2)] : row
+          [row[0], ...row.slice(2)]
         );
         await inspector.open();
         await inspector.setTablePageSize(50);
@@ -536,7 +531,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           ['osx', '228', 'CN', '228'],
         ].map((row) =>
           // the count of records is not shown for every split level in the new charting library
-          isNewChartsLibraryEnabled ? [row[0], ...row.slice(2)] : row
+          [row[0], ...row.slice(2)]
         );
         await visChart.filterLegend('CN');
         await header.waitUntilLoadingHasFinished();

--- a/test/functional/apps/visualize/group3/_pie_chart.ts
+++ b/test/functional/apps/visualize/group3/_pie_chart.ts
@@ -28,11 +28,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
   describe('pie chart', function () {
     // Used to track flag before and after reset
-    let isNewChartsLibraryEnabled = false;
     const vizName1 = 'Visualization PieChart';
     before(async function () {
-      isNewChartsLibraryEnabled = await visChart.isNewChartsLibraryEnabled();
-      await visualize.initTests(isNewChartsLibraryEnabled);
+      await visualize.initTests();
 
       log.debug('navigateToApp visualize');
       await visualize.navigateToNewAggBasedVisualization();

--- a/test/functional/apps/visualize/group5/_tsvb_time_series.ts
+++ b/test/functional/apps/visualize/group5/_tsvb_time_series.ts
@@ -434,7 +434,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
             legendNames = await visualBuilder.getLegendNames();
             expect(legendNames).to.eql(['png', 'php']);
 
-            await visualize.clickRefresh(true);
+            await visualize.clickRefresh();
             legendNames = await visualBuilder.getLegendNames();
             expect(legendNames).to.eql(['png', 'php']);
           });

--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_area_chart.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_area_chart.ts
@@ -49,7 +49,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     const intervalValue = await visEditor.getInterval();
     log.debug('intervalValue = ' + intervalValue);
     expect(intervalValue[0]).to.be('Auto');
-    await visEditor.clickGo(true);
+    await visEditor.clickGo();
   };
 
   describe('area charts', function indexPatternCreation() {
@@ -177,7 +177,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await visEditor.toggleOpenEditor(2);
         await visEditor.setInterval('Second');
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         await inspector.open();
         await inspector.expectTableData(expectedTableData);
         await inspector.close();
@@ -209,7 +209,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await visEditor.toggleAdvancedParams('2');
         await visEditor.toggleScaleMetrics();
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         await inspector.open();
         await inspector.expectTableData(expectedTableData);
         await inspector.close();
@@ -243,7 +243,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectAggregation('Top Hit', 'metrics');
         await visEditor.selectField('bytes', 'metrics');
         await visEditor.selectAggregateWith('average');
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         await inspector.open();
         await inspector.expectTableData(expectedTableData);
         await inspector.close();
@@ -277,7 +277,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.clickYAxisOptions(axisId);
         await visEditor.selectYAxisScaleType(axisId, 'log');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabelsAsNumbers(xyChartSelector);
         const minLabel = 1;
         const maxLabel = 900;
@@ -289,7 +289,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting log scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabelsAsNumbers(xyChartSelector);
         const minLabel = 1;
         const maxLabel = 900;
@@ -302,7 +302,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show ticks on selecting square root scale', async () => {
         await visEditor.selectYAxisScaleType(axisId, 'square root');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
         expect(labels).to.eql(expectedLabels);
@@ -310,7 +310,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting square root scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
         expect(labels).to.eql(expectedLabels);
@@ -319,7 +319,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show ticks on selecting linear scale', async () => {
         await visEditor.selectYAxisScaleType(axisId, 'linear');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         log.debug(labels);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
@@ -328,7 +328,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting linear scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
         expect(labels).to.eql(expectedLabels);
@@ -353,7 +353,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectAggregation('Date Histogram');
         await visEditor.selectField('@timestamp');
         await visEditor.setInterval('Year');
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         // This svg area is composed by 7 years (2013 - 2019).
         // 7 points are used to draw the upper line (usually called y1)
         // 7 points compose the lower line (usually called y0)
@@ -376,7 +376,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectAggregation('Date Histogram');
         await visEditor.selectField('@timestamp');
         await visEditor.setInterval('Month');
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         // This svg area is composed by 67 months 3 (2013) + 5 * 12 + 4 (2019)
         // 67 points are used to draw the upper line (usually called y1)
         // 67 points compose the lower line (usually called y0)

--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_line_chart_split_chart.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_line_chart_split_chart.ts
@@ -41,7 +41,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await visEditor.selectField('extension.raw');
       log.debug('switch from Rows to Columns');
       await visEditor.clickSplitDirection('Columns');
-      await visEditor.clickGo(true);
+      await visEditor.clickGo();
     };
 
     before(async () => {
@@ -96,7 +96,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       log.debug('Order By = Term');
       await visEditor.selectOrderByMetric(2, '_key');
-      await visEditor.clickGo(true);
+      await visEditor.clickGo();
       await retry.try(async function () {
         const data = await visChart.getLineChartData(xyChartSelector);
         log.debug('data=' + data);
@@ -181,7 +181,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.clickYAxisOptions(axisId);
         await visEditor.selectYAxisScaleType(axisId, 'log');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabelsAsNumbers(xyChartSelector);
         const minLabel = 1;
         const maxLabel = 7000;
@@ -193,7 +193,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting log scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabelsAsNumbers(xyChartSelector);
         const minLabel = 1;
         const maxLabel = 7000;
@@ -206,7 +206,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show ticks on selecting square root scale', async () => {
         await visEditor.selectYAxisScaleType(axisId, 'square root');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '2,000', '4,000', '6,000', '8,000'];
 
@@ -215,7 +215,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting square root scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '2,000', '4,000', '6,000', '8,000'];
         expect(labels).to.eql(expectedLabels);
@@ -224,7 +224,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show ticks on selecting linear scale', async () => {
         await visEditor.selectYAxisScaleType(axisId, 'linear');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         log.debug(labels);
         const expectedLabels = ['0', '2,000', '4,000', '6,000', '8,000'];
@@ -233,7 +233,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting linear scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '2,000', '4,000', '6,000', '8,000'];
         expect(labels).to.eql(expectedLabels);
@@ -262,7 +262,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await visEditor.clickBucket('X-axis');
           log.debug('Aggregation = Date Histogram');
           await visEditor.selectAggregation('Date Histogram');
-          await visEditor.clickGo(true);
+          await visEditor.clickGo();
           const title = await visChart.getYAxisTitle(xyChartSelector);
           expect(title).to.be('Serial Diff of Count');
         });
@@ -270,7 +270,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         it('should change y-axis label to custom', async () => {
           log.debug('set custom label of y-axis to "Custom"');
           await visEditor.setCustomLabel('Custom', 1);
-          await visEditor.clickGo(true);
+          await visEditor.clickGo();
           const title = await visChart.getYAxisTitle(xyChartSelector);
           expect(title).to.be('Custom');
         });
@@ -285,7 +285,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         it('should apply with selected bucket', async () => {
           log.debug('Metrics agg = Average Bucket');
           await visEditor.selectAggregation('Average Bucket', 'metrics');
-          await visEditor.clickGo(true);
+          await visEditor.clickGo();
           const title = await visChart.getYAxisTitle(xyChartSelector);
           expect(title).to.be('Overall Average of Count');
         });
@@ -293,7 +293,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         it('should change sub metric custom label and calculate y-axis title', async () => {
           log.debug('set custom label of sub metric to "Cats"');
           await visEditor.setCustomLabel('Cats', '1-metric');
-          await visEditor.clickGo(true);
+          await visEditor.clickGo();
           const title = await visChart.getYAxisTitle(xyChartSelector);
           expect(title).to.be('Overall Average of Cats');
         });
@@ -301,7 +301,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         it('should outer custom label', async () => {
           log.debug('set custom label to "Custom"');
           await visEditor.setCustomLabel('Custom', 1);
-          await visEditor.clickGo(true);
+          await visEditor.clickGo();
           const title = await visChart.getYAxisTitle(xyChartSelector);
           expect(title).to.be('Custom');
         });

--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_line_chart_split_series.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_line_chart_split_series.ts
@@ -39,7 +39,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await visEditor.selectAggregation('Terms');
       log.debug('Field = extension');
       await visEditor.selectField('extension.raw');
-      await visEditor.clickGo(true);
+      await visEditor.clickGo();
     };
 
     before(async () => {
@@ -94,7 +94,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       log.debug('Order By = Term');
       await visEditor.selectOrderByMetric(2, '_key');
-      await visEditor.clickGo(true);
+      await visEditor.clickGo();
       await retry.try(async function () {
         const data = await visChart.getLineChartData(xyChartSelector);
         log.debug('data=' + data);
@@ -180,7 +180,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.clickYAxisOptions(axisId);
         await visEditor.selectYAxisScaleType(axisId, 'log');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabelsAsNumbers(xyChartSelector);
         const minLabel = 1;
         const maxLabel = 900;
@@ -192,7 +192,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting log scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabelsAsNumbers(xyChartSelector);
         const minLabel = 1;
         const maxLabel = 900;
@@ -205,7 +205,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show ticks on selecting square root scale', async () => {
         await visEditor.selectYAxisScaleType(axisId, 'square root');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '2,000', '4,000', '6,000', '8,000'];
         expect(labels).to.eql(expectedLabels);
@@ -213,7 +213,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting square root scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '2,000', '4,000', '6,000', '8,000'];
         expect(labels).to.eql(expectedLabels);
@@ -222,7 +222,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show ticks on selecting linear scale', async () => {
         await visEditor.selectYAxisScaleType(axisId, 'linear');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         log.debug(labels);
         const expectedLabels = ['0', '2,000', '4,000', '6,000', '8,000'];
@@ -231,7 +231,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting linear scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '2,000', '4,000', '6,000', '8,000'];
         expect(labels).to.eql(expectedLabels);
@@ -260,7 +260,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await visEditor.clickBucket('X-axis');
           log.debug('Aggregation = Date Histogram');
           await visEditor.selectAggregation('Date Histogram');
-          await visEditor.clickGo(true);
+          await visEditor.clickGo();
           const title = await visChart.getYAxisTitle(xyChartSelector);
           expect(title).to.be('Serial Diff of Count');
         });
@@ -268,7 +268,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         it('should change y-axis label to custom', async () => {
           log.debug('set custom label of y-axis to "Custom"');
           await visEditor.setCustomLabel('Custom', 1);
-          await visEditor.clickGo(true);
+          await visEditor.clickGo();
           const title = await visChart.getYAxisTitle(xyChartSelector);
           expect(title).to.be('Custom');
         });
@@ -283,7 +283,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         it('should apply with selected bucket', async () => {
           log.debug('Metrics agg = Average Bucket');
           await visEditor.selectAggregation('Average Bucket', 'metrics');
-          await visEditor.clickGo(true);
+          await visEditor.clickGo();
           const title = await visChart.getYAxisTitle(xyChartSelector);
           expect(title).to.be('Overall Average of Count');
         });
@@ -291,7 +291,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         it('should change sub metric custom label and calculate y-axis title', async () => {
           log.debug('set custom label of sub metric to "Cats"');
           await visEditor.setCustomLabel('Cats', '1-metric');
-          await visEditor.clickGo(true);
+          await visEditor.clickGo();
           const title = await visChart.getYAxisTitle(xyChartSelector);
           expect(title).to.be('Overall Average of Cats');
         });
@@ -299,7 +299,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         it('should outer custom label', async () => {
           log.debug('set custom label to "Custom"');
           await visEditor.setCustomLabel('Custom', 1);
-          await visEditor.clickGo(true);
+          await visEditor.clickGo();
           const title = await visChart.getYAxisTitle(xyChartSelector);
           expect(title).to.be('Custom');
         });

--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_point_series_options.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_point_series_options.ts
@@ -58,7 +58,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     log.debug('Average memory value axis - ValueAxis-2');
     await visEditor.setSeriesAxis(1, 'ValueAxis-2');
     await visChart.waitForVisualizationRenderingStabilized();
-    await visEditor.clickGo(true);
+    await visEditor.clickGo();
   }
 
   describe('point series', function describeIndexTests() {
@@ -121,7 +121,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('multiple chart types', function () {
       it('should change average series type to histogram', async function () {
         await visEditor.setSeriesType(1, 'histogram');
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const length = await visChart.getHistogramSeriesCount(xyChartSelector);
         expect(length).to.be(1);
       });
@@ -134,7 +134,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show category grid lines', async function () {
         await visEditor.toggleGridCategoryLines();
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const gridLines = await visChart.getGridLines(xyChartSelector);
         // FLAKY relaxing as depends on chart size/browser size and produce differences between local and CI
         // The objective here is to check whenever the grid lines are rendered, not the exact quantity
@@ -147,7 +147,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show value axis grid lines', async function () {
         await visEditor.setGridValueAxis('ValueAxis-2');
         await visEditor.toggleGridCategoryLines();
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const gridLines = await visChart.getGridLines(xyChartSelector);
         // FLAKY relaxing as depends on chart size/browser size and produce differences between local and CI
         // The objective here is to check whenever the grid lines are rendered, not the exact quantity
@@ -169,21 +169,21 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectAggregation('Terms');
         log.debug('Field = geo.src');
         await visEditor.selectField('geo.src');
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         log.debug('Open Options tab');
         await visEditor.clickOptionsTab();
       });
 
       it('should show values on bar chart', async () => {
         await visEditor.toggleValuesOnChart();
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const values = await visChart.getChartValues(xyChartSelector);
         expect(values).to.eql(['2,592', '2,373', '1,194', '489', '415']);
       });
 
       it('should hide values on bar chart', async () => {
         await visEditor.toggleValuesOnChart();
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const values = await visChart.getChartValues(xyChartSelector);
         expect(values.length).to.be(0);
       });
@@ -198,7 +198,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visualize.clickLineChart();
         await visualize.clickNewSearch();
         await visEditor.selectYAxisAggregation('Average', 'bytes', customLabel, 1);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         await visEditor.clickMetricsAndAxes();
         await visEditor.clickYAxisOptions('ValueAxis-1');
       });
@@ -210,7 +210,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should render a custom axis title when one is set, overriding the custom label', async function () {
         await visEditor.setAxisTitle(axisTitle);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const title = await visChart.getYAxisTitle(xyChartSelector);
         expect(title).to.be(axisTitle);
       });
@@ -223,7 +223,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.clickDataTab();
         await visEditor.toggleOpenEditor(1);
         await visEditor.setCustomLabel('test', 1);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         await visEditor.clickMetricsAndAxes();
         await visEditor.clickYAxisOptions('ValueAxis-1');
         const title = await visChart.getYAxisTitle(xyChartSelector);

--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_point_series_options.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_point_series_options.ts
@@ -331,7 +331,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await browser.refresh();
         // wait some time before trying to check for rendering count
         await header.awaitKibanaChrome();
-        await visualize.clickRefresh(true);
+        await visualize.clickRefresh();
         await visChart.waitForRenderingCount();
         log.debug('getXAxisLabels');
 

--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_timelion.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_timelion.ts
@@ -43,7 +43,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     const initVisualization = async (expression: string, interval: string = '12h') => {
       await visEditor.setTimelionInterval(interval);
       await monacoEditor.setCodeEditorValue(expression);
-      await visEditor.clickGo(true);
+      await visEditor.clickGo();
     };
 
     it('should display correct data for specified index pattern and timefield', async () => {

--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_vertical_bar_chart.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_vertical_bar_chart.ts
@@ -324,7 +324,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       it('should correctly filter by legend', async () => {
-        await visChart.filterLegend('200', true);
+        await visChart.filterLegend('200');
         await visChart.waitForVisualization();
         const legendEntries = await visChart.getLegendEntriesXYCharts(xyChartSelector);
         const expectedEntries = ['200'];

--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_vertical_bar_chart.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_vertical_bar_chart.ts
@@ -52,7 +52,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       log.debug('Field = @timestamp');
       await visEditor.selectField('@timestamp');
       // leaving Interval set to Auto
-      await visEditor.clickGo(true);
+      await visEditor.clickGo();
     };
 
     describe('bar charts x axis tick labels', () => {
@@ -63,7 +63,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         await visEditor.clickMetricsAndAxes();
         await visEditor.selectXAxisPosition('left');
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
 
         // the getYAxisLabels helper always returns the labels on the left axis
         const leftLabels = await visChart.getYAxisLabels(xyChartSelector);
@@ -79,13 +79,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectAggregation('Date Range');
         await visEditor.selectField('@timestamp');
 
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const bottomLabels = await visChart.getXAxisLabels(xyChartSelector);
         expect(bottomLabels.length).to.be(1);
 
         await visEditor.clickMetricsAndAxes();
         await visEditor.selectXAxisPosition('left');
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
 
         // the getYAxisLabels helper always returns the labels on the left axis
         const leftLabels = await visChart.getYAxisLabels(xyChartSelector);
@@ -105,7 +105,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectField('@timestamp');
         await visEditor.clickAddDateRange();
         await visEditor.setDateRangeByIndex('1', 'now-2w/w', 'now-1w/w');
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const bottomLabels = await visChart.getXAxisLabels(xyChartSelector);
         expect(bottomLabels.length).to.be(2);
       });
@@ -194,7 +194,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       await visEditor.toggleOpenEditor(2);
       await visEditor.clickDropPartialBuckets();
-      await visEditor.clickGo(true);
+      await visEditor.clickGo();
 
       expectedChartValues = [
         218, 341, 440, 480, 517, 522, 446, 403, 321, 258, 172, 95, 55, 38, 24, 3, 4, 11, 14, 17, 38,
@@ -222,7 +222,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.clickYAxisOptions(axisId);
         await visEditor.selectYAxisScaleType(axisId, 'log');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabelsAsNumbers(xyChartSelector);
 
         const minLabel = 1;
@@ -235,7 +235,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting log scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabelsAsNumbers(xyChartSelector);
 
         const minLabel = 1;
@@ -249,7 +249,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show ticks on selecting square root scale', async () => {
         await visEditor.selectYAxisScaleType(axisId, 'square root');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
         expect(labels).to.eql(expectedLabels);
@@ -257,7 +257,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting square root scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
         expect(labels).to.eql(expectedLabels);
@@ -266,7 +266,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show ticks on selecting linear scale', async () => {
         await visEditor.selectYAxisScaleType(axisId, 'linear');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         log.debug(labels);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
@@ -275,7 +275,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting linear scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
         expect(labels).to.eql(expectedLabels);
@@ -290,7 +290,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectYAxisMode('percentage');
         await visEditor.changeYAxisShowCheckbox(axisId, true);
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         expect(labels[0]).to.eql('0%');
         expect(labels[labels.length - 1]).to.eql('100%');
@@ -306,7 +306,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectAggregation('Terms');
         await visEditor.selectField('response.raw');
         await visChart.waitForVisualizationRenderingStabilized();
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
 
         const expectedEntries = ['200', '404', '503']; // sorting order aligned with the reading direction
         const legendEntries = await visChart.getLegendEntriesXYCharts(xyChartSelector);
@@ -316,7 +316,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should allow custom sorting of series', async () => {
         await visEditor.toggleOpenEditor(1, 'false');
         await visEditor.selectCustomSortMetric(3, 'Min', 'bytes');
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
 
         const expectedEntries = ['404', '200', '503'];
         const legendEntries = await visChart.getLegendEntriesXYCharts(xyChartSelector);
@@ -349,7 +349,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.selectAggregation('Terms');
         await visEditor.selectField('machine.os');
         await visChart.waitForVisualizationRenderingStabilized();
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
 
         const expectedEntries = [
           '200 - win 8',
@@ -376,7 +376,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         // this will avoid issues with the play tooltip covering the disable agg button
         await testSubjects.scrollIntoView('metricsAggGroup');
         await visEditor.toggleDisabledAgg(3);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
 
         const expectedEntries = ['win 8', 'win xp', 'ios', 'osx', 'win 7'];
         const legendEntries = await visChart.getLegendEntriesXYCharts(xyChartSelector);
@@ -392,7 +392,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.toggleOpenEditor(1);
         await visEditor.selectAggregation('Derivative', 'metrics');
         await visChart.waitForVisualizationRenderingStabilized();
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
 
         const expectedEntries = ['Derivative of Count'];
         const legendEntries = await visChart.getLegendEntriesXYCharts(xyChartSelector);

--- a/test/functional/apps/visualize/replaced_vislib_chart_types/_vertical_bar_chart_nontimeindex.ts
+++ b/test/functional/apps/visualize/replaced_vislib_chart_types/_vertical_bar_chart_nontimeindex.ts
@@ -43,7 +43,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await visEditor.selectField('@timestamp');
       await visEditor.setInterval('3h', { type: 'custom' });
       await visChart.waitForVisualizationRenderingStabilized();
-      await visEditor.clickGo(true);
+      await visEditor.clickGo();
     };
 
     before(async () => {
@@ -117,7 +117,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await visEditor.clickYAxisOptions(axisId);
         await visEditor.selectYAxisScaleType(axisId, 'log');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabelsAsNumbers(xyChartSelector);
         const minLabel = 1;
         const maxLabel = 900;
@@ -129,7 +129,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting log scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabelsAsNumbers(xyChartSelector);
         const minLabel = 1;
         const maxLabel = 900;
@@ -142,7 +142,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show ticks on selecting square root scale', async () => {
         await visEditor.selectYAxisScaleType(axisId, 'square root');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
         expect(labels).to.eql(expectedLabels);
@@ -150,7 +150,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting square root scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
         expect(labels).to.eql(expectedLabels);
@@ -159,7 +159,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       it('should show ticks on selecting linear scale', async () => {
         await visEditor.selectYAxisScaleType(axisId, 'linear');
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, false);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         log.debug(labels);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
@@ -168,7 +168,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show filtered ticks on selecting linear scale', async () => {
         await visEditor.changeYAxisFilterLabelsCheckbox(axisId, true);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         const labels = await visChart.getYAxisLabels(xyChartSelector);
         const expectedLabels = ['0', '200', '400', '600', '800', '1,000', '1,200', '1,400'];
         expect(labels).to.eql(expectedLabels);
@@ -186,7 +186,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await header.waitUntilLoadingHasFinished();
 
         await common.sleep(1003);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         await header.waitUntilLoadingHasFinished();
 
         const expectedEntries = ['200', '404', '503']; // sorting order aligned with reading direction top-bottom
@@ -213,7 +213,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await header.waitUntilLoadingHasFinished();
 
         await common.sleep(1003);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         await header.waitUntilLoadingHasFinished();
 
         const expectedEntries = [
@@ -239,7 +239,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
       it('should show correct series when disabling first agg', async function () {
         await visEditor.toggleDisabledAgg(3);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         await header.waitUntilLoadingHasFinished();
 
         const expectedEntries = ['win 8', 'win xp', 'ios', 'osx', 'win 7'];
@@ -258,7 +258,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await header.waitUntilLoadingHasFinished();
 
         await common.sleep(1003);
-        await visEditor.clickGo(true);
+        await visEditor.clickGo();
         await header.waitUntilLoadingHasFinished();
 
         const expectedEntries = ['Derivative of Count'];

--- a/test/functional/page_objects/visualize_editor_page.ts
+++ b/test/functional/page_objects/visualize_editor_page.ts
@@ -64,8 +64,8 @@ export class VisualizeEditorPageObject extends FtrService {
     await this.visChart.waitForVisualizationRenderingStabilized();
   }
 
-  public async clickGo(isNewChartLibrary = false) {
-    if ((await this.visChart.isNewChartsLibraryEnabled()) || isNewChartLibrary) {
+  public async clickGo(isLegacyChartLib = false) {
+    if ((await this.visChart.isNewChartsLibraryEnabled()) || !isLegacyChartLib) {
       await this.elasticChart.setNewChartUiDebugFlag();
     }
 

--- a/test/functional/page_objects/visualize_page.ts
+++ b/test/functional/page_objects/visualize_page.ts
@@ -517,14 +517,6 @@ export class VisualizePageObject extends FtrService {
     await this.testSubjects.click('visualizesaveAndReturnButton');
   }
 
-  public async getDeprecationWarningStatus() {
-    if (await this.visChart.isNewChartsLibraryEnabled()) {
-      await this.testSubjects.missingOrFail('vizDeprecationWarning');
-    } else {
-      await this.testSubjects.existOrFail('vizDeprecationWarning');
-    }
-  }
-
   public async linkedToOriginatingApp() {
     await this.header.waitUntilLoadingHasFinished();
     await this.testSubjects.existOrFail('visualizesaveAndReturnButton');

--- a/test/functional/page_objects/visualize_page.ts
+++ b/test/functional/page_objects/visualize_page.ts
@@ -149,8 +149,8 @@ export class VisualizePageObject extends FtrService {
     });
   }
 
-  public async clickRefresh(isNewChartLibrary = false) {
-    if ((await this.visChart.isNewChartsLibraryEnabled()) || isNewChartLibrary) {
+  public async clickRefresh(isLegacyChart = false) {
+    if ((await this.visChart.isNewChartsLibraryEnabled()) || !isLegacyChart) {
       await this.elasticChart.setNewChartUiDebugFlag();
     }
     await this.queryBar.clickQuerySubmitButton();

--- a/test/functional/page_objects/visualize_page.ts
+++ b/test/functional/page_objects/visualize_page.ts
@@ -52,7 +52,7 @@ export class VisualizePageObject extends FtrService {
   remoteEsPrefix = 'ftr-remote:';
   defaultIndexString = 'logstash-*';
 
-  public async initTests(isNewLibrary = false) {
+  public async initTests(isLegacyChart = false) {
     await this.kibanaServer.savedObjects.clean({ types: ['visualization'] });
     await this.kibanaServer.importExport.load(
       'test/functional/fixtures/kbn_archiver/visualize.json'
@@ -61,7 +61,7 @@ export class VisualizePageObject extends FtrService {
     await this.kibanaServer.uiSettings.replace({
       defaultIndex: this.defaultIndexString,
       [FORMATS_UI_SETTINGS.FORMAT_BYTES_DEFAULT_PATTERN]: '0,0.[000]b',
-      'visualization:visualize:legacyHeatmapChartsLibrary': !isNewLibrary,
+      'visualization:visualize:legacyHeatmapChartsLibrary': isLegacyChart,
       'histogram:maxBars': 100,
     });
   }

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/gauge.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/gauge.ts
@@ -22,10 +22,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const elasticChart = getService('elasticChart');
 
   describe('Gauge', function describeIndexTests() {
-    const isNewChartsLibraryEnabled = true;
-
     before(async () => {
-      await visualize.initTests(isNewChartsLibraryEnabled);
+      await visualize.initTests();
     });
 
     beforeEach(async () => {

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/goal.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/goal.ts
@@ -20,10 +20,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
 
   describe('Goal', function describeIndexTests() {
-    const isNewChartsLibraryEnabled = true;
-
     before(async () => {
-      await visualize.initTests(isNewChartsLibraryEnabled);
+      await visualize.initTests();
     });
 
     beforeEach(async () => {

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/heatmap.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/heatmap.ts
@@ -18,10 +18,8 @@ export default function ({ getPageObjects }: FtrProviderContext) {
   ]);
 
   describe('Heatmap', function describeIndexTests() {
-    const isNewChartsLibraryEnabled = true;
-
     before(async () => {
-      await visualize.initTests(isNewChartsLibraryEnabled);
+      await visualize.initTests();
     });
 
     beforeEach(async () => {

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/metric.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/metric.ts
@@ -21,10 +21,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const find = getService('find');
 
   describe('Metric', function describeIndexTests() {
-    const isNewChartsLibraryEnabled = true;
-
     before(async () => {
-      await visualize.initTests(isNewChartsLibraryEnabled);
+      await visualize.initTests();
     });
 
     beforeEach(async () => {

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/pie.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/pie.ts
@@ -106,7 +106,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       expect(sliceByText).to.be('machine.os.raw: Descending');
       expect(sizeByText).to.be('Count');
 
-      await pieChart.expectPieChartLabels(expectedTableData, isNewChartsLibraryEnabled);
+      await pieChart.expectPieChartLabels(expectedTableData);
     });
 
     it('should convert types correctly', async () => {

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/pie.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/pie.ts
@@ -21,8 +21,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
 
   describe('Pie', function describeIndexTests() {
-    const isNewChartsLibraryEnabled = true;
-
     before(async () => {
       await visualize.initTests();
     });
@@ -60,7 +58,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.selectAggregation('Terms');
       await visEditor.selectField('machine.os.raw');
       await header.waitUntilLoadingHasFinished();
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
 
       expect(await visualize.hasNavigateToLensButton()).to.eql(true);
     });
@@ -94,7 +92,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.clickBucket('Split slices');
       await visEditor.selectAggregation('Terms');
       await visEditor.selectField('machine.os.raw');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
 
       await visualize.navigateToLensFromAnotherVisualization();
@@ -116,7 +114,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.selectAggregation('Terms');
       await visEditor.selectField('machine.os.raw');
 
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
 
       await visualize.navigateToLensFromAnotherVisualization();
@@ -133,7 +131,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.clickOptionsTab();
       const isDonutButton = await testSubjects.find('visTypePieIsDonut');
       await isDonutButton.click();
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
 
       await visualize.navigateToLensFromAnotherVisualization();

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/pie.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/pie.ts
@@ -24,7 +24,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     const isNewChartsLibraryEnabled = true;
 
     before(async () => {
-      await visualize.initTests(isNewChartsLibraryEnabled);
+      await visualize.initTests();
     });
 
     beforeEach(async () => {

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/table.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/table.ts
@@ -21,10 +21,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const comboBox = getService('comboBox');
 
   describe('Table', function describeIndexTests() {
-    const isNewChartsLibraryEnabled = true;
-
     before(async () => {
-      await visualize.initTests(isNewChartsLibraryEnabled);
+      await visualize.initTests();
     });
 
     beforeEach(async () => {

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/xy.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/xy.ts
@@ -41,7 +41,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.clickBucket('Dot size', 'metrics');
       await visEditor.selectAggregation('Max', 'metrics');
       await visEditor.selectField('memory', 'metrics');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
       expect(await visualize.hasNavigateToLensButton()).to.eql(false);
     });
@@ -50,7 +50,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.clickBucket('Split chart');
       await visEditor.selectAggregation('Terms');
       await visEditor.selectField('machine.os.raw');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
       expect(await visualize.hasNavigateToLensButton()).to.eql(false);
     });
@@ -67,7 +67,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.selectYAxisPosition('ValueAxis-1', 'left');
       await visEditor.clickYAxisOptions('ValueAxis-2');
       await visEditor.selectYAxisPosition('ValueAxis-2', 'left');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
       expect(await visualize.hasNavigateToLensButton()).to.eql(false);
     });
@@ -78,7 +78,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.selectField('machine.os.raw');
       await visEditor.clickBucket('Split series');
       await visEditor.selectAggregation('Date histogram', 'buckets', false, 1);
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
       expect(await visualize.hasNavigateToLensButton()).to.eql(false);
     });
@@ -89,7 +89,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.clickBucket('Split series');
       await visEditor.selectAggregation('Terms');
       await visEditor.selectField('machine.os.raw');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
       expect(await visualize.hasNavigateToLensButton()).to.eql(false);
     });
@@ -99,7 +99,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.selectAggregation('Serial diff', 'metrics');
       await visEditor.clickBucket('Split series');
       await visEditor.selectAggregation('Date histogram');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
       const button = await testSubjects.exists('visualizeEditInLensButton');
       expect(button).to.eql(false);
@@ -114,7 +114,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.setSeriesType(0, 'area');
       await visEditor.toggleAccordion('visEditorSeriesAccordion2');
       await visEditor.setSeriesType(1, 'histogram');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
       await visualize.navigateToLensFromAnotherVisualization();
       await lens.waitForVisualization('xyVisChart');
@@ -141,7 +141,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.setSeriesType(0, 'histogram');
       await visEditor.toggleAccordion('visEditorSeriesAccordion2');
       await visEditor.setSeriesType(1, 'histogram');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
       await visualize.navigateToLensFromAnotherVisualization();
       await lens.waitForVisualization('xyVisChart');
@@ -163,7 +163,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.selectAggregation('Cumulative sum', 'metrics');
       await visEditor.clickBucket('Split series');
       await visEditor.selectAggregation('Date histogram');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
       await visualize.navigateToLensFromAnotherVisualization();
       await lens.waitForVisualization('xyVisChart');
@@ -180,7 +180,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     it('should convert sibling pipeline aggregation', async () => {
       await visEditor.clickMetricEditor();
       await visEditor.selectAggregation('Max Bucket', 'metrics');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
 
       await visualize.navigateToLensFromAnotherVisualization();
@@ -202,7 +202,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     it('should draw a reference line', async () => {
       await visEditor.clickOptionsTab();
       await visEditor.toggleShowThresholdLine();
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       const line = await visChart.getReferenceLine('xyVisChart');
       expect(line?.length).to.be(1);
       await header.waitUntilLoadingHasFinished();
@@ -227,7 +227,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.toggleAccordion('visEditorSeriesAccordion1');
       await visEditor.setSeriesType(0, 'line');
       await visEditor.selectChartMode('stacked');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
 
       await visualize.navigateToLensFromAnotherVisualization();
@@ -247,7 +247,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.selectChartMode('normal');
       await visEditor.clickYAxisOptions('ValueAxis-1');
       await visEditor.selectYAxisMode('percentage');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
 
       await visualize.navigateToLensFromAnotherVisualization();
@@ -266,7 +266,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.setSeriesType(0, 'histogram');
       await visEditor.clickYAxisOptions('ValueAxis-1');
       await visEditor.selectYAxisPosition('ValueAxis-1', 'top');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
 
       await visualize.navigateToLensFromAnotherVisualization();
@@ -292,7 +292,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.selectYAxisPosition('ValueAxis-1', 'left');
       await visEditor.clickYAxisOptions('ValueAxis-2');
       await visEditor.selectYAxisPosition('ValueAxis-2', 'right');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
 
       await visualize.navigateToLensFromAnotherVisualization();
@@ -320,7 +320,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.selectAggregation('Terms');
       await visEditor.selectField('machine.os.raw');
       await header.waitUntilLoadingHasFinished();
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       const expectedData = await visChart.getLegendEntriesXYCharts('xyVisChart');
 
       await visualize.navigateToLensFromAnotherVisualization();
@@ -342,7 +342,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await visEditor.clickBucket('X-axis');
       await visEditor.selectAggregation('Terms');
       await visEditor.selectField('machine.os.raw');
-      await visEditor.clickGo(isNewChartsLibraryEnabled);
+      await visEditor.clickGo();
       await header.waitUntilLoadingHasFinished();
       const expectedData = await visChart.getLegendEntriesXYCharts('xyVisChart');
       await visualize.navigateToLensFromAnotherVisualization();

--- a/x-pack/test/functional/apps/lens/open_in_lens/agg_based/xy.ts
+++ b/x-pack/test/functional/apps/lens/open_in_lens/agg_based/xy.ts
@@ -22,10 +22,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const retry = getService('retry');
 
   describe('XY', function describeIndexTests() {
-    const isNewChartsLibraryEnabled = true;
-
     before(async () => {
-      await visualize.initTests(isNewChartsLibraryEnabled);
+      await visualize.initTests();
     });
 
     beforeEach(async () => {


### PR DESCRIPTION
## Summary

Removes the code that goes through the condition if the vis comes from new or legacy library. Pie charts or xy charts don't use vislib implementation anymore, so the condition will always give the same result.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->