### PR TITLE
[8.x] [Security Solution][Notes] - disable note buttons in the right panel header when in preview mode (#199189)

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/notes.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/notes.test.tsx
@@ -23,6 +23,7 @@ import type { Note } from '../../../../../common/api/timeline';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
 import { LeftPanelNotesTab } from '../../left';
+import { getEmptyValue } from '../../../../common/components/empty_value';
 
 jest.mock('@kbn/expandable-flyout');
 
@@ -43,6 +44,10 @@ jest.mock('react-redux', () => {
 });
 
 describe('<Notes />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render loading spinner', () => {
     (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openLeftPanel: jest.fn() });
 
@@ -99,6 +104,34 @@ describe('<Notes />', () => {
     });
   });
 
+  it('should disabled the Add note button if in preview mode', () => {
+    const contextValue = {
+      ...mockContextValue,
+      isPreviewMode: true,
+    };
+
+    const mockOpenLeftPanel = jest.fn();
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openLeftPanel: mockOpenLeftPanel });
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <DocumentDetailsContext.Provider value={contextValue}>
+          <Notes />
+        </DocumentDetailsContext.Provider>
+      </TestProviders>
+    );
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    const button = getByTestId(NOTES_ADD_NOTE_BUTTON_TEST_ID);
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+
+    button.click();
+
+    expect(mockOpenLeftPanel).not.toHaveBeenCalled();
+  });
+
   it('should render number of notes and plus button', () => {
     const mockOpenLeftPanel = jest.fn();
     (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openLeftPanel: mockOpenLeftPanel });
@@ -133,6 +166,38 @@ describe('<Notes />', () => {
         scopeId: mockContextValue.scopeId,
       },
     });
