### PR TITLE
[ci] Validate bundle limits earlier

### DIFF
--- a/.buildkite/scripts/post_build_kibana.sh
+++ b/.buildkite/scripts/post_build_kibana.sh
@@ -9,7 +9,7 @@ if [[ ! "${DISABLE_CI_STATS_SHIPPING:-}" ]]; then
       "--metrics" "build/kibana/node_modules/@kbn/ui-shared-deps-src/shared_built_assets/metrics.json"
   )
 
-  if [ "$BUILDKITE_PIPELINE_SLUG" == "kibana-on-merge" ]; then
+  if [[ "$BUILDKITE_PIPELINE_SLUG" == "kibana-on-merge" ]] || [[ "$BUILDKITE_PIPELINE_SLUG" == "kibana-pull-request" ]]; then
     cmd+=("--validate")
   fi
 

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -1,5 +1,5 @@
 pageLoadAssetSize:
-  actions: 1
+  actions: 20000
   advancedSettings: 27596
   aiAssistantManagementSelection: 19146
   aiops: 10000

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -1,5 +1,5 @@
 pageLoadAssetSize:
-  actions: 20000
+  actions: 1
   advancedSettings: 27596
   aiAssistantManagementSelection: 19146
   aiops: 10000


### PR DESCRIPTION
Currently pull request builds that create bundle changes over the limits defined in `packages/kbn-optimizer/limits.yml` receive an error in the `Post Build` step.  This information is available earlier, after the `Build Distribution` step.

By failing earlier we can reduce the number of test runs caused by bundle limit changes.  The report created in the `Post Build` step will continue to behave as it currently is.  

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->