### PR TITLE
[Observability Onboarding] fix docker integration double detection

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/assets/auto_detect.sh
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/assets/auto_detect.sh
@@ -343,6 +343,7 @@ read_open_log_file_list() {
     "^\/var\/log\/redis\/"
     "^\/var\/log\/rabbitmq\/"
     "^\/var\/log\/kafka\/"
+    "^\/var\/lib\/docker\/"
     "^\/var\/log\/mongodb\/"
     "^\/opt\/tomcat\/logs\/"
     "^\/var\/log\/prometheus\/"


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/195912

See:
https://github.com/elastic/kibana/issues/195912#issuecomment-2460870604

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->