### PR TITLE
[Canvas] Fix bug when trying to move elements

### DIFF
--- a/x-pack/plugins/canvas/public/state/actions/elements.js
+++ b/x-pack/plugins/canvas/public/state/actions/elements.js
@@ -65,9 +65,12 @@ function getBareElement(el, includeId = false) {
 
 export const elementLayer = createAction('elementLayer');
 
-export const setMultiplePositions = createAction('setMultiplePosition', (repositionedElements) => ({
-  repositionedElements,
-}));
+export const setMultiplePositions = createAction(
+  'setMultiplePositions',
+  (repositionedElements) => ({
+    repositionedElements,
+  })
+);
 
 export const flushContext = createAction('flushContext');
 export const flushContextAfterIndex = createAction('flushContextAfterIndex');


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/199110

## Summary

In https://github.com/elastic/kibana/pull/194634, we switched to hard-coded strings for the reducers to prevent an import circular dependency - see https://github.com/elastic/kibana/pull/194634/files#diff-12e4182415d9eb779aadf492d2b777393e2794c7ac2eb39c48310ab6493ab233L115-R120 for the relevant change.

What we didn't realize at the time, however, is that there was actually a typo in the original creation of the set position action - the `actionType` was set to the singular `setMultiplePosition` rather than `setMultiplePositions`, so there was actually **no** reducer tied to the `setMultiplePositions` action type after our change - i.e. the reducer map was expecting `setMultiplePosition` and did nothing for `setMultiplePositions`. By changing the `actionType` to the proper plural `setMultiplePositions`, the reducer map now has a match, so the reducer gets called as expected.

| Before | After |
|--------|--------|
| ![Nov-06-2024 14-04-37](https://github.com/user-attachments/assets/627a3fee-2835-446a-b949-f44632d797d3) | ![Nov-06-2024 14-05-19](https://github.com/user-attachments/assets/f0baed94-3858-47b7-b979-7f27deb50b08) | 

I looked through the other changes we made to reducer map keys, and every `actionType` defined via `createAction` seems to have a matching reducer map key - so this appears to be a one-off 🙈 

### Checklist

- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



<!--ONMERGE {"backportTargets":["8.16","8.18","8.x"]} ONMERGE-->