### PR TITLE
[Security Solution][Bug] On switching Knowledge Base Index Sharing from Private to Global shows Error updating Knowledge Base Entries (#198891)

### DIFF
--- a/x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.ts
+++ b/x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.ts
@@ -143,7 +143,10 @@ export const getUpdateScript = ({
   return {
     doc: {
       ...entry,
-      semantic_text: entry.text,
+      // Seems like ES bulk update requires the `semantic_text` type fields to be specified
+      // even when they are not required in mapping configs.
+      // Since `semantic_text` is an optional field for index entries, we pass a dummy text to avoid ES error.
+      ...(entry.type === 'index' ? { semantic_text: 'a' } : { semantic_text: entry.text }),
     },
   };
 };


### PR DESCRIPTION
## Summary

BUG: https://github.com/elastic/kibana/issues/198891

These changes fix the issue with the ES bulk update operation and `semantic_text` type fields. ES bulk update operation require such fields to be specified even when those are not required in mappings.

The ES returns an error `Field [semantic_text] must be specified on an update request to calculate inference for field [semantic_text]` in this case.

We do not use `sematic_text` field for index entries in knowledge base and that is why those entries have this field undefined. To avoid an error we pass a dummy text to satisfy ES.

### To test
1. Create an index entry
2. Edit the entry from 1
3. Update the entry (for example change the name)
4. Save entry
