### PR TITLE
Upgrades cypress to 13.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1701,7 +1701,7 @@
     "cssnano": "^5.1.12",
     "cssnano-preset-default": "^5.2.12",
     "csstype": "^3.0.2",
-    "cypress": "13.15.1",
+    "cypress": "13.15.2",
     "cypress-axe": "^1.5.0",
     "cypress-file-upload": "^5.0.8",
     "cypress-multi-reporters": "^1.6.4",

--- a/package.json
+++ b/package.json
@@ -1701,7 +1701,7 @@
     "cssnano": "^5.1.12",
     "cssnano-preset-default": "^5.2.12",
     "csstype": "^3.0.2",
-    "cypress": "13.6.3",
+    "cypress": "13.15.1",
     "cypress-axe": "^1.5.0",
     "cypress-file-upload": "^5.0.8",
     "cypress-multi-reporters": "^1.6.4",

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress.config.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress.config.ts
@@ -13,6 +13,7 @@ export default defineCypressConfig({
   fileServerFolder: './cypress',
   fixturesFolder: './cypress/fixtures',
   screenshotsFolder: './cypress/screenshots',
+  experimentalMemoryManagement: true,
   videosFolder: './cypress/videos',
   requestTimeout: 10000,
   responseTimeout: 40000,

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress.config.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress.config.ts
@@ -13,7 +13,6 @@ export default defineCypressConfig({
   fileServerFolder: './cypress',
   fixturesFolder: './cypress/fixtures',
   screenshotsFolder: './cypress/screenshots',
-  experimentalMemoryManagement: true,
   videosFolder: './cypress/videos',
   requestTimeout: 10000,
   responseTimeout: 40000,
@@ -32,5 +31,6 @@ export default defineCypressConfig({
     baseUrl: 'http://localhost:5601',
     supportFile: './cypress/support/e2e.ts',
     specPattern: './cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+    experimentalMemoryManagement: true,
   },
 });

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
@@ -88,7 +88,7 @@ describe('Service inventory', () => {
       cy.visitKibana(serviceInventoryHref);
     });
 
-    it.skip('with the correct environment when changing the environment', () => {
+    it('with the correct environment when changing the environment', () => {
       cy.wait(mainAliasNames);
 
       cy.getByTestSubj('environmentFilter').type('{selectall}production');

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
@@ -88,7 +88,7 @@ describe('Service inventory', () => {
       cy.visitKibana(serviceInventoryHref);
     });
 
-    it('with the correct environment when changing the environment', () => {
+    it.skip('with the correct environment when changing the environment', () => {
       cy.wait(mainAliasNames);
 
       cy.getByTestSubj('environmentFilter').type('{selectall}production');

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
@@ -93,7 +93,9 @@ describe('Service inventory', () => {
 
       cy.getByTestSubj('environmentFilter').find('input').click();
       cy.getByTestSubj('comboBoxOptionsList environmentFilter-optionsList').should('be.visible');
-      cy.contains('button', 'production').click();
+      cy.getByTestSubj('comboBoxOptionsList environmentFilter-optionsList')
+        .contains('button', 'production')
+        .click();
 
       cy.expectAPIsToHaveBeenCalledWith({
         apisIntercepted: mainAliasNames,

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
@@ -91,8 +91,8 @@ describe('Service inventory', () => {
     it('with the correct environment when changing the environment', () => {
       cy.wait(mainAliasNames);
 
-      cy.getByTestSubj('environmentFilter').type('{selectall}production');
-
+      cy.getByTestSubj('environmentFilter').find('input').click();
+      cy.getByTestSubj('comboBoxOptionsList environmentFilter-optionsList').should('be.visible');
       cy.contains('button', 'production').click();
 
       cy.expectAPIsToHaveBeenCalledWith({

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_overview/service_overview.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_overview/service_overview.cy.ts
@@ -191,20 +191,9 @@ describe('Service Overview', () => {
     it('with the correct environment when changing the environment', () => {
       cy.wait(aliasNames);
 
-      cy.intercept('GET', 'internal/apm/suggestions?*').as('suggestionsRequest');
-
-      cy.getByTestSubj('environmentFilter')
-        .find('input')
-        .type('{selectall}production', { force: true });
-
-      cy.expectAPIsToHaveBeenCalledWith({
-        apisIntercepted: ['@suggestionsRequest'],
-        value: 'fieldValue=production',
-      });
-
-      cy.getByTestSubj('comboBoxOptionsList environmentFilter-optionsList')
-        .contains('production')
-        .click({ force: true });
+      cy.getByTestSubj('environmentFilter').find('input').click();
+      cy.getByTestSubj('comboBoxOptionsList environmentFilter-optionsList').should('be.visible');
+      cy.contains('button', 'production').click();
 
       cy.expectAPIsToHaveBeenCalledWith({
         apisIntercepted: aliasNames,

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_overview/service_overview.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_overview/service_overview.cy.ts
@@ -188,7 +188,7 @@ describe('Service Overview', () => {
       cy.visitKibana(baseUrl);
     });
 
-    it('with the correct environment when changing the environment', () => {
+    it.skip('with the correct environment when changing the environment', () => {
       cy.wait(aliasNames);
 
       cy.intercept('GET', 'internal/apm/suggestions?*').as('suggestionsRequest');

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_overview/service_overview.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_overview/service_overview.cy.ts
@@ -192,10 +192,10 @@ describe('Service Overview', () => {
       cy.wait(aliasNames);
 
       cy.getByTestSubj('environmentFilter').find('input').click();
-      cy.getByTestSubj('comboBoxOptionsList environmentFilter-optionsList').should('be.visible');
       cy.getByTestSubj('comboBoxOptionsList environmentFilter-optionsList')
+        .should('be.visible')
         .contains('button', 'production')
-        .click();
+        .click({ force: true });
 
       cy.expectAPIsToHaveBeenCalledWith({
         apisIntercepted: aliasNames,

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_overview/service_overview.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_overview/service_overview.cy.ts
@@ -193,7 +193,9 @@ describe('Service Overview', () => {
 
       cy.getByTestSubj('environmentFilter').find('input').click();
       cy.getByTestSubj('comboBoxOptionsList environmentFilter-optionsList').should('be.visible');
-      cy.contains('button', 'production').click();
+      cy.getByTestSubj('comboBoxOptionsList environmentFilter-optionsList')
+        .contains('button', 'production')
+        .click();
 
       cy.expectAPIsToHaveBeenCalledWith({
         apisIntercepted: aliasNames,

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_overview/service_overview.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/service_overview/service_overview.cy.ts
@@ -188,7 +188,7 @@ describe('Service Overview', () => {
       cy.visitKibana(baseUrl);
     });
 
-    it.skip('with the correct environment when changing the environment', () => {
+    it('with the correct environment when changing the environment', () => {
       cy.wait(aliasNames);
 
       cy.intercept('GET', 'internal/apm/suggestions?*').as('suggestionsRequest');

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
@@ -122,7 +122,7 @@ describe('Agent configuration', () => {
       cy.contains('Create configuration').should('not.be.disabled');
     });
 
-    it.only('persists service environment when clicking on edit button', () => {
+    it('persists service environment when clicking on edit button', () => {
       cy.intercept('GET', '/api/apm/settings/agent-configuration/environments?*').as(
         'serviceEnvironmentApi'
       );

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
@@ -122,7 +122,7 @@ describe('Agent configuration', () => {
       cy.contains('Create configuration').should('not.be.disabled');
     });
 
-    it('persists service environment when clicking on edit button', () => {
+    it.skip('persists service environment when clicking on edit button', () => {
       cy.intercept('GET', '/api/apm/settings/agent-configuration/environments?*').as(
         'serviceEnvironmentApi'
       );
@@ -147,7 +147,7 @@ describe('Agent configuration', () => {
         .should('contain', 'production');
     });
 
-    it('displays All label when selecting all option', () => {
+    it.skip('displays All label when selecting all option', () => {
       cy.intercept('GET', '/api/apm/settings/agent-configuration/environments').as(
         'serviceEnvironmentApi'
       );

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
@@ -122,16 +122,13 @@ describe('Agent configuration', () => {
       cy.contains('Create configuration').should('not.be.disabled');
     });
 
-    it.skip('persists service environment when clicking on edit button', () => {
+    it.only('persists service environment when clicking on edit button', () => {
       cy.intercept('GET', '/api/apm/settings/agent-configuration/environments?*').as(
         'serviceEnvironmentApi'
       );
       cy.contains('Create configuration').click();
       cy.getByTestSubj('serviceNameComboBox').find('input').click();
       cy.getByTestSubj('serviceNameComboBox').type('opbeans-node{enter}');
-      cy.getByTestSubj('comboBoxOptionsList serviceNameComboBox-optionsList').should('be.visible');
-
-      cy.contains('opbeans-node').click();
       cy.wait('@serviceEnvironmentApi');
 
       cy.getByTestSubj('serviceEnviromentComboBox').find('input').click();

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
@@ -135,7 +135,9 @@ describe('Agent configuration', () => {
       cy.getByTestSubj('comboBoxOptionsList serviceEnviromentComboBox-optionsList').should(
         'be.visible'
       );
-      cy.contains('button', 'production').click();
+      cy.getByTestSubj('comboBoxOptionsList serviceEnviromentComboBox-optionsList')
+        .contains('button', 'production')
+        .click();
 
       cy.contains('Next step').click();
       cy.contains('Create configuration');
@@ -156,14 +158,18 @@ describe('Agent configuration', () => {
       cy.getByTestSubj('serviceNameComboBox').find('input').click();
       cy.getByTestSubj('comboBoxOptionsList serviceNameComboBox-optionsList').should('be.visible');
 
-      cy.contains('button', 'All').click();
+      cy.getByTestSubj('comboBoxOptionsList serviceNameComboBox-optionsList')
+        .contains('button', 'All')
+        .click();
       cy.wait('@serviceEnvironmentApi');
 
       cy.getByTestSubj('serviceEnviromentComboBox').find('input').click();
       cy.getByTestSubj('comboBoxOptionsList serviceEnviromentComboBox-optionsList').should(
         'be.visible'
       );
-      cy.contains('button', 'All').click();
+      cy.getByTestSubj('comboBoxOptionsList serviceEnviromentComboBox-optionsList')
+        .contains('button', 'All')
+        .click();
 
       cy.contains('Next step').click();
       cy.get('[data-test-subj="settingsPage_serviceName"]').contains('All');

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
@@ -122,7 +122,7 @@ describe('Agent configuration', () => {
       cy.contains('Create configuration').should('not.be.disabled');
     });
 
-    it.skip('persists service environment when clicking on edit button', () => {
+    it('persists service environment when clicking on edit button', () => {
       cy.intercept('GET', '/api/apm/settings/agent-configuration/environments?*').as(
         'serviceEnvironmentApi'
       );
@@ -147,7 +147,7 @@ describe('Agent configuration', () => {
         .should('contain', 'production');
     });
 
-    it.skip('displays All label when selecting all option', () => {
+    it('displays All label when selecting all option', () => {
       cy.intercept('GET', '/api/apm/settings/agent-configuration/environments').as(
         'serviceEnvironmentApi'
       );

--- a/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
+++ b/x-pack/plugins/observability_solution/apm/ftr_e2e/cypress/e2e/settings/agent_configurations.cy.ts
@@ -122,21 +122,24 @@ describe('Agent configuration', () => {
       cy.contains('Create configuration').should('not.be.disabled');
     });
 
-    it('persists service environment when clicking on edit button', () => {
+    it.skip('persists service environment when clicking on edit button', () => {
       cy.intercept('GET', '/api/apm/settings/agent-configuration/environments?*').as(
         'serviceEnvironmentApi'
       );
       cy.contains('Create configuration').click();
-      cy.getByTestSubj('serviceNameComboBox').click().type('opbeans-node').type('{enter}');
+      cy.getByTestSubj('serviceNameComboBox').find('input').click();
+      cy.getByTestSubj('serviceNameComboBox').type('opbeans-node{enter}');
+      cy.getByTestSubj('comboBoxOptionsList serviceNameComboBox-optionsList').should('be.visible');
 
-      cy.contains('opbeans-node').realClick();
+      cy.contains('opbeans-node').click();
       cy.wait('@serviceEnvironmentApi');
 
-      cy.getByTestSubj('serviceEnviromentComboBox')
-        .click({ force: true })
-        .type('prod')
-        .type('{enter}');
-      cy.contains('production').realClick();
+      cy.getByTestSubj('serviceEnviromentComboBox').find('input').click();
+      cy.getByTestSubj('comboBoxOptionsList serviceEnviromentComboBox-optionsList').should(
+        'be.visible'
+      );
+      cy.contains('button', 'production').click();
+
       cy.contains('Next step').click();
       cy.contains('Create configuration');
       cy.contains('Edit').click();
@@ -152,13 +155,19 @@ describe('Agent configuration', () => {
         'serviceEnvironmentApi'
       );
       cy.contains('Create configuration').click();
-      cy.getByTestSubj('serviceNameComboBox').click().type('All').type('{enter}');
-      cy.contains('All').realClick();
+      cy.getByTestSubj('serviceNameComboBox').find('input').type('All{enter}');
+      cy.getByTestSubj('serviceNameComboBox').find('input').click();
+      cy.getByTestSubj('comboBoxOptionsList serviceNameComboBox-optionsList').should('be.visible');
+
+      cy.contains('button', 'All').click();
       cy.wait('@serviceEnvironmentApi');
 
-      cy.getByTestSubj('serviceEnviromentComboBox').click({ force: true }).type('All');
+      cy.getByTestSubj('serviceEnviromentComboBox').find('input').click();
+      cy.getByTestSubj('comboBoxOptionsList serviceEnviromentComboBox-optionsList').should(
+        'be.visible'
+      );
+      cy.contains('button', 'All').click();
 
-      cy.get('mark').contains('All').click({ force: true });
       cy.contains('Next step').click();
       cy.get('[data-test-subj="settingsPage_serviceName"]').contains('All');
       cy.get('[data-test-subj="settingsPage_environmentName"]').contains('All');

--- a/yarn.lock
+++ b/yarn.lock
@@ -14651,7 +14651,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.2.1, buffer@^5.5.0, buffer@^5.6.0:
+buffer@^5.2.1, buffer@^5.5.0, buffer@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -16265,19 +16265,19 @@ cypress-recurse@^1.35.2:
   dependencies:
     humanize-duration "^3.27.3"
 
-cypress@13.6.3:
-  version "13.6.3"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.6.3.tgz#54f03ca07ee56b2bc18211e7bd32abd2533982ba"
-  integrity sha512-d/pZvgwjAyZsoyJ3FOsJT5lDsqnxQ/clMqnNc++rkHjbkkiF2h9s0JsZSyyH4QXhVFW3zPFg82jD25roFLOdZA==
+cypress@13.15.1:
+  version "13.15.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.15.1.tgz#d85074e07cc576eb30068617d529719ef6093b69"
+  integrity sha512-DwUFiKXo4lef9kA0M4iEhixFqoqp2hw8igr0lTqafRb9qtU3X0XGxKbkSYsUFdkrAkphc7MPDxoNPhk5pj9PVg==
   dependencies:
-    "@cypress/request" "^3.0.0"
+    "@cypress/request" "^3.0.4"
     "@cypress/xvfb" "^1.2.4"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
     arch "^2.2.0"
     blob-util "^2.0.2"
     bluebird "^3.7.2"
-    buffer "^5.6.0"
+    buffer "^5.7.1"
     cachedir "^2.3.0"
     chalk "^4.1.0"
     check-more-types "^2.24.0"
@@ -16295,7 +16295,7 @@ cypress@13.6.3:
     figures "^3.2.0"
     fs-extra "^9.1.0"
     getos "^3.2.1"
-    is-ci "^3.0.0"
+    is-ci "^3.0.1"
     is-installed-globally "~0.4.0"
     lazy-ass "^1.6.0"
     listr2 "^3.8.3"
@@ -16309,7 +16309,8 @@ cypress@13.6.3:
     request-progress "^3.0.0"
     semver "^7.5.3"
     supports-color "^8.1.1"
-    tmp "~0.2.1"
+    tmp "~0.2.3"
+    tree-kill "1.2.2"
     untildify "^4.0.0"
     yauzl "^2.10.0"
 
@@ -21218,7 +21219,7 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-ci@^3.0.0:
+is-ci@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
   integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
@@ -30191,7 +30192,7 @@ string-replace-loader@^2.2.0:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -30208,6 +30209,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -30319,7 +30329,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -30332,6 +30342,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -31138,7 +31155,7 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-tmp@^0.2.3, tmp@~0.2.1:
+tmp@^0.2.3, tmp@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
   integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
@@ -31293,7 +31310,7 @@ traverse@^0.6.6, traverse@~0.6.6:
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
-tree-kill@^1.2.2:
+tree-kill@1.2.2, tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
@@ -33255,7 +33272,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -33276,6 +33293,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -33393,7 +33419,7 @@ xpath@^0.0.33:
   resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.33.tgz#5136b6094227c5df92002e7c3a13516a5074eb07"
   integrity sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==
 
-"xstate5@npm:xstate@^5.18.1", xstate@^5.18.1:
+"xstate5@npm:xstate@^5.18.1":
   version "5.18.1"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.18.1.tgz#c4d43ceaba6e6c31705d36bd96e285de4be4f7f4"
   integrity sha512-m02IqcCQbaE/kBQLunwub/5i8epvkD2mFutnL17Oeg1eXTShe1sRF4D5mhv1dlaFO4vbW5gRGRhraeAD5c938g==
@@ -33402,6 +33428,11 @@ xstate@^4.38.2:
   version "4.38.2"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.38.2.tgz#1b74544fc9c8c6c713ba77f81c6017e65aa89804"
   integrity sha512-Fba/DwEPDLneHT3tbJ9F3zafbQXszOlyCJyQqqdzmtlY/cwE2th462KK48yaANf98jHlP6lJvxfNtN0LFKXPQg==
+
+xstate@^5.18.1:
+  version "5.18.1"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.18.1.tgz#c4d43ceaba6e6c31705d36bd96e285de4be4f7f4"
+  integrity sha512-m02IqcCQbaE/kBQLunwub/5i8epvkD2mFutnL17Oeg1eXTShe1sRF4D5mhv1dlaFO4vbW5gRGRhraeAD5c938g==
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,7 +2033,7 @@
     find-test-names "^1.19.0"
     globby "^11.0.4"
 
-"@cypress/request@^3.0.0":
+"@cypress/request@^3.0.6":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.6.tgz#f5580add6acee0e183b4d4e07eff4f31327ae12b"
   integrity sha512-fi0eVdCOtKu5Ed6+E8mYxUF6ZTFJDZvHogCBelM0xVXmrDEkyM22gRArQzq1YcHPm1V47Vf/iAD+WgVdUlJCGg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -15152,6 +15152,11 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
 
+ci-info@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.0.0.tgz#65466f8b280fc019b9f50a5388115d17a63a44f2"
+  integrity sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -16265,12 +16270,12 @@ cypress-recurse@^1.35.2:
   dependencies:
     humanize-duration "^3.27.3"
 
-cypress@13.15.1:
-  version "13.15.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.15.1.tgz#d85074e07cc576eb30068617d529719ef6093b69"
-  integrity sha512-DwUFiKXo4lef9kA0M4iEhixFqoqp2hw8igr0lTqafRb9qtU3X0XGxKbkSYsUFdkrAkphc7MPDxoNPhk5pj9PVg==
+cypress@13.15.2:
+  version "13.15.2"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.15.2.tgz#ef19554c274bc4ff23802aeb5c52951677fa67f1"
+  integrity sha512-ARbnUorjcCM3XiPwgHKuqsyr5W9Qn+pIIBPaoilnoBkLdSC2oLQjV1BUpnmc7KR+b7Avah3Ly2RMFnfxr96E/A==
   dependencies:
-    "@cypress/request" "^3.0.4"
+    "@cypress/request" "^3.0.6"
     "@cypress/xvfb" "^1.2.4"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
@@ -16281,6 +16286,7 @@ cypress@13.15.1:
     cachedir "^2.3.0"
     chalk "^4.1.0"
     check-more-types "^2.24.0"
+    ci-info "^4.0.0"
     cli-cursor "^3.1.0"
     cli-table3 "~0.6.1"
     commander "^6.2.1"
@@ -16295,7 +16301,6 @@ cypress@13.15.1:
     figures "^3.2.0"
     fs-extra "^9.1.0"
     getos "^3.2.1"
-    is-ci "^3.0.1"
     is-installed-globally "~0.4.0"
     lazy-ass "^1.6.0"
     listr2 "^3.8.3"
@@ -21218,13 +21223,6 @@ is-ci@^2.0.0:
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
-
-is-ci@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
-  integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
-  dependencies:
-    ci-info "^3.2.0"
 
 is-core-module@^2.11.0, is-core-module@^2.12.1, is-core-module@^2.13.0:
   version "2.13.1"
@@ -30192,7 +30190,7 @@ string-replace-loader@^2.2.0:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -30209,15 +30207,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -30329,7 +30318,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -30342,13 +30331,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -33272,7 +33254,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -33293,15 +33275,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -33419,7 +33392,7 @@ xpath@^0.0.33:
   resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.33.tgz#5136b6094227c5df92002e7c3a13516a5074eb07"
   integrity sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==
 
-"xstate5@npm:xstate@^5.18.1":
+"xstate5@npm:xstate@^5.18.1", xstate@^5.18.1:
   version "5.18.1"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.18.1.tgz#c4d43ceaba6e6c31705d36bd96e285de4be4f7f4"
   integrity sha512-m02IqcCQbaE/kBQLunwub/5i8epvkD2mFutnL17Oeg1eXTShe1sRF4D5mhv1dlaFO4vbW5gRGRhraeAD5c938g==
@@ -33428,11 +33401,6 @@ xstate@^4.38.2:
   version "4.38.2"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.38.2.tgz#1b74544fc9c8c6c713ba77f81c6017e65aa89804"
   integrity sha512-Fba/DwEPDLneHT3tbJ9F3zafbQXszOlyCJyQqqdzmtlY/cwE2th462KK48yaANf98jHlP6lJvxfNtN0LFKXPQg==
-
-xstate@^5.18.1:
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-5.18.1.tgz#c4d43ceaba6e6c31705d36bd96e285de4be4f7f4"
-  integrity sha512-m02IqcCQbaE/kBQLunwub/5i8epvkD2mFutnL17Oeg1eXTShe1sRF4D5mhv1dlaFO4vbW5gRGRhraeAD5c938g==
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Summary

This PR upgrades cypress to `13.15.1`. This is needed to fix an very annoying issue where Cypress tests hangs when ran locally and when the window is not focused

See Cypress issue here: https://github.com/cypress-io/cypress/issues/28392
