### PR TITLE
[OAS][Docs] Use correct bump dependency in makefile

### DIFF
--- a/oas_docs/makefile
+++ b/oas_docs/makefile
@@ -40,14 +40,14 @@ api-docs-lint-serverless: ## Run redocly API docs linter on kibana.serverless.ya
 
 .PHONY: api-docs-overlay
 api-docs-overlay: ## Run spectral API docs linter on kibana.serverless.yaml
-	@npx bump overlay "output/kibana.serverless.yaml" "overlays/kibana.overlays.serverless.yaml" > "output/kibana.serverless.tmp1.yaml"
-	@npx bump overlay "output/kibana.serverless.tmp1.yaml" "overlays/alerting.overlays.yaml" > "output/kibana.serverless.tmp2.yaml"
-	@npx bump overlay "output/kibana.serverless.tmp2.yaml" "overlays/connectors.overlays.yaml" > "output/kibana.serverless.tmp3.yaml"
-	@npx bump overlay "output/kibana.serverless.tmp3.yaml" "overlays/kibana.overlays.shared.yaml" > "output/kibana.serverless.tmp4.yaml"
-	@npx bump overlay "output/kibana.yaml" "overlays/kibana.overlays.yaml" > "output/kibana.tmp1.yaml"
-	@npx bump overlay "output/kibana.tmp1.yaml" "overlays/alerting.overlays.yaml" > "output/kibana.tmp2.yaml"
-	@npx bump overlay "output/kibana.tmp2.yaml" "overlays/connectors.overlays.yaml" > "output/kibana.tmp3.yaml"
-	@npx bump overlay "output/kibana.tmp3.yaml" "overlays/kibana.overlays.shared.yaml" > "output/kibana.tmp4.yaml"
+	@npx bump-cli overlay "output/kibana.serverless.yaml" "overlays/kibana.overlays.serverless.yaml" > "output/kibana.serverless.tmp1.yaml"
+	@npx bump-cli overlay "output/kibana.serverless.tmp1.yaml" "overlays/alerting.overlays.yaml" > "output/kibana.serverless.tmp2.yaml"
+	@npx bump-cli overlay "output/kibana.serverless.tmp2.yaml" "overlays/connectors.overlays.yaml" > "output/kibana.serverless.tmp3.yaml"
+	@npx bump-cli overlay "output/kibana.serverless.tmp3.yaml" "overlays/kibana.overlays.shared.yaml" > "output/kibana.serverless.tmp4.yaml"
+	@npx bump-cli overlay "output/kibana.yaml" "overlays/kibana.overlays.yaml" > "output/kibana.tmp1.yaml"
+	@npx bump-cli overlay "output/kibana.tmp1.yaml" "overlays/alerting.overlays.yaml" > "output/kibana.tmp2.yaml"
+	@npx bump-cli overlay "output/kibana.tmp2.yaml" "overlays/connectors.overlays.yaml" > "output/kibana.tmp3.yaml"
+	@npx bump-cli overlay "output/kibana.tmp3.yaml" "overlays/kibana.overlays.shared.yaml" > "output/kibana.tmp4.yaml"
 	@npx @redocly/cli bundle output/kibana.serverless.tmp4.yaml --ext yaml -o output/kibana.serverless.new.yaml
 	@npx @redocly/cli bundle output/kibana.tmp4.yaml --ext yaml -o output/kibana.new.yaml
 	rm output/kibana.tmp*.yaml
@@ -55,13 +55,13 @@ api-docs-overlay: ## Run spectral API docs linter on kibana.serverless.yaml
 
 .PHONY: api-docs-preview
 api-docs-preview: ## Generate a preview for kibana.yaml and kibana.serverless.yaml
-	@npx bump preview "output/kibana.yaml"
-	@npx bump preview "output/kibana.serverless.yaml"
+	@npx bump-cli preview "output/kibana.yaml"
+	@npx bump-cli preview "output/kibana.serverless.yaml"
 
 .PHONY: api-docs-overlay-preview
 api-docs-overlay-preview: ## Generate a preview for kibana.new.yaml and kibana.serverless.new.yaml
-	@npx bump preview "output/kibana.new.yaml"
-	@npx bump preview "output/kibana.serverless.new.yaml"
+	@npx bump-cli preview "output/kibana.new.yaml"
+	@npx bump-cli preview "output/kibana.serverless.new.yaml"
 
 help:  ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
## Summary

Updates the Open API docs make targets to use the correct bump.sh dependency.

Unless I'm missing something obvious in my local configuration, `@npx bump ...` uses [node-bump](https://www.npmjs.com/package/bump) not the [bump.sh library](https://www.npmjs.com/package/bump-cli). I discovered this while trying to run the make targets locally.



<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->