### PR TITLE
[Security Solution] - skipping failing sourcerer Cypress test failing on main

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/sourcerer/sourcerer_timeline.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/sourcerer/sourcerer_timeline.cy.ts
@@ -63,7 +63,8 @@ describe('Timeline scope', { tags: ['@ess', '@serverless', '@skipInServerless'] 
   });
 
   describe('Modified badge', () => {
-    it('Selecting new data view does not add a modified badge', () => {
+    // failing on main multiple times https://github.com/elastic/kibana/issues/198944#issuecomment-2457665138 and https://github.com/elastic/kibana/issues/198943#issuecomment-2457665072
+    it.skip('Selecting new data view does not add a modified badge', () => {
       openTimelineUsingToggle();
       cy.get(SOURCERER.badgeModified).should(`not.exist`);
       openSourcerer('timeline');
@@ -133,7 +134,8 @@ describe('Timeline scope', { tags: ['@ess', '@serverless', '@skipInServerless'] 
     });
 
     const defaultPatterns = [`auditbeat-*`, `${DEFAULT_ALERTS_INDEX}-default`];
-    it('alerts checkbox behaves as expected', () => {
+    // failing on main multiple times https://github.com/elastic/kibana/issues/198944#issuecomment-2457665138 and https://github.com/elastic/kibana/issues/198943#issuecomment-2457665072
+    it.skip('alerts checkbox behaves as expected', () => {
       isDataViewSelection(siemDataViewTitle);
       defaultPatterns.forEach((pattern) => isSourcererSelection(pattern));
       openDataViewSelection();


### PR DESCRIPTION
## Summary

This PR skips 2 tests failing on `main` at the moment:
- https://github.com/elastic/kibana/issues/198944#issuecomment-2457665138
- https://github.com/elastic/kibana/issues/198943#issuecomment-2457665072

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->