### PR TITLE
[kbn-mock-idp-utils] export plugin and metadata files paths

### DIFF
--- a/packages/kbn-mock-idp-utils/src/constants.ts
+++ b/packages/kbn-mock-idp-utils/src/constants.ts
@@ -7,6 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import path from 'path';
+
+import { REPO_ROOT } from '@kbn/repo-info';
+
 export const MOCK_IDP_LOGIN_PATH = '/mock_idp/login';
 export const MOCK_IDP_LOGOUT_PATH = '/mock_idp/logout';
 
@@ -19,3 +23,30 @@ export const MOCK_IDP_ATTRIBUTE_PRINCIPAL = 'http://saml.elastic-cloud.com/attri
 export const MOCK_IDP_ATTRIBUTE_ROLES = 'http://saml.elastic-cloud.com/attributes/roles';
 export const MOCK_IDP_ATTRIBUTE_EMAIL = 'http://saml.elastic-cloud.com/attributes/email';
 export const MOCK_IDP_ATTRIBUTE_NAME = 'http://saml.elastic-cloud.com/attributes/name';
+
+export const MOCK_IDP_TEST_PLUGIN_PATH = path.resolve(
+  REPO_ROOT,
+  'x-pack',
+  'test',
+  'security_api_integration',
+  'plugins',
+  'saml_provider'
+);
+
+const idPResourcesPath = path.resolve(
+  REPO_ROOT,
+  'x-pack',
+  'test',
+  'security_api_integration',
+  'packages',
+  'helpers',
+  'saml'
+);
+
+export const IDP_METADATA_PATHS = {
+  default: path.resolve(MOCK_IDP_TEST_PLUGIN_PATH, 'metadata.xml'),
+  saml1: path.resolve(idPResourcesPath, 'idp_metadata.xml'),
+  saml2: path.resolve(idPResourcesPath, 'idp_metadata_2.xml'),
+  neverLogin: path.resolve(idPResourcesPath, 'idp_metadata_never_login.xml'),
+  mockIdpPlugin: path.resolve(idPResourcesPath, 'idp_metadata_mock_idp.xml'),
+};

--- a/packages/kbn-mock-idp-utils/src/index.ts
+++ b/packages/kbn-mock-idp-utils/src/index.ts
@@ -18,6 +18,8 @@ export {
   MOCK_IDP_ATTRIBUTE_ROLES,
   MOCK_IDP_ATTRIBUTE_EMAIL,
   MOCK_IDP_ATTRIBUTE_NAME,
+  MOCK_IDP_TEST_PLUGIN_PATH,
+  IDP_METADATA_PATHS,
 } from './constants';
 
 export { createMockIdpMetadata, createSAMLResponse, ensureSAMLRoleMapping } from './utils';

--- a/packages/kbn-mock-idp-utils/tsconfig.json
+++ b/packages/kbn-mock-idp-utils/tsconfig.json
@@ -12,5 +12,6 @@
   ],
   "kbn_references": [
     "@kbn/dev-utils",
+    "@kbn/repo-info",
   ]
 }

