### PR TITLE
[8.x] [Fleet] Added default index pattern creation to stream-based installation (#199122)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
@@ -133,6 +133,20 @@ export async function installKibanaAssets(options: {
     return [];
   }
 
+  await createDefaultIndexPatterns(savedObjectsImporter);
+  await makeManagedIndexPatternsGlobal(savedObjectsClient);
+
+  return await installKibanaSavedObjects({
+    logger,
+    savedObjectsImporter,
+    kibanaAssets: assetsToInstall,
+    assetsChunkSize: MAX_ASSETS_TO_INSTALL_IN_PARALLEL,
+  });
+}
+
+export async function createDefaultIndexPatterns(
+  savedObjectsImporter: SavedObjectsImporterContract
+) {
   // Create index patterns separately with `overwrite: false` to prevent blowing away users' runtime fields.
   // These don't get retried on conflict, because we expect that they exist once an integration has been installed.
   const indexPatternSavedObjects = getIndexPatternSavedObjects() as ArchiveAsset[];
@@ -142,15 +156,6 @@ export async function installKibanaAssets(options: {
     createNewCopies: false,
     refresh: false,
     managed: true,
-  });
-
-  await makeManagedIndexPatternsGlobal(savedObjectsClient);
-
-  return await installKibanaSavedObjects({
-    logger,
-    savedObjectsImporter,
-    kibanaAssets: assetsToInstall,
-    assetsChunkSize: MAX_ASSETS_TO_INSTALL_IN_PARALLEL,
   });
 }
 

--- a/x-pack/plugins/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install_state_machine/steps/step_install_kibana_assets.ts
@@ -40,7 +40,7 @@ export async function stepInstallKibanaAssets(context: InstallContext) {
 }
 
 export async function stepInstallKibanaAssetsWithStreaming(context: InstallContext) {
-  const { savedObjectsClient, installedPkg, packageInstallContext, spaceId } = context;
+  const { savedObjectsClient, packageInstallContext, spaceId } = context;
   const { packageInfo } = packageInstallContext;
   const { name: pkgName } = packageInfo;
 
@@ -51,7 +51,6 @@ export async function stepInstallKibanaAssetsWithStreaming(context: InstallConte
         savedObjectsClient,
         pkgName,
         packageInstallContext,
-        installedPkg,
         spaceId,
       })
   );

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/sourcerer/sourcerer_timeline.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/sourcerer/sourcerer_timeline.cy.ts
@@ -62,8 +62,7 @@ describe('Timeline scope', { tags: ['@ess', '@serverless', '@skipInServerless'] 
     isNotSourcererOption(`${DEFAULT_ALERTS_INDEX}-default`);
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/173854
-  describe.skip('Modified badge', () => {
+  describe('Modified badge', () => {
     it('Selecting new data view does not add a modified badge', () => {
       openTimelineUsingToggle();
       cy.get(SOURCERER.badgeModified).should(`not.exist`);
@@ -134,8 +133,7 @@ describe('Timeline scope', { tags: ['@ess', '@serverless', '@skipInServerless'] 
     });
 
     const defaultPatterns = [`auditbeat-*`, `${DEFAULT_ALERTS_INDEX}-default`];
-    // failing on main multiple times https://github.com/elastic/kibana/issues/198944#issuecomment-2457665138 and https://github.com/elastic/kibana/issues/198943#issuecomment-2457665072
-    it.skip('alerts checkbox behaves as expected', () => {
+    it('alerts checkbox behaves as expected', () => {
       isDataViewSelection(siemDataViewTitle);
       defaultPatterns.forEach((pattern) => isSourcererSelection(pattern));
       openDataViewSelection();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Fleet] Added default index pattern creation to stream-based installation (#199122)](https://github.com/elastic/kibana/pull/199122)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dmitrii Shevchenko","email":"dmitrii.shevchenko@elastic.co"},"sourceCommit":{"committedDate":"2024-11-07T09:04:56Z","message":"[Fleet] Added default index pattern creation to stream-based installation (#199122)\n\n**Related to: https://github.com/elastic/kibana/pull/195888**\r\n\r\n## Summary\r\n\r\nAdd default index pattern creation to the new stream-based package\r\ninstallation method to match the behavior of standard package\r\ninstallation.\r\n\r\nSwitching to stream-based package installation resulted in the default\r\nindex patterns not being created, even after installing the rules\r\npackage. While this likely doesn’t affect production, as multiple\r\nintegrations are usually installed in Kibana (creating the default index\r\npattern in any case), this change has impacted some tests:\r\nhttps://github.com/elastic/kibana/pull/199030. So restoring the original\r\nbehaviour","sha":"22d3e628931706dee4c0d8eec068575d264bb13e","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","backport:version","v8.17.0"],"number":199122,"url":"https://github.com/elastic/kibana/pull/199122","mergeCommit":{"message":"[Fleet] Added default index pattern creation to stream-based installation (#199122)\n\n**Related to: https://github.com/elastic/kibana/pull/195888**\r\n\r\n## Summary\r\n\r\nAdd default index pattern creation to the new stream-based package\r\ninstallation method to match the behavior of standard package\r\ninstallation.\r\n\r\nSwitching to stream-based package installation resulted in the default\r\nindex patterns not being created, even after installing the rules\r\npackage. While this likely doesn’t affect production, as multiple\r\nintegrations are usually installed in Kibana (creating the default index\r\npattern in any case), this change has impacted some tests:\r\nhttps://github.com/elastic/kibana/pull/199030. So restoring the original\r\nbehaviour","sha":"22d3e628931706dee4c0d8eec068575d264bb13e"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/199122","number":199122,"mergeCommit":{"message":"[Fleet] Added default index pattern creation to stream-based installation (#199122)\n\n**Related to: https://github.com/elastic/kibana/pull/195888**\r\n\r\n## Summary\r\n\r\nAdd default index pattern creation to the new stream-based package\r\ninstallation method to match the behavior of standard package\r\ninstallation.\r\n\r\nSwitching to stream-based package installation resulted in the default\r\nindex patterns not being created, even after installing the rules\r\npackage. While this likely doesn’t affect production, as multiple\r\nintegrations are usually installed in Kibana (creating the default index\r\npattern in any case), this change has impacted some tests:\r\nhttps://github.com/elastic/kibana/pull/199030. So restoring the original\r\nbehaviour","sha":"22d3e628931706dee4c0d8eec068575d264bb13e"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->