### PR TITLE
[EDR Workflows] Add DW Cypress and API tests to the Quality Gate.

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/blocklist.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/blocklist.cy.ts
@@ -41,7 +41,7 @@ const {
 describe(
   'Blocklist',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@serverlessQA'],
   },
   () => {
     let indexedPolicy: IndexedFleetEndpointPolicyResponse;

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/policy/policy_list.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/policy/policy_list.cy.ts
@@ -16,7 +16,7 @@ import { createAgentPolicyTask, getEndpointIntegrationVersion } from '../../task
 describe(
   'Policy List',
   {
-    tags: ['@ess', '@serverless'],
+    tags: ['@ess', '@serverless', '@serverlessQA'],
     env: {
       ftrConfig: {
         kbnServerArgs: [

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/api/agent_policy_settings_complete.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/api/agent_policy_settings_complete.cy.ts
@@ -17,7 +17,7 @@ import { login } from '../../../../tasks/login';
 describe(
   'Agent policy settings API operations on Complete',
   {
-    tags: ['@serverless'],
+    tags: ['@serverless', '@serverlessQA'],
     env: {
       ftrConfig: {
         productTypes: [

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/components/agent_policy_settings_complete.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/components/agent_policy_settings_complete.cy.ts
@@ -17,7 +17,7 @@ import {
 describe(
   'Agent Policy Settings - Complete',
   {
-    tags: ['@serverless'],
+    tags: ['@serverless', '@serverlessQA'],
     env: {
       ftrConfig: {
         productTypes: [

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/components/agent_policy_settings_essentials.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/components/agent_policy_settings_essentials.cy.ts
@@ -17,7 +17,7 @@ import {
 describe(
   'Agent Policy Settings - Essentials',
   {
-    tags: ['@serverless'],
+    tags: ['@serverless', '@serverlessQA'],
     env: {
       ftrConfig: {
         productTypes: [

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/components/policy_details_endpoint_essentials.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/feature_access/components/policy_details_endpoint_essentials.cy.ts
@@ -13,7 +13,7 @@ import { APP_POLICIES_PATH } from '../../../../../../../common/constants';
 describe(
   'When displaying the Policy Details in Endpoint Essentials PLI',
   {
-    tags: ['@serverless'],
+    tags: ['@serverless', '@serverlessQA'],
     env: {
       ftrConfig: {
         productTypes: [

--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/resolver/trial_license_complete_tier/entity.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/resolver/trial_license_complete_tier/entity.ts
@@ -15,7 +15,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const utils = getService('securitySolutionUtils');
 
-  describe('@ess @serverless Resolver tests for the entity route', function () {
+  describe('@ess @serverless @serverlessQA Resolver tests for the entity route', function () {
     let adminSupertest: TestAgent;
 
     before(async () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/resolver/trial_license_complete_tier/entity_id.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/resolver/trial_license_complete_tier/entity_id.ts
@@ -38,7 +38,7 @@ export default function ({ getService }: FtrProviderContext) {
     }
   };
 
-  describe('@ess @serverless Resolver handling of entity ids', function () {
+  describe('@ess @serverless @serverlessQA Resolver handling of entity ids', function () {
     let adminSupertest: TestAgent;
 
     before(async () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/resolver/trial_license_complete_tier/events.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/resolver/trial_license_complete_tier/events.ts
@@ -52,7 +52,7 @@ export default function ({ getService }: FtrProviderContext) {
     ancestryArraySize: 2,
   };
 
-  describe('@ess @serverless event route', function () {
+  describe('@ess @serverless @serverlessQA event route', function () {
     let entityIDFilterArray: JsonObject[] | undefined;
     let entityIDFilter: string | undefined;
     let adminSupertest: TestAgent;

--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/resolver/trial_license_complete_tier/tree.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/resolver/trial_license_complete_tier/tree.ts
@@ -56,7 +56,7 @@ export default function ({ getService }: FtrProviderContext) {
     alwaysGenMaxChildrenPerNode: true,
     ancestryArraySize: 2,
   };
-  describe('@ess @serverless Resolver tree', function () {
+  describe('@ess @serverless @serverlessQA Resolver tree', function () {
     let adminSupertest: TestAgent;
 
     before(async () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/response_actions/trial_license_complete_tier/agent_type_support.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/response_actions/trial_license_complete_tier/agent_type_support.ts
@@ -10,7 +10,7 @@ import TestAgent from 'supertest/lib/agent';
 import { FtrProviderContext } from '../../../../ftr_provider_context_edr_workflows';
 
 export default function ({ getService }: FtrProviderContext) {
-  describe('@ess @serverless Response Actions support for sentinelOne agentType', function () {
+  describe('@ess @serverless @serverlessQA Response Actions support for sentinelOne agentType', function () {
     const utils = getService('securitySolutionUtils');
 
     let adminSupertest: TestAgent;


### PR DESCRIPTION
This PR enables tests in the release pipeline that are 1) agentless (do not involve agent enrollment) and 2) have been stable over the past week. These tests are already running in the periodic pipeline, with addition of `@serverlessQA` tag they will be promoted to be executed in the release pipeline.

Test eligibility breakdown - https://github.com/elastic/kibana/issues/187243#issuecomment-2470007062

CC @MadameSheema 