### PR TITLE
[AI Assistant] Enable Search in Solution View

### DIFF
--- a/x-pack/plugins/spaces/server/capabilities/capabilities_switcher.test.ts
+++ b/x-pack/plugins/spaces/server/capabilities/capabilities_switcher.test.ts
@@ -366,14 +366,12 @@ describe('capabilitiesSwitcher', () => {
       {
         space.solution = 'oblt';
 
-        // It should disable enterpriseSearch and securitySolution features
-        // which correspond to feature_1 and feature_3
+        // It should disable securitySolution features
+        // which corresponds to feature_3
         const result = await switcher(request, capabilities, false);
 
         const expectedCapabilities = buildCapabilities();
 
-        expectedCapabilities.feature_1.bar = false;
-        expectedCapabilities.feature_1.foo = false;
         expectedCapabilities.feature_3.bar = false;
         expectedCapabilities.feature_3.foo = false;
 

--- a/x-pack/plugins/spaces/server/lib/utils/space_solution_disabled_features.test.ts
+++ b/x-pack/plugins/spaces/server/lib/utils/space_solution_disabled_features.test.ts
@@ -58,7 +58,7 @@ describe('#withSpaceSolutionDisabledFeatures', () => {
   });
 
   describe('when the space solution is "oblt"', () => {
-    test('it removes the "search" and "security" features', () => {
+    test('it removes the "security" features', () => {
       const spaceDisabledFeatures: string[] = [];
       const spaceSolution = 'oblt';
 
@@ -68,7 +68,7 @@ describe('#withSpaceSolutionDisabledFeatures', () => {
         spaceSolution
       );
 
-      expect(result).toEqual(['feature2', 'feature3']);
+      expect(result).toEqual(['feature3']);
     });
   });
 

--- a/x-pack/plugins/spaces/server/lib/utils/space_solution_disabled_features.ts
+++ b/x-pack/plugins/spaces/server/lib/utils/space_solution_disabled_features.ts
@@ -61,7 +61,6 @@ export function withSpaceSolutionDisabledFeatures(
     ]).filter((featureId) => !enabledFeaturesPerSolution.es.includes(featureId));
   } else if (spaceSolution === 'oblt') {
     disabledFeatureKeysFromSolution = getFeatureIdsForCategories(features, [
-      'enterpriseSearch',
       'securitySolution',
     ]).filter((featureId) => !enabledFeaturesPerSolution.oblt.includes(featureId));
   } else if (spaceSolution === 'security') {


### PR DESCRIPTION
## Summary

This enables the Search solution in the Observability solution view, so that connectors (which are required for the AI Assistant) are available.

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->