### PR TITLE
Fix tablelistview test due to timezone switch

### DIFF
--- a/packages/content-management/table_list_view_table/src/table_list_view.test.tsx
+++ b/packages/content-management/table_list_view_table/src/table_list_view.test.tsx
@@ -242,8 +242,8 @@ describe('TableListView', () => {
       const updatedAtValues: Moment[] = [];
 
       const updatedHits = hits.map(({ id, attributes, references }, i) => {
-        const updatedAt = new Date(new Date().setDate(new Date().getDate() - (7 + i)));
-        updatedAtValues.push(moment(updatedAt));
+        const updatedAt = moment().subtract(7 + i, 'days');
+        updatedAtValues.push(updatedAt)
 
         return {
           id,

--- a/packages/content-management/table_list_view_table/src/table_list_view.test.tsx
+++ b/packages/content-management/table_list_view_table/src/table_list_view.test.tsx
@@ -243,7 +243,7 @@ describe('TableListView', () => {
 
       const updatedHits = hits.map(({ id, attributes, references }, i) => {
         const updatedAt = moment().subtract(7 + i, 'days');
-        updatedAtValues.push(updatedAt)
+        updatedAtValues.push(updatedAt);
 
         return {
           id,


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/198744

Test was subtracting 7 days, but there is 1 hour less now, so the test setup is incorrect. Fixing it by using moment to handle time switch edge case


<!--ONMERGE {"backportTargets":["8.15","8.16","8.x"]} ONMERGE-->