### PR TITLE
[Docs] Fix collapsibles in RNs

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -94,7 +94,7 @@ Deprecated functionality does not have an immediate impact on your application, 
 you make the necessary updates after you upgrade to 8.16.0.
 
 [discrete]
-* The Logs Stream is now hidden by default in favor of the Logs Explorer app.
+.The Logs Stream is now hidden by default in favor of the Logs Explorer app.
 [%collapsible]
 ====
 *Details* +
@@ -105,7 +105,7 @@ You can still show the Logs Stream app again by navigating to Stack Management >
 ====
       
 [discrete]
-* Deprecates the Observability AI Assistant specific advanced setting `observability:aiAssistantLogsIndexPattern`.
+.Deprecates the Observability AI Assistant specific advanced setting `observability:aiAssistantLogsIndexPattern`.
 [%collapsible]
 ====
 *Details* +

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -1725,19 +1725,16 @@ When you create *Lens* visualization, the default for the *Legend width* is now 
 
 [discrete]
 [[deprecation-192003]]
-* Deprecated the Observability AI Assistant specific advanced setting `observability:aiAssistantLogsIndexPattern`. (8.16)
+.Deprecated the Observability AI Assistant specific advanced setting `observability:aiAssistantLogsIndexPattern`. (8.16)
 [%collapsible]
 ====
 *Details* +
 The Observability AI Assistant specific advanced setting for Logs index patterns `observability:aiAssistantLogsIndexPattern` is deprecated and no longer used. The AI Assistant will now use the existing **Log sources** setting `observability:logSources` instead. For more information, refer to ({kibana-pull}192003[#192003]).
-
-//*Impact* +
-//!!TODO!!
 ====
 
 [discrete]
 [[deprecation-194519]]
-* The Logs Stream was hidden by default in favor of the Logs Explorer app. (8.16)
+.The Logs Stream was hidden by default in favor of the Logs Explorer app. (8.16)
 [%collapsible]
 ====
 *Details* +


### PR DESCRIPTION
This PR fixes some formatting in the release notes and upgrade notes

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->