### PR TITLE
[ObsUX] [APM-OTEL] Filter by trace.id instead of transaction.if for dependency spans

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/dependency_operation_detail_view/maybe_redirect_to_available_span_sample.ts
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/dependency_operation_detail_view/maybe_redirect_to_available_span_sample.ts
@@ -24,7 +24,7 @@ export function maybeRedirectToAvailableSpanSample({
   page: number;
   replace: typeof urlHelpersReplace;
   history: History;
-  samples: Array<{ spanId: string; traceId: string; transactionId: string }>;
+  samples: Array<{ spanId: string; traceId: string; transactionId?: string }>;
 }) {
   if (spanFetchStatus !== FETCH_STATUS.SUCCESS) {
     // we're still loading, don't do anything


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/193672

### Summary of the issue

The trace waterfall for dependencies operations is filled querying to span documents using term query for `span.destination.service.resource` and `span.name` fields, and where `transaction.id` exist. The results for this query were empty,  in otel, span documents don't have the `transaction.id` field. After this query another one is made to retrieve the transactions for those spans, querying the transaction ids

### Fix

The query has been changed, so we will check for the `trace.id` instead of the `transaction.id`
On the second query, we will get from those trace ids the ones with `transaction.id` and retrieve the transactions data


https://github.com/user-attachments/assets/fba25f61-0646-4071-b49f-422eab7ff18e



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->