### PR TITLE
support params in esql column ast nodes

### DIFF
--- a/packages/kbn-esql-ast/src/builder/builder.ts
+++ b/packages/kbn-esql-ast/src/builder/builder.ts
@@ -9,6 +9,7 @@
 
 /* eslint-disable @typescript-eslint/no-namespace */
 
+import { LeafPrinter } from '../pretty_print';
 import {
   ESQLAstComment,
   ESQLAstCommentMultiLine,
@@ -18,10 +19,14 @@ import {
   ESQLCommand,
   ESQLCommandOption,
   ESQLDecimalLiteral,
+  ESQLIdentifier,
   ESQLInlineCast,
   ESQLIntegerLiteral,
   ESQLList,
   ESQLLocation,
+  ESQLNamedParamLiteral,
+  ESQLParam,
+  ESQLPositionalParamLiteral,
   ESQLOrderExpression,
   ESQLSource,
 } from '../types';
@@ -124,13 +129,17 @@ export namespace Builder {
       template: Omit<AstNodeTemplate<ESQLColumn>, 'name' | 'quoted'>,
       fromParser?: Partial<AstNodeParserFields>
     ): ESQLColumn => {
-      return {
+      const node: ESQLColumn = {
         ...template,
         ...Builder.parserFields(fromParser),
         quoted: false,
-        name: template.parts.join('.'),
+        name: '',
         type: 'column',
       };
+
+      node.name = LeafPrinter.column(node);
+
+      return node;
     };
 
     export const order = (
@@ -189,5 +198,66 @@ export namespace Builder {
         };
       };
     }
+  }
+
+  export const identifier = (
+    template: AstNodeTemplate<ESQLIdentifier>,
+    fromParser?: Partial<AstNodeParserFields>
+  ): ESQLIdentifier => {
+    return {
+      ...template,
+      ...Builder.parserFields(fromParser),
+      type: 'identifier',
+    };
+  };
+
+  export namespace param {
+    export const unnamed = (fromParser?: Partial<AstNodeParserFields>): ESQLParam => {
+      const node = {
+        ...Builder.parserFields(fromParser),
+        name: '',
+        value: '',
+        paramType: 'unnamed',
+        type: 'literal',
+        literalType: 'param',
+      };
+
+      return node as ESQLParam;
+    };
+
+    export const named = (
+      template: Omit<AstNodeTemplate<ESQLNamedParamLiteral>, 'name' | 'literalType' | 'paramType'>,
+      fromParser?: Partial<AstNodeParserFields>
+    ): ESQLNamedParamLiteral => {
+      const node: ESQLNamedParamLiteral = {
+        ...template,
+        ...Builder.parserFields(fromParser),
+        name: '',
+        type: 'literal',
+        literalType: 'param',
+        paramType: 'named',
+      };
+
+      return node;
+    };
+
+    export const positional = (
+      template: Omit<
+        AstNodeTemplate<ESQLPositionalParamLiteral>,
+        'name' | 'literalType' | 'paramType'
+      >,
+      fromParser?: Partial<AstNodeParserFields>
+    ): ESQLPositionalParamLiteral => {
+      const node: ESQLPositionalParamLiteral = {
+        ...template,
+        ...Builder.parserFields(fromParser),
+        name: '',
+        type: 'literal',
+        literalType: 'param',
+        paramType: 'positional',
+      };
+
+      return node;
+    };
   }
 }

--- a/packages/kbn-esql-ast/src/mutate/commands/from/metadata.test.ts
+++ b/packages/kbn-esql-ast/src/mutate/commands/from/metadata.test.ts
@@ -28,7 +28,13 @@ describe('commands.from.metadata', () => {
 
       expect(column).toMatchObject({
         type: 'column',
-        parts: ['a'],
+        args: [
+          {
+            type: 'identifier',
+            name: 'a',
+          },
+        ],
+        // parts: ['a'],
       });
     });
 
