### PR TITLE
[DOCS] Fix links to aggregation-based visualizations

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -3852,7 +3852,7 @@ In 8.1.0 and later, {kib} uses the field caps API, by default, to determine the 
 `visualization:visualize:legacyPieChartsLibrary` has been removed from *Advanced Settings*. The setting allowed you to create aggregation-based pie chart visualizations using the legacy charts library. For more information, refer to {kibana-pull}146990[#146990].
 
 *Impact* +
-In 7.14.0 and later, the new aggregation-based pie chart visualization is available by default. For more information, check link:https://www.elastic.co/guide/en/kibana/current/add-aggregation-based-visualization-panels.html[Aggregation-based].
+In 7.14.0 and later, the new aggregation-based pie chart visualization is available by default. For more information, check <<add-aggregation-based-visualization-panels>>.
 ====
 
 [discrete]

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -1019,7 +1019,7 @@ In 8.1.0 and later, {kib} uses the field caps API, by default, to determine the 
 `visualization:visualize:legacyPieChartsLibrary` has been removed from *Advanced Settings*. The setting allowed you to create aggregation-based pie chart visualizations using the legacy charts library. For more information, refer to {kibana-pull}146990[#146990].
 
 *Impact* +
-In 7.14.0 and later, the new aggregation-based pie chart visualization is available by default. For more information, check link:https://www.elastic.co/guide/en/kibana/current/add-aggregation-based-visualization-panels.html[Aggregation-based].
+In 7.14.0 and later, the new aggregation-based pie chart visualization is available by default. For more information, check <<add-aggregation-based-visualization-panels>>.
 ====
 
 [discrete]


### PR DESCRIPTION
## Summary

This PR fixes the following broken links that occur when we change "current" to 8.16 in https://github.com/elastic/docs/pull/3104:

```
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.10/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.11/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.12/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.13/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.14/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.15/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.16/breaking-changes-summary.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.16/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.7/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.8/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.9/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.x/breaking-changes-summary.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.x/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/current/breaking-changes-summary.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/current/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/master/breaking-changes-summary.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/master/release-notes-8.7.0.html contains broken links to:
INFO:build_docs:   - en/kibana/current/add-aggregation-based-visualization-panels.html
```

NOTE: The backport PRs for 8.8 and 8.7 will need to be edited to use version-specific URLs since the content in those branches are re-used in https://www.elastic.co/guide/en/elastic-stack/8.7/kibana-breaking-changes.html, for example.

<!--ONMERGE {"backportTargets":["8.10","8.11","8.12","8.13","8.14","8.15","8.16","8.7","8.8","8.9","8.x"]} ONMERGE-->