### PR TITLE
[ResponseOps] mustache lambdas for EncodeURI and EncodeURIComponent

### DIFF
--- a/docs/user/alerting/action-variables.asciidoc
+++ b/docs/user/alerting/action-variables.asciidoc
@@ -329,6 +329,32 @@ If the context variable `context.value.condition0` has a value of `628.4`, it re
 ----
 
 [discrete]
+===== EncodeURI
+
+The `EncodeURI` lambda will evaluate the text passed by returning the value
+of the https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI[`encodeURI()` function] applied to the text.
+
+For example, when the Mustache variable `context.url` is `https://example.com?query=foo bar` (note the embedded space), the following template will render as `https://example.com?query=foo%20bar`:
+
+[source,sh]
+----
+{{#EncodeURI}} {{{context.url}}} {{/EncodeURI}}
+----
+
+[discrete]
+===== EncodeURIComponent
+
+The `EncodeURIComponent` lambda will evaluate the text passed by returning the value
+of the https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent[`encodeURIComponent()` function] applied to the text.
+
+For example, when the Mustache variable `context.url` is `https://example.com?query=foo bar` (note the embedded space), the following template will render as `https%3A%2F%2Fwww.elastic.co%3Ffoo%3Dbar%26baz%3D%20qux`:
+
+[source,sh]
+----
+{{#EncodeURIComponent}} {{{context.url}}} {{/EncodeURIComponent}}
+----
+
+[discrete]
 [[mustache-examples]]
 === Mustache examples
 

--- a/x-pack/plugins/actions/server/lib/mustache_lambdas.test.ts
+++ b/x-pack/plugins/actions/server/lib/mustache_lambdas.test.ts
@@ -259,16 +259,15 @@ describe('mustache lambdas', () => {
       );
     });
 
-    it('logs an error message and returns empty string on errors', () => {
+    it('logs an error message and returns the error message on errors', () => {
       const uri = '\uDC00'; // invalid UTF-8
       const template = dedent`
           {{#EncodeURI}} {{uri}} {{/EncodeURI}}
         `.trim();
 
-      expect(renderMustacheString(logger, template, { uri }, 'none')).toMatch('URI malformed');
-      expect(logger.warn).toHaveBeenCalledWith(
-        `mustache render error: error with encodeURI(\"${uri}\"): URI malformed`
-      );
+      const errMessage = `error evaluating encodeURI(\"${uri}\"): URI malformed`;
+      expect(renderMustacheString(logger, template, { uri }, 'none')).toBe(errMessage);
+      expect(logger.warn).toHaveBeenCalledWith(`mustache render error: ${errMessage}`);
     });
   });
 
@@ -284,16 +283,15 @@ describe('mustache lambdas', () => {
       );
     });
 
-    it('logs an error message and returns empty string on errors', () => {
+    it('logs an error message and returns the error message on errors', () => {
       const uri = '\uDC00'; // invalid UTF-8
       const template = dedent`
           {{#EncodeURIComponent}} {{uri}} {{/EncodeURIComponent}}
         `.trim();
 
-      expect(renderMustacheString(logger, template, { uri }, 'none')).toMatch('URI malformed');
-      expect(logger.warn).toHaveBeenCalledWith(
-        `mustache render error: error with encodeURIComponent(\"${uri}\"): URI malformed`
-      );
+      const errMessage = `error evaluating encodeURIComponent(\"${uri}\"): URI malformed`;
+      expect(renderMustacheString(logger, template, { uri }, 'none')).toBe(errMessage);
+      expect(logger.warn).toHaveBeenCalledWith(`mustache render error: ${errMessage}`);
     });
   });
 });

--- a/x-pack/plugins/actions/server/lib/mustache_lambdas.test.ts
+++ b/x-pack/plugins/actions/server/lib/mustache_lambdas.test.ts
@@ -246,4 +246,54 @@ describe('mustache lambdas', () => {
       expect(logger.warn).toHaveBeenCalledWith(`mustache render error: invalid number: 'nope'`);
     });
   });
