### PR TITLE
Add InfoSec team members as Ironbank project maintainers

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
@@ -67,7 +67,7 @@ maintainers:
     cht_member: false
   - email: 'arsalan.khan@elastic.co'
     name: 'Arsalan Khan'
-    username: 'kharsalan'
+    username: 'khanarsalan'
     cht_member: false
   - email: 'iaroslava.zhomir@elastic.co'
     name: 'Slava Zhomir'
@@ -75,7 +75,7 @@ maintainers:
     cht_member: false
   - email: 'ryan.kam@elastic.co'
     name: 'Ryan Kam'
-    username: <TODO>
+    username: 'ryankam'
     cht_member: false
   - email: 'saumya.shree@elastic.co'
     name: 'Saumya Shree'

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
@@ -71,7 +71,7 @@ maintainers:
     cht_member: false
   - email: 'iaroslava.zhomir@elastic.co'
     name: 'Slava Zhomir'
-    username: <TODO>
+    username: 'slava-elastic'
     cht_member: false
   - email: 'ryan.kam@elastic.co'
     name: 'Ryan Kam'
@@ -79,7 +79,7 @@ maintainers:
     cht_member: false
   - email: 'saumya.shree@elastic.co'
     name: 'Saumya Shree'
-    username: <TODO>
+    username: 'shreesaumya'
     cht_member: false
   # CHT Members
   - email: 'klepal_alexander@bah.com'

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
@@ -63,7 +63,7 @@ maintainers:
   # InfoSec Members
   - email: 'abby.zumstein@elastic.co'
     name: 'Abby Zumstein'
-    username: <TODO>
+    username: 'azumstein'
     cht_member: false
   - email: 'arsalan.khan@elastic.co'
     name: 'Arsalan Khan'

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
@@ -42,39 +42,47 @@ resources:
       value: 0ce56bde1853fed3e53282505bac65707385275a27816c29712ab04c187aa249797c82c58759b2b36c210d4e2683eda92359d739a8045cb8385c2c34d37cc9e1
 # List of project maintainers
 maintainers:
-  - email: 'jon@elastic.co'
-    name: 'Jonathan Budzenski'
-    username: 'jbudz'
-    cht_member: false
+  # AppEx Operations Members
   - email: 'brad.white@elastic.co'
     name: 'Brad White'
     username: 'brad.white'
     cht_member: false
+  - email: 'jon@elastic.co'
+    name: 'Jonathan Budzenski'
+    username: 'jbudz'
+    cht_member: false
+  # AppEx Platform Security Members
+  - email: 'aleh.zasypkin@elastic.co'
+    name: 'Aleh Zasypkin'
+    username: 'azasypkin'
+    cht_member: false
+  - email: 'larry.gregory@elastic.co'
+    name: 'Larry Gregory'
+    username: 'legrego'
+    cht_member: false
+  # InfoSec Members
+  - email: 'abby.zumstein@elastic.co'
+    name: 'Abby Zumstein'
+    username: <TODO>
+    cht_member: false
+  - email: 'arsalan.khan@elastic.co'
+    name: 'Arsalan Khan'
+    username: 'kharsalan'
+    cht_member: false
+  - email: 'iaroslava.zhomir@elastic.co'
+    name: 'Slava Zhomir'
+    username: <TODO>
+    cht_member: false
+  - email: 'ryan.kam@elastic.co'
+    name: 'Ryan Kam'
+    username: <TODO>
+    cht_member: false
+  - email: 'saumya.shree@elastic.co'
+    name: 'Saumya Shree'
+    username: <TODO>
+    cht_member: false
+  # CHT Members
   - email: 'klepal_alexander@bah.com'
     name: 'Alexander Klepal'
     username: 'alexander.klepal'
     cht_member: true
-  - cht_member: false
-    email: larry.gregory@elastic.co
-    name: Larry Gregory
-    username: legrego
-  - cht_member: false
-    email: aleh.zasypkin@elastic.co
-    name: Aleh Zasypkin
-    username: azasypkin
-  - cht_member: false
-    email: kurt.greiner@elastic.co
-    name: Kurt Greiner
-    username: kc13greiner
-  - cht_member: false
-    email: jeramy.soucy@elastic.co
-    name: Jeramy Soucy
-    username: jeramysoucy
-  - cht_member: false
-    email: sid.mantri@elastic.co
-    name: Sid Mantri
-    username: sidmantri
-  - cht_member: false
-    email: elena.shostak@elastic.co
-    name: Elena Shostak
-    username: elena.shostak


### PR DESCRIPTION
Elastic's InfoSec organization has agreed to provide justifications to Elastic's IronBank images. We are adding members of that org to Kibana's hardening manifest, listing them as project maintainers.

This PR:
1/ Adds select members of the infosec organization
2/ Keeps a few members from Operations and Platform Security, in order to monitor in an observational capacity
3/ Removes engineers who are no longer responsible for the upkeep on this project.
4/ Reorganizes the maintainers list

<!--ONMERGE {"backportTargets":["7.17","8.15","8.16","8.x"]} ONMERGE-->