### PR TITLE
[Fleet] Added default index pattern creation to stream-based installation

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
@@ -133,6 +133,20 @@ export async function installKibanaAssets(options: {
     return [];
   }
 
+  await createDefaultIndexPatterns(savedObjectsImporter);
+  await makeManagedIndexPatternsGlobal(savedObjectsClient);
+
+  return await installKibanaSavedObjects({
+    logger,
+    savedObjectsImporter,
+    kibanaAssets: assetsToInstall,
+    assetsChunkSize: MAX_ASSETS_TO_INSTALL_IN_PARALLEL,
+  });
+}
+
+export async function createDefaultIndexPatterns(
+  savedObjectsImporter: SavedObjectsImporterContract
+) {
   // Create index patterns separately with `overwrite: false` to prevent blowing away users' runtime fields.
   // These don't get retried on conflict, because we expect that they exist once an integration has been installed.
   const indexPatternSavedObjects = getIndexPatternSavedObjects() as ArchiveAsset[];
@@ -142,15 +156,6 @@ export async function installKibanaAssets(options: {
     createNewCopies: false,
     refresh: false,
     managed: true,
-  });
-
-  await makeManagedIndexPatternsGlobal(savedObjectsClient);
-
-  return await installKibanaSavedObjects({
-    logger,
-    savedObjectsImporter,
-    kibanaAssets: assetsToInstall,
-    assetsChunkSize: MAX_ASSETS_TO_INSTALL_IN_PARALLEL,
   });
 }
 

--- a/x-pack/plugins/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.ts
@@ -40,7 +40,7 @@ export async function stepInstallKibanaAssets(context: InstallContext) {
 }
 
 export async function stepInstallKibanaAssetsWithStreaming(context: InstallContext) {
-  const { savedObjectsClient, installedPkg, packageInstallContext, spaceId } = context;
+  const { savedObjectsClient, packageInstallContext, spaceId } = context;
   const { packageInfo } = packageInstallContext;
   const { name: pkgName } = packageInfo;
 
@@ -51,7 +51,6 @@ export async function stepInstallKibanaAssetsWithStreaming(context: InstallConte
         savedObjectsClient,
         pkgName,
         packageInstallContext,
-        installedPkg,
         spaceId,
       })
   );

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/sourcerer/sourcerer_timeline.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/sourcerer/sourcerer_timeline.cy.ts
@@ -40,8 +40,7 @@ import { closeTimeline, openTimelineById } from '../../../tasks/timeline';
 const siemDataViewTitle = 'Security Default Data View';
 const dataViews = ['logs-*', 'metrics-*', '.kibana-event-log-*'];
 
-// Failing: See https://github.com/elastic/kibana/issues/198943
-describe.skip('Timeline scope', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
+describe('Timeline scope', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
   before(() => {
     waitForRulesBootstrap();
   });
@@ -64,8 +63,7 @@ describe.skip('Timeline scope', { tags: ['@ess', '@serverless', '@skipInServerle
   });
 
   describe('Modified badge', () => {
-    // failing on main multiple times https://github.com/elastic/kibana/issues/198944#issuecomment-2457665138 and https://github.com/elastic/kibana/issues/198943#issuecomment-2457665072
-    it.skip('Selecting new data view does not add a modified badge', () => {
+    it('Selecting new data view does not add a modified badge', () => {
       openTimelineUsingToggle();
       cy.get(SOURCERER.badgeModified).should(`not.exist`);
       openSourcerer('timeline');
@@ -135,8 +133,7 @@ describe.skip('Timeline scope', { tags: ['@ess', '@serverless', '@skipInServerle
     });
 
     const defaultPatterns = [`auditbeat-*`, `${DEFAULT_ALERTS_INDEX}-default`];
-    // failing on main multiple times https://github.com/elastic/kibana/issues/198944#issuecomment-2457665138 and https://github.com/elastic/kibana/issues/198943#issuecomment-2457665072
-    it.skip('alerts checkbox behaves as expected', () => {
+    it('alerts checkbox behaves as expected', () => {
       isDataViewSelection(siemDataViewTitle);
       defaultPatterns.forEach((pattern) => isSourcererSelection(pattern));
       openDataViewSelection();


### PR DESCRIPTION
**Related to: https://github.com/elastic/kibana/pull/195888**

## Summary

Add default index pattern creation to the new stream-based package installation method to match the behavior of standard package installation.

Switching to stream-based package installation resulted in the default index patterns not being created, even after installing the rules package. While this likely doesn’t affect production, as multiple integrations are usually installed in Kibana (creating the default index pattern in any case), this change has impacted some tests: https://github.com/elastic/kibana/pull/199030. So restoring the original behaviour

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->