### PR TITLE
[ci] Fix extra quick_checks dependency

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -291,9 +291,6 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
-    depends_on:
-      - build
-      - quick_checks
     timeout_in_minutes: 60
     parallelism: 1
     retry:


### PR DESCRIPTION
Keys for on_merge.yml were removed in https://github.com/elastic/kibana/pull/198427, but missed this step.