### PR TITLE
[Observability] Populate service.name for custom logs as part of auto-detect flow

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/server/routes/flow/route.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/routes/flow/route.ts
@@ -300,7 +300,7 @@ const createFlowRoute = createObservabilityOnboardingServerRoute({
  *  --header "Accept: application/x-tar" \
  *  --header "Content-Type: text/tab-separated-values" \
  *  --header "kbn-xsrf: true" \
-    --header "x-elastic-internal-origin: Kibana" \
+ *  --header "x-elastic-internal-origin: Kibana" \
  *  --data $'system\tregistry\twebserver01\nproduct_service\tcustom\t/path/to/access.log\ncheckout_service\tcustom\t/path/to/access.log' \
  *  --output - | tar -tvf -
  * ```

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/routes/flow/route.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/routes/flow/route.ts
@@ -300,7 +300,8 @@ const createFlowRoute = createObservabilityOnboardingServerRoute({
  *  --header "Accept: application/x-tar" \
  *  --header "Content-Type: text/tab-separated-values" \
  *  --header "kbn-xsrf: true" \
- *  --data $'system\tregistry\nproduct_service\tcustom\t/path/to/access.log\ncheckout_service\tcustom\t/path/to/access.log' \
+    --header "x-elastic-internal-origin: Kibana" \
+ *  --data $'system\tregistry\twebserver01\nproduct_service\tcustom\t/path/to/access.log\ncheckout_service\tcustom\t/path/to/access.log' \
  *  --output - | tar -tvf -
  * ```
  */
@@ -456,6 +457,16 @@ async function ensureInstalledIntegrations(
                   id: `filestream-${pkgName}`,
                   data_stream: dataStream,
                   paths: integration.logFilePaths,
+                  processors: [
+                    {
+                      add_fields: {
+                        target: 'service',
+                        fields: {
+                          name: pkgName,
+                        },
+                      },
+                    },
+                  ],
                 },
               ],
             },


### PR DESCRIPTION
Resolves https://github.com/elastic/observability-dev/issues/4038

## Summary

Populate service.name for custom logs as part of auto-detect flow

## Screenshot

<img width="705" alt="Screenshot 2024-11-12 at 17 10 29" src="https://github.com/user-attachments/assets/2eeb846c-9006-4252-81a0-ea5d4b5cdb8b">


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->