### PR TITLE
[Search] [Playground] [Bug] Add Search Playgrounnd to Serverless manifest

### DIFF
--- a/x-pack/plugins/serverless_search/kibana.jsonc
+++ b/x-pack/plugins/serverless_search/kibana.jsonc
@@ -35,6 +35,7 @@
       "indexManagement",
       "searchConnectors",
       "searchInferenceEndpoints",
+      "searchPlayground",
       "usageCollection"
     ],
     "requiredBundles": ["kibanaReact"]


### PR DESCRIPTION
Missed searchPlayground in kibana manifest