### PR TITLE
[Discover] PoC Auto hide the fields for STATS/KEEP ES|QL queries

### DIFF
--- a/packages/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar_container.tsx
+++ b/packages/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar_container.tsx
@@ -51,6 +51,8 @@ import type {
   SearchMode,
 } from '../../types';
 
+const DEFAULT_SIDEBAR_TOGGLE_STATE = { value: false, lastChangedBy: undefined };
+
 export interface UnifiedFieldListSidebarContainerApi {
   sidebarVisibility: SidebarVisibility;
   refetchFieldsExistenceInfo: ExistingFieldsFetcher['refetchFieldsExistenceInfo'];
@@ -131,7 +133,10 @@ const UnifiedFieldListSidebarContainer = memo(
             : undefined,
         })
       );
-      const isSidebarCollapsed = useObservable(sidebarVisibility.isCollapsed$, false);
+      const isSidebarCollapsedState = useObservable(
+        sidebarVisibility.isCollapsed$,
+        DEFAULT_SIDEBAR_TOGGLE_STATE
+      );
 
       const canEditDataView =
         Boolean(dataViewFieldEditor?.userPermissions.editIndexPattern()) ||
@@ -274,7 +279,7 @@ const UnifiedFieldListSidebarContainer = memo(
       };
 
       if (stateService.creationOptions.showSidebarToggleButton) {
-        commonSidebarProps.isSidebarCollapsed = isSidebarCollapsed;
+        commonSidebarProps.isSidebarCollapsed = isSidebarCollapsedState.value;
         commonSidebarProps.onToggleSidebar = sidebarVisibility.toggle;
       }
 

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -339,7 +339,7 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
       sidebarToggleState.lastChangedBy === lastChangedBy
     ) {
       // auto-expand sidebar when switching back to a normal case (unless user has manually collapsed it)
-      sidebarToggleState.toggle?.(false);
+      sidebarToggleState.toggle?.(false, { skipPersisting: true });
     }
   }, [isEsqlMode, query, sidebarToggleState$, sidebarToggle]);
 

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -39,6 +39,7 @@ import { useAdditionalFieldGroups } from '../../hooks/sidebar/use_additional_fie
 import { useIsEsqlMode } from '../../hooks/use_is_esql_mode';
 
 const EMPTY_FIELD_COUNTS = {};
+const DEFAULT_SIDEBAR_TOGGLE_STATE = { value: false, lastChangedBy: undefined };
 
 const getCreationOptions: UnifiedFieldListSidebarContainerProps['getCreationOptions'] = () => {
   return {
@@ -349,17 +350,27 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
     [onRemoveField]
   );
 
-  const isSidebarCollapsed = useObservable(
-    unifiedFieldListSidebarContainerApi?.sidebarVisibility.isCollapsed$ ?? of(false),
-    false
+  const isSidebarCollapsedState = useObservable(
+    unifiedFieldListSidebarContainerApi?.sidebarVisibility.isCollapsed$ ??
+      of(DEFAULT_SIDEBAR_TOGGLE_STATE),
+    DEFAULT_SIDEBAR_TOGGLE_STATE
   );
+
+  const isSidebarCollapsed = isSidebarCollapsedState.value;
+  const sidebarStateLastChangedBy = isSidebarCollapsedState.lastChangedBy;
 
   useEffect(() => {
     sidebarToggleState$.next({
       isCollapsed: isSidebarCollapsed,
+      lastChangedBy: sidebarStateLastChangedBy,
       toggle: unifiedFieldListSidebarContainerApi?.sidebarVisibility.toggle,
     });
-  }, [isSidebarCollapsed, unifiedFieldListSidebarContainerApi, sidebarToggleState$]);
+  }, [
+    isSidebarCollapsed,
+    sidebarStateLastChangedBy,
+    unifiedFieldListSidebarContainerApi,
+    sidebarToggleState$,
+  ]);
 
   return (
     <EuiFlexGroup

--- a/src/plugins/discover/public/application/types.ts
+++ b/src/plugins/discover/public/application/types.ts
@@ -10,6 +10,7 @@
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type { SearchResponseWarning } from '@kbn/search-response-warnings';
+import type { UnifiedFieldListSidebarContainerApi } from '@kbn/unified-field-list';
 
 export enum FetchStatus {
   UNINITIALIZED = 'uninitialized',
@@ -29,5 +30,6 @@ export interface RecordsFetchResponse {
 
 export interface SidebarToggleState {
   isCollapsed: boolean;
-  toggle: undefined | ((isCollapsed: boolean) => void);
+  lastChangedBy?: string;
+  toggle: undefined | UnifiedFieldListSidebarContainerApi['sidebarVisibility']['toggle'];
 }

--- a/src/plugins/discover/public/components/panels_toggle/panels_toggle.tsx
+++ b/src/plugins/discover/public/components/panels_toggle/panels_toggle.tsx
@@ -16,6 +16,8 @@ import { useAppStateSelector } from '../../application/main/state_management/dis
 import { DiscoverStateContainer } from '../../application/main/state_management/discover_state';
 import { SidebarToggleState } from '../../application/types';
 
+export const PANELS_TOGGLE_LAST_CHANGED_BY = 'panels_toggle';
+
 export interface PanelsToggleProps {
   stateContainer: DiscoverStateContainer;
   sidebarToggleState$: BehaviorSubject<SidebarToggleState>;
@@ -61,7 +63,8 @@ export const PanelsToggle: React.FC<PanelsToggleProps> = ({
             'data-test-subj': 'dscShowSidebarButton',
             'aria-expanded': !isSidebarCollapsed,
             'aria-controls': 'discover-sidebar',
-            onClick: () => sidebarToggleState?.toggle?.(false),
+            onClick: () =>
+              sidebarToggleState?.toggle?.(false, { lastChangedBy: PANELS_TOGGLE_LAST_CHANGED_BY }),
           },
         ]
       : []),

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/resizable_layout.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/resizable_layout.tsx
@@ -21,6 +21,8 @@ import { of } from 'rxjs';
 
 export const SIDEBAR_WIDTH_KEY = 'timeline:sidebarWidth';
 
+const DEFAULT_SIDEBAR_TOGGLE_STATE = { value: true, lastChangedBy: undefined };
+
 // TODO: This is almost a duplicate of the logic here: src/plugins/discover/public/application/main/components/layout/discover_resizable_layout.tsx
 // Should this layout be a shared package or just an accepted dupe since the <ResizeableLayout /> is already shared?
 
@@ -51,10 +53,13 @@ export const TimelineResizableLayoutComponent = ({
 
   const isMobile = useIsWithinBreakpoints(['xs', 's']);
 
-  const isSidebarCollapsed = useObservable(
-    unifiedFieldListSidebarContainerApi?.sidebarVisibility.isCollapsed$ ?? of(true),
-    true
+  const isSidebarCollapsedState = useObservable(
+    unifiedFieldListSidebarContainerApi?.sidebarVisibility.isCollapsed$ ??
+      of(DEFAULT_SIDEBAR_TOGGLE_STATE),
+    DEFAULT_SIDEBAR_TOGGLE_STATE
   );
+
+  const isSidebarCollapsed = isSidebarCollapsedState.value;
   const layoutMode =
     isMobile || isSidebarCollapsed ? ResizableLayoutMode.Static : ResizableLayoutMode.Resizable;
   const layoutDirection = isMobile


### PR DESCRIPTION
- Addresses https://github.com/elastic/kibana/issues/198896

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

