### PR TITLE
[Rendering] Parallelize ES requests

### DIFF
--- a/packages/core/rendering/core-rendering-server-internal/src/rendering_service.tsx
+++ b/packages/core/rendering/core-rendering-server-internal/src/rendering_service.tsx
@@ -20,10 +20,10 @@ import type { IUiSettingsClient } from '@kbn/core-ui-settings-server';
 import type { UiPlugins } from '@kbn/core-plugins-base-server-internal';
 import type { CustomBranding } from '@kbn/core-custom-branding-common';
 import {
-  type UserProvidedValues,
   type DarkModeValue,
   parseDarkModeValue,
   type UiSettingsParams,
+  type UserProvidedValues,
 } from '@kbn/core-ui-settings-common';
 import { Template } from './views';
 import {
@@ -148,23 +148,29 @@ export class RenderingService {
     const basePath = http.basePath.get(request);
     const { serverBasePath, publicBaseUrl } = http.basePath;
 
-    let settingsUserValues: Record<string, UserProvidedValues> = {};
-    let globalSettingsUserValues: Record<string, UserProvidedValues> = {};
-
-    if (!isAnonymousPage) {
-      const userValues = await Promise.all([
-        uiSettings.client?.getUserProvided(),
-        uiSettings.globalClient?.getUserProvided(),
-      ]);
-
-      settingsUserValues = userValues[0];
-      globalSettingsUserValues = userValues[1];
-    }
-
-    const defaultSettings = await withAsyncDefaultValues(
-      request,
-      uiSettings.client?.getRegistered()
-    );
+    // Grouping all async HTTP requests to run them concurrently for performance reasons.
+    const [
+      defaultSettings,
+      settingsUserValues = {},
+      globalSettingsUserValues = {},
+      userSettingDarkMode,
+    ] = await Promise.all([
+      // All sites
+      withAsyncDefaultValues(request, uiSettings.client?.getRegistered()),
+      // Only non-anonymous pages
+      ...(!isAnonymousPage
+        ? ([
+            uiSettings.client?.getUserProvided(),
+            uiSettings.globalClient?.getUserProvided(),
+            // dark mode
+            userSettings?.getUserSettingDarkMode(request),
+          ] as [
+            Promise<Record<string, UserProvidedValues>>,
+            Promise<Record<string, UserProvidedValues>>,
+            Promise<DarkModeValue> | undefined
+          ])
+        : []),
+    ]);
 
     const settings = {
       defaults: defaultSettings,
@@ -196,10 +202,6 @@ export class RenderingService {
     }
 
     // dark mode
-    const userSettingDarkMode = isAnonymousPage
-      ? undefined
-      : await userSettings?.getUserSettingDarkMode(request);
-
     const isThemeOverridden = settings.user['theme:darkMode']?.isOverridden ?? false;
 
     let darkMode: DarkModeValue;


### PR DESCRIPTION
## Summary

APM traces have shown that these multiple `GET .kibana/_doc/config` can take up to 400ms, leading to a joined sequential time of 1.2s.

This code aims to run them concurrently to reduce any latency/network/ES effects when serving the `index.html` requests.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->