### PR TITLE
[Discover] PoC Allow to load more Top Values in the field popover

### DIFF
--- a/packages/kbn-unified-field-list/src/components/field_stats/field_stats.tsx
+++ b/packages/kbn-unified-field-list/src/components/field_stats/field_stats.tsx
@@ -198,6 +198,7 @@ const FieldStatsComponent: React.FC<FieldStatsProps> = ({
             toDate,
             baseQuery: query,
             abortController: abortControllerRef.current,
+            size: topValuesSizeLimit,
           })
         : await loadFieldStats({
             services: { data },

--- a/packages/kbn-unified-field-list/src/components/field_stats/field_top_values.tsx
+++ b/packages/kbn-unified-field-list/src/components/field_stats/field_top_values.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { Fragment } from 'react';
-import { euiPaletteColorBlind, EuiSpacer } from '@elastic/eui';
+import { EuiButtonEmpty, euiPaletteColorBlind, EuiSpacer } from '@elastic/eui';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import type { AddFieldFilterHandler, BucketedAggregation } from '../../types';
 import FieldTopValuesBucket from './field_top_values_bucket';
@@ -23,6 +23,7 @@ export interface FieldTopValuesProps {
   color?: string;
   'data-test-subj': string;
   onAddFilter?: AddFieldFilterHandler;
+  onLoadMore?: () => void;
   overrideFieldTopValueBar?: OverrideFieldTopValueBarCallback;
 }
 
@@ -35,6 +36,7 @@ export const FieldTopValues: React.FC<FieldTopValuesProps> = ({
   color = getDefaultColor(),
   'data-test-subj': dataTestSubject,
   onAddFilter,
+  onLoadMore,
   overrideFieldTopValueBar,
 }) => {
   if (!buckets?.length) {
@@ -99,6 +101,11 @@ export const FieldTopValues: React.FC<FieldTopValuesProps> = ({
               onAddFilter={onAddFilter}
               overrideFieldTopValueBar={overrideFieldTopValueBar}
             />
+            {onLoadMore ? (
+              <EuiButtonEmpty flush="both" onClick={onLoadMore}>
+                {'Load more'}
+              </EuiButtonEmpty>
+            ) : null}
           </>
         )}
       </div>

--- a/packages/kbn-unified-field-list/src/services/field_stats_text_based/load_field_stats_text_based.ts
+++ b/packages/kbn-unified-field-list/src/services/field_stats_text_based/load_field_stats_text_based.ts
@@ -29,6 +29,7 @@ interface FetchFieldStatsParamsTextBased {
   toDate: string;
   baseQuery: AggregateQuery;
   abortController?: AbortController;
+  size?: number;
 }
 
 export type LoadFieldStatsTextBasedHandler = (
@@ -53,6 +54,7 @@ export const loadFieldStatsTextBased: LoadFieldStatsTextBasedHandler = async ({
   toDate,
   baseQuery,
   abortController,
+  size,
 }) => {
   const { data } = services;
 
@@ -81,6 +83,7 @@ export const loadFieldStatsTextBased: LoadFieldStatsTextBasedHandler = async ({
       searchHandler,
       field,
       esqlBaseQuery: getESQLWithSafeLimit(baseQuery.esql, ESQL_SAFE_LIMIT),
+      size,
     });
   } catch (error) {
     // console.error(error);


### PR DESCRIPTION
- https://github.com/elastic/kibana/issues/192692

## Summary

This PR allows to fetch more than the default number of Top Values in field popover.

![Nov-01-2024 18-30-23](https://github.com/user-attachments/assets/ae760aad-b162-47ac-92e6-802f9a0e5e1a)



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

