### PR TITLE
[Security Solution][Data Quality Dashboard][Serverless] add start/end time support for latest_results

### DIFF
--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_context/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_context/index.test.tsx
@@ -65,6 +65,8 @@ const ContextWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
       },
     ]}
     setSelectedIlmPhaseOptions={jest.fn()}
+    defaultStartTime="now-7d"
+    defaultEndTime="now"
   >
     {children}
   </DataQualityProvider>

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_context/index.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_context/index.tsx
@@ -41,6 +41,8 @@ export interface DataQualityProviderProps {
   ilmPhases: string[];
   selectedIlmPhaseOptions: EuiComboBoxOptionOption[];
   setSelectedIlmPhaseOptions: (options: EuiComboBoxOptionOption[]) => void;
+  defaultStartTime: string;
+  defaultEndTime: string;
 }
 
 const DataQualityContext = React.createContext<DataQualityProviderProps | undefined>(undefined);
@@ -67,6 +69,8 @@ export const DataQualityProvider: React.FC<PropsWithChildren<DataQualityProvider
   ilmPhases,
   selectedIlmPhaseOptions,
   setSelectedIlmPhaseOptions,
+  defaultStartTime,
+  defaultEndTime,
 }) => {
   const value = useMemo(
     () => ({
@@ -90,6 +94,8 @@ export const DataQualityProvider: React.FC<PropsWithChildren<DataQualityProvider
       ilmPhases,
       selectedIlmPhaseOptions,
       setSelectedIlmPhaseOptions,
+      defaultStartTime,
+      defaultEndTime,
     }),
     [
       httpFetch,
@@ -112,6 +118,8 @@ export const DataQualityProvider: React.FC<PropsWithChildren<DataQualityProvider
       ilmPhases,
       selectedIlmPhaseOptions,
       setSelectedIlmPhaseOptions,
+      defaultStartTime,
+      defaultEndTime,
     ]
   );
 

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/hooks/use_ilm_explain/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/hooks/use_ilm_explain/index.test.tsx
@@ -71,6 +71,8 @@ const ContextWrapper: React.FC<{ children: React.ReactNode; isILMAvailable: bool
       },
     ]}
     setSelectedIlmPhaseOptions={jest.fn()}
+    defaultStartTime={'now-7d'}
+    defaultEndTime={'now'}
   >
     {children}
   </DataQualityProvider>
@@ -159,6 +161,8 @@ describe('useIlmExplain', () => {
               },
             ]}
             setSelectedIlmPhaseOptions={jest.fn()}
+            defaultStartTime={'now-7d'}
+            defaultEndTime={'now'}
           >
             {children}
           </DataQualityProvider>

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/hooks/use_stats/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/hooks/use_stats/index.test.tsx
@@ -69,6 +69,8 @@ const ContextWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => (
       },
     ]}
     setSelectedIlmPhaseOptions={jest.fn()}
+    defaultStartTime={'now-7d'}
+    defaultEndTime={'now'}
   >
     {children}
   </DataQualityProvider>
@@ -119,6 +121,8 @@ const ContextWrapperILMNotAvailable: FC<PropsWithChildren<unknown>> = ({ childre
       },
     ]}
     setSelectedIlmPhaseOptions={jest.fn()}
+    defaultStartTime={'now-7d'}
+    defaultEndTime={'now'}
   >
     {children}
   </DataQualityProvider>

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/hooks/use_results_rollup/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/hooks/use_results_rollup/index.test.tsx
@@ -35,6 +35,8 @@ describe('useResultsRollup', () => {
 
   const patterns = ['auditbeat-*', 'packetbeat-*'];
   const isILMAvailable = true;
+  const startTime = 'now-7d';
+  const endTime = 'now';
 
   const useStoredPatternResultsMock = useStoredPatternResults as jest.Mock;
 
@@ -52,6 +54,8 @@ describe('useResultsRollup', () => {
           patterns,
           isILMAvailable,
           telemetryEvents: mockTelemetryEvents,
+          startTime,
+          endTime,
         })
       );
 
@@ -94,10 +98,19 @@ describe('useResultsRollup', () => {
           patterns: ['auditbeat-*'],
           isILMAvailable,
           telemetryEvents: mockTelemetryEvents,
+          startTime,
+          endTime,
         })
       );
 
