### PR TITLE
Discussion and POC for using a React Context for the Security Rules page

### DIFF
--- a/x-pack/packages/kbn-cloud-security-posture/common/utils/ui_metrics.ts
+++ b/x-pack/packages/kbn-cloud-security-posture/common/utils/ui_metrics.ts
@@ -27,9 +27,9 @@ export const ENTITY_FLYOUT_EXPAND_MISCONFIGURATION_VIEW_VISITS =
   'entity-flyout-expand-misconfiguration-view-visits';
 export const ENTITY_FLYOUT_EXPAND_VULNERABILITY_VIEW_VISITS =
   'entity-flyout-expand-vulnerability-view-visits';
-export const NAV_TO_FINDINGS_BY_HOST_NAME_FRPOM_ENTITY_FLYOUT =
+export const NAV_TO_FINDINGS_BY_HOST_NAME_FROM_ENTITY_FLYOUT =
   'nav-to-findings-by-host-name-from-entity-flyout';
-export const NAV_TO_FINDINGS_BY_RULE_NAME_FRPOM_ENTITY_FLYOUT =
+export const NAV_TO_FINDINGS_BY_RULE_NAME_FROM_ENTITY_FLYOUT =
   'nav-to-findings-by-rule-name-from-entity-flyout';
 export const CREATE_DETECTION_RULE_FROM_FLYOUT = 'create-detection-rule-from-flyout';
 export const CREATE_DETECTION_FROM_TABLE_ROW_ACTION = 'create-detection-from-table-row-action';
@@ -37,20 +37,22 @@ export const VULNERABILITIES_FLYOUT_VISITS = 'vulnerabilities-flyout-visits';
 export const OPEN_FINDINGS_FLYOUT = 'open-findings-flyout';
 export const GROUP_BY_CLICK = 'group-by-click';
 export const CHANGE_RULE_STATE = 'change-rule-state';
+export const CHANGE_MULTIPLE_RULE_STATE = 'change-multiple-rule-state';
 
 type CloudSecurityUiCounters =
   | typeof ENTITY_FLYOUT_WITH_MISCONFIGURATION_VISIT
   | typeof ENTITY_FLYOUT_WITH_VULNERABILITY_PREVIEW
   | typeof ENTITY_FLYOUT_EXPAND_MISCONFIGURATION_VIEW_VISITS
   | typeof ENTITY_FLYOUT_EXPAND_VULNERABILITY_VIEW_VISITS
-  | typeof NAV_TO_FINDINGS_BY_HOST_NAME_FRPOM_ENTITY_FLYOUT
-  | typeof NAV_TO_FINDINGS_BY_RULE_NAME_FRPOM_ENTITY_FLYOUT
+  | typeof NAV_TO_FINDINGS_BY_HOST_NAME_FROM_ENTITY_FLYOUT
+  | typeof NAV_TO_FINDINGS_BY_RULE_NAME_FROM_ENTITY_FLYOUT
   | typeof VULNERABILITIES_FLYOUT_VISITS
   | typeof OPEN_FINDINGS_FLYOUT
   | typeof CREATE_DETECTION_RULE_FROM_FLYOUT
   | typeof CREATE_DETECTION_FROM_TABLE_ROW_ACTION
   | typeof GROUP_BY_CLICK
   | typeof CHANGE_RULE_STATE
+  | typeof CHANGE_MULTIPLE_RULE_STATE
   | typeof MISCONFIGURATION_INSIGHT_HOST_DETAILS
   | typeof MISCONFIGURATION_INSIGHT_USER_DETAILS
   | typeof MISCONFIGURATION_INSIGHT_HOST_ENTITY_OVERVIEW

--- a/x-pack/plugins/cloud_security_posture/public/components/take_action.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/take_action.tsx
@@ -37,8 +37,8 @@ const RULE_PAGE_PATH = '/app/security/rules/id/';
 
 interface TakeActionProps {
   createRuleFn?: (http: HttpSetup) => Promise<RuleResponse>;
-  enableBenchmarkRuleFn?: () => Promise<void>;
-  disableBenchmarkRuleFn?: () => Promise<void>;
+  enableBenchmarkRuleFn?: () => void;
+  disableBenchmarkRuleFn?: () => void;
   isCreateDetectionRuleDisabled?: boolean;
   isDataGridControlColumn?: boolean;
 }
