### PR TITLE
[Security Solution] Adds missing configuration to the cypress tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/cypress_ci_serverless_qa.config.ts
+++ b/x-pack/test/security_solution_cypress/cypress/cypress_ci_serverless_qa.config.ts
@@ -8,6 +8,7 @@
 import { defineCypressConfig } from '@kbn/cypress-config';
 import { esArchiver } from './support/es_archiver';
 import { samlAuthentication } from './support/saml_auth';
+import { esClient } from './support/es_client';
 
 // eslint-disable-next-line import/no-default-export
 export default defineCypressConfig({
@@ -56,6 +57,7 @@ export default defineCypressConfig({
         return launchOptions;
       });
       samlAuthentication(on, config);
+      esClient(on, config);
       process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       require('@cypress/grep/src/plugin')(config);


### PR DESCRIPTION
## Summary

Adds missing configuration to the cypress tests.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->