### PR TITLE
label for enable disable on modal changed to match state of risk scor…

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
@@ -62,6 +62,7 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
     entityStore: !!entityStore.checked,
   });
   const { data: privileges, isLoading: isLoadingPrivileges } = useEntityEnginePrivileges();
+  const isAnyEnabled = enablements.riskScore || enablements.entityStore;
 
   if (!visible) {
     return null;
@@ -135,7 +136,7 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
         <EuiButton onClick={enableStore(enablements)} fill>
           <FormattedMessage
             id="xpack.securitySolution.entityAnalytics.enablements.modal.enable"
-            defaultMessage="Enable"
+            defaultMessage={isAnyEnabled ? 'Enable' : 'Disable'}
           />
         </EuiButton>
       </EuiModalFooter>


### PR DESCRIPTION

## Summary
This PR changes the Enable button on the "Enable entity store and risk score" modal to disable if there are no changes to the confirmation modal.

The current states of this modal can be:
Risk score enabled, Entity Store disabled -> Enable Button
Risk score disabled, Entity Store enabled -> Enable Button
Risk score disabled, Entity Store disabled -> Disable Button

![image](https://github.com/user-attachments/assets/a2173662-93de-4ec7-a88d-ccefc1c9c92b)
![image](https://github.com/user-attachments/assets/1613e0cb-1884-4f55-a492-8888d77ede51)
![image](https://github.com/user-attachments/assets/0282a2fd-4aa8-474f-9003-600cc6ab4ee4)

In draft currently - currently have the visual side of this in place, double checking the logic and handlers for these buttons and getting confirmation that the above combination of states is correct.