-      expect(useStoredPatternResultsMock).toHaveBeenCalledWith(['auditbeat-*'], toasts, httpFetch);
+      expect(useStoredPatternResultsMock).toHaveBeenCalledWith({
+        patterns: ['auditbeat-*'],
+        toasts,
+        httpFetch,
+        isILMAvailable,
+        startTime,
+        endTime,
+      });
 
       expect(result.current.patternRollups).toEqual({
         'auditbeat-*': {
@@ -119,6 +132,8 @@ describe('useResultsRollup', () => {
           patterns,
           isILMAvailable,
           telemetryEvents: mockTelemetryEvents,
+          startTime,
+          endTime,
         })
       );
 
@@ -144,6 +159,8 @@ describe('useResultsRollup', () => {
           patterns,
           isILMAvailable,
           telemetryEvents: mockTelemetryEvents,
+          startTime,
+          endTime,
         })
       );
 
@@ -180,6 +197,8 @@ describe('useResultsRollup', () => {
             patterns,
             isILMAvailable,
             telemetryEvents: mockTelemetryEvents,
+            startTime,
+            endTime,
           })
         );
 
@@ -369,6 +388,8 @@ describe('useResultsRollup', () => {
               patterns,
               isILMAvailable: false,
               telemetryEvents: mockTelemetryEvents,
+              startTime,
+              endTime,
             })
           );
 
@@ -532,6 +553,8 @@ describe('useResultsRollup', () => {
             patterns,
             isILMAvailable,
             telemetryEvents: mockTelemetryEvents,
+            startTime,
+            endTime,
           })
         );
 
@@ -592,6 +615,8 @@ describe('useResultsRollup', () => {
               patterns,
               isILMAvailable,
               telemetryEvents: mockTelemetryEvents,
+              startTime,
+              endTime,
             })
           );
 
