### PR TITLE
[ci] Add package registry promotion pipeline

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-package-registry.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-package-registry.yml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: bk-kibana-package-registry-promote
+  description: Promote package-registry/distribution:lite
+  links:
+    - url: 'https://buildkite.com/elastic/kibana-package-registry-promote'
+      title: Pipeline link
+spec:
+  type: buildkite-pipeline
+  owner: 'group:kibana-operations'
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: kibana / package registry promote
+      description: Promote package-registry/distribution:lite
+    spec:
+      env:
+        SLACK_NOTIFICATIONS_CHANNEL: "#kibana-operations-alerts"
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: "false"
+      repository: elastic/kibana
+      branch_configuration: main
+      default_branch: main
+      pipeline_file: ".buildkite/pipelines/fleet/package_registry.yml"
+      provider_settings:
+        trigger_mode: none
+      teams:
+        everyone:
+          access_level: BUILD_AND_READ
+        kibana-operations:
+          access_level: MANAGE_BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -27,6 +27,7 @@ spec:
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-migration-staging.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
+    - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-package-registry.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-performance-daily.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-performance-data-set-extraction-daily.yml
     - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-pointer-compression.yml

--- a/.buildkite/pipelines/fleet/package_registry.yml
+++ b/.buildkite/pipelines/fleet/package_registry.yml
@@ -1,0 +1,2 @@
+steps:
+  - command: echo "Placeholder"


### PR DESCRIPTION
Adds a placeholder pipeline for `kibana / package registry promote`.

Initially, in a follow up PR, this will run a daily promotion of `docker.elastic.co/package-registry/distribution:lite` to the kibana-ci namespace.  We can also run some verification steps if desired.

The distribution is a relatively large image, and nearly always running uncached on CI due to the update frequency.  This should help us balance having an up to date image and avoiding cache misses.