### PR TITLE
[OpenAPI][Fleet] Add missing operation summaries

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -5628,7 +5628,6 @@
     },
     "/api/fleet/agent_download_sources": {
       "get": {
-        "description": "List agent binary download sources",
         "operationId": "get-fleet-agent-download-sources",
         "parameters": [
           {
@@ -5731,13 +5730,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agent binary download sources",
         "tags": [
           "Elastic Agent binary download sources"
         ]
       },
       "post": {
-        "description": "Create agent binary download source",
         "operationId": "post-fleet-agent-download-sources",
         "parameters": [
           {
@@ -5870,7 +5868,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create an agent binary download source",
         "tags": [
           "Elastic Agent binary download sources"
         ]
@@ -5878,7 +5876,7 @@
     },
     "/api/fleet/agent_download_sources/{sourceId}": {
       "delete": {
-        "description": "Delete agent binary download source by ID",
+        "description": "Delete an agent binary download source by ID.",
         "operationId": "delete-fleet-agent-download-sources-sourceid",
         "parameters": [
           {
@@ -5957,13 +5955,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete an agent binary download source",
         "tags": [
           "Elastic Agent binary download sources"
         ]
       },
       "get": {
-        "description": "Get agent binary download source by ID",
+        "description": "Get an agent binary download source by ID.",
         "operationId": "get-fleet-agent-download-sources-sourceid",
         "parameters": [
           {
@@ -6059,13 +6057,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an agent binary download source",
         "tags": [
           "Elastic Agent binary download sources"
         ]
       },
       "put": {
-        "description": "Update agent binary download source by ID",
+        "description": "Update an agent binary download source by ID.",
         "operationId": "put-fleet-agent-download-sources-sourceid",
         "parameters": [
           {
@@ -6206,7 +6204,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update an agent binary download source",
         "tags": [
           "Elastic Agent binary download sources"
         ]
@@ -6214,7 +6212,6 @@
     },
     "/api/fleet/agent_policies": {
       "get": {
-        "description": "List agent policies",
         "operationId": "get-fleet-agent-policies",
         "parameters": [
           {
@@ -7046,13 +7043,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agent policies",
         "tags": [
           "Elastic Agent policies"
         ]
       },
       "post": {
-        "description": "Create an agent policy",
         "operationId": "post-fleet-agent-policies",
         "parameters": [
           {
@@ -8039,7 +8035,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -8047,7 +8043,6 @@
     },
     "/api/fleet/agent_policies/_bulk_get": {
       "post": {
-        "description": "Bulk get agent policies",
         "operationId": "post-fleet-agent-policies-bulk-get",
         "parameters": [
           {
@@ -8826,7 +8821,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk get agent policies",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -8834,7 +8829,7 @@
     },
     "/api/fleet/agent_policies/delete": {
       "post": {
-        "description": "Delete agent policy by ID",
+        "description": "Delete an agent policy by ID.",
         "operationId": "post-fleet-agent-policies-delete",
         "parameters": [
           {
@@ -8931,7 +8926,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -8939,7 +8934,7 @@
     },
     "/api/fleet/agent_policies/outputs": {
       "post": {
-        "description": "Get list of outputs associated with agent policies",
+        "description": "Get a list of outputs associated with agent policies.",
         "operationId": "post-fleet-agent-policies-outputs",
         "parameters": [
           {
@@ -9116,7 +9111,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get outputs for agent policies",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -9124,7 +9119,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}": {
       "get": {
-        "description": "Get an agent policy by ID",
+        "description": "Get an agent policy by ID.",
         "operationId": "get-fleet-agent-policies-agentpolicyid",
         "parameters": [
           {
@@ -9869,13 +9864,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
       },
       "put": {
-        "description": "Update an agent policy by ID",
+        "description": "Update an agent policy by ID.",
         "operationId": "put-fleet-agent-policies-agentpolicyid",
         "parameters": [
           {
@@ -10874,7 +10869,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -10882,7 +10877,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/copy": {
       "post": {
-        "description": "Copy an agent policy by ID",
+        "description": "Copy an agent policy by ID.",
         "operationId": "post-fleet-agent-policies-agentpolicyid-copy",
         "parameters": [
           {
@@ -11659,7 +11654,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Copy an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -11667,7 +11662,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/download": {
       "get": {
-        "description": "Download an agent policy by ID",
+        "description": "Download an agent policy by ID.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-download",
         "parameters": [
           {
@@ -11776,7 +11771,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Download an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -11784,7 +11779,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/full": {
       "get": {
-        "description": "Get a full agent policy by ID",
+        "description": "Get a full agent policy by ID.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-full",
         "parameters": [
           {
@@ -12278,7 +12273,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a full agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -12286,7 +12281,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/outputs": {
       "get": {
-        "description": "Get list of outputs associated with agent policy by policy id",
+        "description": "Get a list of outputs associated with agent policy by policy id.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-outputs",
         "parameters": [
           {
@@ -12436,7 +12431,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get outputs for an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -12444,7 +12439,6 @@
     },
     "/api/fleet/agent_status": {
       "get": {
-        "description": "Get agent status summary",
         "operationId": "get-fleet-agent-status",
         "parameters": [
           {
@@ -12584,7 +12578,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an agent status summary",
         "tags": [
           "Elastic Agent status"
         ]
@@ -12592,7 +12586,6 @@
     },
     "/api/fleet/agent_status/data": {
       "get": {
-        "description": "Get incoming agent data",
         "operationId": "get-fleet-agent-status-data",
         "parameters": [
           {
@@ -12700,7 +12693,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get incoming agent data",
         "tags": [
           "Elastic Agents"
         ]
@@ -12708,7 +12701,6 @@
     },
     "/api/fleet/agents": {
       "get": {
-        "description": "List agents",
         "operationId": "get-fleet-agents",
         "parameters": [
           {
@@ -13253,13 +13245,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agents",
         "tags": [
           "Elastic Agents"
         ]
       },
       "post": {
-        "description": "List agents by action ids",
         "operationId": "post-fleet-agents",
         "parameters": [
           {
@@ -13354,7 +13345,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agents by action ids",
         "tags": [
           "Elastic Agents"
         ]
@@ -13362,7 +13353,6 @@
     },
     "/api/fleet/agents/action_status": {
       "get": {
-        "description": "Get agent action status",
         "operationId": "get-fleet-agents-action-status",
         "parameters": [
           {
@@ -13590,7 +13580,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an agent action status",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -13598,7 +13588,6 @@
     },
     "/api/fleet/agents/actions/{actionId}/cancel": {
       "post": {
-        "description": "Cancel agent action",
         "operationId": "post-fleet-agents-actions-actionid-cancel",
         "parameters": [
           {
@@ -13732,7 +13721,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Cancel an agent action",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -13740,7 +13729,6 @@
     },
     "/api/fleet/agents/available_versions": {
       "get": {
-        "description": "Get available agent versions",
         "operationId": "get-fleet-agents-available-versions",
         "parameters": [
           {
@@ -13804,7 +13792,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get available agent versions",
         "tags": [
           "Elastic Agents"
         ]
@@ -13812,7 +13800,6 @@
     },
     "/api/fleet/agents/bulk_reassign": {
       "post": {
-        "description": "Bulk reassign agents",
         "operationId": "post-fleet-agents-bulk-reassign",
         "parameters": [
           {
@@ -13922,7 +13909,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk reassign agents",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -13930,7 +13917,6 @@
     },
     "/api/fleet/agents/bulk_request_diagnostics": {
       "post": {
-        "description": "Bulk request diagnostics from agents",
         "operationId": "post-fleet-agents-bulk-request-diagnostics",
         "parameters": [
           {
@@ -14041,7 +14027,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk request diagnostics from agents",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -14049,7 +14035,6 @@
     },
     "/api/fleet/agents/bulk_unenroll": {
       "post": {
-        "description": "Bulk unenroll agents",
         "operationId": "post-fleet-agents-bulk-unenroll",
         "parameters": [
           {
@@ -14165,7 +14150,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk unenroll agents",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -14173,7 +14158,6 @@
     },
     "/api/fleet/agents/bulk_update_agent_tags": {
       "post": {
-        "description": "Bulk update agent tags",
         "operationId": "post-fleet-agents-bulk-update-agent-tags",
         "parameters": [
           {
@@ -14291,7 +14275,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk update agent tags",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -14299,7 +14283,6 @@
     },
     "/api/fleet/agents/bulk_upgrade": {
       "post": {
-        "description": "Bulk upgrade agents",
         "operationId": "post-fleet-agents-bulk-upgrade",
         "parameters": [
           {
@@ -14425,7 +14408,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk upgrade agents",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -14433,7 +14416,7 @@
     },
     "/api/fleet/agents/files/{fileId}": {
       "delete": {
-        "description": "Delete file uploaded by agent",
+        "description": "Delete a file uploaded by an agent.",
         "operationId": "delete-fleet-agents-files-fileid",
         "parameters": [
           {
@@ -14516,7 +14499,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete an uploaded file",
         "tags": [
           "Elastic Agents"
         ]
@@ -14524,7 +14507,7 @@
     },
     "/api/fleet/agents/files/{fileId}/{fileName}": {
       "get": {
-        "description": "Get file uploaded by agent",
+        "description": "Get a file uploaded by an agent.",
         "operationId": "get-fleet-agents-files-fileid-filename",
         "parameters": [
           {
@@ -14592,7 +14575,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an uploaded file",
         "tags": [
           "Elastic Agents"
         ]
@@ -14600,7 +14583,6 @@
     },
     "/api/fleet/agents/setup": {
       "get": {
-        "description": "Get agent setup info",
         "operationId": "get-fleet-agents-setup",
         "parameters": [
           {
@@ -14695,13 +14677,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agent setup info",
         "tags": [
           "Elastic Agents"
         ]
       },
       "post": {
-        "description": "Initiate agent setup",
         "operationId": "post-fleet-agents-setup",
         "parameters": [
           {
@@ -14793,7 +14774,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Initiate agent setup",
         "tags": [
           "Elastic Agents"
         ]
@@ -14801,7 +14782,6 @@
     },
     "/api/fleet/agents/tags": {
       "get": {
-        "description": "List agent tags",
         "operationId": "get-fleet-agents-tags",
         "parameters": [
           {
@@ -14882,7 +14862,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agent tags",
         "tags": [
           "Elastic Agents"
         ]
@@ -14890,7 +14870,7 @@
     },
     "/api/fleet/agents/{agentId}": {
       "delete": {
-        "description": "Delete agent by ID",
+        "description": "Delete an agent by ID.",
         "operationId": "delete-fleet-agents-agentid",
         "parameters": [
           {
@@ -14972,13 +14952,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete an agent",
         "tags": [
           "Elastic Agents"
         ]
       },
       "get": {
-        "description": "Get agent by ID",
+        "description": "Get an agent by ID.",
         "operationId": "get-fleet-agents-agentid",
         "parameters": [
           {
@@ -15437,13 +15417,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an agent",
         "tags": [
           "Elastic Agents"
         ]
       },
       "put": {
-        "description": "Update agent by ID",
+        "description": "Update an agent by ID.",
         "operationId": "put-fleet-agents-agentid",
         "parameters": [
           {
@@ -15925,7 +15905,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update an agent",
         "tags": [
           "Elastic Agents"
         ]
@@ -15933,7 +15913,6 @@
     },
     "/api/fleet/agents/{agentId}/actions": {
       "post": {
-        "description": "Create agent action",
         "operationId": "post-fleet-agents-agentid-actions",
         "parameters": [
           {
@@ -16142,7 +16121,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create an agent action",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -16150,7 +16129,6 @@
     },
     "/api/fleet/agents/{agentId}/reassign": {
       "post": {
-        "description": "Reassign agent",
         "operationId": "post-fleet-agents-agentid-reassign",
         "parameters": [
           {
@@ -16240,7 +16218,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Reassign an agent",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -16248,7 +16226,6 @@
     },
     "/api/fleet/agents/{agentId}/request_diagnostics": {
       "post": {
-        "description": "Request agent diagnostics",
         "operationId": "post-fleet-agents-agentid-request-diagnostics",
         "parameters": [
           {
@@ -16349,7 +16326,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Request agent diagnostics",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -16357,7 +16334,6 @@
     },
     "/api/fleet/agents/{agentId}/unenroll": {
       "post": {
-        "description": "Unenroll agent",
         "operationId": "post-fleet-agents-agentid-unenroll",
         "parameters": [
           {
@@ -16411,7 +16387,7 @@
           }
         },
         "responses": {},
-        "summary": "",
+        "summary": "Unenroll an agent",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -16419,7 +16395,6 @@
     },
     "/api/fleet/agents/{agentId}/upgrade": {
       "post": {
-        "description": "Upgrade agent",
         "operationId": "post-fleet-agents-agentid-upgrade",
         "parameters": [
           {
@@ -16518,7 +16493,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Upgrade an agent",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -16526,7 +16501,6 @@
     },
     "/api/fleet/agents/{agentId}/uploads": {
       "get": {
-        "description": "List agent uploads",
         "operationId": "get-fleet-agents-agentid-uploads",
         "parameters": [
           {
@@ -16638,7 +16612,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agent uploads",
         "tags": [
           "Elastic Agents"
         ]
@@ -16646,7 +16620,6 @@
     },
     "/api/fleet/check-permissions": {
       "get": {
-        "description": "Check permissions",
         "operationId": "get-fleet-check-permissions",
         "parameters": [
           {
@@ -16723,7 +16696,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Check permissions",
         "tags": [
           "Fleet internals"
         ]
@@ -16731,7 +16704,6 @@
     },
     "/api/fleet/data_streams": {
       "get": {
-        "description": "List data streams",
         "operationId": "get-fleet-data-streams",
         "parameters": [
           {
@@ -16881,7 +16853,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get data streams",
         "tags": [
           "Data streams"
         ]
@@ -16889,7 +16861,6 @@
     },
     "/api/fleet/enrollment_api_keys": {
       "get": {
-        "description": "List enrollment API keys",
         "operationId": "get-fleet-enrollment-api-keys",
         "parameters": [
           {
@@ -17027,13 +16998,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get enrollment API keys",
         "tags": [
           "Fleet enrollment API keys"
         ]
       },
       "post": {
-        "description": "Create enrollment API key",
         "operationId": "post-fleet-enrollment-api-keys",
         "parameters": [
           {
@@ -17171,7 +17141,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create an enrollment API key",
         "tags": [
           "Fleet enrollment API keys"
         ]
@@ -17179,7 +17149,7 @@
     },
     "/api/fleet/enrollment_api_keys/{keyId}": {
       "delete": {
-        "description": "Revoke enrollment API key by ID by marking it as inactive",
+        "description": "Revoke an enrollment API key by ID by marking it as inactive.",
         "operationId": "delete-fleet-enrollment-api-keys-keyid",
         "parameters": [
           {
@@ -17261,13 +17231,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Revoke an enrollment API key",
         "tags": [
           "Fleet enrollment API keys"
         ]
       },
       "get": {
-        "description": "Get enrollment API key by ID",
+        "description": "Get an enrollment API key by ID.",
         "operationId": "get-fleet-enrollment-api-keys-keyid",
         "parameters": [
           {
@@ -17372,7 +17342,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an enrollment API key",
         "tags": [
           "Fleet enrollment API keys"
         ]
@@ -17380,7 +17350,6 @@
     },
     "/api/fleet/epm/bulk_assets": {
       "post": {
-        "description": "Bulk get assets",
         "operationId": "post-fleet-epm-bulk-assets",
         "parameters": [
           {
@@ -17523,7 +17492,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk get assets",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -17531,7 +17500,6 @@
     },
     "/api/fleet/epm/categories": {
       "get": {
-        "description": "List package categories",
         "operationId": "get-fleet-epm-categories",
         "parameters": [
           {
@@ -17634,7 +17602,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get package categories",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -17642,7 +17610,6 @@
     },
     "/api/fleet/epm/custom_integrations": {
       "post": {
-        "description": "Create custom integration",
         "operationId": "post-fleet-epm-custom-integrations",
         "parameters": [
           {
@@ -17843,7 +17810,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create a custom integration",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -17851,7 +17818,6 @@
     },
     "/api/fleet/epm/data_streams": {
       "get": {
-        "description": "List data streams",
         "operationId": "get-fleet-epm-data-streams",
         "parameters": [
           {
@@ -17969,7 +17935,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get data streams",
         "tags": [
           "Data streams"
         ]
@@ -17977,7 +17943,6 @@
     },
     "/api/fleet/epm/packages": {
       "get": {
-        "description": "List packages",
         "operationId": "get-fleet-epm-packages",
         "parameters": [
           {
@@ -18543,13 +18508,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get packages",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
       },
       "post": {
-        "description": "Install package by upload",
         "operationId": "post-fleet-epm-packages",
         "parameters": [
           {
@@ -18730,7 +18694,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Install a package by upload",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -18738,7 +18702,6 @@
     },
     "/api/fleet/epm/packages/_bulk": {
       "post": {
-        "description": "Bulk install packages",
         "operationId": "post-fleet-epm-packages-bulk",
         "parameters": [
           {
@@ -19008,7 +18971,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk install packages",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -19016,7 +18979,6 @@
     },
     "/api/fleet/epm/packages/installed": {
       "get": {
-        "description": "Get installed packages",
         "operationId": "get-fleet-epm-packages-installed",
         "parameters": [
           {
@@ -19249,7 +19211,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get installed packages",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -19257,7 +19219,6 @@
     },
     "/api/fleet/epm/packages/limited": {
       "get": {
-        "description": "Get limited package list",
         "operationId": "get-fleet-epm-packages-limited",
         "parameters": [
           {
@@ -19321,7 +19282,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a limited package list",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -19329,7 +19290,6 @@
     },
     "/api/fleet/epm/packages/{pkgName}/stats": {
       "get": {
-        "description": "Get package stats",
         "operationId": "get-fleet-epm-packages-pkgname-stats",
         "parameters": [
           {
@@ -19407,7 +19367,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get package stats",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -19415,7 +19375,6 @@
     },
     "/api/fleet/epm/packages/{pkgName}/{pkgVersion}": {
       "delete": {
-        "description": "Delete package",
         "operationId": "delete-fleet-epm-packages-pkgname-pkgversion",
         "parameters": [
           {
@@ -19579,13 +19538,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete a package",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
       },
       "get": {
-        "description": "Get package",
         "operationId": "get-fleet-epm-packages-pkgname-pkgversion",
         "parameters": [
           {
@@ -20271,13 +20229,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a package",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
       },
       "post": {
-        "description": "Install package from registry",
         "operationId": "post-fleet-epm-packages-pkgname-pkgversion",
         "parameters": [
           {
@@ -20493,13 +20450,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Install a package from the registry",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
       },
       "put": {
-        "description": "Update package settings",
         "operationId": "put-fleet-epm-packages-pkgname-pkgversion",
         "parameters": [
           {
@@ -21168,7 +21124,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update package settings",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -21176,7 +21132,6 @@
     },
     "/api/fleet/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize": {
       "post": {
-        "description": "Authorize transforms",
         "operationId": "post-fleet-epm-packages-pkgname-pkgversion-transforms-authorize",
         "parameters": [
           {
@@ -21312,7 +21267,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Authorize transforms",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -21320,7 +21275,6 @@
     },
     "/api/fleet/epm/packages/{pkgName}/{pkgVersion}/{filePath*}": {
       "get": {
-        "description": "Get package file",
         "operationId": "get-fleet-epm-packages-pkgname-pkgversion-filepath",
         "parameters": [
           {
@@ -21394,7 +21348,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a package file",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -21402,7 +21356,6 @@
     },
     "/api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs": {
       "get": {
-        "description": "Get inputs template",
         "operationId": "get-fleet-epm-templates-pkgname-pkgversion-inputs",
         "parameters": [
           {
@@ -21563,7 +21516,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an inputs template",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -21571,7 +21524,6 @@
     },
     "/api/fleet/epm/verification_key_id": {
       "get": {
-        "description": "Get a package signature verification key ID",
         "operationId": "get-fleet-epm-verification-key-id",
         "parameters": [
           {
@@ -21633,7 +21585,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a package signature verification key ID",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -21641,7 +21593,6 @@
     },
     "/api/fleet/fleet_server_hosts": {
       "get": {
-        "description": "List Fleet Server hosts",
         "operationId": "get-fleet-fleet-server-hosts",
         "parameters": [
           {
@@ -21753,13 +21704,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get Fleet Server hosts",
         "tags": [
           "Fleet Server hosts"
         ]
       },
       "post": {
-        "description": "Create Fleet Server host",
         "operationId": "post-fleet-fleet-server-hosts",
         "parameters": [
           {
@@ -21910,7 +21860,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create a Fleet Server host",
         "tags": [
           "Fleet Server hosts"
         ]
@@ -21918,7 +21868,7 @@
     },
     "/api/fleet/fleet_server_hosts/{itemId}": {
       "delete": {
-        "description": "Delete Fleet Server host by ID",
+        "description": "Delete a Fleet Server host by ID.",
         "operationId": "delete-fleet-fleet-server-hosts-itemid",
         "parameters": [
           {
@@ -21997,13 +21947,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete a Fleet Server host",
         "tags": [
           "Fleet Server hosts"
         ]
       },
       "get": {
-        "description": "Get Fleet Server host by ID",
+        "description": "Get a Fleet Server host by ID.",
         "operationId": "get-fleet-fleet-server-hosts-itemid",
         "parameters": [
           {
@@ -22108,13 +22058,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a Fleet Server host",
         "tags": [
           "Fleet Server hosts"
         ]
       },
       "put": {
-        "description": "Update Fleet Server host by ID",
+        "description": "Update a Fleet Server host by ID.",
         "operationId": "put-fleet-fleet-server-hosts-itemid",
         "parameters": [
           {
@@ -22264,7 +22214,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update a Fleet Server host",
         "tags": [
           "Fleet Server hosts"
         ]
@@ -22272,7 +22222,6 @@
     },
     "/api/fleet/health_check": {
       "post": {
-        "description": "Check Fleet Server health",
         "operationId": "post-fleet-health-check",
         "parameters": [
           {
@@ -22392,7 +22341,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Check Fleet Server health",
         "tags": [
           "Fleet internals"
         ]
@@ -22400,7 +22349,6 @@
     },
     "/api/fleet/kubernetes": {
       "get": {
-        "description": "Get full K8s agent manifest",
         "operationId": "get-fleet-kubernetes",
         "parameters": [
           {
@@ -22485,7 +22433,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a full K8s agent manifest",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -22593,7 +22541,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Download an agent manifest",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -22601,7 +22549,6 @@
     },
     "/api/fleet/logstash_api_keys": {
       "post": {
-        "description": "Generate Logstash API key",
         "operationId": "post-fleet-logstash-api-keys",
         "parameters": [
           {
@@ -22672,7 +22619,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Generate a Logstash API key",
         "tags": [
           "Fleet outputs"
         ]
@@ -22680,7 +22627,6 @@
     },
     "/api/fleet/message_signing_service/rotate_key_pair": {
       "post": {
-        "description": "Rotate fleet message signing key pair",
         "operationId": "post-fleet-message-signing-service-rotate-key-pair",
         "parameters": [
           {
@@ -22785,7 +22731,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Rotate a Fleet message signing key pair",
         "tags": [
           "Message Signing Service"
         ]
@@ -22793,7 +22739,6 @@
     },
     "/api/fleet/outputs": {
       "get": {
-        "description": "List outputs",
         "operationId": "get-fleet-outputs",
         "parameters": [
           {
@@ -23884,13 +23829,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get outputs",
         "tags": [
           "Fleet outputs"
         ]
       },
       "post": {
-        "description": "Create output",
         "operationId": "post-fleet-outputs",
         "parameters": [
           {
@@ -26000,7 +25944,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create output",
         "tags": [
           "Fleet outputs"
         ]
@@ -26008,7 +25952,7 @@
     },
     "/api/fleet/outputs/{outputId}": {
       "delete": {
-        "description": "Delete output by ID",
+        "description": "Delete output by ID.",
         "operationId": "delete-fleet-outputs-outputid",
         "parameters": [
           {
@@ -26112,13 +26056,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete output",
         "tags": [
           "Fleet outputs"
         ]
       },
       "get": {
-        "description": "Get output by ID",
+        "description": "Get output by ID.",
         "operationId": "get-fleet-outputs-outputid",
         "parameters": [
           {
@@ -27202,13 +27146,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get output",
         "tags": [
           "Fleet outputs"
         ]
       },
       "put": {
-        "description": "Update output by ID",
+        "description": "Update output by ID.",
         "operationId": "put-fleet-outputs-outputid",
         "parameters": [
           {
@@ -29302,7 +29246,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update output",
         "tags": [
           "Fleet outputs"
         ]
@@ -29310,7 +29254,6 @@
     },
     "/api/fleet/outputs/{outputId}/health": {
       "get": {
-        "description": "Get latest output health",
         "operationId": "get-fleet-outputs-outputid-health",
         "parameters": [
           {
@@ -29390,7 +29333,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get the latest output health",
         "tags": [
           "Fleet outputs"
         ]
@@ -29398,7 +29341,6 @@
     },
     "/api/fleet/package_policies": {
       "get": {
-        "description": "List package policies",
         "operationId": "get-fleet-package-policies",
         "parameters": [
           {
@@ -30107,13 +30049,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get package policies",
         "tags": [
           "Fleet package policies"
         ]
       },
       "post": {
-        "description": "Create package policy",
         "operationId": "post-fleet-package-policies",
         "parameters": [
           {
@@ -31379,7 +31320,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create a package policy",
         "tags": [
           "Fleet package policies"
         ]
@@ -31387,7 +31328,6 @@
     },
     "/api/fleet/package_policies/_bulk_get": {
       "post": {
-        "description": "Bulk get package policies",
         "operationId": "post-fleet-package-policies-bulk-get",
         "parameters": [
           {
@@ -32077,7 +32017,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk get package policies",
         "tags": [
           "Fleet package policies"
         ]
@@ -32085,7 +32025,6 @@
     },
     "/api/fleet/package_policies/delete": {
       "post": {
-        "description": "Bulk delete package policies",
         "operationId": "post-fleet-package-policies-delete",
         "parameters": [
           {
@@ -32281,7 +32220,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk delete package policies",
         "tags": [
           "Fleet package policies"
         ]
@@ -32289,7 +32228,7 @@
     },
     "/api/fleet/package_policies/upgrade": {
       "post": {
-        "description": "Upgrade package policy to a newer package version",
+        "description": "Upgrade a package policy to a newer package version.",
         "operationId": "post-fleet-package-policies-upgrade",
         "parameters": [
           {
@@ -32406,7 +32345,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Upgrade a package policy",
         "tags": [
           "Fleet package policies"
         ]
@@ -32414,7 +32353,6 @@
     },
     "/api/fleet/package_policies/upgrade/dryrun": {
       "post": {
-        "description": "Dry run package policy upgrade",
         "operationId": "post-fleet-package-policies-upgrade-dryrun",
         "parameters": [
           {
@@ -33592,7 +33530,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Dry run a package policy upgrade",
         "tags": [
           "Fleet package policies"
         ]
@@ -33600,7 +33538,7 @@
     },
     "/api/fleet/package_policies/{packagePolicyId}": {
       "delete": {
-        "description": "Delete package policy by ID",
+        "description": "Delete a package policy by ID.",
         "operationId": "delete-fleet-package-policies-packagepolicyid",
         "parameters": [
           {
@@ -33687,13 +33625,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete a package policy",
         "tags": [
           "Fleet package policies"
         ]
       },
       "get": {
-        "description": "Get package policy by ID",
+        "description": "Get a package policy by ID.",
         "operationId": "get-fleet-package-policies-packagepolicyid",
         "parameters": [
           {
@@ -34353,13 +34291,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a package policy",
         "tags": [
           "Fleet package policies"
         ]
       },
       "put": {
-        "description": "Update package policy by ID",
+        "description": "Update a package policy by ID.",
         "operationId": "put-fleet-package-policies-packagepolicyid",
         "parameters": [
           {
@@ -35625,7 +35563,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update a package policy",
         "tags": [
           "Fleet package policies"
         ]
@@ -35633,7 +35571,6 @@
     },
     "/api/fleet/proxies": {
       "get": {
-        "description": "List proxies",
         "operationId": "get-fleet-proxies",
         "parameters": [
           {
@@ -35759,13 +35696,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get proxies",
         "tags": [
           "Fleet proxies"
         ]
       },
       "post": {
-        "description": "Create proxy",
         "operationId": "post-fleet-proxies",
         "parameters": [
           {
@@ -35944,7 +35880,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create a proxy",
         "tags": [
           "Fleet proxies"
         ]
@@ -35952,7 +35888,7 @@
     },
     "/api/fleet/proxies/{itemId}": {
       "delete": {
-        "description": "Delete proxy by ID",
+        "description": "Delete a proxy by ID",
         "operationId": "delete-fleet-proxies-itemid",
         "parameters": [
           {
@@ -36031,13 +35967,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete a proxy",
         "tags": [
           "Fleet proxies"
         ]
       },
       "get": {
-        "description": "Get proxy by ID",
+        "description": "Get a proxy by ID.",
         "operationId": "get-fleet-proxies-itemid",
         "parameters": [
           {
@@ -36156,13 +36092,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a proxy",
         "tags": [
           "Fleet proxies"
         ]
       },
       "put": {
-        "description": "Update proxy by ID",
+        "description": "Update a proxy by ID.",
         "operationId": "put-fleet-proxies-itemid",
         "parameters": [
           {
@@ -36344,7 +36280,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update a proxy",
         "tags": [
           "Fleet proxies"
         ]
@@ -36352,7 +36288,6 @@
     },
     "/api/fleet/service_tokens": {
       "post": {
-        "description": "Create a service token",
         "operationId": "post-fleet-service-tokens",
         "parameters": [
           {
@@ -36444,7 +36379,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create a service token",
         "tags": [
           "Fleet service tokens"
         ]
@@ -36452,7 +36387,6 @@
     },
     "/api/fleet/settings": {
       "get": {
-        "description": "Get settings",
         "operationId": "get-fleet-settings",
         "parameters": [
           {
@@ -36591,13 +36525,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get settings",
         "tags": [
           "Fleet internals"
         ]
       },
       "put": {
-        "description": "Update settings",
         "operationId": "put-fleet-settings",
         "parameters": [
           {
@@ -36793,7 +36726,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update settings",
         "tags": [
           "Fleet internals"
         ]
@@ -36801,7 +36734,6 @@
     },
     "/api/fleet/setup": {
       "post": {
-        "description": "Initiate Fleet setup",
         "operationId": "post-fleet-setup",
         "parameters": [
           {
@@ -36912,7 +36844,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Initiate Fleet setup",
         "tags": [
           "Fleet internals"
         ]
@@ -36920,7 +36852,7 @@
     },
     "/api/fleet/uninstall_tokens": {
       "get": {
-        "description": "List metadata for latest uninstall tokens per agent policy",
+        "description": "List the metadata for the latest uninstall tokens per agent policy.",
         "operationId": "get-fleet-uninstall-tokens",
         "parameters": [
           {
@@ -37061,7 +36993,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get metadata for latest uninstall tokens",
         "tags": [
           "Fleet uninstall tokens"
         ]
@@ -37069,7 +37001,7 @@
     },
     "/api/fleet/uninstall_tokens/{uninstallTokenId}": {
       "get": {
-        "description": "Get one decrypted uninstall token by its ID",
+        "description": "Get one decrypted uninstall token by its ID.",
         "operationId": "get-fleet-uninstall-tokens-uninstalltokenid",
         "parameters": [
           {
@@ -37169,7 +37101,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a decrypted uninstall token",
         "tags": [
           "Fleet uninstall tokens"
         ]

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -5628,7 +5628,6 @@
     },
     "/api/fleet/agent_download_sources": {
       "get": {
-        "description": "List agent binary download sources",
         "operationId": "get-fleet-agent-download-sources",
         "parameters": [
           {
@@ -5731,13 +5730,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agent binary download sources",
         "tags": [
           "Elastic Agent binary download sources"
         ]
       },
       "post": {
-        "description": "Create agent binary download source",
         "operationId": "post-fleet-agent-download-sources",
         "parameters": [
           {
@@ -5870,7 +5868,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create an agent binary download source",
         "tags": [
           "Elastic Agent binary download sources"
         ]
@@ -5878,7 +5876,7 @@
     },
     "/api/fleet/agent_download_sources/{sourceId}": {
       "delete": {
-        "description": "Delete agent binary download source by ID",
+        "description": "Delete an agent binary download source by ID.",
         "operationId": "delete-fleet-agent-download-sources-sourceid",
         "parameters": [
           {
@@ -5957,13 +5955,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete an agent binary download source",
         "tags": [
           "Elastic Agent binary download sources"
         ]
       },
       "get": {
-        "description": "Get agent binary download source by ID",
+        "description": "Get an agent binary download source by ID.",
         "operationId": "get-fleet-agent-download-sources-sourceid",
         "parameters": [
           {
@@ -6059,13 +6057,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an agent binary download source",
         "tags": [
           "Elastic Agent binary download sources"
         ]
       },
       "put": {
-        "description": "Update agent binary download source by ID",
+        "description": "Update an agent binary download source by ID.",
         "operationId": "put-fleet-agent-download-sources-sourceid",
         "parameters": [
           {
@@ -6206,7 +6204,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update an agent binary download source",
         "tags": [
           "Elastic Agent binary download sources"
         ]
@@ -6214,7 +6212,6 @@
     },
     "/api/fleet/agent_policies": {
       "get": {
-        "description": "List agent policies",
         "operationId": "get-fleet-agent-policies",
         "parameters": [
           {
@@ -7046,13 +7043,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agent policies",
         "tags": [
           "Elastic Agent policies"
         ]
       },
       "post": {
-        "description": "Create an agent policy",
         "operationId": "post-fleet-agent-policies",
         "parameters": [
           {
@@ -8039,7 +8035,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -8047,7 +8043,6 @@
     },
     "/api/fleet/agent_policies/_bulk_get": {
       "post": {
-        "description": "Bulk get agent policies",
         "operationId": "post-fleet-agent-policies-bulk-get",
         "parameters": [
           {
@@ -8826,7 +8821,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk get agent policies",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -8834,7 +8829,7 @@
     },
     "/api/fleet/agent_policies/delete": {
       "post": {
-        "description": "Delete agent policy by ID",
+        "description": "Delete an agent policy by ID.",
         "operationId": "post-fleet-agent-policies-delete",
         "parameters": [
           {
@@ -8931,7 +8926,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -8939,7 +8934,7 @@
     },
     "/api/fleet/agent_policies/outputs": {
       "post": {
-        "description": "Get list of outputs associated with agent policies",
+        "description": "Get a list of outputs associated with agent policies.",
         "operationId": "post-fleet-agent-policies-outputs",
         "parameters": [
           {
@@ -9116,7 +9111,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get outputs for agent policies",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -9124,7 +9119,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}": {
       "get": {
-        "description": "Get an agent policy by ID",
+        "description": "Get an agent policy by ID.",
         "operationId": "get-fleet-agent-policies-agentpolicyid",
         "parameters": [
           {
@@ -9869,13 +9864,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
       },
       "put": {
-        "description": "Update an agent policy by ID",
+        "description": "Update an agent policy by ID.",
         "operationId": "put-fleet-agent-policies-agentpolicyid",
         "parameters": [
           {
@@ -10874,7 +10869,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -10882,7 +10877,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/copy": {
       "post": {
-        "description": "Copy an agent policy by ID",
+        "description": "Copy an agent policy by ID.",
         "operationId": "post-fleet-agent-policies-agentpolicyid-copy",
         "parameters": [
           {
@@ -11659,7 +11654,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Copy an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -11667,7 +11662,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/download": {
       "get": {
-        "description": "Download an agent policy by ID",
+        "description": "Download an agent policy by ID.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-download",
         "parameters": [
           {
@@ -11776,7 +11771,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Download an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -11784,7 +11779,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/full": {
       "get": {
-        "description": "Get a full agent policy by ID",
+        "description": "Get a full agent policy by ID.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-full",
         "parameters": [
           {
@@ -12278,7 +12273,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a full agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -12286,7 +12281,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/outputs": {
       "get": {
-        "description": "Get list of outputs associated with agent policy by policy id",
+        "description": "Get a list of outputs associated with agent policy by policy id.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-outputs",
         "parameters": [
           {
@@ -12436,7 +12431,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get outputs for an agent policy",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -12444,7 +12439,6 @@
     },
     "/api/fleet/agent_status": {
       "get": {
-        "description": "Get agent status summary",
         "operationId": "get-fleet-agent-status",
         "parameters": [
           {
@@ -12584,7 +12578,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an agent status summary",
         "tags": [
           "Elastic Agent status"
         ]
@@ -12592,7 +12586,6 @@
     },
     "/api/fleet/agent_status/data": {
       "get": {
-        "description": "Get incoming agent data",
         "operationId": "get-fleet-agent-status-data",
         "parameters": [
           {
@@ -12700,7 +12693,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get incoming agent data",
         "tags": [
           "Elastic Agents"
         ]
@@ -12708,7 +12701,6 @@
     },
     "/api/fleet/agents": {
       "get": {
-        "description": "List agents",
         "operationId": "get-fleet-agents",
         "parameters": [
           {
@@ -13253,13 +13245,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agents",
         "tags": [
           "Elastic Agents"
         ]
       },
       "post": {
-        "description": "List agents by action ids",
         "operationId": "post-fleet-agents",
         "parameters": [
           {
@@ -13354,7 +13345,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agents by action ids",
         "tags": [
           "Elastic Agents"
         ]
@@ -13362,7 +13353,6 @@
     },
     "/api/fleet/agents/action_status": {
       "get": {
-        "description": "Get agent action status",
         "operationId": "get-fleet-agents-action-status",
         "parameters": [
           {
@@ -13590,7 +13580,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an agent action status",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -13598,7 +13588,6 @@
     },
     "/api/fleet/agents/actions/{actionId}/cancel": {
       "post": {
-        "description": "Cancel agent action",
         "operationId": "post-fleet-agents-actions-actionid-cancel",
         "parameters": [
           {
@@ -13732,7 +13721,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Cancel an agent action",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -13740,7 +13729,6 @@
     },
     "/api/fleet/agents/available_versions": {
       "get": {
-        "description": "Get available agent versions",
         "operationId": "get-fleet-agents-available-versions",
         "parameters": [
           {
@@ -13804,7 +13792,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get available agent versions",
         "tags": [
           "Elastic Agents"
         ]
@@ -13812,7 +13800,6 @@
     },
     "/api/fleet/agents/bulk_reassign": {
       "post": {
-        "description": "Bulk reassign agents",
         "operationId": "post-fleet-agents-bulk-reassign",
         "parameters": [
           {
@@ -13922,7 +13909,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk reassign agents",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -13930,7 +13917,6 @@
     },
     "/api/fleet/agents/bulk_request_diagnostics": {
       "post": {
-        "description": "Bulk request diagnostics from agents",
         "operationId": "post-fleet-agents-bulk-request-diagnostics",
         "parameters": [
           {
@@ -14041,7 +14027,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk request diagnostics from agents",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -14049,7 +14035,6 @@
     },
     "/api/fleet/agents/bulk_unenroll": {
       "post": {
-        "description": "Bulk unenroll agents",
         "operationId": "post-fleet-agents-bulk-unenroll",
         "parameters": [
           {
@@ -14165,7 +14150,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk unenroll agents",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -14173,7 +14158,6 @@
     },
     "/api/fleet/agents/bulk_update_agent_tags": {
       "post": {
-        "description": "Bulk update agent tags",
         "operationId": "post-fleet-agents-bulk-update-agent-tags",
         "parameters": [
           {
@@ -14291,7 +14275,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk update agent tags",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -14299,7 +14283,6 @@
     },
     "/api/fleet/agents/bulk_upgrade": {
       "post": {
-        "description": "Bulk upgrade agents",
         "operationId": "post-fleet-agents-bulk-upgrade",
         "parameters": [
           {
@@ -14425,7 +14408,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk upgrade agents",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -14433,7 +14416,7 @@
     },
     "/api/fleet/agents/files/{fileId}": {
       "delete": {
-        "description": "Delete file uploaded by agent",
+        "description": "Delete a file uploaded by an agent.",
         "operationId": "delete-fleet-agents-files-fileid",
         "parameters": [
           {
@@ -14516,7 +14499,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete an uploaded file",
         "tags": [
           "Elastic Agents"
         ]
@@ -14524,7 +14507,7 @@
     },
     "/api/fleet/agents/files/{fileId}/{fileName}": {
       "get": {
-        "description": "Get file uploaded by agent",
+        "description": "Get a file uploaded by an agent.",
         "operationId": "get-fleet-agents-files-fileid-filename",
         "parameters": [
           {
@@ -14592,7 +14575,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an uploaded file",
         "tags": [
           "Elastic Agents"
         ]
@@ -14600,7 +14583,6 @@
     },
     "/api/fleet/agents/setup": {
       "get": {
-        "description": "Get agent setup info",
         "operationId": "get-fleet-agents-setup",
         "parameters": [
           {
@@ -14695,13 +14677,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agent setup info",
         "tags": [
           "Elastic Agents"
         ]
       },
       "post": {
-        "description": "Initiate agent setup",
         "operationId": "post-fleet-agents-setup",
         "parameters": [
           {
@@ -14793,7 +14774,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Initiate agent setup",
         "tags": [
           "Elastic Agents"
         ]
@@ -14801,7 +14782,6 @@
     },
     "/api/fleet/agents/tags": {
       "get": {
-        "description": "List agent tags",
         "operationId": "get-fleet-agents-tags",
         "parameters": [
           {
@@ -14882,7 +14862,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agent tags",
         "tags": [
           "Elastic Agents"
         ]
@@ -14890,7 +14870,7 @@
     },
     "/api/fleet/agents/{agentId}": {
       "delete": {
-        "description": "Delete agent by ID",
+        "description": "Delete an agent by ID.",
         "operationId": "delete-fleet-agents-agentid",
         "parameters": [
           {
@@ -14972,13 +14952,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete an agent",
         "tags": [
           "Elastic Agents"
         ]
       },
       "get": {
-        "description": "Get agent by ID",
+        "description": "Get an agent by ID.",
         "operationId": "get-fleet-agents-agentid",
         "parameters": [
           {
@@ -15437,13 +15417,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an agent",
         "tags": [
           "Elastic Agents"
         ]
       },
       "put": {
-        "description": "Update agent by ID",
+        "description": "Update an agent by ID.",
         "operationId": "put-fleet-agents-agentid",
         "parameters": [
           {
@@ -15925,7 +15905,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update an agent",
         "tags": [
           "Elastic Agents"
         ]
@@ -15933,7 +15913,6 @@
     },
     "/api/fleet/agents/{agentId}/actions": {
       "post": {
-        "description": "Create agent action",
         "operationId": "post-fleet-agents-agentid-actions",
         "parameters": [
           {
@@ -16142,7 +16121,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create an agent action",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -16150,7 +16129,6 @@
     },
     "/api/fleet/agents/{agentId}/reassign": {
       "post": {
-        "description": "Reassign agent",
         "operationId": "post-fleet-agents-agentid-reassign",
         "parameters": [
           {
@@ -16240,7 +16218,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Reassign an agent",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -16248,7 +16226,6 @@
     },
     "/api/fleet/agents/{agentId}/request_diagnostics": {
       "post": {
-        "description": "Request agent diagnostics",
         "operationId": "post-fleet-agents-agentid-request-diagnostics",
         "parameters": [
           {
@@ -16349,7 +16326,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Request agent diagnostics",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -16357,7 +16334,6 @@
     },
     "/api/fleet/agents/{agentId}/unenroll": {
       "post": {
-        "description": "Unenroll agent",
         "operationId": "post-fleet-agents-agentid-unenroll",
         "parameters": [
           {
@@ -16411,7 +16387,7 @@
           }
         },
         "responses": {},
-        "summary": "",
+        "summary": "Unenroll an agent",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -16419,7 +16395,6 @@
     },
     "/api/fleet/agents/{agentId}/upgrade": {
       "post": {
-        "description": "Upgrade agent",
         "operationId": "post-fleet-agents-agentid-upgrade",
         "parameters": [
           {
@@ -16518,7 +16493,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Upgrade an agent",
         "tags": [
           "Elastic Agent actions"
         ]
@@ -16526,7 +16501,6 @@
     },
     "/api/fleet/agents/{agentId}/uploads": {
       "get": {
-        "description": "List agent uploads",
         "operationId": "get-fleet-agents-agentid-uploads",
         "parameters": [
           {
@@ -16638,7 +16612,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get agent uploads",
         "tags": [
           "Elastic Agents"
         ]
@@ -16646,7 +16620,6 @@
     },
     "/api/fleet/check-permissions": {
       "get": {
-        "description": "Check permissions",
         "operationId": "get-fleet-check-permissions",
         "parameters": [
           {
@@ -16723,7 +16696,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Check permissions",
         "tags": [
           "Fleet internals"
         ]
@@ -16731,7 +16704,6 @@
     },
     "/api/fleet/data_streams": {
       "get": {
-        "description": "List data streams",
         "operationId": "get-fleet-data-streams",
         "parameters": [
           {
@@ -16881,7 +16853,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get data streams",
         "tags": [
           "Data streams"
         ]
@@ -16889,7 +16861,6 @@
     },
     "/api/fleet/enrollment_api_keys": {
       "get": {
-        "description": "List enrollment API keys",
         "operationId": "get-fleet-enrollment-api-keys",
         "parameters": [
           {
@@ -17027,13 +16998,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get enrollment API keys",
         "tags": [
           "Fleet enrollment API keys"
         ]
       },
       "post": {
-        "description": "Create enrollment API key",
         "operationId": "post-fleet-enrollment-api-keys",
         "parameters": [
           {
@@ -17171,7 +17141,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create an enrollment API key",
         "tags": [
           "Fleet enrollment API keys"
         ]
@@ -17179,7 +17149,7 @@
     },
     "/api/fleet/enrollment_api_keys/{keyId}": {
       "delete": {
-        "description": "Revoke enrollment API key by ID by marking it as inactive",
+        "description": "Revoke an enrollment API key by ID by marking it as inactive.",
         "operationId": "delete-fleet-enrollment-api-keys-keyid",
         "parameters": [
           {
@@ -17261,13 +17231,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Revoke an enrollment API key",
         "tags": [
           "Fleet enrollment API keys"
         ]
       },
       "get": {
-        "description": "Get enrollment API key by ID",
+        "description": "Get an enrollment API key by ID.",
         "operationId": "get-fleet-enrollment-api-keys-keyid",
         "parameters": [
           {
@@ -17372,7 +17342,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an enrollment API key",
         "tags": [
           "Fleet enrollment API keys"
         ]
@@ -17380,7 +17350,6 @@
     },
     "/api/fleet/epm/bulk_assets": {
       "post": {
-        "description": "Bulk get assets",
         "operationId": "post-fleet-epm-bulk-assets",
         "parameters": [
           {
@@ -17523,7 +17492,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk get assets",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -17531,7 +17500,6 @@
     },
     "/api/fleet/epm/categories": {
       "get": {
-        "description": "List package categories",
         "operationId": "get-fleet-epm-categories",
         "parameters": [
           {
@@ -17634,7 +17602,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get package categories",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -17642,7 +17610,6 @@
     },
     "/api/fleet/epm/custom_integrations": {
       "post": {
-        "description": "Create custom integration",
         "operationId": "post-fleet-epm-custom-integrations",
         "parameters": [
           {
@@ -17843,7 +17810,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create a custom integration",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -17851,7 +17818,6 @@
     },
     "/api/fleet/epm/data_streams": {
       "get": {
-        "description": "List data streams",
         "operationId": "get-fleet-epm-data-streams",
         "parameters": [
           {
@@ -17969,7 +17935,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get data streams",
         "tags": [
           "Data streams"
         ]
@@ -17977,7 +17943,6 @@
     },
     "/api/fleet/epm/packages": {
       "get": {
-        "description": "List packages",
         "operationId": "get-fleet-epm-packages",
         "parameters": [
           {
@@ -18543,13 +18508,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get packages",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
       },
       "post": {
-        "description": "Install package by upload",
         "operationId": "post-fleet-epm-packages",
         "parameters": [
           {
@@ -18730,7 +18694,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Install a package by upload",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -18738,7 +18702,6 @@
     },
     "/api/fleet/epm/packages/_bulk": {
       "post": {
-        "description": "Bulk install packages",
         "operationId": "post-fleet-epm-packages-bulk",
         "parameters": [
           {
@@ -19008,7 +18971,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk install packages",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -19016,7 +18979,6 @@
     },
     "/api/fleet/epm/packages/installed": {
       "get": {
-        "description": "Get installed packages",
         "operationId": "get-fleet-epm-packages-installed",
         "parameters": [
           {
@@ -19249,7 +19211,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get installed packages",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -19257,7 +19219,6 @@
     },
     "/api/fleet/epm/packages/limited": {
       "get": {
-        "description": "Get limited package list",
         "operationId": "get-fleet-epm-packages-limited",
         "parameters": [
           {
@@ -19321,7 +19282,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a limited package list",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -19329,7 +19290,6 @@
     },
     "/api/fleet/epm/packages/{pkgName}/stats": {
       "get": {
-        "description": "Get package stats",
         "operationId": "get-fleet-epm-packages-pkgname-stats",
         "parameters": [
           {
@@ -19407,7 +19367,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get package stats",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -19415,7 +19375,6 @@
     },
     "/api/fleet/epm/packages/{pkgName}/{pkgVersion}": {
       "delete": {
-        "description": "Delete package",
         "operationId": "delete-fleet-epm-packages-pkgname-pkgversion",
         "parameters": [
           {
@@ -19579,13 +19538,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete a package",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
       },
       "get": {
-        "description": "Get package",
         "operationId": "get-fleet-epm-packages-pkgname-pkgversion",
         "parameters": [
           {
@@ -20271,13 +20229,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a package",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
       },
       "post": {
-        "description": "Install package from registry",
         "operationId": "post-fleet-epm-packages-pkgname-pkgversion",
         "parameters": [
           {
@@ -20493,13 +20450,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Install a package from the registry",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
       },
       "put": {
-        "description": "Update package settings",
         "operationId": "put-fleet-epm-packages-pkgname-pkgversion",
         "parameters": [
           {
@@ -21168,7 +21124,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update package settings",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -21176,7 +21132,6 @@
     },
     "/api/fleet/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize": {
       "post": {
-        "description": "Authorize transforms",
         "operationId": "post-fleet-epm-packages-pkgname-pkgversion-transforms-authorize",
         "parameters": [
           {
@@ -21312,7 +21267,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Authorize transforms",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -21320,7 +21275,6 @@
     },
     "/api/fleet/epm/packages/{pkgName}/{pkgVersion}/{filePath*}": {
       "get": {
-        "description": "Get package file",
         "operationId": "get-fleet-epm-packages-pkgname-pkgversion-filepath",
         "parameters": [
           {
@@ -21394,7 +21348,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a package file",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -21402,7 +21356,6 @@
     },
     "/api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs": {
       "get": {
-        "description": "Get inputs template",
         "operationId": "get-fleet-epm-templates-pkgname-pkgversion-inputs",
         "parameters": [
           {
@@ -21563,7 +21516,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get an inputs template",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -21571,7 +21524,6 @@
     },
     "/api/fleet/epm/verification_key_id": {
       "get": {
-        "description": "Get a package signature verification key ID",
         "operationId": "get-fleet-epm-verification-key-id",
         "parameters": [
           {
@@ -21633,7 +21585,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a package signature verification key ID",
         "tags": [
           "Elastic Package Manager (EPM)"
         ]
@@ -21641,7 +21593,6 @@
     },
     "/api/fleet/fleet_server_hosts": {
       "get": {
-        "description": "List Fleet Server hosts",
         "operationId": "get-fleet-fleet-server-hosts",
         "parameters": [
           {
@@ -21753,13 +21704,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get Fleet Server hosts",
         "tags": [
           "Fleet Server hosts"
         ]
       },
       "post": {
-        "description": "Create Fleet Server host",
         "operationId": "post-fleet-fleet-server-hosts",
         "parameters": [
           {
@@ -21910,7 +21860,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create a Fleet Server host",
         "tags": [
           "Fleet Server hosts"
         ]
@@ -21918,7 +21868,7 @@
     },
     "/api/fleet/fleet_server_hosts/{itemId}": {
       "delete": {
-        "description": "Delete Fleet Server host by ID",
+        "description": "Delete a Fleet Server host by ID.",
         "operationId": "delete-fleet-fleet-server-hosts-itemid",
         "parameters": [
           {
@@ -21997,13 +21947,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete a Fleet Server host",
         "tags": [
           "Fleet Server hosts"
         ]
       },
       "get": {
-        "description": "Get Fleet Server host by ID",
+        "description": "Get a Fleet Server host by ID.",
         "operationId": "get-fleet-fleet-server-hosts-itemid",
         "parameters": [
           {
@@ -22108,13 +22058,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a Fleet Server host",
         "tags": [
           "Fleet Server hosts"
         ]
       },
       "put": {
-        "description": "Update Fleet Server host by ID",
+        "description": "Update a Fleet Server host by ID.",
         "operationId": "put-fleet-fleet-server-hosts-itemid",
         "parameters": [
           {
@@ -22264,7 +22214,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update a Fleet Server host",
         "tags": [
           "Fleet Server hosts"
         ]
@@ -22272,7 +22222,6 @@
     },
     "/api/fleet/health_check": {
       "post": {
-        "description": "Check Fleet Server health",
         "operationId": "post-fleet-health-check",
         "parameters": [
           {
@@ -22392,7 +22341,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Check Fleet Server health",
         "tags": [
           "Fleet internals"
         ]
@@ -22400,7 +22349,6 @@
     },
     "/api/fleet/kubernetes": {
       "get": {
-        "description": "Get full K8s agent manifest",
         "operationId": "get-fleet-kubernetes",
         "parameters": [
           {
@@ -22485,7 +22433,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a full K8s agent manifest",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -22593,7 +22541,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Download an agent manifest",
         "tags": [
           "Elastic Agent policies"
         ]
@@ -22601,7 +22549,6 @@
     },
     "/api/fleet/logstash_api_keys": {
       "post": {
-        "description": "Generate Logstash API key",
         "operationId": "post-fleet-logstash-api-keys",
         "parameters": [
           {
@@ -22672,7 +22619,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Generate a Logstash API key",
         "tags": [
           "Fleet outputs"
         ]
@@ -22680,7 +22627,6 @@
     },
     "/api/fleet/message_signing_service/rotate_key_pair": {
       "post": {
-        "description": "Rotate fleet message signing key pair",
         "operationId": "post-fleet-message-signing-service-rotate-key-pair",
         "parameters": [
           {
@@ -22785,7 +22731,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Rotate a Fleet message signing key pair",
         "tags": [
           "Message Signing Service"
         ]
@@ -22793,7 +22739,6 @@
     },
     "/api/fleet/outputs": {
       "get": {
-        "description": "List outputs",
         "operationId": "get-fleet-outputs",
         "parameters": [
           {
@@ -23884,13 +23829,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get outputs",
         "tags": [
           "Fleet outputs"
         ]
       },
       "post": {
-        "description": "Create output",
         "operationId": "post-fleet-outputs",
         "parameters": [
           {
@@ -26000,7 +25944,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create output",
         "tags": [
           "Fleet outputs"
         ]
@@ -26008,7 +25952,7 @@
     },
     "/api/fleet/outputs/{outputId}": {
       "delete": {
-        "description": "Delete output by ID",
+        "description": "Delete output by ID.",
         "operationId": "delete-fleet-outputs-outputid",
         "parameters": [
           {
@@ -26112,13 +26056,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete output",
         "tags": [
           "Fleet outputs"
         ]
       },
       "get": {
-        "description": "Get output by ID",
+        "description": "Get output by ID.",
         "operationId": "get-fleet-outputs-outputid",
         "parameters": [
           {
@@ -27202,13 +27146,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get output",
         "tags": [
           "Fleet outputs"
         ]
       },
       "put": {
-        "description": "Update output by ID",
+        "description": "Update output by ID.",
         "operationId": "put-fleet-outputs-outputid",
         "parameters": [
           {
@@ -29302,7 +29246,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update output",
         "tags": [
           "Fleet outputs"
         ]
@@ -29310,7 +29254,6 @@
     },
     "/api/fleet/outputs/{outputId}/health": {
       "get": {
-        "description": "Get latest output health",
         "operationId": "get-fleet-outputs-outputid-health",
         "parameters": [
           {
@@ -29390,7 +29333,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get the latest output health",
         "tags": [
           "Fleet outputs"
         ]
@@ -29398,7 +29341,6 @@
     },
     "/api/fleet/package_policies": {
       "get": {
-        "description": "List package policies",
         "operationId": "get-fleet-package-policies",
         "parameters": [
           {
@@ -30107,13 +30049,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get package policies",
         "tags": [
           "Fleet package policies"
         ]
       },
       "post": {
-        "description": "Create package policy",
         "operationId": "post-fleet-package-policies",
         "parameters": [
           {
@@ -31379,7 +31320,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create a package policy",
         "tags": [
           "Fleet package policies"
         ]
@@ -31387,7 +31328,6 @@
     },
     "/api/fleet/package_policies/_bulk_get": {
       "post": {
-        "description": "Bulk get package policies",
         "operationId": "post-fleet-package-policies-bulk-get",
         "parameters": [
           {
@@ -32077,7 +32017,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk get package policies",
         "tags": [
           "Fleet package policies"
         ]
@@ -32085,7 +32025,6 @@
     },
     "/api/fleet/package_policies/delete": {
       "post": {
-        "description": "Bulk delete package policies",
         "operationId": "post-fleet-package-policies-delete",
         "parameters": [
           {
@@ -32281,7 +32220,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Bulk delete package policies",
         "tags": [
           "Fleet package policies"
         ]
@@ -32289,7 +32228,7 @@
     },
     "/api/fleet/package_policies/upgrade": {
       "post": {
-        "description": "Upgrade package policy to a newer package version",
+        "description": "Upgrade a package policy to a newer package version.",
         "operationId": "post-fleet-package-policies-upgrade",
         "parameters": [
           {
@@ -32406,7 +32345,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Upgrade a package policy",
         "tags": [
           "Fleet package policies"
         ]
@@ -32414,7 +32353,6 @@
     },
     "/api/fleet/package_policies/upgrade/dryrun": {
       "post": {
-        "description": "Dry run package policy upgrade",
         "operationId": "post-fleet-package-policies-upgrade-dryrun",
         "parameters": [
           {
@@ -33592,7 +33530,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Dry run a package policy upgrade",
         "tags": [
           "Fleet package policies"
         ]
@@ -33600,7 +33538,7 @@
     },
     "/api/fleet/package_policies/{packagePolicyId}": {
       "delete": {
-        "description": "Delete package policy by ID",
+        "description": "Delete a package policy by ID.",
         "operationId": "delete-fleet-package-policies-packagepolicyid",
         "parameters": [
           {
@@ -33687,13 +33625,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete a package policy",
         "tags": [
           "Fleet package policies"
         ]
       },
       "get": {
-        "description": "Get package policy by ID",
+        "description": "Get a package policy by ID.",
         "operationId": "get-fleet-package-policies-packagepolicyid",
         "parameters": [
           {
@@ -34353,13 +34291,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a package policy",
         "tags": [
           "Fleet package policies"
         ]
       },
       "put": {
-        "description": "Update package policy by ID",
+        "description": "Update a package policy by ID.",
         "operationId": "put-fleet-package-policies-packagepolicyid",
         "parameters": [
           {
@@ -35625,7 +35563,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update a package policy",
         "tags": [
           "Fleet package policies"
         ]
@@ -35633,7 +35571,6 @@
     },
     "/api/fleet/proxies": {
       "get": {
-        "description": "List proxies",
         "operationId": "get-fleet-proxies",
         "parameters": [
           {
@@ -35759,13 +35696,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get proxies",
         "tags": [
           "Fleet proxies"
         ]
       },
       "post": {
-        "description": "Create proxy",
         "operationId": "post-fleet-proxies",
         "parameters": [
           {
@@ -35944,7 +35880,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create a proxy",
         "tags": [
           "Fleet proxies"
         ]
@@ -35952,7 +35888,7 @@
     },
     "/api/fleet/proxies/{itemId}": {
       "delete": {
-        "description": "Delete proxy by ID",
+        "description": "Delete a proxy by ID",
         "operationId": "delete-fleet-proxies-itemid",
         "parameters": [
           {
@@ -36031,13 +35967,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Delete a proxy",
         "tags": [
           "Fleet proxies"
         ]
       },
       "get": {
-        "description": "Get proxy by ID",
+        "description": "Get a proxy by ID.",
         "operationId": "get-fleet-proxies-itemid",
         "parameters": [
           {
@@ -36156,13 +36092,13 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a proxy",
         "tags": [
           "Fleet proxies"
         ]
       },
       "put": {
-        "description": "Update proxy by ID",
+        "description": "Update a proxy by ID.",
         "operationId": "put-fleet-proxies-itemid",
         "parameters": [
           {
@@ -36344,7 +36280,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update a proxy",
         "tags": [
           "Fleet proxies"
         ]
@@ -36352,7 +36288,6 @@
     },
     "/api/fleet/service_tokens": {
       "post": {
-        "description": "Create a service token",
         "operationId": "post-fleet-service-tokens",
         "parameters": [
           {
@@ -36444,7 +36379,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Create a service token",
         "tags": [
           "Fleet service tokens"
         ]
@@ -36452,7 +36387,6 @@
     },
     "/api/fleet/settings": {
       "get": {
-        "description": "Get settings",
         "operationId": "get-fleet-settings",
         "parameters": [
           {
@@ -36591,13 +36525,12 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get settings",
         "tags": [
           "Fleet internals"
         ]
       },
       "put": {
-        "description": "Update settings",
         "operationId": "put-fleet-settings",
         "parameters": [
           {
@@ -36793,7 +36726,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Update settings",
         "tags": [
           "Fleet internals"
         ]
@@ -36801,7 +36734,6 @@
     },
     "/api/fleet/setup": {
       "post": {
-        "description": "Initiate Fleet setup",
         "operationId": "post-fleet-setup",
         "parameters": [
           {
@@ -36912,7 +36844,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Initiate Fleet setup",
         "tags": [
           "Fleet internals"
         ]
@@ -36920,7 +36852,7 @@
     },
     "/api/fleet/uninstall_tokens": {
       "get": {
-        "description": "List metadata for latest uninstall tokens per agent policy",
+        "description": "List the metadata for the latest uninstall tokens per agent policy.",
         "operationId": "get-fleet-uninstall-tokens",
         "parameters": [
           {
@@ -37061,7 +36993,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get metadata for latest uninstall tokens",
         "tags": [
           "Fleet uninstall tokens"
         ]
@@ -37069,7 +37001,7 @@
     },
     "/api/fleet/uninstall_tokens/{uninstallTokenId}": {
       "get": {
-        "description": "Get one decrypted uninstall token by its ID",
+        "description": "Get one decrypted uninstall token by its ID.",
         "operationId": "get-fleet-uninstall-tokens-uninstalltokenid",
         "parameters": [
           {
@@ -37169,7 +37101,7 @@
             }
           }
         },
-        "summary": "",
+        "summary": "Get a decrypted uninstall token",
         "tags": [
           "Fleet uninstall tokens"
         ]

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -9870,7 +9870,6 @@ paths:
         - Security Exceptions API
   /api/fleet/agent_download_sources:
     get:
-      description: List agent binary download sources
       operationId: get-fleet-agent-download-sources
       parameters:
         - description: The version of the API to use
@@ -9942,11 +9941,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agent binary download sources
       tags:
         - Elastic Agent binary download sources
     post:
-      description: Create agent binary download source
       operationId: post-fleet-agent-download-sources
       parameters:
         - description: The version of the API to use
@@ -10040,12 +10038,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create an agent binary download source
       tags:
         - Elastic Agent binary download sources
   /api/fleet/agent_download_sources/{sourceId}:
     delete:
-      description: Delete agent binary download source by ID
+      description: Delete an agent binary download source by ID.
       operationId: delete-fleet-agent-download-sources-sourceid
       parameters:
         - description: The version of the API to use
@@ -10096,11 +10094,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete an agent binary download source
       tags:
         - Elastic Agent binary download sources
     get:
-      description: Get agent binary download source by ID
+      description: Get an agent binary download source by ID.
       operationId: get-fleet-agent-download-sources-sourceid
       parameters:
         - description: The version of the API to use
@@ -10166,11 +10164,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an agent binary download source
       tags:
         - Elastic Agent binary download sources
     put:
-      description: Update agent binary download source by ID
+      description: Update an agent binary download source by ID.
       operationId: put-fleet-agent-download-sources-sourceid
       parameters:
         - description: The version of the API to use
@@ -10269,12 +10267,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update an agent binary download source
       tags:
         - Elastic Agent binary download sources
   /api/fleet/agent_policies:
     get:
-      description: List agent policies
       operationId: get-fleet-agent-policies
       parameters:
         - description: The version of the API to use
@@ -10884,11 +10881,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agent policies
       tags:
         - Elastic Agent policies
     post:
-      description: Create an agent policy
       operationId: post-fleet-agent-policies
       parameters:
         - description: The version of the API to use
@@ -11618,12 +11614,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/_bulk_get:
     post:
-      description: Bulk get agent policies
       operationId: post-fleet-agent-policies-bulk-get
       parameters:
         - description: The version of the API to use
@@ -12198,12 +12193,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk get agent policies
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}:
     get:
-      description: Get an agent policy by ID
+      description: Get an agent policy by ID.
       operationId: get-fleet-agent-policies-agentpolicyid
       parameters:
         - description: The version of the API to use
@@ -12755,11 +12750,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an agent policy
       tags:
         - Elastic Agent policies
     put:
-      description: Update an agent policy by ID
+      description: Update an agent policy by ID.
       operationId: put-fleet-agent-policies-agentpolicyid
       parameters:
         - description: The version of the API to use
@@ -13497,12 +13492,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/copy:
     post:
-      description: Copy an agent policy by ID
+      description: Copy an agent policy by ID.
       operationId: post-fleet-agent-policies-agentpolicyid-copy
       parameters:
         - description: The version of the API to use
@@ -14075,12 +14070,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Copy an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/download:
     get:
-      description: Download an agent policy by ID
+      description: Download an agent policy by ID.
       operationId: get-fleet-agent-policies-agentpolicyid-download
       parameters:
         - description: The version of the API to use
@@ -14149,12 +14144,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Download an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/full:
     get:
-      description: Get a full agent policy by ID
+      description: Get a full agent policy by ID.
       operationId: get-fleet-agent-policies-agentpolicyid-full
       parameters:
         - description: The version of the API to use
@@ -14481,12 +14476,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a full agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/outputs:
     get:
-      description: Get list of outputs associated with agent policy by policy id
+      description: Get a list of outputs associated with agent policy by policy id.
       operationId: get-fleet-agent-policies-agentpolicyid-outputs
       parameters:
         - description: The version of the API to use
@@ -14585,12 +14580,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get outputs for an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/delete:
     post:
-      description: Delete agent policy by ID
+      description: Delete an agent policy by ID.
       operationId: post-fleet-agent-policies-delete
       parameters:
         - description: The version of the API to use
@@ -14655,12 +14650,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/outputs:
     post:
-      description: Get list of outputs associated with agent policies
+      description: Get a list of outputs associated with agent policies.
       operationId: post-fleet-agent-policies-outputs
       parameters:
         - description: The version of the API to use
@@ -14777,12 +14772,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get outputs for agent policies
       tags:
         - Elastic Agent policies
   /api/fleet/agent_status:
     get:
-      description: Get agent status summary
       operationId: get-fleet-agent-status
       parameters:
         - description: The version of the API to use
@@ -14873,12 +14867,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an agent status summary
       tags:
         - Elastic Agent status
   /api/fleet/agent_status/data:
     get:
-      description: Get incoming agent data
       operationId: get-fleet-agent-status-data
       parameters:
         - description: The version of the API to use
@@ -14946,12 +14939,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get incoming agent data
       tags:
         - Elastic Agents
   /api/fleet/agents:
     get:
-      description: List agents
       operationId: get-fleet-agents
       parameters:
         - description: The version of the API to use
@@ -15333,11 +15325,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agents
       tags:
         - Elastic Agents
     post:
-      description: List agents by action ids
       operationId: post-fleet-agents
       parameters:
         - description: The version of the API to use
@@ -15398,12 +15389,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agents by action ids
       tags:
         - Elastic Agents
   /api/fleet/agents/{agentId}:
     delete:
-      description: Delete agent by ID
+      description: Delete an agent by ID.
       operationId: delete-fleet-agents-agentid
       parameters:
         - description: The version of the API to use
@@ -15456,11 +15447,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete an agent
       tags:
         - Elastic Agents
     get:
-      description: Get agent by ID
+      description: Get an agent by ID.
       operationId: get-fleet-agents-agentid
       parameters:
         - description: The version of the API to use
@@ -15784,11 +15775,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an agent
       tags:
         - Elastic Agents
     put:
-      description: Update agent by ID
+      description: Update an agent by ID.
       operationId: put-fleet-agents-agentid
       parameters:
         - description: The version of the API to use
@@ -16127,12 +16118,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update an agent
       tags:
         - Elastic Agents
   /api/fleet/agents/{agentId}/actions:
     post:
-      description: Create agent action
       operationId: post-fleet-agents-agentid-actions
       parameters:
         - description: The version of the API to use
@@ -16272,12 +16262,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create an agent action
       tags:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/reassign:
     post:
-      description: Reassign agent
       operationId: post-fleet-agents-agentid-reassign
       parameters:
         - description: The version of the API to use
@@ -16335,12 +16324,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Reassign an agent
       tags:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/request_diagnostics:
     post:
-      description: Request agent diagnostics
       operationId: post-fleet-agents-agentid-request-diagnostics
       parameters:
         - description: The version of the API to use
@@ -16405,12 +16393,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Request agent diagnostics
       tags:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/unenroll:
     post:
-      description: Unenroll agent
       operationId: post-fleet-agents-agentid-unenroll
       parameters:
         - description: The version of the API to use
@@ -16446,12 +16433,11 @@ paths:
                 revoke:
                   type: boolean
       responses: {}
-      summary: ''
+      summary: Unenroll an agent
       tags:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/upgrade:
     post:
-      description: Upgrade agent
       operationId: post-fleet-agents-agentid-upgrade
       parameters:
         - description: The version of the API to use
@@ -16515,12 +16501,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Upgrade an agent
       tags:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/uploads:
     get:
-      description: List agent uploads
       operationId: get-fleet-agents-agentid-uploads
       parameters:
         - description: The version of the API to use
@@ -16596,12 +16581,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agent uploads
       tags:
         - Elastic Agents
   /api/fleet/agents/action_status:
     get:
-      description: Get agent action status
       operationId: get-fleet-agents-action-status
       parameters:
         - description: The version of the API to use
@@ -16764,12 +16748,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an agent action status
       tags:
         - Elastic Agent actions
   /api/fleet/agents/actions/{actionId}/cancel:
     post:
-      description: Cancel agent action
       operationId: post-fleet-agents-actions-actionid-cancel
       parameters:
         - description: The version of the API to use
@@ -16859,12 +16842,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Cancel an agent action
       tags:
         - Elastic Agent actions
   /api/fleet/agents/available_versions:
     get:
-      description: Get available agent versions
       operationId: get-fleet-agents-available-versions
       parameters:
         - description: The version of the API to use
@@ -16905,12 +16887,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get available agent versions
       tags:
         - Elastic Agents
   /api/fleet/agents/bulk_reassign:
     post:
-      description: Bulk reassign agents
       operationId: post-fleet-agents-bulk-reassign
       parameters:
         - description: The version of the API to use
@@ -16979,12 +16960,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk reassign agents
       tags:
         - Elastic Agent actions
   /api/fleet/agents/bulk_request_diagnostics:
     post:
-      description: Bulk request diagnostics from agents
       operationId: post-fleet-agents-bulk-request-diagnostics
       parameters:
         - description: The version of the API to use
@@ -17053,12 +17033,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk request diagnostics from agents
       tags:
         - Elastic Agent actions
   /api/fleet/agents/bulk_unenroll:
     post:
-      description: Bulk unenroll agents
       operationId: post-fleet-agents-bulk-unenroll
       parameters:
         - description: The version of the API to use
@@ -17134,12 +17113,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk unenroll agents
       tags:
         - Elastic Agent actions
   /api/fleet/agents/bulk_update_agent_tags:
     post:
-      description: Bulk update agent tags
       operationId: post-fleet-agents-bulk-update-agent-tags
       parameters:
         - description: The version of the API to use
@@ -17213,12 +17191,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk update agent tags
       tags:
         - Elastic Agent actions
   /api/fleet/agents/bulk_upgrade:
     post:
-      description: Bulk upgrade agents
       operationId: post-fleet-agents-bulk-upgrade
       parameters:
         - description: The version of the API to use
@@ -17298,12 +17275,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk upgrade agents
       tags:
         - Elastic Agent actions
   /api/fleet/agents/files/{fileId}:
     delete:
-      description: Delete file uploaded by agent
+      description: Delete a file uploaded by an agent.
       operationId: delete-fleet-agents-files-fileid
       parameters:
         - description: The version of the API to use
@@ -17357,12 +17334,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete an uploaded file
       tags:
         - Elastic Agents
   /api/fleet/agents/files/{fileId}/{fileName}:
     get:
-      description: Get file uploaded by agent
+      description: Get a file uploaded by an agent.
       operationId: get-fleet-agents-files-fileid-filename
       parameters:
         - description: The version of the API to use
@@ -17405,12 +17382,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an uploaded file
       tags:
         - Elastic Agents
   /api/fleet/agents/setup:
     get:
-      description: Get agent setup info
       operationId: get-fleet-agents-setup
       parameters:
         - description: The version of the API to use
@@ -17477,11 +17453,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agent setup info
       tags:
         - Elastic Agents
     post:
-      description: Initiate agent setup
       operationId: post-fleet-agents-setup
       parameters:
         - description: The version of the API to use
@@ -17546,12 +17521,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Initiate agent setup
       tags:
         - Elastic Agents
   /api/fleet/agents/tags:
     get:
-      description: List agent tags
       operationId: get-fleet-agents-tags
       parameters:
         - description: The version of the API to use
@@ -17603,12 +17577,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agent tags
       tags:
         - Elastic Agents
   /api/fleet/check-permissions:
     get:
-      description: Check permissions
       operationId: get-fleet-check-permissions
       parameters:
         - description: The version of the API to use
@@ -17658,12 +17631,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Check permissions
       tags:
         - Fleet internals
   /api/fleet/data_streams:
     get:
-      description: List data streams
       operationId: get-fleet-data-streams
       parameters:
         - description: The version of the API to use
@@ -17763,12 +17735,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get data streams
       tags:
         - Data streams
   /api/fleet/enrollment_api_keys:
     get:
-      description: List enrollment API keys
       operationId: get-fleet-enrollment-api-keys
       parameters:
         - description: The version of the API to use
@@ -17868,11 +17839,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get enrollment API keys
       tags:
         - Fleet enrollment API keys
     post:
-      description: Create enrollment API key
       operationId: post-fleet-enrollment-api-keys
       parameters:
         - description: The version of the API to use
@@ -17971,12 +17941,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create an enrollment API key
       tags:
         - Fleet enrollment API keys
   /api/fleet/enrollment_api_keys/{keyId}:
     delete:
-      description: Revoke enrollment API key by ID by marking it as inactive
+      description: Revoke an enrollment API key by ID by marking it as inactive.
       operationId: delete-fleet-enrollment-api-keys-keyid
       parameters:
         - description: The version of the API to use
@@ -18029,11 +17999,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Revoke an enrollment API key
       tags:
         - Fleet enrollment API keys
     get:
-      description: Get enrollment API key by ID
+      description: Get an enrollment API key by ID.
       operationId: get-fleet-enrollment-api-keys-keyid
       parameters:
         - description: The version of the API to use
@@ -18110,12 +18080,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an enrollment API key
       tags:
         - Fleet enrollment API keys
   /api/fleet/epm/bulk_assets:
     post:
-      description: Bulk get assets
       operationId: post-fleet-epm-bulk-assets
       parameters:
         - description: The version of the API to use
@@ -18209,12 +18178,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk get assets
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/categories:
     get:
-      description: List package categories
       operationId: get-fleet-epm-categories
       parameters:
         - description: The version of the API to use
@@ -18281,12 +18249,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get package categories
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/custom_integrations:
     post:
-      description: Create custom integration
       operationId: post-fleet-epm-custom-integrations
       parameters:
         - description: The version of the API to use
@@ -18424,12 +18391,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create a custom integration
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/data_streams:
     get:
-      description: List data streams
       operationId: get-fleet-epm-data-streams
       parameters:
         - description: The version of the API to use
@@ -18507,12 +18473,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get data streams
       tags:
         - Data streams
   /api/fleet/epm/packages:
     get:
-      description: List packages
       operationId: get-fleet-epm-packages
       parameters:
         - description: The version of the API to use
@@ -18908,11 +18873,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get packages
       tags:
         - Elastic Package Manager (EPM)
     post:
-      description: Install package by upload
       operationId: post-fleet-epm-packages
       parameters:
         - description: The version of the API to use
@@ -19035,12 +18999,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Install a package by upload
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/_bulk:
     post:
-      description: Bulk install packages
       operationId: post-fleet-epm-packages-bulk
       parameters:
         - description: The version of the API to use
@@ -19218,12 +19181,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk install packages
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgName}/{pkgVersion}:
     delete:
-      description: Delete package
       operationId: delete-fleet-epm-packages-pkgname-pkgversion
       parameters:
         - description: The version of the API to use
@@ -19334,11 +19296,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete a package
       tags:
         - Elastic Package Manager (EPM)
     get:
-      description: Get package
       operationId: get-fleet-epm-packages-pkgname-pkgversion
       parameters:
         - description: The version of the API to use
@@ -19814,11 +19775,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a package
       tags:
         - Elastic Package Manager (EPM)
     post:
-      description: Install package from registry
       operationId: post-fleet-epm-packages-pkgname-pkgversion
       parameters:
         - description: The version of the API to use
@@ -19964,11 +19924,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Install a package from the registry
       tags:
         - Elastic Package Manager (EPM)
     put:
-      description: Update package settings
       operationId: put-fleet-epm-packages-pkgname-pkgversion
       parameters:
         - description: The version of the API to use
@@ -20433,12 +20392,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update package settings
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgName}/{pkgVersion}/{filePath*}:
     get:
-      description: Get package file
       operationId: get-fleet-epm-packages-pkgname-pkgversion-filepath
       parameters:
         - description: The version of the API to use
@@ -20485,12 +20443,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a package file
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize:
     post:
-      description: Authorize transforms
       operationId: post-fleet-epm-packages-pkgname-pkgversion-transforms-authorize
       parameters:
         - description: The version of the API to use
@@ -20578,12 +20535,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Authorize transforms
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgName}/stats:
     get:
-      description: Get package stats
       operationId: get-fleet-epm-packages-pkgname-stats
       parameters:
         - description: The version of the API to use
@@ -20633,12 +20589,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get package stats
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/installed:
     get:
-      description: Get installed packages
       operationId: get-fleet-epm-packages-installed
       parameters:
         - description: The version of the API to use
@@ -20787,12 +20742,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get installed packages
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/limited:
     get:
-      description: Get limited package list
       operationId: get-fleet-epm-packages-limited
       parameters:
         - description: The version of the API to use
@@ -20833,12 +20787,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a limited package list
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs:
     get:
-      description: Get inputs template
       operationId: get-fleet-epm-templates-pkgname-pkgversion-inputs
       parameters:
         - description: The version of the API to use
@@ -20941,12 +20894,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an inputs template
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/verification_key_id:
     get:
-      description: Get a package signature verification key ID
       operationId: get-fleet-epm-verification-key-id
       parameters:
         - description: The version of the API to use
@@ -20986,12 +20938,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a package signature verification key ID
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/fleet_server_hosts:
     get:
-      description: List Fleet Server hosts
       operationId: get-fleet-fleet-server-hosts
       parameters:
         - description: The version of the API to use
@@ -21067,11 +21018,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get Fleet Server hosts
       tags:
         - Fleet Server hosts
     post:
-      description: Create Fleet Server host
       operationId: post-fleet-fleet-server-hosts
       parameters:
         - description: The version of the API to use
@@ -21173,12 +21123,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create a Fleet Server host
       tags:
         - Fleet Server hosts
   /api/fleet/fleet_server_hosts/{itemId}:
     delete:
-      description: Delete Fleet Server host by ID
+      description: Delete a Fleet Server host by ID.
       operationId: delete-fleet-fleet-server-hosts-itemid
       parameters:
         - description: The version of the API to use
@@ -21229,11 +21179,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete a Fleet Server host
       tags:
         - Fleet Server hosts
     get:
-      description: Get Fleet Server host by ID
+      description: Get a Fleet Server host by ID.
       operationId: get-fleet-fleet-server-hosts-itemid
       parameters:
         - description: The version of the API to use
@@ -21303,11 +21253,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a Fleet Server host
       tags:
         - Fleet Server hosts
     put:
-      description: Update Fleet Server host by ID
+      description: Update a Fleet Server host by ID.
       operationId: put-fleet-fleet-server-hosts-itemid
       parameters:
         - description: The version of the API to use
@@ -21407,12 +21357,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update a Fleet Server host
       tags:
         - Fleet Server hosts
   /api/fleet/health_check:
     post:
-      description: Check Fleet Server health
       operationId: post-fleet-health-check
       parameters:
         - description: The version of the API to use
@@ -21489,12 +21438,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Check Fleet Server health
       tags:
         - Fleet internals
   /api/fleet/kubernetes:
     get:
-      description: Get full K8s agent manifest
       operationId: get-fleet-kubernetes
       parameters:
         - description: The version of the API to use
@@ -21548,7 +21496,7 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a full K8s agent manifest
       tags:
         - Elastic Agent policies
   /api/fleet/kubernetes/download:
@@ -21616,12 +21564,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Download an agent manifest
       tags:
         - Elastic Agent policies
   /api/fleet/logstash_api_keys:
     post:
-      description: Generate Logstash API key
       operationId: post-fleet-logstash-api-keys
       parameters:
         - description: The version of the API to use
@@ -21667,12 +21614,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Generate a Logstash API key
       tags:
         - Fleet outputs
   /api/fleet/message_signing_service/rotate_key_pair:
     post:
-      description: Rotate fleet message signing key pair
       operationId: post-fleet-message-signing-service-rotate-key-pair
       parameters:
         - description: The version of the API to use
@@ -21740,12 +21686,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Rotate a Fleet message signing key pair
       tags:
         - Message Signing Service
   /api/fleet/outputs:
     get:
-      description: List outputs
       operationId: get-fleet-outputs
       parameters:
         - description: The version of the API to use
@@ -22474,11 +22419,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get outputs
       tags:
         - Fleet outputs
     post:
-      description: Create output
       operationId: post-fleet-outputs
       parameters:
         - description: The version of the API to use
@@ -23887,12 +23831,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create output
       tags:
         - Fleet outputs
   /api/fleet/outputs/{outputId}:
     delete:
-      description: Delete output by ID
+      description: Delete output by ID.
       operationId: delete-fleet-outputs-outputid
       parameters:
         - description: The version of the API to use
@@ -23959,11 +23903,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete output
       tags:
         - Fleet outputs
     get:
-      description: Get output by ID
+      description: Get output by ID.
       operationId: get-fleet-outputs-outputid
       parameters:
         - description: The version of the API to use
@@ -24686,11 +24630,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get output
       tags:
         - Fleet outputs
     put:
-      description: Update output by ID
+      description: Update output by ID.
       operationId: put-fleet-outputs-outputid
       parameters:
         - description: The version of the API to use
@@ -26083,12 +26027,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update output
       tags:
         - Fleet outputs
   /api/fleet/outputs/{outputId}/health:
     get:
-      description: Get latest output health
       operationId: get-fleet-outputs-outputid-health
       parameters:
         - description: The version of the API to use
@@ -26141,12 +26084,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get the latest output health
       tags:
         - Fleet outputs
   /api/fleet/package_policies:
     get:
-      description: List package policies
       operationId: get-fleet-package-policies
       parameters:
         - description: The version of the API to use
@@ -26647,11 +26589,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get package policies
       tags:
         - Fleet package policies
     post:
-      description: Create package policy
       operationId: post-fleet-package-policies
       parameters:
         - description: The version of the API to use
@@ -27549,12 +27490,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create a package policy
       tags:
         - Fleet package policies
   /api/fleet/package_policies/_bulk_get:
     post:
-      description: Bulk get package policies
       operationId: post-fleet-package-policies-bulk-get
       parameters:
         - description: The version of the API to use
@@ -28042,12 +27982,12 @@ paths:
                     type: string
                 required:
                   - message
-      summary: ''
+      summary: Bulk get package policies
       tags:
         - Fleet package policies
   /api/fleet/package_policies/{packagePolicyId}:
     delete:
-      description: Delete package policy by ID
+      description: Delete a package policy by ID.
       operationId: delete-fleet-package-policies-packagepolicyid
       parameters:
         - description: The version of the API to use
@@ -28103,11 +28043,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete a package policy
       tags:
         - Fleet package policies
     get:
-      description: Get package policy by ID
+      description: Get a package policy by ID.
       operationId: get-fleet-package-policies-packagepolicyid
       parameters:
         - description: The version of the API to use
@@ -28572,11 +28512,11 @@ paths:
                     type: string
                 required:
                   - message
-      summary: ''
+      summary: Get a package policy
       tags:
         - Fleet package policies
     put:
-      description: Update package policy by ID
+      description: Update a package policy by ID.
       operationId: put-fleet-package-policies-packagepolicyid
       parameters:
         - description: The version of the API to use
@@ -29468,12 +29408,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update a package policy
       tags:
         - Fleet package policies
   /api/fleet/package_policies/delete:
     post:
-      description: Bulk delete package policies
       operationId: post-fleet-package-policies-delete
       parameters:
         - description: The version of the API to use
@@ -29605,12 +29544,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk delete package policies
       tags:
         - Fleet package policies
   /api/fleet/package_policies/upgrade:
     post:
-      description: Upgrade package policy to a newer package version
+      description: Upgrade a package policy to a newer package version.
       operationId: post-fleet-package-policies-upgrade
       parameters:
         - description: The version of the API to use
@@ -29686,12 +29625,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Upgrade a package policy
       tags:
         - Fleet package policies
   /api/fleet/package_policies/upgrade/dryrun:
     post:
-      description: Dry run package policy upgrade
       operationId: post-fleet-package-policies-upgrade-dryrun
       parameters:
         - description: The version of the API to use
@@ -30536,12 +30474,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Dry run a package policy upgrade
       tags:
         - Fleet package policies
   /api/fleet/proxies:
     get:
-      description: List proxies
       operationId: get-fleet-proxies
       parameters:
         - description: The version of the API to use
@@ -30623,11 +30560,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get proxies
       tags:
         - Fleet proxies
     post:
-      description: Create proxy
       operationId: post-fleet-proxies
       parameters:
         - description: The version of the API to use
@@ -30741,12 +30677,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create a proxy
       tags:
         - Fleet proxies
   /api/fleet/proxies/{itemId}:
     delete:
-      description: Delete proxy by ID
+      description: Delete a proxy by ID
       operationId: delete-fleet-proxies-itemid
       parameters:
         - description: The version of the API to use
@@ -30797,11 +30733,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete a proxy
       tags:
         - Fleet proxies
     get:
-      description: Get proxy by ID
+      description: Get a proxy by ID.
       operationId: get-fleet-proxies-itemid
       parameters:
         - description: The version of the API to use
@@ -30877,11 +30813,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a proxy
       tags:
         - Fleet proxies
     put:
-      description: Update proxy by ID
+      description: Update a proxy by ID.
       operationId: put-fleet-proxies-itemid
       parameters:
         - description: The version of the API to use
@@ -30997,12 +30933,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update a proxy
       tags:
         - Fleet proxies
   /api/fleet/service_tokens:
     post:
-      description: Create a service token
       operationId: post-fleet-service-tokens
       parameters:
         - description: The version of the API to use
@@ -31062,12 +30997,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create a service token
       tags:
         - Fleet service tokens
   /api/fleet/settings:
     get:
-      description: Get settings
       operationId: get-fleet-settings
       parameters:
         - description: The version of the API to use
@@ -31158,11 +31092,10 @@ paths:
                     type: string
                 required:
                   - message
-      summary: ''
+      summary: Get settings
       tags:
         - Fleet internals
     put:
-      description: Update settings
       operationId: put-fleet-settings
       parameters:
         - description: The version of the API to use
@@ -31291,12 +31224,11 @@ paths:
                     type: string
                 required:
                   - message
-      summary: ''
+      summary: Update settings
       tags:
         - Fleet internals
   /api/fleet/setup:
     post:
-      description: Initiate Fleet setup
       operationId: post-fleet-setup
       parameters:
         - description: The version of the API to use
@@ -31373,12 +31305,12 @@ paths:
                     type: string
                 required:
                   - message
-      summary: ''
+      summary: Initiate Fleet setup
       tags:
         - Fleet internals
   /api/fleet/uninstall_tokens:
     get:
-      description: List metadata for latest uninstall tokens per agent policy
+      description: List the metadata for the latest uninstall tokens per agent policy.
       operationId: get-fleet-uninstall-tokens
       parameters:
         - description: The version of the API to use
@@ -31473,12 +31405,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get metadata for latest uninstall tokens
       tags:
         - Fleet uninstall tokens
   /api/fleet/uninstall_tokens/{uninstallTokenId}:
     get:
-      description: Get one decrypted uninstall token by its ID
+      description: Get one decrypted uninstall token by its ID.
       operationId: get-fleet-uninstall-tokens-uninstalltokenid
       parameters:
         - description: The version of the API to use
@@ -31544,7 +31476,7 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a decrypted uninstall token
       tags:
         - Fleet uninstall tokens
   /api/lists:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -13303,7 +13303,6 @@ paths:
         - Security Exceptions API
   /api/fleet/agent_download_sources:
     get:
-      description: List agent binary download sources
       operationId: get-fleet-agent-download-sources
       parameters:
         - description: The version of the API to use
@@ -13375,11 +13374,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agent binary download sources
       tags:
         - Elastic Agent binary download sources
     post:
-      description: Create agent binary download source
       operationId: post-fleet-agent-download-sources
       parameters:
         - description: The version of the API to use
@@ -13473,12 +13471,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create an agent binary download source
       tags:
         - Elastic Agent binary download sources
   /api/fleet/agent_download_sources/{sourceId}:
     delete:
-      description: Delete agent binary download source by ID
+      description: Delete an agent binary download source by ID.
       operationId: delete-fleet-agent-download-sources-sourceid
       parameters:
         - description: The version of the API to use
@@ -13529,11 +13527,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete an agent binary download source
       tags:
         - Elastic Agent binary download sources
     get:
-      description: Get agent binary download source by ID
+      description: Get an agent binary download source by ID.
       operationId: get-fleet-agent-download-sources-sourceid
       parameters:
         - description: The version of the API to use
@@ -13599,11 +13597,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an agent binary download source
       tags:
         - Elastic Agent binary download sources
     put:
-      description: Update agent binary download source by ID
+      description: Update an agent binary download source by ID.
       operationId: put-fleet-agent-download-sources-sourceid
       parameters:
         - description: The version of the API to use
@@ -13702,12 +13700,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update an agent binary download source
       tags:
         - Elastic Agent binary download sources
   /api/fleet/agent_policies:
     get:
-      description: List agent policies
       operationId: get-fleet-agent-policies
       parameters:
         - description: The version of the API to use
@@ -14317,11 +14314,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agent policies
       tags:
         - Elastic Agent policies
     post:
-      description: Create an agent policy
       operationId: post-fleet-agent-policies
       parameters:
         - description: The version of the API to use
@@ -15051,12 +15047,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/_bulk_get:
     post:
-      description: Bulk get agent policies
       operationId: post-fleet-agent-policies-bulk-get
       parameters:
         - description: The version of the API to use
@@ -15631,12 +15626,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk get agent policies
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}:
     get:
-      description: Get an agent policy by ID
+      description: Get an agent policy by ID.
       operationId: get-fleet-agent-policies-agentpolicyid
       parameters:
         - description: The version of the API to use
@@ -16188,11 +16183,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an agent policy
       tags:
         - Elastic Agent policies
     put:
-      description: Update an agent policy by ID
+      description: Update an agent policy by ID.
       operationId: put-fleet-agent-policies-agentpolicyid
       parameters:
         - description: The version of the API to use
@@ -16930,12 +16925,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/copy:
     post:
-      description: Copy an agent policy by ID
+      description: Copy an agent policy by ID.
       operationId: post-fleet-agent-policies-agentpolicyid-copy
       parameters:
         - description: The version of the API to use
@@ -17508,12 +17503,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Copy an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/download:
     get:
-      description: Download an agent policy by ID
+      description: Download an agent policy by ID.
       operationId: get-fleet-agent-policies-agentpolicyid-download
       parameters:
         - description: The version of the API to use
@@ -17582,12 +17577,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Download an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/full:
     get:
-      description: Get a full agent policy by ID
+      description: Get a full agent policy by ID.
       operationId: get-fleet-agent-policies-agentpolicyid-full
       parameters:
         - description: The version of the API to use
@@ -17914,12 +17909,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a full agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/outputs:
     get:
-      description: Get list of outputs associated with agent policy by policy id
+      description: Get a list of outputs associated with agent policy by policy id.
       operationId: get-fleet-agent-policies-agentpolicyid-outputs
       parameters:
         - description: The version of the API to use
@@ -18018,12 +18013,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get outputs for an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/delete:
     post:
-      description: Delete agent policy by ID
+      description: Delete an agent policy by ID.
       operationId: post-fleet-agent-policies-delete
       parameters:
         - description: The version of the API to use
@@ -18088,12 +18083,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete an agent policy
       tags:
         - Elastic Agent policies
   /api/fleet/agent_policies/outputs:
     post:
-      description: Get list of outputs associated with agent policies
+      description: Get a list of outputs associated with agent policies.
       operationId: post-fleet-agent-policies-outputs
       parameters:
         - description: The version of the API to use
@@ -18210,12 +18205,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get outputs for agent policies
       tags:
         - Elastic Agent policies
   /api/fleet/agent_status:
     get:
-      description: Get agent status summary
       operationId: get-fleet-agent-status
       parameters:
         - description: The version of the API to use
@@ -18306,12 +18300,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an agent status summary
       tags:
         - Elastic Agent status
   /api/fleet/agent_status/data:
     get:
-      description: Get incoming agent data
       operationId: get-fleet-agent-status-data
       parameters:
         - description: The version of the API to use
@@ -18379,12 +18372,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get incoming agent data
       tags:
         - Elastic Agents
   /api/fleet/agents:
     get:
-      description: List agents
       operationId: get-fleet-agents
       parameters:
         - description: The version of the API to use
@@ -18766,11 +18758,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agents
       tags:
         - Elastic Agents
     post:
-      description: List agents by action ids
       operationId: post-fleet-agents
       parameters:
         - description: The version of the API to use
@@ -18831,12 +18822,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agents by action ids
       tags:
         - Elastic Agents
   /api/fleet/agents/{agentId}:
     delete:
-      description: Delete agent by ID
+      description: Delete an agent by ID.
       operationId: delete-fleet-agents-agentid
       parameters:
         - description: The version of the API to use
@@ -18889,11 +18880,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete an agent
       tags:
         - Elastic Agents
     get:
-      description: Get agent by ID
+      description: Get an agent by ID.
       operationId: get-fleet-agents-agentid
       parameters:
         - description: The version of the API to use
@@ -19217,11 +19208,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an agent
       tags:
         - Elastic Agents
     put:
-      description: Update agent by ID
+      description: Update an agent by ID.
       operationId: put-fleet-agents-agentid
       parameters:
         - description: The version of the API to use
@@ -19560,12 +19551,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update an agent
       tags:
         - Elastic Agents
   /api/fleet/agents/{agentId}/actions:
     post:
-      description: Create agent action
       operationId: post-fleet-agents-agentid-actions
       parameters:
         - description: The version of the API to use
@@ -19705,12 +19695,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create an agent action
       tags:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/reassign:
     post:
-      description: Reassign agent
       operationId: post-fleet-agents-agentid-reassign
       parameters:
         - description: The version of the API to use
@@ -19768,12 +19757,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Reassign an agent
       tags:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/request_diagnostics:
     post:
-      description: Request agent diagnostics
       operationId: post-fleet-agents-agentid-request-diagnostics
       parameters:
         - description: The version of the API to use
@@ -19838,12 +19826,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Request agent diagnostics
       tags:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/unenroll:
     post:
-      description: Unenroll agent
       operationId: post-fleet-agents-agentid-unenroll
       parameters:
         - description: The version of the API to use
@@ -19879,12 +19866,11 @@ paths:
                 revoke:
                   type: boolean
       responses: {}
-      summary: ''
+      summary: Unenroll an agent
       tags:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/upgrade:
     post:
-      description: Upgrade agent
       operationId: post-fleet-agents-agentid-upgrade
       parameters:
         - description: The version of the API to use
@@ -19948,12 +19934,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Upgrade an agent
       tags:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/uploads:
     get:
-      description: List agent uploads
       operationId: get-fleet-agents-agentid-uploads
       parameters:
         - description: The version of the API to use
@@ -20029,12 +20014,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agent uploads
       tags:
         - Elastic Agents
   /api/fleet/agents/action_status:
     get:
-      description: Get agent action status
       operationId: get-fleet-agents-action-status
       parameters:
         - description: The version of the API to use
@@ -20197,12 +20181,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an agent action status
       tags:
         - Elastic Agent actions
   /api/fleet/agents/actions/{actionId}/cancel:
     post:
-      description: Cancel agent action
       operationId: post-fleet-agents-actions-actionid-cancel
       parameters:
         - description: The version of the API to use
@@ -20292,12 +20275,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Cancel an agent action
       tags:
         - Elastic Agent actions
   /api/fleet/agents/available_versions:
     get:
-      description: Get available agent versions
       operationId: get-fleet-agents-available-versions
       parameters:
         - description: The version of the API to use
@@ -20338,12 +20320,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get available agent versions
       tags:
         - Elastic Agents
   /api/fleet/agents/bulk_reassign:
     post:
-      description: Bulk reassign agents
       operationId: post-fleet-agents-bulk-reassign
       parameters:
         - description: The version of the API to use
@@ -20412,12 +20393,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk reassign agents
       tags:
         - Elastic Agent actions
   /api/fleet/agents/bulk_request_diagnostics:
     post:
-      description: Bulk request diagnostics from agents
       operationId: post-fleet-agents-bulk-request-diagnostics
       parameters:
         - description: The version of the API to use
@@ -20486,12 +20466,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk request diagnostics from agents
       tags:
         - Elastic Agent actions
   /api/fleet/agents/bulk_unenroll:
     post:
-      description: Bulk unenroll agents
       operationId: post-fleet-agents-bulk-unenroll
       parameters:
         - description: The version of the API to use
@@ -20567,12 +20546,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk unenroll agents
       tags:
         - Elastic Agent actions
   /api/fleet/agents/bulk_update_agent_tags:
     post:
-      description: Bulk update agent tags
       operationId: post-fleet-agents-bulk-update-agent-tags
       parameters:
         - description: The version of the API to use
@@ -20646,12 +20624,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk update agent tags
       tags:
         - Elastic Agent actions
   /api/fleet/agents/bulk_upgrade:
     post:
-      description: Bulk upgrade agents
       operationId: post-fleet-agents-bulk-upgrade
       parameters:
         - description: The version of the API to use
@@ -20731,12 +20708,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk upgrade agents
       tags:
         - Elastic Agent actions
   /api/fleet/agents/files/{fileId}:
     delete:
-      description: Delete file uploaded by agent
+      description: Delete a file uploaded by an agent.
       operationId: delete-fleet-agents-files-fileid
       parameters:
         - description: The version of the API to use
@@ -20790,12 +20767,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete an uploaded file
       tags:
         - Elastic Agents
   /api/fleet/agents/files/{fileId}/{fileName}:
     get:
-      description: Get file uploaded by agent
+      description: Get a file uploaded by an agent.
       operationId: get-fleet-agents-files-fileid-filename
       parameters:
         - description: The version of the API to use
@@ -20838,12 +20815,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an uploaded file
       tags:
         - Elastic Agents
   /api/fleet/agents/setup:
     get:
-      description: Get agent setup info
       operationId: get-fleet-agents-setup
       parameters:
         - description: The version of the API to use
@@ -20910,11 +20886,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agent setup info
       tags:
         - Elastic Agents
     post:
-      description: Initiate agent setup
       operationId: post-fleet-agents-setup
       parameters:
         - description: The version of the API to use
@@ -20979,12 +20954,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Initiate agent setup
       tags:
         - Elastic Agents
   /api/fleet/agents/tags:
     get:
-      description: List agent tags
       operationId: get-fleet-agents-tags
       parameters:
         - description: The version of the API to use
@@ -21036,12 +21010,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get agent tags
       tags:
         - Elastic Agents
   /api/fleet/check-permissions:
     get:
-      description: Check permissions
       operationId: get-fleet-check-permissions
       parameters:
         - description: The version of the API to use
@@ -21091,12 +21064,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Check permissions
       tags:
         - Fleet internals
   /api/fleet/data_streams:
     get:
-      description: List data streams
       operationId: get-fleet-data-streams
       parameters:
         - description: The version of the API to use
@@ -21196,12 +21168,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get data streams
       tags:
         - Data streams
   /api/fleet/enrollment_api_keys:
     get:
-      description: List enrollment API keys
       operationId: get-fleet-enrollment-api-keys
       parameters:
         - description: The version of the API to use
@@ -21301,11 +21272,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get enrollment API keys
       tags:
         - Fleet enrollment API keys
     post:
-      description: Create enrollment API key
       operationId: post-fleet-enrollment-api-keys
       parameters:
         - description: The version of the API to use
@@ -21404,12 +21374,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create an enrollment API key
       tags:
         - Fleet enrollment API keys
   /api/fleet/enrollment_api_keys/{keyId}:
     delete:
-      description: Revoke enrollment API key by ID by marking it as inactive
+      description: Revoke an enrollment API key by ID by marking it as inactive.
       operationId: delete-fleet-enrollment-api-keys-keyid
       parameters:
         - description: The version of the API to use
@@ -21462,11 +21432,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Revoke an enrollment API key
       tags:
         - Fleet enrollment API keys
     get:
-      description: Get enrollment API key by ID
+      description: Get an enrollment API key by ID.
       operationId: get-fleet-enrollment-api-keys-keyid
       parameters:
         - description: The version of the API to use
@@ -21543,12 +21513,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an enrollment API key
       tags:
         - Fleet enrollment API keys
   /api/fleet/epm/bulk_assets:
     post:
-      description: Bulk get assets
       operationId: post-fleet-epm-bulk-assets
       parameters:
         - description: The version of the API to use
@@ -21642,12 +21611,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk get assets
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/categories:
     get:
-      description: List package categories
       operationId: get-fleet-epm-categories
       parameters:
         - description: The version of the API to use
@@ -21714,12 +21682,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get package categories
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/custom_integrations:
     post:
-      description: Create custom integration
       operationId: post-fleet-epm-custom-integrations
       parameters:
         - description: The version of the API to use
@@ -21857,12 +21824,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create a custom integration
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/data_streams:
     get:
-      description: List data streams
       operationId: get-fleet-epm-data-streams
       parameters:
         - description: The version of the API to use
@@ -21940,12 +21906,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get data streams
       tags:
         - Data streams
   /api/fleet/epm/packages:
     get:
-      description: List packages
       operationId: get-fleet-epm-packages
       parameters:
         - description: The version of the API to use
@@ -22341,11 +22306,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get packages
       tags:
         - Elastic Package Manager (EPM)
     post:
-      description: Install package by upload
       operationId: post-fleet-epm-packages
       parameters:
         - description: The version of the API to use
@@ -22468,12 +22432,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Install a package by upload
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/_bulk:
     post:
-      description: Bulk install packages
       operationId: post-fleet-epm-packages-bulk
       parameters:
         - description: The version of the API to use
@@ -22651,12 +22614,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk install packages
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgName}/{pkgVersion}:
     delete:
-      description: Delete package
       operationId: delete-fleet-epm-packages-pkgname-pkgversion
       parameters:
         - description: The version of the API to use
@@ -22767,11 +22729,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete a package
       tags:
         - Elastic Package Manager (EPM)
     get:
-      description: Get package
       operationId: get-fleet-epm-packages-pkgname-pkgversion
       parameters:
         - description: The version of the API to use
@@ -23247,11 +23208,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a package
       tags:
         - Elastic Package Manager (EPM)
     post:
-      description: Install package from registry
       operationId: post-fleet-epm-packages-pkgname-pkgversion
       parameters:
         - description: The version of the API to use
@@ -23397,11 +23357,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Install a package from the registry
       tags:
         - Elastic Package Manager (EPM)
     put:
-      description: Update package settings
       operationId: put-fleet-epm-packages-pkgname-pkgversion
       parameters:
         - description: The version of the API to use
@@ -23866,12 +23825,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update package settings
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgName}/{pkgVersion}/{filePath*}:
     get:
-      description: Get package file
       operationId: get-fleet-epm-packages-pkgname-pkgversion-filepath
       parameters:
         - description: The version of the API to use
@@ -23918,12 +23876,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a package file
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgName}/{pkgVersion}/transforms/authorize:
     post:
-      description: Authorize transforms
       operationId: post-fleet-epm-packages-pkgname-pkgversion-transforms-authorize
       parameters:
         - description: The version of the API to use
@@ -24011,12 +23968,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Authorize transforms
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgName}/stats:
     get:
-      description: Get package stats
       operationId: get-fleet-epm-packages-pkgname-stats
       parameters:
         - description: The version of the API to use
@@ -24066,12 +24022,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get package stats
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/installed:
     get:
-      description: Get installed packages
       operationId: get-fleet-epm-packages-installed
       parameters:
         - description: The version of the API to use
@@ -24220,12 +24175,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get installed packages
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/limited:
     get:
-      description: Get limited package list
       operationId: get-fleet-epm-packages-limited
       parameters:
         - description: The version of the API to use
@@ -24266,12 +24220,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a limited package list
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs:
     get:
-      description: Get inputs template
       operationId: get-fleet-epm-templates-pkgname-pkgversion-inputs
       parameters:
         - description: The version of the API to use
@@ -24374,12 +24327,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get an inputs template
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/verification_key_id:
     get:
-      description: Get a package signature verification key ID
       operationId: get-fleet-epm-verification-key-id
       parameters:
         - description: The version of the API to use
@@ -24419,12 +24371,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a package signature verification key ID
       tags:
         - Elastic Package Manager (EPM)
   /api/fleet/fleet_server_hosts:
     get:
-      description: List Fleet Server hosts
       operationId: get-fleet-fleet-server-hosts
       parameters:
         - description: The version of the API to use
@@ -24500,11 +24451,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get Fleet Server hosts
       tags:
         - Fleet Server hosts
     post:
-      description: Create Fleet Server host
       operationId: post-fleet-fleet-server-hosts
       parameters:
         - description: The version of the API to use
@@ -24606,12 +24556,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create a Fleet Server host
       tags:
         - Fleet Server hosts
   /api/fleet/fleet_server_hosts/{itemId}:
     delete:
-      description: Delete Fleet Server host by ID
+      description: Delete a Fleet Server host by ID.
       operationId: delete-fleet-fleet-server-hosts-itemid
       parameters:
         - description: The version of the API to use
@@ -24662,11 +24612,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete a Fleet Server host
       tags:
         - Fleet Server hosts
     get:
-      description: Get Fleet Server host by ID
+      description: Get a Fleet Server host by ID.
       operationId: get-fleet-fleet-server-hosts-itemid
       parameters:
         - description: The version of the API to use
@@ -24736,11 +24686,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a Fleet Server host
       tags:
         - Fleet Server hosts
     put:
-      description: Update Fleet Server host by ID
+      description: Update a Fleet Server host by ID.
       operationId: put-fleet-fleet-server-hosts-itemid
       parameters:
         - description: The version of the API to use
@@ -24840,12 +24790,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update a Fleet Server host
       tags:
         - Fleet Server hosts
   /api/fleet/health_check:
     post:
-      description: Check Fleet Server health
       operationId: post-fleet-health-check
       parameters:
         - description: The version of the API to use
@@ -24922,12 +24871,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Check Fleet Server health
       tags:
         - Fleet internals
   /api/fleet/kubernetes:
     get:
-      description: Get full K8s agent manifest
       operationId: get-fleet-kubernetes
       parameters:
         - description: The version of the API to use
@@ -24981,7 +24929,7 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a full K8s agent manifest
       tags:
         - Elastic Agent policies
   /api/fleet/kubernetes/download:
@@ -25049,12 +24997,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Download an agent manifest
       tags:
         - Elastic Agent policies
   /api/fleet/logstash_api_keys:
     post:
-      description: Generate Logstash API key
       operationId: post-fleet-logstash-api-keys
       parameters:
         - description: The version of the API to use
@@ -25100,12 +25047,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Generate a Logstash API key
       tags:
         - Fleet outputs
   /api/fleet/message_signing_service/rotate_key_pair:
     post:
-      description: Rotate fleet message signing key pair
       operationId: post-fleet-message-signing-service-rotate-key-pair
       parameters:
         - description: The version of the API to use
@@ -25173,12 +25119,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Rotate a Fleet message signing key pair
       tags:
         - Message Signing Service
   /api/fleet/outputs:
     get:
-      description: List outputs
       operationId: get-fleet-outputs
       parameters:
         - description: The version of the API to use
@@ -25907,11 +25852,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get outputs
       tags:
         - Fleet outputs
     post:
-      description: Create output
       operationId: post-fleet-outputs
       parameters:
         - description: The version of the API to use
@@ -27320,12 +27264,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create output
       tags:
         - Fleet outputs
   /api/fleet/outputs/{outputId}:
     delete:
-      description: Delete output by ID
+      description: Delete output by ID.
       operationId: delete-fleet-outputs-outputid
       parameters:
         - description: The version of the API to use
@@ -27392,11 +27336,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete output
       tags:
         - Fleet outputs
     get:
-      description: Get output by ID
+      description: Get output by ID.
       operationId: get-fleet-outputs-outputid
       parameters:
         - description: The version of the API to use
@@ -28119,11 +28063,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get output
       tags:
         - Fleet outputs
     put:
-      description: Update output by ID
+      description: Update output by ID.
       operationId: put-fleet-outputs-outputid
       parameters:
         - description: The version of the API to use
@@ -29516,12 +29460,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update output
       tags:
         - Fleet outputs
   /api/fleet/outputs/{outputId}/health:
     get:
-      description: Get latest output health
       operationId: get-fleet-outputs-outputid-health
       parameters:
         - description: The version of the API to use
@@ -29574,12 +29517,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get the latest output health
       tags:
         - Fleet outputs
   /api/fleet/package_policies:
     get:
-      description: List package policies
       operationId: get-fleet-package-policies
       parameters:
         - description: The version of the API to use
@@ -30080,11 +30022,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get package policies
       tags:
         - Fleet package policies
     post:
-      description: Create package policy
       operationId: post-fleet-package-policies
       parameters:
         - description: The version of the API to use
@@ -30982,12 +30923,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create a package policy
       tags:
         - Fleet package policies
   /api/fleet/package_policies/_bulk_get:
     post:
-      description: Bulk get package policies
       operationId: post-fleet-package-policies-bulk-get
       parameters:
         - description: The version of the API to use
@@ -31475,12 +31415,12 @@ paths:
                     type: string
                 required:
                   - message
-      summary: ''
+      summary: Bulk get package policies
       tags:
         - Fleet package policies
   /api/fleet/package_policies/{packagePolicyId}:
     delete:
-      description: Delete package policy by ID
+      description: Delete a package policy by ID.
       operationId: delete-fleet-package-policies-packagepolicyid
       parameters:
         - description: The version of the API to use
@@ -31536,11 +31476,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete a package policy
       tags:
         - Fleet package policies
     get:
-      description: Get package policy by ID
+      description: Get a package policy by ID.
       operationId: get-fleet-package-policies-packagepolicyid
       parameters:
         - description: The version of the API to use
@@ -32005,11 +31945,11 @@ paths:
                     type: string
                 required:
                   - message
-      summary: ''
+      summary: Get a package policy
       tags:
         - Fleet package policies
     put:
-      description: Update package policy by ID
+      description: Update a package policy by ID.
       operationId: put-fleet-package-policies-packagepolicyid
       parameters:
         - description: The version of the API to use
@@ -32901,12 +32841,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update a package policy
       tags:
         - Fleet package policies
   /api/fleet/package_policies/delete:
     post:
-      description: Bulk delete package policies
       operationId: post-fleet-package-policies-delete
       parameters:
         - description: The version of the API to use
@@ -33038,12 +32977,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Bulk delete package policies
       tags:
         - Fleet package policies
   /api/fleet/package_policies/upgrade:
     post:
-      description: Upgrade package policy to a newer package version
+      description: Upgrade a package policy to a newer package version.
       operationId: post-fleet-package-policies-upgrade
       parameters:
         - description: The version of the API to use
@@ -33119,12 +33058,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Upgrade a package policy
       tags:
         - Fleet package policies
   /api/fleet/package_policies/upgrade/dryrun:
     post:
-      description: Dry run package policy upgrade
       operationId: post-fleet-package-policies-upgrade-dryrun
       parameters:
         - description: The version of the API to use
@@ -33969,12 +33907,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Dry run a package policy upgrade
       tags:
         - Fleet package policies
   /api/fleet/proxies:
     get:
-      description: List proxies
       operationId: get-fleet-proxies
       parameters:
         - description: The version of the API to use
@@ -34056,11 +33993,10 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get proxies
       tags:
         - Fleet proxies
     post:
-      description: Create proxy
       operationId: post-fleet-proxies
       parameters:
         - description: The version of the API to use
@@ -34174,12 +34110,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create a proxy
       tags:
         - Fleet proxies
   /api/fleet/proxies/{itemId}:
     delete:
-      description: Delete proxy by ID
+      description: Delete a proxy by ID
       operationId: delete-fleet-proxies-itemid
       parameters:
         - description: The version of the API to use
@@ -34230,11 +34166,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Delete a proxy
       tags:
         - Fleet proxies
     get:
-      description: Get proxy by ID
+      description: Get a proxy by ID.
       operationId: get-fleet-proxies-itemid
       parameters:
         - description: The version of the API to use
@@ -34310,11 +34246,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a proxy
       tags:
         - Fleet proxies
     put:
-      description: Update proxy by ID
+      description: Update a proxy by ID.
       operationId: put-fleet-proxies-itemid
       parameters:
         - description: The version of the API to use
@@ -34430,12 +34366,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Update a proxy
       tags:
         - Fleet proxies
   /api/fleet/service_tokens:
     post:
-      description: Create a service token
       operationId: post-fleet-service-tokens
       parameters:
         - description: The version of the API to use
@@ -34495,12 +34430,11 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Create a service token
       tags:
         - Fleet service tokens
   /api/fleet/settings:
     get:
-      description: Get settings
       operationId: get-fleet-settings
       parameters:
         - description: The version of the API to use
@@ -34591,11 +34525,10 @@ paths:
                     type: string
                 required:
                   - message
-      summary: ''
+      summary: Get settings
       tags:
         - Fleet internals
     put:
-      description: Update settings
       operationId: put-fleet-settings
       parameters:
         - description: The version of the API to use
@@ -34724,12 +34657,11 @@ paths:
                     type: string
                 required:
                   - message
-      summary: ''
+      summary: Update settings
       tags:
         - Fleet internals
   /api/fleet/setup:
     post:
-      description: Initiate Fleet setup
       operationId: post-fleet-setup
       parameters:
         - description: The version of the API to use
@@ -34806,12 +34738,12 @@ paths:
                     type: string
                 required:
                   - message
-      summary: ''
+      summary: Initiate Fleet setup
       tags:
         - Fleet internals
   /api/fleet/uninstall_tokens:
     get:
-      description: List metadata for latest uninstall tokens per agent policy
+      description: List the metadata for the latest uninstall tokens per agent policy.
       operationId: get-fleet-uninstall-tokens
       parameters:
         - description: The version of the API to use
@@ -34906,12 +34838,12 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get metadata for latest uninstall tokens
       tags:
         - Fleet uninstall tokens
   /api/fleet/uninstall_tokens/{uninstallTokenId}:
     get:
-      description: Get one decrypted uninstall token by its ID
+      description: Get one decrypted uninstall token by its ID.
       operationId: get-fleet-uninstall-tokens-uninstalltokenid
       parameters:
         - description: The version of the API to use
@@ -34977,7 +34909,7 @@ paths:
                     type: number
                 required:
                   - message
-      summary: ''
+      summary: Get a decrypted uninstall token
       tags:
         - Fleet uninstall tokens
   /api/lists:

--- a/x-pack/plugins/fleet/server/routes/agent/index.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/index.ts
@@ -97,7 +97,8 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      description: `Get agent by ID`,
+      summary: `Get an agent`,
+      description: `Get an agent by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },
@@ -127,7 +128,8 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Update agent by ID`,
+      summary: `Update an agent`,
+      description: `Update an agent by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },
@@ -157,7 +159,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Bulk update agent tags`,
+      summary: `Bulk update agent tags`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -187,7 +189,8 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Delete agent by ID`,
+      summary: `Delete an agent`,
+      description: `Delete an agent by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },
@@ -218,7 +221,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      description: `List agents`,
+      summary: `Get agents`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },
@@ -248,7 +251,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      description: `List agent tags`,
+      summary: `Get agent tags`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },
@@ -278,7 +281,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Create agent action`,
+      summary: `Create an agent action`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -312,7 +315,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Cancel agent action`,
+      summary: `Cancel an agent action`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -347,7 +350,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      description: `List agents by action ids`,
+      summary: `Get agents by action ids`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },
@@ -376,7 +379,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Unenroll agent`,
+      summary: `Unenroll an agent`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -395,7 +398,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Reassign agent`,
+      summary: `Reassign an agent`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -424,7 +427,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      description: `Request agent diagnostics`,
+      summary: `Request agent diagnostics`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -453,7 +456,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      description: `Bulk request diagnostics from agents`,
+      summary: `Bulk request diagnostics from agents`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -482,7 +485,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      description: `List agent uploads`,
+      summary: `Get agent uploads`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },
@@ -511,7 +514,8 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      description: `Get file uploaded by agent`,
+      summary: `Get an uploaded file`,
+      description: `Get a file uploaded by an agent.`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },
@@ -540,7 +544,8 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Delete file uploaded by agent`,
+      summary: `Delete an uploaded file`,
+      description: `Delete a file uploaded by an agent.`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },
@@ -572,7 +577,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
           fleetAuthz,
           getRouteRequiredAuthz('get', AGENT_API_ROUTES.STATUS_PATTERN)
         ).granted,
-      description: `Get agent status summary`,
+      summary: `Get an agent status summary`,
       options: {
         tags: ['oas-tag:Elastic Agent status'],
       },
@@ -601,7 +606,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      description: `Get incoming agent data`,
+      summary: `Get incoming agent data`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },
@@ -631,7 +636,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Upgrade agent`,
+      summary: `Upgrade an agent`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -660,7 +665,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Bulk upgrade agents`,
+      summary: `Bulk upgrade agents`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -690,7 +695,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      description: `Get agent action status`,
+      summary: `Get an agent action status`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -720,7 +725,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Bulk reassign agents`,
+      summary: `Bulk reassign agents`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -750,7 +755,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Bulk unenroll agents`,
+      summary: `Bulk unenroll agents`,
       options: {
         tags: ['oas-tag:Elastic Agent actions'],
       },
@@ -780,7 +785,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
       fleetAuthz: {
         fleet: { readAgents: true },
       },
-      description: `Get available agent versions`,
+      summary: `Get available agent versions`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },

--- a/x-pack/plugins/fleet/server/routes/agent_policy/index.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/index.ts
@@ -64,7 +64,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
         //  Allow to retrieve agent policies metadata (no full) for user with only read agents permissions
         return authz.fleet.readAgentPolicies || authz.fleet.readAgents;
       },
-      description: `List agent policies`,
+      summary: `Get agent policies`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -95,7 +95,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
         //  Allow to retrieve agent policies metadata (no full) for user with only read agents permissions
         return authz.fleet.readAgentPolicies || authz.fleet.readAgents;
       },
-      description: `Bulk get agent policies`,
+      summary: `Bulk get agent policies`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -126,7 +126,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
         //  Allow to retrieve agent policies metadata (no full) for user with only read agents permissions
         return authz.fleet.readAgentPolicies || authz.fleet.readAgents;
       },
-      description: `Get an agent policy by ID`,
+      summary: `Get an agent policy`,
+      description: `Get an agent policy by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -156,7 +157,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allAgentPolicies: true },
       },
-      description: `Create an agent policy`,
+      summary: `Create an agent policy`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -186,7 +187,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allAgentPolicies: true },
       },
-      description: `Update an agent policy by ID`,
+      summary: `Update an agent policy`,
+      description: `Update an agent policy by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -216,7 +218,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allAgentPolicies: true },
       },
-      description: `Copy an agent policy by ID`,
+      summary: `Copy an agent policy`,
+      description: `Copy an agent policy by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -246,7 +249,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allAgentPolicies: true },
       },
-      description: `Delete agent policy by ID`,
+      summary: `Delete an agent policy`,
+      description: `Delete an agent policy by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -276,7 +280,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readAgentPolicies: true },
       },
-      description: `Get a full agent policy by ID`,
+      summary: `Get a full agent policy`,
+      description: `Get a full agent policy by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -307,7 +312,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
         fleet: { readAgentPolicies: true },
       },
       enableQueryVersion: true,
-      description: `Download an agent policy by ID`,
+      summary: `Download an agent policy`,
+      description: `Download an agent policy by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -340,7 +346,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readAgentPolicies: true },
       },
-      description: `Get full K8s agent manifest`,
+      summary: `Get a full K8s agent manifest`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -371,7 +377,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
         fleet: { readAgentPolicies: true },
       },
       enableQueryVersion: true,
-      description: ``,
+      summary: `Download an agent manifest`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -403,7 +409,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: (authz) => {
         return authz.fleet.readAgentPolicies && authz.fleet.readSettings;
       },
-      description: `Get list of outputs associated with agent policies`,
+      summary: `Get outputs for agent policies`,
+      description: `Get a list of outputs associated with agent policies.`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },
@@ -432,7 +439,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: (authz) => {
         return authz.fleet.readAgentPolicies && authz.fleet.readSettings;
       },
-      description: `Get list of outputs associated with agent policy by policy id`,
+      summary: `Get outputs for an agent policy`,
+      description: `Get a list of outputs associated with agent policy by policy id.`,
       options: {
         tags: ['oas-tag:Elastic Agent policies'],
       },

--- a/x-pack/plugins/fleet/server/routes/app/index.ts
+++ b/x-pack/plugins/fleet/server/routes/app/index.ts
@@ -218,7 +218,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
   router.versioned
     .get({
       path: APP_API_ROUTES.CHECK_PERMISSIONS_PATTERN,
-      description: `Check permissions`,
+      summary: `Check permissions`,
       options: {
         tags: ['oas-tag:Fleet internals'],
       },
@@ -263,7 +263,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Create a service token`,
+      summary: `Create a service token`,
       options: {
         tags: ['oas-tag:Fleet service tokens'],
       },

--- a/x-pack/plugins/fleet/server/routes/data_streams/index.ts
+++ b/x-pack/plugins/fleet/server/routes/data_streams/index.ts
@@ -52,7 +52,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { all: true },
       },
-      description: `List data streams`,
+      summary: `Get data streams`,
       options: {
         tags: ['oas-tag:Data streams'],
       },

--- a/x-pack/plugins/fleet/server/routes/download_source/index.ts
+++ b/x-pack/plugins/fleet/server/routes/download_source/index.ts
@@ -39,7 +39,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: (authz) => {
         return authz.fleet.readSettings || authz.fleet.readAgentPolicies;
       },
-      description: `List agent binary download sources`,
+      summary: `Get agent binary download sources`,
       options: {
         tags: ['oas-tag:Elastic Agent binary download sources'],
       },
@@ -68,7 +68,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: (authz) => {
         return authz.fleet.readSettings || authz.fleet.readAgentPolicies;
       },
-      description: `Get agent binary download source by ID`,
+      summary: `Get an agent binary download source`,
+      description: `Get an agent binary download source by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agent binary download sources'],
       },
@@ -97,7 +98,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: `Update agent binary download source by ID`,
+      summary: `Update an agent binary download source`,
+      description: `Update an agent binary download source by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agent binary download sources'],
       },
@@ -126,7 +128,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: `Create agent binary download source`,
+      summary: `Create an agent binary download source`,
       options: {
         tags: ['oas-tag:Elastic Agent binary download sources'],
       },
@@ -155,7 +157,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: `Delete agent binary download source by ID`,
+      summary: `Delete an agent binary download source`,
+      description: `Delete an agent binary download source by ID.`,
       options: {
         tags: ['oas-tag:Elastic Agent binary download sources'],
       },

--- a/x-pack/plugins/fleet/server/routes/enrollment_api_key/index.ts
+++ b/x-pack/plugins/fleet/server/routes/enrollment_api_key/index.ts
@@ -39,7 +39,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readEnrollmentTokens: true },
       },
-      description: `Get enrollment API key by ID`,
+      summary: `Get an enrollment API key`,
+      description: `Get an enrollment API key by ID.`,
       options: {
         tags: ['oas-tag:Fleet enrollment API keys'],
       },
@@ -68,7 +69,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Revoke enrollment API key by ID by marking it as inactive`,
+      summary: `Revoke an enrollment API key`,
+      description: `Revoke an enrollment API key by ID by marking it as inactive.`,
       options: {
         tags: ['oas-tag:Fleet enrollment API keys'],
       },
@@ -97,7 +99,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readEnrollmentTokens: true },
       },
-      description: `List enrollment API keys`,
+      summary: `Get enrollment API keys`,
       options: {
         tags: ['oas-tag:Fleet enrollment API keys'],
       },
@@ -126,7 +128,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allAgents: true },
       },
-      description: `Create enrollment API key`,
+      summary: `Create an enrollment API key`,
       options: {
         tags: ['oas-tag:Fleet enrollment API keys'],
       },

--- a/x-pack/plugins/fleet/server/routes/epm/index.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/index.ts
@@ -102,7 +102,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .get({
       path: EPM_API_ROUTES.CATEGORIES_PATTERN,
       fleetAuthz: READ_PACKAGE_INFO_AUTHZ,
-      description: `List package categories`,
+      summary: `Get package categories`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -129,7 +129,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .get({
       path: EPM_API_ROUTES.LIST_PATTERN,
       fleetAuthz: READ_PACKAGE_INFO_AUTHZ,
-      description: `List packages`,
+      summary: `Get packages`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -156,7 +156,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .get({
       path: EPM_API_ROUTES.INSTALLED_LIST_PATTERN,
       fleetAuthz: READ_PACKAGE_INFO_AUTHZ,
-      description: `Get installed packages`,
+      summary: `Get installed packages`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -183,7 +183,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .get({
       path: EPM_API_ROUTES.LIMITED_LIST_PATTERN,
       fleetAuthz: READ_PACKAGE_INFO_AUTHZ,
-      description: `Get limited package list`,
+      summary: `Get a limited package list`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -210,7 +210,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .get({
       path: EPM_API_ROUTES.STATS_PATTERN,
       fleetAuthz: READ_PACKAGE_INFO_AUTHZ,
-      description: `Get package stats`,
+      summary: `Get package stats`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -237,7 +237,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .get({
       path: EPM_API_ROUTES.INPUTS_PATTERN,
       fleetAuthz: READ_PACKAGE_INFO_AUTHZ,
-      description: `Get inputs template`,
+      summary: `Get an inputs template`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -264,7 +264,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .get({
       path: EPM_API_ROUTES.FILEPATH_PATTERN,
       fleetAuthz: READ_PACKAGE_INFO_AUTHZ,
-      description: `Get package file`,
+      summary: `Get a package file`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -293,7 +293,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       fleetAuthz: (fleetAuthz: FleetAuthz): boolean =>
         calculateRouteAuthz(fleetAuthz, getRouteRequiredAuthz('get', EPM_API_ROUTES.INFO_PATTERN))
           .granted,
-      description: `Get package`,
+      summary: `Get a package`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -322,7 +322,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       fleetAuthz: {
         integrations: { writePackageSettings: true },
       },
-      description: `Update package settings`,
+      summary: `Update package settings`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -349,7 +349,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .post({
       path: EPM_API_ROUTES.INSTALL_FROM_REGISTRY_PATTERN,
       fleetAuthz: INSTALL_PACKAGES_AUTHZ,
-      description: `Install package from registry`,
+      summary: `Install a package from the registry`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -379,7 +379,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
         fleetAuthz: {
           integrations: { installPackages: true },
         },
-        description: `Install Kibana assets for package`,
+        summary: `Install Kibana assets for a package`,
         options: {
           tags: ['oas-tag:Elastic Package Manager (EPM)'],
         },
@@ -408,7 +408,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
         fleetAuthz: {
           integrations: { installPackages: true },
         },
-        description: `Delete Kibana assets for package`,
+        summary: `Delete Kibana assets for a package`,
         options: {
           tags: ['oas-tag:Elastic Package Manager (EPM)'],
         },
@@ -438,7 +438,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       fleetAuthz: {
         integrations: { installPackages: true, upgradePackages: true },
       },
-      description: `Bulk install packages`,
+      summary: `Bulk install packages`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -476,7 +476,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       fleetAuthz: {
         integrations: { uploadPackages: true },
       },
-      description: `Install package by upload`,
+      summary: `Install a package by upload`,
     })
     .addVersion(
       {
@@ -500,7 +500,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .post({
       path: EPM_API_ROUTES.CUSTOM_INTEGRATIONS_PATTERN,
       fleetAuthz: INSTALL_PACKAGES_AUTHZ,
-      description: `Create custom integration`,
+      summary: `Create a custom integration`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -529,7 +529,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       fleetAuthz: {
         integrations: { removePackages: true },
       },
-      description: `Delete package`,
+      summary: `Delete a package`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -557,7 +557,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .get({
       path: EPM_API_ROUTES.VERIFICATION_KEY_ID,
       fleetAuthz: READ_PACKAGE_INFO_AUTHZ,
-      description: `Get a package signature verification key ID`,
+      summary: `Get a package signature verification key ID`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -584,7 +584,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .get({
       path: EPM_API_ROUTES.DATA_STREAMS_PATTERN,
       fleetAuthz: READ_PACKAGE_INFO_AUTHZ,
-      description: `List data streams`,
+      summary: `Get data streams`,
       options: {
         tags: ['oas-tag:Data streams'],
       },
@@ -611,7 +611,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
     .post({
       path: EPM_API_ROUTES.BULK_ASSETS_PATTERN,
       fleetAuthz: READ_PACKAGE_INFO_AUTHZ,
-      description: `Bulk get assets`,
+      summary: `Bulk get assets`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },
@@ -651,7 +651,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
           },
         },
       },
-      description: `Authorize transforms`,
+      summary: `Authorize transforms`,
       options: {
         tags: ['oas-tag:Elastic Package Manager (EPM)'],
       },

--- a/x-pack/plugins/fleet/server/routes/fleet_proxies/index.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_proxies/index.ts
@@ -37,7 +37,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readSettings: true },
       },
-      description: `List proxies`,
+      summary: `Get proxies`,
       options: {
         tags: ['oas-tag:Fleet proxies'],
       },
@@ -66,7 +66,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: `Create proxy`,
+      summary: `Create a proxy`,
       options: {
         tags: ['oas-tag:Fleet proxies'],
       },
@@ -95,7 +95,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: `Update proxy by ID`,
+      summary: `Update a proxy`,
+      description: `Update a proxy by ID.`,
       options: {
         tags: ['oas-tag:Fleet proxies'],
       },
@@ -124,7 +125,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readSettings: true },
       },
-      description: `Get proxy by ID`,
+      summary: `Get a proxy`,
+      description: `Get a proxy by ID.`,
       options: {
         tags: ['oas-tag:Fleet proxies'],
       },
@@ -153,7 +155,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: `Delete proxy by ID`,
+      summary: `Delete a proxy`,
+      description: `Delete a proxy by ID`,
       options: {
         tags: ['oas-tag:Fleet proxies'],
       },

--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/index.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/index.ts
@@ -39,7 +39,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: (authz) => {
         return authz.fleet.addAgents || authz.fleet.addFleetServers || authz.fleet.readSettings;
       },
-      description: `List Fleet Server hosts`,
+      summary: `Get Fleet Server hosts`,
       options: {
         tags: ['oas-tag:Fleet Server hosts'],
       },
@@ -67,7 +67,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: `Create Fleet Server host`,
+      summary: `Create a Fleet Server host`,
       options: {
         tags: ['oas-tag:Fleet Server hosts'],
       },
@@ -95,7 +95,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readSettings: true },
       },
-      description: `Get Fleet Server host by ID`,
+      summary: `Get a Fleet Server host`,
+      description: `Get a Fleet Server host by ID.`,
       options: {
         tags: ['oas-tag:Fleet Server hosts'],
       },
@@ -123,7 +124,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: `Delete Fleet Server host by ID`,
+      summary: `Delete a Fleet Server host`,
+      description: `Delete a Fleet Server host by ID.`,
       options: {
         tags: ['oas-tag:Fleet Server hosts'],
       },
@@ -154,7 +156,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: `Update Fleet Server host by ID`,
+      summary: `Update a Fleet Server host`,
+      description: `Update a Fleet Server host by ID.`,
       options: {
         tags: ['oas-tag:Fleet Server hosts'],
       },

--- a/x-pack/plugins/fleet/server/routes/health_check/index.ts
+++ b/x-pack/plugins/fleet/server/routes/health_check/index.ts
@@ -22,7 +22,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: `Check Fleet Server health`,
+      summary: `Check Fleet Server health`,
       options: {
         tags: ['oas-tag:Fleet internals'],
       },

--- a/x-pack/plugins/fleet/server/routes/message_signing_service/index.ts
+++ b/x-pack/plugins/fleet/server/routes/message_signing_service/index.ts
@@ -23,7 +23,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { all: true },
       },
-      description: 'Rotate fleet message signing key pair',
+      summary: 'Rotate a Fleet message signing key pair',
       options: {
         tags: ['oas-tag:Message Signing Service'],
       },

--- a/x-pack/plugins/fleet/server/routes/output/index.ts
+++ b/x-pack/plugins/fleet/server/routes/output/index.ts
@@ -43,7 +43,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: (authz) => {
         return authz.fleet.readSettings || authz.fleet.readAgentPolicies;
       },
-      description: 'List outputs',
+      summary: 'Get outputs',
       options: {
         tags: ['oas-tag:Fleet outputs'],
       },
@@ -71,7 +71,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: (authz) => {
         return authz.fleet.readSettings || authz.fleet.readAgentPolicies;
       },
-      description: 'Get output by ID',
+      summary: 'Get output',
+      description: 'Get output by ID.',
       options: {
         tags: ['oas-tag:Fleet outputs'],
       },
@@ -99,7 +100,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: (authz) => {
         return authz.fleet.allSettings || authz.fleet.allAgentPolicies;
       },
-      description: 'Update output by ID',
+      summary: 'Update output',
+      description: 'Update output by ID.',
       options: {
         tags: ['oas-tag:Fleet outputs'],
       },
@@ -128,7 +130,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: 'Create output',
+      summary: 'Create output',
       options: {
         tags: ['oas-tag:Fleet outputs'],
       },
@@ -157,7 +159,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: 'Delete output by ID',
+      summary: 'Delete output',
+      description: 'Delete output by ID.',
       options: {
         tags: ['oas-tag:Fleet outputs'],
       },
@@ -189,7 +192,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: 'Generate Logstash API key',
+      summary: 'Generate a Logstash API key',
       options: {
         tags: ['oas-tag:Fleet outputs'],
       },
@@ -218,7 +221,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readSettings: true },
       },
-      description: 'Get latest output health',
+      summary: 'Get the latest output health',
       options: {
         tags: ['oas-tag:Fleet outputs'],
       },

--- a/x-pack/plugins/fleet/server/routes/package_policy/index.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/index.ts
@@ -61,7 +61,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
           fleetAuthz,
           getRouteRequiredAuthz('get', PACKAGE_POLICY_API_ROUTES.LIST_PATTERN)
         ).granted,
-      description: 'List package policies',
+      summary: 'Get package policies',
       options: {
         tags: ['oas-tag:Fleet package policies'],
       },
@@ -93,7 +93,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
           fleetAuthz,
           getRouteRequiredAuthz('post', PACKAGE_POLICY_API_ROUTES.BULK_GET_PATTERN)
         ).granted,
-      description: 'Bulk get package policies',
+      summary: 'Bulk get package policies',
       options: {
         tags: ['oas-tag:Fleet package policies'],
       },
@@ -128,7 +128,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
           fleetAuthz,
           getRouteRequiredAuthz('get', PACKAGE_POLICY_API_ROUTES.INFO_PATTERN)
         ).granted,
-      description: 'Get package policy by ID',
+      summary: 'Get a package policy',
+      description: 'Get a package policy by ID.',
       options: {
         tags: ['oas-tag:Fleet package policies'],
       },
@@ -187,7 +188,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
   router.versioned
     .post({
       path: PACKAGE_POLICY_API_ROUTES.CREATE_PATTERN,
-      description: 'Create package policy',
+      summary: 'Create a package policy',
       options: {
         tags: ['oas-tag:Fleet package policies'],
       },
@@ -222,7 +223,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
           fleetAuthz,
           getRouteRequiredAuthz('put', PACKAGE_POLICY_API_ROUTES.UPDATE_PATTERN)
         ).granted,
-      description: 'Update package policy by ID',
+      summary: 'Update a package policy',
+      description: 'Update a package policy by ID.',
       options: {
         tags: ['oas-tag:Fleet package policies'],
       },
@@ -259,7 +261,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         integrations: { writeIntegrationPolicies: true },
       },
-      description: 'Bulk delete package policies',
+      summary: 'Bulk delete package policies',
       options: {
         tags: ['oas-tag:Fleet package policies'],
       },
@@ -288,7 +290,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         integrations: { writeIntegrationPolicies: true },
       },
-      description: 'Delete package policy by ID',
+      summary: 'Delete a package policy',
+      description: 'Delete a package policy by ID.',
       options: {
         tags: ['oas-tag:Fleet package policies'],
       },
@@ -318,7 +321,8 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         integrations: { writeIntegrationPolicies: true },
       },
-      description: 'Upgrade package policy to a newer package version',
+      summary: 'Upgrade a package policy',
+      description: 'Upgrade a package policy to a newer package version.',
       options: {
         tags: ['oas-tag:Fleet package policies'],
       },
@@ -348,7 +352,7 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         integrations: { readIntegrationPolicies: true },
       },
-      description: 'Dry run package policy upgrade',
+      summary: 'Dry run a package policy upgrade',
       options: {
         tags: ['oas-tag:Fleet package policies'],
       },

--- a/x-pack/plugins/fleet/server/routes/settings/index.ts
+++ b/x-pack/plugins/fleet/server/routes/settings/index.ts
@@ -45,7 +45,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
             authz.fleet.allAgentPolicies
           );
         },
-        description: `Get space settings`,
+        summary: `Get space settings`,
       })
       .addVersion(
         {
@@ -68,7 +68,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
         fleetAuthz: {
           fleet: { allSettings: true },
         },
-        description: `Put space settings`,
+        summary: `Create space settings`,
       })
       .addVersion(
         {
@@ -92,7 +92,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       fleetAuthz: {
         fleet: { readSettings: true },
       },
-      description: `Get settings`,
+      summary: `Get settings`,
       options: {
         tags: ['oas-tag:Fleet internals'],
       },
@@ -123,7 +123,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       fleetAuthz: {
         fleet: { allSettings: true },
       },
-      description: `Update settings`,
+      summary: `Update settings`,
       options: {
         tags: ['oas-tag:Fleet internals'],
       },
@@ -154,7 +154,7 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
       fleetAuthz: (authz) => {
         return authz.fleet.addAgents || authz.fleet.addFleetServers;
       },
-      description: `Get enrollment settings`,
+      summary: `Get enrollment settings`,
       options: {
         tags: ['oas-tag:Fleet internals'],
       },

--- a/x-pack/plugins/fleet/server/routes/setup/index.ts
+++ b/x-pack/plugins/fleet/server/routes/setup/index.ts
@@ -42,7 +42,7 @@ export const registerFleetSetupRoute = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { setup: true },
       },
-      description: `Initiate Fleet setup`,
+      summary: `Initiate Fleet setup`,
       options: {
         tags: ['oas-tag:Fleet internals'],
       },
@@ -104,7 +104,7 @@ export const registerCreateFleetSetupRoute = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { setup: true },
       },
-      description: `Initiate agent setup`,
+      summary: `Initiate agent setup`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },
@@ -135,7 +135,7 @@ export const registerGetFleetStatusRoute = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { setup: true },
       },
-      description: `Get agent setup info`,
+      summary: `Get agent setup info`,
       options: {
         tags: ['oas-tag:Elastic Agents'],
       },

--- a/x-pack/plugins/fleet/server/routes/uninstall_token/index.ts
+++ b/x-pack/plugins/fleet/server/routes/uninstall_token/index.ts
@@ -31,7 +31,8 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
         fleetAuthz: {
           fleet: { allAgents: true },
         },
-        description: 'List metadata for latest uninstall tokens per agent policy',
+        summary: 'Get metadata for latest uninstall tokens',
+        description: 'List the metadata for the latest uninstall tokens per agent policy.',
         options: {
           tags: ['oas-tag:Fleet uninstall tokens'],
         },
@@ -60,7 +61,8 @@ export const registerRoutes = (router: FleetAuthzRouter, config: FleetConfigType
         fleetAuthz: {
           fleet: { allAgents: true },
         },
-        description: 'Get one decrypted uninstall token by its ID',
+        summary: 'Get a decrypted uninstall token',
+        description: 'Get one decrypted uninstall token by its ID.',
         options: {
           tags: ['oas-tag:Fleet uninstall tokens'],
         },


### PR DESCRIPTION
## Summary

This PR addresses the following type of linting messages that are occurring for the Fleet APIs:

```
18769:16      warning  operation-summary-length    Operation summary should be between 5 and 45 characters                           paths./api/fleet/agents.get.summary
 18834:16      warning  operation-summary-length    Operation summary should be between 5 and 45 characters                           paths./api/fleet/agents.post.summary
 18892:16      warning  operation-summary-length    Operation summary should be between 5 and 45 characters                           paths./api/fleet/agents/{agentId}.delete.summary
```

In some cases the summary was missing entirely, in others it was empty.

Operation summaries are mandatory for the purposes of our documentation. They should be concise--at most 30 characters--and start with a verb. We use common verbs like Get, Update, Delete whenever possible.

In most cases I have changed the "description" declaration to a "summary" since the former is optional and only required when there's longer form information that needs to be added to the docs.

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->