+  });
+
+  it('should disable the plus button if in preview mode', () => {
+    const mockOpenLeftPanel = jest.fn();
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openLeftPanel: mockOpenLeftPanel });
+
+    const contextValue = {
+      ...mockContextValue,
+      eventId: '1',
+      isPreviewMode: true,
+    };
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <DocumentDetailsContext.Provider value={contextValue}>
+          <Notes />
+        </DocumentDetailsContext.Provider>
+      </TestProviders>
+    );
+
+    expect(getByTestId(NOTES_COUNT_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(NOTES_COUNT_TEST_ID)).toHaveTextContent('1');
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    const button = getByTestId(NOTES_ADD_NOTE_ICON_BUTTON_TEST_ID);
+
+    expect(button).toBeInTheDocument();
+    button.click();
+    expect(button).toBeDisabled();
+
+    expect(mockOpenLeftPanel).not.toHaveBeenCalled();
   });
 
   it('should render number of notes in scientific notation for big numbers', () => {
@@ -178,6 +243,30 @@ describe('<Notes />', () => {
     );
 
     expect(getByTestId(NOTES_COUNT_TEST_ID)).toHaveTextContent('1k');
+  });
+
+  it('should show a - when in rule creation workflow', () => {
+    const contextValue = {
+      ...mockContextValue,
+      isPreview: true,
+    };
+
+    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openLeftPanel: jest.fn() });
+
+    const { getByText, queryByTestId } = render(
+      <TestProviders>
+        <DocumentDetailsContext.Provider value={contextValue}>
+          <Notes />
+        </DocumentDetailsContext.Provider>
+      </TestProviders>
+    );
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    expect(queryByTestId(NOTES_ADD_NOTE_ICON_BUTTON_TEST_ID)).not.toBeInTheDocument();
+    expect(queryByTestId(NOTES_ADD_NOTE_BUTTON_TEST_ID)).not.toBeInTheDocument();
+    expect(queryByTestId(NOTES_COUNT_TEST_ID)).not.toBeInTheDocument();
+    expect(getByText(getEmptyValue())).toBeInTheDocument();
   });
 
   it('should render toast error', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][Notes] - disable note buttons in the right panel header when in preview mode (#199189)](https://github.com/elastic/kibana/pull/199189)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2024-11-06T21:14:14Z","message":"[Security Solution][Notes] - disable note buttons in the right panel header when in preview mode (#199189)\n\n## Summary\r\n\r\nThis PR fixes a issue where the `Add note` button and the `+` icon\r\nbutton are clickable when an alert is viewed in preview mode. Users\r\nshould not be able to perform actions here, as the action expands the\r\nflyouts and opens the left panel Notes tab, but the issue is the left\r\npanel now shows a different alert from the right panel. If the user\r\ncloses the preview panel, they now see a different alerts on the left\r\nand right panels but they have no way to know this.\r\n\r\n#### Add note button disabled\r\n\r\nhttps://github.com/user-attachments/assets/20554b60-39a1-4c6d-b215-e502b5b24dbd\r\n\r\n#### + button disabled\r\n\r\nhttps://github.com/user-attachments/assets/df540aed-b583-457d-a9f4-0093a171ddaa\r\n\r\nAlso adding notes should be disabled when in the rule creation page, as\r\nwe do not want to generate notes for alerts that actually do not exist\r\nyet. To be consistent with the other blocks in the flyout header, we\r\nshow a `-`.\r\n\r\nhttps://github.com/user-attachments/assets/b62ecf85-ee0f-4bee-853c-ff1034b5bf25","sha":"53acbab23b29e8aac7d7fdb0dfebac690640339c","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Threat Hunting:Investigations","v8.16.0","backport:version","v8.17.0"],"number":199189,"url":"https://github.com/elastic/kibana/pull/199189","mergeCommit":{"message":"[Security Solution][Notes] - disable note buttons in the right panel header when in preview mode (#199189)\n\n## Summary\r\n\r\nThis PR fixes a issue where the `Add note` button and the `+` icon\r\nbutton are clickable when an alert is viewed in preview mode. Users\r\nshould not be able to perform actions here, as the action expands the\r\nflyouts and opens the left panel Notes tab, but the issue is the left\r\npanel now shows a different alert from the right panel. If the user\r\ncloses the preview panel, they now see a different alerts on the left\r\nand right panels but they have no way to know this.\r\n\r\n#### Add note button disabled\r\n\r\nhttps://github.com/user-attachments/assets/20554b60-39a1-4c6d-b215-e502b5b24dbd\r\n\r\n#### + button disabled\r\n\r\nhttps://github.com/user-attachments/assets/df540aed-b583-457d-a9f4-0093a171ddaa\r\n\r\nAlso adding notes should be disabled when in the rule creation page, as\r\nwe do not want to generate notes for alerts that actually do not exist\r\nyet. To be consistent with the other blocks in the flyout header, we\r\nshow a `-`.\r\n\r\nhttps://github.com/user-attachments/assets/b62ecf85-ee0f-4bee-853c-ff1034b5bf25","sha":"53acbab23b29e8aac7d7fdb0dfebac690640339c"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/199189","number":199189,"mergeCommit":{"message":"[Security Solution][Notes] - disable note buttons in the right panel header when in preview mode (#199189)\n\n## Summary\r\n\r\nThis PR fixes a issue where the `Add note` button and the `+` icon\r\nbutton are clickable when an alert is viewed in preview mode. Users\r\nshould not be able to perform actions here, as the action expands the\r\nflyouts and opens the left panel Notes tab, but the issue is the left\r\npanel now shows a different alert from the right panel. If the user\r\ncloses the preview panel, they now see a different alerts on the left\r\nand right panels but they have no way to know this.\r\n\r\n#### Add note button disabled\r\n\r\nhttps://github.com/user-attachments/assets/20554b60-39a1-4c6d-b215-e502b5b24dbd\r\n\r\n#### + button disabled\r\n\r\nhttps://github.com/user-attachments/assets/df540aed-b583-457d-a9f4-0093a171ddaa\r\n\r\nAlso adding notes should be disabled when in the rule creation page, as\r\nwe do not want to generate notes for alerts that actually do not exist\r\nyet. To be consistent with the other blocks in the flyout header, we\r\nshow a `-`.\r\n\r\nhttps://github.com/user-attachments/assets/b62ecf85-ee0f-4bee-853c-ff1034b5bf25","sha":"53acbab23b29e8aac7d7fdb0dfebac690640339c"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/199231","number":199231,"state":"OPEN"},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->