### PR TITLE
[Cloud Security] Add AWS account credentials for the Agentless tests in Serverless Quality Gates 

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
@@ -41,6 +41,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it(`should create agentless-agent`, async () => {
+      if (process.env.TEST_CLOUD) {
+        expect(process.env.CSPM_AWS_ACCOUNT_ID).to.be.ok();
+        expect(process.env.CSPM_AWS_SECRET_KEY).to.be.ok();
+      }
+
       const integrationPolicyName = `cloud_security_posture-${new Date().toISOString()}`;
       await cisIntegration.navigateToAddIntegrationCspmWithVersionPage(
         CLOUD_CREDENTIALS_PACKAGE_VERSION
@@ -53,6 +58,22 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       await cisIntegration.selectSetupTechnology('agentless');
       await cisIntegration.selectAwsCredentials('direct');
+
+      if (
+        process.env.TEST_CLOUD &&
+        process.env.CSPM_AWS_ACCOUNT_ID &&
+        process.env.CSPM_AWS_SECRET_KEY
+      ) {
+        await cisIntegration.fillInTextField(
+          cisIntegration.testSubjectIds.DIRECT_ACCESS_KEY_ID_TEST_ID,
+          process.env.CSPM_AWS_ACCOUNT_ID
+        );
+
+        await cisIntegration.fillInTextField(
+          cisIntegration.testSubjectIds.DIRECT_ACCESS_SECRET_KEY_TEST_ID,
+          process.env.CSPM_AWS_SECRET_KEY
+        );
+      }
 
       await pageObjects.header.waitUntilLoadingHasFinished();
 

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { CLOUD_CREDENTIALS_PACKAGE_VERSION } from '@kbn/cloud-security-posture-plugin/common/constants';
 import * as http from 'http';
 import expect from '@kbn/expect';
 import { setupMockServer } from './mock_agentless_api';
@@ -40,13 +41,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it(`should create agentless-agent`, async () => {
-      if (process.env.TEST_CLOUD) {
-        // If the test is running in the Serverless Quality Gates
-        // expect that the Vault secrets were added to the environment
-        expect(process.env.CSPM_AWS_ACCOUNT_ID).to.be.ok();
-        expect(process.env.CSPM_AWS_SECRET_KEY).to.be.ok();
-      }
-
       const integrationPolicyName = `cloud_security_posture-${new Date().toISOString()}`;
       await cisIntegration.navigateToAddIntegrationCspmWithVersionPage(
         CLOUD_CREDENTIALS_PACKAGE_VERSION

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
@@ -41,6 +41,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
     it(`should create agentless-agent`, async () => {
       if (process.env.TEST_CLOUD) {
+        // If the test is running in the Serverless Quality Gates
+        // expect that the Vault secrets were added to the environment
         expect(process.env.CSPM_AWS_ACCOUNT_ID).to.be.ok();
         expect(process.env.CSPM_AWS_SECRET_KEY).to.be.ok();
       }

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { CLOUD_CREDENTIALS_PACKAGE_VERSION } from '@kbn/cloud-security-posture-plugin/common/constants';
 import * as http from 'http';
 import expect from '@kbn/expect';
 import { setupMockServer } from './mock_agentless_api';


### PR DESCRIPTION
## Summary

Added the use the AWS credentials to create an agentless agent in MKI when the test is running in the Serverless Quality Gates 


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->