### PR TITLE
Increase GCP button size to match Azure and AWS

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
@@ -500,7 +500,7 @@ export const GcpCredentialsForm = ({
       <EuiSpacer size="l" />
       <RadioGroup
         disabled={disabled}
-        size="s"
+        size="m"
         options={getSetupFormatOptions()}
         idSelected={setupFormat}
         onChange={(idSelected: SetupFormatGCP) =>


### PR DESCRIPTION
## Summary

Hi! this PR deals with issue #198878 .

The `RadioGroup` size for GCP was changed from `"s"` to `"m"` to match the buttons for Azure and AWS.

Thanks!

<img width="751" alt="Screenshot 2024-11-06 at 12 39 09 PM" src="https://github.com/user-attachments/assets/43d9c51b-1519-4065-90ca-a957a8cdbae1">
<img width="746" alt="Screenshot 2024-11-06 at 12 39 20 PM" src="https://github.com/user-attachments/assets/dced0d76-9430-43ea-a0dd-141665def411">



### Checklist
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
(https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers
- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->