### PR TITLE
[ci] Skip intermediate builds

### DIFF
--- a/.buildkite/pipeline-resource-definitions/_templates/_new_pipeline.yml
+++ b/.buildkite/pipeline-resource-definitions/_templates/_new_pipeline.yml
@@ -44,7 +44,6 @@ spec:
       repository: elastic/kibana
       # Point to a pipeline implementation, detailing the pipeline steps to run
       pipeline_file: .buildkite/pipelines/your-pipeline-name.yml
-      skip_intermediate_builds: false
       provider_settings:
         prefix_pull_request_fork_branch_names: false
         skip_pull_request_builds_for_existing_commits: true

--- a/.buildkite/pipeline-resource-definitions/kibana-api-docs.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-api-docs.yml
@@ -27,7 +27,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/build_api_docs.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-apis-capacity-testing-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-apis-capacity-testing-daily.yml
@@ -27,7 +27,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/scalability/api_capacity_testing_daily.yml
-      skip_intermediate_builds: false
       provider_settings:
         trigger_mode: none
         build_branches: true

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-snapshot.yml
@@ -25,7 +25,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/artifacts.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-staging.yml
@@ -25,7 +25,6 @@ spec:
       allow_rebuilds: true
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/artifacts.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-artifacts-trigger.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-artifacts-trigger.yml
@@ -26,7 +26,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/artifacts_trigger.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-chrome-forward-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-chrome-forward-testing.yml
@@ -27,7 +27,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/chrome_forward_testing.yml
-      skip_intermediate_builds: true
       provider_settings:
         prefix_pull_request_fork_branch_names: false
         skip_pull_request_builds_for_existing_commits: true

--- a/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-coverage-daily.yml
@@ -29,7 +29,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/code_coverage/daily.yml
-      skip_intermediate_builds: false
       provider_settings:
         prefix_pull_request_fork_branch_names: false
         skip_pull_request_builds_for_existing_commits: true

--- a/.buildkite/pipeline-resource-definitions/kibana-deploy-project.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-deploy-project.yml
@@ -26,7 +26,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/serverless_deployment/project-build-and-deploy-pr.yml
-      skip_intermediate_builds: true
       provider_settings:
         build_pull_requests: true
         prefix_pull_request_fork_branch_names: false

--- a/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing.yml
@@ -27,7 +27,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_forward.yml # Note: this file exists in 7.17 only
-      skip_intermediate_builds: false
       provider_settings:
         prefix_pull_request_fork_branch_names: false
         trigger_mode: none

--- a/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-serverless-snapshots.yml
@@ -28,7 +28,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
@@ -26,7 +26,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/build.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false
@@ -96,7 +95,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/promote.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false
@@ -146,7 +144,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/verify.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-esql-grammar-sync.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-esql-grammar-sync.yml
@@ -26,7 +26,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/esql_grammar_sync.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-flaky.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-flaky.yml
@@ -22,7 +22,6 @@ spec:
       default_branch: refs/pull/INSERT_PR_NUMBER/head
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/flaky_tests/pipeline.sh
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: true
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-fleet-packages-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-fleet-packages-daily.yml
@@ -26,7 +26,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/fleet/packages_daily.yml
-      skip_intermediate_builds: false
       provider_settings:
         trigger_mode: none
         publish_commit_status: false

--- a/.buildkite/pipeline-resource-definitions/kibana-performance-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-performance-daily.yml
@@ -27,7 +27,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/performance/daily.yml
-      skip_intermediate_builds: false
       provider_settings:
         trigger_mode: none
         build_branches: true

--- a/.buildkite/pipeline-resource-definitions/kibana-pr.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-pr.yml
@@ -29,7 +29,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/scripts/pipelines/pull_request/pipeline.sh
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: true

--- a/.buildkite/pipeline-resource-definitions/kibana-purge-cloud-deployments.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-purge-cloud-deployments.yml
@@ -26,7 +26,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/purge_cloud_deployments.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release-testing.yml
@@ -26,7 +26,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_serverless/emergency_release_branch_testing.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: true
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-serverless-release.yml
@@ -23,7 +23,6 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       default_branch: main
       allow_rebuilds: false
-      skip_intermediate_builds: false
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/serverless_deployment/run_serverless_release_assistant.yml
       provider_settings:

--- a/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
@@ -24,7 +24,6 @@ spec:
       default_branch: main
       repository: elastic/ci-agent-images
       pipeline_file: vm-images/.buildkite/pipeline.yml
-      skip_intermediate_builds: false
       provider_settings:
         trigger_mode: none
       schedules:

--- a/.buildkite/pipeline-resource-definitions/scalability_testing-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/scalability_testing-daily.yml
@@ -27,7 +27,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/scalability/daily.yml
-      skip_intermediate_builds: false
       provider_settings:
         trigger_mode: none
         build_branches: true

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-defend-workflows.yml
@@ -17,7 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_defend_workflows.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-detection-engine.yml
@@ -17,7 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_detection_engine.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-entity-analytics.yml
@@ -17,7 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_entity_analytics.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-explore.yml
@@ -17,7 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_explore.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-gen-ai.yml
@@ -17,7 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_gen_ai.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-investigations.yml
@@ -17,7 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_investigations.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
+++ b/.buildkite/pipeline-resource-definitions/security-solution-quality-gate/kibana-serverless-security-solution-quality-gate-rule-management.yml
@@ -17,7 +17,6 @@ spec:
     spec:
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/security_solution_quality_gate/mki_security_solution_rule_management.yml
-      skip_intermediate_builds: false
       provider_settings:
         build_branches: false
         build_pull_requests: false

--- a/.buildkite/pipeline-resource-definitions/trigger-version-dependent-jobs.yml
+++ b/.buildkite/pipeline-resource-definitions/trigger-version-dependent-jobs.yml
@@ -31,7 +31,6 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/scripts/pipelines/trigger_version_dependent_jobs/pipeline.sh
-      skip_intermediate_builds: false
       provider_settings:
         prefix_pull_request_fork_branch_names: false
         skip_pull_request_builds_for_existing_commits: true


### PR DESCRIPTION
Removes intermediate builds from all pipelines except on-merge or pipelines triggered from on-merge.

https://registry.terraform.io/providers/buildkite/buildkite/1.0.0-docs/docs/resources/pipeline#skip_intermediate_builds-1
> (Boolean) Whether to skip queued builds if a new commit is pushed to a matching branch.

e.g. push several commits to a pull request before the first build has started and CI will run for each commit.