### PR TITLE
[kbn-repo-packages] Add sort locale

### DIFF
--- a/packages/kbn-repo-packages/modern/package.js
+++ b/packages/kbn-repo-packages/modern/package.js
@@ -44,7 +44,7 @@ class Package {
    * @param {Package} b
    */
   static sorter(a, b) {
-    return a.manifest.id.localeCompare(b.manifest.id);
+    return a.manifest.id.localeCompare(b.manifest.id, 'en');
   }
 
   /**


### PR DESCRIPTION
In some situations `yarn kbn bootstrap` is causing the sort order of tsconfig.base.json to change.  

This adds a locale to the comparative to keep the sort order consistent.

<!--ONMERGE {"backportTargets":["8.15","8.16","8.x"]} ONMERGE-->