### PR TITLE
[Fleet] POC of we can use enrich index

### DIFF
--- a/x-pack/plugins/fleet/server/routes/setup/index.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/index.ts
@@ -16,6 +16,10 @@ import type { FleetConfigType } from '../../../common/types';
 import { genericErrorResponse, internalErrorResponse } from '../schema/errors';
 
 import { getFleetStatusHandler, fleetSetupHandler } from './handlers';
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { agentPolicyService } from '../../services';
+import { FleetRequestHandler } from '../../types';
 
 export const FleetSetupResponseSchema = schema.object(
   {
@@ -34,6 +38,76 @@ export const FleetSetupResponseSchema = schema.object(
     },
   }
 );
+
+async function createAgentEnrichment(
+  esClient: ElasticsearchClient,
+  soClient: SavedObjectsClientContract
+) {
+  // Sync agent policies in a new index that will be used for enrichment
+  // This could happen in the agent policy service when policies are created/updated
+  const agentPoliciesData = await agentPolicyService.list(soClient, {
+    perPage: 10000,
+  });
+
+  for (const agentPolicy of agentPoliciesData.items) {
+    await esClient.index({
+      index: 'fleet-agent-policy-enrich',
+      id: agentPolicy.id,
+      document: {
+        policy_id: agentPolicy.id,
+        is_managed: agentPolicy.is_managed,
+        data_output_id: agentPolicy.data_output_id,
+        monitoring_output_id: agentPolicy.monitoring_output_id,
+      },
+    });
+  }
+
+  await esClient.enrich
+    .putPolicy({
+      name: 'fleet-agent-policy',
+      match: {
+        indices: 'fleet-agent-policy-enrich',
+        match_field: 'policy_id',
+        enrich_fields: ['is_managed', 'data_output_id', 'monitoring_output_id'],
+      },
+    })
+    // Catch if already exists
+    .catch(() => {});
+
+  await esClient.enrich.executePolicy({
+    name: 'fleet-agent-policy',
+  });
+
+  await esClient.ingest.putPipeline({
+    id: 'fleet-agents-pipeline',
+    processors: [
+      {
+        enrich: {
+          description: "Add 'user' data based on 'email'",
+          policy_name: 'fleet-agent-policy',
+          field: 'policy_id',
+          target_field: 'agent_policy',
+          max_matches: 1,
+        },
+      },
+    ],
+  });
+
+  // Hacky way to tests copy .fleet-agents in a .fleet-agents-test as we cannot update settings (index.default_pipeline) of a system indices
+  const agentRes = await esClient.search({
+    index: '.fleet-agents',
+    size: 10000,
+  });
+
+  for (const agentDoc of agentRes.hits.hits) {
+    await esClient.index({
+      index: '.fleet-agents-test',
+      id: agentDoc._id,
+      document: agentDoc._source,
+      pipeline: 'fleet-agents-pipeline',
+    });
+  }
+}
 
 export const registerFleetSetupRoute = (router: FleetAuthzRouter) => {
   router.versioned
@@ -67,6 +141,47 @@ export const registerFleetSetupRoute = (router: FleetAuthzRouter) => {
       },
       fleetSetupHandler
     );
+
+  router.versioned
+    .post({
+      path: '/api/fleet/poc-agent-enrichment',
+      fleetAuthz: {
+        fleet: { setup: true },
+      },
+      description: `Initiate Fleet setup`,
+      options: {
+        tags: ['oas-tag:Fleet internals'],
+      },
+    })
+    .addVersion(
+      {
+        version: API_VERSIONS.public.v1,
+        validate: {
+          request: {},
+          response: {
+            200: {
+              body: () => FleetSetupResponseSchema,
+            },
+            400: {
+              body: genericErrorResponse,
+            },
+            500: {
+              body: internalErrorResponse,
+            },
+          },
+        },
+      },
+      testHandler
+    );
+};
+
+const testHandler: FleetRequestHandler = async (context, request, response) => {
+  const esClient = (await context.core).elasticsearch.client.asCurrentUser;
+  const soClient = await (await context.core).savedObjects.client;
+
+  await createAgentEnrichment(esClient, soClient).catch(console.log);
+
+  return response.ok({});
 };
 
 export const GetAgentsSetupResponseSchema = schema.object(

--- a/x-pack/plugins/fleet/server/routes/setup/index.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/index.ts
@@ -62,6 +62,7 @@ async function createAgentEnrichment(
     });
   }
 
+  // Create the enrich policy and pipeline, this should probably be part the ES fleet plugin if move forward with that
   await esClient.enrich
     .putPolicy({
       name: 'fleet-agent-policy',


### PR DESCRIPTION
## Summary

We are limited on the way we provide search for agents to the field present on the `.fleet-agents` I explored how we can use enrich policy to enrich the fleet-agents document with fields from agent policies.

Proof of concept of using an enrich policy to add `agent_policy` property to `.fleet-agents` (Link to enrich policy [doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-enriching-data.html#enrich-policy)) 

Create a new API that simulate what we could do with an enrich policy and an ingest pipeline for fleet-agents 
```
POST kbn:/api/fleet/poc-agent-enrichment
```

Create an enrich policy and index with the agent policies data

and simulate writing new agent doc by copying them from .fleet-agents to `.fleet-agents-test`

Each time a new fleet agents doc is created (here in fleet-agents-test, it will add the agent_policy field)

<img width="1476" alt="Screenshot 2024-11-08 at 10 05 05 AM" src="https://github.com/user-attachments/assets/cf107c70-6413-40ff-a593-5df6666de128">




Update to an agent policy will have to update the existing agent document, and update the enrich index.

Same for reassigning agent to a new policy, this will require a manual update of the agents documents

## Questions

We could probably achieve a similar results with a transform too, which one will be better to use?

Performance impact? 