### PR TITLE
[ML] Fix Trained model deletion with expanded row

### DIFF
--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -957,6 +957,14 @@ export const ModelsList: FC<Props> = ({
               }
             });
 
+            setItemIdToExpandedRowMap((prev) => {
+              const newMap = { ...prev };
+              modelsToDelete.forEach((model) => {
+                delete newMap[model.model_id];
+              });
+              return newMap;
+            });
+
             setModelsToDelete([]);
 
             if (refreshList) {

--- a/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
@@ -416,7 +416,8 @@ export default function ({ getService }: FtrProviderContext) {
 
       it('displays a model without an ingest pipeline and model can be deleted', async () => {
         await ml.testExecution.logTestStep('should display the model in the table');
-        await ml.trainedModelsTable.filterWithSearchString(modelWithoutPipelineData.modelId, 1);
+        await ml.testExecution.logTestStep('expands the row to show the model details');
+        await ml.trainedModelsTable.ensureRowIsExpanded(modelWithoutPipelineData.modelId);
 
         await ml.testExecution.logTestStep(
           'displays expected row values for the model in the table'


### PR DESCRIPTION
## Summary

Fixes #198408.

Fixes trained model item deletion with expanded row.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->