### PR TITLE
[7.17] encoding fixes

### DIFF
--- a/packages/elastic-apm-synthtrace/src/lib/utils/create_picker.ts
+++ b/packages/elastic-apm-synthtrace/src/lib/utils/create_picker.ts
@@ -8,7 +8,7 @@
 export function createPicker(fields: string[]) {
   const wildcards = fields
     .filter((field) => field.endsWith('.*'))
-    .map((field) => field.replace('*', ''));
+    .map((field) => field.replace(/\*/g, ''));
 
   return (value: unknown, key: string) => {
     return fields.includes(key) || wildcards.some((field) => key.startsWith(field));

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/helpers/create_tsvb_link.ts
@@ -114,7 +114,7 @@ export const createFilterFromOptions = (
     filters.push(options.filterQuery);
   }
   if (options.groupBy) {
-    const id = series.id.replace('"', '\\"');
+    const id = series.id.replace(/"/g, '\\"');
     const groupByFilters = Array.isArray(options.groupBy)
       ? options.groupBy
           .map((field, index) => {


### PR DESCRIPTION
## Summary

Fixes encoding errors where only the first `replace` match was getting replaced. 
