### PR TITLE
[Dashboard] fix Export CSV doesnt work

### DIFF
--- a/src/plugins/dashboard/kibana.jsonc
+++ b/src/plugins/dashboard/kibana.jsonc
@@ -16,6 +16,7 @@
       "dataViews",
       "dataViewEditor",
       "embeddable",
+      "fieldFormats",
       "controls",
       "inspector",
       "navigation",


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/198517

https://github.com/elastic/kibana/pull/193644 refactored Dashboard services. Part of this refactor moved `fieldFormats` from `data.fieldFormats` to getting `fieldFormats` directly from the fieldFormats plugin. That is because `data.fieldFormats` is marked as deprecated. The problem is that the fieldFormats plugin was not defined under `requiredPlugins` and thus was undefined at runtime.

### Test instructions
1) install web logs sample data
2) open web logs sample data dashboard
3) hover over "[Logs] Response Codes Over Time + Annotations" panel and select "three dots" icon. Then select "Download CSV". Verify there are no errors in web browser console and CSV is downloaded.

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->