@@ -263,7 +263,7 @@ const EnableBenchmarkRule = ({
   setIsLoading,
   closePopover,
 }: {
-  enableBenchmarkRuleFn: () => Promise<void>;
+  enableBenchmarkRuleFn: () => void;
   setIsLoading: (isLoading: boolean) => void;
   closePopover: () => void;
 }) => {
@@ -288,7 +288,7 @@ const DisableBenchmarkRule = ({
   setIsLoading,
   closePopover,
 }: {
-  disableBenchmarkRuleFn: () => Promise<void>;
+  disableBenchmarkRuleFn: () => void;
   setIsLoading: (isLoading: boolean) => void;
   closePopover: () => void;
 }) => {

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -19,7 +19,6 @@ import { useSecuritySolutionContext } from '../../application/security_solution_
 import { useCspBenchmarkIntegrationsV2 } from '../benchmarks/use_csp_benchmark_integrations';
 import { CISBenchmarkIcon } from '../../components/cis_benchmark_icon';
 import { getBenchmarkCisName } from '../../../common/utils/helpers';
-import { RulesProvider } from './rules_context';
 
 export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>) => {
   const benchmarksInfo = useCspBenchmarkIntegrationsV2();
@@ -64,9 +63,7 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
         }
       />
       <EuiSpacer />
-      <RulesProvider>
-        <RulesContainer />
-      </RulesProvider>
+      <RulesContainer />
       {SpyRoute && (
         <SpyRoute
           pageName={cloudPosturePages.benchmarks.id}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -19,6 +19,7 @@ import { useSecuritySolutionContext } from '../../application/security_solution_
 import { useCspBenchmarkIntegrationsV2 } from '../benchmarks/use_csp_benchmark_integrations';
 import { CISBenchmarkIcon } from '../../components/cis_benchmark_icon';
 import { getBenchmarkCisName } from '../../../common/utils/helpers';
+import { RulesProvider } from './rules_context';
 
 export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>) => {
   const benchmarksInfo = useCspBenchmarkIntegrationsV2();
@@ -63,7 +64,9 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
         }
       />
       <EuiSpacer />
-      <RulesContainer />
+      <RulesProvider>
+        <RulesContainer />
+      </RulesProvider>
       {SpyRoute && (
         <SpyRoute
           pageName={cloudPosturePages.benchmarks.id}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -14,12 +14,11 @@ import { RulesTableHeader } from './rules_table_header';
 import * as TEST_SUBJECTS from './test_subjects';
 import { RuleFlyout } from './rules_flyout';
 import { RulesCounters } from './rules_counters';
-import { useRules } from './rules_context';
+import { RulesProvider } from './rules_context';
 
 export const RulesContainer = () => {
   const params = useParams<PageUrlParams>();
   const history = useHistory();
-  const { rulesFlyoutData } = useRules();
 
   const navToRuleFlyout = (ruleId: string) => {
     history.push(
@@ -42,14 +41,14 @@ export const RulesContainer = () => {
 
   return (
     <div data-test-subj={TEST_SUBJECTS.CSP_RULES_CONTAINER}>
-      <RulesCounters />
-      <EuiSpacer />
-      <RulesTableHeader isSearching={status === 'loading'} />
-      <EuiSpacer />
-      <RulesTable selectedRuleId={params.ruleId} onRuleClick={navToRuleFlyout} />
-      {params.ruleId && rulesFlyoutData.metadata && (
-        <RuleFlyout rule={rulesFlyoutData} onClose={navToRulePage} />
-      )}
+      <RulesProvider>
+        <RulesCounters />
+        <EuiSpacer />
+        <RulesTableHeader />
+        <EuiSpacer />
+        <RulesTable selectedRuleId={params.ruleId} onRuleClick={navToRuleFlyout} />
+        <RuleFlyout onClose={navToRulePage} />
+      </RulesProvider>
     </div>
   );
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_container.tsx
@@ -4,72 +4,22 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useState, useMemo } from 'react';
+import React from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { useParams, useHistory, generatePath } from 'react-router-dom';
-import type {
-  CspBenchmarkRule,
-  PageUrlParams,
-  RuleStateAttributes,
-} from '@kbn/cloud-security-posture-common/schema/rules/latest';
-import { extractErrorMessage } from '@kbn/cloud-security-posture-common';
-import semVerCompare from 'semver/functions/compare';
-import semVerCoerce from 'semver/functions/coerce';
+import type { PageUrlParams } from '@kbn/cloud-security-posture-common/schema/rules/latest';
 import { benchmarksNavigation } from '../../common/navigation/constants';
-import { buildRuleKey } from '../../../common/utils/rules_states';
 import { RulesTable } from './rules_table';
 import { RulesTableHeader } from './rules_table_header';
-import { useFindCspBenchmarkRule, type RulesQuery } from './use_csp_benchmark_rules';
 import * as TEST_SUBJECTS from './test_subjects';
 import { RuleFlyout } from './rules_flyout';
-import { useCspGetRulesStates } from './use_csp_rules_state';
 import { RulesCounters } from './rules_counters';
 import { useRules } from './rules_context';
-
-export interface CspBenchmarkRulesWithStates {
-  metadata: CspBenchmarkRule['metadata'];
-  state: 'muted' | 'unmuted';
-}
-
-interface RulesPageData {
-  rules_page: CspBenchmarkRulesWithStates[];
-  all_rules: CspBenchmarkRulesWithStates[];
-  rules_map: Map<string, CspBenchmarkRulesWithStates>;
-  total: number;
-  error?: string;
-  loading: boolean;
-}
-
-export type RulesState = RulesPageData & RulesQuery;
-
-const getPage = (data: CspBenchmarkRulesWithStates[], { page, perPage }: RulesQuery) =>
-  data.slice(page * perPage, (page + 1) * perPage);
-
-const getRulesPageData = (
-  data: CspBenchmarkRulesWithStates[],
-  status: string,
-  error: unknown,
-  query: RulesQuery
-): RulesPageData => {
-  const page = getPage(data, query);
-
-  return {
-    loading: status === 'loading',
-    error: error ? extractErrorMessage(error) : undefined,
-    all_rules: data,
-    rules_map: new Map(data.map((rule) => [rule.metadata.id, rule])),
-    rules_page: page,
-    total: data?.length || 0,
-  };
-};
-
-const MAX_ITEMS_PER_PAGE = 10000;
 
 export const RulesContainer = () => {
   const params = useParams<PageUrlParams>();
   const history = useHistory();
-  const [enabledDisabledItemsFilter, setEnabledDisabledItemsFilter] = useState('no-filter');
-  const { allRules, rulesQuery, pageSize } = useRules();
+  const { rulesFlyoutData } = useRules();
 
   const navToRuleFlyout = (ruleId: string) => {
     history.push(
@@ -90,127 +40,13 @@ export const RulesContainer = () => {
     );
   };
 
-  const { data, status, error } = useFindCspBenchmarkRule(
-    {
-      section: rulesQuery.section,
-      ruleNumber: rulesQuery.ruleNumber,
-      search: rulesQuery.search,
-      page: 1,
-      perPage: MAX_ITEMS_PER_PAGE,
-      sortField: 'metadata.benchmark.rule_number',
-      sortOrder: rulesQuery.sortOrder,
-    },
-    params.benchmarkId,
-    params.benchmarkVersion
-  );
-
-  const rulesStates = useCspGetRulesStates();
-  const arrayRulesStates: RuleStateAttributes[] = Object.values(rulesStates.data || {});
-
-  const rulesWithStates: CspBenchmarkRulesWithStates[] = useMemo(() => {
-    if (!data) return [];
-
-    return data.items
-      .filter((rule: CspBenchmarkRule) => rule.metadata.benchmark.rule_number !== undefined)
-      .map((rule: CspBenchmarkRule) => {
-        const rulesKey = buildRuleKey(
-          rule.metadata.benchmark.id,
-          rule.metadata.benchmark.version,
-          /* Rule number always exists* from 8.7 */
-          rule.metadata.benchmark.rule_number!
-        );
-
-        const match = rulesStates?.data?.[rulesKey];
-        const rulesState = match?.muted ? 'muted' : 'unmuted';
-
-        return { ...rule, state: rulesState || 'unmuted' };
-      });
-  }, [data, rulesStates?.data]);
-
-  const mutedRulesCount = rulesWithStates.filter((rule) => rule.state === 'muted').length;
-
-  const filteredRulesWithStates: CspBenchmarkRulesWithStates[] = useMemo(() => {
-    if (enabledDisabledItemsFilter === 'disabled')
-      return rulesWithStates?.filter((rule) => rule?.state === 'muted');
-    else if (enabledDisabledItemsFilter === 'enabled')
-      return rulesWithStates?.filter((rule) => rule?.state === 'unmuted');
-    else return rulesWithStates;
-  }, [rulesWithStates, enabledDisabledItemsFilter]);
-
-  const sectionList = useMemo(
-    () => allRules?.items.map((rule) => rule.metadata.section),
-    [allRules]
-  );
-
-  const ruleNumberList = useMemo(
-    () => allRules?.items.map((rule) => rule.metadata.benchmark.rule_number || ''),
-    [allRules]
-  );
-
-  const cleanedSectionList = [...new Set(sectionList)].sort((a, b) => {
-    return a.localeCompare(b, 'en', { sensitivity: 'base' });
-  });
-
-  const cleanedRuleNumberList = [...new Set(ruleNumberList)].sort((a, b) =>
-    semVerCompare(semVerCoerce(a) ?? '', semVerCoerce(b) ?? '')
-  );
-
-  const rulesPageData = useMemo(
-    () => getRulesPageData(filteredRulesWithStates, status, error, rulesQuery),
-    [filteredRulesWithStates, status, error, rulesQuery]
-  );
-
-  const [selectedRules, setSelectedRules] = useState<CspBenchmarkRulesWithStates[]>([]);
-
-  const setSelectAllRules = () => {
-    setSelectedRules(rulesPageData.all_rules);
-  };
-
-  const rulesFlyoutData: CspBenchmarkRulesWithStates = {
-    ...{
-      state:
-        arrayRulesStates.find((filteredRuleState) => filteredRuleState.rule_id === params.ruleId)
-          ?.muted === true
-          ? 'muted'
-          : 'unmuted',
-    },
-    ...{
-      metadata: allRules?.items.find((rule) => rule.metadata.id === params.ruleId)?.metadata!,
-    },
-  };
-
   return (
     <div data-test-subj={TEST_SUBJECTS.CSP_RULES_CONTAINER}>
-      <RulesCounters
-        mutedRulesCount={mutedRulesCount}
-        setEnabledDisabledItemsFilter={setEnabledDisabledItemsFilter}
-      />
+      <RulesCounters />
       <EuiSpacer />
-      <RulesTableHeader
-        sectionSelectOptions={cleanedSectionList}
-        ruleNumberSelectOptions={cleanedRuleNumberList}
-        searchValue={rulesQuery.search || ''}
-        totalRulesCount={rulesPageData.all_rules.length}
-        pageSize={rulesPageData.rules_page.length}
-        isSearching={status === 'loading'}
-        selectedRules={selectedRules}
-        setEnabledDisabledItemsFilter={setEnabledDisabledItemsFilter}
-        enabledDisabledItemsFilterState={enabledDisabledItemsFilter}
-        setSelectAllRules={setSelectAllRules}
-        setSelectedRules={setSelectedRules}
-      />
+      <RulesTableHeader isSearching={status === 'loading'} />
       <EuiSpacer />
-      <RulesTable
-        rules_page={rulesPageData.rules_page}
-        total={rulesPageData.total}
-        error={rulesPageData.error}
-        loading={rulesPageData.loading}
-        perPage={pageSize || rulesQuery.perPage}
-        selectedRuleId={params.ruleId}
-        onRuleClick={navToRuleFlyout}
-        selectedRules={selectedRules}
-        setSelectedRules={setSelectedRules}
-      />
+      <RulesTable selectedRuleId={params.ruleId} onRuleClick={navToRuleFlyout} />
       {params.ruleId && rulesFlyoutData.metadata && (
         <RuleFlyout rule={rulesFlyoutData} onClose={navToRulePage} />
       )}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_context.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_context.tsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { createContext, useContext, useMemo, useEffect, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+
+import {
+  FindCspBenchmarkRuleResponse,
+  PageUrlParams,
+} from '@kbn/cloud-security-posture-common/schema/rules/latest';
+import { RulesQuery, useFindCspBenchmarkRule } from './use_csp_benchmark_rules';
+import { usePageSize } from '../../common/hooks/use_page_size';
+import { LOCAL_STORAGE_PAGE_SIZE_RULES_KEY } from '../../common/constants';
+
+// type Dispatch = (action: Action) => void;
+interface RulesProviderProps {
+  children: React.ReactNode;
+}
+interface RulesContextValue {
+  allRules: FindCspBenchmarkRuleResponse | undefined;
+  rulesQuery: RulesQuery;
+  setRulesQuery: (query: Partial<RulesQuery>) => void;
+  pageSize: number;
+  setPageSize: (pageSize: number) => void;
+  page: number;
+  setPage: (page: number) => void;
+}
+
+const RulesContext = createContext<RulesContextValue | undefined>(undefined);
+const MAX_ITEMS_PER_PAGE = 10000;
+
+interface State {
+  rulesQuery: RulesQuery;
+  pageSize?: number;
+  page: number;
+}
+
+type Action =
+  | {
+      type: 'setRulesQuery';
+      value: Partial<RulesQuery>;
+    }
+  | { type: 'setPageSize'; value: number }
+  | { type: 'setPage'; value: number };
+
+function rulesReducer(state: State, action: Action) {
+  switch (action.type) {
+    case 'setRulesQuery': {
+      return { ...state, rulesQuery: { ...state.rulesQuery, ...action.value } };
+    }
+    case 'setPage': {
+      return { ...state, page: action.value };
+    }
+    case 'setPageSize': {
+      return { ...state, pageSize: action.value };
+    }
+    default: {
+      throw new Error(`Unhandled action type: ${action}`);
+    }
+  }
+}
+
+const initialState: State = {
+  page: 1,
+  pageSize: 10,
+  rulesQuery: {
+    section: undefined,
+    ruleNumber: undefined,
+    search: '',
+    page: 0,
+    perPage: 10,
+    sortField: 'metadata.benchmark.rule_number',
+    sortOrder: 'asc',
+  },
+};
+
+export function RulesProvider({ children }: RulesProviderProps) {
+  const params = useParams<PageUrlParams>();
+  const { pageSize: localStoragePageSize, setPageSize: setLocalStoragePageSize } = usePageSize(
+    LOCAL_STORAGE_PAGE_SIZE_RULES_KEY
+  );
+  const allRules = useFindCspBenchmarkRule(
+    {
+      page: 1,
+      perPage: MAX_ITEMS_PER_PAGE,
+      sortField: 'metadata.benchmark.rule_number',
+      sortOrder: 'asc',
+    },
+    params.benchmarkId,
+    params.benchmarkVersion
+  );
+
+  const [state, dispatch] = React.useReducer(rulesReducer, initialState);
+
+  // This useEffect is in charge of auto paginating to the correct page of a rule from the url params
+  useEffect(() => {
+    const getPageByRuleId = () => {
+      if (params.ruleId && allRules?.data?.items) {
+        const ruleIndex = allRules?.data?.items.findIndex(
+          (rule) => rule.metadata.id === params.ruleId
+        );
+
+        if (ruleIndex !== -1) {
+          // Calculate the page based on the rule index and page size
+          const rulePage = Math.floor(ruleIndex / localStoragePageSize);
+          return rulePage;
+        }
+      }
+      return 0;
+    };
+
+    dispatch({ type: 'setPageSize', value: getPageByRuleId() });
+  }, [allRules?.data?.items, params.ruleId, localStoragePageSize]);
+
+  const setRulesQuery = useCallback(
+    () => (query: Partial<RulesQuery>) => {
+      dispatch({ type: 'setRulesQuery', value: query });
+    },
+    []
+  );
+
+  const setPageSize = useCallback(
+    () => (value: number) => {
+      setLocalStoragePageSize(value);
+      dispatch({ type: 'setPageSize', value });
+    },
+    [setLocalStoragePageSize]
+  );
+
+  const initialContextValue = useMemo(
+    () => ({
+      allRules: allRules.data,
+      rulesQuery: state.rulesQuery,
+      setRulesQuery,
+      pageSize: state.pageSize || localStoragePageSize,
+      setPageSize,
+      page: state.page,
+      setPage: (value: number) => dispatch({ type: 'setPage', value }),
+    }),
+    [
+      allRules,
+      state.rulesQuery,
+      state.pageSize,
+      state.page,
+      localStoragePageSize,
+      setRulesQuery,
+      setPageSize,
+    ]
+  );
+
+  return <RulesContext.Provider value={initialContextValue}>{children}</RulesContext.Provider>;
+}
+
+export function useRules() {
+  const context = useContext(RulesContext);
+  if (context === undefined) {
+    throw new Error('useRules must be used within a RulesProvider');
+  }
+  return context;
+}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_context.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_context.tsx
@@ -8,74 +8,79 @@ import React, { createContext, useContext, useMemo, useEffect, useCallback, useS
 import { useParams } from 'react-router-dom';
 
 import {
-  FindCspBenchmarkRuleResponse,
+  CspBenchmarkRule,
   PageUrlParams,
+  RuleStateAttributes,
 } from '@kbn/cloud-security-posture-common/schema/rules/latest';
+import { extractErrorMessage } from '@kbn/cloud-security-posture-common';
+import { buildRuleKey } from '../../../common/utils/rules_states';
 import { RulesQuery, useFindCspBenchmarkRule } from './use_csp_benchmark_rules';
 import { usePageSize } from '../../common/hooks/use_page_size';
 import { LOCAL_STORAGE_PAGE_SIZE_RULES_KEY } from '../../common/constants';
+import { useCspGetRulesStates } from './use_csp_rules_state';
 
-// type Dispatch = (action: Action) => void;
+export interface CspBenchmarkRulesWithStates {
+  metadata: CspBenchmarkRule['metadata'];
+  state: 'muted' | 'unmuted';
+}
+
+interface RulesPageData {
+  rules_page: CspBenchmarkRulesWithStates[];
+  all_rules: CspBenchmarkRulesWithStates[];
+  rules_map: Map<string, CspBenchmarkRulesWithStates>;
+  total: number;
+  error?: string;
+  loading: boolean;
+}
+
+export type RulesState = RulesPageData & RulesQuery;
+
 interface RulesProviderProps {
   children: React.ReactNode;
 }
 interface RulesContextValue {
-  allRules: FindCspBenchmarkRuleResponse | undefined;
   rulesQuery: RulesQuery;
+  rulesPageData: RulesPageData;
   setRulesQuery: (query: Partial<RulesQuery>) => void;
   pageSize: number;
   setPageSize: (pageSize: number) => void;
   page: number;
   setPage: (page: number) => void;
+  sectionList: string[] | undefined;
+  ruleNumberSelectOptions: string[];
+  sectionSelectOptions: string[];
+  selectedRules: CspBenchmarkRulesWithStates[];
+  setSelectedRules: (rules: CspBenchmarkRulesWithStates[]) => void;
+  setSelectAllRules: () => void;
+  setEnabledDisabledItemsFilter: (filter: string) => void;
+  enabledDisabledItemsFilter: string;
+  mutedRulesCount?: number;
+  rulesFlyoutData: CspBenchmarkRulesWithStates;
 }
 
 const RulesContext = createContext<RulesContextValue | undefined>(undefined);
 const MAX_ITEMS_PER_PAGE = 10000;
 
-// interface State {
-//   rulesQuery: RulesQuery;
-//   pageSize?: number;
-//   page: number;
-// }
+const getPage = (data: CspBenchmarkRulesWithStates[], { page, perPage }: RulesQuery) =>
+  data.slice(page * perPage, (page + 1) * perPage);
 
-// type Action =
-//   | {
-//       type: 'setRulesQuery';
-//       value: Partial<RulesQuery>;
-//     }
-//   | { type: 'setPageSize'; value: number }
-//   | { type: 'setPage'; value: number };
+const getRulesPageData = (
+  data: CspBenchmarkRulesWithStates[],
+  status: string,
+  error: unknown,
+  query: RulesQuery
+): RulesPageData => {
+  const page = getPage(data, query);
 
-// function rulesReducer(state: State, action: Action) {
-//   switch (action.type) {
-//     case 'setRulesQuery': {
-//       return { ...state, rulesQuery: { ...state.rulesQuery, ...action.value } };
-//     }
-//     case 'setPage': {
-//       return { ...state, page: action.value };
-//     }
-//     case 'setPageSize': {
-//       return { ...state, pageSize: action.value };
-//     }
-//     default: {
-//       throw new Error(`Unhandled action type: ${action}`);
-//     }
-//   }
-// }
-
-// const initialState: State = {
-//   page: 1,
-//   pageSize: 10,
-//   rulesQuery: {
-//     section: undefined,
-//     ruleNumber: undefined,
-//     search: '',
-//     page: 0,
-//     perPage: 10,
-//     sortField: 'metadata.benchmark.rule_number',
-//     sortOrder: 'asc',
-//   },
-// };
+  return {
+    loading: status === 'loading',
+    error: error ? extractErrorMessage(error) : undefined,
+    all_rules: data,
+    rules_map: new Map(data.map((rule) => [rule.metadata.id, rule])),
+    rules_page: page,
+    total: data?.length || 0,
+  };
+};
 
 export function RulesProvider({ children }: RulesProviderProps) {
   const params = useParams<PageUrlParams>();
@@ -90,6 +95,8 @@ export function RulesProvider({ children }: RulesProviderProps) {
     sortField: 'metadata.benchmark.rule_number',
     sortOrder: 'asc',
   });
+  const [selectedRules, setSelectedRules] = useState<CspBenchmarkRulesWithStates[]>([]);
+  const [enabledDisabledItemsFilter, setEnabledDisabledItemsFilter] = useState('no-filter');
 
   const allRules = useFindCspBenchmarkRule(
     {
@@ -150,28 +157,137 @@ export function RulesProvider({ children }: RulesProviderProps) {
     [setPage]
   );
 
-  const initialContextValue = useMemo(
+  const sectionList = useMemo(
+    () => allRules?.data?.items.map((rule) => rule.metadata.section),
+    [allRules]
+  );
+
+  const ruleNumberSelectOptions = useMemo(
+    () =>
+      allRules.data
+        ? allRules.data.items.map((rule) => rule.metadata.benchmark.rule_number || '')
+        : [],
+    [allRules]
+  );
+
+  const sectionSelectOptions = [...new Set(sectionList)].sort((a, b) => {
+    return a.localeCompare(b, 'en', { sensitivity: 'base' });
+  });
+
+  const { data, status, error } = useFindCspBenchmarkRule(
+    {
+      section: rulesQuery.section,
+      ruleNumber: rulesQuery.ruleNumber,
+      search: rulesQuery.search,
+      page: 1,
+      perPage: MAX_ITEMS_PER_PAGE,
+      sortField: 'metadata.benchmark.rule_number',
+      sortOrder: rulesQuery.sortOrder,
+    },
+    params.benchmarkId,
+    params.benchmarkVersion
+  );
+
+  const rulesStates = useCspGetRulesStates();
+
+  const rulesWithStates: CspBenchmarkRulesWithStates[] = useMemo(() => {
+    if (!data) return [];
+
+    return data.items
+      .filter((rule: CspBenchmarkRule) => rule.metadata.benchmark.rule_number !== undefined)
+      .map((rule: CspBenchmarkRule) => {
+        const rulesKey = buildRuleKey(
+          rule.metadata.benchmark.id,
+          rule.metadata.benchmark.version,
+          /* Rule number always exists* from 8.7 */
+          rule.metadata.benchmark.rule_number!
+        );
+
+        const match = rulesStates?.data?.[rulesKey];
+        const rulesState = match?.muted ? 'muted' : 'unmuted';
+
+        return { ...rule, state: rulesState || 'unmuted' };
+      });
+  }, [data, rulesStates?.data]);
+
+  const mutedRulesCount = rulesWithStates.filter((rule) => rule.state === 'muted').length;
+
+  const filteredRulesWithStates: CspBenchmarkRulesWithStates[] = useMemo(() => {
+    if (enabledDisabledItemsFilter === 'disabled')
+      return rulesWithStates?.filter((rule) => rule?.state === 'muted');
+    else if (enabledDisabledItemsFilter === 'enabled')
+      return rulesWithStates?.filter((rule) => rule?.state === 'unmuted');
+    else return rulesWithStates;
+  }, [rulesWithStates, enabledDisabledItemsFilter]);
+
+  const rulesPageData = useMemo(
+    () => getRulesPageData(filteredRulesWithStates, status, error, rulesQuery),
+    [filteredRulesWithStates, status, error, rulesQuery]
+  );
+
+  const setSelectAllRules = useCallback(() => {
+    setSelectedRules(rulesPageData.all_rules);
+  }, [rulesPageData.all_rules]);
+
+  const rulesFlyoutData: CspBenchmarkRulesWithStates = useMemo(() => {
+    const arrayRulesStates: RuleStateAttributes[] = Object.values(rulesStates.data || {});
+    return {
+      ...{
+        state:
+          arrayRulesStates.find((filteredRuleState) => filteredRuleState.rule_id === params.ruleId)
+            ?.muted === true
+            ? 'muted'
+            : 'unmuted',
+      },
+      ...{
+        metadata: allRules?.data?.items.find((rule) => rule.metadata.id === params.ruleId)
+          ?.metadata!,
+      },
+    };
+  }, [rulesStates, params.ruleId, allRules]);
+
+  const contextValue: RulesContextValue = useMemo(
     () => ({
-      allRules: allRules.data,
       rulesQuery,
+      rulesPageData,
       setRulesQuery: setRulesQueryCallback,
       pageSize,
       setPageSize: setPageSizeCallback,
       page,
       setPage: setPageCallback,
+      sectionList,
+      ruleNumberSelectOptions,
+      sectionSelectOptions,
+      selectedRules,
+      setSelectedRules,
+      setSelectAllRules,
+      setEnabledDisabledItemsFilter,
+      enabledDisabledItemsFilter,
+      mutedRulesCount,
+      rulesFlyoutData,
     }),
     [
-      allRules,
       rulesQuery,
+      rulesPageData,
       setRulesQueryCallback,
       pageSize,
       setPageSizeCallback,
       page,
       setPageCallback,
+      sectionList,
+      ruleNumberSelectOptions,
+      sectionSelectOptions,
+      selectedRules,
+      setSelectedRules,
+      setSelectAllRules,
+      setEnabledDisabledItemsFilter,
+      enabledDisabledItemsFilter,
+      mutedRulesCount,
+      rulesFlyoutData,
     ]
   );
 
-  return <RulesContext.Provider value={initialContextValue}>{children}</RulesContext.Provider>;
+  return <RulesContext.Provider value={contextValue}>{children}</RulesContext.Provider>;
 }
 
 export function useRules() {

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_context.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_context.tsx
@@ -72,6 +72,14 @@ interface RulesContextValue {
 const RulesContext = createContext<RulesContextValue | undefined>(undefined);
 const MAX_ITEMS_PER_PAGE = 10000;
 
+export function useRules() {
+  const context = useContext(RulesContext);
+  if (context === undefined) {
+    throw new Error('useRules must be used within a RulesProvider');
+  }
+  return context;
+}
+
 export function RulesProvider({ children }: RulesProviderProps) {
   const params = useParams<PageUrlParams>();
   const { pageSize, setPageSize } = usePageSize(LOCAL_STORAGE_PAGE_SIZE_RULES_KEY);
@@ -328,14 +336,6 @@ const getRulesPageData = (
     total: data?.length || 0,
   };
 };
-
-export function useRules() {
-  const context = useContext(RulesContext);
-  if (context === undefined) {
-    throw new Error('useRules must be used within a RulesProvider');
-  }
-  return context;
-}
 
 const getRulesWithStates = (
   data: FindCspBenchmarkRuleResponse | undefined,

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_counters.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_counters.tsx
@@ -29,6 +29,7 @@ import { RULE_FAILED, RULE_PASSED } from '../../../common/constants';
 import { useCspBenchmarkIntegrationsV2 } from '../benchmarks/use_csp_benchmark_integrations';
 import { CspCounterCard } from '../../components/csp_counter_card';
 import { useKibana } from '../../common/hooks/use_kibana';
+import { useRules } from './rules_context';
 
 const EvaluationPieChart = ({ failed, passed }: { failed: number; passed: number }) => {
   const {
@@ -84,18 +85,13 @@ const EvaluationPieChart = ({ failed, passed }: { failed: number; passed: number
   );
 };
 
-export const RulesCounters = ({
-  mutedRulesCount,
-  setEnabledDisabledItemsFilter,
-}: {
-  mutedRulesCount: number;
-  setEnabledDisabledItemsFilter: (filterState: string) => void;
-}) => {
+export const RulesCounters = () => {
   const { http } = useKibana().services;
   const { getBenchmarkDynamicValues } = useBenchmarkDynamicValues();
   const rulesPageParams = useParams<{ benchmarkId: string; benchmarkVersion: string }>();
   const getBenchmarks = useCspBenchmarkIntegrationsV2();
   const navToFindings = useNavigateFindings();
+  const { setEnabledDisabledItemsFilter, mutedRulesCount } = useRules();
 
   const benchmarkRulesStats = getBenchmarks.data?.items.find(
     (benchmark) =>

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_flyout.tsx
@@ -35,7 +35,6 @@ export const RULES_FLYOUT_SWITCH_BUTTON = 'rule-flyout-switch-button';
 
 interface RuleFlyoutProps {
   onClose(): void;
-  rule: CspBenchmarkRulesWithStates;
 }
 
 const tabs = [
@@ -57,9 +56,13 @@ const tabs = [
 
 type RuleTab = (typeof tabs)[number]['id'];
 
-export const RuleFlyout = ({ onClose, rule }: RuleFlyoutProps) => {
+export const RuleFlyout = ({ onClose }: RuleFlyoutProps) => {
   const [tab, setTab] = useState<RuleTab>('overview');
-  const { toggleRuleState } = useRules();
+  const { toggleRuleState, rulesFlyoutData: rule } = useRules();
+
+  if (!rule) {
+    return null;
+  }
 
   const isRuleMuted = rule?.state === 'muted';
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -48,18 +48,18 @@ export const RulesTable = ({ selectedRuleId, onRuleClick }: RulesTableProps) => 
   const { euiTheme } = useEuiTheme();
   const {
     page,
+    setPage,
     setSelectedRules,
     selectedRules,
-    rulesPageData,
+    rules: items,
+    total,
+    error,
+    loading,
     pageSize,
     setPageSize,
     sortOrder,
     setSortOrder,
   } = useRules();
-  const items = rulesPageData.all_rules;
-  const total = rulesPageData.total;
-  const error = rulesPageData.error;
-  const loading = rulesPageData.loading;
 
   const euiPagination: EuiBasicTableProps<CspBenchmarkRulesWithStates>['pagination'] = {
     pageIndex: page,
@@ -78,7 +78,7 @@ export const RulesTable = ({ selectedRuleId, onRuleClick }: RulesTableProps) => 
     if (!pagination) return;
     if (pagination && (pagination.index !== page || pagination.size !== pageSize)) {
       setPageSize(pagination.size);
-      setPageSize(pagination.index);
+      setPage(pagination.index);
     }
     if (sort && sort.direction !== sortOrder) {
       setSortOrder(sort.direction);

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -46,16 +46,24 @@ type GetColumnProps = Pick<RulesTableProps, 'onRuleClick'> & {
 
 export const RulesTable = ({ selectedRuleId, onRuleClick }: RulesTableProps) => {
   const { euiTheme } = useEuiTheme();
-  const { setRulesQuery, page, setSelectedRules, selectedRules, rulesQuery, rulesPageData } =
-    useRules();
-  const items = rulesPageData.rules_page;
+  const {
+    page,
+    setSelectedRules,
+    selectedRules,
+    rulesPageData,
+    pageSize,
+    setPageSize,
+    sortOrder,
+    setSortOrder,
+  } = useRules();
+  const items = rulesPageData.all_rules;
   const total = rulesPageData.total;
   const error = rulesPageData.error;
   const loading = rulesPageData.loading;
 
   const euiPagination: EuiBasicTableProps<CspBenchmarkRulesWithStates>['pagination'] = {
     pageIndex: page,
-    pageSize: rulesQuery.perPage,
+    pageSize,
     totalItemCount: total,
     pageSizeOptions: [10, 25, 100],
   };
@@ -63,22 +71,17 @@ export const RulesTable = ({ selectedRuleId, onRuleClick }: RulesTableProps) => 
   const sorting: EuiTableSortingType<CspBenchmarkRulesWithStates> = {
     sort: {
       field: 'metadata.benchmark.rule_number' as keyof CspBenchmarkRulesWithStates,
-      direction: rulesQuery.sortOrder,
+      direction: sortOrder,
     },
   };
-  const onTableChange = ({
-    page: pagination,
-    sort: sortOrder,
-  }: Criteria<CspBenchmarkRulesWithStates>) => {
+  const onTableChange = ({ page: pagination, sort }: Criteria<CspBenchmarkRulesWithStates>) => {
     if (!pagination) return;
-    if (
-      pagination &&
-      (pagination.index !== rulesQuery.page || pagination.size !== rulesQuery.perPage)
-    ) {
-      setRulesQuery({ page: pagination.index, perPage: pagination.size });
+    if (pagination && (pagination.index !== page || pagination.size !== pageSize)) {
+      setPageSize(pagination.size);
+      setPageSize(pagination.index);
     }
-    if (sortOrder && sortOrder.direction !== rulesQuery.sortOrder) {
-      setRulesQuery({ sortOrder: sortOrder.direction });
+    if (sort && sort.direction !== sortOrder) {
+      setSortOrder(sort.direction);
     }
   };
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -19,15 +19,9 @@ import {
   EuiTableSortingType,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { METRIC_TYPE } from '@kbn/analytics';
-import {
-  CHANGE_RULE_STATE,
-  uiMetricService,
-} from '@kbn/cloud-security-posture-common/utils/ui_metrics';
 import { uniqBy } from 'lodash';
 import { ColumnNameWithTooltip } from '../../components/column_name_with_tooltip';
 import * as TEST_SUBJECTS from './test_subjects';
-import { useChangeCspRuleState } from './use_change_csp_rule_state';
 import { CspBenchmarkRulesWithStates, useRules } from './rules_context';
 
 export const RULES_ROWS_ENABLE_SWITCH_BUTTON = 'rules-row-enable-switch-button';
@@ -262,34 +256,16 @@ const getColumns = ({
 ];
 
 const RuleStateSwitch = ({ rule }: { rule: CspBenchmarkRulesWithStates }) => {
+  const { toggleRuleState } = useRules();
   const isRuleMuted = rule?.state === 'muted';
-  const nextRuleState = isRuleMuted ? 'unmute' : 'mute';
 
-  const { mutate: mutateRulesStates } = useChangeCspRuleState();
-
-  const rulesObjectRequest = {
-    benchmark_id: rule?.metadata.benchmark.id,
-    benchmark_version: rule?.metadata.benchmark.version,
-    /* Rule number always exists from 8.7 */
-    rule_number: rule?.metadata.benchmark.rule_number!,
-    rule_id: rule?.metadata.id,
-  };
-  const changeCspRuleStateFn = async () => {
-    if (rule?.metadata.benchmark.rule_number) {
-      uiMetricService.trackUiMetric(METRIC_TYPE.COUNT, CHANGE_RULE_STATE);
-      mutateRulesStates({
-        newState: nextRuleState,
-        ruleIds: [rulesObjectRequest],
-      });
-    }
-  };
   return (
     <EuiFlexGroup justifyContent="flexEnd">
       <EuiFlexItem grow={false}>
         <EuiSwitch
           className="eui-textTruncate"
           checked={!isRuleMuted}
-          onChange={changeCspRuleStateFn}
+          onChange={() => toggleRuleState(rule)}
           data-test-subj={RULES_ROWS_ENABLE_SWITCH_BUTTON}
           label=""
           compressed={true}

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -52,8 +52,8 @@ type GetColumnProps = Pick<RulesTableProps, 'onRuleClick'> & {
 
 export const RulesTable = ({ selectedRuleId, onRuleClick }: RulesTableProps) => {
   const { euiTheme } = useEuiTheme();
-  const { setRulesQuery, setPageSize, page, setSelectedRules, selectedRules } = useRules();
-  const { pageSize, rulesQuery, rulesPageData } = useRules();
+  const { setRulesQuery, page, setSelectedRules, selectedRules, rulesQuery, rulesPageData } =
+    useRules();
   const items = rulesPageData.rules_page;
   const total = rulesPageData.total;
   const error = rulesPageData.error;
@@ -61,15 +61,15 @@ export const RulesTable = ({ selectedRuleId, onRuleClick }: RulesTableProps) => 
 
   const euiPagination: EuiBasicTableProps<CspBenchmarkRulesWithStates>['pagination'] = {
     pageIndex: page,
-    pageSize: pageSize || rulesQuery.perPage,
+    pageSize: rulesQuery.perPage,
     totalItemCount: total,
     pageSizeOptions: [10, 25, 100],
   };
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
   const sorting: EuiTableSortingType<CspBenchmarkRulesWithStates> = {
     sort: {
       field: 'metadata.benchmark.rule_number' as keyof CspBenchmarkRulesWithStates,
-      direction: sortDirection,
+      direction: rulesQuery.sortOrder,
     },
   };
   const onTableChange = ({
@@ -77,12 +77,13 @@ export const RulesTable = ({ selectedRuleId, onRuleClick }: RulesTableProps) => 
     sort: sortOrder,
   }: Criteria<CspBenchmarkRulesWithStates>) => {
     if (!pagination) return;
-    if (pagination) {
-      setPageSize(pagination.size);
+    if (
+      pagination &&
+      (pagination.index !== rulesQuery.page || pagination.size !== rulesQuery.perPage)
+    ) {
       setRulesQuery({ page: pagination.index, perPage: pagination.size });
     }
-    if (sortOrder) {
-      setSortDirection(sortOrder.direction);
+    if (sortOrder && sortOrder.direction !== rulesQuery.sortOrder) {
       setRulesQuery({ sortOrder: sortOrder.direction });
     }
   };

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -26,28 +26,21 @@ import {
 } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
 import { uniqBy } from 'lodash';
 import { ColumnNameWithTooltip } from '../../components/column_name_with_tooltip';
-import type { CspBenchmarkRulesWithStates, RulesState } from './rules_container';
 import * as TEST_SUBJECTS from './test_subjects';
 import { useChangeCspRuleState } from './use_change_csp_rule_state';
-import { useRules } from './rules_context';
+import { CspBenchmarkRulesWithStates, useRules } from './rules_context';
 
 export const RULES_ROWS_ENABLE_SWITCH_BUTTON = 'rules-row-enable-switch-button';
 export const RULES_ROW_SELECT_ALL_CURRENT_PAGE = 'cloud-security-fields-selector-item-all';
 
-type RulesTableProps = Pick<
-  RulesState,
-  'loading' | 'error' | 'rules_page' | 'total' | 'perPage'
-> & {
+interface RulesTableProps {
   onRuleClick: (ruleID: string) => void;
   selectedRuleId?: string;
+}
+
+type GetColumnProps = Pick<RulesTableProps, 'onRuleClick'> & {
   selectedRules: CspBenchmarkRulesWithStates[];
   setSelectedRules: (rules: CspBenchmarkRulesWithStates[]) => void;
-};
-
-type GetColumnProps = Pick<
-  RulesTableProps,
-  'onRuleClick' | 'selectedRules' | 'setSelectedRules'
-> & {
   items: CspBenchmarkRulesWithStates[];
   setIsAllRulesSelectedThisPage: (isAllRulesSelected: boolean) => void;
   isAllRulesSelectedThisPage: boolean;
@@ -57,22 +50,18 @@ type GetColumnProps = Pick<
   ) => boolean;
 };
 
-export const RulesTable = ({
-  perPage: pageSize,
-  rules_page: items,
-  total,
-  loading,
-  error,
-  selectedRuleId,
-  selectedRules,
-  setSelectedRules,
-  onRuleClick,
-}: RulesTableProps) => {
+export const RulesTable = ({ selectedRuleId, onRuleClick }: RulesTableProps) => {
   const { euiTheme } = useEuiTheme();
-  const { setRulesQuery, setPageSize, page } = useRules();
+  const { setRulesQuery, setPageSize, page, setSelectedRules, selectedRules } = useRules();
+  const { pageSize, rulesQuery, rulesPageData } = useRules();
+  const items = rulesPageData.rules_page;
+  const total = rulesPageData.total;
+  const error = rulesPageData.error;
+  const loading = rulesPageData.loading;
+
   const euiPagination: EuiBasicTableProps<CspBenchmarkRulesWithStates>['pagination'] = {
     pageIndex: page,
-    pageSize,
+    pageSize: pageSize || rulesQuery.perPage,
     totalItemCount: total,
     pageSizeOptions: [10, 25, 100],
   };

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table.tsx
@@ -29,20 +29,19 @@ import { ColumnNameWithTooltip } from '../../components/column_name_with_tooltip
 import type { CspBenchmarkRulesWithStates, RulesState } from './rules_container';
 import * as TEST_SUBJECTS from './test_subjects';
 import { useChangeCspRuleState } from './use_change_csp_rule_state';
+import { useRules } from './rules_context';
 
 export const RULES_ROWS_ENABLE_SWITCH_BUTTON = 'rules-row-enable-switch-button';
 export const RULES_ROW_SELECT_ALL_CURRENT_PAGE = 'cloud-security-fields-selector-item-all';
 
 type RulesTableProps = Pick<
   RulesState,
-  'loading' | 'error' | 'rules_page' | 'total' | 'perPage' | 'page'
+  'loading' | 'error' | 'rules_page' | 'total' | 'perPage'
 > & {
-  setPagination(pagination: Pick<RulesState, 'perPage' | 'page'>): void;
   onRuleClick: (ruleID: string) => void;
   selectedRuleId?: string;
   selectedRules: CspBenchmarkRulesWithStates[];
   setSelectedRules: (rules: CspBenchmarkRulesWithStates[]) => void;
-  onSortChange: (value: 'asc' | 'desc') => void;
 };
 
 type GetColumnProps = Pick<
@@ -59,10 +58,8 @@ type GetColumnProps = Pick<
 };
 
 export const RulesTable = ({
-  setPagination,
   perPage: pageSize,
   rules_page: items,
-  page,
   total,
   loading,
   error,
@@ -70,9 +67,9 @@ export const RulesTable = ({
   selectedRules,
   setSelectedRules,
   onRuleClick,
-  onSortChange,
 }: RulesTableProps) => {
   const { euiTheme } = useEuiTheme();
+  const { setRulesQuery, setPageSize, page } = useRules();
   const euiPagination: EuiBasicTableProps<CspBenchmarkRulesWithStates>['pagination'] = {
     pageIndex: page,
     pageSize,
@@ -91,10 +88,13 @@ export const RulesTable = ({
     sort: sortOrder,
   }: Criteria<CspBenchmarkRulesWithStates>) => {
     if (!pagination) return;
-    if (pagination) setPagination({ page: pagination.index, perPage: pagination.size });
+    if (pagination) {
+      setPageSize(pagination.size);
+      setRulesQuery({ page: pagination.index, perPage: pagination.size });
+    }
     if (sortOrder) {
       setSortDirection(sortOrder.direction);
-      onSortChange(sortOrder.direction);
+      setRulesQuery({ sortOrder: sortOrder.direction });
     }
   };
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -29,6 +29,7 @@ import {
 } from './use_change_csp_rule_state';
 import { CspBenchmarkRulesWithStates } from './rules_container';
 import { MultiSelectFilter } from '../../common/component/multi_select_filter';
+import { useRules } from './rules_context';
 
 export const RULES_BULK_ACTION_BUTTON = 'bulk-action-button';
 export const RULES_BULK_ACTION_OPTION_ENABLE = 'bulk-action-option-enable';
@@ -39,9 +40,6 @@ export const RULES_DISABLED_FILTER = 'rules-disabled-filter';
 export const RULES_ENABLED_FILTER = 'rules-enabled-filter';
 
 interface RulesTableToolbarProps {
-  search: (value: string) => void;
-  onSectionChange: (value: string[] | undefined) => void;
-  onRuleNumberChange: (value: string[] | undefined) => void;
   sectionSelectOptions: string[];
   ruleNumberSelectOptions: string[];
   totalRulesCount: number;
@@ -64,13 +62,10 @@ interface RuleTableCount {
 }
 
 export const RulesTableHeader = ({
-  search,
   searchValue,
   isSearching,
   totalRulesCount,
   pageSize,
-  onSectionChange,
-  onRuleNumberChange,
   sectionSelectOptions,
   ruleNumberSelectOptions,
   selectedRules,
@@ -79,6 +74,7 @@ export const RulesTableHeader = ({
   setSelectAllRules,
   setSelectedRules,
 }: RulesTableToolbarProps) => {
+  const { setRulesQuery } = useRules();
   const [selectedSection, setSelectedSection] = useState<string[]>([]);
   const [selectedRuleNumber, setSelectedRuleNumber] = useState<string[]>([]);
   const sectionOptions = sectionSelectOptions.map((option) => ({
@@ -104,7 +100,7 @@ export const RulesTableHeader = ({
     <EuiFlexGroup direction="column">
       <EuiFlexGroup wrap={true}>
         <EuiFlexItem grow={1}>
-          <SearchField isSearching={isSearching} searchValue={searchValue} search={search} />
+          <SearchField isSearching={isSearching} searchValue={searchValue} />
         </EuiFlexItem>
         <EuiFlexItem grow={0}>
           <EuiFlexGroup gutterSize="s" direction="row">
@@ -123,9 +119,9 @@ export const RulesTableHeader = ({
                 id={'cis-section-multi-select-filter'}
                 onChange={(section) => {
                   setSelectedSection([...section?.selectedOptionKeys]);
-                  onSectionChange(
-                    section?.selectedOptionKeys ? section?.selectedOptionKeys : undefined
-                  );
+                  setRulesQuery({
+                    section: section?.selectedOptionKeys ? section?.selectedOptionKeys : undefined,
+                  });
                 }}
                 options={sectionOptions}
                 selectedOptionKeys={selectedSection}
@@ -146,9 +142,11 @@ export const RulesTableHeader = ({
                 id={'rule-number-multi-select-filter'}
                 onChange={(ruleNumber) => {
                   setSelectedRuleNumber([...ruleNumber?.selectedOptionKeys]);
-                  onRuleNumberChange(
-                    ruleNumber?.selectedOptionKeys ? ruleNumber?.selectedOptionKeys : undefined
-                  );
+                  setRulesQuery({
+                    ruleNumber: ruleNumber?.selectedOptionKeys
+                      ? ruleNumber?.selectedOptionKeys
+                      : undefined,
+                  });
                 }}
                 options={ruleNumberOptions}
                 selectedOptionKeys={selectedRuleNumber}
@@ -202,13 +200,20 @@ export const RulesTableHeader = ({
 const SEARCH_DEBOUNCE_MS = 300;
 
 const SearchField = ({
-  search,
   isSearching,
   searchValue,
-}: Pick<RulesTableToolbarProps, 'isSearching' | 'searchValue' | 'search'>) => {
+}: Pick<RulesTableToolbarProps, 'isSearching' | 'searchValue'>) => {
   const [localValue, setLocalValue] = useState(searchValue);
+  const { setRulesQuery } = useRules();
 
-  useDebounce(() => search(localValue), SEARCH_DEBOUNCE_MS, [localValue]);
+  useDebounce(
+    () =>
+      setRulesQuery({
+        search: localValue,
+      }),
+    SEARCH_DEBOUNCE_MS,
+    [localValue]
+  );
 
   return (
     <div>

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -23,12 +23,8 @@ import useDebounce from 'react-use/lib/useDebounce';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
-import {
-  RuleStateAttributesWithoutStates,
-  useChangeCspRuleState,
-} from './use_change_csp_rule_state';
 import { MultiSelectFilter } from '../../common/component/multi_select_filter';
-import { CspBenchmarkRulesWithStates, useRules } from './rules_context';
+import { useRules } from './rules_context';
 
 export const RULES_BULK_ACTION_BUTTON = 'bulk-action-button';
 export const RULES_BULK_ACTION_OPTION_ENABLE = 'bulk-action-option-enable';
@@ -200,39 +196,23 @@ const SearchField = ({ isSearching }: Pick<RulesTableToolbarProps, 'isSearching'
 };
 
 const CurrentPageOfTotal = () => {
-  const { selectedRules, setSelectedRules, rulesPageData, setSelectAllRules } = useRules();
+  const {
+    selectedRules,
+    setSelectedRules,
+    rulesPageData,
+    setSelectAllRules,
+    toggleSelectedRulesStates,
+  } = useRules();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const onPopoverClick = () => {
     setIsPopoverOpen((e) => !e);
   };
 
-  const { mutate: mutateRulesStates } = useChangeCspRuleState();
-
-  const changeCspRuleState = (state: 'mute' | 'unmute') => {
-    const bulkSelectedRules: RuleStateAttributesWithoutStates[] = selectedRules.map(
-      (e: CspBenchmarkRulesWithStates) => ({
-        benchmark_id: e?.metadata.benchmark.id,
-        benchmark_version: e?.metadata.benchmark.version,
-        rule_number: e?.metadata.benchmark.rule_number!,
-        rule_id: e?.metadata.id,
-      })
-    );
-    // Only do the API Call IF there are no undefined value for rule number in the selected rules
-    if (!bulkSelectedRules.some((rule) => rule.rule_number === undefined)) {
-      mutateRulesStates({
-        newState: state,
-        ruleIds: bulkSelectedRules,
-      });
-      setIsPopoverOpen(false);
-    }
-    setSelectedRules([]);
-  };
-
   const changeCspRuleStateMute = () => {
-    changeCspRuleState('mute');
+    toggleSelectedRulesStates('mute');
   };
   const changeCspRuleStateUnmute = () => {
-    changeCspRuleState('unmute');
+    toggleSelectedRulesStates('unmute');
   };
 
   const areAllSelectedRulesMuted = selectedRules.every((rule) => rule?.state === 'muted');

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -39,14 +39,15 @@ interface RulesTableToolbarProps {
 }
 export const RulesTableHeader = ({ isSearching }: RulesTableToolbarProps) => {
   const {
-    setRulesQuery,
+    section,
+    setSection,
+    ruleNumber,
+    setRuleNumber,
     sectionSelectOptions,
     ruleNumberSelectOptions,
     setEnabledDisabledItemsFilter,
     enabledDisabledItemsFilter,
   } = useRules();
-  const [selectedSection, setSelectedSection] = useState<string[]>([]);
-  const [selectedRuleNumber, setSelectedRuleNumber] = useState<string[]>([]);
   const sectionOptions = sectionSelectOptions.map((option) => ({
     key: option,
     label: option,
@@ -87,14 +88,15 @@ export const RulesTableHeader = ({ isSearching }: RulesTableToolbarProps) => {
                   }
                 )}
                 id={'cis-section-multi-select-filter'}
-                onChange={(section) => {
-                  setSelectedSection([...section?.selectedOptionKeys]);
-                  setRulesQuery({
-                    section: section?.selectedOptionKeys ? section?.selectedOptionKeys : undefined,
-                  });
+                onChange={(changedSections) => {
+                  setSection(
+                    changedSections?.selectedOptionKeys
+                      ? changedSections?.selectedOptionKeys
+                      : undefined
+                  );
                 }}
                 options={sectionOptions}
-                selectedOptionKeys={selectedSection}
+                selectedOptionKeys={section}
               />
             </EuiFlexItem>
             <EuiFlexItem
@@ -110,16 +112,15 @@ export const RulesTableHeader = ({ isSearching }: RulesTableToolbarProps) => {
                   }
                 )}
                 id={'rule-number-multi-select-filter'}
-                onChange={(ruleNumber) => {
-                  setSelectedRuleNumber([...ruleNumber?.selectedOptionKeys]);
-                  setRulesQuery({
-                    ruleNumber: ruleNumber?.selectedOptionKeys
-                      ? ruleNumber?.selectedOptionKeys
-                      : undefined,
-                  });
+                onChange={(changedRuleNumbers) => {
+                  setRuleNumber(
+                    changedRuleNumbers?.selectedOptionKeys
+                      ? changedRuleNumbers?.selectedOptionKeys
+                      : undefined
+                  );
                 }}
                 options={ruleNumberOptions}
-                selectedOptionKeys={selectedRuleNumber}
+                selectedOptionKeys={ruleNumber}
               />
             </EuiFlexItem>
             <EuiFlexItem
@@ -164,18 +165,10 @@ export const RulesTableHeader = ({ isSearching }: RulesTableToolbarProps) => {
 const SEARCH_DEBOUNCE_MS = 300;
 
 const SearchField = ({ isSearching }: Pick<RulesTableToolbarProps, 'isSearching'>) => {
-  const { rulesQuery } = useRules();
-  const [localValue, setLocalValue] = useState(rulesQuery.search);
-  const { setRulesQuery } = useRules();
+  const { search, setSearch } = useRules();
+  const [localValue, setLocalValue] = useState(search);
 
-  useDebounce(
-    () =>
-      setRulesQuery({
-        search: localValue,
-      }),
-    SEARCH_DEBOUNCE_MS,
-    [localValue]
-  );
+  useDebounce(() => setSearch(localValue), SEARCH_DEBOUNCE_MS, [localValue]);
 
   return (
     <div>

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -192,7 +192,8 @@ const CurrentPageOfTotal = () => {
   const {
     selectedRules,
     setSelectedRules,
-    rulesPageData,
+    rulesShown,
+    total,
     setSelectAllRules,
     toggleSelectedRulesStates,
   } = useRules();
@@ -243,9 +244,6 @@ const CurrentPageOfTotal = () => {
     </EuiContextMenuItem>,
   ];
 
-  const pageSize = rulesPageData.rules_page.length;
-  const total = rulesPageData.all_rules.length;
-
   return (
     <EuiFlexItem grow={false}>
       <EuiSpacer size="s" />
@@ -254,9 +252,9 @@ const CurrentPageOfTotal = () => {
           <EuiText size="xs" textAlign="left" color="subdued" style={{ marginLeft: '8px' }}>
             <FormattedMessage
               id="xpack.csp.rules.rulesTable.showingPageOfTotalLabel"
-              defaultMessage="Showing {pageSize} of {total, plural, one {# rule} other {# rules}} {pipe} Selected {selectedRulesAmount, plural, one {# rule} other {# rules}}"
+              defaultMessage="Showing {rulesShown} of {total, plural, one {# rule} other {# rules}} {pipe} Selected {selectedRulesAmount, plural, one {# rule} other {# rules}}"
               values={{
-                pageSize,
+                rulesShown,
                 total,
                 selectedRulesAmount: selectedRules.length || 0,
                 pipe: '\u2000|\u2000',

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -34,10 +34,7 @@ export const RULES_CLEAR_ALL_RULES_SELECTION = 'clear-rules-selection-button';
 export const RULES_DISABLED_FILTER = 'rules-disabled-filter';
 export const RULES_ENABLED_FILTER = 'rules-enabled-filter';
 
-interface RulesTableToolbarProps {
-  isSearching: boolean;
-}
-export const RulesTableHeader = ({ isSearching }: RulesTableToolbarProps) => {
+export const RulesTableHeader = () => {
   const {
     section,
     setSection,
@@ -71,7 +68,7 @@ export const RulesTableHeader = ({ isSearching }: RulesTableToolbarProps) => {
     <EuiFlexGroup direction="column">
       <EuiFlexGroup wrap={true}>
         <EuiFlexItem grow={1}>
-          <SearchField isSearching={isSearching} />
+          <SearchField />
         </EuiFlexItem>
         <EuiFlexItem grow={0}>
           <EuiFlexGroup gutterSize="s" direction="row">
@@ -164,8 +161,8 @@ export const RulesTableHeader = ({ isSearching }: RulesTableToolbarProps) => {
 
 const SEARCH_DEBOUNCE_MS = 300;
 
-const SearchField = ({ isSearching }: Pick<RulesTableToolbarProps, 'isSearching'>) => {
-  const { search, setSearch } = useRules();
+const SearchField = () => {
+  const { search, setSearch, loading } = useRules();
   const [localValue, setLocalValue] = useState(search);
 
   useDebounce(() => setSearch(localValue), SEARCH_DEBOUNCE_MS, [localValue]);
@@ -174,7 +171,7 @@ const SearchField = ({ isSearching }: Pick<RulesTableToolbarProps, 'isSearching'
     <div>
       <EuiFlexItem grow={true} style={{ alignItems: 'flex-end' }}>
         <EuiFieldSearch
-          isLoading={isSearching}
+          isLoading={loading}
           placeholder={i18n.translate('xpack.csp.rules.rulesTable.searchPlaceholder', {
             defaultMessage: 'Search by Rule Name',
           })}


### PR DESCRIPTION
## Summary

#### Code speaks louder than words. 😉 

I put together a real-world example using a complex page of what a refactor to using a React Context would look like so that we can discuss and put together an action plan (or no action) to identify and address changes for other pages.

#### Things I noticed
1. We can do refactors like this over multiple PRs,  we don't need to do this in one PR. 
2. Moving the business logic to the `Context` allowed me to understand easier how the page behaves during state change.
3. I was able to fix bugs much easier since much of the logic is in the context.
4. When I search for all references to a function or data object exported from the Context, I can see the places it is used.  When we are prop drilling, we do not see where it is being used if it is passed down to sibling components.
5. Fewer props were needed in components.
6. The components are not implementing business logic, nor are they fetching data therefore they are acting more like pure components.
7. There is some duplication between the usage of `rulesPage`, `rulesQuery` and `page` attributes.  The `page` attribute exists in  `rulesPage` and `rulesQuery` but seems to be used interchangeably in the components.  This is a good example of what a Context could resolve for us.  I've fixed this by removing the `rulesQuery` and `rulesPage` objects and passing mostly primitive types and arrays.

#### Things I could have done but thought it was enough for a demo.
1. Create a `Context` test to test state changes and expected behaviours
2. Create some UI tests using the `Context`,  this will remove some complexity with mocks since we are creating the data
3. Introduce a `useReducer` pattern to control state changes. However,  this would have made this page complex

#### Issues to resolve
1. Fetching all rules,  I could have spent more time preventing all rules from being fetched on every state change, considered `useRef` but we might be able to set a prop in `useQuery`. 
2. Fix the paging issue
4. The UnifiedDataTable is causing an infinite loop when it receives the same pagination and number of pages.  The Unified table should be checking this before updating its state.
5. Remove the dependency on useEffect in the Context.
6. The loading status needs to be implemented


### Checklist

Delete any items that do not apply to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

