### PR TITLE
Use getUrlPartsWithStrippedDefaultPort instead of getUrlParts

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/custom_threshold/custom_eq_avg_bytes_fired.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/custom_threshold/custom_eq_avg_bytes_fired.ts
@@ -249,7 +249,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           docCountTarget: 1,
         });
 
-        const { protocol, hostname, port } = kbnTestConfig.getUrlParts();
+        const { protocol, hostname, port } = kbnTestConfig.getUrlPartsWithStrippedDefaultPort();
         expect(resp.hits.hits[0]._source?.ruleType).eql('observability.rules.custom_threshold');
         expect(resp.hits.hits[0]._source?.alertDetailsUrl).eql(
           `${protocol}://${hostname}${port ? `:${port}` : ''}/app/observability/alerts/${alertId}`

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/custom_threshold/documents_count_fired.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/custom_threshold/documents_count_fired.ts
@@ -247,7 +247,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           docCountTarget: 1,
         });
 
-        const { protocol, hostname, port } = kbnTestConfig.getUrlParts();
+        const { protocol, hostname, port } = kbnTestConfig.getUrlPartsWithStrippedDefaultPort();
 
         expect(resp.hits.hits[0]._source?.ruleType).eql('observability.rules.custom_threshold');
         expect(resp.hits.hits[0]._source?.alertDetailsUrl).eql(

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/custom_threshold/group_by_fired.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/custom_threshold/group_by_fired.ts
@@ -272,7 +272,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         const resp = await alertingApi.waitForDocumentInIndex<ActionDocument>({
           indexName: ALERT_ACTION_INDEX,
         });
-        const { protocol, hostname, port } = kbnTestConfig.getUrlParts();
+        const { protocol, hostname, port } = kbnTestConfig.getUrlPartsWithStrippedDefaultPort();
 
         expect(resp.hits.hits[0]._source?.ruleType).eql('observability.rules.custom_threshold');
         expect(resp.hits.hits[0]._source?.alertDetailsUrl).eql(

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/custom_threshold/p99_pct_fired.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/alerting/custom_threshold/p99_pct_fired.ts
@@ -244,7 +244,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           docCountTarget: 1,
         });
 
-        const { protocol, hostname, port } = kbnTestConfig.getUrlParts();
+        const { protocol, hostname, port } = kbnTestConfig.getUrlPartsWithStrippedDefaultPort();
         expect(resp.hits.hits[0]._source?.ruleType).eql('observability.rules.custom_threshold');
         expect(resp.hits.hits[0]._source?.alertDetailsUrl).eql(
           `${protocol}://${hostname}${port ? `:${port}` : ''}/app/observability/alerts/${alertId}`


### PR DESCRIPTION
## Summary

Use getUrlPartsWithStrippedDefaultPort to avoid this [issue](https://github.com/elastic/kibana/pull/195902#issuecomment-2411667499) on MKI:

```
Serverless Observability - Deployment-agnostic api integration - Custom Threshold rule AVG - PCT - FIRED Rule creation should set correct action variables

Error: expected 'https://bk-serverless-ftr-3067-e697d43e3ad9-e0ac80.kb.eu-west-1.aws.qa.elastic.cloud/app/observability/alerts/1e0c2d3e-e5c2-4bfe-9df0-d46681253b9f'
to sort of equal 'https://bk-serverless-ftr-3067-e697d43e3ad9-e0ac80.kb.eu-west-1.aws.qa.elastic.cloud:443/app/observability/alerts/1e0c2d3e-e5c2-4bfe-9df0-d46681253b9f'
```

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->