### PR TITLE
Flaky #111821 - Refresh index

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/event_loop_delays/rollups/integration_tests/daily_rollups.test.ts
@@ -8,7 +8,12 @@
  */
 
 import moment, { type MomentInput } from 'moment';
-import type { Logger, ISavedObjectsRepository, SavedObject } from '@kbn/core/server';
+import type {
+  Logger,
+  ISavedObjectsRepository,
+  SavedObject,
+  ElasticsearchClient,
+} from '@kbn/core/server';
 import {
   type TestElasticsearchUtils,
   type TestKibanaUtils,
@@ -72,11 +77,11 @@ function createRawEventLoopDelaysDailyDocs() {
   return { rawEventLoopDelaysDaily, outdatedRawEventLoopDelaysDaily };
 }
 
-// Failing: See https://github.com/elastic/kibana/issues/111821
-describe.skip(`daily rollups integration test`, () => {
+describe(`daily rollups integration test`, () => {
   let esServer: TestElasticsearchUtils;
   let root: TestKibanaUtils['root'];
   let internalRepository: ISavedObjectsRepository;
+  let esClient: ElasticsearchClient;
   let logger: Logger;
   let rawEventLoopDelaysDaily: Array<SavedObject<EventLoopDelaysDaily>>;
   let outdatedRawEventLoopDelaysDaily: Array<SavedObject<EventLoopDelaysDaily>>;
@@ -94,6 +99,7 @@ describe.skip(`daily rollups integration test`, () => {
     const start = await root.start();
     logger = root.logger.get('test daily rollups');
     internalRepository = start.savedObjects.createInternalRepository([SAVED_OBJECTS_DAILY_TYPE]);
+    esClient = start.elasticsearch.client.asInternalUser;
 
     // Create the docs now
     const rawDailyDocs = createRawEventLoopDelaysDailyDocs();
@@ -113,6 +119,7 @@ describe.skip(`daily rollups integration test`, () => {
 
   it('deletes documents older that 3 days from the saved objects repository', async () => {
     await rollDailyData(logger, internalRepository);
+    await esClient.indices.refresh({ index: `.kibana` }); // Make sure that the changes are searchable
     const { total, saved_objects: savedObjects } =
       await internalRepository.find<EventLoopDelaysDaily>({ type: SAVED_OBJECTS_DAILY_TYPE });
     expect(total).toBe(rawEventLoopDelaysDaily.length);


### PR DESCRIPTION
## Summary

Resolves #111821


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->