### PR TITLE
[ResponseOps][Rules] Allow users to create rules with predefined non random IDs

### DIFF
--- a/x-pack/plugins/alerting/server/saved_objects/index.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/index.ts
@@ -217,6 +217,11 @@ export function setupSavedObjects(
   // Encrypted attributes
   encryptedSavedObjects.registerType({
     type: RULE_SAVED_OBJECT_TYPE,
+    /**
+     * We disable enforcing random SO IDs for the rule SO
+     * to allow users creating rules with a predefined ID.
+     */
+    enforceRandomId: false,
     attributesToEncrypt: new Set(RuleAttributesToEncrypt),
     attributesToIncludeInAAD: new Set(RuleAttributesIncludedInAAD),
   });

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/create.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/create.ts
@@ -395,20 +395,18 @@ export default function createAlertTests({ getService }: FtrProviderContext) {
       });
     });
 
-    it('should not allow providing simple custom ids (non uuid)', async () => {
-      const customId = '1';
-      const response = await supertest
-        .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule/${customId}`)
-        .set('kbn-xsrf', 'foo')
-        .send(getTestRuleData());
+    it('should create a rule with a predefined non random ID', async () => {
+      const ruleId = 'my_id';
 
-      expect(response.status).to.eql(400);
-      expect(response.body).to.eql({
-        statusCode: 400,
-        error: 'Bad Request',
-        message:
-          'Predefined IDs are not allowed for saved objects with encrypted attributes unless the ID is a UUID.: Bad Request',
-      });
+      const response = await supertest
+        .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule/${ruleId}`)
+        .set('kbn-xsrf', 'foo')
+        .send(getTestRuleData())
+        .expect(200);
+
+      objectRemover.add(Spaces.space1.id, response.body.id, 'rule', 'alerting');
+
+      expect(response.body.id).to.eql(ruleId);
     });
 
     it('should return 409 when document with id already exists', async () => {
@@ -478,20 +476,6 @@ export default function createAlertTests({ getService }: FtrProviderContext) {
         error: 'Bad Request',
         message: 'Group is not defined in action test-id',
       });
-    });
-
-    it('should create a rule with a predefined non random ID', async () => {
-      const ruleId = 'my_id';
-
-      const response = await supertest
-        .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule/${ruleId}`)
-        .set('kbn-xsrf', 'foo')
-        .send(getTestRuleData())
-        .expect(200);
-
-      objectRemover.add(Spaces.space1.id, response.body.id, 'rule', 'alerting');
-
-      expect(response.body.id).to.eql(ruleId);
     });
 
     describe('system actions', () => {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/create.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/create.ts
@@ -480,6 +480,20 @@ export default function createAlertTests({ getService }: FtrProviderContext) {
       });
     });
 
+    it('should create a rule with a predefined non random ID', async () => {
+      const ruleId = 'my_id';
+
+      const response = await supertest
+        .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule/${ruleId}`)
+        .set('kbn-xsrf', 'foo')
+        .send(getTestRuleData())
+        .expect(200);
+
+      objectRemover.add(Spaces.space1.id, response.body.id, 'rule', 'alerting');
+
+      expect(response.body.id).to.eql(ruleId);
+    });
+
     describe('system actions', () => {
       const systemAction = {
         id: 'system-connector-test.system-action',


### PR DESCRIPTION
## Summary

This PR allows users to create rules with predefined nonrandom IDs. To test it, try to create a rule with a predefined ID like `POST /api/alerting/rule/<my_rule_id>`

Fixes: https://github.com/elastic/kibana/issues/182594

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->