### PR TITLE
[Spaces] Visual adjustment to solution view selection

### DIFF
--- a/x-pack/plugins/spaces/public/management/components/solution_view/solution_view.tsx
+++ b/x-pack/plugins/spaces/public/management/components/solution_view/solution_view.tsx
@@ -79,7 +79,7 @@ const getOptions = ({ size }: EuiThemeComputed): Array<EuiSuperSelectOption<Solu
       value: 'classic',
       inputDisplay: (
         <>
-          <EuiIcon type="logoKibana" css={iconCss} />
+          <EuiIcon type="logoElasticStack" css={iconCss} />
           {i18n.translate(
             'xpack.spaces.management.manageSpacePage.solutionViewSelect.classicOptionLabel',
             { defaultMessage: 'Classic' }
@@ -151,6 +151,16 @@ export const SolutionView: FunctionComponent<Props> = ({
               defaultMessage: 'Solution view',
             })}
             fullWidth
+            helpText={
+              <React.Fragment>
+                {showClassicDefaultViewCallout ? (
+                  <FormattedMessage
+                    id="xpack.spaces.management.manageSpacePage.solutionViewSelect.classicDefaultViewCallout"
+                    defaultMessage="Affects all users of the space"
+                  />
+                ) : null}
+              </React.Fragment>
+            }
             {...validator.validateSolutionView(space, isEditing)}
           >
             <EuiSuperSelect
@@ -174,13 +184,6 @@ export const SolutionView: FunctionComponent<Props> = ({
 
           {showClassicDefaultViewCallout && (
             <>
-              <EuiText size="s" color="subdued">
-                <FormattedMessage
-                  id="xpack.spaces.management.manageSpacePage.solutionViewSelect.classicDefaultViewCallout"
-                  defaultMessage="Affects all users of the space"
-                />
-              </EuiText>
-
               <EuiSpacer size="m" />
               <EuiCallOut
                 color="primary"


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana-team/issues/1259, https://github.com/elastic/kibana-team/issues/1260

#### Visuals

##### Before
<img width="1495" alt="Screenshot 2024-11-08 at 16 39 26" src="https://github.com/user-attachments/assets/0ecd6d29-7cca-4455-8c11-c85f6d21e681">


##### After

<img width="1501" alt="Screenshot 2024-11-08 at 16 37 02" src="https://github.com/user-attachments/assets/0cace84f-1491-45f6-aa9b-b097b76ebdb9">

<!--
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->