@@ -40,19 +46,39 @@ describe('commands.from.metadata', () => {
       expect(columns).toMatchObject([
         {
           type: 'column',
-          parts: ['a'],
+          args: [
+            {
+              type: 'identifier',
+              name: 'a',
+            },
+          ],
         },
         {
           type: 'column',
-          parts: ['b'],
+          args: [
+            {
+              type: 'identifier',
+              name: 'b',
+            },
+          ],
         },
         {
           type: 'column',
-          parts: ['_id'],
+          args: [
+            {
+              type: 'identifier',
+              name: '_id',
+            },
+          ],
         },
         {
           type: 'column',
-          parts: ['_lang'],
+          args: [
+            {
+              type: 'identifier',
+              name: '_lang',
+            },
+          ],
         },
       ]);
     });
@@ -156,7 +182,6 @@ describe('commands.from.metadata', () => {
     it('return inserted `column` node, and parent `option` node', () => {
       const src1 = 'FROM index METADATA a';
       const { root } = parse(src1);
-
       const tuple = commands.from.metadata.insert(root, 'b');
 
       expect(tuple).toMatchObject([

--- a/packages/kbn-esql-ast/src/mutate/commands/from/metadata.ts
+++ b/packages/kbn-esql-ast/src/mutate/commands/from/metadata.ts
@@ -74,7 +74,10 @@ export const find = (
   }
 
   const predicate: Predicate<[ESQLColumn, unknown]> = ([field]) =>
-    cmpArr(field.parts, fieldName as string[]);
+    cmpArr(
+      field.args.map((arg) => (arg.type === 'identifier' ? arg.name : '')),
+      fieldName as string[]
+    );
 
   return findByPredicate(list(ast), predicate);
 };
@@ -128,7 +131,12 @@ export const remove = (
     fieldName = [fieldName];
   }
 
-  return removeByPredicate(ast, (field) => cmpArr(field.parts, fieldName as string[]));
+  return removeByPredicate(ast, (field) =>
+    cmpArr(
+      field.args.map((arg) => (arg.type === 'identifier' ? arg.name : '')),
+      fieldName as string[]
+    )
+  );
 };
 
 /**
@@ -161,7 +169,8 @@ export const insert = (
   }
 
   const parts: string[] = typeof fieldName === 'string' ? [fieldName] : fieldName;
-  const column = Builder.expression.column({ parts });
+  const args = parts.map((part) => Builder.identifier({ name: part }));
+  const column = Builder.expression.column({ args });
 
   if (index === -1) {
     option.args.push(column);
@@ -195,7 +204,12 @@ export const upsert = (
     const parts = Array.isArray(fieldName) ? fieldName : [fieldName];
     const existing = Walker.find(
       option,
-      (node) => node.type === 'column' && cmpArr(node.parts, parts)
+      (node) =>
+        node.type === 'column' &&
+        cmpArr(
+          node.args.map((arg) => (arg.type === 'identifier' ? arg.name : '')),
+          parts
+        )
     );
     if (existing) {
       return undefined;

--- a/packages/kbn-esql-ast/src/mutate/commands/sort/index.ts
+++ b/packages/kbn-esql-ast/src/mutate/commands/sort/index.ts
@@ -50,7 +50,7 @@ const createSortExpression = (
   template: string | string[] | NewSortExpressionTemplate
 ): SortExpression => {
   const column = Builder.expression.column({
-    parts:
+    args:
       typeof template === 'string'
         ? [template]
         : Array.isArray(template)
@@ -189,9 +189,9 @@ export const find = (
   return findByPredicate(ast, ([node]) => {
     let isMatch = false;
     if (node.type === 'column') {
-      isMatch = util.cmpArr(node.parts, arrParts);
+      isMatch = util.cmpArr(node.args, arrParts);
     } else if (node.type === 'order') {
-      const columnParts = (node.args[0] as ESQLColumn)?.parts;
+      const columnParts = (node.args[0] as ESQLColumn)?.args;
 
       if (Array.isArray(columnParts)) {
         isMatch = util.cmpArr(columnParts, arrParts);

--- a/packages/kbn-esql-ast/src/parser/__tests__/columns.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/columns.test.ts
@@ -10,6 +10,57 @@
 import { parse } from '..';
 
 describe('Column Identifier Expressions', () => {
+  it('can parse star column as function argument', () => {
+    const text = 'ROW fn(*)';
+    const { ast } = parse(text);
+
+    expect(ast).toMatchObject([
+      {
+        type: 'command',
+        name: 'row',
+        args: [
+          {
+            type: 'function',
+            name: 'fn',
+            args: [
+              {
+                type: 'column',
+                args: [
+                  {
+                    type: 'identifier',
+                    name: '*',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('can parse a single identifier', () => {
+    const text = 'ROW hello';
+    const { ast } = parse(text);
+
+    expect(ast).toMatchObject([
+      {
+        type: 'command',
+        args: [
+          {
+            type: 'column',
+            args: [
+              {
+                type: 'identifier',
+                name: 'hello',
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
   it('can parse un-quoted identifiers', () => {
     const text = 'ROW a, b.c';
     const { ast } = parse(text);
@@ -20,11 +71,25 @@ describe('Column Identifier Expressions', () => {
         args: [
           {
             type: 'column',
-            parts: ['a'],
+            args: [
+              {
+                type: 'identifier',
+                name: 'a',
+              },
+            ],
           },
           {
             type: 'column',
-            parts: ['b', 'c'],
+            args: [
+              {
+                type: 'identifier',
+                name: 'b',
+              },
+              {
+                type: 'identifier',
+                name: 'c',
+              },
+            ],
           },
         ],
       },
@@ -41,15 +106,42 @@ describe('Column Identifier Expressions', () => {
         args: [
           {
             type: 'column',
-            parts: ['a'],
+            args: [
+              {
+                type: 'identifier',
+                name: 'a',
+              },
+            ],
           },
           {
             type: 'column',
-            parts: ['b', 'c'],
+            args: [
+              {
+                type: 'identifier',
+                name: 'b',
+              },
+              {
+                type: 'identifier',
+                name: 'c',
+              },
+            ],
           },
           {
             type: 'column',
-            parts: ['d', '👍', '123`123'],
+            args: [
+              {
+                type: 'identifier',
+                name: 'd',
+              },
+              {
+                type: 'identifier',
+                name: '👍',
+              },
+              {
+                type: 'identifier',
+                name: '123`123',
+              },
+            ],
           },
         ],
       },
@@ -66,7 +158,20 @@ describe('Column Identifier Expressions', () => {
         args: [
           {
             type: 'column',
-            parts: ['part1', 'part2', 'part`3️⃣'],
+            args: [
+              {
+                type: 'identifier',
+                name: 'part1',
+              },
+              {
+                type: 'identifier',
+                name: 'part2',
+              },
+              {
+                type: 'identifier',
+                name: 'part`3️⃣',
+              },
+            ],
           },
         ],
       },
@@ -84,10 +189,70 @@ describe('Column Identifier Expressions', () => {
         args: [
           {
             type: 'column',
-            parts: ['a', 'b'],
+            args: [
+              {
+                type: 'identifier',
+                name: 'a',
+              },
+              {
+                type: 'identifier',
+                name: 'b',
+              },
+            ],
           },
         ],
       },
     ]);
+  });
+
+  describe('params', () => {
+    it('can parse named param as a single param node', () => {
+      const text = 'ROW ?test';
+      const { ast } = parse(text);
+
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          args: [
+            {
+              type: 'literal',
+              literalType: 'param',
+              paramType: 'named',
+              value: 'test',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('can parse nested named params as column', () => {
+      const text = 'ROW ?test1.?test2';
+      const { ast } = parse(text);
+
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          args: [
+            {
+              type: 'column',
+              args: [
+                {
+                  type: 'literal',
+                  literalType: 'param',
+                  paramType: 'named',
+                  value: 'test1',
+                },
+                {
+                  type: 'literal',
+                  literalType: 'param',
+                  paramType: 'named',
+                  value: 'test2',
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
   });
 });

--- a/packages/kbn-esql-ast/src/parser/__tests__/function.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/function.test.ts
@@ -69,6 +69,103 @@ describe('function AST nodes', () => {
         },
       ]);
     });
+
+    it('parses out function name as identifier node', () => {
+      const query = 'ROW fn(1, 2, 3)';
+      const { ast, errors } = parse(query);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'row',
+          args: [
+            {
+              type: 'function',
+              name: 'fn',
+              operator: {
+                type: 'identifier',
+                name: 'fn',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('parses out function name as named param', () => {
+      const query = 'ROW ?insert_here(1, 2, 3)';
+      const { ast, errors } = parse(query);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'row',
+          args: [
+            {
+              type: 'function',
+              name: '?insert_here',
+              operator: {
+                type: 'literal',
+                literalType: 'param',
+                paramType: 'named',
+                value: 'insert_here',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('parses out function name as unnamed param', () => {
+      const query = 'ROW ?(1, 2, 3)';
+      const { ast, errors } = parse(query);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'row',
+          args: [
+            {
+              type: 'function',
+              name: '?',
+              operator: {
+                type: 'literal',
+                literalType: 'param',
+                paramType: 'unnamed',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('parses out function name as positional param', () => {
+      const query = 'ROW ?30035(1, 2, 3)';
+      const { ast, errors } = parse(query);
+
+      expect(errors.length).toBe(0);
+      expect(ast).toMatchObject([
+        {
+          type: 'command',
+          name: 'row',
+          args: [
+            {
+              type: 'function',
+              name: '?30035',
+              operator: {
+                type: 'literal',
+                literalType: 'param',
+                paramType: 'positional',
+                value: 30035,
+              },
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('"unary-expression"', () => {

--- a/packages/kbn-esql-ast/src/parser/factories.ts
+++ b/packages/kbn-esql-ast/src/parser/factories.ts
@@ -11,7 +11,13 @@
  * In case of changes in the grammar, this script should be updated: esql_update_ast_script.js
  */
 
-import type { Token, ParserRuleContext, TerminalNode, RecognitionException } from 'antlr4';
+import type {
+  Token,
+  ParserRuleContext,
+  TerminalNode,
+  RecognitionException,
+  ParseTree,
+} from 'antlr4';
 import {
   IndexPatternContext,
   QualifiedNameContext,
@@ -21,6 +27,11 @@ import {
   type IntegerValueContext,
   type QualifiedIntegerLiteralContext,
   QualifiedNamePatternContext,
+  FunctionContext,
+  IdentifierContext,
+  InputParamContext,
+  InputNamedOrPositionalParamContext,
+  IdentifierOrParameterContext,
 } from '../antlr/esql_parser';
 import { DOUBLE_TICKS_REGEX, SINGLE_BACKTICK, TICKS_REGEX } from './constants';
 import type {
@@ -42,6 +53,8 @@ import type {
   ESQLNumericLiteral,
   ESQLOrderExpression,
   InlineCastingType,
+  ESQLFunctionCallExpression,
+  ESQLIdentifier,
 } from '../types';
 import { parseIdentifier, getPosition } from './helpers';
 import { Builder, type AstNodeParserFields } from '../builder';
@@ -200,6 +213,69 @@ export function createFunction<Subtype extends FunctionSubtype>(
   }
   return node;
 }
+
+export const createFunctionCall = (ctx: FunctionContext): ESQLFunctionCallExpression => {
+  const functionExpressionCtx = ctx.functionExpression();
+  const functionName = functionExpressionCtx.functionName();
+  const node: ESQLFunctionCallExpression = {
+    type: 'function',
+    subtype: 'variadic-call',
+    name: functionName.getText().toLowerCase(),
+    text: ctx.getText(),
+    location: getPosition(ctx.start, ctx.stop),
+    args: [],
+    incomplete: Boolean(ctx.exception),
+  };
+
+  const identifierOrParameter = functionName.identifierOrParameter();
+
+  if (identifierOrParameter instanceof IdentifierOrParameterContext) {
+    const operator = createIdentifierOrParam(identifierOrParameter);
+
+    if (operator) {
+      node.operator = operator;
+    }
+  }
+
+  return node;
+};
+
+export const createIdentifierOrParam = (ctx: IdentifierOrParameterContext) => {
+  const identifier = ctx.identifier();
+  if (identifier) {
+    return createIdentifier(identifier);
+  } else {
+    const parameter = ctx.parameter();
+    if (parameter) {
+      return createParam(parameter);
+    }
+  }
+};
+
+export const createIdentifier = (identifier: IdentifierContext): ESQLIdentifier => {
+  const text = identifier.getText();
+  const name = parseIdentifier(text);
+
+  return Builder.identifier({ name }, createParserFields(identifier));
+};
+
+export const createParam = (ctx: ParseTree) => {
+  if (ctx instanceof InputParamContext) {
+    return Builder.param.unnamed(createParserFields(ctx));
+  } else if (ctx instanceof InputNamedOrPositionalParamContext) {
+    const text = ctx.getText();
+    const value = text.slice(1);
+    const valueAsNumber = Number(value);
+    const isPositional = String(valueAsNumber) === value;
+    const parserFields = createParserFields(ctx);
+
+    if (isPositional) {
+      return Builder.param.positional({ value: valueAsNumber }, parserFields);
+    } else {
+      return Builder.param.named({ value }, parserFields);
+    }
+  }
+};
 
 export const createOrderExpression = (
   ctx: ParserRuleContext,
@@ -407,37 +483,59 @@ export function createSource(
 
 export function createColumnStar(ctx: TerminalNode): ESQLColumn {
   const text = ctx.getText();
-
-  return {
-    type: 'column',
-    name: text,
-    parts: [text],
+  const parserFields = {
     text,
     location: getPosition(ctx.symbol),
     incomplete: ctx.getText() === '',
     quoted: false,
   };
+
+  return {
+    type: 'column',
+    name: text,
+    args: [Builder.identifier({ name: '*' }, parserFields)],
+    ...parserFields,
+  };
 }
 
 export function createColumn(ctx: ParserRuleContext): ESQLColumn {
-  const parts: string[] = [];
+  const args: ESQLColumn['args'] = [];
+
   if (ctx instanceof QualifiedNamePatternContext) {
-    parts.push(
-      ...ctx.identifierPattern_list().map((identifier) => parseIdentifier(identifier.getText()))
-    );
+    const list = ctx.identifierPattern_list();
+
+    for (const identifier of list) {
+      const name = parseIdentifier(identifier.getText());
+      const node = Builder.identifier({ name }, createParserFields(identifier));
+
+      args.push(node);
+    }
   } else if (ctx instanceof QualifiedNameContext) {
-    parts.push(
-      ...ctx.identifierOrParameter_list().map((identifier) => parseIdentifier(identifier.getText()))
-    );
+    const list = ctx.identifierOrParameter_list();
+
+    for (const item of list) {
+      if (item instanceof IdentifierOrParameterContext) {
+        const node = createIdentifierOrParam(item);
+
+        if (node) {
+          args.push(node);
+        }
+      }
+    }
   } else {
-    parts.push(sanitizeIdentifierString(ctx));
+    const name = sanitizeIdentifierString(ctx);
+    const node = Builder.identifier({ name }, createParserFields(ctx));
+
+    args.push(node);
   }
+
   const text = sanitizeIdentifierString(ctx);
   const hasQuotes = Boolean(getQuotedText(ctx) || isQuoted(ctx.getText()));
+
   return {
     type: 'column' as const,
     name: text,
-    parts,
+    args,
     text: ctx.getText(),
     location: getPosition(ctx.start, ctx.stop),
     incomplete: Boolean(ctx.exception || text === ''),

--- a/packages/kbn-esql-ast/src/parser/walkers.ts
+++ b/packages/kbn-esql-ast/src/parser/walkers.ts
@@ -60,8 +60,6 @@ import {
   type ValueExpressionContext,
   ValueExpressionDefaultContext,
   InlineCastContext,
-  InputNamedOrPositionalParamContext,
-  InputParamContext,
   IndexPatternContext,
   InlinestatsCommandContext,
 } from '../antlr/esql_parser';
@@ -86,8 +84,9 @@ import {
   createInlineCast,
   createUnknownItem,
   createOrderExpression,
+  createFunctionCall,
+  createParam,
 } from './factories';
-import { getPosition } from './helpers';
 
 import {
   ESQLLiteral,
@@ -97,9 +96,6 @@ import {
   ESQLAstItem,
   ESQLAstField,
   ESQLInlineCast,
-  ESQLUnnamedParamLiteral,
-  ESQLPositionalParamLiteral,
-  ESQLNamedParamLiteral,
   ESQLOrderExpression,
 } from '../types';
 import { firstItem, lastItem } from '../visitor/utils';
@@ -390,50 +386,8 @@ function getConstant(ctx: ConstantContext): ESQLAstItem {
     const values: ESQLLiteral[] = [];
 
     for (const child of ctx.children) {
-      if (child instanceof InputParamContext) {
-        const literal: ESQLUnnamedParamLiteral = {
-          type: 'literal',
-          literalType: 'param',
-          paramType: 'unnamed',
-          text: ctx.getText(),
-          name: '',
-          value: '',
-          location: getPosition(ctx.start, ctx.stop),
-          incomplete: Boolean(ctx.exception),
-        };
-        values.push(literal);
-      } else if (child instanceof InputNamedOrPositionalParamContext) {
-        const text = child.getText();
-        const value = text.slice(1);
-        const valueAsNumber = Number(value);
-        const isPositional = String(valueAsNumber) === value;
-
-        if (isPositional) {
-          const literal: ESQLPositionalParamLiteral = {
-            type: 'literal',
-            literalType: 'param',
-            paramType: 'positional',
-            value: valueAsNumber,
-            text,
-            name: '',
-            location: getPosition(ctx.start, ctx.stop),
-            incomplete: Boolean(ctx.exception),
-          };
-          values.push(literal);
-        } else {
-          const literal: ESQLNamedParamLiteral = {
-            type: 'literal',
-            literalType: 'param',
-            paramType: 'named',
-            value,
-            text,
-            name: '',
-            location: getPosition(ctx.start, ctx.stop),
-            incomplete: Boolean(ctx.exception),
-          };
-          values.push(literal);
-        }
-      }
+      const param = createParam(child);
+      if (param) values.push(param);
     }
 
     return values;
@@ -478,15 +432,7 @@ export function visitPrimaryExpression(ctx: PrimaryExpressionContext): ESQLAstIt
   }
   if (ctx instanceof FunctionContext) {
     const functionExpressionCtx = ctx.functionExpression();
-    const functionNameContext = functionExpressionCtx.functionName().MATCH()
-      ? functionExpressionCtx.functionName().MATCH()
-      : functionExpressionCtx.functionName().identifierOrParameter();
-    const fn = createFunction(
-      functionNameContext.getText().toLowerCase(),
-      ctx,
-      undefined,
-      'variadic-call'
-    );
+    const fn = createFunctionCall(ctx);
     const asteriskArg = functionExpressionCtx.ASTERISK()
       ? createColumnStar(functionExpressionCtx.ASTERISK()!)
       : undefined;

--- a/packages/kbn-esql-ast/src/pretty_print/leaf_printer.ts
+++ b/packages/kbn-esql-ast/src/pretty_print/leaf_printer.ts
@@ -27,20 +27,37 @@ export const LeafPrinter = {
   source: (node: ESQLSource) => node.name,
 
   column: (node: ESQLColumn) => {
-    const parts: string[] = node.parts;
+    const args = node.args;
 
     let formatted = '';
 
-    for (const part of parts) {
-      if (formatted.length > 0) {
-        formatted += '.';
-      }
-      if (regexUnquotedIdPattern.test(part)) {
-        formatted += part;
-      } else {
-        // Escape backticks "`" with double backticks "``".
-        const escaped = part.replace(/`/g, '``');
-        formatted += '`' + escaped + '`';
+    for (const arg of args) {
+      switch (arg.type) {
+        case 'identifier': {
+          const name = arg.name;
+
+          if (formatted.length > 0) {
+            formatted += '.';
+          }
+          if (regexUnquotedIdPattern.test(name)) {
+            formatted += name;
+          } else {
+            // Escape backticks "`" with double backticks "``".
+            const escaped = name.replace(/`/g, '``');
+            formatted += '`' + escaped + '`';
+          }
+
+          break;
+        }
+        case 'literal': {
+          if (formatted.length > 0) {
+            formatted += '.';
+          }
+
+          formatted += LeafPrinter.literal(arg);
+
+          break;
+        }
       }
     }
 

--- a/packages/kbn-esql-ast/src/types.ts
+++ b/packages/kbn-esql-ast/src/types.ts
@@ -26,6 +26,7 @@ export type ESQLSingleAstItem =
   | ESQLTimeInterval
   | ESQLList
   | ESQLLiteral
+  | ESQLIdentifier
   | ESQLCommandMode
   | ESQLInlineCast
   | ESQLOrderExpression
@@ -131,6 +132,11 @@ export interface ESQLFunction<
    * Default is 'variadic-call'.
    */
   subtype?: Subtype;
+
+  /**
+   * A node representing the function or operator being called.
+   */
+  operator?: ESQLIdentifier | ESQLParamLiteral;
 
   args: ESQLAstItem[];
 }
@@ -271,11 +277,13 @@ export interface ESQLColumn extends ESQLAstBaseItem {
   type: 'column';
 
   /**
-   * An identifier can be composed of multiple parts, e.g: part1.part2.`part``3️⃣`.
-   * This property contains the parsed unquoted parts of the identifier.
-   * For example: `['part1', 'part2', 'part`3️⃣']`.
+   * A ES|QL column name can be composed of multiple parts,
+   * e.g: part1.part2.`part``3️⃣`.?param. Where parts can be quoted, or not
+   * quoted, or even be a parameter.
+   *
+   * The args list contains the parts of the column name.
    */
-  parts: string[];
+  args: Array<ESQLIdentifier | ESQLParam>;
 
   /**
    * @deprecated
@@ -363,6 +371,10 @@ export interface ESQLNamedParamLiteral extends ESQLParamLiteral<'named'> {
   value: string;
 }
 
+export interface ESQLIdentifier extends ESQLAstBaseItem {
+  type: 'identifier';
+}
+
 export const isESQLNamedParamLiteral = (node: ESQLAstItem): node is ESQLNamedParamLiteral =>
   isESQLAstBaseItem(node) &&
   (node as ESQLNamedParamLiteral).literalType === 'param' &&
@@ -375,6 +387,11 @@ export const isESQLNamedParamLiteral = (node: ESQLAstItem): node is ESQLNamedPar
 export interface ESQLPositionalParamLiteral extends ESQLParamLiteral<'positional'> {
   value: number;
 }
+
+export type ESQLParam =
+  | ESQLUnnamedParamLiteral
+  | ESQLNamedParamLiteral
+  | ESQLPositionalParamLiteral;
 
 export interface ESQLMessage {
   type: 'error' | 'warning';


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

