### PR TITLE
[Discover][ES|QL] Investigate Histogram many fields performance 

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/public/helpers/data_layers.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/helpers/data_layers.tsx
@@ -131,6 +131,7 @@ export const getFormattedRow = (
 ): { row: Datatable['rows'][number]; formattedColumns: Record<string, true> } =>
   columns.reduce(
     (formattedInfo, { id }) => {
+      console.count('iterations');
       const record = formattedInfo.row[id];
       if (
         record != null &&
@@ -159,12 +160,15 @@ export const getFormattedTable = (
   accessors: Array<string | ExpressionValueVisDimension>,
   xScaleType: XScaleType
 ): { table: Datatable; formattedColumns: Record<string, true> } => {
+  debugger;
   console.time('getFormattedTable');
   const columnsFormatters = table.columns.reduce<Record<string, IFieldFormat>>(
     (formatters, { id, meta }) => {
-      const accessor: string | ExpressionValueVisDimension | undefined = accessors.find(
-        (a) => getAccessorByDimension(a, table.columns) === id
-      );
+      console.count('iterations');
+      const accessor: string | ExpressionValueVisDimension | undefined = accessors.find((a) => {
+        console.count('iterations');
+        return getAccessorByDimension(a, table.columns) === id;
+      });
 
       return {
         ...formatters,
@@ -182,6 +186,7 @@ export const getFormattedTable = (
     formattedColumns: {},
   };
   for (const row of table.rows) {
+    console.count('iterations');
     const formattedRowInfo = getFormattedRow(
       row,
       table.columns,

--- a/src/plugins/chart_expressions/expression_xy/public/helpers/data_layers.tsx
+++ b/src/plugins/chart_expressions/expression_xy/public/helpers/data_layers.tsx
@@ -159,6 +159,7 @@ export const getFormattedTable = (
   accessors: Array<string | ExpressionValueVisDimension>,
   xScaleType: XScaleType
 ): { table: Datatable; formattedColumns: Record<string, true> } => {
+  console.time('getFormattedTable');
   const columnsFormatters = table.columns.reduce<Record<string, IFieldFormat>>(
     (formatters, { id, meta }) => {
       const accessor: string | ExpressionValueVisDimension | undefined = accessors.find(
@@ -196,6 +197,7 @@ export const getFormattedTable = (
       ...formattedRowInfo.formattedColumns,
     };
   }
+  console.timeEnd('getFormattedTable');
 
   return {
     table: { ...table, rows: formattedTableInfo.rows },

--- a/src/plugins/visualizations/common/utils/accessors.ts
+++ b/src/plugins/visualizations/common/utils/accessors.ts
@@ -114,7 +114,10 @@ export const getColumnByAccessor = (
   columns: Datatable['columns'] = []
 ) => {
   if (typeof accessor === 'string') {
-    return columns.find(({ id }) => accessor === id);
+    return columns.find(({ id }) => {
+      console.count('iterations');
+      return accessor === id;
+    });
   }
 
   const visDimensionAccessor = accessor.accessor;
@@ -122,7 +125,10 @@ export const getColumnByAccessor = (
     return columns[visDimensionAccessor];
   }
 
-  return columns.find(({ id }) => visDimensionAccessor.id === id);
+  return columns.find(({ id }) => {
+    console.count('iterations');
+    return visDimensionAccessor.id === id;
+  });
 };
 
 export function isVisDimension(


### PR DESCRIPTION
## Summary

Adding console.time and console.time to analyze preformance problem is code 


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

