### PR TITLE
[Security Solution][Bug] Incorrect message as Duplicate entry? shown on creating New Knowledge Base index. (#198892)

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/index.test.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/index.test.tsx
@@ -425,6 +425,63 @@ describe('KnowledgeBaseSettingsManagement', () => {
     expect(mockCreateEntry).toHaveBeenCalledWith({ ...mockData[3], users: undefined });
   });
 
+  it('does not show duplicate entry modal on new document entry creation', async () => {
+    // Covers the BUG: https://github.com/elastic/kibana/issues/198892
+    const closeFlyoutMock = jest.fn();
+    (useFlyoutModalVisibility as jest.Mock).mockReturnValue({
+      isFlyoutOpen: true,
+      openFlyout: jest.fn(),
+      closeFlyout: closeFlyoutMock,
+    });
+    render(<KnowledgeBaseSettingsManagement dataViews={mockDataViews} />, {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      fireEvent.click(screen.getAllByTestId('edit-button')[3]);
+    });
+    expect(screen.getByTestId('flyout')).toBeVisible();
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit document entry')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('sharing-select'));
+      fireEvent.click(screen.getByTestId('sharing-private-option'));
+      fireEvent.click(screen.getByTestId('save-button'));
+    });
+
+    expect(screen.getByTestId('create-duplicate-entry-modal')).toBeInTheDocument();
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('confirmModalConfirmButton'));
+    });
+    expect(screen.queryByTestId('create-duplicate-entry-modal')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockCreateEntry).toHaveBeenCalledTimes(1);
+    });
+
+    // Create a new document entry
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('addEntry'));
+    });
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('addDocument'));
+    });
+
+    expect(screen.getByTestId('flyout')).toBeVisible();
+
+    await userEvent.type(screen.getByTestId('entryNameInput'), 'hi');
+    await userEvent.type(screen.getByTestId('entryMarkdownInput'), 'hi');
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('save-button'));
+    });
+
+    expect(screen.queryByTestId('create-duplicate-entry-modal')).not.toBeInTheDocument();
+    expect(closeFlyoutMock).toHaveBeenCalled();
+  });
+
   it('shows warning icon for index entries with missing indices', async () => {
     render(<KnowledgeBaseSettingsManagement dataViews={mockDataViews} />, {
       wrapper,

--- a/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/index.tsx
@@ -166,26 +166,31 @@ export const KnowledgeBaseSettingsManagement: React.FC<Params> = React.memo(({ d
     isRefetching: kbStatus?.is_setup_in_progress,
   });
 
+  const resetStateAndCloseFlyout = useCallback(() => {
+    setOriginalEntry(undefined);
+    setSelectedEntry(undefined);
+    setDuplicateKBItem(null);
+    closeFlyout();
+  }, [closeFlyout]);
+
   // Flyout Save/Cancel Actions
   const onSaveConfirmed = useCallback(async () => {
     if (isKnowledgeBaseEntryResponse(selectedEntry)) {
       await updateEntries([selectedEntry]);
-      closeFlyout();
+      resetStateAndCloseFlyout();
     } else if (isKnowledgeBaseEntryCreateProps(selectedEntry)) {
       if (originalEntry) {
         setDuplicateKBItem(selectedEntry);
         return;
       }
       await createEntry(selectedEntry);
-      closeFlyout();
+      resetStateAndCloseFlyout();
     }
-  }, [selectedEntry, originalEntry, updateEntries, closeFlyout, createEntry]);
+  }, [selectedEntry, updateEntries, resetStateAndCloseFlyout, originalEntry, createEntry]);
 
   const onSaveCancelled = useCallback(() => {
-    setOriginalEntry(undefined);
-    setSelectedEntry(undefined);
-    closeFlyout();
-  }, [closeFlyout]);
+    resetStateAndCloseFlyout();
+  }, [resetStateAndCloseFlyout]);
 
   const { value: existingIndices } = useAsync(() => {
     const indices: string[] = [];
@@ -323,10 +328,9 @@ export const KnowledgeBaseSettingsManagement: React.FC<Params> = React.memo(({ d
   const handleDuplicateEntry = useCallback(async () => {
     if (duplicateKBItem) {
       await createEntry(duplicateKBItem);
-      closeFlyout();
-      setDuplicateKBItem(null);
+      resetStateAndCloseFlyout();
     }
-  }, [closeFlyout, createEntry, duplicateKBItem]);
+  }, [createEntry, duplicateKBItem, resetStateAndCloseFlyout]);
 
   if (!enableKnowledgeBaseByDefault) {
     return (


### PR DESCRIPTION
## Summary

BUG: https://github.com/elastic/kibana/issues/198892

This PR fixes the BUG where we would show `Duplicate entry?` confirmation modal on new document creation. This happens because the state is not being reset properly on flyout close and we use previous values in the new entry creation flow.

### To test

1. Create a global entry (document or index)
2. Edit the entry from 1
3. Switch global to private
4. Save entry => This will trigger `Duplicate entry?` confirmation modal (save it)
5. Press `New > Index/Document`
6. Fill out required fields
7. Press `Save` button

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->