### PR TITLE
[Fleet] Add feature for syncing integrations on remote output target cluster

### DIFF
--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -28,6 +28,7 @@ const _allowedExperimentalValues = {
   useSpaceAwareness: false,
   enableReusableIntegrationPolicies: true,
   asyncDeployPolicies: true,
+  remoteIntegrationSync: false,
 };
 
 /**

--- a/x-pack/plugins/fleet/common/types/models/output.ts
+++ b/x-pack/plugins/fleet/common/types/models/output.ts
@@ -63,8 +63,12 @@ export interface NewElasticsearchOutput extends NewBaseOutput {
 export interface NewRemoteElasticsearchOutput extends NewBaseOutput {
   type: OutputType['RemoteElasticsearch'];
   service_token?: string | null;
+  integration_sync?: boolean;
+  remote_kibana_url?: string | null;
+  remote_api_key?: string | null;
   secrets?: {
     service_token?: OutputSecret;
+    remote_api_key?: OutputSecret | null;
   };
 }
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_remote_es.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_remote_es.tsx
@@ -6,11 +6,20 @@
  */
 
 import React, { useEffect } from 'react';
-import { EuiCallOut, EuiCodeBlock, EuiFieldText, EuiSpacer } from '@elastic/eui';
+import {
+  EuiCallOut,
+  EuiCodeBlock,
+  EuiFieldText,
+  EuiFormRow,
+  EuiSpacer,
+  EuiSwitch,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 
 import { MultiRowInput } from '../multi_row_input';
+
+import { ExperimentalFeaturesService } from '../../../../services';
 
 import type { OutputFormInputsType } from './use_output_form';
 import { SecretFormRow } from './output_form_secret_form_row';
@@ -25,7 +34,10 @@ export const OutputFormRemoteEsSection: React.FunctionComponent<Props> = (props)
   const { inputs, useSecretsStorage, onToggleSecretStorage } = props;
   const [isConvertedToSecret, setIsConvertedToSecret] = React.useState({
     serviceToken: false,
+    apiKey: false,
   });
+
+  const { remoteIntegrationSync } = ExperimentalFeaturesService.get();
 
   const [isFirstLoad, setIsFirstLoad] = React.useState(true);
 
@@ -37,7 +49,15 @@ export const OutputFormRemoteEsSection: React.FunctionComponent<Props> = (props)
       if (inputs.serviceTokenInput.value && !inputs.serviceTokenSecretInput.value) {
         inputs.serviceTokenSecretInput.setValue(inputs.serviceTokenInput.value);
         inputs.serviceTokenInput.clear();
-        setIsConvertedToSecret({ serviceToken: true });
+        setIsConvertedToSecret({ ...isConvertedToSecret, serviceToken: true });
+      }
+      if (
+        inputs.integrationSyncApiKeyInput.value &&
+        !inputs.integrationSyncApiKeySecretInput.value
+      ) {
+        inputs.integrationSyncApiKeySecretInput.setValue(inputs.integrationSyncApiKeyInput.value);
+        inputs.integrationSyncApiKeyInput.clear();
+        setIsConvertedToSecret({ ...isConvertedToSecret, apiKey: true });
       }
     }
   }, [
@@ -47,15 +67,27 @@ export const OutputFormRemoteEsSection: React.FunctionComponent<Props> = (props)
     isFirstLoad,
     setIsFirstLoad,
     isConvertedToSecret,
+    inputs.integrationSyncApiKeyInput,
+    inputs.integrationSyncApiKeySecretInput,
   ]);
 
-  const onToggleSecretAndClearValue = (secretEnabled: boolean) => {
+  const onToggleServiceTokenSecretAndClearValue = (secretEnabled: boolean) => {
     if (secretEnabled) {
       inputs.serviceTokenInput.clear();
     } else {
       inputs.serviceTokenSecretInput.setValue('');
     }
     setIsConvertedToSecret({ ...isConvertedToSecret, serviceToken: false });
+    onToggleSecretStorage(secretEnabled);
+  };
+
+  const onToggleAPIKeySecretAndClearValue = (secretEnabled: boolean) => {
+    if (secretEnabled) {
+      inputs.integrationSyncApiKeyInput.clear();
+    } else {
+      inputs.integrationSyncApiKeySecretInput.setValue('');
+    }
+    setIsConvertedToSecret({ ...isConvertedToSecret, apiKey: false });
     onToggleSecretStorage(secretEnabled);
   };
 
@@ -87,7 +119,7 @@ export const OutputFormRemoteEsSection: React.FunctionComponent<Props> = (props)
           }
           {...inputs.serviceTokenInput.formRowProps}
           useSecretsStorage={useSecretsStorage}
