### PR TITLE
[Observability] [Alerts table] Fix cannot display alerts error

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/components/alert_overview/helpers/map_rules_params_with_flyout.ts
+++ b/x-pack/plugins/observability_solution/observability/public/components/alert_overview/helpers/map_rules_params_with_flyout.ts
@@ -286,7 +286,7 @@ export const mapRuleParamsWithFlyout = (alert: TopAlert): FlyoutThresholdData[] 
       const { thresholdComparator, threshold } = ruleParams as EsQueryRuleParams;
       const ESQueryFlyoutMap = {
         observedValue: [alert.fields[ALERT_EVALUATION_VALUE]],
-        threshold: threshold.join(' AND '),
+        threshold: [threshold].flat().join(' AND '),
         comparator: thresholdComparator,
         pctAboveThreshold: getPctAboveThreshold(
           threshold,


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/198912

### Testing
- Create ES query rule in Observability
- Open Alert flyout of the ES query alert
- Verify that Alert flyout opens as expected

<!--ONMERGE {"backportTargets":["8.15","8.16","8.x"]} ONMERGE-->