### PR TITLE
[Security Solution] Remove bulk create rules API calls from rule export tests

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/prebuilt_rule_customization/trial_license_complete_tier/rules_export.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/prebuilt_rule_customization/trial_license_complete_tier/rules_export.ts
@@ -46,14 +46,14 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     it('exports a set of custom installed rules via the _export API', async () => {
-      await securitySolutionApi
-        .bulkCreateRules({
-          body: [
-            getCustomQueryRuleParams({ rule_id: 'rule-id-1' }),
-            getCustomQueryRuleParams({ rule_id: 'rule-id-2' }),
-          ],
-        })
-        .expect(200);
+      await Promise.all([
+        securitySolutionApi
+          .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-1' }) })
+          .expect(200),
+        securitySolutionApi
+          .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-2' }) })
+          .expect(200),
+      ]);
 
       const { body: exportResult } = await securitySolutionApi
         .exportRules({ query: {}, body: null })
@@ -182,14 +182,14 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('exports a set of custom and prebuilt installed rules via the _export API', async () => {
-        await securitySolutionApi
-          .bulkCreateRules({
-            body: [
-              getCustomQueryRuleParams({ rule_id: 'rule-id-1' }),
-              getCustomQueryRuleParams({ rule_id: 'rule-id-2' }),
-            ],
-          })
-          .expect(200);
+        await Promise.all([
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-1' }) })
+            .expect(200),
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-2' }) })
+            .expect(200),
+        ]);
 
         const { body: exportResult } = await securitySolutionApi
           .exportRules({ query: {}, body: null })
@@ -232,14 +232,14 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('exports both custom and prebuilt rules when rule_ids are specified via the _export API', async () => {
-        await securitySolutionApi
-          .bulkCreateRules({
-            body: [
-              getCustomQueryRuleParams({ rule_id: 'rule-id-1' }),
-              getCustomQueryRuleParams({ rule_id: 'rule-id-2' }),
-            ],
-          })
-          .expect(200);
+        await Promise.all([
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-1' }) })
+            .expect(200),
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-2' }) })
+            .expect(200),
+        ]);
 
         const { body: exportResult } = await securitySolutionApi
           .exportRules({
@@ -277,14 +277,14 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('exports a set of custom and prebuilt installed rules via the bulk_actions API', async () => {
-        await securitySolutionApi
-          .bulkCreateRules({
-            body: [
-              getCustomQueryRuleParams({ rule_id: 'rule-id-1' }),
-              getCustomQueryRuleParams({ rule_id: 'rule-id-2' }),
-            ],
-          })
-          .expect(200);
+        await Promise.all([
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-1' }) })
+            .expect(200),
+          securitySolutionApi
+            .createRule({ body: getCustomQueryRuleParams({ rule_id: 'rule-id-2' }) })
+            .expect(200),
+        ]);
 
         const { body: exportResult } = await securitySolutionApi
           .performRulesBulkAction({


### PR DESCRIPTION
**Follow-up to:** https://github.com/elastic/kibana/pull/197422#discussion_r1826076368

## Summary

This PR manually "backports" some of the changes from https://github.com/elastic/kibana/pull/197422 directly to the `8.x` branch. Specifically, it removes API calls to the rules `_bulk_create` API endpoint from the tests for exporting rules. This API endpoint has been disabled in `main` (=> Serverless and Kibana 9.0) and should not be used in code. This PR aims to reduce the chances of introducing conflicts with any further changes to rule export tests.
