### PR TITLE
[Agentless] Fix agentless global_data_tags

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/agentless_agent.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/agentless_agent.test.ts
@@ -814,9 +814,11 @@ describe('Agentless Agent service', () => {
           policy_id: 'mocked-agentless-agent-policy-id',
           stack_version: 'mocked-kibana-version-infinite',
           labels: {
-            organization: 'elastic',
-            division: 'cloud',
-            team: 'fleet',
+            owner: {
+              org: 'elastic',
+              division: 'cloud',
+              team: 'fleet',
+            },
           },
         }),
         headers: expect.anything(),
@@ -911,9 +913,11 @@ describe('Agentless Agent service', () => {
           fleet_url: 'http://fleetserver:8220',
           policy_id: 'mocked-agentless-agent-policy-id',
           labels: {
-            organization: 'elastic',
-            division: 'cloud',
-            team: 'fleet',
+            owner: {
+              org: 'elastic',
+              division: 'cloud',
+              team: 'fleet',
+            },
           },
         },
         headers: expect.anything(),

--- a/x-pack/plugins/fleet/server/services/agents/agentless_agent.ts
+++ b/x-pack/plugins/fleet/server/services/agents/agentless_agent.ts
@@ -220,9 +220,11 @@ class AgentlessAgentService {
       agentlessAgentPolicy.global_data_tags?.find((tag) => tag.name === name)?.value;
 
     return {
-      organization: getGlobalTagValueByName(AGENTLESS_GLOBAL_TAG_NAME_ORGANIZATION),
-      division: getGlobalTagValueByName(AGENTLESS_GLOBAL_TAG_NAME_DIVISION),
-      team: getGlobalTagValueByName(AGENTLESS_GLOBAL_TAG_NAME_TEAM),
+      owner: {
+        org: getGlobalTagValueByName(AGENTLESS_GLOBAL_TAG_NAME_ORGANIZATION),
+        division: getGlobalTagValueByName(AGENTLESS_GLOBAL_TAG_NAME_DIVISION),
+        team: getGlobalTagValueByName(AGENTLESS_GLOBAL_TAG_NAME_TEAM),
+      },
     };
   }
 

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
@@ -7,7 +7,7 @@
 
 import { CLOUD_CREDENTIALS_PACKAGE_VERSION } from '@kbn/cloud-security-posture-plugin/common/constants';
 import * as http from 'http';
-import expect from '@kbn/expect/expect';
+import expect from '@kbn/expect';
 import { setupMockServer } from './mock_agentless_api';
 import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 export default function ({ getPageObjects, getService }: FtrProviderContext) {

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
@@ -7,7 +7,7 @@
 
 import { CLOUD_CREDENTIALS_PACKAGE_VERSION } from '@kbn/cloud-security-posture-plugin/common/constants';
 import * as http from 'http';
-import expect from '@kbn/expect';
+import expect from '@kbn/expect/expect';
 import { setupMockServer } from './mock_agentless_api';
 import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
@@ -25,8 +25,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const AWS_SINGLE_ACCOUNT_TEST_ID = 'awsSingleTestId';
 
   describe('Agentless API Serverless', function () {
-    // see details: https://github.com/elastic/kibana/issues/199091
-    this.tags(['failsOnMKI']);
     let mockApiServer: http.Server;
     let cisIntegration: typeof pageObjects.cisAddIntegration;
 


### PR DESCRIPTION
## Summary

It closes #199091

It fixes the Serverless Quality Gates that started to fail once a [fix](https://github.com/elastic/kibana/pull/198735) to enable sending the `global_data_tags` was merged here. 

In order to fix the issue, it updates the Agentless Tags to match the format expected in the [Agentless Schema](https://github.com/elastic/agentless-api/blob/main/api/spec.yaml)


_Note: An investigation ticket will be added as part of the [Reliability epic](https://github.com/elastic/security-team/issues/10877) on how can we ensure the Agentless Schema and Kibana are in sync_

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->