-          onToggleSecretStorage={onToggleSecretAndClearValue}
+          onToggleSecretStorage={onToggleServiceTokenSecretAndClearValue}
         >
           <EuiFieldText
             fullWidth
@@ -111,7 +143,7 @@ export const OutputFormRemoteEsSection: React.FunctionComponent<Props> = (props)
           cancelEdit={inputs.serviceTokenSecretInput.cancelEdit}
           useSecretsStorage={useSecretsStorage}
           isConvertedToSecret={isConvertedToSecret.serviceToken}
-          onToggleSecretStorage={onToggleSecretAndClearValue}
+          onToggleSecretStorage={onToggleServiceTokenSecretAndClearValue}
         >
           <EuiFieldText
             data-test-subj="serviceTokenSecretInput"
@@ -143,6 +175,144 @@ export const OutputFormRemoteEsSection: React.FunctionComponent<Props> = (props)
 }`}
         </EuiCodeBlock>
       </EuiCallOut>
+      <EuiSpacer size="m" />
+      {remoteIntegrationSync && (
+        <EuiFormRow
+          fullWidth
+          helpText={
+            <FormattedMessage
+              id="xpack.fleet.settings.editOutputFlyout.remoteESTypeText"
+              defaultMessage="If enabled, integrations assets will be installed on the remote Elasticsearch cluster."
+            />
+          }
+        >
+          <>
+            <EuiSwitch
+              {...inputs.integrationSyncInput.props}
+              label={
+                <FormattedMessage
+                  id="xpack.fleet.settings.editOutputFlyout.synchronizeIntegrationsSwitchLabel"
+                  defaultMessage="Synchronize integrations."
+                />
+              }
+            />
+          </>
+        </EuiFormRow>
+      )}
+      {inputs.integrationSyncInput.value && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiFormRow
+            fullWidth
+            label={
+              <FormattedMessage
+                id="xpack.fleet.settings.editOutputFlyout.remoteKibanaUrlInputLabel"
+                defaultMessage="Kibana URL"
+              />
+            }
+            {...inputs.integrationSyncKibanaUrlInput.formRowProps}
+          >
+            <EuiFieldText
+              fullWidth
+              {...inputs.integrationSyncKibanaUrlInput.props}
+              placeholder={i18n.translate(
+                'xpack.fleet.settings.editOutputFlyout.remoteKibanaUrlInputPlaceholder',
+                {
+                  defaultMessage: 'Specify Kibana URL',
+                }
+              )}
+            />
+          </EuiFormRow>
+        </>
+      )}
+      {inputs.integrationSyncInput.value &&
+        (!useSecretsStorage ? (
+          <SecretFormRow
+            fullWidth
+            label={
+              <FormattedMessage
+                id="xpack.fleet.settings.editOutputFlyout.synchronizeIntegrationsAPIKeyLabel"
+                defaultMessage="Kibana API key"
+              />
+            }
+            {...inputs.integrationSyncApiKeyInput.formRowProps}
+            useSecretsStorage={useSecretsStorage}
+            onToggleSecretStorage={onToggleAPIKeySecretAndClearValue}
+          >
+            <EuiFieldText
+              data-test-subj="kibanaAPIKeySecretInput"
+              fullWidth
+              {...inputs.integrationSyncApiKeyInput.props}
+              placeholder={i18n.translate(
+                'xpack.fleet.settings.editOutputFlyout.remoteAPIKeyPlaceholder',
+                {
+                  defaultMessage: 'Specify API key',
+                }
+              )}
+            />
+          </SecretFormRow>
+        ) : (
+          <SecretFormRow
+            fullWidth
+            title={i18n.translate(
+              'xpack.fleet.settings.editOutputFlyout.synchronizeIntegrationsAPIKeyLabel',
+              {
+                defaultMessage: 'Kibana API key',
+              }
+            )}
+            {...inputs.integrationSyncApiKeySecretInput.formRowProps}
+            cancelEdit={inputs.integrationSyncApiKeySecretInput.cancelEdit}
+            useSecretsStorage={useSecretsStorage}
+            isConvertedToSecret={isConvertedToSecret.apiKey}
+            onToggleSecretStorage={onToggleAPIKeySecretAndClearValue}
+          >
+            <EuiFieldText
+              data-test-subj="kibanaAPIKeySecretInput"
+              fullWidth
+              {...inputs.integrationSyncApiKeySecretInput.props}
+              placeholder={i18n.translate(
+                'xpack.fleet.settings.editOutputFlyout.remoteAPIKeyPlaceholder',
+                {
+                  defaultMessage: 'Specify API key',
+                }
+              )}
+            />
+          </SecretFormRow>
+        ))}
+      {inputs.integrationSyncInput.value && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiCallOut
+            title={
+              <FormattedMessage
+                id="xpack.fleet.settings.editOutputFlyout.remoteAPIKeyCalloutText"
+                defaultMessage="Generate an API key by running this API request in the Remote Kibana Console and copy the response value"
+              />
+            }
+            data-test-subj="remoteAPIKeyCallout"
+          >
+            <EuiCodeBlock isCopyable={true}>
+              {`POST /_security/api_key
+{
+  "name": "integration_sync",
+  "role_descriptors": {
+    "integration_writer": {
+      "cluster": [],
+      "indices":[],
+      "applications": [
+        {
+          "application": "kibana-.kibana",
+            "privileges": ["feature_fleet.all", "feature_fleetv2.all"],
+            "resources": ["*"]
+        }
+      ]
+    }
+  }
+}`}
+            </EuiCodeBlock>
+          </EuiCallOut>
+        </>
+      )}
       <EuiSpacer size="m" />
     </>
   );

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
@@ -286,6 +286,28 @@ export function validateServiceToken(value: string) {
 
 export const validateServiceTokenSecret = toSecretValidator(validateServiceToken);
 
+export function validateIntegrationSyncKibanaUrl(value: string) {
+  if (!value || value === '') {
+    return [
+      i18n.translate('xpack.fleet.settings.outputForm.KibanaUrlRequiredErrorMessage', {
+        defaultMessage: 'Kibana URL is required',
+      }),
+    ];
+  }
+}
+
+export function validateIntegrationSyncApiKey(value: string) {
+  if (!value || value === '') {
+    return [
+      i18n.translate('xpack.fleet.settings.outputForm.ApiKeyRequiredErrorMessage', {
+        defaultMessage: 'API key is required',
+      }),
+    ];
+  }
+}
+
+export const validateIntegrationSyncApiKeySecret = toSecretValidator(validateIntegrationSyncApiKey);
+
 export function validateSSLCertificate(value: string) {
   if (!value || value === '') {
     return [

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -370,6 +370,9 @@ export const getSavedObjectTypes = (
           ca_sha256: { type: 'keyword', index: false },
           ca_trusted_fingerprint: { type: 'keyword', index: false },
           service_token: { type: 'keyword', index: false },
+          integration_sync: { type: 'boolean', index: false },
+          remote_kibana_url: { type: 'keyword', index: false },
+          remote_api_key: { type: 'keyword', index: false },
           config: { type: 'flattened' },
           config_yaml: { type: 'text' },
           is_preconfigured: { type: 'boolean', index: false },
@@ -464,6 +467,12 @@ export const getSavedObjectTypes = (
                 },
               },
               service_token: {
+                dynamic: false,
+                properties: {
+                  id: { type: 'keyword' },
+                },
+              },
+              remote_api_key: {
                 dynamic: false,
                 properties: {
                   id: { type: 'keyword' },
@@ -568,6 +577,43 @@ export const getSavedObjectTypes = (
             {
               type: 'data_backfill',
               backfillFn: backfillOutputPolicyToV7,
+            },
+          ],
+        },
+        '8': {
+          changes: [
+            {
+              type: 'mappings_addition',
+              addedMappings: {
+                integration_sync: { type: 'boolean', index: false },
+              },
+            },
+            {
+              type: 'mappings_addition',
+              addedMappings: {
+                remote_kibana_url: { type: 'keyword', index: false },
+              },
+            },
+            {
+              type: 'mappings_addition',
+              addedMappings: {
+                remote_api_key: { type: 'keyword', index: false },
+              },
+            },
+            {
+              type: 'mappings_addition',
+              addedMappings: {
+                secrets: {
+                  properties: {
+                    remote_api_key: {
+                      dynamic: false,
+                      properties: {
+                        id: { type: 'keyword' },
+                      },
+                    },
+                  },
+                },
+              },
             },
           ],
         },

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -67,7 +67,7 @@ import {
   MAX_TIME_COMPLETE_INSTALL,
   MAX_REINSTALL_RETRIES,
 } from '../../../constants';
-import { dataStreamService, licenseService } from '../..';
+import { dataStreamService, licenseService, outputService } from '../..';
 import { appContextService } from '../../app_context';
 import * as Registry from '../registry';
 import {
@@ -718,6 +718,7 @@ async function installPackageWithStateMachine(options: {
           pkgName: packageInfo.name,
           currentVersion: packageInfo.version,
         });
+        await outputService.syncIntegrationsForAllRemoteESOutputs(savedObjectsClient);
         sendEvent({
           ...telemetryEvent!,
           status: 'success',

--- a/x-pack/plugins/fleet/server/services/epm/packages/update.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/update.ts
@@ -16,6 +16,8 @@ import { PackageNotFoundError } from '../../../errors';
 
 import { auditLoggingService } from '../../audit_logging';
 
+import { outputService } from '../..';
+
 import { getInstallationObject, getPackageInfo } from './get';
 
 export async function updatePackage(
@@ -31,6 +33,8 @@ export async function updatePackage(
   if (!installedPackage) {
     throw new PackageNotFoundError(`Error while updating package: ${pkgName} is not installed`);
   }
+
+  await outputService.syncIntegrationsForAllRemoteESOutputs(savedObjectsClient);
 
   auditLoggingService.writeCustomSoAuditLog({
     action: 'update',

--- a/x-pack/plugins/fleet/server/services/remote.ts
+++ b/x-pack/plugins/fleet/server/services/remote.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+
+import { PACKAGES_SAVED_OBJECT_TYPE, SO_SEARCH_LIMIT } from '../constants';
+import {
+  FLEET_SYNTHETICS_PACKAGE,
+  FLEET_SERVER_PACKAGE,
+  FLEET_ELASTIC_AGENT_PACKAGE,
+} from '../../common/constants';
+import type { Installation } from '../types';
+
+import { appContextService } from './app_context';
+
+class RemoteClusterService {
+  /**
+   * Install packages that are installed on current stack into remote stack if they are not
+   * already installed there.
+   */
+  public async syncPackagesWithRemote(
+    soClient: SavedObjectsClientContract,
+    kibanaUrl: string,
+    apiKey: string
+  ) {
+    const logger = appContextService.getLogger();
+    const cleanedKibanaUrl = kibanaUrl.replace(/\/+$/, '');
+
+    // List installed packages
+    const installedPackagesRes = await soClient.find<Installation>({
+      type: PACKAGES_SAVED_OBJECT_TYPE,
+      perPage: SO_SEARCH_LIMIT,
+      filter: `${PACKAGES_SAVED_OBJECT_TYPE}.attributes.install_status:installed`,
+    });
+    // TODO: check if some packages should be skipped
+    const packagesToSkip = [
+      FLEET_ELASTIC_AGENT_PACKAGE,
+      FLEET_SERVER_PACKAGE,
+      FLEET_SYNTHETICS_PACKAGE,
+    ];
+    const installedPackages = installedPackagesRes.saved_objects
+      .map((so) => ({
+        name: so.attributes.name,
+        version: so.attributes.version,
+      }))
+      .filter((p) => !packagesToSkip.includes(p.name));
+
+    // List installed packages on remote
+    const installedPackagesOnRemoteRes = await fetch(
+      `${cleanedKibanaUrl}/api/fleet/epm/packages/installed`,
+      {
+        headers: {
+          'content-type': 'application/json',
+          'kbn-xsrf': 'true',
+          Authorization: `ApiKey ${apiKey}`,
+        },
+        method: 'GET',
+      }
+    );
+    if (!installedPackagesOnRemoteRes.ok) {
+      logger.error(
+        `Failed to retrieve installed packages on remote cluster: ${installedPackagesOnRemoteRes.statusText}`
+      );
+      return;
+    }
+    const body = await installedPackagesOnRemoteRes.json();
+    const installedPackagesOnRemote = body.items;
+
+    // Install missing packages on remote
+    const packagesToInstall = installedPackages.filter(
+      (localPackage) =>
+        !installedPackagesOnRemote.some(
+          (remotePackage: { name: string; version: string }) =>
+            localPackage.name === remotePackage.name &&
+            localPackage.version === remotePackage.version
+        )
+    );
+    if (packagesToInstall.length === 0) {
+      logger.debug('All integrations already installed on remote');
+      return;
+    }
+
+    logger.debug(
+      `Installing following integrations on remote cluster: ${packagesToInstall
+        .map((p) => `${p.name}:${p.version}`)
+        .join(', ')}`
+    );
+    const res = await fetch(`${cleanedKibanaUrl}/api/fleet/epm/packages/_bulk`, {
+      headers: {
+        'content-type': 'application/json',
+        'kbn-xsrf': 'true',
+        Authorization: `ApiKey ${apiKey}`,
+      },
+      method: 'POST',
+      body: JSON.stringify({ packages: packagesToInstall }),
+    });
+    if (res.ok) {
+      logger.debug('Integrations installed on remote cluster');
+    } else {
+      logger.error(`Failed to install packages on remote cluster: ${res.statusText}`);
+    }
+  }
+}
+
+export const remoteClusterService = new RemoteClusterService();

--- a/x-pack/plugins/fleet/server/services/secrets.test.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.test.ts
@@ -1420,6 +1420,9 @@ describe('secrets', () => {
             service_token: {
               id: 'token',
             },
+            remote_api_key: {
+              id: 'key',
+            },
           },
         },
         outputUpdate: {
@@ -1437,7 +1440,7 @@ describe('secrets', () => {
         esClient: esClientMock,
       });
 
-      expect(result.secretsToDelete).toEqual([{ id: 'token' }]);
+      expect(result.secretsToDelete).toEqual([{ id: 'token' }, { id: 'key' }]);
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/secrets.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.ts
@@ -333,6 +333,12 @@ function getOutputSecretPaths(
         value: remoteESOutput.secrets.service_token,
       });
     }
+    if (remoteESOutput.secrets?.remote_api_key) {
+      outputSecretPaths.push({
+        path: 'secrets.remote_api_key',
+        value: remoteESOutput.secrets.remote_api_key,
+      });
+    }
   }
 
   return outputSecretPaths;
@@ -378,13 +384,20 @@ export function getOutputSecretReferences(output: Output): PolicySecretReference
     });
   }
 
-  if (
-    output.type === 'remote_elasticsearch' &&
-    typeof output?.secrets?.service_token === 'object'
-  ) {
-    outputSecretPaths.push({
-      id: output.secrets.service_token.id,
-    });
+  if (output.type === 'remote_elasticsearch') {
+    if (typeof output?.secrets?.service_token === 'object') {
+      outputSecretPaths.push({
+        id: output.secrets.service_token.id,
+      });
+    }
+    if (
+      typeof output?.secrets?.remote_api_key === 'object' &&
+      output?.secrets?.remote_api_key !== null
+    ) {
+      outputSecretPaths.push({
+        id: output.secrets.remote_api_key.id,
+      });
+    }
   }
 
   return outputSecretPaths;

--- a/x-pack/plugins/fleet/server/types/models/output.ts
+++ b/x-pack/plugins/fleet/server/types/models/output.ts
@@ -149,9 +149,13 @@ export const RemoteElasticSearchSchema = {
   ...ElasticSearchSchema,
   type: schema.literal(outputType.RemoteElasticsearch),
   service_token: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  integration_sync: schema.maybe(schema.boolean()),
+  remote_kibana_url: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  remote_api_key: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
   secrets: schema.maybe(
     schema.object({
       service_token: schema.maybe(secretRefSchema),
+      remote_api_key: schema.maybe(schema.oneOf([schema.literal(null), secretRefSchema])),
     })
   ),
 };
@@ -160,9 +164,13 @@ const RemoteElasticSearchUpdateSchema = {
   ...ElasticSearchUpdateSchema,
   type: schema.maybe(schema.literal(outputType.RemoteElasticsearch)),
   service_token: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  integration_sync: schema.maybe(schema.boolean()),
+  remote_kibana_url: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
+  remote_api_key: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
   secrets: schema.maybe(
     schema.object({
       service_token: schema.maybe(secretRefSchema),
+      remote_api_key: schema.maybe(schema.oneOf([schema.literal(null), secretRefSchema])),
     })
   ),
 };

--- a/x-pack/plugins/fleet/server/types/so_attributes.ts
+++ b/x-pack/plugins/fleet/server/types/so_attributes.ts
@@ -165,8 +165,12 @@ interface OutputSoElasticsearchAttributes extends OutputSoBaseAttributes {
 export interface OutputSoRemoteElasticsearchAttributes extends OutputSoBaseAttributes {
   type: OutputType['RemoteElasticsearch'];
   service_token?: string;
+  integration_sync?: boolean;
+  remote_kibana_url?: string;
+  remote_api_key?: string;
   secrets?: {
     service_token?: { id: string };
+    remote_api_key?: { id: string } | null;
   };
 }
 


### PR DESCRIPTION
🚧 WIP

## Summary

Closes https://github.com/elastic/kibana/issues/192361

This PR adds a feature to remote Elasticsearch Fleet outputs for syncing integrations on remote clusters. It is guarded behind the `remoteIntegrationSync` feature flag.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

