### PR TITLE
Add cURL example for Kibana snapshot restore in rollback instructions

### DIFF
--- a/docs/setup/upgrade/rollback-migration.asciidoc
+++ b/docs/setup/upgrade/rollback-migration.asciidoc
@@ -22,11 +22,12 @@ To roll back after a failed upgrade migration, you must also roll back the {kib}
 +
 [source,sh]
 --------------------------------------------
-POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
+curl -X POST "localhost:9200/_snapshot/my_repository/my_snapshot_2099.05.06/_restore" -H "Content-Type: application/json" -d'
 {
   "indices": "-*", <1>
   "feature_states": ["kibana"]
 }
+'
 --------------------------------------------
 <1> Exclude all indices and data streams from the restore operation to ensure that only the {kib} system indices included in the {kib} feature state will be restored.
 . Start all {kib} instances on the older version you want to rollback to.

--- a/docs/setup/upgrade/rollback-migration.asciidoc
+++ b/docs/setup/upgrade/rollback-migration.asciidoc
@@ -24,10 +24,10 @@ To roll back after a failed upgrade migration, you must also roll back the {kib}
 --------------------------------------------
 curl -X POST "localhost:9200/_snapshot/my_repository/my_snapshot_2099.05.06/_restore" -H "Content-Type: application/json" -d'
 {
-  "indices": "-*", <1>
+  "indices": "-*",
   "feature_states": ["kibana"]
 }
 '
 --------------------------------------------
-<1> Exclude all indices and data streams from the restore operation to ensure that only the {kib} system indices included in the {kib} feature state will be restored.
+<1> `"-*"` excludes all indices and data streams from the restore operation to ensure that only the {kib} system indices included in the {kib} feature state will be restored.
 . Start all {kib} instances on the older version you want to rollback to.


### PR DESCRIPTION
## Summary

Hi, this PR deals with #198490 .


Before:

```sh
POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
{
  "indices": "-*", 
  "feature_states": ["kibana"]
}
```
After:
```sh
curl -X POST "localhost:9200/_snapshot/my_repository/my_snapshot_2099.05.06/_restore" -H "Content-Type: application/json" -d'
{
  "indices": "-*", 
  "feature_states": ["kibana"]
}
'
```
