### PR TITLE
[Security Solution][Session view] - fix EuiButton key not unique throwing error

### DIFF
--- a/x-pack/plugins/session_view/public/components/process_tree_node/buttons.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/buttons.tsx
@@ -86,8 +86,8 @@ export const AlertButton = ({
       {alertsCount > 1 ? ALERTS : ALERT}
       {alertsCount > 1 &&
         (alertsCount > MAX_ALERT_COUNT ? ` (${MAX_ALERT_COUNT}+)` : ` (${alertsCount})`)}
-      {alertIcons?.map((icon: string) => (
-        <EuiIcon className="alertIcon" key={icon} size="s" type={icon} />
+      {alertIcons?.map((icon: string, index: number) => (
+        <EuiIcon className="alertIcon" key={`${icon}-${index}`} size="s" type={icon} />
       ))}
       <EuiIcon css={buttonArrow} size="s" type="arrowDown" />
     </EuiButton>


### PR DESCRIPTION
## Summary

This PR fixes a very small console error because of a EuiButton key that is not unique in the Session View component.

Before fix

https://github.com/user-attachments/assets/930adc5d-1505-43c1-ac2f-451172e803e5

After fix

https://github.com/user-attachments/assets/5a4a824d-d048-4822-a930-a30bb87336cc


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->