### PR TITLE
[ES|QL] Group by histogram suggestion first in the list

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/commands/stats/util.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/commands/stats/util.ts
@@ -99,6 +99,6 @@ export const getDateHistogramCompletionItem: (
       defaultMessage: 'Add date histogram using bucket()',
     }
   ),
-  sortText: '1A',
+  sortText: '1',
   command: TRIGGER_SUGGESTION_COMMAND,
 });


### PR DESCRIPTION
## Summary

Ensures that group BY histogram suggestion is first on the list. It fixes a regression caused from the refactoring of autocomplete


<img width="1108" alt="image" src="https://github.com/user-attachments/assets/a6d6ba7b-c346-4d07-98f4-ac4c4b3ae857">


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->