### PR TITLE
[8.x] [DOCS][OpenAPI] Change x-technical-preview to x-state in case APIs (#195325)

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -7452,7 +7452,7 @@ paths:
       summary: Get all alerts for a case
       tags:
         - cases
-      x-technical-preview: true
+      x-state: Technical preview
   '/api/cases/{caseId}/comments':
     delete:
       description: >
@@ -7820,7 +7820,7 @@ paths:
       summary: Get cases for an alert
       tags:
         - cases
-      x-technical-preview: true
+      x-state: Technical preview
   /api/cases/configure:
     get:
       description: >
@@ -27276,7 +27276,7 @@ components:
           maxItems: 1000
           type: array
       title: Alert identifiers
-      x-technical-preview: true
+      x-state: Technical preview
     Cases_alert_indices:
       description: >
         The alert indices. It is required only when `type` is `alert`. If you
@@ -27294,7 +27294,7 @@ components:
           maxItems: 1000
           type: array
       title: Alert indices
-      x-technical-preview: true
+      x-state: Technical preview
     Cases_alert_response_properties:
       type: object
       properties:
@@ -28432,7 +28432,7 @@ components:
           description: The rule name.
           example: security_rule
           type: string
-      x-technical-preview: true
+      x-state: Technical preview
     Cases_searchFieldsType:
       description: The fields to perform the `simple_query_string` parsed query against.
       enum:
@@ -28625,7 +28625,7 @@ components:
                         - type: string
                         - type: boolean
                 type: array
-                x-technical-preview: true
+                x-state: Technical preview
               description:
                 $ref: '#/components/schemas/Cases_case_description'
               settings:
@@ -28651,7 +28651,7 @@ components:
           tags:
             $ref: '#/components/schemas/Cases_template_tags'
       type: array
-      x-technical-preview: true
+      x-state: Technical preview
     Cases_update_alert_comment_request_properties:
       description: Defines properties for case comment requests when type is alert.
       type: object

--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -288,7 +288,7 @@
         "summary": "Get cases for an alert",
         "operationId": "getCasesByAlertDefaultSpace",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
-        "x-technical-preview": true,
+        "x-state": "Technical preview",
         "tags": [
           "cases"
         ],
@@ -1264,7 +1264,7 @@
       "get": {
         "summary": "Get all alerts for a case",
         "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
-        "x-technical-preview": true,
+        "x-state": "Technical preview",
         "operationId": "getCaseAlertsDefaultSpace",
         "tags": [
           "cases"
@@ -3573,7 +3573,7 @@
       },
       "templates": {
         "type": "array",
-        "x-technical-preview": true,
+        "x-state": "Technical preview",
         "items": {
           "type": "object",
           "properties": {
@@ -3611,7 +3611,7 @@
                 },
                 "customFields": {
                   "type": "array",
-                  "x-technical-preview": true,
+                  "x-state": "Technical preview",
                   "description": "Custom field values in the template.",
                   "items": {
                     "type": "object",
@@ -3976,7 +3976,7 @@
             "maxItems": 1000
           }
         ],
-        "x-technical-preview": true,
+        "x-state": "Technical preview",
         "example": "6b24c4dc44bc720cfc92797f3d61fff952f2b2627db1fb4f8cc49f4530c4ff42"
       },
       "alert_indices": {
@@ -3994,13 +3994,13 @@
             "maxItems": 1000
           }
         ],
-        "x-technical-preview": true
+        "x-state": "Technical preview"
       },
       "rule": {
         "title": "Alerting rule",
         "description": "The rule that is associated with the alerts. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "type": "object",
-        "x-technical-preview": true,
+        "x-state": "Technical preview",
         "properties": {
           "id": {
             "description": "The rule identifier.",

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -168,7 +168,7 @@ paths:
       operationId: getCasesByAlertDefaultSpace
       description: |
         You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.
-      x-technical-preview: true
+      x-state: Technical preview
       tags:
         - cases
       parameters:
@@ -844,7 +844,7 @@ paths:
       summary: Get all alerts for a case
       description: |
         You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.
-      x-technical-preview: true
+      x-state: Technical preview
       operationId: getCaseAlertsDefaultSpace
       tags:
         - cases
@@ -2468,7 +2468,7 @@ components:
         maxLength: 256
     templates:
       type: array
-      x-technical-preview: true
+      x-state: Technical preview
       items:
         type: object
         properties:
@@ -2498,7 +2498,7 @@ components:
                     $ref: '#/components/schemas/connector_types'
               customFields:
                 type: array
-                x-technical-preview: true
+                x-state: Technical preview
                 description: Custom field values in the template.
                 items:
                   type: object
@@ -2765,7 +2765,7 @@ components:
           items:
             type: string
           maxItems: 1000
-      x-technical-preview: true
+      x-state: Technical preview
       example: 6b24c4dc44bc720cfc92797f3d61fff952f2b2627db1fb4f8cc49f4530c4ff42
     alert_indices:
       title: Alert indices
@@ -2777,13 +2777,13 @@ components:
           items:
             type: string
           maxItems: 1000
-      x-technical-preview: true
+      x-state: Technical preview
     rule:
       title: Alerting rule
       description: |
         The rule that is associated with the alerts. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       type: object
-      x-technical-preview: true
+      x-state: Technical preview
       properties:
         id:
           description: The rule identifier.

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/alert_identifiers.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/alert_identifiers.yaml
@@ -12,5 +12,5 @@ oneOf:
     items:
       type: string
     maxItems: 1000
-x-technical-preview: true
+x-state: Technical preview
 example: 6b24c4dc44bc720cfc92797f3d61fff952f2b2627db1fb4f8cc49f4530c4ff42

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/alert_indices.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/alert_indices.yaml
@@ -11,4 +11,4 @@ oneOf:
     items:
       type: string
     maxItems: 1000
-x-technical-preview: true
+x-state: Technical preview

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/rule.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/rule.yaml
@@ -5,7 +5,7 @@ description: >
   This functionality is in technical preview and may be changed or removed in a future release.
   Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
 type: object
-x-technical-preview: true
+x-state: Technical preview
 properties:
   id:
     description: The rule identifier.

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/templates.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/templates.yaml
@@ -1,5 +1,5 @@
 type: array
-x-technical-preview: true
+x-state: Technical preview
 items:
   type: object
   properties:
@@ -16,7 +16,7 @@ items:
             $ref: 'case_configure_connector_properties.yaml'
         customFields:
           type: array
-          x-technical-preview: true
+          x-state: Technical preview
           description: Custom field values in the template.
           items:
             type: object

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@alerts@{alertid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@alerts@{alertid}.yaml
@@ -5,7 +5,7 @@ get:
     You must have `read` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
     feature privileges, depending on the owner of the cases you're seeking.
-  x-technical-preview: true
+  x-state: Technical preview
   tags:
     - cases
   parameters:

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@alerts.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@alerts.yaml
@@ -4,7 +4,7 @@ get:
     You must have `read` privileges for the **Cases** feature in the
     **Management**, **Observability**, or **Security** section of the Kibana
     feature privileges, depending on the owner of the cases you're seeking.
-  x-technical-preview: true
+  x-state: Technical preview
   operationId: getCaseAlertsDefaultSpace
   tags:
     - cases


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS][OpenAPI] Change x-technical-preview to x-state in case APIs (#195325)](https://github.com/elastic/kibana/pull/195325)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2024-10-17T23:14:34Z","message":"[DOCS][OpenAPI] Change x-technical-preview to x-state in case APIs (#195325)","sha":"7b106f7235e014563ed90721791d6516a9287d3f","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","backport:skip","v9.0.0","docs","Feature:Cases","v8.16.0","v8.17.0"],"number":195325,"url":"https://github.com/elastic/kibana/pull/195325","mergeCommit":{"message":"[DOCS][OpenAPI] Change x-technical-preview to x-state in case APIs (#195325)","sha":"7b106f7235e014563ed90721791d6516a9287d3f"}},"sourceBranch":"main","suggestedTargetBranches":["8.16","8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/195325","number":195325,"mergeCommit":{"message":"[DOCS][OpenAPI] Change x-technical-preview to x-state in case APIs (#195325)","sha":"7b106f7235e014563ed90721791d6516a9287d3f"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->