### PR TITLE
[8.16] kbn-doc-links: remove functionbeat (#198902)

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -287,9 +287,6 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       base: `${ELASTIC_WEBSITE_URL}guide/en/logstash/${DOC_LINK_VERSION}`,
       inputElasticAgent: `${ELASTIC_WEBSITE_URL}guide/en/logstash/${DOC_LINK_VERSION}/plugins-inputs-elastic_agent.html`,
     },
-    functionbeat: {
-      base: `${ELASTIC_WEBSITE_URL}guide/en/beats/functionbeat/${DOC_LINK_VERSION}`,
-    },
     winlogbeat: {
       base: `${ELASTIC_WEBSITE_URL}guide/en/beats/winlogbeat/${DOC_LINK_VERSION}`,
     },

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -243,9 +243,6 @@ export interface DocLinks {
     readonly base: string;
     readonly inputElasticAgent: string;
   };
-  readonly functionbeat: {
-    readonly base: string;
-  };
   readonly winlogbeat: {
     readonly base: string;
   };


### PR DESCRIPTION
## Summary

Remove docs link to functionbeat as it has been deprecated and will be removed in 9.0
