### PR TITLE
[8.16] [Observability Onboarding] Change CTA for System integration in Auto Detect (#197836)

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
@@ -23,6 +23,7 @@ import {
 } from '@kbn/deeplinks-observability/locators';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { DASHBOARD_APP_LOCATOR } from '@kbn/deeplinks-analytics';
+import { ASSET_DETAILS_LOCATOR_ID } from '@kbn/observability-shared-plugin/common';
 import { getAutoDetectCommand } from './get_auto_detect_command';
 import { DASHBOARDS, useOnboardingFlow } from './use_onboarding_flow';
 import { ProgressIndicator } from '../shared/progress_indicator';
@@ -66,6 +67,7 @@ export const AutoDetectPanel: FunctionComponent = () => {
     (integration) => integration.installSource === 'custom'
   );
   const dashboardLocator = share.url.locators.get(DASHBOARD_APP_LOCATOR);
+  const assetDetailsLocator = share.url.locators.get(ASSET_DETAILS_LOCATOR_ID);
 
   return (
     <EuiPanel hasBorder paddingSize="xl">
@@ -147,88 +149,133 @@ export const AutoDetectPanel: FunctionComponent = () => {
                 installedIntegrations.length > 0 ? (
                   <>
                     <EuiSpacer />
-                    {registryIntegrations.map((integration) => (
-                      <AccordionWithIcon
-                        key={integration.pkgName}
-                        id={`${accordionId}_${integration.pkgName}`}
-                        icon={
-                          isSupportedLogo(integration.pkgName) ? (
-                            <LogoIcon size="l" logo={integration.pkgName} />
-                          ) : (
-                            <EuiIcon type="desktop" size="l" />
-                          )
-                        }
-                        title={i18n.translate(
-                          'xpack.observability_onboarding.autoDetectPanel.h3.getStartedWithNginxLabel',
-                          {
-                            defaultMessage: 'Get started with {title}',
-                            values: { title: integration.title },
-                          }
-                        )}
-                        isDisabled={status !== 'dataReceived'}
-                        initialIsOpen
-                      >
-                        <GetStartedPanel
-                          onboardingFlowType="auto-detect"
-                          dataset={integration.pkgName}
-                          onboardingId={data?.onboardingFlow?.id}
-                          telemetryEventContext={{
-                            autoDetect: {
-                              installSource: integration.installSource,
-                              pkgVersion: integration.pkgVersion,
-                              title: integration.title,
-                            },
-                          }}
-                          integration={integration.pkgName}
-                          newTab
-                          isLoading={status !== 'dataReceived'}
-                          actionLinks={integration.kibanaAssets
-                            .filter((asset) => asset.type === 'dashboard')
-                            .map((asset) => {
-                              const dashboard = DASHBOARDS[asset.id as keyof typeof DASHBOARDS];
-                              const href =
-                                dashboardLocator?.getRedirectUrl({
-                                  dashboardId: asset.id,
-                                }) ?? '';
+                    {registryIntegrations
+                      .slice()
+                      /**
+                       * System integration should always be on top
+                       */
+                      .sort((a, b) => (a.pkgName === 'system' ? -1 : 0))
+                      .map((integration) => {
+                        let actionLinks;
 
-                              return {
-                                id: asset.id,
-                                title:
-                                  dashboard.type === 'metrics'
-                                    ? i18n.translate(
-                                        'xpack.observability_onboarding.autoDetectPanel.exploreMetricsDataTitle',
+                        switch (integration.pkgName) {
+                          case 'system':
+                            actionLinks =
+                              assetDetailsLocator !== undefined
+                                ? [
+                                    {
+                                      id: 'inventory-host-details',
+                                      title: i18n.translate(
+                                        'xpack.observability_onboarding.autoDetectPanel.systemOverviewTitle',
                                         {
                                           defaultMessage:
-                                            'Overview your metrics data with this pre-made dashboard',
-                                        }
-                                      )
-                                    : i18n.translate(
-                                        'xpack.observability_onboarding.autoDetectPanel.exploreLogsDataTitle',
-                                        {
-                                          defaultMessage:
-                                            'Overview your logs data with this pre-made dashboard',
+                                            'Overview your system health within the Hosts Inventory',
                                         }
                                       ),
-                                label:
-                                  dashboard.type === 'metrics'
-                                    ? i18n.translate(
-                                        'xpack.observability_onboarding.autoDetectPanel.exploreMetricsDataLabel',
+                                      label: i18n.translate(
+                                        'xpack.observability_onboarding.autoDetectPanel.systemOverviewLabel',
                                         {
                                           defaultMessage: 'Explore metrics data',
                                         }
-                                      )
-                                    : i18n.translate(
-                                        'xpack.observability_onboarding.autoDetectPanel.exploreLogsDataLabel',
-                                        {
-                                          defaultMessage: 'Explore logs data',
-                                        }
                                       ),
-                                href,
-                              };
-                            })}
-                        />
-                      </AccordionWithIcon>
-                    ))}
+                                      href: assetDetailsLocator.getRedirectUrl({
+                                        assetType: 'host',
+                                        assetId: integration.metadata?.hostname,
+                                      }),
+                                    },
+                                  ]
+                                : [];
+                            break;
+                          default:
+                            actionLinks =
+                              dashboardLocator !== undefined
+                                ? integration.kibanaAssets
+                                    .filter((asset) => asset.type === 'dashboard')
+                                    .map((asset) => {
+                                      const dashboard =
+                                        DASHBOARDS[asset.id as keyof typeof DASHBOARDS];
+                                      const href = dashboardLocator.getRedirectUrl({
+                                        dashboardId: asset.id,
+                                      });
+
+                                      return {
+                                        id: asset.id,
+                                        title:
+                                          dashboard.type === 'metrics'
+                                            ? i18n.translate(
+                                                'xpack.observability_onboarding.autoDetectPanel.exploreMetricsDataTitle',
+                                                {
+                                                  defaultMessage:
+                                                    'Overview your metrics data with this pre-made dashboard',
+                                                }
+                                              )
+                                            : i18n.translate(
+                                                'xpack.observability_onboarding.autoDetectPanel.exploreLogsDataTitle',
+                                                {
+                                                  defaultMessage:
+                                                    'Overview your logs data with this pre-made dashboard',
+                                                }
+                                              ),
+                                        label:
+                                          dashboard.type === 'metrics'
+                                            ? i18n.translate(
+                                                'xpack.observability_onboarding.autoDetectPanel.exploreMetricsDataLabel',
+                                                {
+                                                  defaultMessage: 'Explore metrics data',
+                                                }
+                                              )
+                                            : i18n.translate(
+                                                'xpack.observability_onboarding.autoDetectPanel.exploreLogsDataLabel',
+                                                {
+                                                  defaultMessage: 'Explore logs data',
+                                                }
+                                              ),
+                                        href,
+                                      };
+                                    })
+                                : [];
+                        }
+
+                        return (
+                          <AccordionWithIcon
+                            key={integration.pkgName}
+                            id={`${accordionId}_${integration.pkgName}`}
+                            icon={
+                              isSupportedLogo(integration.pkgName) ? (
+                                <LogoIcon size="l" logo={integration.pkgName} />
+                              ) : (
+                                <EuiIcon type="desktop" size="l" />
+                              )
+                            }
+                            title={i18n.translate(
+                              'xpack.observability_onboarding.autoDetectPanel.h3.getStartedWithNginxLabel',
+                              {
+                                defaultMessage: 'Get started with {title}',
+                                values: { title: integration.title },
+                              }
+                            )}
+                            isDisabled={status !== 'dataReceived'}
+                            initialIsOpen
+                          >
+                            <GetStartedPanel
+                              onboardingFlowType="auto-detect"
+                              dataset={integration.pkgName}
+                              onboardingId={data?.onboardingFlow?.id}
+                              telemetryEventContext={{
+                                autoDetect: {
+                                  installSource: integration.installSource,
+                                  pkgVersion: integration.pkgVersion,
+                                  title: integration.title,
+                                },
+                              }}
+                              integration={integration.pkgName}
+                              newTab
+                              isLoading={status !== 'dataReceived'}
+                              actionLinks={actionLinks}
+                            />
+                          </AccordionWithIcon>
+                        );
+                      })}
                     {customIntegrations.length > 0 && (
                       <AccordionWithIcon
                         id={`${accordionId}_custom`}

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/assets/auto_detect.sh
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/assets/auto_detect.sh
@@ -256,7 +256,15 @@ install_integrations() {
   local install_integrations_api_body_string=""
 
   for item in "${selected_known_integrations_array[@]}"; do
-    install_integrations_api_body_string+="$item\tregistry\n"
+    local metadata=""
+
+    case "$item" in
+    "system")
+      metadata="\t$(hostname | tr '[:upper:]' '[:lower:]')"
+      ;;
+    esac
+
+    install_integrations_api_body_string+="$item\tregistry$metadata\n"
   done
 
   for item in "${selected_unknown_log_file_pattern_array[@]}" "${custom_log_file_path_list_array[@]}"; do

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/routes/types.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/routes/types.ts
@@ -52,25 +52,30 @@ export interface ObservabilityOnboardingRouteCreateOptions {
   };
 }
 
-export const IntegrationRT = t.type({
-  installSource: t.union([t.literal('registry'), t.literal('custom')]),
-  pkgName: t.string,
-  pkgVersion: t.string,
-  title: t.string,
-  inputs: t.array(t.unknown),
-  dataStreams: t.array(
-    t.type({
-      type: t.string,
-      dataset: t.string,
-    })
-  ),
-  kibanaAssets: t.array(
-    t.type({
-      type: t.string,
-      id: t.string,
-    })
-  ),
-});
+export const IntegrationRT = t.intersection([
+  t.type({
+    installSource: t.union([t.literal('registry'), t.literal('custom')]),
+    pkgName: t.string,
+    pkgVersion: t.string,
+    title: t.string,
+    config: t.string,
+    dataStreams: t.array(
+      t.type({
+        type: t.string,
+        dataset: t.string,
+      })
+    ),
+    kibanaAssets: t.array(
+      t.type({
+        type: t.string,
+        id: t.string,
+      })
+    ),
+  }),
+  t.partial({
+    metadata: t.type({ hostname: t.string }),
+  }),
+]);
 
 export type InstalledIntegration = t.TypeOf<typeof IntegrationRT>;
 

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/saved_objects/observability_onboarding_status.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/saved_objects/observability_onboarding_status.ts
@@ -79,6 +79,13 @@ export const InstallIntegrationsStepPayloadSchema = schema.arrayOf(
         id: schema.string(),
       })
     ),
+    metadata: schema.maybe(
+      schema.oneOf([
+        schema.object({
+          hostname: schema.string(),
+        }),
+      ])
+    ),
   })
 );
 

--- a/x-pack/test_serverless/functional/test_suites/observability/onboarding/auto_detect.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/onboarding/auto_detect.ts
@@ -60,7 +60,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         .set('Content-Type', 'text/tab-separated-values')
         .set('x-elastic-internal-origin', 'Kibana')
         .set('kbn-xsrf', 'true')
-        .send('system\tregistry\n')
+        .send('system\tregistry\ttest-host\n')
         .expect(200);
 
       // Simulate bash script installing Elastic Agent


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Observability Onboarding] Change CTA for System integration in Auto Detect (#197836) (0ee96848)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Mykola Harmash","email":"mykola.harmash@gmail.com"},"sourceCommit":{"committedDate":"2024-10-30T10:54:15Z","message":"[Observability Onboarding] Change CTA for System integration in Auto Detect (#197836)\n\nCloses https://github.com/elastic/observability-dev/issues/4053 🔒\r\n\r\n* Adds an option to specify metadata for integrations installed from\r\nregistry as a third parameter in the TSV provided to the\r\n`/integrations/install` endpoint. For now only `system` integration has\r\nmetadata with a hostname, but it's made generic to support other\r\nintegrations when needed.\r\n* Changes CTA for the System integration to point to the Host details\r\n* Adds sorting in the detected integrations in the UI to alway show\r\nSystem integration at the top","sha":"0ee968480cac02640939a552276aaf4213fbd43d"},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->