### PR TITLE
[8.x] [Logs] Deprecation warning for Logs Explorer and Logs Stream (#199652)

### DIFF
--- a/x-pack/plugins/observability_solution/infra/common/ui_settings.ts
+++ b/x-pack/plugins/observability_solution/infra/common/ui_settings.ts
@@ -23,6 +23,13 @@ export const uiSettings: Record<string, UiSettingsParams> = {
     description: i18n.translate('xpack.infra.enableLogsStreamDescription', {
       defaultMessage: 'Enables the legacy Logs Stream application and dashboard panel. ',
     }),
+    deprecation: {
+      message: i18n.translate('xpack.infra.enableLogsStreamDeprecationWarning', {
+        defaultMessage:
+          'Logs Stream is deprecated, and this setting will be removed in Kibana 9.0.',
+      }),
+      docLinksKey: 'generalSettings',
+    },
     type: 'boolean',
     schema: schema.boolean(),
     requiresPageReload: true,

--- a/x-pack/plugins/observability_solution/infra/public/components/logs_deprecation_callout.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/logs_deprecation_callout.tsx
@@ -9,40 +9,32 @@ import { EuiCallOut } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiButton } from '@elastic/eui';
-import {
-  AllDatasetsLocatorParams,
-  ALL_DATASETS_LOCATOR_ID,
-  DatasetLocatorParams,
-  OBSERVABILITY_LOGS_EXPLORER_APP_ID,
-} from '@kbn/deeplinks-observability';
+import { OBSERVABILITY_LOGS_EXPLORER_APP_ID } from '@kbn/deeplinks-observability';
 import { getRouterLinkProps } from '@kbn/router-utils';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
-
 import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/css';
 import { LocatorPublic } from '@kbn/share-plugin/common';
 import useObservable from 'react-use/lib/useObservable';
 import { AppStatus } from '@kbn/core/public';
 import { map } from 'rxjs';
+import { DISCOVER_APP_LOCATOR, DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
 import { useKibanaContextForPlugin } from '../hooks/use_kibana';
 
 const pageConfigurations = {
   stream: {
     dismissalStorageKey: 'log_stream_deprecation_callout_dismissed',
-    message: i18n.translate('xpack.infra.logsDeprecationCallout.p.theNewLogsExplorerLabel', {
+    message: i18n.translate('xpack.infra.logsDeprecationCallout.stream.exploreWithDiscover', {
       defaultMessage:
-        'The new Logs Explorer makes viewing and inspecting your logs easier with more features, better performance, and more intuitive navigation. We recommend switching to Logs Explorer, as it will replace Logs Stream in a future version.',
+        'Logs Stream and Logs Explorer are set to be deprecated. Switch to Discover which now includes their functionality plus more features, better performance, and more intuitive navigation. ',
     }),
   },
   settings: {
     dismissalStorageKey: 'log_settings_deprecation_callout_dismissed',
-    message: i18n.translate(
-      'xpack.infra.logsSettingsDeprecationCallout.p.theNewLogsExplorerLabel',
-      {
-        defaultMessage:
-          'These settings only apply to the legacy Logs Stream app, and we do not recommend configuring them. Instead, use Logs Explorer which makes viewing and inspecting your logs easier with more features, better performance, and more intuitive navigation.',
-      }
-    ),
+    message: i18n.translate('xpack.infra.logsDeprecationCallout.settings.exploreWithDiscover', {
+      defaultMessage:
+        'These settings only apply to the legacy Logs Stream app. Switch to Discover for the same functionality plus more features, better performance, and more intuitive navigation.',
+    }),
   },
 };
 
@@ -74,12 +66,10 @@ export const LogsDeprecationCallout = ({ page }: LogsDeprecationCalloutProps) =>
 
   const [isDismissed, setDismissed] = useLocalStorage(dismissalStorageKey, false);
 
-  if (isDismissed || !isLogsExplorerAppAccessible) {
+  const discoverLocator = share.url.locators.get<DiscoverAppLocatorParams>(DISCOVER_APP_LOCATOR);
+  if (isDismissed || !discoverLocator || !isLogsExplorerAppAccessible) {
     return null;
   }
-
-  const allDatasetLocator =
-    share.url.locators.get<AllDatasetsLocatorParams>(ALL_DATASETS_LOCATOR_ID);
 
   return (
     <EuiCallOut
@@ -95,19 +85,19 @@ export const LogsDeprecationCallout = ({ page }: LogsDeprecationCalloutProps) =>
       <p>{message}</p>
       <EuiButton
         fill
-        data-test-subj="infraLogsDeprecationCalloutTryLogsExplorerButton"
+        data-test-subj="infraLogsDeprecationCalloutGoToDiscoverButton"
         color="warning"
-        {...getLogsExplorerLinkProps(allDatasetLocator!)}
+        {...getDiscoverLinkProps(discoverLocator)}
       >
-        {i18n.translate('xpack.infra.logsDeprecationCallout.tryLogsExplorerButtonLabel', {
-          defaultMessage: 'Try Logs Explorer',
+        {i18n.translate('xpack.infra.logsDeprecationCallout.goToDiscoverButtonLabel', {
+          defaultMessage: 'Go to Discover',
         })}
       </EuiButton>
     </EuiCallOut>
   );
 };
 
-const getLogsExplorerLinkProps = (locator: LocatorPublic<DatasetLocatorParams>) => {
+const getDiscoverLinkProps = (locator: LocatorPublic<DiscoverAppLocatorParams>) => {
   return getRouterLinkProps({
     href: locator.getRedirectUrl({}),
     onClick: () => locator.navigate({}),

--- a/x-pack/plugins/observability_solution/observability_logs_explorer/common/translations.ts
+++ b/x-pack/plugins/observability_solution/observability_logs_explorer/common/translations.ts
@@ -22,14 +22,26 @@ export const observabilityAppTitle = i18n.translate(
   }
 );
 
-export const betaBadgeTitle = i18n.translate('xpack.observabilityLogsExplorer.betaBadgeTitle', {
-  defaultMessage: 'Beta',
-});
-
-export const betaBadgeDescription = i18n.translate(
-  'xpack.observabilityLogsExplorer.betaBadgeDescription',
+export const deprecationBadgeTitle = i18n.translate(
+  'xpack.observabilityLogsExplorer.deprecationBadgeTitle',
   {
-    defaultMessage: 'This application is in beta and therefore subject to change.',
+    defaultMessage: 'Deprecation notice',
+  }
+);
+
+export const deprecationBadgeDescription = i18n.translate(
+  'xpack.observabilityLogsExplorer.deprecationBadgeDescription',
+  {
+    defaultMessage:
+      'Logs Stream and Logs Explorer are set to be deprecated. Switch to Discover which now includes their functionality plus more features and better performance.',
+  }
+);
+
+export const deprecationBadgeGuideline = i18n.translate(
+  'xpack.observabilityLogsExplorer.deprecationBadgeGuideline',
+  {
+    defaultMessage:
+      'You can temporarily access Logs Stream by re-enabling it in Advanced Settings.',
   }
 );
 

--- a/x-pack/plugins/observability_solution/observability_logs_explorer/public/components/logs_explorer_top_nav_menu.tsx
+++ b/x-pack/plugins/observability_solution/observability_logs_explorer/public/components/logs_explorer_top_nav_menu.tsx
@@ -21,7 +21,11 @@ import { LogsExplorerTabs } from '@kbn/discover-plugin/public';
 import React, { useEffect, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { filter, take } from 'rxjs';
-import { betaBadgeDescription, betaBadgeTitle } from '../../common/translations';
+import {
+  deprecationBadgeDescription,
+  deprecationBadgeGuideline,
+  deprecationBadgeTitle,
+} from '../../common/translations';
 import { useKibanaContextForPlugin } from '../utils/use_kibana';
 import { ConnectedDiscoverLink } from './discover_link';
 import { FeedbackLink } from './feedback_link';
@@ -59,13 +63,7 @@ const ProjectTopNav = () => {
         `}
       >
         <EuiHeaderSectionItem>
-          <EuiBetaBadge
-            size="s"
-            iconType="beta"
-            label={betaBadgeTitle}
-            tooltipContent={betaBadgeDescription}
-            alignment="middle"
-          />
+          <DeprecationNoticeBadge />
         </EuiHeaderSectionItem>
         <EuiHeaderSectionItem>
           <EuiHeaderLinks gutterSize="xs">
@@ -116,15 +114,6 @@ const ClassicTopNav = () => {
             `}
           >
             <EuiHeaderSectionItem>
-              <EuiBetaBadge
-                size="s"
-                iconType="beta"
-                label={betaBadgeTitle}
-                tooltipContent={betaBadgeDescription}
-                alignment="middle"
-              />
-            </EuiHeaderSectionItem>
-            <EuiHeaderSectionItem>
               <FeedbackLink />
             </EuiHeaderSectionItem>
           </EuiHeaderSection>,
@@ -145,6 +134,9 @@ const ClassicTopNav = () => {
       <EuiHeaderSection data-test-subj="logsExplorerHeaderMenu">
         <EuiHeaderSectionItem>
           <EuiHeaderLinks gutterSize="xs">
+            <EuiHeaderSectionItem>
+              <DeprecationNoticeBadge />
+            </EuiHeaderSectionItem>
             <ConnectedDiscoverLink />
             <ConditionalVerticalRule Component={ConnectedDatasetQualityLink()} />
             <VerticalRule />
@@ -171,3 +163,19 @@ const ConditionalVerticalRule = ({ Component }: { Component: JSX.Element | null 
       {Component}
     </>
   );
+
+const DeprecationNoticeBadge = () => (
+  <EuiBetaBadge
+    label={deprecationBadgeTitle}
+    color="subdued"
+    tooltipContent={
+      <>
+        {deprecationBadgeDescription}
+        <br />
+        <br />
+        {deprecationBadgeGuideline}
+      </>
+    }
+    alignment="middle"
+  />
+);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Logs] Deprecation warning for Logs Explorer and Logs Stream (#199652)](https://github.com/elastic/kibana/pull/199652)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Marco Antonio Ghiani","email":"marcoantonio.ghiani01@gmail.com"},"sourceCommit":{"committedDate":"2024-11-12T13:25:09Z","message":"[Logs] Deprecation warning for Logs Explorer and Logs Stream (#199652)\n\n## 📓 Summary\r\n\r\nCloses https://github.com/elastic/observability-dev/issues/4070\r\n\r\n- Update the deprecation callouts to suggest that the user use Discover.\r\n- Replace the beta badge in Logs Explorer with a deprecation notice.\r\n- Mark the advanced setting to enable the log stream to be deprecated.\r\n\r\n<img width=\"844\" alt=\"Screenshot 2024-11-11 at 15 22 51\"\r\nsrc=\"https://github.com/user-attachments/assets/5f8a4858-cad5-4d75-9868-d1c9d54a9ce5\">\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: Mike Birnstiehl <114418652+mdbirnstiehl@users.noreply.github.com>","sha":"9975c552da13e778b82ffa91d1a6fe1de8cac4a6","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","backport:prev-minor","ci:project-deploy-observability","Team:obs-ux-logs"],"number":199652,"url":"https://github.com/elastic/kibana/pull/199652","mergeCommit":{"message":"[Logs] Deprecation warning for Logs Explorer and Logs Stream (#199652)\n\n## 📓 Summary\r\n\r\nCloses https://github.com/elastic/observability-dev/issues/4070\r\n\r\n- Update the deprecation callouts to suggest that the user use Discover.\r\n- Replace the beta badge in Logs Explorer with a deprecation notice.\r\n- Mark the advanced setting to enable the log stream to be deprecated.\r\n\r\n<img width=\"844\" alt=\"Screenshot 2024-11-11 at 15 22 51\"\r\nsrc=\"https://github.com/user-attachments/assets/5f8a4858-cad5-4d75-9868-d1c9d54a9ce5\">\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: Mike Birnstiehl <114418652+mdbirnstiehl@users.noreply.github.com>","sha":"9975c552da13e778b82ffa91d1a6fe1de8cac4a6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/199652","number":199652,"mergeCommit":{"message":"[Logs] Deprecation warning for Logs Explorer and Logs Stream (#199652)\n\n## 📓 Summary\r\n\r\nCloses https://github.com/elastic/observability-dev/issues/4070\r\n\r\n- Update the deprecation callouts to suggest that the user use Discover.\r\n- Replace the beta badge in Logs Explorer with a deprecation notice.\r\n- Mark the advanced setting to enable the log stream to be deprecated.\r\n\r\n<img width=\"844\" alt=\"Screenshot 2024-11-11 at 15 22 51\"\r\nsrc=\"https://github.com/user-attachments/assets/5f8a4858-cad5-4d75-9868-d1c9d54a9ce5\">\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: Mike Birnstiehl <114418652+mdbirnstiehl@users.noreply.github.com>","sha":"9975c552da13e778b82ffa91d1a6fe1de8cac4a6"}}]}] BACKPORT-->