### PR TITLE
[Search] [Onboarding] Fix colors for dark theme

### DIFF
--- a/x-pack/plugins/search_indices/public/components/quick_stats/quick_stat.tsx
+++ b/x-pack/plugins/search_indices/public/components/quick_stats/quick_stat.tsx
@@ -70,7 +70,7 @@ export const QuickStat: React.FC<BaseQuickStatProps> = ({
           marginRight: euiTheme.size.s,
         },
         '.euiAccordion__triggerWrapper': {
-          background: euiTheme.colors.ghost,
+          background: euiTheme.colors.emptyShade,
         },
         '.euiAccordion__children': {
           borderTop: euiTheme.border.thin,

--- a/x-pack/plugins/search_indices/public/components/quick_stats/quick_stats.tsx
+++ b/x-pack/plugins/search_indices/public/components/quick_stats/quick_stats.tsx
@@ -87,7 +87,7 @@ export const QuickStats: React.FC<QuickStatsProps> = ({ index, mappings, indexDo
             open={open}
             setOpen={setOpen}
             icon="documents"
-            iconColor="black"
+            iconColor={euiTheme.colors.fullShade}
             title={i18n.translate('xpack.searchIndices.quickStats.document_count_heading', {
               defaultMessage: 'Document count',
             })}
@@ -115,7 +115,7 @@ export const QuickStats: React.FC<QuickStatsProps> = ({ index, mappings, indexDo
             open={open}
             setOpen={setOpen}
             icon="sparkles"
-            iconColor="black"
+            iconColor={euiTheme.colors.fullShade}
             title={i18n.translate('xpack.searchIndices.quickStats.ai_search_heading', {
               defaultMessage: 'AI Search',
             })}


### PR DESCRIPTION
In dark mode, colors are not changed for some components in indexManagement

- Change according background color base on theme
- Change icons color base on theme

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/f448b522-03cc-4e17-89dd-4a460983bbac">


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->