### PR TITLE
[Alerts] Use unmapped_type: keyword for unmapped fields in alerts query

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_columns/use_columns.ts
@@ -302,7 +302,13 @@ export const useColumns = ({
   );
 
   const fieldsToFetch = useMemo(
-    () => [...columns.map((col) => ({ field: col.id, include_unmapped: true }))],
+    () => [
+      ...columns.map((col) => ({
+        field: col.id,
+        include_unmapped: true,
+        unmapped_type: 'keyword',
+      })),
+    ],
     [columns]
   );
 


### PR DESCRIPTION
## Summary

Currently if a user tries to sort the alerts table by an umapped field, for instance data_stream.dataset, the table will show 0 results, with no easy way to remove this sort. Adds unmapped_type: keyword to the alerts query to help mitigate this, but there should be a ux way to clear filters/sort as well. Related: https://github.com/elastic/kibana/issues/170167 and https://github.com/elastic/kibana/issues/171104

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios







