### PR TITLE
[APM] Migrate `/anomalies` to deployment agnostic tests

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/anomalies/anomaly_charts.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/anomalies/anomaly_charts.spec.ts
@@ -1,0 +1,286 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AnomalyDetectorType } from '@kbn/apm-plugin/common/anomaly_detection/apm_ml_detectors';
+import { ServiceAnomalyTimeseries } from '@kbn/apm-plugin/common/anomaly_detection/service_anomaly_timeseries';
+import { Environment } from '@kbn/apm-plugin/common/environment_rt';
+import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
+import { apm, timerange } from '@kbn/apm-synthtrace-client';
+import expect from '@kbn/expect';
+import { last, omit, range } from 'lodash';
+import moment from 'moment';
+import { ApmApiError } from '../../../../../../apm_api_integration/common/apm_api_supertest';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../../ftr_provider_context';
+import { createAndRunApmMlJobs } from '../../../../../../apm_api_integration/common/utils/create_and_run_apm_ml_jobs';
+
+export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const apmApiClient = getService('apmApi');
+  const ml = getService('mlApi');
+  const es = getService('es');
+  const logger = getService('log');
+  const synthtrace = getService('synthtrace');
+
+  const start = moment().subtract(2, 'days');
+  const end = moment();
+  const spikeStart = moment().subtract(8, 'hours');
+  const spikeEnd = moment().subtract(6, 'hours');
+
+  async function statusOf(p: Promise<{ status: number }>) {
+    try {
+      const { status } = await p;
+      return status;
+    } catch (err) {
+      if (err instanceof ApmApiError) {
+        return err.res.status;
+      }
+      throw err;
+    }
+  }
+
+  function getAnomalyCharts(
+    {
+      transactionType,
+      serviceName,
+      environment,
+    }: {
+      transactionType: string;
+      serviceName: string;
+      environment: Environment;
+    },
+    user = apmApiClient.readUser
+  ) {
+    return user({
+      endpoint: 'GET /internal/apm/services/{serviceName}/anomaly_charts',
+      params: {
+        path: {
+          serviceName,
+        },
+        query: {
+          start: start.toISOString(),
+          end: end.toISOString(),
+          transactionType,
+          environment,
+        },
+      },
+    });
+  }
+
+  describe('Anomaly charts', () => {
+    const NORMAL_DURATION = 100;
+    const NORMAL_RATE = 1;
+    let apmSynthtraceEsClient: ApmSynthtraceEsClient;
+
+    before(async () => {
+      apmSynthtraceEsClient = await synthtrace.createApmSynthtraceEsClient();
+    });
+
+    beforeEach(async () => {
+      const serviceA = apm
+        .service({ name: 'a', environment: 'production', agentName: 'java' })
+        .instance('a');
+
+      const serviceB = apm
+        .service({ name: 'b', environment: 'development', agentName: 'go' })
+        .instance('b');
+
+      const events = timerange(start.valueOf(), end.valueOf())
+        .interval('1m')
+        .rate(1)
+        .generator((timestamp) => {
+          const isInSpike = timestamp >= spikeStart.valueOf() && timestamp < spikeEnd.valueOf();
+          const count = isInSpike ? 4 : NORMAL_RATE;
+          const duration = isInSpike ? 10000 : NORMAL_DURATION;
+          const outcome = isInSpike ? 'failure' : 'success';
+
+          return [
+            ...range(0, count).flatMap((_) =>
+              serviceA
+                .transaction({ transactionName: 'tx', transactionType: 'request' })
+                .timestamp(timestamp)
+                .duration(duration)
+                .outcome(outcome)
+            ),
+            serviceB
+              .transaction({ transactionName: 'tx', transactionType: 'Worker' })
+              .timestamp(timestamp)
+              .duration(duration)
+              .success(),
+          ];
+        });
+
+      await apmSynthtraceEsClient.index(events);
+    });
+
+    afterEach(async () => {
+      await cleanup();
+    });
+
+    async function cleanup() {
+      await apmSynthtraceEsClient.clean();
+      await ml.cleanMlIndices();
+    }
+
+    describe('without ml jobs', () => {
+      it('returns a 200 for a user _with_ access to ML', async () => {
+        const status = await statusOf(
+          getAnomalyCharts({
+            serviceName: 'a',
+            transactionType: 'request',
+            environment: 'ENVIRONMENT_ALL',
+          })
+        );
+
+        expect(status).to.eql(200);
+      });
+    });
+
+    // FLAKY: https://github.com/elastic/kibana/issues/176966
+    describe('with ml jobs', () => {
+      beforeEach(async () => {
+        await createAndRunApmMlJobs({
+          es,
+          ml,
+          environments: ['production', 'development'],
+          logger,
+        });
+      });
+
+      it('returns a 200 for a user _with_ access to ML', async () => {
+        const status = await statusOf(
+          getAnomalyCharts({
+            serviceName: 'a',
+            transactionType: 'request',
+            environment: 'ENVIRONMENT_ALL',
+          })
+        );
+
+        expect(status).to.eql(200);
+      });
+
+      describe('inspecting the body', () => {
+        let allAnomalyTimeseries: ServiceAnomalyTimeseries[];
+
+        let latencySeries: ServiceAnomalyTimeseries | undefined;
+        let throughputSeries: ServiceAnomalyTimeseries | undefined;
+        let failureRateSeries: ServiceAnomalyTimeseries | undefined;
+        const endTimeMs = end.valueOf();
+
+        beforeEach(async () => {
+          allAnomalyTimeseries = (
+            await getAnomalyCharts({
+              serviceName: 'a',
+              transactionType: 'request',
+              environment: 'ENVIRONMENT_ALL',
+            })
+          ).body.allAnomalyTimeseries;
+
+          latencySeries = allAnomalyTimeseries.find(
+            (spec) => spec.type === AnomalyDetectorType.txLatency
+          );
+          throughputSeries = allAnomalyTimeseries.find(
+            (spec) => spec.type === AnomalyDetectorType.txThroughput
+          );
+          failureRateSeries = allAnomalyTimeseries.find(
+            (spec) => spec.type === AnomalyDetectorType.txFailureRate
+          );
+        });
+
+        it('returns model plots for all detectors and job ids for the given transaction type', () => {
+          expect(allAnomalyTimeseries.length).to.eql(3);
+
+          expect(
+            allAnomalyTimeseries.every((spec) => spec.bounds.some((bound) => bound.y0 ?? 0 > 0))
+          );
+        });
+
+        it('returns model plots with bounds for x range within start and end', () => {
+          expect(allAnomalyTimeseries.length).to.eql(3);
+
+          expect(
+            allAnomalyTimeseries.every((spec) =>
+              spec.bounds.every((bound) => bound.x >= start.valueOf() && bound.x <= endTimeMs)
+            )
+          );
+        });
+
+        it('returns model plots with latest bucket matching the end time', () => {
+          expect(allAnomalyTimeseries.every((spec) => last(spec.bounds)?.x === endTimeMs));
+        });
+
+        it('returns the correct metadata', () => {
+          function omitTimeseriesData(series: ServiceAnomalyTimeseries | undefined) {
+            return series ? omit(series, 'anomalies', 'bounds') : undefined;
+          }
+
+          expect(omitTimeseriesData(latencySeries)).to.eql({
+            type: AnomalyDetectorType.txLatency,
+            jobId: 'apm-tx-metrics-production',
+            serviceName: 'a',
+            environment: 'production',
+            transactionType: 'request',
+            version: 3,
+          });
+
+          expect(omitTimeseriesData(throughputSeries)).to.eql({
+            type: AnomalyDetectorType.txThroughput,
+            jobId: 'apm-tx-metrics-production',
+            serviceName: 'a',
+            environment: 'production',
+            transactionType: 'request',
+            version: 3,
+          });
+
+          expect(omitTimeseriesData(failureRateSeries)).to.eql({
+            type: AnomalyDetectorType.txFailureRate,
+            jobId: 'apm-tx-metrics-production',
+            serviceName: 'a',
+            environment: 'production',
+            transactionType: 'request',
+            version: 3,
+          });
+        });
+
+        it('returns anomalies for during the spike', () => {
+          const latencyAnomalies = latencySeries?.anomalies.filter((anomaly) => anomaly.y ?? 0 > 0);
+
+          const throughputAnomalies = throughputSeries?.anomalies.filter(
+            (anomaly) => anomaly.y ?? 0 > 0
+          );
+
+          const failureRateAnomalies = failureRateSeries?.anomalies.filter(
+            (anomaly) => anomaly.y ?? 0 > 0
+          );
+
+          expect(latencyAnomalies?.length).to.be.greaterThan(0);
+
+          expect(throughputAnomalies?.length).to.be.greaterThan(0);
+
+          expect(failureRateAnomalies?.length).to.be.greaterThan(0);
+
+          expect(
+            latencyAnomalies?.every(
+              (anomaly) =>
+                anomaly.x >= spikeStart.valueOf() && (anomaly.actual ?? 0) > NORMAL_DURATION
+            )
+          );
+
+          expect(
+            throughputAnomalies?.every(
+              (anomaly) => anomaly.x >= spikeStart.valueOf() && (anomaly.actual ?? 0) > NORMAL_RATE
+            )
+          );
+
+          expect(
+            failureRateAnomalies?.every(
+              (anomaly) => anomaly.x >= spikeStart.valueOf() && (anomaly.actual ?? 0) > 0
+            )
+          );
+        });
+      });
+    });
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/anomalies/index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/anomalies/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DeploymentAgnosticFtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+  describe('anomalies', () => {
+    loadTestFile(require.resolve('./anomaly_charts.spec.ts'));
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts
@@ -12,5 +12,6 @@ export default function apmApiIntegrationTests({
 }: DeploymentAgnosticFtrProviderContext) {
   describe('APM', function () {
     loadTestFile(require.resolve('./agent_explorer'));
+    loadTestFile(require.resolve('./anomalies'));
   });
 }

--- a/x-pack/test/apm_api_integration/tests/anomalies/anomaly_charts.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/anomalies/anomaly_charts.spec.ts
@@ -5,16 +5,13 @@
  * 2.0.
  */
 
-import { AnomalyDetectorType } from '@kbn/apm-plugin/common/anomaly_detection/apm_ml_detectors';
-import { ServiceAnomalyTimeseries } from '@kbn/apm-plugin/common/anomaly_detection/service_anomaly_timeseries';
 import { Environment } from '@kbn/apm-plugin/common/environment_rt';
 import { apm, timerange } from '@kbn/apm-synthtrace-client';
 import expect from '@kbn/expect';
-import { last, omit, range } from 'lodash';
+import { range } from 'lodash';
 import moment from 'moment';
 import { ApmApiError } from '../../common/apm_api_supertest';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
-import { createAndRunApmMlJobs } from '../../common/utils/create_and_run_apm_ml_jobs';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
@@ -156,168 +153,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             )
           )
         ).to.eql(403);
-      });
-
-      describe('without ml jobs', () => {
-        it('returns a 200 for a user _with_ access to ML', async () => {
-          const status = await statusOf(
-            getAnomalyCharts({
-              serviceName: 'a',
-              transactionType: 'request',
-              environment: 'ENVIRONMENT_ALL',
-            })
-          );
-
-          expect(status).to.eql(200);
-        });
-      });
-
-      // FLAKY: https://github.com/elastic/kibana/issues/176966
-      describe('with ml jobs', () => {
-        beforeEach(async () => {
-          await createAndRunApmMlJobs({
-            es,
-            ml,
-            environments: ['production', 'development'],
-            logger,
-          });
-        });
-
-        it('returns a 200 for a user _with_ access to ML', async () => {
-          const status = await statusOf(
-            getAnomalyCharts({
-              serviceName: 'a',
-              transactionType: 'request',
-              environment: 'ENVIRONMENT_ALL',
-            })
-          );
-
-          expect(status).to.eql(200);
-        });
-
-        describe('inspecting the body', () => {
-          let allAnomalyTimeseries: ServiceAnomalyTimeseries[];
-
-          let latencySeries: ServiceAnomalyTimeseries | undefined;
-          let throughputSeries: ServiceAnomalyTimeseries | undefined;
-          let failureRateSeries: ServiceAnomalyTimeseries | undefined;
-          const endTimeMs = end.valueOf();
-
-          beforeEach(async () => {
-            allAnomalyTimeseries = (
-              await getAnomalyCharts({
-                serviceName: 'a',
-                transactionType: 'request',
-                environment: 'ENVIRONMENT_ALL',
-              })
-            ).body.allAnomalyTimeseries;
-
-            latencySeries = allAnomalyTimeseries.find(
-              (spec) => spec.type === AnomalyDetectorType.txLatency
-            );
-            throughputSeries = allAnomalyTimeseries.find(
-              (spec) => spec.type === AnomalyDetectorType.txThroughput
-            );
-            failureRateSeries = allAnomalyTimeseries.find(
-              (spec) => spec.type === AnomalyDetectorType.txFailureRate
-            );
-          });
-
-          it('returns model plots for all detectors and job ids for the given transaction type', () => {
-            expect(allAnomalyTimeseries.length).to.eql(3);
-
-            expect(
-              allAnomalyTimeseries.every((spec) => spec.bounds.some((bound) => bound.y0 ?? 0 > 0))
-            );
-          });
-
-          it('returns model plots with bounds for x range within start and end', () => {
-            expect(allAnomalyTimeseries.length).to.eql(3);
-
-            expect(
-              allAnomalyTimeseries.every((spec) =>
-                spec.bounds.every((bound) => bound.x >= start.valueOf() && bound.x <= endTimeMs)
-              )
-            );
-          });
-
-          it('returns model plots with latest bucket matching the end time', () => {
-            expect(allAnomalyTimeseries.every((spec) => last(spec.bounds)?.x === endTimeMs));
-          });
-
-          it('returns the correct metadata', () => {
-            function omitTimeseriesData(series: ServiceAnomalyTimeseries | undefined) {
-              return series ? omit(series, 'anomalies', 'bounds') : undefined;
-            }
-
-            expect(omitTimeseriesData(latencySeries)).to.eql({
-              type: AnomalyDetectorType.txLatency,
-              jobId: 'apm-tx-metrics-production',
-              serviceName: 'a',
-              environment: 'production',
-              transactionType: 'request',
-              version: 3,
-            });
-
-            expect(omitTimeseriesData(throughputSeries)).to.eql({
-              type: AnomalyDetectorType.txThroughput,
-              jobId: 'apm-tx-metrics-production',
-              serviceName: 'a',
-              environment: 'production',
-              transactionType: 'request',
-              version: 3,
-            });
-
-            expect(omitTimeseriesData(failureRateSeries)).to.eql({
-              type: AnomalyDetectorType.txFailureRate,
-              jobId: 'apm-tx-metrics-production',
-              serviceName: 'a',
-              environment: 'production',
-              transactionType: 'request',
-              version: 3,
-            });
-          });
-
-          it('returns anomalies for during the spike', () => {
-            const latencyAnomalies = latencySeries?.anomalies.filter(
-              (anomaly) => anomaly.y ?? 0 > 0
-            );
-
-            const throughputAnomalies = throughputSeries?.anomalies.filter(
-              (anomaly) => anomaly.y ?? 0 > 0
-            );
-
-            const failureRateAnomalies = failureRateSeries?.anomalies.filter(
-              (anomaly) => anomaly.y ?? 0 > 0
-            );
-
-            expect(latencyAnomalies?.length).to.be.greaterThan(0);
-
-            expect(throughputAnomalies?.length).to.be.greaterThan(0);
-
-            expect(failureRateAnomalies?.length).to.be.greaterThan(0);
-
-            expect(
-              latencyAnomalies?.every(
-                (anomaly) =>
-                  anomaly.x >= spikeStart.valueOf() && (anomaly.actual ?? 0) > NORMAL_DURATION
-              )
-            );
-
-            expect(
-              throughputAnomalies?.every(
-                (anomaly) =>
-                  anomaly.x >= spikeStart.valueOf() && (anomaly.actual ?? 0) > NORMAL_RATE
-              )
-            );
-
-            expect(
-              failureRateAnomalies?.every(
-                (anomaly) => anomaly.x >= spikeStart.valueOf() && (anomaly.actual ?? 0) > 0
-              )
-            );
-          });
-        });
       });
     }
   );


### PR DESCRIPTION
## Summary

Depends on https://github.com/elastic/kibana/pull/199097
Closes https://github.com/elastic/kibana/issues/198960
Part of https://github.com/elastic/kibana/issues/193245

This PR contains the changes to migrate `anomalies` test folder to Deployment-agnostic testing strategy.

### How to test

- Serverless

```
node scripts/functional_tests_server --config x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts
node scripts/functional_test_runner --config x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts --grep="APM API tests"
```

 It's recommended to be run against [MKI](https://github.com/crespocarlos/kibana/blob/main/x-pack/test_serverless/README.md#run-tests-on-mki)  

- Stateful
```
node scripts/functional_tests_server --config x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.stateful.config.ts
node scripts/functional_test_runner --config x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.stateful.config.ts --grep="APM API tests"
```

