### PR TITLE
Enhance documentation on accessing hidden SO types

### DIFF
--- a/dev_docs/tutorials/saved_objects.mdx
+++ b/dev_docs/tutorials/saved_objects.mdx
@@ -46,8 +46,8 @@ these should follow our API URL path convention and always be written in snake c
 that objects of this type can only exist in a single space. See
 <DocLink id="kibDevDocsSavedObjectsIntro" section="sharing-saved-objects" text="Sharing Saved Objects"/> for more information.
 
-[3] This field determines whether repositories have access to the type by default. he hidden types will not be automatically exposed via the HTTP API.
-Access a hidden type with a client that explicitly includes a list of hidden types `SavedObjectsClientProviderOptions[includedHiddenTypes]`.
+[3] This field determines whether repositories have access to the type by default. Hidden types will not be automatically exposed via the Saved Objects Client APIs.
+Hidden types must be listed in `SavedObjectsClientProviderOptions[includedHiddenTypes]` to be accessible by the client.
 
 **src/plugins/my_plugin/server/saved_objects/index.ts**
 

--- a/dev_docs/tutorials/saved_objects.mdx
+++ b/dev_docs/tutorials/saved_objects.mdx
@@ -18,7 +18,7 @@ import { SavedObjectsType } from 'src/core/server';
 
 export const dashboardVisualization: SavedObjectsType = {
   name: 'dashboard_visualization', [1]
-  hidden: true,
+  hidden: true, [3]
   switchToModelVersionAt: '8.10.0', // this is the default, feel free to omit it unless you intend to switch to using model versions before 8.10.0
   namespaceType: 'multiple-isolated', [2]
   mappings: {
@@ -45,6 +45,9 @@ these should follow our API URL path convention and always be written in snake c
 [2] This field determines "space behavior" -- whether these objects can exist in one space, multiple spaces, or all spaces. This value means
 that objects of this type can only exist in a single space. See
 <DocLink id="kibDevDocsSavedObjectsIntro" section="sharing-saved-objects" text="Sharing Saved Objects"/> for more information.
+
+[3] This field determines whether repositories have access to the type by default. he hidden types will not be automatically exposed via the HTTP API.
+Access a hidden type with a client that explicitly includes a list of hidden types `SavedObjectsClientProviderOptions[includedHiddenTypes]`.
 
 **src/plugins/my_plugin/server/saved_objects/index.ts**
 

--- a/packages/core/saved-objects/core-saved-objects-server/src/saved_objects_type.ts
+++ b/packages/core/saved-objects/core-saved-objects-server/src/saved_objects_type.ts
@@ -37,7 +37,12 @@ export interface SavedObjectsType<Attributes = any> {
    * The hidden types will not be automatically exposed via the HTTP API.
    * Therefore, that should prevent unexpected behavior in the client code, as all the interactions will be done via the plugin API.
    *
+   * Access a hidden type with a client that explicitly includes a list of hidden types
+   *
+   * (await context.core).savedObjects.getClient({ includeHiddenTypes: [MY_PLUGIN_HIDDEN_SAVED_OBJECT_TYPE] })
+   *
    * See {@link SavedObjectsServiceStart.createInternalRepository | createInternalRepository}.
+   *
    */
   hidden: boolean;
   /**

--- a/packages/core/saved-objects/core-saved-objects-server/src/saved_objects_type.ts
+++ b/packages/core/saved-objects/core-saved-objects-server/src/saved_objects_type.ts
@@ -37,7 +37,7 @@ export interface SavedObjectsType<Attributes = any> {
    * The hidden types will not be automatically exposed via the HTTP API.
    * Therefore, that should prevent unexpected behavior in the client code, as all the interactions will be done via the plugin API.
    *
-   * Access a hidden type with a client that explicitly includes a list of hidden types
+   * Hidden types must be listed to be accessible by the client.
    *
    * (await context.core).savedObjects.getClient({ includeHiddenTypes: [MY_PLUGIN_HIDDEN_SAVED_OBJECT_TYPE] })
    *


### PR DESCRIPTION
Saved objects declared as `hidden` can only be accessed with a client that explicitly includes hidden types.

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->