### PR TITLE
[Search] Enable AI Assistant in Search solution view

### DIFF
--- a/x-pack/plugins/spaces/server/lib/utils/space_solution_disabled_features.ts
+++ b/x-pack/plugins/spaces/server/lib/utils/space_solution_disabled_features.ts
@@ -24,6 +24,10 @@ const getFeatureIdsForCategories = (
     .map((feature) => feature.id);
 };
 
+/**
+ * These features will be enabled per solution view, even if they fall under a category that is disabled in the solution.
+ */
+
 const enabledFeaturesPerSolution: Record<SolutionId, string[]> = {
   es: ['observabilityAIAssistant'],
   oblt: [],

--- a/x-pack/plugins/spaces/server/lib/utils/space_solution_disabled_features.ts
+++ b/x-pack/plugins/spaces/server/lib/utils/space_solution_disabled_features.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { SolutionId } from '@kbn/core-chrome-browser';
 import type { KibanaFeature } from '@kbn/features-plugin/server';
 
 import type { SolutionView } from '../../../common';
@@ -21,6 +22,12 @@ const getFeatureIdsForCategories = (
         : false
     )
     .map((feature) => feature.id);
+};
+
+const enabledFeaturesPerSolution: Record<SolutionId, string[]> = {
+  es: ['observabilityAIAssistant'],
+  oblt: [],
+  security: [],
 };
 
 /**
@@ -47,17 +54,17 @@ export function withSpaceSolutionDisabledFeatures(
     disabledFeatureKeysFromSolution = getFeatureIdsForCategories(features, [
       'observability',
       'securitySolution',
-    ]);
+    ]).filter((featureId) => !enabledFeaturesPerSolution.es.includes(featureId));
   } else if (spaceSolution === 'oblt') {
     disabledFeatureKeysFromSolution = getFeatureIdsForCategories(features, [
       'enterpriseSearch',
       'securitySolution',
-    ]);
+    ]).filter((featureId) => !enabledFeaturesPerSolution.oblt.includes(featureId));
   } else if (spaceSolution === 'security') {
     disabledFeatureKeysFromSolution = getFeatureIdsForCategories(features, [
       'observability',
       'enterpriseSearch',
-    ]);
+    ]).filter((featureId) => !enabledFeaturesPerSolution.security.includes(featureId));
   }
 
   return Array.from(new Set([...disabledFeatureKeysFromSolution]));

--- a/x-pack/test/spaces_api_integration/common/suites/create.ts
+++ b/x-pack/test/spaces_api_integration/common/suites/create.ts
@@ -80,7 +80,6 @@ export function createTestSuiteFactory(esArchiver: any, supertest: SuperTest<any
         'infrastructure',
         'inventory',
         'logs',
-        'observabilityAIAssistant',
         'observabilityCases',
         'securitySolutionAssistant',
         'securitySolutionAttackDiscovery',

--- a/x-pack/test/spaces_api_integration/common/suites/get.ts
+++ b/x-pack/test/spaces_api_integration/common/suites/get.ts
@@ -84,7 +84,6 @@ export function getTestSuiteFactory(esArchiver: any, supertest: SuperAgent<any>)
           'infrastructure',
           'inventory',
           'logs',
-          'observabilityAIAssistant',
           'observabilityCases',
           'securitySolutionAssistant',
           'securitySolutionAttackDiscovery',

--- a/x-pack/test/spaces_api_integration/common/suites/get_all.ts
+++ b/x-pack/test/spaces_api_integration/common/suites/get_all.ts
@@ -79,7 +79,6 @@ const ALL_SPACE_RESULTS: Space[] = [
       'infrastructure',
       'inventory',
       'logs',
-      'observabilityAIAssistant',
       'observabilityCases',
       'securitySolutionAssistant',
       'securitySolutionAttackDiscovery',


### PR DESCRIPTION
## Summary

This enables the Observability AI Assistant (which is also the Search AI Assistant) in the Search solution view.


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->