### PR TITLE
[ES|QL] Function location parsing tests

### DIFF
--- a/packages/kbn-esql-ast/src/parser/__tests__/function.test.ts
+++ b/packages/kbn-esql-ast/src/parser/__tests__/function.test.ts
@@ -355,13 +355,29 @@ describe('location', () => {
     ]);
   });
 
-  it('with comment after function name identifier', () => {
+  it('with the simplest comment after function name identifier', () => {
+    const texts1 = getFunctionTexts('FROM index | STATS agg/* */()');
+    expect(texts1).toEqual(['agg/* */()']);
+
+    const texts2 = getFunctionTexts('FROM index | STATS agg/* A */()');
+    expect(texts2).toEqual(['agg/* A */()']);
+
+    const texts3 = getFunctionTexts('FROM index | STATS agg /* A */ ()');
+    expect(texts3).toEqual(['agg /* A */ ()']);
+  });
+
+  it('with the simplest emoji comment after function name identifier', () => {
+    const texts = getFunctionTexts('FROM index | STATS agg/* 😎 */()');
+    expect(texts).toEqual(['agg/* 😎 */()']);
+  });
+
+  it('with comment and emoji after function name identifier', () => {
     const texts = getFunctionTexts('FROM index | STATS agg /* haha 😅 */ ()');
 
     expect(texts).toEqual(['agg /* haha 😅 */ ()']);
   });
 
-  it('with comment inside argumetn list', () => {
+  it('with comment inside argument list', () => {
     const texts = getFunctionTexts('FROM index | STATS agg  ( /* haha 😅 */ )');
 
     expect(texts).toEqual(['agg  ( /* haha 😅 */ )']);

--- a/packages/kbn-esql-ast/src/parser/helpers.ts
+++ b/packages/kbn-esql-ast/src/parser/helpers.ts
@@ -41,17 +41,16 @@ export const formatIdentifierParts = (parts: string[]): string =>
   parts.map(formatIdentifier).join('.');
 
 export const getPosition = (
-  token: Pick<Token, 'start' | 'stop'> | null,
-  lastToken?: Pick<Token, 'stop'> | undefined
+  start: Pick<Token, 'start' | 'stop'> | null,
+  stop?: Pick<Token, 'stop'> | undefined
 ) => {
-  if (!token || token.start < 0) {
+  if (!start || start.start < 0) {
     return { min: 0, max: 0 };
   }
-  const endFirstToken = token.stop > -1 ? Math.max(token.stop + 1, token.start) : undefined;
-  const endLastToken = lastToken?.stop;
+  const endFirstToken = start.stop > -1 ? Math.max(start.stop + 1, start.start) : undefined;
   return {
-    min: token.start,
-    max: endLastToken ?? endFirstToken ?? Infinity,
+    min: start.start,
+    max: stop?.stop ?? endFirstToken ?? Infinity,
   };
 };
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/199319

After debugging it this morning I realized that there is no bug in the parser, per se. But the bug is in all the places where we cut a slice of text from the source text based on the positions reported in AST. So, this patch does not contain a fix, but just some tests I used for debugging.

The ANTLR parser reports positions in Unicode code points, not in UTF-16 offsets (which are used by JavaScript).

Which means, given an AST `node`, to find its source text we often do:

```js
text.slice(node.location.min, node.location.max + 1);
```

That is not correct because it uses UTF-16 offsets to compute the `.slice()`, which will incorrectly cut text when there are characters that are encoded as two bytes in UTF-16.

The correct way is to use Unicode codepoints, which can be done like so:

```js
[...text].slice(node.location.min, node.location.max + 1).join('');
```


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->