### PR TITLE
Assign SavedObjects Plugin to SharedUX

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -754,7 +754,7 @@ src/plugins/saved_objects_finder @elastic/kibana-data-discovery
 test/plugin_functional/plugins/saved_objects_hidden_from_http_apis_type @elastic/kibana-core
 test/plugin_functional/plugins/saved_objects_hidden_type @elastic/kibana-core
 src/plugins/saved_objects_management @elastic/kibana-core
-src/plugins/saved_objects @elastic/kibana-core
+src/plugins/saved_objects @elastic/appex-sharedux
 packages/kbn-saved-objects-settings @elastic/appex-sharedux
 src/plugins/saved_objects_tagging_oss @elastic/appex-sharedux
 x-pack/plugins/saved_objects_tagging @elastic/appex-sharedux

--- a/src/plugins/saved_objects/kibana.jsonc
+++ b/src/plugins/saved_objects/kibana.jsonc
@@ -2,7 +2,7 @@
   "type": "plugin",
   "id": "@kbn/saved-objects-plugin",
   "owner": [
-    "@elastic/kibana-core"
+    "@elastic/appex-sharedux"
   ],
   "group": "platform",
   "visibility": "shared",


### PR DESCRIPTION
## Summary

The `savedObjects` plugin should be owned by SharedUX since it's only used for the SavedModal component, and we're migrating away from the SO HTTP APIs to a content-management approach.

Latest changes to that plugin: https://github.com/elastic/kibana/pull/198777


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)

