### PR TITLE
Kibana Sustainable Architecture: Force `visibility: 'private'` for solutions in manifest

### DIFF
--- a/packages/kbn-kibana-manifest-schema/src/kibana_json_v2_schema.ts
+++ b/packages/kbn-kibana-manifest-schema/src/kibana_json_v2_schema.ts
@@ -55,13 +55,6 @@ export const MANIFEST_V2: JSONSchema = {
       `,
       default: 'common',
     },
-    visibility: {
-      enum: ['private', 'shared'],
-      description: desc`
-        Specifies the visibility of this module, i.e. whether it can be accessed by everybody or only modules in the same group
-      `,
-      default: 'shared',
-    },
     devOnly: {
       type: 'boolean',
       description: desc`
@@ -112,6 +105,37 @@ export const MANIFEST_V2: JSONSchema = {
       type: 'string',
     },
   },
+  allOf: [
+    {
+      if: {
+        properties: { group: { const: 'platform' } },
+      },
+      then: {
+        properties: {
+          visibility: {
+            enum: ['private', 'shared'],
+            description: desc`
+        Specifies the visibility of this module, i.e. whether it can be accessed by everybody or only modules in the same group
+      `,
+            default: 'shared',
+          },
+        },
+        required: ['visibility'],
+      },
+      else: {
+        properties: {
+          visibility: {
+            const: 'private',
+            description: desc`
+        Specifies the visibility of this module, i.e. whether it can be accessed by everybody or only modules in the same group
+      `,
+            default: 'private',
+          },
+        },
+        required: ['visibility'],
+      },
+    },
+  ],
   oneOf: [
     {
       type: 'object',

--- a/packages/kbn-kibana-manifest-schema/src/kibana_json_v2_schema.ts
+++ b/packages/kbn-kibana-manifest-schema/src/kibana_json_v2_schema.ts
@@ -49,11 +49,10 @@ export const MANIFEST_V2: JSONSchema = {
       `,
     },
     group: {
-      enum: ['common', 'platform', 'observability', 'security', 'search'],
+      enum: ['platform', 'observability', 'security', 'search'],
       description: desc`
         Specifies the group to which this module pertains.
       `,
-      default: 'common',
     },
     devOnly: {
       type: 'boolean',


### PR DESCRIPTION
## Summary

Small improvements for the JSON schema for `kibana.jsonc` manifests:
* Allow `visibility: 'shared'` only when `group: 'platform'` (thanks @dgieselaar!)
* Remove `group: 'common'` option. We don't want users categorising modules as `'common'` (it has the semantic meaning of "not categorised").

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->