+
+  describe('EncodeURI', () => {
+    it('valid string is successful', () => {
+      const uri = 'https://www.elastic.co?foo=bar&baz= qux'; // note the space
+      const template = dedent`
+          {{#EncodeURI}} {{uri}} {{/EncodeURI}}
+        `.trim();
+
+      expect(renderMustacheString(logger, template, { uri }, 'none')).toEqual(
+        'https://www.elastic.co?foo=bar&baz=%20qux'
+      );
+    });
+
+    it('logs an error message and returns empty string on errors', () => {
+      const uri = '\uDC00'; // invalid UTF-8
+      const template = dedent`
+          {{#EncodeURI}} {{uri}} {{/EncodeURI}}
+        `.trim();
+
+      expect(renderMustacheString(logger, template, { uri }, 'none')).toMatch('URI malformed');
+      expect(logger.warn).toHaveBeenCalledWith(
+        `mustache render error: error with encodeURI(\"${uri}\"): URI malformed`
+      );
+    });
+  });
+
+  describe('EncodeURIComponent', () => {
+    it('valid string is successful', () => {
+      const uri = 'https://www.elastic.co?foo=bar&baz= qux'; // note the space
+      const template = dedent`
+          {{#EncodeURIComponent}} {{uri}} {{/EncodeURIComponent}}
+        `.trim();
+
+      expect(renderMustacheString(logger, template, { uri }, 'none')).toEqual(
+        'https%3A%2F%2Fwww.elastic.co%3Ffoo%3Dbar%26baz%3D%20qux'
+      );
+    });
+
+    it('logs an error message and returns empty string on errors', () => {
+      const uri = '\uDC00'; // invalid UTF-8
+      const template = dedent`
+          {{#EncodeURIComponent}} {{uri}} {{/EncodeURIComponent}}
+        `.trim();
+
+      expect(renderMustacheString(logger, template, { uri }, 'none')).toMatch('URI malformed');
+      expect(logger.warn).toHaveBeenCalledWith(
+        `mustache render error: error with encodeURIComponent(\"${uri}\"): URI malformed`
+      );
+    });
+  });
 });

--- a/x-pack/plugins/actions/server/lib/mustache_lambdas.ts
+++ b/x-pack/plugins/actions/server/lib/mustache_lambdas.ts
@@ -46,7 +46,35 @@ function getLambdas(logger: Logger) {
         const numberString = render(text.trim()).trim();
         return formatNumber(logger, numberString);
       },
+    EncodeURI: () =>
+      function (text: string, render: RenderFn) {
+        const string = render(text.trim()).trim();
+        return callEncodeURI(logger, string);
+      },
+    EncodeURIComponent: () =>
+      function (text: string, render: RenderFn) {
+        const string = render(text.trim()).trim();
+        return callEncodeURIComponent(logger, string);
+      },
   };
