### PR TITLE
[unified-data-table] clean up another SASS compilation warnings

### DIFF
--- a/packages/kbn-unified-data-table/src/components/data_table.scss
+++ b/packages/kbn-unified-data-table/src/components/data_table.scss
@@ -99,7 +99,7 @@
   align-items: start;
 
   .euiDataGridHeaderCell__draggableIcon {
-    padding-block: $euiSizeXS / 2; // to align with a token height
+    padding-block: calc($euiSizeXS / 2); // to align with a token height
   }
 
   .euiDataGridHeaderCell__button {


### PR DESCRIPTION
## Summary

Follows https://github.com/elastic/kibana/pull/198876. I found one more instance of SASS code that created compilation warnings.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->