### PR TITLE
[8.x] [Security Solution] Add Alert Suppression editable component (#198673)

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -33105,17 +33105,20 @@ components:
       type: object
       properties:
         unit:
-          enum:
-            - s
-            - m
-            - h
-          type: string
+          $ref: >-
+            #/components/schemas/Security_Detections_API_AlertSuppressionDurationUnit
         value:
           minimum: 1
           type: integer
       required:
         - value
         - unit
+    Security_Detections_API_AlertSuppressionDurationUnit:
+      enum:
+        - s
+        - m
+        - h
+      type: string
     Security_Detections_API_AlertSuppressionGroupBy:
       items:
         type: string

--- a/x-pack/plugins/security_solution/common/api/detection_engine/model/rule_schema/common_attributes.gen.ts
+++ b/x-pack/plugins/security_solution/common/api/detection_engine/model/rule_schema/common_attributes.gen.ts
@@ -555,10 +555,15 @@ export const RuleExceptionList = z.object({
   namespace_type: z.enum(['agnostic', 'single']),
 });
 
+export type AlertSuppressionDurationUnit = z.infer<typeof AlertSuppressionDurationUnit>;
+export const AlertSuppressionDurationUnit = z.enum(['s', 'm', 'h']);
+export type AlertSuppressionDurationUnitEnum = typeof AlertSuppressionDurationUnit.enum;
+export const AlertSuppressionDurationUnitEnum = AlertSuppressionDurationUnit.enum;
+
 export type AlertSuppressionDuration = z.infer<typeof AlertSuppressionDuration>;
 export const AlertSuppressionDuration = z.object({
   value: z.number().int().min(1),
-  unit: z.enum(['s', 'm', 'h']),
+  unit: AlertSuppressionDurationUnit,
 });
 
 /**

--- a/x-pack/plugins/security_solution/common/api/detection_engine/model/rule_schema/common_attributes.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/detection_engine/model/rule_schema/common_attributes.schema.yaml
@@ -581,6 +581,13 @@ components:
         - type
         - namespace_type
 
+    AlertSuppressionDurationUnit:
+      type: string
+      enum:
+        - s
+        - m
+        - h
+
     AlertSuppressionDuration:
       type: object
       properties:
@@ -588,11 +595,7 @@ components:
           type: integer
           minimum: 1
         unit:
-          type: string
-          enum:
-            - s
-            - m
-            - h
+          $ref: '#/components/schemas/AlertSuppressionDurationUnit'
       required:
         - value
         - unit

--- a/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -1560,17 +1560,19 @@ components:
       type: object
       properties:
         unit:
-          enum:
-            - s
-            - m
-            - h
-          type: string
+          $ref: '#/components/schemas/AlertSuppressionDurationUnit'
         value:
           minimum: 1
           type: integer
       required:
         - value
         - unit
+    AlertSuppressionDurationUnit:
+      enum:
+        - s
+        - m
+        - h
+      type: string
     AlertSuppressionGroupBy:
       items:
         type: string

--- a/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -850,17 +850,19 @@ components:
       type: object
       properties:
         unit:
-          enum:
-            - s
-            - m
-            - h
-          type: string
+          $ref: '#/components/schemas/AlertSuppressionDurationUnit'
         value:
           minimum: 1
           type: integer
       required:
         - value
         - unit
+    AlertSuppressionDurationUnit:
+      enum:
+        - s
+        - m
+        - h
+      type: string
     AlertSuppressionGroupBy:
       items:
         type: string

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/index.ts
@@ -24,8 +24,8 @@ export const uiPlugins = ({
   insightsUpsellingMessage,
   interactionsUpsellingMessage,
 }: {
-  insightsUpsellingMessage: string | null;
-  interactionsUpsellingMessage: string | null;
+  insightsUpsellingMessage?: string;
+  interactionsUpsellingMessage?: string;
 }) => {
   const currentPlugins = nonStatefulUiPlugins.map((plugin) => plugin.name);
   const insightPluginWithLicense = insightMarkdownPlugin.plugin({

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.test.tsx
@@ -135,7 +135,7 @@ describe('plugin', () => {
   });
 
   it('show investigate message when insightsUpsellingMessage is not provided', () => {
-    const result = plugin({ insightsUpsellingMessage: null });
+    const result = plugin({ insightsUpsellingMessage: undefined });
 
     expect(result.button.label).toEqual('Investigate');
   });

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/index.tsx
@@ -541,11 +541,7 @@ const exampleInsight = `${insightPrefix}{
   ]
 }}`;
 
-export const plugin = ({
-  insightsUpsellingMessage,
-}: {
-  insightsUpsellingMessage: string | null;
-}) => {
+export const plugin = ({ insightsUpsellingMessage }: { insightsUpsellingMessage?: string }) => {
   return {
     name: 'insights',
     button: {

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/osquery/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/osquery/plugin.tsx
@@ -161,7 +161,7 @@ const OsqueryEditor = React.memo(OsqueryEditorComponent);
 export const plugin = ({
   interactionsUpsellingMessage,
 }: {
-  interactionsUpsellingMessage: string | null;
+  interactionsUpsellingMessage?: string;
 }) => {
   return {
     name: 'osquery',

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/timeline/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/timeline/plugin.tsx
@@ -78,7 +78,7 @@ const TimelineEditor = memo(TimelineEditorComponent);
 export const plugin = ({
   interactionsUpsellingMessage,
 }: {
-  interactionsUpsellingMessage: string | null;
+  interactionsUpsellingMessage?: string;
 }): EuiMarkdownEditorUiPlugin => {
   return {
     name: ID,

--- a/x-pack/plugins/security_solution/public/common/hooks/use_upselling.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_upselling.test.tsx
@@ -71,7 +71,7 @@ describe('use_upselling', () => {
     expect(result.all.length).toBe(1); // assert that it should not cause unnecessary re-renders
   });
 
-  test('useUpsellingMessage returns null when upsellingMessageId not found', () => {
+  test('useUpsellingMessage returns undefined when upsellingMessageId not found', () => {
     const emptyMessages = {};
     mockUpselling.setPages(emptyMessages);
 
@@ -81,6 +81,6 @@ describe('use_upselling', () => {
         wrapper: RenderWrapper,
       }
     );
-    expect(result.current).toBe(null);
+    expect(result.current).toBeUndefined();
   });
 });

--- a/x-pack/plugins/security_solution/public/common/hooks/use_upselling.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_upselling.ts
@@ -22,11 +22,11 @@ export const useUpsellingComponent = (id: UpsellingSectionId): React.ComponentTy
   return useMemo(() => upsellingSections?.get(id) ?? null, [id, upsellingSections]);
 };
 
-export const useUpsellingMessage = (id: UpsellingMessageId): string | null => {
+export const useUpsellingMessage = (id: UpsellingMessageId): string | undefined => {
   const upselling = useUpsellingService();
   const upsellingMessages = useObservable(upselling.messages$, upselling.getMessagesValue());
 
-  return useMemo(() => upsellingMessages?.get(id) ?? null, [id, upsellingMessages]);
+  return useMemo(() => upsellingMessages?.get(id), [id, upsellingMessages]);
 };
 
 export const useUpsellingPage = (pageName: SecurityPageName): React.ComponentType | null => {

--- a/x-pack/plugins/security_solution/public/common/test/eui/combobox.ts
+++ b/x-pack/plugins/security_solution/public/common/test/eui/combobox.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { act, fireEvent, waitFor } from '@testing-library/react';
+
+export function showEuiComboBoxOptions(comboBoxToggleButton: HTMLElement): Promise<void> {
+  fireEvent.click(comboBoxToggleButton);
+
+  return waitFor(() => {
+    const listWithOptionsElement = document.querySelector('[role="listbox"]');
+    const emptyListElement = document.querySelector('.euiComboBoxOptionsList__empty');
+
+    expect(listWithOptionsElement || emptyListElement).toBeInTheDocument();
+  });
+}
+
+type SelectEuiComboBoxOptionParameters =
+  | {
+      comboBoxToggleButton: HTMLElement;
+      optionIndex: number;
+      optionText?: undefined;
+    }
+  | {
+      comboBoxToggleButton: HTMLElement;
+      optionText: string;
+      optionIndex?: undefined;
+    };
+
+export function selectEuiComboBoxOption({
+  comboBoxToggleButton,
+  optionIndex,
+  optionText,
+}: SelectEuiComboBoxOptionParameters): Promise<void> {
+  return act(async () => {
+    await showEuiComboBoxOptions(comboBoxToggleButton);
+
+    const options = Array.from(
+      document.querySelectorAll('[data-test-subj*="comboBoxOptionsList"] [role="option"]')
+    );
+
+    if (typeof optionText === 'string') {
+      const optionToSelect = options.find((option) => option.textContent === optionText);
+
+      if (optionToSelect) {
+        fireEvent.click(optionToSelect);
+      } else {
+        throw new Error(
+          `Could not find option with text "${optionText}". Available options: ${options
+            .map((option) => option.textContent)
+            .join(', ')}`
+        );
+      }
+    } else {
+      fireEvent.click(options[optionIndex]);
+    }
+  });
+}
+
+export function selectFirstEuiComboBoxOption({
+  comboBoxToggleButton,
+}: {
+  comboBoxToggleButton: HTMLElement;
+}): Promise<void> {
+  return selectEuiComboBoxOption({ comboBoxToggleButton, optionIndex: 0 });
+}
+
+export function clearEuiComboBoxSelection({
+  clearButton,
+}: {
+  clearButton: HTMLElement;
+}): Promise<void> {
+  return act(async () => {
+    fireEvent.click(clearButton);
+  });
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/alert_suppression_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/alert_suppression_edit.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { EuiPanel, EuiText, EuiToolTip } from '@elastic/eui';
+import type { DataViewFieldBase } from '@kbn/es-query';
+import { useFormData } from '../../../../../shared_imports';
+import { MissingFieldsStrategySelector } from './missing_fields_strategy_selector';
+import { SuppressionDurationSelector } from './suppression_duration_selector';
+import { SuppressionFieldsSelector } from './suppression_fields_selector';
+import { ALERT_SUPPRESSION_FIELDS_FIELD_NAME } from '../constants/fields';
+
+interface AlertSuppressionEditProps {
+  suppressibleFields: DataViewFieldBase[];
+  labelAppend?: React.ReactNode;
+  disabled?: boolean;
+  disabledText?: string;
+  warningText?: string;
+}
+
+export const AlertSuppressionEdit = memo(function AlertSuppressionEdit({
+  suppressibleFields,
+  labelAppend,
+  disabled,
+  disabledText,
+  warningText,
+}: AlertSuppressionEditProps): JSX.Element {
+  const [{ [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: suppressionFields }] = useFormData<{
+    [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: string[];
+  }>({
+    watch: ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  });
+  const hasSelectedFields = suppressionFields?.length > 0;
+  const content = (
+    <>
+      <SuppressionFieldsSelector
+        suppressibleFields={suppressibleFields}
+        labelAppend={labelAppend}
+        disabled={disabled}
+      />
+      {warningText && (
+        <EuiText size="xs" color="warning" data-test-subj="alertSuppressionWarning">
+          {warningText}
+        </EuiText>
+      )}
+      <EuiPanel paddingSize="m" hasShadow={false}>
+        <SuppressionDurationSelector disabled={disabled || !hasSelectedFields} />
+        <MissingFieldsStrategySelector disabled={disabled || !hasSelectedFields} />
+      </EuiPanel>
+    </>
+  );
+
+  return disabled && disabledText ? (
+    <EuiToolTip position="right" content={disabledText}>
+      {content}
+    </EuiToolTip>
+  ) : (
+    content
+  );
+});

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/missing_fields_strategy_selector.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/missing_fields_strategy_selector.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import type { EuiFormRowProps, EuiRadioGroupOption, EuiRadioGroupProps } from '@elastic/eui';
+import { RadioGroupField } from '@kbn/es-ui-shared-plugin/static/forms/components';
+import { AlertSuppressionMissingFieldsStrategyEnum } from '../../../../../../common/api/detection_engine';
+import { UseField } from '../../../../../shared_imports';
+import { SuppressionInfoIcon } from './suppression_info_icon';
+import { ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME } from '../constants/fields';
+import * as i18n from './translations';
+
+interface MissingFieldsStrategySelectorProps {
+  disabled?: boolean;
+}
+
+export function MissingFieldsStrategySelector({
+  disabled,
+}: MissingFieldsStrategySelectorProps): JSX.Element {
+  const radioFieldProps: Partial<EuiRadioGroupProps> = useMemo(
+    () => ({
+      options: ALERT_SUPPRESSION_MISSING_FIELDS_STRATEGY_OPTIONS,
+      'data-test-subj': 'suppressionMissingFieldsOptions',
+      disabled,
+    }),
+    [disabled]
+  );
+
+  return (
+    <UseField
+      path={ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME}
+      component={RadioGroupField}
+      componentProps={EUI_FORM_ROW_PROPS}
+      euiFieldProps={radioFieldProps}
+    />
+  );
+}
+
+const EUI_FORM_ROW_PROPS: Partial<EuiFormRowProps> = {
+  label: (
+    <span>
+      {i18n.ALERT_SUPPRESSION_MISSING_FIELDS_LABEL} <SuppressionInfoIcon />
+    </span>
+  ),
+  'data-test-subj': 'alertSuppressionMissingFields',
+};
+
+const ALERT_SUPPRESSION_MISSING_FIELDS_STRATEGY_OPTIONS: EuiRadioGroupOption[] = [
+  {
+    id: AlertSuppressionMissingFieldsStrategyEnum.suppress,
+    label: i18n.ALERT_SUPPRESSION_MISSING_FIELDS_SUPPRESS_OPTION,
+  },
+  {
+    id: AlertSuppressionMissingFieldsStrategyEnum.doNotSuppress,
+    label: i18n.ALERT_SUPPRESSION_MISSING_FIELDS_DO_NOT_SUPPRESS_OPTION,
+  },
+];

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_duration_selector.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_duration_selector.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useEffect } from 'react';
+import { EuiFormRow, EuiRadioGroup, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/css';
+import type { FieldHook } from '../../../../../shared_imports';
+import { UseMultiFields } from '../../../../../shared_imports';
+import { AlertSuppressionDurationType } from '../../../../../detections/pages/detection_engine/rules/types';
+import { DurationInput } from '../../duration_input';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME,
+} from '../constants/fields';
+import * as i18n from './translations';
+
+interface AlertSuppressionDurationProps {
+  onlyPerTimePeriod?: boolean;
+  onlyPerTimePeriodReasonMessage?: string;
+  disabled?: boolean;
+}
+
+export function SuppressionDurationSelector({
+  onlyPerTimePeriod,
+  onlyPerTimePeriodReasonMessage,
+  disabled,
+}: AlertSuppressionDurationProps): JSX.Element {
+  return (
+    <EuiFormRow data-test-subj="alertSuppressionDuration">
+      <UseMultiFields<{
+        suppressionDurationSelector: string;
+        suppressionDurationValue: number | undefined;
+        suppressionDurationUnit: string;
+      }>
+        fields={{
+          suppressionDurationSelector: {
+            path: ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+          },
+          suppressionDurationValue: {
+            path: `${ALERT_SUPPRESSION_DURATION_FIELD_NAME}.${ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME}`,
+          },
+          suppressionDurationUnit: {
+            path: `${ALERT_SUPPRESSION_DURATION_FIELD_NAME}.${ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME}`,
+          },
+        }}
+      >
+        {({ suppressionDurationSelector, suppressionDurationValue, suppressionDurationUnit }) => (
+          <SuppressionDurationSelectorFields
+            suppressionDurationSelectorField={suppressionDurationSelector}
+            suppressionDurationValueField={suppressionDurationValue}
+            suppressionDurationUnitField={suppressionDurationUnit}
+            onlyPerTimePeriod={onlyPerTimePeriod}
+            onlyPerTimePeriodReasonMessage={onlyPerTimePeriodReasonMessage}
+            disabled={disabled}
+          />
+        )}
+      </UseMultiFields>
+    </EuiFormRow>
+  );
+}
+
+interface SuppressionDurationSelectorFieldsProps {
+  suppressionDurationSelectorField: FieldHook<string, string>;
+  suppressionDurationValueField: FieldHook<number | undefined, number | undefined>;
+  suppressionDurationUnitField: FieldHook<string, string>;
+  onlyPerTimePeriod?: boolean;
+  onlyPerTimePeriodReasonMessage?: string;
+  disabled?: boolean;
+}
+
+const SuppressionDurationSelectorFields = memo(function SuppressionDurationSelectorFields({
+  suppressionDurationSelectorField,
+  suppressionDurationValueField,
+  suppressionDurationUnitField,
+  onlyPerTimePeriod = false,
+  onlyPerTimePeriodReasonMessage,
+  disabled,
+}: SuppressionDurationSelectorFieldsProps): JSX.Element {
+  const { euiTheme } = useEuiTheme();
+  const { value: durationType, setValue: setDurationType } = suppressionDurationSelectorField;
+
+  useEffect(() => {
+    if (onlyPerTimePeriod && durationType !== AlertSuppressionDurationType.PerTimePeriod) {
+      setDurationType(AlertSuppressionDurationType.PerTimePeriod);
+    }
+  }, [onlyPerTimePeriod, durationType, setDurationType]);
+
+  return (
+    <>
+      <EuiRadioGroup
+        disabled={disabled}
+        idSelected={suppressionDurationSelectorField.value}
+        options={[
+          {
+            id: AlertSuppressionDurationType.PerRuleExecution,
+            label: onlyPerTimePeriod ? (
+              <EuiToolTip content={onlyPerTimePeriodReasonMessage}>
+                <> {i18n.ALERT_SUPPRESSION_DURATION_PER_RULE_EXECUTION_OPTION}</>
+              </EuiToolTip>
+            ) : (
+              i18n.ALERT_SUPPRESSION_DURATION_PER_RULE_EXECUTION_OPTION
+            ),
+            disabled: onlyPerTimePeriod ? true : disabled,
+          },
+          {
+            id: AlertSuppressionDurationType.PerTimePeriod,
+            disabled,
+            label: i18n.ALERT_SUPPRESSION_DURATION_PER_TIME_PERIOD_OPTION,
+          },
+        ]}
+        onChange={(id) => {
+          suppressionDurationSelectorField.setValue(id);
+        }}
+        data-test-subj="alertSuppressionDurationOptions"
+      />
+      <div
+        className={css`
+          padding-left: ${euiTheme.size.l};
+        `}
+      >
+        <DurationInput
+          durationValueField={suppressionDurationValueField}
+          durationUnitField={suppressionDurationUnitField}
+          // Suppression duration is also disabled suppression by rule execution is selected in radio button
+          isDisabled={
+            disabled ||
+            suppressionDurationSelectorField.value !== AlertSuppressionDurationType.PerTimePeriod
+          }
+          minimumValue={1}
+        />
+      </div>
+    </>
+  );
+});

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_fields_selector.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_fields_selector.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiFormRow } from '@elastic/eui';
+import type { DataViewFieldBase } from '@kbn/es-query';
+import { UseField } from '../../../../../shared_imports';
+import { MultiSelectFieldsAutocomplete } from '../../../../rule_creation_ui/components/multi_select_fields';
+import { ALERT_SUPPRESSION_FIELDS_FIELD_NAME } from '../constants/fields';
+import * as i18n from './translations';
+
+interface SuppressionFieldsSelectorProps {
+  suppressibleFields: DataViewFieldBase[];
+  labelAppend?: React.ReactNode;
+  disabled?: boolean;
+}
+
+export function SuppressionFieldsSelector({
+  suppressibleFields,
+  labelAppend,
+  disabled,
+}: SuppressionFieldsSelectorProps): JSX.Element {
+  return (
+    <EuiFormRow
+      data-test-subj="alertSuppressionInput"
+      label={i18n.ALERT_SUPPRESSION_SUPPRESS_BY_FIELD_LABEL}
+      labelAppend={labelAppend}
+      helpText={i18n.ALERT_SUPPRESSION_SUPPRESS_BY_FIELD_HELP_TEXT}
+    >
+      <>
+        <UseField
+          path={ALERT_SUPPRESSION_FIELDS_FIELD_NAME}
+          component={MultiSelectFieldsAutocomplete}
+          componentProps={{
+            browserFields: suppressibleFields,
+            isDisabled: disabled,
+          }}
+        />
+      </>
+    </EuiFormRow>
+  );
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_info_icon.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/suppression_info_icon.tsx
@@ -5,28 +5,25 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { EuiLink, EuiPopover, EuiText, EuiButtonIcon } from '@elastic/eui';
+import { useBoolean } from '@kbn/react-hooks';
 import { FormattedMessage } from '@kbn/i18n-react';
-
-import { useKibana } from '../../../../common/lib/kibana';
+import { useKibana } from '../../../../../common/lib/kibana';
 
 const POPOVER_WIDTH = 320;
 
 /**
  * Icon and popover that gives hint to users how suppression for missing fields work
  */
-const SuppressionInfoIconComponent = () => {
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+export function SuppressionInfoIcon(): JSX.Element {
+  const [isPopoverOpen, { off: closePopover, toggle: togglePopover }] = useBoolean(false);
   const { docLinks } = useKibana().services;
-
-  const onButtonClick = () => setIsPopoverOpen(!isPopoverOpen);
-  const closePopover = () => setIsPopoverOpen(false);
 
   const button = (
     <EuiButtonIcon
       iconType="questionInCircle"
-      onClick={onButtonClick}
+      onClick={togglePopover}
       aria-label="Open help popover"
     />
   );
@@ -59,8 +56,4 @@ const SuppressionInfoIconComponent = () => {
       </EuiText>
     </EuiPopover>
   );
-};
-
-export const SuppressionInfoIcon = React.memo(SuppressionInfoIconComponent);
-
-SuppressionInfoIcon.displayName = 'SuppressionInfoIcon';
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/translations.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/components/translations.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const ALERT_SUPPRESSION_SUPPRESS_BY_FIELD_LABEL = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.fieldsSelector.label',
+  {
+    defaultMessage: 'Suppress alerts by',
+  }
+);
+
+export const ALERT_SUPPRESSION_SUPPRESS_BY_FIELD_HELP_TEXT = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.suppressByFields.helpText',
+  {
+    defaultMessage: 'Select field(s) to use for suppressing extra alerts',
+  }
+);
+
+export const ALERT_SUPPRESSION_DURATION_PER_RULE_EXECUTION_OPTION = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.suppressionDuration.perRuleExecutionOption',
+  {
+    defaultMessage: 'Per rule execution',
+  }
+);
+
+export const ALERT_SUPPRESSION_DURATION_PER_TIME_PERIOD_OPTION = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.suppressionDuration.perTimePeriodOption',
+  {
+    defaultMessage: 'Per time period',
+  }
+);
+
+export const ALERT_SUPPRESSION_MISSING_FIELDS_LABEL = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.missingFields.label',
+  {
+    defaultMessage: 'If a suppression field is missing',
+  }
+);
+
+export const ALERT_SUPPRESSION_MISSING_FIELDS_SUPPRESS_OPTION = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.missingFields.suppressOption',
+  {
+    defaultMessage: 'Suppress and group alerts for events with missing fields',
+  }
+);
+
+export const ALERT_SUPPRESSION_MISSING_FIELDS_DO_NOT_SUPPRESS_OPTION = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.missingFields.doNotSuppressOption',
+  {
+    defaultMessage: 'Do not suppress alerts for events with missing fields',
+  }
+);
+
+export const ALERT_SUPPRESSION_NOT_SUPPORTED_FOR_EQL_SEQUENCE = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.notSupportedForEqlSequence',
+  {
+    defaultMessage: 'Suppression is not supported for EQL sequence queries',
+  }
+);
+
+export const MACHINE_LEARNING_SUPPRESSION_FIELDS_LOADING = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.machineLearningSuppressionFieldsLoading',
+  {
+    defaultMessage: 'Machine Learning suppression fields are loading',
+  }
+);
+
+export const MACHINE_LEARNING_NO_SUPPRESSION_FIELDS = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.machineLearningNoSuppressionFields',
+  {
+    defaultMessage:
+      'Unable to load machine Learning suppression fields, start relevant Machine Learning jobs.',
+  }
+);
+
+export const ESQL_SUPPRESSION_FIELDS_LOADING = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.esqlFieldsLoading',
+  {
+    defaultMessage: 'ES|QL suppression fields are loading',
+  }
+);
+
+export const MACHINE_LEARNING_SUPPRESSION_INCOMPLETE_LABEL = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.alertSuppression.machineLearningSuppressionIncomplete',
+  {
+    defaultMessage:
+      'This list of fields might be incomplete as some Machine Learning jobs are not running. Start all relevant jobs for a complete list.',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/constants/default_duration.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/constants/default_duration.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AlertSuppressionDurationUnitEnum } from '../../../../../../common/api/detection_engine';
+import {
+  ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME,
+} from './fields';
+
+export const ALERT_SUPPRESSION_DEFAULT_DURATION = {
+  [ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME]: 5,
+  [ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME]: AlertSuppressionDurationUnitEnum.m,
+};

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/constants/fields.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/constants/fields.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const ALERT_SUPPRESSION_FIELDS_FIELD_NAME = 'alertSuppressionFields' as const;
+export const ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME = 'alertSuppressionDurationType' as const;
+export const ALERT_SUPPRESSION_DURATION_FIELD_NAME = 'alertSuppressionDuration' as const;
+export const ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME = 'value' as const;
+export const ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME = 'unit' as const;
+export const ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME = 'alertSuppressionMissingFields' as const;

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/index.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './components/alert_suppression_edit';
+export * from './components/suppression_duration_selector';
+export * from './constants/fields';
+export * from './constants/default_duration';

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/test_helpers.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/alert_suppression_edit/test_helpers.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act, fireEvent, waitFor, within, screen } from '@testing-library/react';
+import type { AlertSuppressionDurationUnit } from '../../../../../common/api/detection_engine';
+import { selectEuiComboBoxOption } from '../../../../common/test/eui/combobox';
+
+const COMBO_BOX_TOGGLE_BUTTON_TEST_ID = 'comboBoxToggleListButton';
+
+export async function setSuppressionFields(fieldNames: string[]): Promise<void> {
+  const getAlertSuppressionFieldsComboBoxToggleButton = () =>
+    within(screen.getByTestId('alertSuppressionInput')).getByTestId(
+      COMBO_BOX_TOGGLE_BUTTON_TEST_ID
+    );
+
+  await waitFor(() => {
+    expect(getAlertSuppressionFieldsComboBoxToggleButton()).toBeInTheDocument();
+  });
+
+  for (const fieldName of fieldNames) {
+    await selectEuiComboBoxOption({
+      comboBoxToggleButton: getAlertSuppressionFieldsComboBoxToggleButton(),
+      optionText: fieldName,
+    });
+  }
+}
+
+export function expectSuppressionFields(fieldNames: string[]): void {
+  for (const fieldName of fieldNames) {
+    expect(
+      within(screen.getByTestId('alertSuppressionInput')).getByTitle(fieldName)
+    ).toBeInTheDocument();
+  }
+}
+
+export function setDurationType(value: 'Per rule execution' | 'Per time period'): void {
+  act(() => {
+    fireEvent.click(within(screen.getByTestId('alertSuppressionDuration')).getByLabelText(value));
+  });
+}
+
+export function setDuration(value: number, unit: AlertSuppressionDurationUnit): void {
+  act(() => {
+    fireEvent.input(
+      within(screen.getByTestId('alertSuppressionDuration')).getByTestId('interval'),
+      {
+        target: { value: value.toString() },
+      }
+    );
+
+    fireEvent.change(
+      within(screen.getByTestId('alertSuppressionDuration')).getByTestId('timeType'),
+      {
+        target: { value: unit },
+      }
+    );
+  });
+}
+
+export function expectDuration(value: number, unit: AlertSuppressionDurationUnit): void {
+  expect(
+    within(screen.getByTestId('alertSuppressionDuration')).getByTestId('interval')
+  ).toHaveValue(value);
+  expect(
+    within(screen.getByTestId('alertSuppressionDuration')).getByTestId('timeType')
+  ).toHaveValue(unit);
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/duration_input/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/duration_input/index.tsx
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
-import { EuiFieldNumber, EuiFormRow, EuiSelect, transparentize } from '@elastic/eui';
-import React, { useCallback } from 'react';
-import styled from 'styled-components';
-
+import React, { memo, useCallback } from 'react';
+import { css } from '@emotion/css';
+import { EuiFieldNumber, EuiFormRow, EuiSelect, transparentize, useEuiTheme } from '@elastic/eui';
 import type { FieldHook } from '../../../../shared_imports';
 import { getFieldValidityAndErrorMessage } from '../../../../shared_imports';
 import * as I18n from './translations';
@@ -21,39 +20,10 @@ interface DurationInputProps {
   durationUnitOptions?: Array<{ value: 's' | 'm' | 'h' | 'd'; text: string }>;
 }
 
-const getNumberFromUserInput = (input: string, minimumValue = 0): number | undefined => {
-  const number = parseInt(input, 10);
-  if (Number.isNaN(number)) {
-    return minimumValue;
-  } else {
-    return Math.max(minimumValue, Math.min(number, Number.MAX_SAFE_INTEGER));
-  }
-};
-
-const StyledEuiFormRow = styled(EuiFormRow)`
-  max-width: 235px;
-
-  .euiFormControlLayout__append {
-    padding-inline: 0 !important;
-  }
-
-  .euiFormControlLayoutIcons {
-    color: ${({ theme }) => theme.eui.euiColorPrimary};
-  }
-`;
-
-const MyEuiSelect = styled(EuiSelect)`
-  min-width: 106px; // Preserve layout when disabled & dropdown arrow is not rendered
-  box-shadow: none;
-  background: ${({ theme }) =>
-    transparentize(theme.eui.euiColorPrimary, 0.1)} !important; // Override focus states etc.
-  color: ${({ theme }) => theme.eui.euiColorPrimary};
-`;
-
 // This component is similar to the ScheduleItem component, but instead of combining the value
 // and unit into a single string it keeps them separate. This makes the component simpler and
 // allows for easier validation of values and units in APIs as well.
-const DurationInputComponent: React.FC<DurationInputProps> = ({
+export const DurationInput = memo(function DurationInputComponent({
   durationValueField,
   durationUnitField,
   minimumValue = 0,
@@ -64,7 +34,8 @@ const DurationInputComponent: React.FC<DurationInputProps> = ({
     { value: 'h', text: I18n.HOURS },
   ],
   ...props
-}: DurationInputProps) => {
+}: DurationInputProps): JSX.Element {
+  const { euiTheme } = useEuiTheme();
   const { isInvalid, errorMessage } = getFieldValidityAndErrorMessage(durationValueField);
   const { value: durationValue, setValue: setDurationValue } = durationValueField;
   const { value: durationUnit, setValue: setDurationUnit } = durationUnitField;
@@ -84,17 +55,40 @@ const DurationInputComponent: React.FC<DurationInputProps> = ({
     [minimumValue, setDurationValue]
   );
 
+  const durationFormRowStyle = css`
+    max-width: 235px;
+
+    .euiFormControlLayout__append {
+      padding-inline: 0 !important;
+    }
+
+    .euiFormControlLayoutIcons {
+      color: ${euiTheme.colors.primary};
+    }
+  `;
+  const durationUnitSelectStyle = css`
+    min-width: 106px; // Preserve layout when disabled & dropdown arrow is not rendered
+    box-shadow: none;
+    background: ${transparentize(
+      euiTheme.colors.primary,
+      0.1
+    )} !important; // Override focus states etc.
+    color: ${euiTheme.colors.primary};
+  `;
+
   // EUI missing some props
   const rest = { disabled: isDisabled, ...props };
 
   return (
-    <StyledEuiFormRow error={errorMessage} isInvalid={isInvalid}>
+    <EuiFormRow className={durationFormRowStyle} error={errorMessage} isInvalid={isInvalid}>
       <EuiFieldNumber
         append={
-          <MyEuiSelect
+          <EuiSelect
+            className={durationUnitSelectStyle}
             options={durationUnitOptions}
             onChange={onChangeTimeType}
             value={durationUnit}
+            aria-label={I18n.DURATION_UNIT_SELECTOR}
             data-test-subj="timeType"
             {...rest}
           />
@@ -106,8 +100,16 @@ const DurationInputComponent: React.FC<DurationInputProps> = ({
         data-test-subj="interval"
         {...rest}
       />
-    </StyledEuiFormRow>
+    </EuiFormRow>
   );
-};
+});
 
-export const DurationInput = React.memo(DurationInputComponent);
+function getNumberFromUserInput(input: string, minimumValue = 0): number | undefined {
+  const number = parseInt(input, 10);
+
+  if (Number.isNaN(number)) {
+    return minimumValue;
+  } else {
+    return Math.max(minimumValue, Math.min(number, Number.MAX_SAFE_INTEGER));
+  }
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/duration_input/translations.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/duration_input/translations.ts
@@ -34,3 +34,10 @@ export const DAYS = i18n.translate(
     defaultMessage: 'Days',
   }
 );
+
+export const DURATION_UNIT_SELECTOR = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.stepScheduleRuleForm.durationUnitSelector',
+  {
+    defaultMessage: 'Duration unit selector',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/related_integrations.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/related_integrations.test.tsx
@@ -6,19 +6,24 @@
  */
 
 import React from 'react';
-import {
-  screen,
-  render,
-  act,
-  fireEvent,
-  waitFor,
-  waitForElementToBeRemoved,
-} from '@testing-library/react';
+import { screen, render, act, fireEvent, waitFor } from '@testing-library/react';
 import type { RelatedIntegration } from '../../../../../common/api/detection_engine';
 import { FIELD_TYPES, Form, useForm } from '../../../../shared_imports';
 import { createReactQueryWrapper } from '../../../../common/mock';
 import { fleetIntegrationsApi } from '../../../fleet_integrations/api/__mocks__';
 import { RelatedIntegrations } from './related_integrations';
+import {
+  clearEuiComboBoxSelection,
+  selectEuiComboBoxOption,
+  selectFirstEuiComboBoxOption,
+  showEuiComboBoxOptions,
+} from '../../../../common/test/eui/combobox';
+import {
+  addRelatedIntegrationRow,
+  removeLastRelatedIntegrationRow,
+  setVersion,
+  waitForIntegrationsToBeLoaded,
+} from './test_helpers';
 
 // must match to the import in rules/related_integrations/use_integrations.tsx
 jest.mock('../../../fleet_integrations/api');
@@ -41,7 +46,6 @@ const COMBO_BOX_TOGGLE_BUTTON_TEST_ID = 'comboBoxToggleListButton';
 const COMBO_BOX_SELECTION_TEST_ID = 'euiComboBoxPill';
 const COMBO_BOX_CLEAR_BUTTON_TEST_ID = 'comboBoxClearButton';
 const VERSION_INPUT_TEST_ID = 'relatedIntegrationVersionDependency';
-const REMOVE_INTEGRATION_ROW_BUTTON_TEST_ID = 'relatedIntegrationRemove';
 
 describe('RelatedIntegrations form part', () => {
   beforeEach(() => {
@@ -706,72 +710,6 @@ function TestForm({ initialState, onSubmit }: TestFormProps): JSX.Element {
       </button>
     </Form>
   );
-}
-
-function waitForIntegrationsToBeLoaded(): Promise<void> {
-  return waitForElementToBeRemoved(screen.queryAllByRole('progressbar'));
-}
-
-function addRelatedIntegrationRow(): Promise<void> {
-  return act(async () => {
-    fireEvent.click(screen.getByText('Add integration'));
-  });
-}
-
-function removeLastRelatedIntegrationRow(): Promise<void> {
-  return act(async () => {
-    const lastRemoveButton = screen.getAllByTestId(REMOVE_INTEGRATION_ROW_BUTTON_TEST_ID).at(-1);
-
-    if (!lastRemoveButton) {
-      throw new Error(`There are no "${REMOVE_INTEGRATION_ROW_BUTTON_TEST_ID}" found`);
-    }
-
-    fireEvent.click(lastRemoveButton);
-  });
-}
-
-function showEuiComboBoxOptions(comboBoxToggleButton: HTMLElement): Promise<void> {
-  fireEvent.click(comboBoxToggleButton);
-
-  return waitFor(() => {
-    expect(screen.getByRole('listbox')).toBeInTheDocument();
-  });
-}
-
-function selectEuiComboBoxOption({
-  comboBoxToggleButton,
-  optionIndex,
-}: {
-  comboBoxToggleButton: HTMLElement;
-  optionIndex: number;
-}): Promise<void> {
-  return act(async () => {
-    await showEuiComboBoxOptions(comboBoxToggleButton);
-
-    fireEvent.click(screen.getAllByRole('option')[optionIndex]);
-  });
-}
-
-function clearEuiComboBoxSelection({ clearButton }: { clearButton: HTMLElement }): Promise<void> {
-  return act(async () => {
-    fireEvent.click(clearButton);
-  });
-}
-
-function selectFirstEuiComboBoxOption({
-  comboBoxToggleButton,
-}: {
-  comboBoxToggleButton: HTMLElement;
-}): Promise<void> {
-  return selectEuiComboBoxOption({ comboBoxToggleButton, optionIndex: 0 });
-}
-
-function setVersion({ input, value }: { input: HTMLInputElement; value: string }): Promise<void> {
-  return act(async () => {
-    fireEvent.input(input, {
-      target: { value },
-    });
-  });
 }
 
 function submitForm(): Promise<void> {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/test_helpers.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/related_integrations/test_helpers.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act, fireEvent, waitForElementToBeRemoved, screen } from '@testing-library/react';
+
+const REMOVE_INTEGRATION_ROW_BUTTON_TEST_ID = 'relatedIntegrationRemove';
+
+export function waitForIntegrationsToBeLoaded(): Promise<void> {
+  return waitForElementToBeRemoved(screen.queryAllByRole('progressbar'));
+}
+
+export function addRelatedIntegrationRow(): Promise<void> {
+  return act(async () => {
+    fireEvent.click(screen.getByText('Add integration'));
+  });
+}
+
+export function removeLastRelatedIntegrationRow(): Promise<void> {
+  return act(async () => {
+    const lastRemoveButton = screen.getAllByTestId(REMOVE_INTEGRATION_ROW_BUTTON_TEST_ID).at(-1);
+
+    if (!lastRemoveButton) {
+      throw new Error(`There are no "${REMOVE_INTEGRATION_ROW_BUTTON_TEST_ID}" found`);
+    }
+
+    fireEvent.click(lastRemoveButton);
+  });
+}
+
+export function setVersion({
+  input,
+  value,
+}: {
+  input: HTMLInputElement;
+  value: string;
+}): Promise<void> {
+  return act(async () => {
+    fireEvent.input(input, {
+      target: { value },
+    });
+  });
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/fields.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/fields.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const THRESHOLD_ALERT_SUPPRESSION_ENABLED = 'thresholdAlertSuppressionEnabled' as const;

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/index.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './threshold_alert_suppression_edit';
+export * from './fields';

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/threshold_alert_suppression_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/threshold_alert_suppression_edit.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { EuiPanel, EuiToolTip } from '@elastic/eui';
+import { CheckBoxField } from '@kbn/es-ui-shared-plugin/static/forms/components';
+import { UseField, useFormData } from '../../../../shared_imports';
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from './fields';
+import { SuppressionDurationSelector } from '../alert_suppression_edit';
+import * as i18n from './translations';
+
+interface ThresholdAlertSuppressionEditProps {
+  suppressionFieldNames: string[] | undefined;
+  disabled?: boolean;
+  disabledText?: string;
+}
+
+export const ThresholdAlertSuppressionEdit = memo(function ThresholdAlertSuppressionEdit({
+  suppressionFieldNames,
+  disabled,
+  disabledText,
+}: ThresholdAlertSuppressionEditProps): JSX.Element {
+  const [{ [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: suppressionEnabled }] = useFormData({
+    watch: THRESHOLD_ALERT_SUPPRESSION_ENABLED,
+  });
+  const content = (
+    <>
+      <UseField
+        path={THRESHOLD_ALERT_SUPPRESSION_ENABLED}
+        component={CheckBoxField}
+        componentProps={{
+          idAria: 'thresholdAlertSuppressionEnabled',
+          'data-test-subj': 'thresholdAlertSuppressionEnabled',
+        }}
+        euiFieldProps={{
+          label: suppressionFieldNames?.length
+            ? i18n.enableSuppressionForFields(suppressionFieldNames)
+            : i18n.SUPPRESS_ALERTS,
+          disabled,
+        }}
+      />
+      <EuiPanel paddingSize="m" hasShadow={false}>
+        <SuppressionDurationSelector
+          onlyPerTimePeriod
+          onlyPerTimePeriodReasonMessage={i18n.THRESHOLD_SUPPRESSION_PER_RULE_EXECUTION_WARNING}
+          disabled={!suppressionEnabled || disabled}
+        />
+      </EuiPanel>
+    </>
+  );
+
+  return disabled && disabledText ? (
+    <EuiToolTip position="right" content={disabledText}>
+      {content}
+    </EuiToolTip>
+  ) : (
+    content
+  );
+});

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation/components/threshold_alert_suppression_edit/translations.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+export const enableSuppressionForFields = (fields: string[]) => (
+  <FormattedMessage
+    id="xpack.securitySolution.ruleManagement.ruleFields.thresholdAlertSuppression.enableForFields"
+    defaultMessage="Suppress alerts by selected fields: {fieldsString}"
+    values={{ fieldsString: <strong>{fields.join(', ')}</strong> }}
+  />
+);
+
+export const SUPPRESS_ALERTS = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.thresholdAlertSuppression.enable',
+  {
+    defaultMessage: 'Suppress alerts',
+  }
+);
+
+export const THRESHOLD_SUPPRESSION_PER_RULE_EXECUTION_WARNING = i18n.translate(
+  'xpack.securitySolution.ruleManagement.ruleFields.thresholdAlertSuppression.perRuleExecutionWarning',
+  {
+    defaultMessage: 'Per rule execution option is not available for Threshold rule type',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/data_view_selector_field/__mocks__/use_data_view_list_items.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/data_view_selector_field/__mocks__/use_data_view_list_items.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export const useDataViews = jest.fn().mockReturnValue({
+export const useDataViewListItems = jest.fn().mockReturnValue({
   data: [],
   isFetching: false,
 });

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/data_view_selector_field/data_view_selector_field.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/data_view_selector_field/data_view_selector_field.test.tsx
@@ -9,14 +9,14 @@ import React from 'react';
 import { screen, render } from '@testing-library/react';
 import { TestProviders, useFormFieldMock } from '../../../../common/mock';
 import { DataViewSelectorField } from './data_view_selector_field';
-import { useDataViews } from './use_data_views';
+import { useDataViewListItems } from './use_data_view_list_items';
 
 jest.mock('../../../../common/lib/kibana');
-jest.mock('./use_data_views');
+jest.mock('./use_data_view_list_items');
 
 describe('data_view_selector', () => {
   it('renders correctly', () => {
-    (useDataViews as jest.Mock).mockReturnValue({ data: [], isFetching: false });
+    (useDataViewListItems as jest.Mock).mockReturnValue({ data: [], isFetching: false });
 
     render(
       <DataViewSelectorField
@@ -31,7 +31,7 @@ describe('data_view_selector', () => {
   });
 
   it('disables the combobox while data views are fetching', () => {
-    (useDataViews as jest.Mock).mockReturnValue({ data: [], isFetching: true });
+    (useDataViewListItems as jest.Mock).mockReturnValue({ data: [], isFetching: true });
 
     render(
       <DataViewSelectorField
@@ -57,7 +57,7 @@ describe('data_view_selector', () => {
         title: 'logs-*',
       },
     ];
-    (useDataViews as jest.Mock).mockReturnValue({ data: dataViews, isFetching: false });
+    (useDataViewListItems as jest.Mock).mockReturnValue({ data: dataViews, isFetching: false });
 
     render(
       <DataViewSelectorField
@@ -83,7 +83,7 @@ describe('data_view_selector', () => {
         title: 'logs-*',
       },
     ];
-    (useDataViews as jest.Mock).mockReturnValue({ data: dataViews, isFetching: false });
+    (useDataViewListItems as jest.Mock).mockReturnValue({ data: dataViews, isFetching: false });
 
     render(
       <DataViewSelectorField
@@ -98,7 +98,7 @@ describe('data_view_selector', () => {
   });
 
   it('displays warning on missing data view', () => {
-    (useDataViews as jest.Mock).mockReturnValue({ data: [], isFetching: false });
+    (useDataViewListItems as jest.Mock).mockReturnValue({ data: [], isFetching: false });
 
     render(
       <DataViewSelectorField

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/data_view_selector_field/data_view_selector_field.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/data_view_selector_field/data_view_selector_field.tsx
@@ -11,7 +11,7 @@ import { EuiCallOut, EuiComboBox, EuiFormRow, EuiSpacer } from '@elastic/eui';
 import type { FieldHook } from '../../../../shared_imports';
 import { getFieldValidityAndErrorMessage } from '../../../../shared_imports';
 import { isDataViewIdValid } from '../../validators/data_view_id_validator_factory';
-import { useDataViews } from './use_data_views';
+import { useDataViewListItems } from './use_data_view_list_items';
 import * as i18n from './translations';
 
 const SECURITY_DEFAULT_DATA_VIEW_ID = 'security-solution-default';
@@ -21,7 +21,7 @@ export interface DataViewSelectorProps {
 }
 
 export function DataViewSelectorField({ field }: DataViewSelectorProps): JSX.Element {
-  const { data: dataViews, isFetching: areDataViewsFetching } = useDataViews();
+  const { data: dataViews, isFetching: areDataViewsFetching } = useDataViewListItems();
   const fieldAndError = field ? getFieldValidityAndErrorMessage(field) : undefined;
   const isInvalid = fieldAndError?.isInvalid;
   const errorMessage = fieldAndError?.errorMessage;

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/data_view_selector_field/use_data_view_list_items.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/data_view_selector_field/use_data_view_list_items.ts
@@ -19,7 +19,7 @@ interface UseDataViewsResult {
 /**
  * Fetches known Kibana data views from the Data View Service.
  */
-export function useDataViews(): UseDataViewsResult {
+export function useDataViewListItems(): UseDataViewsResult {
   const {
     data: { dataViews: dataViewsService },
   } = useKibana().services;

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/helpers.tsx
@@ -45,7 +45,7 @@ import type {
   AboutStepSeverity,
   Duration,
 } from '../../../../detections/pages/detection_engine/rules/types';
-import { GroupByOptions } from '../../../../detections/pages/detection_engine/rules/types';
+import { AlertSuppressionDurationType } from '../../../../detections/pages/detection_engine/rules/types';
 import { defaultToEmptyTag } from '../../../../common/components/empty_value';
 import { RequiredFieldIcon } from '../../../rule_management/components/rule_details/required_field_icon';
 import { ThreatEuiFlexGroup } from './threat_description';
@@ -582,7 +582,7 @@ export const buildRequiredFieldsDescription = (
 };
 
 export const buildAlertSuppressionDescription = (
-  label: string = i18n.GROUP_BY_LABEL,
+  label: string = i18n.ALERT_SUPPRESSION_LABEL,
   values: string[],
   ruleType: Type
 ): ListItems[] => {
@@ -615,11 +615,11 @@ export const buildAlertSuppressionDescription = (
 export const buildAlertSuppressionWindowDescription = (
   label: string,
   value: Duration,
-  groupByRadioSelection: GroupByOptions,
+  alertSuppressionDuration: AlertSuppressionDurationType,
   ruleType: Type
 ): ListItems[] => {
   const description =
-    groupByRadioSelection === GroupByOptions.PerTimePeriod
+    alertSuppressionDuration === AlertSuppressionDurationType.PerTimePeriod
       ? `${value.value}${value.unit}`
       : i18n.ALERT_SUPPRESSION_PER_RULE_EXECUTION;
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/index.test.tsx
@@ -30,6 +30,15 @@ import { schema } from '../step_about_rule/schema';
 import type { ListItems } from './types';
 import type { AboutStepRule } from '../../../../detections/pages/detection_engine/rules/types';
 import { createLicenseServiceMock } from '../../../../../common/license/mocks';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+} from '../../../rule_creation/components/alert_suppression_edit';
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from '../../../rule_creation/components/threshold_alert_suppression_edit';
 
 jest.mock('../../../../common/lib/kibana');
 
@@ -575,25 +584,25 @@ describe('description_step', () => {
 
     describe('alert suppression', () => {
       const suppressionFields = {
-        groupByDuration: {
-          unit: 'm',
-          value: 50,
+        [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: {
+          [ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME]: 50,
+          [ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME]: 'm',
         },
-        groupByRadioSelection: 'per-time-period',
-        enableThresholdSuppression: true,
-        groupByFields: ['agent.name'],
-        suppressionMissingFields: 'suppress',
+        [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: 'per-time-period',
+        [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: true,
+        [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: ['agent.name'],
+        [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]: 'suppress',
       };
-      describe('groupByDuration', () => {
+      describe(ALERT_SUPPRESSION_DURATION_FIELD_NAME, () => {
         ['query', 'saved_query'].forEach((ruleType) => {
-          test(`should be empty if groupByFields empty for ${ruleType} rule`, () => {
+          test(`should be empty if ${ALERT_SUPPRESSION_FIELDS_FIELD_NAME} empty for ${ruleType} rule`, () => {
             const result: ListItems[] = getDescriptionItem(
-              'groupByDuration',
+              ALERT_SUPPRESSION_DURATION_FIELD_NAME,
               'label',
               {
                 ruleType: 'query',
                 ...suppressionFields,
-                groupByFields: [],
+                [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: [],
               },
               mockFilterManager,
               mockLicenseService
@@ -604,7 +613,7 @@ describe('description_step', () => {
 
           test(`should return item for ${ruleType} rule`, () => {
             const result: ListItems[] = getDescriptionItem(
-              'groupByDuration',
+              ALERT_SUPPRESSION_DURATION_FIELD_NAME,
               'label',
               {
                 ruleType: 'query',
@@ -620,7 +629,7 @@ describe('description_step', () => {
 
         test('should return item for threshold rule', () => {
           const result: ListItems[] = getDescriptionItem(
-            'groupByDuration',
+            ALERT_SUPPRESSION_DURATION_FIELD_NAME,
             'label',
             {
               ruleType: 'threshold',
@@ -633,14 +642,14 @@ describe('description_step', () => {
           expect(result[0].description).toBe('50m');
         });
 
-        test('should return item for threshold rule if groupByFields empty', () => {
+        test(`should return item for threshold rule if ${ALERT_SUPPRESSION_FIELDS_FIELD_NAME} empty`, () => {
           const result: ListItems[] = getDescriptionItem(
-            'groupByDuration',
+            ALERT_SUPPRESSION_DURATION_FIELD_NAME,
             'label',
             {
               ruleType: 'threshold',
               ...suppressionFields,
-              groupByFields: [],
+              [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: [],
             },
             mockFilterManager,
             mockLicenseService
@@ -651,12 +660,12 @@ describe('description_step', () => {
 
         test('should be empty for threshold rule if suppression not enabled', () => {
           const result: ListItems[] = getDescriptionItem(
-            'groupByDuration',
+            ALERT_SUPPRESSION_DURATION_FIELD_NAME,
             'label',
             {
               ruleType: 'threshold',
               ...suppressionFields,
-              enableThresholdSuppression: false,
+              [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: false,
             },
             mockFilterManager,
             mockLicenseService
@@ -666,10 +675,10 @@ describe('description_step', () => {
         });
       });
 
-      describe('groupByFields', () => {
+      describe(ALERT_SUPPRESSION_FIELDS_FIELD_NAME, () => {
         test(`should be empty if rule type is 'threshold'`, () => {
           const result: ListItems[] = getDescriptionItem(
-            'groupByFields',
+            ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
             'label',
             {
               ruleType: 'threshold',
@@ -685,7 +694,7 @@ describe('description_step', () => {
         ['query', 'saved_query'].forEach((ruleType) => {
           test(`should return item for ${ruleType} rule`, () => {
             const result: ListItems[] = getDescriptionItem(
-              'groupByFields',
+              ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
               'label',
               {
                 ruleType,
@@ -699,10 +708,10 @@ describe('description_step', () => {
         });
       });
 
-      describe('suppressionMissingFields', () => {
+      describe(ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME, () => {
         test(`should be empty if rule type is 'threshold'`, () => {
           const result: ListItems[] = getDescriptionItem(
-            'suppressionMissingFields',
+            ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
             'label',
             {
               ruleType: 'threshold',
@@ -718,7 +727,7 @@ describe('description_step', () => {
         ['query', 'saved_query'].forEach((ruleType) => {
           test(`should return item for ${ruleType} rule`, () => {
             const result: ListItems[] = getDescriptionItem(
-              'suppressionMissingFields',
+              ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
               'label',
               {
                 ruleType,
@@ -730,14 +739,14 @@ describe('description_step', () => {
             expect(result[0].description).toContain('Suppress');
           });
 
-          test(`should be empty if groupByFields empty for ${ruleType} rule`, () => {
+          test(`should be empty if ${ALERT_SUPPRESSION_FIELDS_FIELD_NAME} empty for ${ruleType} rule`, () => {
             const result: ListItems[] = getDescriptionItem(
-              'suppressionMissingFields',
+              ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
               'label',
               {
                 ruleType: 'query',
                 ...suppressionFields,
-                groupByFields: [],
+                [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: [],
               },
               mockFilterManager,
               mockLicenseService

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/index.tsx
@@ -65,6 +65,13 @@ import {
   isSuppressionRuleConfiguredWithGroupBy,
   isSuppressionRuleConfiguredWithDuration,
 } from '../../../../../common/detection_engine/utils';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+} from '../../../rule_creation/components/alert_suppression_edit';
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from '../../../rule_creation/components/threshold_alert_suppression_edit';
 
 const DescriptionListContainer = styled(EuiDescriptionList)`
   max-width: 600px;
@@ -217,7 +224,7 @@ export const getDescriptionItem = (
     });
   } else if (field === 'responseActions') {
     return [];
-  } else if (field === 'groupByFields') {
+  } else if (field === ALERT_SUPPRESSION_FIELDS_FIELD_NAME) {
     const ruleType: Type = get('ruleType', data);
 
     const ruleCanHaveGroupByFields = isSuppressionRuleConfiguredWithGroupBy(ruleType);
@@ -226,9 +233,9 @@ export const getDescriptionItem = (
     }
     const values: string[] = get(field, data);
     return buildAlertSuppressionDescription(label, values, ruleType);
-  } else if (field === 'groupByRadioSelection') {
+  } else if (field === ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME) {
     return [];
-  } else if (field === 'groupByDuration') {
+  } else if (field === ALERT_SUPPRESSION_DURATION_FIELD_NAME) {
     const ruleType: Type = get('ruleType', data);
 
     const ruleCanHaveDuration = isSuppressionRuleConfiguredWithDuration(ruleType);
@@ -239,21 +246,21 @@ export const getDescriptionItem = (
     // threshold rule has suppression duration without grouping fields, but suppression should be explicitly enabled by user
     // query rule have suppression duration only if group by fields selected
     const showDuration = isThresholdRule(ruleType)
-      ? get('enableThresholdSuppression', data) === true
-      : get('groupByFields', data).length > 0;
+      ? get(THRESHOLD_ALERT_SUPPRESSION_ENABLED, data) === true
+      : get(ALERT_SUPPRESSION_FIELDS_FIELD_NAME, data).length > 0;
 
     if (showDuration) {
       const value: Duration = get(field, data);
       return buildAlertSuppressionWindowDescription(
         label,
         value,
-        get('groupByRadioSelection', data),
+        get(ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME, data),
         ruleType
       );
     } else {
       return [];
     }
-  } else if (field === 'suppressionMissingFields') {
+  } else if (field === ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME) {
     const ruleType: Type = get('ruleType', data);
     const ruleCanHaveSuppressionMissingFields =
       isSuppressionRuleConfiguredWithMissingFields(ruleType);
@@ -261,7 +268,7 @@ export const getDescriptionItem = (
     if (!ruleCanHaveSuppressionMissingFields) {
       return [];
     }
-    if (get('groupByFields', data).length > 0) {
+    if (get(ALERT_SUPPRESSION_FIELDS_FIELD_NAME, data).length > 0) {
       const value = get(field, data);
       return buildAlertSuppressionMissingFieldsDescription(label, value, ruleType);
     } else {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/translations.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/description_step/translations.ts
@@ -182,8 +182,8 @@ export const BUILDING_BLOCK_DESCRIPTION = i18n.translate(
   }
 );
 
-export const GROUP_BY_LABEL = i18n.translate(
-  'xpack.securitySolution.detectionEngine.ruleDescription.groupByFieldsLabel',
+export const ALERT_SUPPRESSION_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDescription.alertSuppressionFieldsLabel',
   {
     defaultMessage: 'Suppress alerts by',
   }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/multi_select_fields/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/multi_select_fields/index.tsx
@@ -6,11 +6,9 @@
  */
 
 import React, { useMemo } from 'react';
-
-import { EuiToolTip } from '@elastic/eui';
 import type { DataViewFieldBase } from '@kbn/es-query';
+import { ComboBoxField } from '@kbn/es-ui-shared-plugin/static/forms/components';
 import type { FieldHook } from '../../../../shared_imports';
-import { Field } from '../../../../shared_imports';
 import { FIELD_PLACEHOLDER } from './translations';
 
 interface MultiSelectAutocompleteProps {
@@ -18,7 +16,6 @@ interface MultiSelectAutocompleteProps {
   isDisabled: boolean;
   field: FieldHook;
   fullWidth?: boolean;
-  disabledText?: string;
   dataTestSubj?: string;
 }
 
@@ -28,7 +25,6 @@ const fieldDescribedByIds = 'detectionEngineMultiSelectAutocompleteField';
 
 export const MultiSelectAutocompleteComponent: React.FC<MultiSelectAutocompleteProps> = ({
   browserFields,
-  disabledText,
   isDisabled,
   field,
   fullWidth = false,
@@ -46,20 +42,14 @@ export const MultiSelectAutocompleteComponent: React.FC<MultiSelectAutocompleteP
     }),
     [browserFields, isDisabled, fullWidth]
   );
-  const fieldComponent = (
-    <Field
+
+  return (
+    <ComboBoxField
       field={field}
       idAria={fieldDescribedByIds}
       euiFieldProps={fieldEuiFieldProps}
       data-test-subj={dataTestSubj}
     />
-  );
-  return isDisabled ? (
-    <EuiToolTip position="right" content={disabledText}>
-      {fieldComponent}
-    </EuiToolTip>
-  ) : (
-    fieldComponent
   );
 };
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_about_rule/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_about_rule/index.test.tsx
@@ -23,7 +23,7 @@ import type {
 } from '../../../../detections/pages/detection_engine/rules/types';
 import {
   DataSourceType,
-  GroupByOptions,
+  AlertSuppressionDurationType,
 } from '../../../../detections/pages/detection_engine/rules/types';
 import { fillEmptySeverityMappings } from '../../../../detections/pages/detection_engine/rules/helpers';
 import { TestProviders } from '../../../../common/mock';
@@ -36,6 +36,16 @@ import {
 import type { FormHook } from '../../../../shared_imports';
 import { useKibana as mockUseKibana } from '../../../../common/lib/kibana/__mocks__';
 import { useKibana } from '../../../../common/lib/kibana';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+} from '../../../rule_creation/components/alert_suppression_edit';
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from '../../../rule_creation/components/threshold_alert_suppression_edit';
+import { AlertSuppressionMissingFieldsStrategyEnum } from '../../../../../common/api/detection_engine';
 
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../../../../common/containers/source');
@@ -69,16 +79,17 @@ export const stepDefineStepMLRule: DefineStepRule = {
   timeline: { id: null, title: null },
   eqlOptions: {},
   dataSourceType: DataSourceType.IndexPatterns,
-  groupByFields: ['host.name'],
-  groupByRadioSelection: GroupByOptions.PerRuleExecution,
-  groupByDuration: {
-    unit: 'm',
-    value: 5,
+  [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: ['host.name'],
+  [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: AlertSuppressionDurationType.PerRuleExecution,
+  [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: {
+    [ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME]: 5,
+    [ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME]: 'm',
   },
+  [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]: AlertSuppressionMissingFieldsStrategyEnum.suppress,
+  [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: false,
   newTermsFields: ['host.ip'],
   historyWindowSize: '7d',
   shouldLoadQueryDynamically: false,
-  enableThresholdSuppression: false,
 };
 
 describe('StepAboutRuleComponent', () => {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/index.test.tsx
@@ -9,7 +9,8 @@ import React, { useEffect, useState } from 'react';
 import { screen, fireEvent, render, within, act, waitFor } from '@testing-library/react';
 import type { Type as RuleType } from '@kbn/securitysolution-io-ts-alerting-types';
 import type { DataViewBase } from '@kbn/es-query';
-import { StepDefineRule, aggregatableFields } from '.';
+import type { FieldSpec } from '@kbn/data-plugin/common';
+import { StepDefineRule } from '.';
 import type { StepDefineRuleProps } from '.';
 import { mockBrowserFields } from '../../../../common/containers/source/mock';
 import { useRuleFromTimeline } from '../../../../detections/containers/detection_engine/rules/use_rule_from_timeline';
@@ -25,6 +26,22 @@ import {
   createIndexPatternField,
   getSelectToggleButtonForName,
 } from '../../../rule_creation/components/required_fields/required_fields.test';
+import { ALERT_SUPPRESSION_FIELDS_FIELD_NAME } from '../../../rule_creation/components/alert_suppression_edit';
+import {
+  expectDuration,
+  expectSuppressionFields,
+  setDuration,
+  setDurationType,
+  setSuppressionFields,
+} from '../../../rule_creation/components/alert_suppression_edit/test_helpers';
+import {
+  selectEuiComboBoxOption,
+  selectFirstEuiComboBoxOption,
+} from '../../../../common/test/eui/combobox';
+import {
+  addRelatedIntegrationRow,
+  setVersion,
+} from '../../../rule_creation/components/related_integrations/test_helpers';
 
 // Mocks integrations
 jest.mock('../../../fleet_integrations/api');
@@ -48,7 +65,13 @@ jest.mock('../ai_assistant', () => {
   };
 });
 
-jest.mock('../data_view_selector_field/use_data_views');
+jest.mock('../data_view_selector_field/use_data_view_list_items');
+
+jest.mock('../../../../common/hooks/use_license', () => ({
+  useLicense: jest.fn().mockReturnValue({
+    isAtLeast: jest.fn().mockReturnValue(true),
+  }),
+}));
 
 const mockRedirectLegacyUrl = jest.fn();
 const mockGetLegacyUrlConflict = jest.fn();
@@ -149,53 +172,6 @@ jest.mock('react-redux', () => {
 
 jest.mock('../../../../detections/containers/detection_engine/rules/use_rule_from_timeline');
 
-test('aggregatableFields', function () {
-  expect(
-    aggregatableFields([
-      {
-        name: 'error.message',
-        type: 'string',
-        esTypes: ['text'],
-        searchable: true,
-        aggregatable: false,
-        readFromDocValues: false,
-      },
-    ])
-  ).toEqual([]);
-});
-
-test('aggregatableFields with aggregatable: true', function () {
-  expect(
-    aggregatableFields([
-      {
-        name: 'error.message',
-        type: 'string',
-        esTypes: ['text'],
-        searchable: true,
-        aggregatable: false,
-        readFromDocValues: false,
-      },
-      {
-        name: 'file.path',
-        type: 'string',
-        esTypes: ['keyword'],
-        searchable: true,
-        aggregatable: true,
-        readFromDocValues: false,
-      },
-    ])
-  ).toEqual([
-    {
-      name: 'file.path',
-      type: 'string',
-      esTypes: ['keyword'],
-      searchable: true,
-      aggregatable: true,
-      readFromDocValues: false,
-    },
-  ]);
-});
-
 const mockUseRuleFromTimeline = useRuleFromTimeline as jest.Mock;
 const onOpenTimeline = jest.fn();
 
@@ -216,6 +192,62 @@ describe.skip('StepDefineRule', () => {
     });
 
     expect(screen.getByTestId('stepDefineRule')).toBeDefined();
+  });
+
+  describe('alert suppression', () => {
+    it('persists state when switching between custom query and threshold rule types', async () => {
+      const mockFields: FieldSpec[] = [
+        {
+          name: 'test-field',
+          type: 'string',
+          searchable: false,
+          aggregatable: true,
+        },
+      ];
+
+      const { rerender } = render(
+        <TestForm
+          indexPattern={{
+            title: '',
+            fields: mockFields,
+          }}
+        />,
+        {
+          wrapper: TestProviders,
+        }
+      );
+
+      await setSuppressionFields(['test-field']);
+      setDurationType('Per time period');
+      setDuration(10, 'h');
+
+      // switch to threshold rule type
+      rerender(
+        <TestForm
+          ruleType="threshold"
+          indexPattern={{
+            title: '',
+            fields: mockFields,
+          }}
+        />
+      );
+
+      expectDuration(10, 'h');
+
+      // switch back to custom query rule type
+      rerender(
+        <TestForm
+          ruleType="query"
+          indexPattern={{
+            title: '',
+            fields: mockFields,
+          }}
+        />
+      );
+
+      expectSuppressionFields(['test-field']);
+      expectDuration(10, 'h');
+    });
   });
 
   describe('related integrations', () => {
@@ -631,13 +663,12 @@ function TestForm({
         ruleType={ruleType}
         index={stepDefineDefaultValue.index}
         threatIndex={stepDefineDefaultValue.threatIndex}
-        groupByFields={stepDefineDefaultValue.groupByFields}
+        alertSuppressionFields={stepDefineDefaultValue[ALERT_SUPPRESSION_FIELDS_FIELD_NAME]}
         dataSourceType={stepDefineDefaultValue.dataSourceType}
         shouldLoadQueryDynamically={stepDefineDefaultValue.shouldLoadQueryDynamically}
         queryBarTitle=""
         queryBarSavedId=""
         thresholdFields={[]}
-        enableThresholdSuppression={false}
         {...formProps}
       />
       <button type="button" onClick={form.submit}>
@@ -651,79 +682,4 @@ function submitForm(): Promise<void> {
   return act(async () => {
     fireEvent.click(screen.getByText('Submit'));
   });
-}
-
-function addRelatedIntegrationRow(): Promise<void> {
-  return act(async () => {
-    fireEvent.click(screen.getByText('Add integration'));
-  });
-}
-
-function setVersion({ input, value }: { input: HTMLInputElement; value: string }): Promise<void> {
-  return act(async () => {
-    fireEvent.input(input, {
-      target: { value },
-    });
-  });
-}
-
-function showEuiComboBoxOptions(comboBoxToggleButton: HTMLElement): Promise<void> {
-  fireEvent.click(comboBoxToggleButton);
-
-  return waitFor(() => {
-    const listWithOptionsElement = document.querySelector('[role="listbox"]');
-    const emptyListElement = document.querySelector('.euiComboBoxOptionsList__empty');
-
-    expect(listWithOptionsElement || emptyListElement).toBeInTheDocument();
-  });
-}
-
-type SelectEuiComboBoxOptionParameters =
-  | {
-      comboBoxToggleButton: HTMLElement;
-      optionIndex: number;
-      optionText?: undefined;
-    }
-  | {
-      comboBoxToggleButton: HTMLElement;
-      optionText: string;
-      optionIndex?: undefined;
-    };
-
-function selectEuiComboBoxOption({
-  comboBoxToggleButton,
-  optionIndex,
-  optionText,
-}: SelectEuiComboBoxOptionParameters): Promise<void> {
-  return act(async () => {
-    await showEuiComboBoxOptions(comboBoxToggleButton);
-
-    const options = Array.from(
-      document.querySelectorAll('[data-test-subj*="comboBoxOptionsList"] [role="option"]')
-    );
-
-    if (typeof optionText === 'string') {
-      const optionToSelect = options.find((option) => option.textContent === optionText);
-
-      if (optionToSelect) {
-        fireEvent.click(optionToSelect);
-      } else {
-        throw new Error(
-          `Could not find option with text "${optionText}". Available options: ${options
-            .map((option) => option.textContent)
-            .join(', ')}`
-        );
-      }
-    } else {
-      fireEvent.click(options[optionIndex]);
-    }
-  });
-}
-
-function selectFirstEuiComboBoxOption({
-  comboBoxToggleButton,
-}: {
-  comboBoxToggleButton: HTMLElement;
-}): Promise<void> {
-  return selectEuiComboBoxOption({ comboBoxToggleButton, optionIndex: 0 });
 }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/index.tsx
@@ -14,8 +14,6 @@ import {
   EuiSpacer,
   EuiButtonGroup,
   EuiText,
-  EuiRadioGroup,
-  EuiToolTip,
 } from '@elastic/eui';
 import type { FC } from 'react';
 import React, { memo, useCallback, useState, useEffect, useMemo, useRef } from 'react';
@@ -41,10 +39,7 @@ import type {
   DefineStepRule,
   RuleStepProps,
 } from '../../../../detections/pages/detection_engine/rules/types';
-import {
-  DataSourceType,
-  GroupByOptions,
-} from '../../../../detections/pages/detection_engine/rules/types';
+import { DataSourceType } from '../../../../detections/pages/detection_engine/rules/types';
 import { StepRuleDescription } from '../description_step';
 import type { QueryBarDefineRuleProps } from '../query_bar';
 import { QueryBarDefineRule } from '../query_bar';
@@ -54,7 +49,6 @@ import { MlJobSelect } from '../../../rule_creation/components/ml_job_select';
 import { PickTimeline } from '../../../rule_creation/components/pick_timeline';
 import { StepContentWrapper } from '../../../rule_creation/components/step_content_wrapper';
 import { ThresholdInput } from '../threshold_input';
-import { SuppressionInfoIcon } from '../suppression_info_icon';
 import { EsqlInfoIcon } from '../../../rule_creation/components/esql_info_icon';
 import {
   Field,
@@ -89,10 +83,7 @@ import { ScheduleItem } from '../../../rule_creation/components/schedule_item_fo
 import { RequiredFields } from '../../../rule_creation/components/required_fields';
 import { DocLink } from '../../../../common/components/links_to_docs/doc_link';
 import { defaultCustomQuery } from '../../../../detections/pages/detection_engine/rules/utils';
-import { MultiSelectFieldsAutocomplete } from '../multi_select_fields';
 import { useLicense } from '../../../../common/hooks/use_license';
-import { AlertSuppressionMissingFieldsStrategyEnum } from '../../../../../common/api/detection_engine/model/rule_schema';
-import { DurationInput } from '../duration_input';
 import { MINIMUM_LICENSE_FOR_SUPPRESSION } from '../../../../../common/detection_engine/constants';
 import { useUpsellingMessage } from '../../../../common/hooks/use_upselling';
 import { useAllEsqlRuleFields } from '../../hooks';
@@ -100,6 +91,9 @@ import { useAlertSuppression } from '../../../rule_management/logic/use_alert_su
 import { AiAssistant } from '../ai_assistant';
 import { RelatedIntegrations } from '../../../rule_creation/components/related_integrations';
 import { useMLRuleConfig } from '../../../../common/components/ml/hooks/use_ml_rule_config';
+import { AlertSuppressionEdit } from '../../../rule_creation/components/alert_suppression_edit';
+import { ThresholdAlertSuppressionEdit } from '../../../rule_creation/components/threshold_alert_suppression_edit';
+import { usePersistentAlertSuppressionState } from './use_persistent_alert_suppression_state';
 
 const CommonUseField = getUseField({ component: Field });
 
@@ -121,13 +115,12 @@ export interface StepDefineRuleProps extends RuleStepProps {
   ruleType: Type;
   index: string[];
   threatIndex: string[];
-  groupByFields: string[];
+  alertSuppressionFields?: string[];
   dataSourceType: DataSourceType;
   shouldLoadQueryDynamically: boolean;
   queryBarTitle: string | undefined;
   queryBarSavedId: string | null | undefined;
   thresholdFields: string[] | undefined;
-  enableThresholdSuppression: boolean;
 }
 
 interface StepDefineRuleReadOnlyProps {
@@ -157,25 +150,12 @@ const RuleTypeEuiFormRow = styled(EuiFormRow).attrs<{ $isVisible: boolean }>(({ 
   },
 }))<{ $isVisible: boolean }>``;
 
-const IntendedRuleTypeEuiFormRow = styled(RuleTypeEuiFormRow)`
-  ${({ theme }) => `padding-left: ${theme.eui.euiSizeXL};`}
-`;
-
-/* eslint-disable react/no-unused-prop-types */
-interface GroupByChildrenProps {
-  groupByRadioSelection: FieldHook<string>;
-  groupByDurationUnit: FieldHook<string>;
-  groupByDurationValue: FieldHook<number | undefined>;
-}
-/* eslint-enable react/no-unused-prop-types */
-
 // eslint-disable-next-line complexity
 const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
   dataSourceType,
   defaultSavedQuery,
-  enableThresholdSuppression,
   form,
-  groupByFields,
+  alertSuppressionFields,
   index,
   indexPattern,
   indicesConfig,
@@ -272,10 +252,11 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
     [form]
   );
 
-  const [aggFields, setAggregatableFields] = useState<FieldSpec[]>([]);
-
-  useEffect(() => {
-    const { fields } = indexPattern;
+  const aggFields = useMemo(
+    () => (indexPattern.fields as FieldSpec[]).filter((field) => field.aggregatable === true),
+    [indexPattern.fields]
+  );
+  const termsAggregationFields = useMemo(
     /**
      * Typecasting to FieldSpec because fields is
      * typed as DataViewFieldBase[] which does not have
@@ -285,12 +266,8 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
      * We will need to determine where these types are defined and
      * figure out where the discrepency is.
      */
-    setAggregatableFields(aggregatableFields(fields as FieldSpec[]));
-  }, [indexPattern]);
-
-  const termsAggregationFields: FieldSpec[] = useMemo(
-    () => getTermsAggregationFields(aggFields),
-    [aggFields]
+    () => getTermsAggregationFields(indexPattern.fields as FieldSpec[]),
+    [indexPattern.fields]
   );
 
   const [threatIndexPatternsLoading, { indexPatterns: threatIndexPatterns }] =
@@ -397,14 +374,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
     }
   }, [ruleType, previousRuleType, getFields]);
 
-  /**
-   * for threshold rule suppression only time interval suppression mode is available
-   */
-  useEffect(() => {
-    if (isThresholdRule) {
-      form.setFieldValue('groupByRadioSelection', GroupByOptions.PerTimePeriod);
-    }
-  }, [isThresholdRule, form]);
+  usePersistentAlertSuppressionState({ form });
 
   // if saved query failed to load:
   // - reset shouldLoadFormDynamically to false, as non existent query cannot be used for loading and execution
@@ -484,18 +454,16 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
    * disable these fields and leave users in a bad state that they cannot change.
    * The exception is threshold rules, which use an existing threshold field for the same
    * purpose and so are treated as if the field is always selected.  */
-  const areSuppressionFieldsSelected = isThresholdRule || groupByFields.length > 0;
+  const areSuppressionFieldsSelected = isThresholdRule || Boolean(alertSuppressionFields?.length);
 
   const areSuppressionFieldsDisabledBySequence =
     isEqlRule(ruleType) &&
     isEqlSequenceQuery(queryBar?.query?.query as string) &&
-    groupByFields.length === 0;
+    alertSuppressionFields?.length === 0;
 
   /** If we don't have ML field information, users can't meaningfully interact with suppression fields */
   const areSuppressionFieldsDisabledByMlFields =
     isMlRule(ruleType) && (mlRuleConfigLoading || !mlSuppressionFields.length);
-
-  const isThresholdSuppressionDisabled = isThresholdRule && !enableThresholdSuppression;
 
   /** Suppression fields are generally disabled if either:
    * - License is insufficient (i.e. less than platinum)
@@ -534,96 +502,15 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
     }
   }, [esqlSuppressionFields, mlSuppressionFields, ruleType, termsAggregationFields]);
 
-  const isGroupByChildrenDisabled =
-    areSuppressionFieldsDisabled || isThresholdSuppressionDisabled || !areSuppressionFieldsSelected;
-  const isPerRuleExecutionDisabled = areSuppressionFieldsDisabled || isThresholdRule;
-  const isPerTimePeriodDisabled =
-    areSuppressionFieldsDisabled || isThresholdSuppressionDisabled || !areSuppressionFieldsSelected;
-  const isDurationDisabled =
-    areSuppressionFieldsDisabled || isThresholdSuppressionDisabled || !areSuppressionFieldsSelected;
-  const isMissingFieldsDisabled = areSuppressionFieldsDisabled || !areSuppressionFieldsSelected;
-
-  const GroupByChildren = useCallback(
-    ({
-      groupByRadioSelection,
-      groupByDurationUnit,
-      groupByDurationValue,
-    }: GroupByChildrenProps) => (
-      <EuiRadioGroup
-        disabled={isGroupByChildrenDisabled}
-        idSelected={groupByRadioSelection.value}
-        options={[
-          {
-            id: GroupByOptions.PerRuleExecution,
-            label: (
-              <EuiToolTip
-                content={
-                  isThresholdRule ? i18n.THRESHOLD_SUPPRESSION_PER_RULE_EXECUTION_WARNING : null
-                }
-              >
-                <> {i18n.ALERT_SUPPRESSION_PER_RULE_EXECUTION}</>
-              </EuiToolTip>
-            ),
-            disabled: isPerRuleExecutionDisabled,
-          },
-          {
-            id: GroupByOptions.PerTimePeriod,
-            disabled: isPerTimePeriodDisabled,
-            label: (
-              <>
-                {i18n.ALERT_SUPPRESSION_PER_TIME_PERIOD}
-                <DurationInput
-                  data-test-subj="alertSuppressionDurationInput"
-                  durationValueField={groupByDurationValue}
-                  durationUnitField={groupByDurationUnit}
-                  // Suppression duration is also disabled suppression by rule execution is selected in radio button
-                  isDisabled={
-                    isDurationDisabled ||
-                    groupByRadioSelection.value !== GroupByOptions.PerTimePeriod
-                  }
-                  minimumValue={1}
-                />
-              </>
-            ),
-          },
-        ]}
-        onChange={(id: string) => {
-          groupByRadioSelection.setValue(id);
-        }}
-        data-test-subj="groupByDurationOptions"
-      />
+  const alertSuppressionFieldsAppendText = useMemo(
+    () => (
+      <EuiText color="subdued" size="xs">
+        {isSuppressionRuleInGA(ruleType)
+          ? i18n.ALERT_SUPPRESSION_FIELDS_GA_LABEL_APPEND
+          : i18n.ALERT_SUPPRESSION_FIELDS_TECH_PREVIEW_LABEL_APPEND}
+      </EuiText>
     ),
-    [
-      isThresholdRule,
-      isDurationDisabled,
-      isPerTimePeriodDisabled,
-      isPerRuleExecutionDisabled,
-      isGroupByChildrenDisabled,
-    ]
-  );
-
-  const AlertSuppressionMissingFields = useCallback(
-    ({ suppressionMissingFields }: Record<string, FieldHook<string | undefined>>) => (
-      <EuiRadioGroup
-        disabled={isMissingFieldsDisabled}
-        idSelected={suppressionMissingFields.value}
-        options={[
-          {
-            id: AlertSuppressionMissingFieldsStrategyEnum.suppress,
-            label: i18n.ALERT_SUPPRESSION_MISSING_FIELDS_SUPPRESS_OPTION,
-          },
-          {
-            id: AlertSuppressionMissingFieldsStrategyEnum.doNotSuppress,
-            label: i18n.ALERT_SUPPRESSION_MISSING_FIELDS_DO_NOT_SUPPRESS_OPTION,
-          },
-        ]}
-        onChange={(id: string) => {
-          suppressionMissingFields.setValue(id);
-        }}
-        data-test-subj="suppressionMissingFieldsOptions"
-      />
-    ),
-    [isMissingFieldsDisabled]
+    [ruleType]
   );
 
   const dataViewIndexPatternToggleButtonOptions: EuiButtonGroupOptionProps[] = useMemo(
@@ -938,7 +825,6 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
               )}
             </>
           </RuleTypeEuiFormRow>
-
           {!isMlRule(ruleType) && !isQueryBarValid && queryBar?.query?.query && (
             <AiAssistant
               getFields={form.getFields}
@@ -946,7 +832,6 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
               language={queryBar?.query?.language}
             />
           )}
-
           {isQueryRule(ruleType) && (
             <>
               <EuiSpacer size="s" />
@@ -1058,99 +943,27 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
           </RuleTypeEuiFormRow>
           <EuiSpacer size="m" />
 
-          <>
-            <RuleTypeEuiFormRow $isVisible={isAlertSuppressionEnabled && isThresholdRule} fullWidth>
-              <EuiToolTip content={alertSuppressionUpsellingMessage} position="right">
-                <CommonUseField
-                  path="enableThresholdSuppression"
-                  componentProps={{
-                    idAria: 'detectionEngineStepDefineRuleThresholdEnableSuppression',
-                    'data-test-subj': 'detectionEngineStepDefineRuleThresholdEnableSuppression',
-                    euiFieldProps: {
-                      label: i18n.getEnableThresholdSuppressionLabel(thresholdFields),
-                      disabled: !isAlertSuppressionLicenseValid,
-                    },
-                  }}
-                />
-              </EuiToolTip>
-            </RuleTypeEuiFormRow>
-
-            <RuleTypeEuiFormRow
-              $isVisible={isAlertSuppressionEnabled && !isThresholdRule}
-              data-test-subj="alertSuppressionInput"
-              label={i18n.GROUP_BY_LABEL}
-              labelAppend={
-                <EuiText color="subdued" size="xs">
-                  {isSuppressionRuleInGA(ruleType)
-                    ? i18n.GROUP_BY_GA_LABEL_APPEND
-                    : i18n.GROUP_BY_TECH_PREVIEW_LABEL_APPEND}
-                </EuiText>
-              }
-            >
-              <>
-                <UseField
-                  path="groupByFields"
-                  component={MultiSelectFieldsAutocomplete}
-                  componentProps={{
-                    browserFields: suppressionGroupByFields,
-                    isDisabled: isSuppressionGroupByDisabled,
-                    disabledText: suppressionGroupByDisabledText,
-                  }}
-                />
-                {isMlSuppressionIncomplete && (
-                  <EuiText size="xs" color="warning">
-                    {i18n.MACHINE_LEARNING_SUPPRESSION_INCOMPLETE_LABEL}
-                  </EuiText>
-                )}
-              </>
-            </RuleTypeEuiFormRow>
-
-            <IntendedRuleTypeEuiFormRow
-              $isVisible={isAlertSuppressionEnabled}
-              data-test-subj="alertSuppressionDuration"
-            >
-              <UseMultiFields
-                fields={{
-                  groupByRadioSelection: {
-                    path: 'groupByRadioSelection',
-                  },
-                  groupByDurationValue: {
-                    path: 'groupByDuration.value',
-                  },
-                  groupByDurationUnit: {
-                    path: 'groupByDuration.unit',
-                  },
-                }}
-              >
-                {GroupByChildren}
-              </UseMultiFields>
-            </IntendedRuleTypeEuiFormRow>
-
-            <IntendedRuleTypeEuiFormRow
-              // threshold rule does not have this suppression configuration
-              $isVisible={isAlertSuppressionEnabled && !isThresholdRule}
-              data-test-subj="alertSuppressionMissingFields"
-              label={
-                <span>
-                  {i18n.ALERT_SUPPRESSION_MISSING_FIELDS_FORM_ROW_LABEL} <SuppressionInfoIcon />
-                </span>
-              }
-              fullWidth
-            >
-              <UseMultiFields
-                fields={{
-                  suppressionMissingFields: {
-                    path: 'suppressionMissingFields',
-                  },
-                }}
-              >
-                {AlertSuppressionMissingFields}
-              </UseMultiFields>
-            </IntendedRuleTypeEuiFormRow>
-          </>
-
-          <EuiSpacer size="l" />
-
+          <RuleTypeEuiFormRow $isVisible={isAlertSuppressionEnabled} fullWidth>
+            {isThresholdRule ? (
+              <ThresholdAlertSuppressionEdit
+                suppressionFieldNames={thresholdFields}
+                disabled={!isAlertSuppressionLicenseValid}
+                disabledText={alertSuppressionUpsellingMessage}
+              />
+            ) : (
+              <AlertSuppressionEdit
+                suppressibleFields={suppressionGroupByFields}
+                labelAppend={alertSuppressionFieldsAppendText}
+                warningText={
+                  isMlSuppressionIncomplete
+                    ? i18n.MACHINE_LEARNING_SUPPRESSION_INCOMPLETE_LABEL
+                    : undefined
+                }
+                disabled={isSuppressionGroupByDisabled}
+                disabledText={suppressionGroupByDisabledText}
+              />
+            )}
+          </RuleTypeEuiFormRow>
           {!isMlRule(ruleType) && (
             <>
               <RequiredFields
@@ -1161,9 +974,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
               <EuiSpacer size="l" />
             </>
           )}
-
           <RelatedIntegrations path="relatedIntegrations" dataTestSubj="relatedIntegrations" />
-
           <UseField
             path="timeline"
             component={PickTimeline}
@@ -1201,7 +1012,3 @@ const StepDefineRuleReadOnlyComponent: FC<StepDefineRuleReadOnlyProps> = ({
   );
 };
 export const StepDefineRuleReadOnly = memo(StepDefineRuleReadOnlyComponent);
-
-export function aggregatableFields<T extends { aggregatable: boolean }>(browserFields: T[]): T[] {
-  return browserFields.filter((field) => field.aggregatable === true);
-}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/schema.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/schema.tsx
@@ -34,6 +34,9 @@ import type { DefineStepRule } from '../../../../detections/pages/detection_engi
 import { DataSourceType } from '../../../../detections/pages/detection_engine/rules/types';
 import { debounceAsync, eqlValidator } from '../eql_query_bar/validators';
 import { esqlValidator } from '../../../rule_creation/logic/esql_validator';
+import { dataViewIdValidatorFactory } from '../../validators/data_view_id_validator_factory';
+import { indexPatternValidatorFactory } from '../../validators/index_pattern_validator_factory';
+import { alertSuppressionFieldsValidatorFactory } from '../../validators/alert_suppression_fields_validator_factory';
 import {
   CUSTOM_QUERY_REQUIRED,
   INVALID_CUSTOM_QUERY,
@@ -44,8 +47,12 @@ import {
   EQL_SEQUENCE_SUPPRESSION_GROUPBY_VALIDATION_TEXT,
 } from './translations';
 import { getQueryRequiredMessage } from './utils';
-import { dataViewIdValidatorFactory } from '../../validators/data_view_id_validator_factory';
-import { indexPatternValidatorFactory } from '../../validators/index_pattern_validator_factory';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+} from '../../../rule_creation/components/alert_suppression_edit';
+import * as alertSuppressionEditI81n from '../../../rule_creation/components/alert_suppression_edit/components/translations';
 
 export const schema: FormSchema<DefineStepRule> = {
   index: {
@@ -112,7 +119,7 @@ export const schema: FormSchema<DefineStepRule> = {
     fieldsToValidateOnChange: ['eqlOptions', 'queryBar'],
   },
   queryBar: {
-    fieldsToValidateOnChange: ['queryBar', 'groupByFields'],
+    fieldsToValidateOnChange: ['queryBar', ALERT_SUPPRESSION_FIELDS_FIELD_NAME],
     validations: [
       {
         validator: (
@@ -648,34 +655,18 @@ export const schema: FormSchema<DefineStepRule> = {
       },
     ],
   },
-  groupByFields: {
-    type: FIELD_TYPES.COMBO_BOX,
-    helpText: i18n.translate(
-      'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.fieldGroupByFieldHelpText',
-      {
-        defaultMessage: 'Select field(s) to use for suppressing extra alerts',
-      }
-    ),
+  [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: {
     validations: [
       {
-        validator: (
-          ...args: Parameters<ValidationFunc>
-        ): ReturnType<ValidationFunc<{}, ERROR_CODE>> | undefined => {
+        validator: (...args: Parameters<ValidationFunc>) => {
           const [{ formData }] = args;
           const needsValidation = isSuppressionRuleConfiguredWithGroupBy(formData.ruleType);
 
           if (!needsValidation) {
             return;
           }
-          return fieldValidators.maxLengthField({
-            length: 3,
-            message: i18n.translate(
-              'xpack.securitySolution.detectionEngine.validations.stepDefineRule.groupByFieldsMax',
-              {
-                defaultMessage: 'Number of grouping fields must be at most 3',
-              }
-            ),
-          })(...args);
+
+          return alertSuppressionFieldsValidatorFactory()(...args);
         },
       },
       {
@@ -683,13 +674,13 @@ export const schema: FormSchema<DefineStepRule> = {
           ...args: Parameters<ValidationFunc>
         ): ReturnType<ValidationFunc<{}, ERROR_CODE>> | undefined => {
           const [{ formData, value }] = args;
-          const groupByLength = (value as string[]).length;
-          const needsValidation = isEqlRule(formData.ruleType) && groupByLength > 0;
-          if (!needsValidation) {
+
+          if (!isEqlRule(formData.ruleType) || !Array.isArray(value) || value.length === 0) {
             return;
           }
 
           const query: string = formData.queryBar?.query?.query ?? '';
+
           if (isEqlSequenceQuery(query)) {
             return {
               message: EQL_SEQUENCE_SUPPRESSION_GROUPBY_VALIDATION_TEXT,
@@ -699,36 +690,18 @@ export const schema: FormSchema<DefineStepRule> = {
       },
     ],
   },
-  groupByRadioSelection: {},
-  groupByDuration: {
+  [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: {
     label: i18n.translate(
       'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.groupByDurationValueLabel',
       {
         defaultMessage: 'Suppress alerts for',
       }
     ),
-    helpText: i18n.translate(
-      'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.fieldGroupByDurationValueHelpText',
-      {
-        defaultMessage: 'Suppress alerts for',
-      }
-    ),
-    value: {},
-    unit: {},
   },
-  suppressionMissingFields: {
-    label: i18n.translate(
-      'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.suppressionMissingFieldsLabel',
-      {
-        defaultMessage: 'If a suppression field is missing',
-      }
-    ),
+  [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]: {
+    label: alertSuppressionEditI81n.ALERT_SUPPRESSION_MISSING_FIELDS_LABEL,
   },
   shouldLoadQueryDynamically: {
-    type: FIELD_TYPES.CHECKBOX,
-    defaultValue: false,
-  },
-  enableThresholdSuppression: {
     type: FIELD_TYPES.CHECKBOX,
     defaultValue: false,
   },

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/translations.tsx
@@ -249,23 +249,16 @@ export const MACHINE_LEARNING_SUPPRESSION_INCOMPLETE_LABEL = i18n.translate(
   }
 );
 
-export const GROUP_BY_TECH_PREVIEW_LABEL_APPEND = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.groupByFieldsTechPreviewLabelAppend',
+export const ALERT_SUPPRESSION_FIELDS_TECH_PREVIEW_LABEL_APPEND = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.alertSuppressionTechPreviewLabelAppend',
   {
     defaultMessage: 'Optional (Technical Preview)',
   }
 );
 
-export const GROUP_BY_GA_LABEL_APPEND = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.groupByFieldsGALabelAppend',
+export const ALERT_SUPPRESSION_FIELDS_GA_LABEL_APPEND = i18n.translate(
+  'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.alertSuppressionGALabelAppend',
   {
     defaultMessage: 'Optional',
-  }
-);
-
-export const GROUP_BY_LABEL = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.groupByFieldsLabel',
-  {
-    defaultMessage: 'Suppress alerts by',
   }
 );

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/use_persistent_alert_suppression_state.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/use_persistent_alert_suppression_state.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+import { isThresholdRule } from '../../../../../common/detection_engine/utils';
+import type { FormHook } from '../../../../shared_imports';
+import { useFormData } from '../../../../shared_imports';
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from '../../../rule_creation/components/threshold_alert_suppression_edit';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+} from '../../../rule_creation/components/alert_suppression_edit';
+import {
+  AlertSuppressionDurationType,
+  type DefineStepRule,
+} from '../../../../detections/pages/detection_engine/rules/types';
+
+interface UsePersistentAlertSuppressionStateParams {
+  form: FormHook<DefineStepRule>;
+}
+
+export function usePersistentAlertSuppressionState({
+  form,
+}: UsePersistentAlertSuppressionStateParams): void {
+  const [
+    {
+      ruleType,
+      [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: thresholdAlertSuppressionEnabled,
+      [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: suppressionFields,
+      [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: suppressionDurationType,
+      [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: suppressionDuration,
+      [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]: suppressionMissingFieldsStrategy,
+    },
+  ] = useFormData({
+    form,
+    watch: [
+      'ruleType',
+      THRESHOLD_ALERT_SUPPRESSION_ENABLED,
+      ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+      ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+      `${ALERT_SUPPRESSION_DURATION_FIELD_NAME}.${ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME}`,
+      `${ALERT_SUPPRESSION_DURATION_FIELD_NAME}.${ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME}`,
+      ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+    ],
+  });
+
+  useEffect(() => {
+    form.updateFieldValues({
+      [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: thresholdAlertSuppressionEnabled,
+      [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: suppressionFields,
+      ...(isThresholdRule(ruleType)
+        ? {
+            [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]:
+              AlertSuppressionDurationType.PerTimePeriod,
+          }
+        : { [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: suppressionDurationType }),
+      [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: suppressionDuration,
+      [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]: suppressionMissingFieldsStrategy,
+    });
+  }, [
+    form,
+    ruleType,
+    thresholdAlertSuppressionEnabled,
+    suppressionFields,
+    suppressionDurationType,
+    suppressionDuration,
+    suppressionMissingFieldsStrategy,
+  ]);
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/utils.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/utils.ts
@@ -18,12 +18,13 @@ import { isEqlRule, isEsqlRule } from '../../../../../common/detection_engine/ut
  * Keyword, Numeric, ip, boolean, or binary.
  * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html
  */
-export const getTermsAggregationFields = (fields: FieldSpec[]): FieldSpec[] => {
-  // binary types is excluded, as binary field has property aggregatable === false
-  const allowedTypesSet = new Set(['string', 'number', 'ip', 'boolean']);
+export const getTermsAggregationFields = (fields: FieldSpec[]): FieldSpec[] =>
+  fields.filter(
+    (field) => field.aggregatable === true && ALLOWED_AGGREGATABLE_FIELD_TYPES_SET.has(field.type)
+  );
 
-  return fields.filter((field) => field.aggregatable === true && allowedTypesSet.has(field.type));
-};
+// binary types is excluded, as binary field has property aggregatable === false
+const ALLOWED_AGGREGATABLE_FIELD_TYPES_SET = new Set(['string', 'number', 'ip', 'boolean']);
 
 /**
  * return query is required message depends on a rule type

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/form.test.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/form.test.ts
@@ -18,6 +18,7 @@ import type {
 
 import { useRuleFormsErrors } from './form';
 import { transformEqlResponseErrorToValidationError } from '../components/eql_query_bar/validators';
+import { ALERT_SUPPRESSION_FIELDS_FIELD_NAME } from '../../rule_creation/components/alert_suppression_edit';
 
 const getFormWithErrorsMock = <T extends FormData = FormData>(fields: {
   [key: string]: { errors: Array<ValidationError<EQL_ERROR_CODES | ESQL_ERROR_CODES>> };
@@ -248,7 +249,7 @@ describe('useRuleFormsErrors', () => {
 
       const defineStepForm = getFormWithErrorsMock<DefineStepRule>({
         queryBar: { errors: [esqlValidationError] },
-        groupByFields: { errors: [groupByValidationError] },
+        [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: { errors: [groupByValidationError] },
       });
       const aboutStepForm = getFormWithErrorsMock<AboutStepRule>({
         name: {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/helpers.test.ts
@@ -25,7 +25,7 @@ import type {
   ScheduleStepRule,
   DefineStepRule,
 } from '../../../../detections/pages/detection_engine/rules/types';
-import { GroupByOptions } from '../../../../detections/pages/detection_engine/rules/types';
+import { AlertSuppressionDurationType } from '../../../../detections/pages/detection_engine/rules/types';
 import {
   getTimeTypeValue,
   formatDefineStepData,
@@ -45,6 +45,13 @@ import {
 } from '../../../rule_management_ui/components/rules_table/__mocks__/mock';
 import { getThreatMock } from '../../../../../common/detection_engine/schemas/types/threat.mock';
 import type { Threat, Threats } from '@kbn/securitysolution-io-ts-alerting-types';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+} from '../../../rule_creation/components/alert_suppression_edit';
 
 describe('helpers', () => {
   describe('getTimeTypeValue', () => {
@@ -458,8 +465,9 @@ describe('helpers', () => {
               query: 'process where process_name == "explorer.exe"',
             },
           },
-          groupByFields: ['event.type'],
-          groupByRadioSelection: GroupByOptions.PerRuleExecution,
+          [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: ['event.type'],
+          [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]:
+            AlertSuppressionDurationType.PerRuleExecution,
         };
         const result = formatDefineStepData(mockStepData);
 
@@ -491,9 +499,9 @@ describe('helpers', () => {
               query: 'process where process_name == "explorer.exe"',
             },
           },
-          groupByFields: ['event.type'],
-          groupByRadioSelection: GroupByOptions.PerTimePeriod,
-          groupByDuration: { value: 10, unit: 'm' },
+          [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: ['event.type'],
+          [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: AlertSuppressionDurationType.PerTimePeriod,
+          [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: { value: 10, unit: 'm' },
         };
         const result = formatDefineStepData(mockStepData);
 
@@ -597,9 +605,12 @@ describe('helpers', () => {
         ruleType: 'machine_learning',
         machineLearningJobId: ['some_jobert_id'],
         anomalyThreshold: 44,
-        groupByFields: ['event.type'],
-        groupByRadioSelection: GroupByOptions.PerTimePeriod,
-        groupByDuration: { value: 10, unit: 'm' },
+        [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: ['event.type'],
+        [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: AlertSuppressionDurationType.PerTimePeriod,
+        [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: {
+          [ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME]: 10,
+          [ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME]: 'm',
+        },
       };
       const result = formatDefineStepData(mockStepData);
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/helpers.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/helpers.ts
@@ -52,7 +52,7 @@ import type {
 } from '../../../../detections/pages/detection_engine/rules/types';
 import {
   DataSourceType,
-  GroupByOptions,
+  AlertSuppressionDurationType,
 } from '../../../../detections/pages/detection_engine/rules/types';
 import type {
   RuleCreateProps,
@@ -63,6 +63,13 @@ import type {
 } from '../../../../../common/api/detection_engine/model/rule_schema';
 import { stepActionsDefaultValue } from '../../../rule_creation/components/step_rule_actions';
 import { DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY } from '../../../../../common/detection_engine/constants';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+} from '../../../rule_creation/components/alert_suppression_edit';
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from '../../../rule_creation/components/threshold_alert_suppression_edit';
 
 export const getTimeTypeValue = (time: string): { unit: Unit; value: number } => {
   const timeObj: { unit: Unit; value: number } = {
@@ -432,16 +439,18 @@ export const formatDefineStepData = (defineStepData: DefineStepRule): DefineStep
       }),
   };
 
+  // Threshold rule won't contain alert suppression fields
   const alertSuppressionFields =
-    ruleFields.groupByFields.length > 0
+    ruleFields[ALERT_SUPPRESSION_FIELDS_FIELD_NAME]?.length > 0
       ? {
           alert_suppression: {
-            group_by: ruleFields.groupByFields,
+            group_by: ruleFields[ALERT_SUPPRESSION_FIELDS_FIELD_NAME],
             duration:
-              ruleFields.groupByRadioSelection === GroupByOptions.PerTimePeriod
-                ? ruleFields.groupByDuration
+              ruleFields[ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME] ===
+              AlertSuppressionDurationType.PerTimePeriod
+                ? ruleFields[ALERT_SUPPRESSION_DURATION_FIELD_NAME]
                 : undefined,
-            missing_fields_strategy: (ruleFields.suppressionMissingFields ||
+            missing_fields_strategy: (ruleFields[ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME] ||
               DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY) as AlertSuppression['missing_fields_strategy'],
           },
         }
@@ -478,8 +487,8 @@ export const formatDefineStepData = (defineStepData: DefineStepRule): DefineStep
                   ]
                 : [],
           },
-          ...(ruleFields.enableThresholdSuppression && {
-            alert_suppression: { duration: ruleFields.groupByDuration },
+          ...(ruleFields[THRESHOLD_ALERT_SUPPRESSION_ENABLED] && {
+            alert_suppression: { duration: ruleFields[ALERT_SUPPRESSION_DURATION_FIELD_NAME] },
           }),
         }),
       }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_creation/index.tsx
@@ -81,6 +81,7 @@ import { NextStep } from '../../components/next_step';
 import { useRuleForms, useRuleFormsErrors, useRuleIndexPattern } from '../form';
 import { CustomHeaderPageMemo } from '..';
 import { SaveWithErrorsModal } from '../../components/save_with_errors_confirmation';
+import { ALERT_SUPPRESSION_FIELDS_FIELD_NAME } from '../../../rule_creation/components/alert_suppression_edit';
 
 const MyEuiPanel = styled(EuiPanel)<{
   zindex?: number;
@@ -565,13 +566,12 @@ const CreateRulePageComponent: React.FC = () => {
             ruleType={defineStepData.ruleType}
             index={memoizedIndex}
             threatIndex={defineStepData.threatIndex}
-            groupByFields={defineStepData.groupByFields}
+            alertSuppressionFields={defineStepData[ALERT_SUPPRESSION_FIELDS_FIELD_NAME]}
             dataSourceType={defineStepData.dataSourceType}
             shouldLoadQueryDynamically={defineStepData.shouldLoadQueryDynamically}
             queryBarTitle={defineStepData.queryBar.title}
             queryBarSavedId={defineStepData.queryBar.saved_id}
             thresholdFields={defineStepData.threshold.field}
-            enableThresholdSuppression={defineStepData.enableThresholdSuppression}
           />
           <NextStep
             dataTestSubj="define-continue"
@@ -585,14 +585,8 @@ const CreateRulePageComponent: React.FC = () => {
     [
       activeStep,
       defineRuleNextStep,
-      defineStepData.dataSourceType,
-      defineStepData.groupByFields,
+      defineStepData,
       memoizedIndex,
-      defineStepData.queryBar.saved_id,
-      defineStepData.queryBar.title,
-      defineStepData.ruleType,
-      defineStepData.shouldLoadQueryDynamically,
-      defineStepData.threatIndex,
       defineStepForm,
       eqlOptionsSelected,
       indexPattern,
@@ -604,8 +598,6 @@ const CreateRulePageComponent: React.FC = () => {
       memoDefineStepReadOnly,
       setEqlOptionsSelected,
       threatIndicesConfig,
-      defineStepData.threshold.field,
-      defineStepData.enableThresholdSuppression,
     ]
   );
   const memoDefineStepExtraAction = useMemo(

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
@@ -69,6 +69,7 @@ import { useRuleForms, useRuleFormsErrors, useRuleIndexPattern } from '../form';
 import { useEsqlIndex, useEsqlQueryForAboutStep } from '../../hooks';
 import { CustomHeaderPageMemo } from '..';
 import { SaveWithErrorsModal } from '../../components/save_with_errors_confirmation';
+import { ALERT_SUPPRESSION_FIELDS_FIELD_NAME } from '../../../rule_creation/components/alert_suppression_edit';
 
 const EditRulePageComponent: FC<{ rule: RuleResponse }> = ({ rule }) => {
   const { addSuccess } = useAppToasts();
@@ -238,13 +239,12 @@ const EditRulePageComponent: FC<{ rule: RuleResponse }> = ({ rule }) => {
                   ruleType={defineStepData.ruleType}
                   index={memoizedIndex}
                   threatIndex={defineStepData.threatIndex}
-                  groupByFields={defineStepData.groupByFields}
+                  alertSuppressionFields={defineStepData[ALERT_SUPPRESSION_FIELDS_FIELD_NAME]}
                   dataSourceType={defineStepData.dataSourceType}
                   shouldLoadQueryDynamically={defineStepData.shouldLoadQueryDynamically}
                   queryBarTitle={defineStepData.queryBar.title}
                   queryBarSavedId={defineStepData.queryBar.saved_id}
                   thresholdFields={defineStepData.threshold.field}
-                  enableThresholdSuppression={defineStepData.enableThresholdSuppression}
                 />
               )}
               <EuiSpacer />

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/validators/alert_suppression_fields_validator_factory.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/validators/alert_suppression_fields_validator_factory.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { fieldValidators, type FormData, type ValidationFunc } from '../../../shared_imports';
+
+export function alertSuppressionFieldsValidatorFactory(): ValidationFunc<
+  FormData,
+  string,
+  unknown
+> {
+  return fieldValidators.maxLengthField({
+    length: 3,
+    message: i18n.translate(
+      'xpack.securitySolution.ruleManagement.ruleCreation.validation.alertSuppressionFields.maxLengthError',
+      {
+        defaultMessage: 'Number of grouping fields must be at most 3',
+      }
+    ),
+  });
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/custom_query_rule_field_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/custom_query_rule_field_edit.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import type { UpgradeableCustomQueryFields } from '../../../../model/prebuilt_rule_upgrade/fields';
 import { KqlQueryEditForm } from './fields/kql_query';
 import { DataSourceEditForm } from './fields/data_source';
+import { AlertSuppressionEditForm } from './fields/alert_suppression';
 
 interface CustomQueryRuleFieldEditProps {
   fieldName: UpgradeableCustomQueryFields;
@@ -20,6 +21,8 @@ export function CustomQueryRuleFieldEdit({ fieldName }: CustomQueryRuleFieldEdit
       return <KqlQueryEditForm />;
     case 'data_source':
       return <DataSourceEditForm />;
+    case 'alert_suppression':
+      return <AlertSuppressionEditForm />;
     default:
       return null; // Will be replaced with `assertUnreachable(fieldName)` once all fields are implemented
   }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/eql_rule_field_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/eql_rule_field_edit.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import type { UpgradeableEqlFields } from '../../../../model/prebuilt_rule_upgrade/fields';
 import { DataSourceEditForm } from './fields/data_source';
+import { AlertSuppressionEditForm } from './fields/alert_suppression';
 
 interface EqlRuleFieldEditProps {
   fieldName: UpgradeableEqlFields;
@@ -17,6 +18,8 @@ export function EqlRuleFieldEdit({ fieldName }: EqlRuleFieldEditProps) {
   switch (fieldName) {
     case 'data_source':
       return <DataSourceEditForm />;
+    case 'alert_suppression':
+      return <AlertSuppressionEditForm />;
     default:
       return null; // Will be replaced with `assertUnreachable(fieldName)` once all fields are implemented
   }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/esql_rule_field_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/esql_rule_field_edit.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { UpgradeableEsqlFields } from '../../../../model/prebuilt_rule_upgrade/fields';
+import { AlertSuppressionEditForm } from './fields/alert_suppression';
+
+interface EqQlRuleFieldEditProps {
+  fieldName: UpgradeableEsqlFields;
+}
+
+export function EsqlRuleFieldEdit({ fieldName }: EqQlRuleFieldEditProps) {
+  switch (fieldName) {
+    case 'alert_suppression':
+      return <AlertSuppressionEditForm />;
+    default:
+      return null; // Will be replaced with `assertUnreachable(fieldName)` once all fields are implemented
+  }
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/alert_suppression/form_schema.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/alert_suppression/form_schema.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+} from '../../../../../../../rule_creation/components/alert_suppression_edit';
+import { ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME } from '../../../../../../../rule_creation/components/alert_suppression_edit';
+import type {
+  AlertSuppressionDurationUnit,
+  AlertSuppressionMissingFieldsStrategy,
+} from '../../../../../../../../../common/api/detection_engine';
+import { DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY } from '../../../../../../../../../common/detection_engine/constants';
+import { type FormSchema } from '../../../../../../../../shared_imports';
+
+export interface AlertSuppressionFormData {
+  [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: string[];
+  [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: string;
+  [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: {
+    [ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME]: number;
+    [ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME]: AlertSuppressionDurationUnit;
+  };
+  [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]: AlertSuppressionMissingFieldsStrategy;
+}
+
+export const alertSuppressionFormSchema = {
+  [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]: {
+    defaultValue: DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY,
+  },
+} as FormSchema<AlertSuppressionFormData>;

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/alert_suppression/index.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/alert_suppression/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './suppression_edit_form';

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/alert_suppression/suppression_edit_adapter.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/alert_suppression/suppression_edit_adapter.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { AlertSuppressionEdit } from '../../../../../../../rule_creation/components/alert_suppression_edit';
+import { getTermsAggregationFields } from '../../../../../../../rule_creation_ui/components/step_define_rule/utils';
+import { isEsqlRule, isMlRule } from '../../../../../../../../../common/detection_engine/utils';
+import { useAllEsqlRuleFields } from '../../../../../../../rule_creation_ui/hooks';
+import { useMLRuleConfig } from '../../../../../../../../common/components/ml/hooks/use_ml_rule_config';
+import type { RuleFieldEditComponentProps } from '../rule_field_edit_component_props';
+import { useDiffableRuleDataView } from '../hooks/use_diffable_rule_data_view';
+import * as i18n from './translations';
+
+export function AlertSuppressionEditAdapter({
+  finalDiffableRule,
+}: RuleFieldEditComponentProps): JSX.Element {
+  const { dataView } = useDiffableRuleDataView(finalDiffableRule);
+  const { fields: esqlSuppressionFields, isLoading: isEsqlSuppressionLoading } =
+    useAllEsqlRuleFields({
+      esqlQuery: 'esql_query' in finalDiffableRule ? finalDiffableRule.esql_query.query : undefined,
+      indexPatternsFields: dataView?.fields ?? [],
+    });
+  const machineLearningJobIds = useMemo(
+    () =>
+      'machine_learning_job_id' in finalDiffableRule
+        ? [finalDiffableRule.machine_learning_job_id].flat()
+        : [],
+    [finalDiffableRule]
+  );
+  const {
+    mlSuppressionFields,
+    loading: mlRuleConfigLoading,
+    allJobsStarted,
+  } = useMLRuleConfig({
+    machineLearningJobId: machineLearningJobIds,
+  });
+  const isMlSuppressionIncomplete =
+    isMlRule(finalDiffableRule.type) && machineLearningJobIds.length > 0 && !allJobsStarted;
+
+  const suppressibleFieldSpecs = useMemo(() => {
+    if (isEsqlRule(finalDiffableRule.type)) {
+      return esqlSuppressionFields;
+    } else if (isMlRule(finalDiffableRule.type)) {
+      return mlSuppressionFields;
+    } else {
+      return getTermsAggregationFields(
+        (dataView?.fields ?? []).filter((field) => field.aggregatable === true)
+      );
+    }
+  }, [finalDiffableRule.type, esqlSuppressionFields, mlSuppressionFields, dataView?.fields]);
+
+  const disabledText = useMemo(() => {
+    if (isMlRule(finalDiffableRule.type) && mlRuleConfigLoading) {
+      return i18n.MACHINE_LEARNING_SUPPRESSION_FIELDS_LOADING;
+    } else if (isMlRule(finalDiffableRule.type) && mlSuppressionFields.length === 0) {
+      return i18n.MACHINE_LEARNING_NO_SUPPRESSION_FIELDS;
+    } else if (isEsqlRule(finalDiffableRule.type) && isEsqlSuppressionLoading) {
+      return i18n.ESQL_SUPPRESSION_FIELDS_LOADING;
+    }
+  }, [
+    finalDiffableRule,
+    mlRuleConfigLoading,
+    mlSuppressionFields.length,
+    isEsqlSuppressionLoading,
+  ]);
+
+  return (
+    <AlertSuppressionEdit
+      suppressibleFields={suppressibleFieldSpecs}
+      disabled={Boolean(disabledText)}
+      disabledText={disabledText}
+      warningText={
+        isMlSuppressionIncomplete ? i18n.MACHINE_LEARNING_SUPPRESSION_INCOMPLETE_LABEL : undefined
+      }
+    />
+  );
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/alert_suppression/suppression_edit_form.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/alert_suppression/suppression_edit_form.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_DEFAULT_DURATION,
+} from '../../../../../../../rule_creation/components/alert_suppression_edit';
+import { AlertSuppressionDurationType } from '../../../../../../../../detections/pages/detection_engine/rules/types';
+import { type FormData } from '../../../../../../../../shared_imports';
+import { DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY } from '../../../../../../../../../common/detection_engine/constants';
+import { type AlertSuppression } from '../../../../../../../../../common/api/detection_engine';
+import { RuleFieldEditFormWrapper } from '../rule_field_edit_form_wrapper';
+import { AlertSuppressionEditAdapter } from './suppression_edit_adapter';
+import { alertSuppressionFormSchema, type AlertSuppressionFormData } from './form_schema';
+
+export function AlertSuppressionEditForm(): JSX.Element {
+  return (
+    <RuleFieldEditFormWrapper
+      component={AlertSuppressionEditAdapter}
+      ruleFieldFormSchema={alertSuppressionFormSchema}
+      deserializer={deserializer}
+      serializer={serializer}
+    />
+  );
+}
+
+function deserializer(defaultValue: FormData): AlertSuppressionFormData {
+  const alertSuppression = defaultValue.alert_suppression as AlertSuppression | undefined;
+
+  return {
+    [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: alertSuppression?.group_by ?? [],
+    [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: alertSuppression?.duration
+      ? AlertSuppressionDurationType.PerTimePeriod
+      : AlertSuppressionDurationType.PerRuleExecution,
+    [ALERT_SUPPRESSION_DURATION_FIELD_NAME]:
+      alertSuppression?.duration ?? ALERT_SUPPRESSION_DEFAULT_DURATION,
+    [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]:
+      alertSuppression?.missing_fields_strategy ?? DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY,
+  };
+}
+
+function serializer(formData: FormData): { alert_suppression?: AlertSuppression } {
+  const alertSuppressionFormData = formData as AlertSuppressionFormData;
+
+  if (alertSuppressionFormData[ALERT_SUPPRESSION_FIELDS_FIELD_NAME].length === 0) {
+    return {};
+  }
+
+  return {
+    alert_suppression: {
+      group_by: alertSuppressionFormData[ALERT_SUPPRESSION_FIELDS_FIELD_NAME],
+      duration:
+        alertSuppressionFormData[ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME] ===
+        AlertSuppressionDurationType.PerTimePeriod
+          ? alertSuppressionFormData[ALERT_SUPPRESSION_DURATION_FIELD_NAME]
+          : undefined,
+      missing_fields_strategy:
+        alertSuppressionFormData[ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME] ||
+        DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY,
+    },
+  };
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/alert_suppression/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/alert_suppression/translations.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const MACHINE_LEARNING_SUPPRESSION_FIELDS_LOADING = i18n.translate(
+  'xpack.securitySolution.ruleManagement.threeWayDiff.finalEdit.alertSuppression.machineLearningSuppressionFieldsLoading',
+  {
+    defaultMessage: 'Machine Learning suppression fields are loading',
+  }
+);
+
+export const MACHINE_LEARNING_NO_SUPPRESSION_FIELDS = i18n.translate(
+  'xpack.securitySolution.ruleManagement.threeWayDiff.finalEdit.alertSuppression.machineLearningNoSuppressionFields',
+  {
+    defaultMessage:
+      'Unable to load machine Learning suppression fields, start relevant Machine Learning jobs.',
+  }
+);
+
+export const MACHINE_LEARNING_SUPPRESSION_INCOMPLETE_LABEL = i18n.translate(
+  'xpack.securitySolution.ruleManagement.threeWayDiff.finalEdit.alertSuppression.machineLearningSuppressionIncomplete',
+  {
+    defaultMessage:
+      'This list of fields might be incomplete as some Machine Learning jobs are not running. Start all relevant jobs for a complete list.',
+  }
+);
+
+export const ESQL_SUPPRESSION_FIELDS_LOADING = i18n.translate(
+  'xpack.securitySolution.ruleManagement.threeWayDiff.finalEdit.alertSuppression.esqlFieldsLoading',
+  {
+    defaultMessage: 'ES|QL suppression fields are loading',
+  }
+);

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/data_source/data_source_edit_form.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/data_source/data_source_edit_form.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
 import { EuiText } from '@elastic/eui';
 import { indexPatternValidatorFactory } from '../../../../../../../rule_creation_ui/validators/index_pattern_validator_factory';
 import { dataViewIdValidatorFactory } from '../../../../../../../rule_creation_ui/validators/data_view_id_validator_factory';
@@ -20,6 +19,7 @@ import { DataSourceType } from '../../../../../../../../../common/api/detection_
 import { RuleFieldEditFormWrapper } from '../rule_field_edit_form_wrapper';
 import { DataSourceEdit } from './data_source_edit';
 import { INDEX_HELPER_TEXT } from '../../../../../../../rule_creation_ui/components/step_define_rule/translations';
+import * as i18n from './translations';
 
 export function DataSourceEditForm(): JSX.Element {
   return (
@@ -53,12 +53,7 @@ const dataSourceSchema = {
   index_patterns: {
     defaultValue: [],
     type: FIELD_TYPES.COMBO_BOX,
-    label: i18n.translate(
-      'xpack.securitySolution.ruleManagement.threeWayDiff.finalEdit.indexPatterns.label',
-      {
-        defaultMessage: 'Index patterns',
-      }
-    ),
+    label: i18n.INDEX_PATTERNS,
     helpText: <EuiText size="xs">{INDEX_HELPER_TEXT}</EuiText>,
     validations: [
       {
@@ -77,12 +72,7 @@ const dataSourceSchema = {
     ],
   },
   data_view_id: {
-    label: i18n.translate(
-      'xpack.securitySolution.ruleManagement.threeWayDiff.finalEdit.dataViewSelector.name',
-      {
-        defaultMessage: 'Data view',
-      }
-    ),
+    label: i18n.DATA_VIEW,
     validations: [
       {
         validator: (...args: Parameters<ValidationFunc>) => {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/data_source/data_source_type_selector_field.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/data_source/data_source_type_selector_field.tsx
@@ -6,12 +6,12 @@
  */
 
 import React, { useCallback, useMemo } from 'react';
-import { i18n as i18nCore } from '@kbn/i18n';
 import type { EuiButtonGroupOptionProps } from '@elastic/eui';
 import { EuiButtonGroup } from '@elastic/eui';
 import { DataSourceType } from '../../../../../../../../../common/api/detection_engine/prebuilt_rules';
 import type { FieldHook } from '../../../../../../../../shared_imports';
 import type { ResetFormFn } from '../rule_field_edit_component_props';
+import * as i18n from './translations';
 
 interface DataSourceTypeSelectorFieldProps {
   field: FieldHook<string>;
@@ -26,20 +26,13 @@ export function DataSourceTypeSelectorField({
     () => [
       {
         id: DataSourceType.index_patterns,
-        label: i18nCore.translate(
-          'xpack.securitySolution.ruleDefine.indexTypeSelect.indexPattern',
-          {
-            defaultMessage: 'Index Patterns',
-          }
-        ),
+        label: i18n.INDEX_PATTERNS,
         iconType: field.value === DataSourceType.index_patterns ? 'checkInCircleFilled' : 'empty',
         'data-test-subj': `rule-index-toggle-${DataSourceType.index_patterns}`,
       },
       {
         id: DataSourceType.data_view,
-        label: i18nCore.translate('xpack.securitySolution.ruleDefine.indexTypeSelect.dataView', {
-          defaultMessage: 'Data View',
-        }),
+        label: i18n.DATA_VIEW,
         iconType: field.value === DataSourceType.data_view ? 'checkInCircleFilled' : 'empty',
         'data-test-subj': `rule-index-toggle-${DataSourceType.data_view}`,
       },

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/data_source/index_pattern_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/data_source/index_pattern_edit.tsx
@@ -44,7 +44,7 @@ export function IndexPatternField({ field }: IndexPatternFieldProps): JSX.Elemen
             iconType="refresh"
             onClick={handleResetIndices}
           >
-            {i18n.RESET_DEFAULT_INDEX}
+            {i18n.RESET_TO_DEFAULT_INDEX_PATTERNS}
           </EuiButtonEmpty>
         ) : undefined
       }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/data_source/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/data_source/translations.tsx
@@ -7,8 +7,22 @@
 
 import { i18n } from '@kbn/i18n';
 
-export const RESET_DEFAULT_INDEX = i18n.translate(
-  'xpack.securitySolution.detectionEngine.createRule.stepDefineRule.resetDefaultIndicesButton',
+export const INDEX_PATTERNS = i18n.translate(
+  'xpack.securitySolution.ruleManagement.threeWayDiff.finalEdit.indexPatterns.label',
+  {
+    defaultMessage: 'Index patterns',
+  }
+);
+
+export const DATA_VIEW = i18n.translate(
+  'xpack.securitySolution.ruleManagement.threeWayDiff.finalEdit.dataViewSelector.name',
+  {
+    defaultMessage: 'Data view',
+  }
+);
+
+export const RESET_TO_DEFAULT_INDEX_PATTERNS = i18n.translate(
+  'xpack.securitySolution.ruleManagement.threeWayDiff.finalEdit.indexPatterns.resetToDefault',
   {
     defaultMessage: 'Reset to default index patterns',
   }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/hooks/use_data_view.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/hooks/use_data_view.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect, useState } from 'react';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { useKibana } from '../../../../../../../../common/lib/kibana';
+
+type UseDataViewParams =
+  | { indexPatterns: string[]; dataViewId?: never }
+  | { indexPatterns?: never; dataViewId: string };
+
+interface UseDataViewResult {
+  dataView: DataView | undefined;
+  isLoading: boolean;
+}
+
+export function useDataView(indexPatternsOrDataViewId: UseDataViewParams): UseDataViewResult {
+  const {
+    data: { dataViews: dataViewsService },
+  } = useKibana().services;
+  const [dataView, setDataView] = useState<DataView | undefined>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(true);
+
+    (async () => {
+      try {
+        if (indexPatternsOrDataViewId.indexPatterns) {
+          const indexPatternsDataView = await dataViewsService.create({
+            title: indexPatternsOrDataViewId.indexPatterns.join(','),
+            allowNoIndex: true,
+          });
+
+          setDataView(indexPatternsDataView);
+          return;
+        }
+
+        if (indexPatternsOrDataViewId.dataViewId) {
+          const ruleDataView = await dataViewsService.get(indexPatternsOrDataViewId.dataViewId);
+
+          setDataView(ruleDataView);
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [
+    dataViewsService,
+    indexPatternsOrDataViewId.indexPatterns,
+    indexPatternsOrDataViewId.dataViewId,
+  ]);
+
+  return { dataView, isLoading };
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/hooks/use_diffable_rule_data_view.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/hooks/use_diffable_rule_data_view.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { DataView } from '@kbn/data-views-plugin/common';
+import type { DiffableRule } from '../../../../../../../../../common/api/detection_engine';
+import { DataSourceType } from '../../../../../../../../../common/api/detection_engine';
+import { useDefaultIndexPattern } from '../../../../../../hooks/use_default_index_pattern';
+import { useDataView } from './use_data_view';
+
+interface UseDiffableRuleDataViewResult {
+  dataView: DataView | undefined;
+  isLoading: boolean;
+}
+
+export function useDiffableRuleDataView(diffableRule: DiffableRule): UseDiffableRuleDataViewResult {
+  const defaultIndexPattern = useDefaultIndexPattern();
+  const defaultDataSource = {
+    type: DataSourceType.index_patterns,
+    index_patterns: defaultIndexPattern,
+  } as const;
+  const dataSource =
+    ('data_source' in diffableRule && diffableRule.data_source) || defaultDataSource;
+
+  return useDataView(
+    dataSource.type === DataSourceType.index_patterns
+      ? { indexPatterns: dataSource.index_patterns }
+      : { dataViewId: dataSource.data_view_id }
+  );
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/threshold_alert_suppression/form_schema.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/threshold_alert_suppression/form_schema.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from '../../../../../../../rule_creation/components/threshold_alert_suppression_edit';
+import type {
+  ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME,
+} from '../../../../../../../rule_creation/components/alert_suppression_edit';
+import { ALERT_SUPPRESSION_DURATION_FIELD_NAME } from '../../../../../../../rule_creation/components/alert_suppression_edit';
+import type { AlertSuppressionDurationUnit } from '../../../../../../../../../common/api/detection_engine';
+import { type FormSchema, FIELD_TYPES } from '../../../../../../../../shared_imports';
+
+export interface ThresholdAlertSuppressionFormData {
+  [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: boolean;
+  [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: {
+    [ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME]: number;
+    [ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME]: AlertSuppressionDurationUnit;
+  };
+}
+
+export const thresholdAlertSuppressionFormSchema = {
+  [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: {
+    type: FIELD_TYPES.CHECKBOX,
+  },
+  [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: {
+    value: {},
+    unit: {},
+  },
+} as FormSchema<ThresholdAlertSuppressionFormData>;

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/threshold_alert_suppression/index.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/threshold_alert_suppression/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './suppression_edit_form';

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/threshold_alert_suppression/suppression_edit_form.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/threshold_alert_suppression/suppression_edit_form.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  THRESHOLD_ALERT_SUPPRESSION_ENABLED,
+  ThresholdAlertSuppressionEdit,
+} from '../../../../../../../rule_creation/components/threshold_alert_suppression_edit';
+import { ALERT_SUPPRESSION_DURATION_FIELD_NAME } from '../../../../../../../rule_creation/components/alert_suppression_edit';
+import { type FormData } from '../../../../../../../../shared_imports';
+import type { ThresholdAlertSuppression } from '../../../../../../../../../common/api/detection_engine';
+import { RuleFieldEditFormWrapper } from '../rule_field_edit_form_wrapper';
+import {
+  thresholdAlertSuppressionFormSchema,
+  type ThresholdAlertSuppressionFormData,
+} from './form_schema';
+import type { RuleFieldEditComponentProps } from '../rule_field_edit_component_props';
+
+export function ThresholdAlertSuppressionEditForm(): JSX.Element {
+  return (
+    <RuleFieldEditFormWrapper
+      component={ThresholdAlertSuppressionEditAdapter}
+      ruleFieldFormSchema={thresholdAlertSuppressionFormSchema}
+      deserializer={deserializer}
+      serializer={serializer}
+    />
+  );
+}
+
+function ThresholdAlertSuppressionEditAdapter({
+  finalDiffableRule,
+}: RuleFieldEditComponentProps): JSX.Element {
+  if (finalDiffableRule.type !== 'threshold') {
+    throw new Error('Threshold rule type expected');
+  }
+
+  const suppressibleFields = [finalDiffableRule.threshold.field].flat();
+
+  return <ThresholdAlertSuppressionEdit suppressionFieldNames={suppressibleFields} />;
+}
+
+function deserializer(defaultValue: FormData): ThresholdAlertSuppressionFormData {
+  const alertSuppression = defaultValue.alert_suppression as ThresholdAlertSuppression | undefined;
+
+  return {
+    [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: Boolean(alertSuppression?.duration),
+    [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: alertSuppression?.duration ?? {
+      value: 5,
+      unit: 'm',
+    },
+  };
+}
+
+function serializer(formData: FormData): { alert_suppression?: ThresholdAlertSuppression } {
+  const alertSuppressionFormData = formData as ThresholdAlertSuppressionFormData;
+
+  if (!alertSuppressionFormData[THRESHOLD_ALERT_SUPPRESSION_ENABLED]) {
+    return {};
+  }
+
+  return {
+    alert_suppression: {
+      duration: alertSuppressionFormData[ALERT_SUPPRESSION_DURATION_FIELD_NAME],
+    },
+  };
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/final_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/final_edit.tsx
@@ -21,10 +21,14 @@ import type {
   UpgradeableThresholdFields,
   UpgradeableNewTermsFields,
   UpgradeableEqlFields,
+  UpgradeableEsqlFields,
+  UpgradeableMachineLearningFields,
 } from '../../../../model/prebuilt_rule_upgrade/fields';
 import { isCommonFieldName } from '../../../../model/prebuilt_rule_upgrade/fields';
 import { useFinalSideContext } from '../final_side/final_side_context';
 import { EqlRuleFieldEdit } from './eql_rule_field_edit';
+import { EsqlRuleFieldEdit } from './esql_rule_field_edit';
+import { MachineLearningRuleFieldEdit } from './machine_learning_rule_field_edit';
 
 export function FinalEdit() {
   const { finalDiffableRule } = useDiffableRuleContext();
@@ -44,13 +48,15 @@ export function FinalEdit() {
     case 'eql':
       return <EqlRuleFieldEdit fieldName={fieldName as UpgradeableEqlFields} />;
     case 'esql':
-      return <span>{'Rule type not yet implemented'}</span>;
+      return <EsqlRuleFieldEdit fieldName={fieldName as UpgradeableEsqlFields} />;
     case 'threat_match':
       return <ThreatMatchRuleFieldEdit fieldName={fieldName as UpgradeableThreatMatchFields} />;
     case 'threshold':
       return <ThresholdRuleFieldEdit fieldName={fieldName as UpgradeableThresholdFields} />;
     case 'machine_learning':
-      return <span>{'Rule type not yet implemented'}</span>;
+      return (
+        <MachineLearningRuleFieldEdit fieldName={fieldName as UpgradeableMachineLearningFields} />
+      );
     case 'new_terms':
       return <NewTermsRuleFieldEdit fieldName={fieldName as UpgradeableNewTermsFields} />;
     default:

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/machine_learning_rule_field_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/machine_learning_rule_field_edit.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import type { UpgradeableMachineLearningFields } from '../../../../model/prebuilt_rule_upgrade/fields';
+import { AlertSuppressionEditForm } from './fields/alert_suppression';
+
+interface MachineLearningRuleFieldEditProps {
+  fieldName: UpgradeableMachineLearningFields;
+}
+
+export function MachineLearningRuleFieldEdit({ fieldName }: MachineLearningRuleFieldEditProps) {
+  switch (fieldName) {
+    case 'alert_suppression':
+      return <AlertSuppressionEditForm />;
+    default:
+      return null; // Will be replaced with `assertUnreachable(fieldName)` once all fields are implemented
+  }
+}

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/new_terms_rule_field_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/new_terms_rule_field_edit.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import type { UpgradeableNewTermsFields } from '../../../../model/prebuilt_rule_upgrade/fields';
 import { KqlQueryEditForm } from './fields/kql_query';
 import { DataSourceEditForm } from './fields/data_source';
+import { AlertSuppressionEditForm } from './fields/alert_suppression';
 
 interface NewTermsRuleFieldEditProps {
   fieldName: UpgradeableNewTermsFields;
@@ -20,6 +21,8 @@ export function NewTermsRuleFieldEdit({ fieldName }: NewTermsRuleFieldEditProps)
       return <KqlQueryEditForm />;
     case 'data_source':
       return <DataSourceEditForm />;
+    case 'alert_suppression':
+      return <AlertSuppressionEditForm />;
     default:
       return null; // Will be replaced with `assertUnreachable(fieldName)` once all fields are implemented
   }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/saved_query_rule_field_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/saved_query_rule_field_edit.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import type { UpgradeableSavedQueryFields } from '../../../../model/prebuilt_rule_upgrade/fields';
 import { KqlQueryEditForm } from './fields/kql_query';
 import { DataSourceEditForm } from './fields/data_source';
+import { AlertSuppressionEditForm } from './fields/alert_suppression';
 
 interface SavedQueryRuleFieldEditProps {
   fieldName: UpgradeableSavedQueryFields;
@@ -20,6 +21,8 @@ export function SavedQueryRuleFieldEdit({ fieldName }: SavedQueryRuleFieldEditPr
       return <KqlQueryEditForm />;
     case 'data_source':
       return <DataSourceEditForm />;
+    case 'alert_suppression':
+      return <AlertSuppressionEditForm />;
     default:
       return null; // Will be replaced with `assertUnreachable(fieldName)` once all fields are implemented
   }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/threat_match_rule_field_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/threat_match_rule_field_edit.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import type { UpgradeableThreatMatchFields } from '../../../../model/prebuilt_rule_upgrade/fields';
 import { KqlQueryEditForm } from './fields/kql_query';
 import { DataSourceEditForm } from './fields/data_source';
+import { AlertSuppressionEditForm } from './fields/alert_suppression';
 
 interface ThreatMatchRuleFieldEditProps {
   fieldName: UpgradeableThreatMatchFields;
@@ -20,6 +21,8 @@ export function ThreatMatchRuleFieldEdit({ fieldName }: ThreatMatchRuleFieldEdit
       return <KqlQueryEditForm />;
     case 'data_source':
       return <DataSourceEditForm />;
+    case 'alert_suppression':
+      return <AlertSuppressionEditForm />;
     default:
       return null; // Will be replaced with `assertUnreachable(fieldName)` once all fields are implemented
   }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/threshold_rule_field_edit.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/threshold_rule_field_edit.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import type { UpgradeableThresholdFields } from '../../../../model/prebuilt_rule_upgrade/fields';
 import { KqlQueryEditForm } from './fields/kql_query';
 import { DataSourceEditForm } from './fields/data_source';
+import { ThresholdAlertSuppressionEditForm } from './fields/threshold_alert_suppression';
 
 interface ThresholdRuleFieldEditProps {
   fieldName: UpgradeableThresholdFields;
@@ -20,6 +21,8 @@ export function ThresholdRuleFieldEdit({ fieldName }: ThresholdRuleFieldEditProp
       return <KqlQueryEditForm />;
     case 'data_source':
       return <DataSourceEditForm />;
+    case 'alert_suppression':
+      return <ThresholdAlertSuppressionEditForm />;
     default:
       return null; // Will be replaced with `assertUnreachable(fieldName)` once all fields are implemented
   }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/__mocks__/mock.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/__mocks__/mock.ts
@@ -14,12 +14,25 @@ import type {
 } from '../../../../../detections/pages/detection_engine/rules/types';
 import {
   DataSourceType,
-  GroupByOptions,
+  AlertSuppressionDurationType,
 } from '../../../../../detections/pages/detection_engine/rules/types';
 import type { FieldValueQueryBar } from '../../../../rule_creation_ui/components/query_bar';
 import { fillEmptySeverityMappings } from '../../../../../detections/pages/detection_engine/rules/helpers';
 import { getThreatMock } from '../../../../../../common/detection_engine/schemas/types/threat.mock';
-import type { RuleResponse, SavedQueryRule } from '../../../../../../common/api/detection_engine';
+import {
+  AlertSuppressionMissingFieldsStrategyEnum,
+  type RuleResponse,
+  type SavedQueryRule,
+} from '../../../../../../common/api/detection_engine';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+} from '../../../../rule_creation/components/alert_suppression_edit';
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from '../../../../rule_creation/components/threshold_alert_suppression_edit';
 
 export const mockQueryBar: FieldValueQueryBar = {
   query: {
@@ -248,13 +261,14 @@ export const mockDefineStepRule = (): DefineStepRule => ({
   newTermsFields: ['host.ip'],
   historyWindowSize: '7d',
   shouldLoadQueryDynamically: false,
-  groupByFields: [],
-  groupByRadioSelection: GroupByOptions.PerRuleExecution,
-  groupByDuration: {
-    unit: 'm',
-    value: 5,
+  [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: [],
+  [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: AlertSuppressionDurationType.PerRuleExecution,
+  [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: {
+    [ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME]: 5,
+    [ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME]: 'm',
   },
-  enableThresholdSuppression: false,
+  [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]: AlertSuppressionMissingFieldsStrategyEnum.suppress,
+  [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: false,
 });
 
 export const mockScheduleStepRule = (): ScheduleStepRule => ({

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.test.tsx
@@ -36,6 +36,15 @@ import type {
   ActionsStepRule,
 } from './types';
 import { getThreatMock } from '../../../../../common/detection_engine/schemas/types/threat.mock';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+} from '../../../../detection_engine/rule_creation/components/alert_suppression_edit';
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from '../../../../detection_engine/rule_creation/components/threshold_alert_suppression_edit';
 
 describe('rule helpers', () => {
   moment.suppressDeprecationWarnings = true;
@@ -116,16 +125,16 @@ describe('rule helpers', () => {
           eventCategoryField: undefined,
           tiebreakerField: undefined,
         },
-        groupByFields: ['host.name'],
-        groupByDuration: {
-          value: 5,
-          unit: 'm',
+        [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: ['host.name'],
+        [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: {
+          [ALERT_SUPPRESSION_DURATION_VALUE_FIELD_NAME]: 5,
+          [ALERT_SUPPRESSION_DURATION_UNIT_FIELD_NAME]: 'm',
         },
-        groupByRadioSelection: 'per-rule-execution',
+        [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: 'per-rule-execution',
         newTermsFields: ['host.name'],
         historyWindowSize: '7d',
-        suppressionMissingFields: expect.any(String),
-        enableThresholdSuppression: false,
+        [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]: expect.any(String),
+        [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: false,
       };
 
       const aboutRuleStepData: AboutStepRule = {
@@ -294,7 +303,8 @@ describe('rule helpers', () => {
       test('returns default suppress value in suppress strategy is missing', () => {
         const result: DefineStepRule = getDefineStepsData(mockRule('test-id'));
         const expected = expect.objectContaining({
-          suppressionMissingFields: AlertSuppressionMissingFieldsStrategyEnum.suppress,
+          [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]:
+            AlertSuppressionMissingFieldsStrategyEnum.suppress,
         });
 
         expect(result).toEqual(expected);
@@ -309,7 +319,8 @@ describe('rule helpers', () => {
           },
         });
         const expected = expect.objectContaining({
-          suppressionMissingFields: AlertSuppressionMissingFieldsStrategyEnum.doNotSuppress,
+          [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]:
+            AlertSuppressionMissingFieldsStrategyEnum.doNotSuppress,
         });
 
         expect(result).toEqual(expected);

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/helpers.tsx
@@ -22,6 +22,13 @@ import { ENDPOINT_LIST_ID } from '@kbn/securitysolution-list-constants';
 import type { Filter } from '@kbn/es-query';
 import type { ActionVariables } from '@kbn/triggers-actions-ui-plugin/public';
 import { requiredOptional } from '@kbn/zod-helpers';
+import {
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+} from '../../../../detection_engine/rule_creation/components/alert_suppression_edit';
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from '../../../../detection_engine/rule_creation/components/threshold_alert_suppression_edit';
 import type { ResponseAction } from '../../../../../common/api/detection_engine/model/rule_response_actions';
 import { normalizeThresholdField } from '../../../../../common/detection_engine/utils';
 import { assertUnreachable } from '../../../../../common/utility_types';
@@ -36,7 +43,7 @@ import type {
   ScheduleStepRule,
   ActionsStepRule,
 } from './types';
-import { DataSourceType, GroupByOptions } from './types';
+import { DataSourceType, AlertSuppressionDurationType } from './types';
 import { severityOptions } from '../../../../detection_engine/rule_creation_ui/components/step_about_rule/data';
 import { DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY } from '../../../../../common/detection_engine/constants';
 import type { RuleAction, RuleResponse } from '../../../../../common/api/detection_engine';
@@ -156,27 +163,28 @@ export const getDefineStepsData = (rule: RuleResponse): DefineStepRule => ({
       ? convertHistoryStartToSize(rule.history_window_start)
       : '7d',
   shouldLoadQueryDynamically: Boolean(rule.type === 'saved_query' && rule.saved_id),
-  groupByFields:
+  [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]:
     ('alert_suppression' in rule &&
       rule.alert_suppression &&
       'group_by' in rule.alert_suppression &&
       rule.alert_suppression.group_by) ||
     [],
-  groupByRadioSelection:
+  [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]:
     'alert_suppression' in rule && rule.alert_suppression?.duration
-      ? GroupByOptions.PerTimePeriod
-      : GroupByOptions.PerRuleExecution,
-  groupByDuration: ('alert_suppression' in rule && rule.alert_suppression?.duration) || {
+      ? AlertSuppressionDurationType.PerTimePeriod
+      : AlertSuppressionDurationType.PerRuleExecution,
+  [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: ('alert_suppression' in rule &&
+    rule.alert_suppression?.duration) || {
     value: 5,
     unit: 'm',
   },
-  suppressionMissingFields:
+  [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]:
     ('alert_suppression' in rule &&
       rule.alert_suppression &&
       'missing_fields_strategy' in rule.alert_suppression &&
       rule.alert_suppression.missing_fields_strategy) ||
     DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY,
-  enableThresholdSuppression: Boolean(
+  [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: Boolean(
     'alert_suppression' in rule && rule.alert_suppression?.duration
   ),
 });

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/types.ts
@@ -23,6 +23,13 @@ import type {
 } from '@kbn/alerting-plugin/common';
 import type { DataViewListItem } from '@kbn/data-views-plugin/common';
 
+import type {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+} from '../../../../detection_engine/rule_creation/components/alert_suppression_edit';
+import type { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from '../../../../detection_engine/rule_creation/components/threshold_alert_suppression_edit';
 import type { FieldValueQueryBar } from '../../../../detection_engine/rule_creation_ui/components/query_bar';
 import type { FieldValueTimeline } from '../../../../detection_engine/rule_creation/components/pick_timeline';
 import type { FieldValueThreshold } from '../../../../detection_engine/rule_creation_ui/components/threshold_input';
@@ -132,7 +139,7 @@ export enum DataSourceType {
   DataView = 'dataView',
 }
 
-export enum GroupByOptions {
+export enum AlertSuppressionDurationType {
   PerRuleExecution = 'per-rule-execution',
   PerTimePeriod = 'per-time-period',
 }
@@ -162,11 +169,11 @@ export interface DefineStepRule {
   newTermsFields: string[];
   historyWindowSize: string;
   shouldLoadQueryDynamically: boolean;
-  groupByFields: string[];
-  groupByRadioSelection: GroupByOptions;
-  groupByDuration: Duration;
-  suppressionMissingFields?: AlertSuppressionMissingFieldsStrategy;
-  enableThresholdSuppression: boolean;
+  [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: string[];
+  [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: AlertSuppressionDurationType;
+  [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: Duration;
+  [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]: AlertSuppressionMissingFieldsStrategy;
+  [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: boolean;
 }
 
 export interface QueryDefineStep {

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/rules/utils.ts
@@ -6,12 +6,20 @@
  */
 
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
+import {
+  ALERT_SUPPRESSION_DURATION_FIELD_NAME,
+  ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME,
+  ALERT_SUPPRESSION_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME,
+  ALERT_SUPPRESSION_DEFAULT_DURATION,
+} from '../../../../detection_engine/rule_creation/components/alert_suppression_edit';
+import { THRESHOLD_ALERT_SUPPRESSION_ENABLED } from '../../../../detection_engine/rule_creation/components/threshold_alert_suppression_edit';
 import { isThreatMatchRule } from '../../../../../common/detection_engine/utils';
 import { DEFAULT_TIMELINE_TITLE } from '../../../../timelines/components/timeline/translations';
 import { DEFAULT_MAX_SIGNALS, DEFAULT_THREAT_MATCH_QUERY } from '../../../../../common/constants';
 import { DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY } from '../../../../../common/detection_engine/constants';
 import type { AboutStepRule, DefineStepRule, RuleStepsOrder, ScheduleStepRule } from './types';
-import { DataSourceType, GroupByOptions, RuleStep } from './types';
+import { DataSourceType, AlertSuppressionDurationType, RuleStep } from './types';
 import { fillEmptySeverityMappings } from './helpers';
 
 export const ruleStepsOrder: RuleStepsOrder = [
@@ -66,14 +74,11 @@ export const stepDefineDefaultValue: DefineStepRule = {
   newTermsFields: [],
   historyWindowSize: '7d',
   shouldLoadQueryDynamically: false,
-  groupByFields: [],
-  groupByRadioSelection: GroupByOptions.PerRuleExecution,
-  groupByDuration: {
-    value: 5,
-    unit: 'm',
-  },
-  suppressionMissingFields: DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY,
-  enableThresholdSuppression: false,
+  [ALERT_SUPPRESSION_FIELDS_FIELD_NAME]: [],
+  [ALERT_SUPPRESSION_DURATION_TYPE_FIELD_NAME]: AlertSuppressionDurationType.PerRuleExecution,
+  [ALERT_SUPPRESSION_DURATION_FIELD_NAME]: ALERT_SUPPRESSION_DEFAULT_DURATION,
+  [ALERT_SUPPRESSION_MISSING_FIELDS_FIELD_NAME]: DEFAULT_SUPPRESSION_MISSING_FIELDS_STRATEGY,
+  [THRESHOLD_ALERT_SUPPRESSION_ENABLED]: false,
 };
 
 export const stepAboutDefaultValue: AboutStepRule = {

--- a/x-pack/plugins/security_solution/tsconfig.json
+++ b/x-pack/plugins/security_solution/tsconfig.json
@@ -230,5 +230,6 @@
     "@kbn/core-lifecycle-server",
     "@kbn/core-user-profile-common",
     "@kbn/langchain",
+    "@kbn/react-hooks"
   ]
 }

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/common_flows_supression_ess_basic.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/common_flows_supression_ess_basic.cy.ts
@@ -7,8 +7,9 @@
 
 import {
   THRESHOLD_ENABLE_SUPPRESSION_CHECKBOX,
-  ALERT_SUPPRESSION_DURATION_INPUT,
+  ALERT_SUPPRESSION_DURATION_VALUE_INPUT,
   MACHINE_LEARNING_TYPE,
+  ALERT_SUPPRESSION_DURATION_UNIT_INPUT,
 } from '../../../../screens/create_new_rule';
 
 import {
@@ -62,8 +63,8 @@ describe(
         // Platinum license is required, tooltip on disabled alert suppression checkbox should tell this
         cy.get(TOOLTIP).contains('Platinum license');
 
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT).eq(0).should('be.disabled');
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT).eq(1).should('be.disabled');
+        cy.get(ALERT_SUPPRESSION_DURATION_VALUE_INPUT).should('be.disabled');
+        cy.get(ALERT_SUPPRESSION_DURATION_UNIT_INPUT).should('be.disabled');
       });
     });
   }

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/machine_learning_rule_suppression.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/machine_learning_rule_suppression.cy.ts
@@ -8,8 +8,8 @@
 import { getMachineLearningRule } from '../../../../objects/rule';
 import { TOOLTIP } from '../../../../screens/common';
 import {
-  ALERT_SUPPRESSION_FIELDS,
   ALERT_SUPPRESSION_FIELDS_INPUT,
+  ALERT_SUPPRESSION_WARNING,
 } from '../../../../screens/create_new_rule';
 import {
   DEFINITION_DETAILS,
@@ -102,7 +102,7 @@ describe(
 
           it('displays a warning message on the suppression fields', () => {
             cy.get(ALERT_SUPPRESSION_FIELDS_INPUT).should('be.enabled');
-            cy.get(ALERT_SUPPRESSION_FIELDS).should(
+            cy.get(ALERT_SUPPRESSION_WARNING).should(
               'contain.text',
               'This list of fields might be incomplete as some Machine Learning jobs are not running. Start all relevant jobs for a complete list.'
             );

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/esql_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/esql_rule.cy.ts
@@ -18,9 +18,10 @@ import {
 
 import {
   ESQL_QUERY_BAR,
-  ALERT_SUPPRESSION_DURATION_INPUT,
   ALERT_SUPPRESSION_FIELDS,
   ALERT_SUPPRESSION_MISSING_FIELDS_SUPPRESS,
+  ALERT_SUPPRESSION_DURATION_VALUE_INPUT,
+  ALERT_SUPPRESSION_DURATION_UNIT_INPUT,
 } from '../../../../screens/create_new_rule';
 
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -134,9 +135,8 @@ describe(
         editFirstRule();
 
         // check saved suppression settings
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT).eq(0).should('be.enabled').should('have.value', 3);
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT)
-          .eq(1)
+        cy.get(ALERT_SUPPRESSION_DURATION_VALUE_INPUT).should('be.enabled').should('have.value', 3);
+        cy.get(ALERT_SUPPRESSION_DURATION_UNIT_INPUT)
           .should('be.enabled')
           .should('have.value', 'h');
         cy.get(ALERT_SUPPRESSION_FIELDS).should('contain', SUPPRESS_BY_FIELDS.join(''));

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/indicator_match_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/indicator_match_rule.cy.ts
@@ -15,7 +15,8 @@ import {
 } from '../../../../screens/rule_details';
 
 import {
-  ALERT_SUPPRESSION_DURATION_INPUT,
+  ALERT_SUPPRESSION_DURATION_UNIT_INPUT,
+  ALERT_SUPPRESSION_DURATION_VALUE_INPUT,
   ALERT_SUPPRESSION_FIELDS,
   ALERT_SUPPRESSION_MISSING_FIELDS_DO_NOT_SUPPRESS,
 } from '../../../../screens/create_new_rule';
@@ -112,12 +113,10 @@ describe(
         goToRuleEditSettings();
 
         // check saved suppression settings
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT)
-          .eq(0)
+        cy.get(ALERT_SUPPRESSION_DURATION_VALUE_INPUT)
           .should('be.enabled')
           .should('have.value', 360);
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT)
-          .eq(1)
+        cy.get(ALERT_SUPPRESSION_DURATION_UNIT_INPUT)
           .should('be.enabled')
           .should('have.value', 's');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/machine_learning_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/machine_learning_rule.cy.ts
@@ -7,7 +7,8 @@
 
 import { getMachineLearningRule } from '../../../../objects/rule';
 import {
-  ALERT_SUPPRESSION_DURATION_INPUT,
+  ALERT_SUPPRESSION_DURATION_UNIT_INPUT,
+  ALERT_SUPPRESSION_DURATION_VALUE_INPUT,
   ALERT_SUPPRESSION_FIELDS,
   ALERT_SUPPRESSION_MISSING_FIELDS_DO_NOT_SUPPRESS,
 } from '../../../../screens/create_new_rule';
@@ -109,12 +110,10 @@ describe(
 
       it('allows editing of a rule to change its suppression configuration', () => {
         // check saved suppression settings
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT)
-          .eq(0)
+        cy.get(ALERT_SUPPRESSION_DURATION_VALUE_INPUT)
           .should('be.enabled')
           .should('have.value', 360);
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT)
-          .eq(1)
+        cy.get(ALERT_SUPPRESSION_DURATION_UNIT_INPUT)
           .should('be.enabled')
           .should('have.value', 's');
 
@@ -135,12 +134,10 @@ describe(
 
       it('allows editing of a rule to remove suppression configuration', () => {
         // check saved suppression settings
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT)
-          .eq(0)
+        cy.get(ALERT_SUPPRESSION_DURATION_VALUE_INPUT)
           .should('be.enabled')
           .should('have.value', 360);
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT)
-          .eq(1)
+        cy.get(ALERT_SUPPRESSION_DURATION_UNIT_INPUT)
           .should('be.enabled')
           .should('have.value', 's');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/new_terms_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/new_terms_rule.cy.ts
@@ -15,7 +15,8 @@ import {
 } from '../../../../screens/rule_details';
 
 import {
-  ALERT_SUPPRESSION_DURATION_INPUT,
+  ALERT_SUPPRESSION_DURATION_UNIT_INPUT,
+  ALERT_SUPPRESSION_DURATION_VALUE_INPUT,
   ALERT_SUPPRESSION_FIELDS,
   ALERT_SUPPRESSION_MISSING_FIELDS_SUPPRESS,
 } from '../../../../screens/create_new_rule';
@@ -69,12 +70,10 @@ describe(
         editFirstRule();
 
         // check saved suppression settings
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT)
-          .eq(0)
+        cy.get(ALERT_SUPPRESSION_DURATION_VALUE_INPUT)
           .should('be.enabled')
           .should('have.value', 20);
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT)
-          .eq(1)
+        cy.get(ALERT_SUPPRESSION_DURATION_UNIT_INPUT)
           .should('be.enabled')
           .should('have.value', 'm');
         cy.get(ALERT_SUPPRESSION_FIELDS).should('contain', SUPPRESS_BY_FIELDS.join(''));

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/threshold_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/threshold_rule.cy.ts
@@ -14,11 +14,12 @@ import {
 } from '../../../../screens/rule_details';
 
 import {
-  ALERT_SUPPRESSION_DURATION_INPUT,
   THRESHOLD_ENABLE_SUPPRESSION_CHECKBOX,
   ALERT_SUPPRESSION_DURATION_PER_RULE_EXECUTION,
   ALERT_SUPPRESSION_DURATION_PER_TIME_INTERVAL,
   ALERT_SUPPRESSION_FIELDS,
+  ALERT_SUPPRESSION_DURATION_VALUE_INPUT,
+  ALERT_SUPPRESSION_DURATION_UNIT_INPUT,
 } from '../../../../screens/create_new_rule';
 
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -54,7 +55,7 @@ describe(
         editFirstRule();
 
         // suppression fields are hidden since threshold fields used for suppression
-        cy.get(ALERT_SUPPRESSION_FIELDS).should('not.be.visible');
+        cy.get(ALERT_SUPPRESSION_FIELDS).should('not.exist');
 
         enablesAndPopulatesThresholdSuppression(60, 'm');
 
@@ -89,12 +90,10 @@ describe(
 
         // ensures enable suppression checkbox is checked and suppression options displayed correctly
         cy.get(THRESHOLD_ENABLE_SUPPRESSION_CHECKBOX).should('be.enabled').should('be.checked');
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT)
-          .eq(0)
+        cy.get(ALERT_SUPPRESSION_DURATION_VALUE_INPUT)
           .should('be.enabled')
           .should('have.value', 360);
-        cy.get(ALERT_SUPPRESSION_DURATION_INPUT)
-          .eq(1)
+        cy.get(ALERT_SUPPRESSION_DURATION_UNIT_INPUT)
           .should('be.enabled')
           .should('have.value', 's');
 

--- a/x-pack/test/security_solution_cypress/cypress/screens/create_new_rule.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/create_new_rule.ts
@@ -26,8 +26,10 @@ export const ALERT_SUPPRESSION_FIELDS_COMBO_BOX =
 
 export const ALERT_SUPPRESSION_FIELDS_INPUT = `${ALERT_SUPPRESSION_FIELDS_COMBO_BOX} input`;
 
+export const ALERT_SUPPRESSION_WARNING = '[data-test-subj="alertSuppressionWarning"]';
+
 export const ALERT_SUPPRESSION_DURATION_OPTIONS =
-  '[data-test-subj="alertSuppressionDuration"] [data-test-subj="groupByDurationOptions"]';
+  '[data-test-subj="alertSuppressionDuration"] [data-test-subj="alertSuppressionDurationOptions"]';
 
 export const ALERT_SUPPRESSION_DURATION_PER_TIME_INTERVAL = `${ALERT_SUPPRESSION_DURATION_OPTIONS} #per-time-period`;
 
@@ -40,11 +42,14 @@ export const ALERT_SUPPRESSION_MISSING_FIELDS_SUPPRESS = `${ALERT_SUPPRESSION_MI
 
 export const ALERT_SUPPRESSION_MISSING_FIELDS_DO_NOT_SUPPRESS = `${ALERT_SUPPRESSION_MISSING_FIELDS_OPTIONS} #doNotSuppress`;
 
-export const ALERT_SUPPRESSION_DURATION_INPUT =
-  '[data-test-subj="alertSuppressionDuration"] [data-test-subj="alertSuppressionDurationInput"]';
+export const ALERT_SUPPRESSION_DURATION_VALUE_INPUT =
+  '[data-test-subj="alertSuppressionDuration"] [data-test-subj="interval"]';
+
+export const ALERT_SUPPRESSION_DURATION_UNIT_INPUT =
+  '[data-test-subj="alertSuppressionDuration"] [data-test-subj="timeType"]';
 
 export const THRESHOLD_ENABLE_SUPPRESSION_CHECKBOX =
-  '[data-test-subj="detectionEngineStepDefineRuleThresholdEnableSuppression"] input';
+  '[data-test-subj="thresholdAlertSuppressionEnabled"] input';
 
 export const ANOMALY_THRESHOLD_INPUT = '[data-test-subj="anomalyThresholdSlider"] .euiFieldNumber';
 

--- a/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -31,7 +31,6 @@ import { convertHistoryStartToSize, getHumanizedDuration } from '../helpers/rule
 
 import {
   ABOUT_CONTINUE_BTN,
-  ALERT_SUPPRESSION_DURATION_INPUT,
   ALERT_SUPPRESSION_FIELDS,
   ALERT_SUPPRESSION_FIELDS_INPUT,
   ALERT_SUPPRESSION_FIELDS_COMBO_BOX,
@@ -133,6 +132,8 @@ import {
   PREVIEW_LOGGED_REQUESTS_ACCORDION_BUTTON,
   PREVIEW_LOGGED_REQUESTS_ITEM_ACCORDION_BUTTON,
   PREVIEW_LOGGED_REQUESTS_CHECKBOX,
+  ALERT_SUPPRESSION_DURATION_VALUE_INPUT,
+  ALERT_SUPPRESSION_DURATION_UNIT_INPUT,
 } from '../screens/create_new_rule';
 import {
   INDEX_SELECTOR,
@@ -951,8 +952,8 @@ export const selectDoNotSuppressForMissingFields = () => {
 };
 
 export const setAlertSuppressionDuration = (interval: number, timeUnit: 's' | 'm' | 'h') => {
-  cy.get(ALERT_SUPPRESSION_DURATION_INPUT).first().type(`{selectall}${interval}`);
-  cy.get(ALERT_SUPPRESSION_DURATION_INPUT).eq(1).select(timeUnit);
+  cy.get(ALERT_SUPPRESSION_DURATION_VALUE_INPUT).type(`{selectall}${interval}`);
+  cy.get(ALERT_SUPPRESSION_DURATION_UNIT_INPUT).select(timeUnit);
 };
 
 /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution] Add Alert Suppression editable component (#198673)](https://github.com/elastic/kibana/pull/198673)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2024-11-12T14:46:39Z","message":"[Security Solution] Add Alert Suppression editable component (#198673)\n\n**Partially addresses:** https://github.com/elastic/kibana/issues/171520\r\n\r\n## Summary\r\n\r\nThis PR adds is built on top of https://github.com/elastic/kibana/pull/193828 and https://github.com/elastic/kibana/pull/196948 and adds an Alert Suppression editable component for Three Way Diff tab's final edit side of the upgrade prebuilt rule workflow.\r\n\r\n## Details\r\n\r\nhttps://github.com/elastic/kibana/issues/171520 required adding editable components for each field diffable rule field. Alert Suppression edit component was extracted from Define Rule Step Component into a separate reusable component. To simplify the logic it was split into common Alert Suppression and Threshold Alert Suppression since the latter is a specific use case.\r\n\r\n## Caveats\r\n\r\nUpgrade prebuilt rules workflow is quite different from rule creation and editing. In create and edit rule forms users are capable to change any field at their will. Upgrade prebuilt rules workflow allow to modify only specific fields having diff in the current rule upgrade.\r\n\r\nThere are fields which depend on each other. In particular Alert Suppression isn't supported for EQL sequence though it's addressed in https://github.com/elastic/kibana/pull/189725. \r\n\r\n- Alert Suppression editable component in Three Way Diff workflow isn't disabled EQL sequence rule queries. Alert suppression support for rules with EQL sequence queries is implemented in https://github.com/elastic/kibana/pull/189725. \r\n\r\n- Machine learning rule type require running selected machine learning jobs otherwise input could be disabled in case of there are no fields to pick from otherwise a warning message below the combobox is shown.\r\n\r\n## How to test\r\n\r\nThe simplest way to test is via patching installed prebuilt rules via Rule Patch API. Please follow steps below\r\n\r\n- Enable Prebuilt rule customization feature by adding a `prebuiltRulesCustomizationEnabled` feature flag\r\n- Run Kibana locally\r\n- Install a prebuilt rule, e.g. `Potential Code Execution via Postgresql` with rule_id `2a692072-d78d-42f3-a48a-775677d79c4e`\r\n- Patch the installed rule by running a query below\r\n\r\n```bash\r\ncurl -X PATCH --user elastic:changeme  -H 'Content-Type: application/json' -H 'kbn-xsrf: 123' -H \"elastic-api-version: 2023-10-31\" -d '{\"rule_id\":\"2a692072-d78d-42f3-a48a-775677d79c4e\",\"version\":1,\"alert_suppression\":{\"group_by\":[\"host.name\"]}}' http://localhost:5601/kbn/api/detection_engine/rules\r\n```\r\n\r\n- Open `Detection Rules (SIEM)` Page -> `Rule Updates` -> click on `Potential Code Execution via Postgresql` rule -> expand `EQL Query` to see EQL Query -> press `Edit` button\r\n\r\n## Screenshots\r\n\r\nCustom query prebuilt rule (UI looks similar for EQL, Indicator Match, New Terms and ES|QL rule types)\r\n\r\n![image](https://github.com/user-attachments/assets/86015d5b-e252-4d0b-9aa3-fc14679a493b)\r\n\r\nMachine learning prebuilt rule with a diff in alert suppression\r\n\r\n![image](https://github.com/user-attachments/assets/210246cd-27fd-4976-befc-dee023101ec9)\r\n\r\nThreshold prebuilt rule\r\n\r\n![image](https://github.com/user-attachments/assets/44b0c1bc-4134-4d58-bd9a-e8e2d4c50802)","sha":"06986e4a86a0fa3c3951fcb6b2ba34ebe2769820","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:prev-minor","v8.17.0"],"number":198673,"url":"https://github.com/elastic/kibana/pull/198673","mergeCommit":{"message":"[Security Solution] Add Alert Suppression editable component (#198673)\n\n**Partially addresses:** https://github.com/elastic/kibana/issues/171520\r\n\r\n## Summary\r\n\r\nThis PR adds is built on top of https://github.com/elastic/kibana/pull/193828 and https://github.com/elastic/kibana/pull/196948 and adds an Alert Suppression editable component for Three Way Diff tab's final edit side of the upgrade prebuilt rule workflow.\r\n\r\n## Details\r\n\r\nhttps://github.com/elastic/kibana/issues/171520 required adding editable components for each field diffable rule field. Alert Suppression edit component was extracted from Define Rule Step Component into a separate reusable component. To simplify the logic it was split into common Alert Suppression and Threshold Alert Suppression since the latter is a specific use case.\r\n\r\n## Caveats\r\n\r\nUpgrade prebuilt rules workflow is quite different from rule creation and editing. In create and edit rule forms users are capable to change any field at their will. Upgrade prebuilt rules workflow allow to modify only specific fields having diff in the current rule upgrade.\r\n\r\nThere are fields which depend on each other. In particular Alert Suppression isn't supported for EQL sequence though it's addressed in https://github.com/elastic/kibana/pull/189725. \r\n\r\n- Alert Suppression editable component in Three Way Diff workflow isn't disabled EQL sequence rule queries. Alert suppression support for rules with EQL sequence queries is implemented in https://github.com/elastic/kibana/pull/189725. \r\n\r\n- Machine learning rule type require running selected machine learning jobs otherwise input could be disabled in case of there are no fields to pick from otherwise a warning message below the combobox is shown.\r\n\r\n## How to test\r\n\r\nThe simplest way to test is via patching installed prebuilt rules via Rule Patch API. Please follow steps below\r\n\r\n- Enable Prebuilt rule customization feature by adding a `prebuiltRulesCustomizationEnabled` feature flag\r\n- Run Kibana locally\r\n- Install a prebuilt rule, e.g. `Potential Code Execution via Postgresql` with rule_id `2a692072-d78d-42f3-a48a-775677d79c4e`\r\n- Patch the installed rule by running a query below\r\n\r\n```bash\r\ncurl -X PATCH --user elastic:changeme  -H 'Content-Type: application/json' -H 'kbn-xsrf: 123' -H \"elastic-api-version: 2023-10-31\" -d '{\"rule_id\":\"2a692072-d78d-42f3-a48a-775677d79c4e\",\"version\":1,\"alert_suppression\":{\"group_by\":[\"host.name\"]}}' http://localhost:5601/kbn/api/detection_engine/rules\r\n```\r\n\r\n- Open `Detection Rules (SIEM)` Page -> `Rule Updates` -> click on `Potential Code Execution via Postgresql` rule -> expand `EQL Query` to see EQL Query -> press `Edit` button\r\n\r\n## Screenshots\r\n\r\nCustom query prebuilt rule (UI looks similar for EQL, Indicator Match, New Terms and ES|QL rule types)\r\n\r\n![image](https://github.com/user-attachments/assets/86015d5b-e252-4d0b-9aa3-fc14679a493b)\r\n\r\nMachine learning prebuilt rule with a diff in alert suppression\r\n\r\n![image](https://github.com/user-attachments/assets/210246cd-27fd-4976-befc-dee023101ec9)\r\n\r\nThreshold prebuilt rule\r\n\r\n![image](https://github.com/user-attachments/assets/44b0c1bc-4134-4d58-bd9a-e8e2d4c50802)","sha":"06986e4a86a0fa3c3951fcb6b2ba34ebe2769820"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/198673","number":198673,"mergeCommit":{"message":"[Security Solution] Add Alert Suppression editable component (#198673)\n\n**Partially addresses:** https://github.com/elastic/kibana/issues/171520\r\n\r\n## Summary\r\n\r\nThis PR adds is built on top of https://github.com/elastic/kibana/pull/193828 and https://github.com/elastic/kibana/pull/196948 and adds an Alert Suppression editable component for Three Way Diff tab's final edit side of the upgrade prebuilt rule workflow.\r\n\r\n## Details\r\n\r\nhttps://github.com/elastic/kibana/issues/171520 required adding editable components for each field diffable rule field. Alert Suppression edit component was extracted from Define Rule Step Component into a separate reusable component. To simplify the logic it was split into common Alert Suppression and Threshold Alert Suppression since the latter is a specific use case.\r\n\r\n## Caveats\r\n\r\nUpgrade prebuilt rules workflow is quite different from rule creation and editing. In create and edit rule forms users are capable to change any field at their will. Upgrade prebuilt rules workflow allow to modify only specific fields having diff in the current rule upgrade.\r\n\r\nThere are fields which depend on each other. In particular Alert Suppression isn't supported for EQL sequence though it's addressed in https://github.com/elastic/kibana/pull/189725. \r\n\r\n- Alert Suppression editable component in Three Way Diff workflow isn't disabled EQL sequence rule queries. Alert suppression support for rules with EQL sequence queries is implemented in https://github.com/elastic/kibana/pull/189725. \r\n\r\n- Machine learning rule type require running selected machine learning jobs otherwise input could be disabled in case of there are no fields to pick from otherwise a warning message below the combobox is shown.\r\n\r\n## How to test\r\n\r\nThe simplest way to test is via patching installed prebuilt rules via Rule Patch API. Please follow steps below\r\n\r\n- Enable Prebuilt rule customization feature by adding a `prebuiltRulesCustomizationEnabled` feature flag\r\n- Run Kibana locally\r\n- Install a prebuilt rule, e.g. `Potential Code Execution via Postgresql` with rule_id `2a692072-d78d-42f3-a48a-775677d79c4e`\r\n- Patch the installed rule by running a query below\r\n\r\n```bash\r\ncurl -X PATCH --user elastic:changeme  -H 'Content-Type: application/json' -H 'kbn-xsrf: 123' -H \"elastic-api-version: 2023-10-31\" -d '{\"rule_id\":\"2a692072-d78d-42f3-a48a-775677d79c4e\",\"version\":1,\"alert_suppression\":{\"group_by\":[\"host.name\"]}}' http://localhost:5601/kbn/api/detection_engine/rules\r\n```\r\n\r\n- Open `Detection Rules (SIEM)` Page -> `Rule Updates` -> click on `Potential Code Execution via Postgresql` rule -> expand `EQL Query` to see EQL Query -> press `Edit` button\r\n\r\n## Screenshots\r\n\r\nCustom query prebuilt rule (UI looks similar for EQL, Indicator Match, New Terms and ES|QL rule types)\r\n\r\n![image](https://github.com/user-attachments/assets/86015d5b-e252-4d0b-9aa3-fc14679a493b)\r\n\r\nMachine learning prebuilt rule with a diff in alert suppression\r\n\r\n![image](https://github.com/user-attachments/assets/210246cd-27fd-4976-befc-dee023101ec9)\r\n\r\nThreshold prebuilt rule\r\n\r\n![image](https://github.com/user-attachments/assets/44b0c1bc-4134-4d58-bd9a-e8e2d4c50802)","sha":"06986e4a86a0fa3c3951fcb6b2ba34ebe2769820"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->