### PR TITLE
[8.x] [OAS][Docs] Use correct bump dependency in makefile (#199876)

### DIFF
--- a/oas_docs/makefile
+++ b/oas_docs/makefile
@@ -30,21 +30,21 @@ api-docs-lint-stateful: ## Run redocly API docs linter on kibana.yaml
 	@npx @redocly/cli lint "output/kibana.yaml" --config "linters/redocly.yaml" --format stylish --max-problems 500
 
 .PHONY: api-docs-overlay
-api-docs-overlay: ## Run spectral API docs linter 
-	@npx bump overlay "output/kibana.yaml" "overlays/kibana.overlays.yaml" > "output/kibana.tmp1.yaml"
-	@npx bump overlay "output/kibana.tmp1.yaml" "overlays/alerting.overlays.yaml" > "output/kibana.tmp2.yaml"
-	@npx bump overlay "output/kibana.tmp2.yaml" "overlays/connectors.overlays.yaml" > "output/kibana.tmp3.yaml"
-	@npx bump overlay "output/kibana.tmp3.yaml" "overlays/kibana.overlays.shared.yaml" > "output/kibana.tmp4.yaml"
+api-docs-overlay: ## Run spectral API docs linter
+	@npx bump-cli overlay "output/kibana.yaml" "overlays/kibana.overlays.yaml" > "output/kibana.tmp1.yaml"
+	@npx bump-cli overlay "output/kibana.tmp1.yaml" "overlays/alerting.overlays.yaml" > "output/kibana.tmp2.yaml"
+	@npx bump-cli overlay "output/kibana.tmp2.yaml" "overlays/connectors.overlays.yaml" > "output/kibana.tmp3.yaml"
+	@npx bump-cli overlay "output/kibana.tmp3.yaml" "overlays/kibana.overlays.shared.yaml" > "output/kibana.tmp4.yaml"
 	@npx @redocly/cli bundle output/kibana.tmp4.yaml --ext yaml -o output/kibana.new.yaml
 	rm output/kibana.tmp*.yaml
 
 .PHONY: api-docs-preview
 api-docs-preview: ## Generate a preview for kibana.yaml
-	@npx bump preview "output/kibana.yaml"
+	@npx bump-cli preview "output/kibana.yaml"
 
 .PHONY: api-docs-overlay-preview
 api-docs-overlay-preview: ## Generate a preview for kibana.new.yaml
-	@npx bump preview "output/kibana.new.yaml"
+	@npx bump-cli preview "output/kibana.new.yaml"
 
 help:  ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[OAS][Docs] Use correct bump dependency in makefile (#199876)](https://github.com/elastic/kibana/pull/199876)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nick Peihl","email":"nick.peihl@elastic.co"},"sourceCommit":{"committedDate":"2024-11-13T13:13:54Z","message":"[OAS][Docs] Use correct bump dependency in makefile (#199876)\n\n## Summary\r\n\r\nUpdates the Open API docs make targets to use the correct bump.sh\r\ndependency.\r\n\r\nUnless I'm missing something obvious in my local configuration, `@npx\r\nbump ...` uses [node-bump](https://www.npmjs.com/package/bump) not the\r\n[bump.sh library](https://www.npmjs.com/package/bump-cli). I discovered\r\nthis while trying to run the make targets locally.","sha":"fcc939281d504a368f96c89d302c860ccb7c4dfe","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Feature:OAS","backport:version","v8.17.0","v8.16.1"],"number":199876,"url":"https://github.com/elastic/kibana/pull/199876","mergeCommit":{"message":"[OAS][Docs] Use correct bump dependency in makefile (#199876)\n\n## Summary\r\n\r\nUpdates the Open API docs make targets to use the correct bump.sh\r\ndependency.\r\n\r\nUnless I'm missing something obvious in my local configuration, `@npx\r\nbump ...` uses [node-bump](https://www.npmjs.com/package/bump) not the\r\n[bump.sh library](https://www.npmjs.com/package/bump-cli). I discovered\r\nthis while trying to run the make targets locally.","sha":"fcc939281d504a368f96c89d302c860ccb7c4dfe"}},"sourceBranch":"main","suggestedTargetBranches":["8.x","8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/199876","number":199876,"mergeCommit":{"message":"[OAS][Docs] Use correct bump dependency in makefile (#199876)\n\n## Summary\r\n\r\nUpdates the Open API docs make targets to use the correct bump.sh\r\ndependency.\r\n\r\nUnless I'm missing something obvious in my local configuration, `@npx\r\nbump ...` uses [node-bump](https://www.npmjs.com/package/bump) not the\r\n[bump.sh library](https://www.npmjs.com/package/bump-cli). I discovered\r\nthis while trying to run the make targets locally.","sha":"fcc939281d504a368f96c89d302c860ccb7c4dfe"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.16","label":"v8.16.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->