+}
+
+function callEncodeURI(logger: Logger, string: string): string {
+  const s = `${string}`;
+  try {
+    return encodeURI(s);
+  } catch (err) {
+    return logAndReturnErr(logger, `error with encodeURI("${s}"): ${err.message}`);
+  }
+}
+
+function callEncodeURIComponent(logger: Logger, string: string): string {
+  const s = `${string}`;
+  try {
+    return encodeURIComponent(s);
+  } catch (err) {
+    return logAndReturnErr(logger, `error with encodeURIComponent("${s}"): ${err.message}`);
+  }
 }
 
 function evalMath(vars: Variables, o: unknown, logger: Logger): string {

--- a/x-pack/plugins/actions/server/lib/mustache_lambdas.ts
+++ b/x-pack/plugins/actions/server/lib/mustache_lambdas.ts
@@ -64,7 +64,7 @@ function callEncodeURI(logger: Logger, string: string): string {
   try {
     return encodeURI(s);
   } catch (err) {
-    return logAndReturnErr(logger, `error with encodeURI("${s}"): ${err.message}`);
+    return logAndReturnErr(logger, `error evaluating encodeURI("${s}"): ${err.message}`);
   }
 }
 
@@ -73,7 +73,7 @@ function callEncodeURIComponent(logger: Logger, string: string): string {
   try {
     return encodeURIComponent(s);
   } catch (err) {
-    return logAndReturnErr(logger, `error with encodeURIComponent("${s}"): ${err.message}`);
+    return logAndReturnErr(logger, `error evaluating encodeURIComponent("${s}"): ${err.message}`);
   }
 }
 

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
@@ -48,6 +48,7 @@ export const DeepContextVariables = {
   nullJ: null,
   undefinedK: undefined,
   dateL: '2023-04-20T04:13:17.858Z',
+  encodeableUrl: 'https://www.elastic.co?foo=bar&baz= qux',
 };
 
 function getAlwaysFiringRuleType() {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/mustache_templates.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/mustache_templates.ts
@@ -220,7 +220,7 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
     });
 
     it('should handle FormatNumber', async () => {
-      // from xx-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
+      // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
       // const DeepContextVariables
       const template = `{{#context.deep}}{{#FormatNumber}}
         {{{arrayI.1}}}; en-US; style: currency, currency: EUR
@@ -237,7 +237,7 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
     });
 
     it('should handle EncodeURI', async () => {
-      // from xx-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
+      // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
       // const DeepContextVariables
       const template = `{{#context.deep}}{{#EncodeURI}}{{{encodeableUrl}}}{{/EncodeURI}}{{/context.deep}}`;
       const rule = await createRule({
@@ -252,7 +252,7 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
     });
 
     it('should handle EncodeURIComponent', async () => {
-      // from xx-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
+      // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
       // const DeepContextVariables
       const template = `{{#context.deep}}{{#EncodeURIComponent}}{{{encodeableUrl}}}{{/EncodeURIComponent}}{{/context.deep}}`;
       const rule = await createRule({

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/mustache_templates.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/mustache_templates.ts
@@ -66,7 +66,7 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
 
     describe('escaping', () => {
       it('should handle escapes in webhook', async () => {
-        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/alert_types.ts,
+        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
         // const EscapableStrings
         const template = '{{context.escapableDoubleQuote}} -- {{context.escapableLineFeed}}';
         const rule = await createRule({
@@ -81,7 +81,7 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
       });
 
       it('should handle escapes in slack', async () => {
-        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/alert_types.ts,
+        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
         // const EscapableStrings
         const template =
           '{{context.escapableBacktic}} -- {{context.escapableBold}} -- {{context.escapableBackticBold}} -- {{context.escapableHtml}} -- {{context.escapableLink}}';
@@ -101,7 +101,7 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
       });
 
       it('should handle context variable object expansion', async () => {
-        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/alert_types.ts,
+        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
         // const DeepContextVariables
         const template = '{{context.deep}}';
         const rule = await createRule({
@@ -113,7 +113,7 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
         });
         const body = await retry.try(async () => waitForActionBody(slackSimulatorURL, rule.id));
         expect(body).to.be(
-          '{"objectA":{"stringB":"B","arrayC":[{"stringD":"D1","numberE":42},{"stringD":"D2","numberE":43}],"objectF":{"stringG":"G","nullG":null}},"stringH":"H","arrayI":[44,45],"nullJ":null,"dateL":"2023-04-20T04:13:17.858Z"}'
+          '{"objectA":{"stringB":"B","arrayC":[{"stringD":"D1","numberE":42},{"stringD":"D2","numberE":43}],"objectF":{"stringG":"G","nullG":null}},"stringH":"H","arrayI":[44,45],"nullJ":null,"dateL":"2023-04-20T04:13:17.858Z","encodeableUrl":"https://www.elastic.co?foo=bar&amp;baz= qux"}'
         );
       });
 
@@ -165,7 +165,7 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
       });
 
       it('should handle asJSON', async () => {
-        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/alert_types.ts,
+        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
         // const DeepContextVariables
         const template = `{{#context.deep.objectA}}
           {{{arrayC}}} {{{arrayC.asJSON}}}
@@ -185,7 +185,7 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
       });
 
       it('should handle EvalMath', async () => {
-        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/alert_types.ts,
+        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
         // const DeepContextVariables
         const template = `{{#context.deep}}avg({{arrayI.0}}, {{arrayI.1}})/100 => {{#EvalMath}}
           round((arrayI[0] + arrayI[1]) / 2 / 100, 2)
@@ -202,7 +202,7 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
       });
 
       it('should handle FormatDate', async () => {
-        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/alert_types.ts,
+        // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
         // const DeepContextVariables
         const template = `{{#context.deep}}{{#FormatDate}}
           {{{dateL}}} ; America/New_York; dddd MMM Do YYYY HH:mm:ss
@@ -220,7 +220,7 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
     });
 
     it('should handle FormatNumber', async () => {
-      // from x-pack/test/alerting_api_integration/common/plugins/alerts/server/alert_types.ts,
+      // from xx-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
       // const DeepContextVariables
       const template = `{{#context.deep}}{{#FormatNumber}}
         {{{arrayI.1}}}; en-US; style: currency, currency: EUR
@@ -234,6 +234,36 @@ export default function executionStatusAlertTests({ getService }: FtrProviderCon
       });
       const body = await retry.try(async () => waitForActionBody(slackSimulatorURL, rule.id));
       expect(body.trim()).to.be('€45.00');
+    });
+
+    it('should handle EncodeURI', async () => {
+      // from xx-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
+      // const DeepContextVariables
+      const template = `{{#context.deep}}{{#EncodeURI}}{{{encodeableUrl}}}{{/EncodeURI}}{{/context.deep}}`;
+      const rule = await createRule({
+        id: slackConnector.id,
+        group: 'default',
+        params: {
+          message: `message {{rule.id}} - ${template}`,
+        },
+      });
+      const body = await retry.try(async () => waitForActionBody(slackSimulatorURL, rule.id));
+      expect(body.trim()).to.be('https://www.elastic.co?foo=bar&baz=%20qux');
+    });
+
+    it('should handle EncodeURIComponent', async () => {
+      // from xx-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
+      // const DeepContextVariables
+      const template = `{{#context.deep}}{{#EncodeURIComponent}}{{{encodeableUrl}}}{{/EncodeURIComponent}}{{/context.deep}}`;
+      const rule = await createRule({
+        id: slackConnector.id,
+        group: 'default',
+        params: {
+          message: `message {{rule.id}} - ${template}`,
+        },
+      });
+      const body = await retry.try(async () => waitForActionBody(slackSimulatorURL, rule.id));
+      expect(body.trim()).to.be('https%3A%2F%2Fwww.elastic.co%3Ffoo%3Dbar%26baz%3D%20qux');
     });
 
     async function createRule(action: any) {


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/168728

## Summary

Adds mustache lambdas for action parameter templates for uri encoding, using the existing Javascript functions [encodeURI()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) and [encodeURIComponent()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

