### PR TITLE
[Discover] Replace nested EuiFlyoutBody with EuiPanel in example profile

### DIFF
--- a/src/plugins/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
+++ b/src/plugins/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiBadge, EuiLink, EuiFlyout, EuiFlyoutBody } from '@elastic/eui';
+import { EuiBadge, EuiLink, EuiFlyout, EuiPanel } from '@elastic/eui';
 import {
   AppMenuActionId,
   AppMenuActionType,
@@ -89,12 +89,12 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
               title: 'Example',
               order: 0,
               component: () => (
-                <EuiFlyoutBody>
+                <EuiPanel color="transparent" hasShadow={false}>
                   <div data-test-subj="exampleDataSourceProfileDocView">Example Doc View</div>
                   <pre data-test-subj="exampleDataSourceProfileDocViewRecord">
                     {context.formatRecord(params.record.flattened)}
                   </pre>
-                </EuiFlyoutBody>
+                </EuiPanel>
               ),
             });
 


### PR DESCRIPTION
## Summary

Just a minor cleanup from #198637.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->