--- a/x-pack/test/api_integration/deployment_agnostic/default_configs/stateful.config.base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/default_configs/stateful.config.base.ts
@@ -11,6 +11,8 @@ import {
   MOCK_IDP_ATTRIBUTE_ROLES,
   MOCK_IDP_ATTRIBUTE_EMAIL,
   MOCK_IDP_ATTRIBUTE_NAME,
+  MOCK_IDP_TEST_PLUGIN_PATH,
+  IDP_METADATA_PATHS,
 } from '@kbn/mock-idp-utils';
 import {
   esTestConfig,
@@ -61,15 +63,6 @@ export function createStatefulTestConfig<T extends DeploymentAgnosticCommonServi
 
     const xPackAPITestsConfig = await readConfigFile(require.resolve('../../config.ts'));
 
-    // TODO: move to kbn-es because currently metadata file has hardcoded entityID and Location
-    const idpPath = require.resolve(
-      '@kbn/security-api-integration-helpers/saml/idp_metadata_mock_idp.xml'
-    );
-    const samlIdPPlugin = path.resolve(
-      __dirname,
-      '../../../security_api_integration/plugins/saml_provider'
-    );
-
     const servers = {
       kibana: {
         ...kbnTestConfig.getUrlParts(systemIndicesSuperuser),
@@ -109,7 +102,8 @@ export function createStatefulTestConfig<T extends DeploymentAgnosticCommonServi
           ...xPackAPITestsConfig.get('esTestCluster.serverArgs'),
           'xpack.security.authc.token.enabled=true',
           `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.order=0`,
-          `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.idp.metadata.path=${idpPath}`,
+          // TODO: move to kbn-es because currently metadata file has hardcoded entityID and Location
+          `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.idp.metadata.path=${IDP_METADATA_PATHS.default}`,
           `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.idp.entity_id=${MOCK_IDP_ENTITY_ID}`,
           `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.sp.entity_id=${kbnUrl}`,
           `xpack.security.authc.realms.saml.${MOCK_IDP_REALM_NAME}.sp.acs=${kbnUrl}/api/security/saml/callback`,
@@ -133,7 +127,7 @@ export function createStatefulTestConfig<T extends DeploymentAgnosticCommonServi
           ...(isRunOnCI ? [] : ['--mock_idp_plugin.enabled=true']),
           // This ensures that we register the Security SAML API endpoints.
           // In the real world the SAML config is injected by control plane.
-          `--plugin-path=${samlIdPPlugin}`,
+          `--plugin-path=${MOCK_IDP_TEST_PLUGIN_PATH}`,
           '--xpack.cloud.id=ftr_fake_cloud_id',
           // Ensure that SAML is used as the default authentication method whenever a user navigates to Kibana. In other
           // words, Kibana should attempt to authenticate the user using the provider with the lowest order if the Login

--- a/x-pack/test_serverless/shared/config.base.ts
+++ b/x-pack/test_serverless/shared/config.base.ts
@@ -18,7 +18,11 @@ import {
 } from '@kbn/test';
 import { CA_CERT_PATH, kibanaDevServiceAccount } from '@kbn/dev-utils';
 import { commonFunctionalServices } from '@kbn/ftr-common-functional-services';
-import { MOCK_IDP_REALM_NAME } from '@kbn/mock-idp-utils';
+import {
+  MOCK_IDP_REALM_NAME,
+  MOCK_IDP_TEST_PLUGIN_PATH,
+  IDP_METADATA_PATHS,
+} from '@kbn/mock-idp-utils';
 import path from 'path';
 import { defineDockerServersConfig } from '@kbn/test';
 import { dockerImage } from '@kbn/test-suites-xpack/fleet_api_integration/config.base';
@@ -49,16 +53,6 @@ export default async () => {
     },
   };
 
-  // "Fake" SAML provider
-  const idpPath = resolve(
-    __dirname,
-    '../../test/security_api_integration/plugins/saml_provider/metadata.xml'
-  );
-  const samlIdPPlugin = resolve(
-    __dirname,
-    '../../test/security_api_integration/plugins/saml_provider'
-  );
-
   const jwksPath = require.resolve('@kbn/security-api-integration-helpers/oidc/jwks.json');
 
   return {
@@ -79,7 +73,7 @@ export default async () => {
     },
     esTestCluster: {
       from: 'serverless',
-      files: [idpPath, jwksPath],
+      files: [IDP_METADATA_PATHS.default, jwksPath],
       serverArgs: [
         'xpack.security.authc.realms.file.file1.order=-100',
         `xpack.security.authc.realms.native.native1.enabled=false`,
@@ -155,7 +149,7 @@ export default async () => {
         })}`,
         // This ensures that we register the Security SAML API endpoints.
         // In the real world the SAML config is injected by control plane.
-        `--plugin-path=${samlIdPPlugin}`,
+        `--plugin-path=${MOCK_IDP_TEST_PLUGIN_PATH}`,
         // Ensure that SAML is used as the default authentication method whenever a user navigates to Kibana. In other
         // words, Kibana should attempt to authenticate the user using the provider with the lowest order if the Login
         // Selector is disabled (which is how Serverless Kibana is configured). By declaring `cloud-basic` with a higher


### PR DESCRIPTION
## Summary

Exporting paths from package will allow us to import it in `kbn-scout` test package (new test framework), where will store default server configurations