### PR TITLE
[ES|QL] Improve `STATS` command summary extraction

### DIFF
--- a/packages/kbn-esql-ast/src/ast/helpers.ts
+++ b/packages/kbn-esql-ast/src/ast/helpers.ts
@@ -14,6 +14,7 @@ import type {
   ESQLFunction,
   ESQLIntegerLiteral,
   ESQLLiteral,
+  ESQLParamLiteral,
   ESQLProperNode,
 } from '../types';
 import { BinaryExpressionGroup } from './constants';
@@ -47,6 +48,9 @@ export const isIntegerLiteral = (node: unknown): node is ESQLIntegerLiteral =>
 
 export const isDoubleLiteral = (node: unknown): node is ESQLIntegerLiteral =>
   isLiteral(node) && node.literalType === 'double';
+
+export const isParamLiteral = (node: unknown): node is ESQLParamLiteral =>
+  isLiteral(node) && node.literalType === 'param';
 
 export const isColumn = (node: unknown): node is ESQLColumn =>
   isProperNode(node) && node.type === 'column';

--- a/packages/kbn-esql-ast/src/mutate/README.md
+++ b/packages/kbn-esql-ast/src/mutate/README.md
@@ -60,3 +60,21 @@ console.log(src); // FROM index METADATA _lang, _id
     - `.remove()` &mdash; Remove a `LIMIT` command by index.
     - `.set()` &mdash; Set the limit value of a specific `LIMIT` command.
     - `.upsert()` &mdash; Insert a `LIMIT` command, or update the limit value if it already exists.
+  - `.stats`
+    - `.list()` &mdash; List all `STATS` commands.
+    - `.byIndex()` &mdash; Find a `STATS` command by index.
+    - `.summarize()` &mdash; Summarize all `STATS` commands.
+    - `.summarizeCommand()` &mdash; Summarize a specific `STATS` command.
+
+
+## Examples
+
+Extract all "new" and "used" fields from all `STATS` commands:
+
+```ts
+const query = EsqlQuery.fromSrc('FROM index | STATS a = max(b), agg(c) BY d');
+const summary = mutate.commands.stats.summarize(query);
+
+console.log(summary.newFields);     // [ 'a', '`agg(c)`' ]
+console.log(summary.usedFields);    // [ 'b', 'c', 'd' ]
+```


### PR DESCRIPTION
## Summary

Partially addresses https://github.com/elastic/kibana/issues/191812

- Correctly extracts summary of fields from the `BY` clause of `STATS` command.
- The `.summarize()` command now returns `newFields` and `usedFields` properties. The `newFields` is a list of newly created fields by the `STATS` command. The `usedFields` is a list of all fields which were used by the `STATS` command.
- Improves parameter node handling.


### Example

Extract all "new" and "used" fields from all `STATS` commands:

```ts
const query = EsqlQuery.fromSrc('FROM index | STATS a = max(b), agg(c) BY d');
const summary = mutate.commands.stats.summarize(query);

console.log(summary.newFields);     // [ 'a', '`agg(c)`' ]
console.log(summary.usedFields);    // [ 'b', 'c', 'd' ]
```


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->