### PR TITLE
[8.x] migrate es query rule tests to the deployment agnostic framework (#195715)

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/index.ts
@@ -8,8 +8,9 @@
 import { DeploymentAgnosticFtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
-  describe('SLO - Burn rate rule', () => {
+  describe('Observability Alerting', () => {
     loadTestFile(require.resolve('./burn_rate_rule'));
     loadTestFile(require.resolve('./custom_threshold'));
+    loadTestFile(require.resolve('./es_query_rule'));
   });
 }

--- a/x-pack/test_serverless/api_integration/test_suites/observability/index.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/index.ts
@@ -15,7 +15,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./apm_api_integration/service_maps/service_maps'));
     loadTestFile(require.resolve('./apm_api_integration/traces/critical_path'));
     loadTestFile(require.resolve('./cases'));
-    loadTestFile(require.resolve('./es_query_rule/es_query_rule'));
     loadTestFile(require.resolve('./slos'));
     loadTestFile(require.resolve('./synthetics'));
     loadTestFile(require.resolve('./dataset_quality_api_integration'));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - migrate es query rule tests to the deployment agnostic framework (#195715) (512bfccd)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Panagiota Mitsopoulou","email":"panagiota.mitsopoulou@elastic.co"},"sourceCommit":{"committedDate":"2024-10-24T07:23:15Z","message":"migrate es query rule tests to the deployment agnostic framework (#195715)\n\nFixes https://github.com/elastic/kibana/issues/183395\r\n\r\nThis PR migrates the ES query rule tests to the [deployment agnostic\r\nframework](https://github.com/elastic/kibana/tree/main/x-pack/test/api_integration/deployment_agnostic)\r\n\r\n### TODO\r\n\r\n- [x] Migrate ES rule tests into the deployment agnostic solution\r\n- [ ] Test in MKI before merging\r\n\r\n### How to run tests locally\r\n\r\nTo run serverless\r\n```\r\nnode scripts/functional_tests_server --config x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts\r\nnode scripts/functional_test_runner --config x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts --grep=\"ElasticSearch query rule\"\r\n```\r\n\r\nTo run stateful\r\n```\r\nnode scripts/functional_tests_server --config x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.stateful.config.ts\r\nnode scripts/functional_test_runner --config x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.stateful.config.ts --grep=\"ElasticSearch query rule\"\r\n```\r\n\r\n### How to run tests on MKI\r\n\r\nAccording to this\r\n[discussion](https://github.com/elastic/observability-dev/issues/3519#issuecomment-2379914274),\r\nwe should test in MKI environment before merging. For details on how to\r\nrun in MKI, see [this section of the\r\ndocument](https://docs.google.com/document/d/1tiax7xoDYwFXYZjRTgVKkVMjN-SQzBWk4yn1JY6Z5UY/edit#heading=h.ece2z8p74izh)\r\nand [this\r\nreadme](https://github.com/elastic/kibana/blob/main/x-pack/test_serverless/README.md#run-tests-on-mki).\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\r\nCo-authored-by: Maryam Saeidi <maryam.saeidi@elastic.co>","sha":"512bfccd7187c1107ec143498daf980a1422fb4d"},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->