### PR TITLE
[8.x] [SecuritySolution] Fix issue with duplicate timeline reloading (#198652)

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/use_update_timeline.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/use_update_timeline.test.tsx
@@ -116,7 +116,7 @@ describe('dispatchUpdateTimeline', () => {
           ...mockTimelineModel,
           version: null,
           updated: undefined,
-          changed: undefined,
+          changed: true,
         },
       });
     });

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/use_update_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/use_update_timeline.tsx
@@ -53,7 +53,9 @@ export const useUpdateTimeline = () => {
     }: UpdateTimeline) => {
       let _timeline = timeline;
       if (duplicate) {
-        _timeline = { ...timeline, updated: undefined, changed: undefined, version: null };
+        // Reset the `updated` and `version` fields because a duplicated timeline has not been saved yet.
+        // The `changed` field is set to true because the duplicated timeline needs to be saved.
+        _timeline = { ...timeline, updated: undefined, changed: true, version: null };
       }
       if (!isEmpty(_timeline.indexNames)) {
         dispatch(

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/unsaved_timeline.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/unsaved_timeline.cy.ts
@@ -18,7 +18,7 @@ import {
   openKibanaNavigation,
 } from '../../../tasks/kibana_navigation';
 import { login } from '../../../tasks/login';
-import { visitWithTimeRange } from '../../../tasks/navigation';
+import { visit, visitWithTimeRange } from '../../../tasks/navigation';
 import {
   closeTimelineUsingCloseButton,
   openTimelineUsingToggle,
@@ -32,13 +32,14 @@ import {
 } from '../../../tasks/serverless/navigation';
 import {
   addNameToTimelineAndSave,
+  closeTimeline,
   createNewTimeline,
+  duplicateFirstTimeline,
   populateTimeline,
 } from '../../../tasks/timeline';
-import { EXPLORE_URL, hostsUrl, MANAGE_URL } from '../../../urls/navigation';
+import { EXPLORE_URL, hostsUrl, MANAGE_URL, TIMELINES_URL } from '../../../urls/navigation';
 
-// FLAKY: https://github.com/elastic/kibana/issues/174068
-describe.skip('[ESS] Save Timeline Prompts', { tags: ['@ess'] }, () => {
+describe('[ESS] Save Timeline Prompts', { tags: ['@ess'] }, () => {
   beforeEach(() => {
     login();
     visitWithTimeRange(hostsUrl('allHosts'));
@@ -118,6 +119,17 @@ describe.skip('[ESS] Save Timeline Prompts', { tags: ['@ess'] }, () => {
     // should not be manage page i.e. successfull navigation
     cy.get(TIMELINE_SAVE_MODAL).should('not.exist');
     cy.url().should('not.contain', MANAGE_URL);
+  });
+
+  it('should prompt when a timeline is duplicated but not saved', () => {
+    addNameToTimelineAndSave('Original');
+    closeTimeline();
+    visit(TIMELINES_URL);
+    duplicateFirstTimeline();
+    closeTimeline();
+    openKibanaNavigation();
+    navigateFromKibanaCollapsibleTo(MANAGE_PAGE);
+    cy.get(APP_LEAVE_CONFIRM_MODAL).should('be.visible');
   });
 });
 
@@ -200,5 +212,15 @@ describe('[serverless] Save Timeline Prompts', { tags: ['@serverless'] }, () => 
     addNameToTimelineAndSave('Test');
     navigateToExploreUsingBreadcrumb(); // explore has timelines disabled
     cy.get(APP_LEAVE_CONFIRM_MODAL).should('not.exist');
+  });
+
+  it('should prompt when a timeline is duplicated but not saved', () => {
+    addNameToTimelineAndSave('Original');
+    closeTimeline();
+    visit(TIMELINES_URL);
+    duplicateFirstTimeline();
+    closeTimeline();
+    navigateToExplorePageInServerless(); // security page with timelines disabled
+    cy.get(APP_LEAVE_CONFIRM_MODAL).should('be.visible');
   });
 });

--- a/x-pack/test/security_solution_cypress/cypress/screens/timelines.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/timelines.ts
@@ -38,6 +38,8 @@ export const TIMELINES_PINNED_EVENT_COUNT = '[data-test-subj="pinned-event-count
 
 export const TIMELINES_TABLE = '[data-test-subj="timelines-table"]';
 
+export const DUPLICATE_TIMELINE = '[data-test-subj="open-duplicate"]';
+
 export const TIMELINES_USERNAME = '[data-test-subj="username"]';
 
 export const REFRESH_BUTTON = '[data-test-subj="refreshButton-linkIcon"]';

--- a/x-pack/test/security_solution_cypress/cypress/tasks/timeline.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/timeline.ts
@@ -90,15 +90,22 @@ import {
   TIMELINE_FULL_SCREEN_BUTTON,
   QUERY_EVENT_COUNT,
   TIMELINE_ENABLE_DISABLE_ALL_ROW_RENDERER,
+  TIMELINE_TITLE,
 } from '../screens/timeline';
 
-import { REFRESH_BUTTON, TIMELINE, TIMELINES_TAB_TEMPLATE } from '../screens/timelines';
+import {
+  DUPLICATE_TIMELINE,
+  REFRESH_BUTTON,
+  TIMELINE,
+  TIMELINES_TABLE,
+  TIMELINES_TAB_TEMPLATE,
+} from '../screens/timelines';
 import { waitForTabToBeLoaded } from './common';
 
 import { closeFieldsBrowser, filterFieldsBrowser } from './fields_browser';
 import { TIMELINE_CONTEXT_MENU_BTN } from '../screens/alerts';
 import { LOADING_INDICATOR } from '../screens/security_header';
-import { TOASTER } from '../screens/alerts_detection_rules';
+import { COLLAPSED_ACTION_BTN, TOASTER } from '../screens/alerts_detection_rules';
 
 const hostExistsQuery = 'host.name: *';
 
@@ -146,6 +153,14 @@ export const addNameAndDescriptionToTimeline = (
   cy.get(TIMELINE_DESCRIPTION_INPUT).invoke('val').should('equal', timeline.description);
   cy.get(TIMELINE_SAVE_MODAL_SAVE_BUTTON).click();
   cy.get(TIMELINE_TITLE_INPUT).should('not.exist');
+};
+
+export const duplicateFirstTimeline = () => {
+  cy.get(TIMELINES_TABLE).within(() => {
+    cy.get(COLLAPSED_ACTION_BTN).first().click();
+  });
+  cy.get(DUPLICATE_TIMELINE).click();
+  cy.get(TIMELINE_TITLE).should('be.visible');
 };
 
 export const goToNotesTab = () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[SecuritySolution] Fix issue with duplicate timeline reloading (#198652)](https://github.com/elastic/kibana/pull/198652)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jan Monschke","email":"jan.monschke@elastic.co"},"sourceCommit":{"committedDate":"2024-11-06T07:55:19Z","message":"[SecuritySolution] Fix issue with duplicate timeline reloading (#198652)\n\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/173240\r\n\r\nUnsaved duplicated timelines will now show the save notification when\r\nthe user is trying to leave security solution without saving.\r\n\r\nThe PR also re-enables the `unsaved_timelines` cypress tests.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/429d23fc-0cd5-4f0a-bcc9-0fd025856b6e\r\n\r\n\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bde5e11526c222dd0697dbeb092b8f53dbd2c859","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:Threat Hunting:Investigations","backport:prev-minor"],"number":198652,"url":"https://github.com/elastic/kibana/pull/198652","mergeCommit":{"message":"[SecuritySolution] Fix issue with duplicate timeline reloading (#198652)\n\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/173240\r\n\r\nUnsaved duplicated timelines will now show the save notification when\r\nthe user is trying to leave security solution without saving.\r\n\r\nThe PR also re-enables the `unsaved_timelines` cypress tests.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/429d23fc-0cd5-4f0a-bcc9-0fd025856b6e\r\n\r\n\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bde5e11526c222dd0697dbeb092b8f53dbd2c859"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/198652","number":198652,"mergeCommit":{"message":"[SecuritySolution] Fix issue with duplicate timeline reloading (#198652)\n\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/173240\r\n\r\nUnsaved duplicated timelines will now show the save notification when\r\nthe user is trying to leave security solution without saving.\r\n\r\nThe PR also re-enables the `unsaved_timelines` cypress tests.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/429d23fc-0cd5-4f0a-bcc9-0fd025856b6e\r\n\r\n\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"bde5e11526c222dd0697dbeb092b8f53dbd2c859"}}]}] BACKPORT-->