### PR TITLE
[8.16] [Security Solution] Skip a flaky legacy actions migration upon bulk action FTR test

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_ess.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_ess.ts
@@ -170,7 +170,9 @@ export default ({ getService }: FtrProviderContext): void => {
       await waitForRuleSuccess({ id: rule.id, supertest, log });
     });
 
-    it('should disable rules and migrate actions', async () => {
+    // Flaky test see https://github.com/elastic/kibana/issues/196462
+    // Flakiness reproduced in 8.16 only.
+    it.skip('should disable rules and migrate actions', async () => {
       const ruleId = 'ruleId';
       const [connector, rule] = await Promise.all([
         supertest


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/196462

## Summary

`perform_bulk_action_ess.ts`'s `ESS specific logic` -> `should disable rules and migrate actions` FTR test is flaky in `8.16`. This skips only this particular test.

## More details on flakiness

Flakiness isn't reproducible in `main` which is `v9.0` currently.  It's suspected that modification of rule's SO interferences with rules bulk action performing a legacy action migration. Though a quick fix like waiting for rule execution completion before performing bulk action didn't help. It requires further investigation.

Another idea `8.16` could require some PR from to be backported which fixed this issue in `main`.


