### PR TITLE
[8.16] [ResponseOps]]MaintenaceWindow] Increase MW table limit to 1k (#198504)

### DIFF
--- a/x-pack/plugins/alerting/common/routes/maintenance_window/apis/find/schemas/v1.ts
+++ b/x-pack/plugins/alerting/common/routes/maintenance_window/apis/find/schemas/v1.ts
@@ -12,26 +12,24 @@ const MAX_DOCS = 10000;
 
 export const findMaintenanceWindowsRequestQuerySchema = schema.object(
   {
-    page: schema.maybe(
-      schema.number({
-        defaultValue: 1,
-        min: 1,
-        max: MAX_DOCS,
-        meta: {
-          description: 'The page number to return.',
-        },
-      })
-    ),
-    per_page: schema.maybe(
-      schema.number({
-        defaultValue: 20,
-        min: 0,
-        max: 100,
-        meta: {
-          description: 'The number of maintenance windows to return per page.',
-        },
-      })
-    ),
+    // we do not need to use schema.maybe here, because if we do not pass property page, defaultValue will be used
+    page: schema.number({
+      defaultValue: 1,
+      min: 1,
+      max: MAX_DOCS,
+      meta: {
+        description: 'The page number to return.',
+      },
+    }),
+    // we do not need to use schema.maybe here, because if we do not pass property per_page, defaultValue will be used
+    per_page: schema.number({
+      defaultValue: 1000,
+      min: 0,
+      max: 100,
+      meta: {
+        description: 'The number of maintenance windows to return per page.',
+      },
+    }),
   },
   {
     validate: (params) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [ResponseOps]]MaintenaceWindow] Increase MW table limit to 1k (#198504) (3413cbbb)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julia","email":"iuliia.guskova@elastic.co"},"sourceCommit":{"committedDate":"2024-10-31T14:40:36Z","message":"[ResponseOps]]MaintenaceWindow] Increase MW table limit to 1k (#198504)\n\nHere in this PR I am increasing the limit for MW to 1K.\r\nEven I've changed schema for query params(deleted maybe) I did not add\r\nadditional tests, because we already have one integration test for the\r\ncase, when we do not have `page` and `per_page` params.","sha":"3413cbbb1bbe323f40cb9c6b9ff7a98a32b534d8"},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->