@@ -654,6 +679,8 @@ describe('useResultsRollup', () => {
             patterns: ['packetbeat-*', 'auditbeat-*'],
             isILMAvailable,
             telemetryEvents: mockTelemetryEvents,
+            startTime,
+            endTime,
           })
         );
 

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/hooks/use_results_rollup/index.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/hooks/use_results_rollup/index.tsx
@@ -40,6 +40,8 @@ interface Props {
   httpFetch: HttpHandler;
   telemetryEvents: TelemetryEvents;
   isILMAvailable: boolean;
+  startTime: string;
+  endTime: string;
 }
 export const useResultsRollup = ({
   httpFetch,
@@ -47,11 +49,20 @@ export const useResultsRollup = ({
   patterns,
   isILMAvailable,
   telemetryEvents,
+  startTime,
+  endTime,
 }: Props): UseResultsRollupReturnValue => {
   const [patternIndexNames, setPatternIndexNames] = useState<Record<string, string[]>>({});
   const [patternRollups, setPatternRollups] = useState<Record<string, PatternRollup>>({});
 
-  const storedPatternsResults = useStoredPatternResults(patterns, toasts, httpFetch);
+  const storedPatternsResults = useStoredPatternResults({
+    httpFetch,
+    patterns,
+    toasts,
+    isILMAvailable,
+    startTime,
+    endTime,
+  });
 
   useEffect(() => {
     if (!isEmpty(storedPatternsResults)) {

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/hooks/use_results_rollup/utils/storage.test.ts
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/hooks/use_results_rollup/utils/storage.test.ts
@@ -200,4 +200,26 @@ describe('getStorageResults', () => {
     expect(toasts.addError).toHaveBeenCalledWith('test-error', { title: expect.any(String) });
     expect(results).toEqual([]);
   });
+
+  it('should provide stad and end date', async () => {
+    await getStorageResults({
+      httpFetch: fetch,
+      abortController: new AbortController(),
+      pattern: 'auditbeat-*',
+      toasts,
+      startTime: 'now-7d',
+      endTime: 'now',
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/internal/ecs_data_quality_dashboard/results_latest/auditbeat-*',
+      expect.objectContaining({
+        method: 'GET',
+        query: {
+          startDate: 'now-7d',
+          endDate: 'now',
+        },
+      })
+    );
+  });
 });

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/index.test.tsx
@@ -67,6 +67,8 @@ describe('DataQualityPanel', () => {
           setLastChecked={jest.fn()}
           baseTheme={DARK_THEME}
           toasts={toasts}
+          defaultStartTime={'now-7d'}
+          defaultEndTime={'now'}
         />
       </TestExternalProviders>
     );

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/index.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/index.tsx
@@ -46,6 +46,8 @@ interface Props {
   setLastChecked: (lastChecked: string) => void;
   startDate?: string | null;
   theme?: PartialTheme;
+  defaultStartTime: string;
+  defaultEndTime: string;
 }
 
 const defaultSelectedIlmPhaseOptions: EuiComboBoxOptionOption[] = ilmPhaseOptionsStatic.filter(
@@ -71,6 +73,8 @@ const DataQualityPanelComponent: React.FC<Props> = ({
   setLastChecked,
   startDate,
   theme,
+  defaultStartTime,
+  defaultEndTime,
 }) => {
   const [selectedIlmPhaseOptions, setSelectedIlmPhaseOptions] = useState<EuiComboBoxOptionOption[]>(
     defaultSelectedIlmPhaseOptions
@@ -109,6 +113,8 @@ const DataQualityPanelComponent: React.FC<Props> = ({
     toasts,
     isILMAvailable,
     telemetryEvents,
+    startTime: defaultStartTime,
+    endTime: defaultEndTime,
   });
 
   const indicesCheckHookReturnValue = useIndicesCheck({
@@ -137,6 +143,8 @@ const DataQualityPanelComponent: React.FC<Props> = ({
       ilmPhases={ilmPhases}
       selectedIlmPhaseOptions={selectedIlmPhaseOptions}
       setSelectedIlmPhaseOptions={setSelectedIlmPhaseOptions}
+      defaultStartTime={defaultStartTime}
+      defaultEndTime={defaultEndTime}
     >
       <ResultsRollupContext.Provider value={resultsRollupHookReturnValue}>
         <IndicesCheckContext.Provider value={indicesCheckHookReturnValue}>

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/mock/test_providers/test_providers.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/mock/test_providers/test_providers.tsx
@@ -135,6 +135,8 @@ const TestDataQualityProvidersComponent: React.FC<TestDataQualityProvidersProps>
     ilmPhases,
     selectedIlmPhaseOptions,
     setSelectedIlmPhaseOptions,
+    defaultStartTime,
+    defaultEndTime,
   } = getMergedDataQualityContextProps(dataQualityContextProps);
 
   const mergedResultsRollupContextProps =
@@ -162,6 +164,8 @@ const TestDataQualityProvidersComponent: React.FC<TestDataQualityProvidersProps>
       ilmPhases={ilmPhases}
       selectedIlmPhaseOptions={selectedIlmPhaseOptions}
       setSelectedIlmPhaseOptions={setSelectedIlmPhaseOptions}
+      defaultStartTime={defaultStartTime}
+      defaultEndTime={defaultEndTime}
     >
       <ResultsRollupContext.Provider value={mergedResultsRollupContextProps}>
         <IndicesCheckContext.Provider

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/mock/test_providers/utils/get_merged_data_quality_context_props.ts
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/mock/test_providers/utils/get_merged_data_quality_context_props.ts
@@ -30,6 +30,8 @@ export const getMergedDataQualityContextProps = (
     ilmPhases,
     selectedIlmPhaseOptions,
     setSelectedIlmPhaseOptions,
+    defaultStartTime,
+    defaultEndTime,
   } = {
     isILMAvailable: true,
     addSuccessToast: jest.fn(),
@@ -69,6 +71,8 @@ export const getMergedDataQualityContextProps = (
       },
     ],
     setSelectedIlmPhaseOptions: jest.fn(),
+    defaultStartTime: 'now-7d/d',
+    defaultEndTime: 'now/d',
     ...dataQualityContextProps,
   };
 
@@ -90,5 +94,7 @@ export const getMergedDataQualityContextProps = (
     ilmPhases,
     selectedIlmPhaseOptions,
     setSelectedIlmPhaseOptions,
+    defaultStartTime,
+    defaultEndTime,
   };
 };

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/helpers/get_available_indices.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/helpers/get_available_indices.ts
@@ -8,15 +8,15 @@
 import type { SearchRequest } from '@elastic/elasticsearch/lib/api/types';
 
 export const getRequestBody = ({
-  indexPattern,
+  indexNameOrPattern,
   startDate = 'now-7d/d',
   endDate = 'now/d',
 }: {
-  indexPattern: string;
+  indexNameOrPattern: string;
   startDate: string;
   endDate: string;
 }): SearchRequest => ({
-  index: indexPattern,
+  index: indexNameOrPattern,
   aggs: {
     index: {
       terms: {

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/helpers/get_range_filtered_indices.test.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/helpers/get_range_filtered_indices.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getRangeFilteredIndices } from './get_range_filtered_indices';
+import { fetchAvailableIndices } from '../lib/fetch_available_indices';
+import type { IScopedClusterClient, Logger } from '@kbn/core/server';
+
+jest.mock('../lib/fetch_available_indices');
+
+const fetchAvailableIndicesMock = fetchAvailableIndices as jest.Mock;
+
+describe('getRangeFilteredIndices', () => {
+  let client: jest.Mocked<IScopedClusterClient>;
+  let logger: jest.Mocked<Logger>;
+
+  beforeEach(() => {
+    client = {
+      asCurrentUser: jest.fn(),
+    } as unknown as jest.Mocked<IScopedClusterClient>;
+
+    logger = {
+      warn: jest.fn(),
+      error: jest.fn(),
+    } as unknown as jest.Mocked<Logger>;
+
+    jest.clearAllMocks();
+  });
+
+  describe('when fetching available indices is successful', () => {
+    describe('and there are available indices', () => {
+      it('should return the flattened available indices', async () => {
+        fetchAvailableIndicesMock.mockResolvedValueOnce(['index1', 'index2']);
+        fetchAvailableIndicesMock.mockResolvedValueOnce(['index3']);
+
+        const result = await getRangeFilteredIndices({
+          client,
+          authorizedIndexNames: ['auth1', 'auth2'],
+          startDate: '2023-01-01',
+          endDate: '2023-01-31',
+          logger,
+          pattern: 'pattern*',
+        });
+
+        expect(fetchAvailableIndices).toHaveBeenCalledTimes(2);
+        expect(result).toEqual(['index1', 'index2', 'index3']);
+        expect(logger.warn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('and there are no available indices', () => {
+      it('should log a warning and return an empty array', async () => {
+        fetchAvailableIndicesMock.mockResolvedValue([]);
+
+        const result = await getRangeFilteredIndices({
+          client,
+          authorizedIndexNames: ['auth1', 'auth2'],
+          startDate: '2023-01-01',
+          endDate: '2023-01-31',
+          logger,
+          pattern: 'pattern*',
+        });
+
+        expect(fetchAvailableIndices).toHaveBeenCalledTimes(2);
+        expect(result).toEqual([]);
+        expect(logger.warn).toHaveBeenCalledWith(
+          'No available authorized indices found under pattern: pattern*, in the given date range: 2023-01-01 - 2023-01-31'
+        );
+      });
+    });
+  });
+
+  describe('when fetching available indices fails', () => {
+    it('should log an error and return an empty array', async () => {
+      fetchAvailableIndicesMock.mockRejectedValue(new Error('Fetch error'));
+
+      const result = await getRangeFilteredIndices({
+        client,
+        authorizedIndexNames: ['auth1'],
+        startDate: '2023-01-01',
+        endDate: '2023-01-31',
+        logger,
+        pattern: 'pattern*',
+      });
+
+      expect(fetchAvailableIndices).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([]);
+      expect(logger.error).toHaveBeenCalledWith(
+        'Error fetching available indices in the given data range: 2023-01-01 - 2023-01-31'
+      );
+    });
+  });
+});

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/helpers/get_range_filtered_indices.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/helpers/get_range_filtered_indices.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IScopedClusterClient, Logger } from '@kbn/core/server';
+
+import { fetchAvailableIndices } from '../lib/fetch_available_indices';
+
+export const getRangeFilteredIndices = async ({
+  client,
+  authorizedIndexNames,
+  startDate,
+  endDate,
+  logger,
+  pattern,
+}: {
+  client: IScopedClusterClient;
+  authorizedIndexNames: string[];
+  startDate: string;
+  endDate: string;
+  logger: Logger;
+  pattern: string;
+}): Promise<string[]> => {
+  const decodedStartDate = decodeURIComponent(startDate);
+  const decodedEndDate = decodeURIComponent(endDate);
+  try {
+    const currentUserEsClient = client.asCurrentUser;
+
+    const availableIndicesPromises: Array<Promise<string[]>> = [];
+
+    for (const indexName of authorizedIndexNames) {
+      availableIndicesPromises.push(
+        fetchAvailableIndices(currentUserEsClient, {
+          indexNameOrPattern: indexName,
+          startDate: decodedStartDate,
+          endDate: decodedEndDate,
+        })
+      );
+    }
+
+    const availableIndices = await Promise.all(availableIndicesPromises);
+
+    const flattenedAvailableIndices = availableIndices.flat();
+
+    if (flattenedAvailableIndices.length === 0) {
+      logger.warn(
+        `No available authorized indices found under pattern: ${pattern}, in the given date range: ${decodedStartDate} - ${decodedEndDate}`
+      );
+    }
+
+    return flattenedAvailableIndices;
+  } catch (err) {
+    logger.error(
+      `Error fetching available indices in the given data range: ${decodedStartDate} - ${decodedEndDate}`
+    );
+    return [];
+  }
+};

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/lib/fetch_available_indices.test.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/lib/fetch_available_indices.test.ts
@@ -61,7 +61,7 @@ describe('fetchAvailableIndices', () => {
     const esClientMock = getEsClientMock();
 
     await fetchAvailableIndices(esClientMock, {
-      indexPattern: 'logs-*',
+      indexNameOrPattern: 'logs-*',
       startDate: startDateString,
       endDate: endDateString,
     });
@@ -101,7 +101,7 @@ describe('fetchAvailableIndices', () => {
     const esClientMock = getEsClientMock();
 
     await fetchAvailableIndices(esClientMock, {
-      indexPattern: 'logs-*',
+      indexNameOrPattern: 'logs-*',
       startDate: startDateString,
       endDate: endDateString,
     });
@@ -133,7 +133,7 @@ describe('fetchAvailableIndices', () => {
       ]);
 
       const result = await fetchAvailableIndices(esClientMock, {
-        indexPattern: 'logs-*',
+        indexNameOrPattern: 'logs-*',
         startDate: startDateString,
         endDate: endDateString,
       });
@@ -164,7 +164,7 @@ describe('fetchAvailableIndices', () => {
       ]);
 
       const result = await fetchAvailableIndices(esClientMock, {
-        indexPattern: 'logs-*',
+        indexNameOrPattern: 'logs-*',
         startDate: startDateString,
         endDate: endDateString,
       });
@@ -180,7 +180,7 @@ describe('fetchAvailableIndices', () => {
       esClientMock.cat.indices.mockResolvedValue([]);
 
       const result = await fetchAvailableIndices(esClientMock, {
-        indexPattern: 'nonexistent-*',
+        indexNameOrPattern: 'nonexistent-*',
         startDate: startDateString,
         endDate: endDateString,
       });
@@ -209,7 +209,7 @@ describe('fetchAvailableIndices', () => {
       });
 
       const result = await fetchAvailableIndices(esClientMock, {
-        indexPattern: 'logs-*',
+        indexNameOrPattern: 'logs-*',
         startDate: startDateString,
         endDate: endDateString,
       });
@@ -243,7 +243,7 @@ describe('fetchAvailableIndices', () => {
       });
 
       const result = await fetchAvailableIndices(esClientMock, {
-        indexPattern: 'logs-*',
+        indexNameOrPattern: 'logs-*',
         startDate: startDateString,
         endDate: endDateString,
       });
@@ -268,7 +268,7 @@ describe('fetchAvailableIndices', () => {
       ]);
 
       const result = await fetchAvailableIndices(esClientMock, {
-        indexPattern: 'logs-*',
+        indexNameOrPattern: 'logs-*',
         startDate: startDateString,
         endDate: endDateString,
       });
@@ -285,7 +285,7 @@ describe('fetchAvailableIndices', () => {
 
       await expect(
         fetchAvailableIndices(esClientMock, {
-          indexPattern: 'logs-*',
+          indexNameOrPattern: 'logs-*',
           startDate: startDateString,
           endDate: endDateString,
         })
@@ -307,7 +307,7 @@ describe('fetchAvailableIndices', () => {
       });
 
       const result = await fetchAvailableIndices(esClientMock, {
-        indexPattern: 'logs-*',
+        indexNameOrPattern: 'logs-*',
         startDate: startDateString,
         endDate: endDateString,
       });
@@ -336,7 +336,7 @@ describe('fetchAvailableIndices', () => {
       });
 
       const result = await fetchAvailableIndices(esClientMock, {
-        indexPattern: 'logs-*',
+        indexNameOrPattern: 'logs-*',
         startDate: startDateString,
         endDate: endDateString,
       });
@@ -371,7 +371,7 @@ describe('fetchAvailableIndices', () => {
         ]);
 
         const results = await fetchAvailableIndices(esClientMock, {
-          indexPattern: 'logs-*',
+          indexNameOrPattern: 'logs-*',
           startDate: 'now-7d/d',
           endDate: 'now/d',
         });
@@ -390,7 +390,7 @@ describe('fetchAvailableIndices', () => {
         ]);
 
         const results = await fetchAvailableIndices(esClientMock, {
-          indexPattern: 'logs-*',
+          indexNameOrPattern: 'logs-*',
           startDate: 'now-7d/d',
           endDate: 'now-1d/d',
         });
@@ -415,7 +415,7 @@ describe('fetchAvailableIndices', () => {
 
         await expect(
           fetchAvailableIndices(esClientMock, {
-            indexPattern: 'logs-*',
+            indexNameOrPattern: 'logs-*',
             startDate: startDateString,
             endDate: endDateString,
           })
@@ -429,7 +429,7 @@ describe('fetchAvailableIndices', () => {
 
         await expect(
           fetchAvailableIndices(esClientMock, {
-            indexPattern: 'logs-*',
+            indexNameOrPattern: 'logs-*',
             startDate: 'invalid-date',
             endDate: endDateString,
           })
@@ -443,7 +443,7 @@ describe('fetchAvailableIndices', () => {
 
         await expect(
           fetchAvailableIndices(esClientMock, {
-            indexPattern: 'logs-*',
+            indexNameOrPattern: 'logs-*',
             startDate: startDateString,
             endDate: 'invalid-date',
           })

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/lib/fetch_available_indices.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/lib/fetch_available_indices.ts
@@ -32,15 +32,15 @@ const getParsedDateMs = (dateStr: string, roundUp = false) => {
 
 export const fetchAvailableIndices = async (
   esClient: ElasticsearchClient,
-  params: { indexPattern: string; startDate: string; endDate: string }
+  params: { indexNameOrPattern: string; startDate: string; endDate: string }
 ): Promise<string[]> => {
-  const { indexPattern, startDate, endDate } = params;
+  const { indexNameOrPattern, startDate, endDate } = params;
 
   const startDateMs = getParsedDateMs(startDate);
   const endDateMs = getParsedDateMs(endDate, true);
 
   const indicesCats = (await esClient.cat.indices({
-    index: indexPattern,
+    index: indexNameOrPattern,
     format: 'json',
     h: 'index,creation.date',
   })) as FetchAvailableCatIndicesResponseRequired;

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
@@ -85,7 +85,7 @@ export const getIndexStatsRoute = (router: IRouter, logger: Logger) => {
             const meteringStatsIndices = parseMeteringStats(meteringStats.indices);
 
             const availableIndices = await fetchAvailableIndices(esClient, {
-              indexPattern: decodedIndexName,
+              indexNameOrPattern: decodedIndexName,
               startDate: decodedStartDate,
               endDate: decodedEndDate,
             });

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/schemas/result.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/schemas/result.ts
@@ -69,6 +69,11 @@ export const PostIndexResultBody = ResultDocument;
 export const GetIndexResultsLatestParams = t.type({ pattern: t.string });
 export type GetIndexResultsLatestParams = t.TypeOf<typeof GetIndexResultsLatestParams>;
 
+export const GetIndexResultsLatestQuery = t.partial({
+  startDate: t.string,
+  endDate: t.string,
+});
+
 export const GetIndexResultsParams = t.type({
   pattern: t.string,
 });

--- a/x-pack/plugins/security_solution/public/overview/pages/data_quality.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/pages/data_quality.test.tsx
@@ -8,6 +8,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import type { HttpFetchOptions } from '@kbn/core-http-browser';
 
 import { useKibana as mockUseKibana } from '../../common/lib/kibana/__mocks__';
 import { TestProviders } from '../../common/mock';
@@ -22,7 +23,17 @@ jest.mock('../../common/lib/kibana', () => {
 
   const mockKibanaServices = {
     get: () => ({
-      http: { fetch: jest.fn() },
+      http: {
+        fetch: jest.fn().mockImplementation((path: string, options: HttpFetchOptions) => {
+          if (
+            path.startsWith('/internal/ecs_data_quality_dashboard/results_latest') &&
+            options.method === 'GET'
+          ) {
+            return Promise.resolve([]);
+          }
+          return Promise.resolve();
+        }),
+      },
     }),
   };
 

--- a/x-pack/plugins/security_solution/public/overview/pages/data_quality.tsx
+++ b/x-pack/plugins/security_solution/public/overview/pages/data_quality.tsx
@@ -171,6 +171,8 @@ const DataQualityComponent: React.FC = () => {
             startDate={startDate}
             theme={theme}
             toasts={toasts}
+            defaultStartTime={DEFAULT_START_TIME}
+            defaultEndTime={DEFAULT_END_TIME}
           />
         </SecuritySolutionPageWrapper>
       ) : (


### PR DESCRIPTION
addresses #191053

- Introduce `defaultStartTime` and `defaultEndTime` props across data quality context and panels for fetching latest_results and align them with serverless default time range of last week
- Update hooks to handle new time parameters and include them in storage results queries.
- Modify server-side helpers and routes to process and filter indices based on the provided time range.
- Update related tests to accommodate the new time parameters.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->