### PR TITLE
[SecuritySolution] Fix dashboard page when the entity store state is stopped

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_panels.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_panels.tsx
@@ -141,6 +141,7 @@ const EntityStoreDashboardPanelsComponent = () => {
     );
   }
 
+  // TODO Rename variable because the Risk score could be installed but disabled
   const isRiskScoreAvailable =
     riskEngineStatus.data &&
     riskEngineStatus.data.risk_engine_status !== RiskEngineStatusEnum.NOT_INSTALLED;
@@ -199,35 +200,37 @@ const EntityStoreDashboardPanelsComponent = () => {
         </>
       )}
 
-      {entityStore.status === 'not_installed' && !isRiskScoreAvailable && (
-        // TODO: Move modal inside EnableEntityStore component, eliminating the onEnable prop in favour of forwarding the riskScoreEnabled status
-        <EnableEntityStore
-          enablements="both"
-          onEnable={() => setModalState({ visible: true })}
-          loadingRiskEngine={riskEngineInitializing}
-        />
-      )}
+      {(entityStore.status === 'not_installed' || entityStore.status === 'stopped') &&
+        !isRiskScoreAvailable && (
+          // TODO: Move modal inside EnableEntityStore component, eliminating the onEnable prop in favour of forwarding the riskScoreEnabled status
+          <EnableEntityStore
+            enablements="both"
+            onEnable={() => setModalState({ visible: true })}
+            loadingRiskEngine={riskEngineInitializing}
+          />
+        )}
 
-      {entityStore.status === 'not_installed' && isRiskScoreAvailable && (
-        <>
-          <EuiFlexItem>
-            <EnableEntityStore
-              enablements="store"
-              onEnable={() =>
-                setModalState({
-                  visible: true,
-                })
-              }
-            />
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EntityAnalyticsRiskScores riskEntity={RiskScoreEntity.user} />
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EntityAnalyticsRiskScores riskEntity={RiskScoreEntity.host} />
-          </EuiFlexItem>
-        </>
-      )}
+      {(entityStore.status === 'not_installed' || entityStore.status === 'stopped') &&
+        isRiskScoreAvailable && (
+          <>
+            <EuiFlexItem>
+              <EnableEntityStore
+                enablements="store"
+                onEnable={() =>
+                  setModalState({
+                    visible: true,
+                  })
+                }
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EntityAnalyticsRiskScores riskEntity={RiskScoreEntity.user} />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EntityAnalyticsRiskScores riskEntity={RiskScoreEntity.host} />
+            </EuiFlexItem>
+          </>
+        )}
 
       <EntityStoreEnablementModal
         visible={modal.visible}


### PR DESCRIPTION
## Summary

Fix the dashboard page when the entity store state is stopped
Previously, the EntityStoreDashboardPanels component didn't account for the installed but disabled state (stopped).

I made the minimum changes necessary to fix the bug, but this component needs to be refactored, unit-tested, and written in a storybook with all possible states. Technical debt Issue: https://github.com/elastic/security-team/issues/11035


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->