### PR TITLE
[8.16] [Fleet] [Cloud Security] Add Testing Library ESLint for handling waitFor (#198735)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1024,7 +1024,9 @@ module.exports = {
      */
     {
       files: ['x-pack/plugins/fleet/**/*.{js,mjs,ts,tsx}'],
+      plugins: ['testing-library'],
       rules: {
+        'testing-library/await-async-utils': 'error',
         '@typescript-eslint/consistent-type-imports': 'error',
         'import/order': [
           'warn',
@@ -1954,6 +1956,16 @@ module.exports = {
       },
     },
 
+    /**
+     * Cloud Security Team overrides
+     */
+    {
+      files: ['x-pack/plugins/cloud_security_posture/**/*.{js,mjs,ts,tsx}'],
+      plugins: ['testing-library'],
+      rules: {
+        'testing-library/await-async-utils': 'error',
+      },
+    },
     /**
      * Code inside .buildkite runs separately from everything else in CI, before bootstrap, with ts-node. It needs a few tweaks because of this.
      */

--- a/package.json
+++ b/package.json
@@ -1728,6 +1728,7 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-perf": "^3.3.1",
+    "eslint-plugin-testing-library": "^6.4.0",
     "eslint-traverse": "^1.0.0",
     "exit-hook": "^2.2.0",
     "expect": "^29.7.0",

--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -174,4 +174,4 @@ export const SINGLE_ACCOUNT = 'single-account';
 
 export const CLOUD_SECURITY_PLUGIN_VERSION = '1.9.0';
 // Cloud Credentials Template url was implemented in 1.10.0-preview01. See PR - https://github.com/elastic/integrations/pull/9828
-export const CLOUD_CREDENTIALS_PACKAGE_VERSION = '1.11.0-preview10';
+export const CLOUD_CREDENTIALS_PACKAGE_VERSION = '1.11.0-preview13';

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
-import { act, fireEvent, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
+
+import { userEvent } from '@testing-library/user-event';
 
 import type { TestRenderer } from '../../../../../../../mock';
 import { createFleetTestRendererMock } from '../../../../../../../mock';
@@ -108,22 +110,23 @@ describe('StepSelectHosts', () => {
     testRenderer = createFleetTestRendererMock();
   });
 
-  it('should display create form when no agent policies', () => {
+  it('should display create form when no agent policies', async () => {
     (useGetAgentPolicies as jest.MockedFunction<any>).mockReturnValue({
       data: {
         items: [],
       },
     });
+    (useAllNonManagedAgentPolicies as jest.MockedFunction<any>).mockReturnValue([]);
 
     render();
 
-    waitFor(() => {
-      expect(renderResult.getByText('Agent policy 1')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(renderResult.getByText('New agent policy name')).toBeInTheDocument();
     });
     expect(renderResult.queryByRole('tablist')).not.toBeInTheDocument();
   });
 
-  it('should display tabs with New hosts selected when agent policies exist', () => {
+  it('should display tabs with New hosts selected when agent policies exist', async () => {
     (useGetAgentPolicies as jest.MockedFunction<any>).mockReturnValue({
       data: {
         items: [{ id: '1', name: 'Agent policy 1', namespace: 'default' }],
@@ -135,10 +138,7 @@ describe('StepSelectHosts', () => {
 
     render();
 
-    waitFor(() => {
-      expect(renderResult.getByRole('tablist')).toBeInTheDocument();
-      expect(renderResult.getByText('Agent policy 3')).toBeInTheDocument();
-    });
+    expect(renderResult.getByRole('tablist')).toBeInTheDocument();
     expect(renderResult.getByText('New hosts').closest('button')).toHaveAttribute(
       'aria-selected',
       'true'
@@ -157,16 +157,15 @@ describe('StepSelectHosts', () => {
 
     render();
 
-    waitFor(() => {
-      expect(renderResult.getByRole('tablist')).toBeInTheDocument();
-    });
-    act(() => {
-      fireEvent.click(renderResult.getByText('Existing hosts').closest('button')!);
-    });
+    expect(renderResult.getByRole('tablist')).toBeInTheDocument();
 
-    expect(
-      renderResult.container.querySelector('[data-test-subj="agentPolicySelect"]')?.textContent
-    ).toContain('Agent policy 1');
+    await userEvent.click(renderResult.getByText('Existing hosts').closest('button')!);
+
+    await waitFor(() => {
+      expect(
+        renderResult.container.querySelector('[data-test-subj="agentPolicySelect"]')?.textContent
+      ).toContain('Agent policy 1');
+    });
   });
 
   it('should display dropdown without preselected value when Existing hosts selected with mulitple agent policies', async () => {
@@ -185,14 +184,11 @@ describe('StepSelectHosts', () => {
 
     render();
 
-    waitFor(() => {
-      expect(renderResult.getByRole('tablist')).toBeInTheDocument();
-    });
-    act(() => {
-      fireEvent.click(renderResult.getByText('Existing hosts').closest('button')!);
-    });
+    expect(renderResult.getByRole('tablist')).toBeInTheDocument();
 
-    await act(async () => {
+    await userEvent.click(renderResult.getByText('Existing hosts').closest('button')!);
+
+    await waitFor(() => {
       const select = renderResult.container.querySelector('[data-test-subj="agentPolicySelect"]');
       expect((select as any)?.value).toEqual('');
     });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks/dom';
 
 import { waitFor } from '@testing-library/react';
 
@@ -195,7 +195,7 @@ describe('useSetupTechnology', () => {
   });
 
   it('should fetch agentless policy if agentless feature is enabled and isServerless is true', async () => {
-    const { waitForNextUpdate } = renderHook(() =>
+    renderHook(() =>
       useSetupTechnology({
         setNewAgentPolicy,
         newAgentPolicy: newAgentPolicyMock,
@@ -205,9 +205,9 @@ describe('useSetupTechnology', () => {
       })
     );
 
-    await waitForNextUpdate();
-
-    expect(sendGetOneAgentPolicy).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(sendGetOneAgentPolicy).toHaveBeenCalled();
+    });
   });
 
   it('should set agentless setup technology if agent policy supports agentless in edit page', async () => {
@@ -253,7 +253,7 @@ describe('useSetupTechnology', () => {
         isCloudEnabled: true,
       },
     });
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useSetupTechnology({
         setNewAgentPolicy,
         newAgentPolicy: newAgentPolicyMock,
@@ -268,14 +268,13 @@ describe('useSetupTechnology', () => {
     act(() => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
     });
-
-    waitForNextUpdate();
-
-    expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENTLESS);
-    expect(setNewAgentPolicy).toHaveBeenCalledWith({
-      name: 'Agentless policy for endpoint-1',
-      supports_agentless: true,
-      inactivity_timeout: 3600,
+    await waitFor(() => {
+      expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENTLESS);
+      expect(setNewAgentPolicy).toHaveBeenCalledWith({
+        name: 'Agentless policy for endpoint-1',
+        supports_agentless: true,
+        inactivity_timeout: 3600,
+      });
     });
   });
 
@@ -293,15 +292,18 @@ describe('useSetupTechnology', () => {
         isCloudEnabled: true,
       },
     });
-    const { result, rerender } = renderHook(() =>
-      useSetupTechnology({
-        setNewAgentPolicy,
-        newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicies: updateAgentPoliciesMock,
-        setSelectedPolicyTab: setSelectedPolicyTabMock,
-        packagePolicy: packagePolicyMock,
-      })
-    );
+
+    const initialProps = {
+      setNewAgentPolicy,
+      newAgentPolicy: newAgentPolicyMock,
+      updateAgentPolicies: updateAgentPoliciesMock,
+      setSelectedPolicyTab: setSelectedPolicyTabMock,
+      packagePolicy: packagePolicyMock,
+    };
+
+    const { result, rerender } = renderHook((props = initialProps) => useSetupTechnology(props), {
+      initialProps,
+    });
 
     expect(generateNewAgentPolicyWithDefaults).toHaveBeenCalled();
 
@@ -327,7 +329,7 @@ describe('useSetupTechnology', () => {
       },
     });
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(setNewAgentPolicy).toHaveBeenCalledWith({
         name: 'Agentless policy for endpoint-2',
         inactivity_timeout: 3600,
@@ -344,7 +346,7 @@ describe('useSetupTechnology', () => {
       },
     });
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useSetupTechnology({
         setNewAgentPolicy,
         newAgentPolicy: newAgentPolicyMock,
@@ -360,8 +362,7 @@ describe('useSetupTechnology', () => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENT_BASED);
     });
 
-    waitForNextUpdate();
-    expect(setNewAgentPolicy).toHaveBeenCalledTimes(0);
+    await waitFor(() => expect(setNewAgentPolicy).toHaveBeenCalledTimes(0));
   });
 
   it('should not fetch agentless policy if agentless is enabled but serverless is disabled', async () => {
@@ -386,7 +387,7 @@ describe('useSetupTechnology', () => {
   });
 
   it('should update agent policy and selected policy tab when setup technology is agentless', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useSetupTechnology({
         setNewAgentPolicy,
         newAgentPolicy: newAgentPolicyMock,
@@ -395,19 +396,25 @@ describe('useSetupTechnology', () => {
         packagePolicy: packagePolicyMock,
       })
     );
-
-    await waitForNextUpdate();
 
     act(() => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
     });
 
-    expect(updateAgentPoliciesMock).toHaveBeenCalledWith([{ id: 'agentless-policy-id' }]);
-    expect(setSelectedPolicyTabMock).toHaveBeenCalledWith(SelectedPolicyTab.EXISTING);
+    await waitFor(() => {
+      expect(updateAgentPoliciesMock).toHaveBeenCalledWith([
+        {
+          inactivity_timeout: 3600,
+          name: 'Agentless policy for endpoint-1',
+          supports_agentless: true,
+        },
+      ]);
+      expect(setSelectedPolicyTabMock).toHaveBeenCalledWith(SelectedPolicyTab.EXISTING);
+    });
   });
 
   it('should update new agent policy and selected policy tab when setup technology is agent-based', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useSetupTechnology({
         setNewAgentPolicy,
         newAgentPolicy: newAgentPolicyMock,
@@ -416,8 +423,6 @@ describe('useSetupTechnology', () => {
         packagePolicy: packagePolicyMock,
       })
     );
-
-    await waitForNextUpdate();
 
     expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
 
@@ -433,8 +438,10 @@ describe('useSetupTechnology', () => {
 
     expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
 
-    expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
-    expect(setSelectedPolicyTabMock).toHaveBeenCalledWith(SelectedPolicyTab.NEW);
+    await waitFor(() => {
+      expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
+      expect(setSelectedPolicyTabMock).toHaveBeenCalledWith(SelectedPolicyTab.NEW);
+    });
   });
 
   it('should not update agent policy and selected policy tab when agentless is disabled', async () => {
@@ -462,7 +469,7 @@ describe('useSetupTechnology', () => {
   });
 
   it('should not update agent policy and selected policy tab when setup technology matches the current one ', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useSetupTechnology({
         setNewAgentPolicy,
         newAgentPolicy: newAgentPolicyMock,
@@ -472,7 +479,7 @@ describe('useSetupTechnology', () => {
       })
     );
 
-    await waitForNextUpdate();
+    await waitFor(() => new Promise((resolve) => resolve(null)));
 
     expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
 
@@ -487,7 +494,7 @@ describe('useSetupTechnology', () => {
   });
 
   it('should revert the agent policy name to the original value when switching from agentless back to agent-based', async () => {
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useSetupTechnology({
         setNewAgentPolicy,
         newAgentPolicy: newAgentPolicyMock,
@@ -497,8 +504,6 @@ describe('useSetupTechnology', () => {
       })
     );
 
-    await waitForNextUpdate();
-
     expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
 
     act(() => {
@@ -507,7 +512,7 @@ describe('useSetupTechnology', () => {
 
     expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENTLESS);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(setNewAgentPolicy).toHaveBeenCalledWith({
         name: 'Agentless policy for endpoint-1',
         supports_agentless: true,
@@ -521,5 +526,248 @@ describe('useSetupTechnology', () => {
 
     expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
     expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
+  });
+
+  it('should have global_data_tags with the integration team when creating agentless policy with global_data_tags', async () => {
+    (useConfig as MockFn).mockReturnValue({
+      agentless: {
+        enabled: true,
+        api: {
+          url: 'https://agentless.api.url',
+        },
+      },
+    } as any);
+    (useStartServices as MockFn).mockReturnValue({
+      cloud: {
+        isCloudEnabled: true,
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useSetupTechnology({
+        setNewAgentPolicy,
+        newAgentPolicy: newAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
+        setSelectedPolicyTab: setSelectedPolicyTabMock,
+        packagePolicy: packagePolicyMock,
+        packageInfo: packageInfoMock,
+      })
+    );
+
+    act(() => {
+      result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS, 'cspm');
+    });
+
+    await waitFor(() => {
+      expect(setNewAgentPolicy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          supports_agentless: true,
+          global_data_tags: [
+            { name: 'organization', value: 'org' },
+            { name: 'division', value: 'div' },
+            { name: 'team', value: 'team' },
+          ],
+        })
+      );
+    });
+  });
+
+  it('should not fail and not have global_data_tags when creating the agentless policy when it cannot find the policy template', async () => {
+    (useConfig as MockFn).mockReturnValue({
+      agentless: {
+        enabled: true,
+        api: {
+          url: 'https://agentless.api.url',
+        },
+      },
+    } as any);
+    (useStartServices as MockFn).mockReturnValue({
+      cloud: {
+        isCloudEnabled: true,
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useSetupTechnology({
+        setNewAgentPolicy,
+        newAgentPolicy: newAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
+        setSelectedPolicyTab: setSelectedPolicyTabMock,
+        packagePolicy: packagePolicyMock,
+        packageInfo: packageInfoMock,
+      })
+    );
+
+    act(() => {
+      result.current.handleSetupTechnologyChange(
+        SetupTechnology.AGENTLESS,
+        'never-gonna-give-you-up'
+      );
+    });
+
+    await waitFor(() => {
+      expect(setNewAgentPolicy).toHaveBeenCalledWith({
+        name: 'Agentless policy for endpoint-1',
+        supports_agentless: true,
+        inactivity_timeout: 3600,
+      });
+      expect(setNewAgentPolicy).not.toHaveBeenCalledWith({
+        global_data_tags: [
+          { name: 'organization', value: 'org' },
+          { name: 'division', value: 'div' },
+          { name: 'team', value: 'team' },
+        ],
+      });
+    });
+  });
+
+  it('should not fail and not have global_data_tags when creating the agentless policy without the policy template name', async () => {
+    (useConfig as MockFn).mockReturnValue({
+      agentless: {
+        enabled: true,
+        api: {
+          url: 'https://agentless.api.url',
+        },
+      },
+    } as any);
+    (useStartServices as MockFn).mockReturnValue({
+      cloud: {
+        isCloudEnabled: true,
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useSetupTechnology({
+        setNewAgentPolicy,
+        newAgentPolicy: newAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
+        setSelectedPolicyTab: setSelectedPolicyTabMock,
+        packagePolicy: packagePolicyMock,
+        packageInfo: packageInfoMock,
+      })
+    );
+
+    act(() => {
+      result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
+    });
+
+    await waitFor(() => {
+      expect(setNewAgentPolicy).toHaveBeenCalledWith({
+        name: 'Agentless policy for endpoint-1',
+        supports_agentless: true,
+        inactivity_timeout: 3600,
+      });
+      expect(setNewAgentPolicy).not.toHaveBeenCalledWith({
+        global_data_tags: [
+          { name: 'organization', value: 'org' },
+          { name: 'division', value: 'div' },
+          { name: 'team', value: 'team' },
+        ],
+      });
+    });
+  });
+
+  it('should not fail and not have global_data_tags when creating the agentless policy without the packageInfo', async () => {
+    (useConfig as MockFn).mockReturnValue({
+      agentless: {
+        enabled: true,
+        api: {
+          url: 'https://agentless.api.url',
+        },
+      },
+    } as any);
+    (useStartServices as MockFn).mockReturnValue({
+      cloud: {
+        isCloudEnabled: true,
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useSetupTechnology({
+        setNewAgentPolicy,
+        newAgentPolicy: newAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
+        setSelectedPolicyTab: setSelectedPolicyTabMock,
+        packagePolicy: packagePolicyMock,
+      })
+    );
+
+    act(() => {
+      result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS, 'cspm');
+    });
+
+    await waitFor(() => {
+      expect(setNewAgentPolicy).toHaveBeenCalledWith({
+        name: 'Agentless policy for endpoint-1',
+        supports_agentless: true,
+        inactivity_timeout: 3600,
+      });
+      expect(setNewAgentPolicy).not.toHaveBeenCalledWith({
+        global_data_tags: [
+          { name: 'organization', value: 'org' },
+          { name: 'division', value: 'div' },
+          { name: 'team', value: 'team' },
+        ],
+      });
+    });
+  });
+
+  it('should not have global_data_tags when switching from agentless to agent-based policy', async () => {
+    (useConfig as MockFn).mockReturnValue({
+      agentless: {
+        enabled: true,
+        api: {
+          url: 'https://agentless.api.url',
+        },
+      },
+    } as any);
+    (useStartServices as MockFn).mockReturnValue({
+      cloud: {
+        isCloudEnabled: true,
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useSetupTechnology({
+        setNewAgentPolicy,
+        newAgentPolicy: newAgentPolicyMock,
+        updateAgentPolicies: updateAgentPoliciesMock,
+        setSelectedPolicyTab: setSelectedPolicyTabMock,
+        packagePolicy: packagePolicyMock,
+        packageInfo: packageInfoMock,
+      })
+    );
+
+    act(() => {
+      result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS, 'cspm');
+    });
+
+    await waitFor(() => {
+      expect(setNewAgentPolicy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          supports_agentless: true,
+          global_data_tags: [
+            { name: 'organization', value: 'org' },
+            { name: 'division', value: 'div' },
+            { name: 'team', value: 'team' },
+          ],
+        })
+      );
+    });
+
+    act(() => {
+      result.current.handleSetupTechnologyChange(SetupTechnology.AGENT_BASED);
+    });
+
+    await waitFor(() => {
+      expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
+      expect(setNewAgentPolicy).not.toHaveBeenCalledWith({
+        global_data_tags: [
+          { name: 'organization', value: 'org' },
+          { name: 'division', value: 'div' },
+          { name: 'team', value: 'team' },
+        ],
+      });
+    });
   });
 });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
@@ -157,7 +157,13 @@ export function useSetupTechnology({
 
       if (setupTechnology === SetupTechnology.AGENTLESS) {
         if (isAgentlessApiEnabled) {
-          setNewAgentPolicy(newAgentlessPolicy as NewAgentPolicy);
+          const agentlessPolicy = {
+            ...newAgentlessPolicy,
+            ...getAdditionalAgentlessPolicyInfo(policyTemplateName, packageInfo),
+          } as NewAgentPolicy;
+
+          setNewAgentPolicy(agentlessPolicy);
+          setNewAgentlessPolicy(agentlessPolicy);
           setSelectedPolicyTab(SelectedPolicyTab.NEW);
           updateAgentPolicies([newAgentlessPolicy] as AgentPolicy[]);
         }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/components/step_edit_hosts.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/components/step_edit_hosts.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
-import { act, fireEvent, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
+
+import { userEvent } from '@testing-library/user-event';
 
 import type { TestRenderer } from '../../../../../../mock';
 import { createFleetTestRendererMock } from '../../../../../../mock';
@@ -111,18 +113,18 @@ describe('StepEditHosts', () => {
     testRenderer = createFleetTestRendererMock();
   });
 
-  it('should display create form when no agent policies', () => {
+  it('should display create form when no agent policies', async () => {
     (useGetAgentPolicies as jest.MockedFunction<any>).mockReturnValue({
       data: {
         items: [],
       },
     });
 
+    (useAllNonManagedAgentPolicies as jest.MockedFunction<any>).mockReturnValue([]);
+
     render();
 
-    waitFor(() => {
-      expect(renderResult.getByText('Agent policy 1')).toBeInTheDocument();
-    });
+    expect(renderResult.getByText('New agent policy name')).toBeInTheDocument();
     expect(renderResult.queryByRole('tablist')).not.toBeInTheDocument();
   });
 
@@ -144,7 +146,7 @@ describe('StepEditHosts', () => {
     ).toContain('Agent policy 1');
   });
 
-  it('should display dropdown without preselected value when mulitple agent policies', () => {
+  it('should display dropdown without preselected value when multiple agent policies', async () => {
     (useGetAgentPolicies as jest.MockedFunction<any>).mockReturnValue({
       data: {
         items: [
@@ -156,12 +158,12 @@ describe('StepEditHosts', () => {
 
     render();
 
-    waitFor(() => {
-      expect(renderResult.getByText('At least one agent policy is required.')).toBeInTheDocument();
-    });
+    expect(
+      renderResult.getByText('Select an agent policy to add this integration to')
+    ).toBeInTheDocument();
   });
 
-  it('should display delete button when add button clicked', () => {
+  it('should display delete button when add button clicked', async () => {
     (useGetAgentPolicies as jest.MockedFunction<any>).mockReturnValue({
       data: {
         items: [{ id: '1', name: 'Agent policy 1', namespace: 'default' }],
@@ -173,10 +175,12 @@ describe('StepEditHosts', () => {
 
     render();
 
-    act(() => {
-      fireEvent.click(renderResult.getByTestId('createNewAgentPolicyButton').closest('button')!);
-    });
+    await userEvent.click(
+      renderResult.getByTestId('createNewAgentPolicyButton').closest('button')!
+    );
 
-    expect(renderResult.getByTestId('deleteNewAgentPolicyButton')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(renderResult.getByTestId('deleteNewAgentPolicyButton')).toBeInTheDocument();
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11801,7 +11801,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^6.18.1":
+"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.62.0", "@typescript-eslint/utils@^6.18.1":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
   integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
@@ -17548,6 +17548,13 @@ eslint-plugin-react@^7.32.2:
     resolve "^2.0.0-next.4"
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
+
+eslint-plugin-testing-library@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.4.0.tgz#1ba8a7422e3e31cc315a73ff17c34908f56f9838"
+  integrity sha512-yeWF+YgCgvNyPNI9UKnG0FjeE2sk93N/3lsKqcmR8dSfeXJwFT5irnWo7NjLf152HkRzfoFjh3LsBUrhvFz4eA==
+  dependencies:
+    "@typescript-eslint/utils" "^5.62.0"
 
 eslint-rule-composer@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Fleet] [Cloud Security] Add Testing Library ESLint for handling waitFor (#198735)](https://github.com/elastic/kibana/pull/198735)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Paulo Silva","email":"paulo.henrique@elastic.co"},"sourceCommit":{"committedDate":"2024-11-05T22:34:18Z","message":"[Fleet] [Cloud Security] Add Testing Library ESLint for handling waitFor (#198735)\n\n## Summary\r\n\r\nThis PR aims to fix Flaky tests related to agentless detected by\r\nhttps://github.com/elastic/kibana/issues/189038 and\r\nhttps://github.com/elastic/kibana/issues/192126 by adding proper\r\nhandling of the `waitFor` methods.\r\n\r\nIt was also detected with\r\nhttps://github.com/elastic/security-team/issues/10979 that some other\r\nmethods were not proper handled by `waitFor`, leading to the assertions\r\ninside those unhandled `waitFor` being skipped by Jest.\r\n\r\nThis PR also introduces ESLint to enforce proper handling of waitFor\r\nmethods in tests files for Fleet and Cloud Security plugins.\r\n\r\nAdditional note: These changes should also unblock the failing tests on\r\nthe [React18 use waitFor with assertion callbacks in place of\r\nwaitForNextUpdate](https://github.com/elastic/kibana/pull/195087) PR\r\n\r\n\r\n**Fleet changes**\r\n\r\n- ESLint rule added to enforce handling `waitFor` on React Testing\r\nLibrary.\r\n- `useSetupTechnology` hook tests reviewed and updated to handle the\r\nwaitFor. Fixed issue identified when reviewing the tests.\r\n- step_define_package_policy.test.tsx: Added package policy vars to the\r\nmock to proper handle the use cases\r\n- step_select_hosts.test.tsx: Handled waitFor, identified outdated test\r\n- step_edit_hosts.test.tsx: Handled waitFor, identified outdated test\r\nWith the introduction of the ESLint rule other tests were triggering\r\nESLint errors, I attempted to fix them while retaining the same\r\nintention, let me know if more changes are needed.\r\n\r\n**Cloud Security changes**\r\n\r\n- ESLint rule added to enforce handling `waitFor` on React Testing\r\nLibrary.\r\n- Updated cloud security posture version to include agentless global\r\ntags on End to End tests\r\n\r\n**@elastic/kibana-operations changes**\r\n\r\n- Added\r\n[eslint-plugin-testing-library](https://testing-library.com/docs/ecosystem-eslint-plugin-testing-library/)\r\nan ESLint plugin for Testing Library that helps users to follow best\r\npractices and anticipate common mistakes when writing tests.\r\n- The adoption and enablement of the rules are opt-in.","sha":"5ab59fba401a189c290e55b3f73fd4fd23106e13","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","Team:Cloud Security","v8.16.0","backport:version","v8.17.0"],"number":198735,"url":"https://github.com/elastic/kibana/pull/198735","mergeCommit":{"message":"[Fleet] [Cloud Security] Add Testing Library ESLint for handling waitFor (#198735)\n\n## Summary\r\n\r\nThis PR aims to fix Flaky tests related to agentless detected by\r\nhttps://github.com/elastic/kibana/issues/189038 and\r\nhttps://github.com/elastic/kibana/issues/192126 by adding proper\r\nhandling of the `waitFor` methods.\r\n\r\nIt was also detected with\r\nhttps://github.com/elastic/security-team/issues/10979 that some other\r\nmethods were not proper handled by `waitFor`, leading to the assertions\r\ninside those unhandled `waitFor` being skipped by Jest.\r\n\r\nThis PR also introduces ESLint to enforce proper handling of waitFor\r\nmethods in tests files for Fleet and Cloud Security plugins.\r\n\r\nAdditional note: These changes should also unblock the failing tests on\r\nthe [React18 use waitFor with assertion callbacks in place of\r\nwaitForNextUpdate](https://github.com/elastic/kibana/pull/195087) PR\r\n\r\n\r\n**Fleet changes**\r\n\r\n- ESLint rule added to enforce handling `waitFor` on React Testing\r\nLibrary.\r\n- `useSetupTechnology` hook tests reviewed and updated to handle the\r\nwaitFor. Fixed issue identified when reviewing the tests.\r\n- step_define_package_policy.test.tsx: Added package policy vars to the\r\nmock to proper handle the use cases\r\n- step_select_hosts.test.tsx: Handled waitFor, identified outdated test\r\n- step_edit_hosts.test.tsx: Handled waitFor, identified outdated test\r\nWith the introduction of the ESLint rule other tests were triggering\r\nESLint errors, I attempted to fix them while retaining the same\r\nintention, let me know if more changes are needed.\r\n\r\n**Cloud Security changes**\r\n\r\n- ESLint rule added to enforce handling `waitFor` on React Testing\r\nLibrary.\r\n- Updated cloud security posture version to include agentless global\r\ntags on End to End tests\r\n\r\n**@elastic/kibana-operations changes**\r\n\r\n- Added\r\n[eslint-plugin-testing-library](https://testing-library.com/docs/ecosystem-eslint-plugin-testing-library/)\r\nan ESLint plugin for Testing Library that helps users to follow best\r\npractices and anticipate common mistakes when writing tests.\r\n- The adoption and enablement of the rules are opt-in.","sha":"5ab59fba401a189c290e55b3f73fd4fd23106e13"}},"sourceBranch":"main","suggestedTargetBranches":["8.16","8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/198735","number":198735,"mergeCommit":{"message":"[Fleet] [Cloud Security] Add Testing Library ESLint for handling waitFor (#198735)\n\n## Summary\r\n\r\nThis PR aims to fix Flaky tests related to agentless detected by\r\nhttps://github.com/elastic/kibana/issues/189038 and\r\nhttps://github.com/elastic/kibana/issues/192126 by adding proper\r\nhandling of the `waitFor` methods.\r\n\r\nIt was also detected with\r\nhttps://github.com/elastic/security-team/issues/10979 that some other\r\nmethods were not proper handled by `waitFor`, leading to the assertions\r\ninside those unhandled `waitFor` being skipped by Jest.\r\n\r\nThis PR also introduces ESLint to enforce proper handling of waitFor\r\nmethods in tests files for Fleet and Cloud Security plugins.\r\n\r\nAdditional note: These changes should also unblock the failing tests on\r\nthe [React18 use waitFor with assertion callbacks in place of\r\nwaitForNextUpdate](https://github.com/elastic/kibana/pull/195087) PR\r\n\r\n\r\n**Fleet changes**\r\n\r\n- ESLint rule added to enforce handling `waitFor` on React Testing\r\nLibrary.\r\n- `useSetupTechnology` hook tests reviewed and updated to handle the\r\nwaitFor. Fixed issue identified when reviewing the tests.\r\n- step_define_package_policy.test.tsx: Added package policy vars to the\r\nmock to proper handle the use cases\r\n- step_select_hosts.test.tsx: Handled waitFor, identified outdated test\r\n- step_edit_hosts.test.tsx: Handled waitFor, identified outdated test\r\nWith the introduction of the ESLint rule other tests were triggering\r\nESLint errors, I attempted to fix them while retaining the same\r\nintention, let me know if more changes are needed.\r\n\r\n**Cloud Security changes**\r\n\r\n- ESLint rule added to enforce handling `waitFor` on React Testing\r\nLibrary.\r\n- Updated cloud security posture version to include agentless global\r\ntags on End to End tests\r\n\r\n**@elastic/kibana-operations changes**\r\n\r\n- Added\r\n[eslint-plugin-testing-library](https://testing-library.com/docs/ecosystem-eslint-plugin-testing-library/)\r\nan ESLint plugin for Testing Library that helps users to follow best\r\npractices and anticipate common mistakes when writing tests.\r\n- The adoption and enablement of the rules are opt-in.","sha":"5ab59fba401a189c290e55b3f73fd4fd23106e13"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->