### PR TITLE
Improves cleanup in spaces data functional test

### DIFF
--- a/x-pack/test/functional/apps/spaces/spaces_selection.ts
+++ b/x-pack/test/functional/apps/spaces/spaces_selection.ts
@@ -21,6 +21,7 @@ export default function spaceSelectorFunctionalTests({
     'spaceSelector',
   ]);
   const spacesService = getService('spaces');
+  const sampleData = getService('sampleData');
 
   describe('Spaces', function () {
     const testSpacesIds = ['another-space', ...Array.from('123456789', (idx) => `space-${idx}`)];
@@ -158,14 +159,7 @@ export default function spaceSelectorFunctionalTests({
       });
 
       after(async () => {
-        // No need to remove the same sample data in both spaces, the index
-        // data will be removed in the first call. By feature limitation,
-        // the created saved objects in the second space will be broken but removed
-        // when we call esArchiver.unload('x-pack/test/functional/es_archives/spaces').
-        await PageObjects.common.navigateToApp('home', {
-          hash: sampleDataHash,
-        });
-        await PageObjects.home.removeSampleDataSet('logs');
+        await sampleData.testResources.removeKibanaSampleData('logs');
         await PageObjects.security.forceLogout();
       });
 


### PR DESCRIPTION
Closes #52714

## Summary

Uses the sample data FTR service to remove the sample data via API during cleanup. Previously, the after block only removed the sample data from one space and attempted to rely on an esArchiver call to clean up remaining data later on. As the scope of the test does not use the esArchiver any longer, it seems more appropriate to remove the sample data more deterministically.

### Flaky test runner

- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7335


<!--ONMERGE {"backportTargets":["7.17","8.15","8.16","8.x"]} ONMERGE-->