### PR TITLE
[8.x] Upgrade EUI to v97.3.1 (#199186)

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@elastic/ecs": "^8.11.1",
     "@elastic/elasticsearch": "^8.15.0",
     "@elastic/ems-client": "8.5.3",
-    "@elastic/eui": "97.3.0",
+    "@elastic/eui": "97.3.1",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "^1.2.3",
     "@elastic/numeral": "^2.5.1",

--- a/packages/kbn-securitysolution-exception-list-components/src/list_header/__snapshots__/list_header.test.tsx.snap
+++ b/packages/kbn-securitysolution-exception-list-components/src/list_header/__snapshots__/list_header.test.tsx.snap
@@ -152,7 +152,7 @@ Object {
                 class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
               >
                 <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
+                  class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
                 >
                   <div
                     class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
@@ -533,7 +533,7 @@ Object {
               class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
+                class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
               >
                 <div
                   class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
@@ -808,7 +808,7 @@ Object {
                 class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
               >
                 <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
+                  class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
                 >
                   <div
                     class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
@@ -1026,7 +1026,7 @@ Object {
               class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
+                class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
               >
                 <div
                   class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
@@ -1273,7 +1273,7 @@ Object {
                 class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
               >
                 <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
+                  class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
                 >
                   <div
                     class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
@@ -1464,7 +1464,7 @@ Object {
               class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
+                class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
               >
                 <div
                   class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
@@ -1712,7 +1712,7 @@ Object {
                 class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
               >
                 <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
+                  class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
                 >
                   <div
                     class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"
@@ -1973,7 +1973,7 @@ Object {
               class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
+                class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
               >
                 <div
                   class="euiFlexGroup emotion-euiFlexGroup-responsive-l-center-baseline-row"

--- a/packages/kbn-test-jest-helpers/src/testbed/testbed.ts
+++ b/packages/kbn-test-jest-helpers/src/testbed/testbed.ts
@@ -223,7 +223,7 @@ export function registerTestBed<T extends string = string, P extends object = an
         const formInput = findTestSubject(comboBox, 'comboBoxSearchInput');
         setInputValue(formInput, value);
 
-        comboBox.simulate('keydown', { key: 'Enter' });
+        formInput.simulate('keydown', { key: 'Enter' });
         component.update();
       };
 

--- a/packages/shared-ux/page/kibana_template/impl/src/__snapshots__/page_template.test.tsx.snap
+++ b/packages/shared-ux/page/kibana_template/impl/src/__snapshots__/page_template.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`KibanaPageTemplate render basic template 1`] = `
             class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
           >
             <div
-              class="euiFlexItem emotion-euiFlexItem-growZero"
+              class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
             >
               test
             </div>

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -87,7 +87,7 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.5.3': ['Elastic License 2.0'],
-  '@elastic/eui@97.3.0': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
+  '@elastic/eui@97.3.1': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
   'buffers@0.1.1': ['MIT'], // license in importing module https://www.npmjs.com/package/binary
   '@bufbuild/protobuf@1.2.1': ['Apache-2.0'], // license (Apache-2.0 AND BSD-3-Clause)

--- a/src/plugins/saved_objects_management/public/management_section/object_view/components/__snapshots__/header.test.tsx.snap
+++ b/src/plugins/saved_objects_management/public/management_section/object_view/components/__snapshots__/header.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Intro component renders correctly 1`] = `
         class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
       >
         <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
+          class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
         >
           <button
             class="euiButton emotion-euiButtonDisplay-s-defaultMinWidth-base-danger"
@@ -42,7 +42,7 @@ exports[`Intro component renders correctly 1`] = `
           </button>
         </div>
         <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
+          class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
         >
           <a
             class="euiButton emotion-euiButtonDisplay-s-defaultMinWidth-base-primary"

--- a/src/plugins/vis_types/timeseries/public/application/components/color_rules.test.tsx
+++ b/src/plugins/vis_types/timeseries/public/application/components/color_rules.test.tsx
@@ -81,7 +81,7 @@ describe('src/legacy/core_plugins/metrics/public/components/color_rules.test.js'
     it('should handle change of operator and value correctly', () => {
       collectionActions.handleChange = jest.fn();
       const wrapper = mountWithIntl(<ColorRules {...defaultProps} />);
-      const operatorInput = findTestSubject(wrapper, 'colorRuleOperator');
+      const operatorInput = findTestSubject(wrapper, 'colorRuleOperator').find('input');
       operatorInput.simulate('keyDown', { key: keys.ARROW_DOWN });
       operatorInput.simulate('keyDown', { key: keys.ARROW_DOWN });
       operatorInput.simulate('keyDown', { key: keys.ENTER });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1748,10 +1748,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@97.3.0":
-  version "97.3.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-97.3.0.tgz#3961e39a6a8ac38e1af999baf0e96de8e1671943"
-  integrity sha512-Ic9DXHlh9yVumYypoLSM+plM0xBjSPc8PPRT4z5bHXLXZrLuSEVoqfix3co5yl4+ibLwfxNPCZFflbFiMl2apA==
+"@elastic/eui@97.3.1":
+  version "97.3.1"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-97.3.1.tgz#b0f07c603042bd359544b41829507e65f4fa3cd2"
+  integrity sha512-zJs3aaO6qjTdxJM2mPahcqaC6FfaC34yTc3qpQq7+Cbhw2xGrwx8bAfIzhttLU87mwgr59Sqv9Ojvwk8c3js7A==
   dependencies:
     "@hello-pangea/dnd" "^16.6.0"
     "@types/lodash" "^4.14.202"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Upgrade EUI to v97.3.1 (#199186)](https://github.com/elastic/kibana/pull/199186)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Cee Chen","email":"549407+cee-chen@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-11-12T01:02:34Z","message":"Upgrade EUI to v97.3.1 (#199186)\n\n`v97.3.0`⏩`v97.3.1`\r\n\r\n_[Questions? Please see our Kibana upgrade\r\nFAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)_\r\n\r\n---\r\n\r\n## [`v97.3.1`](https://github.com/elastic/eui/releases/v97.3.1)\r\n\r\n**Bug fixes**\r\n\r\n- Fixed an `EuiComboBox` bug where Enter keypresses were not working\r\ncorrectly on selection clear buttons\r\n([#8105](https://github.com/elastic/eui/pull/8105))\r\n- Fixed an `EuiSuperDatePicker` bug where inputs would overflow out of\r\nsmaller widths instead of truncating\r\n([#8109](https://github.com/elastic/eui/pull/8109))\r\n- Fixed a bug with `EuiPageHeader`'s `rightSideItems` responsiveness\r\nwhere single items could overflow past the intended max width\r\n([#8110](https://github.com/elastic/eui/pull/8110))","sha":"4e65ae9b1e69fc92341de99078bde179708b3394","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","EUI","v9.0.0","backport:version","v8.17.0"],"number":199186,"url":"https://github.com/elastic/kibana/pull/199186","mergeCommit":{"message":"Upgrade EUI to v97.3.1 (#199186)\n\n`v97.3.0`⏩`v97.3.1`\r\n\r\n_[Questions? Please see our Kibana upgrade\r\nFAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)_\r\n\r\n---\r\n\r\n## [`v97.3.1`](https://github.com/elastic/eui/releases/v97.3.1)\r\n\r\n**Bug fixes**\r\n\r\n- Fixed an `EuiComboBox` bug where Enter keypresses were not working\r\ncorrectly on selection clear buttons\r\n([#8105](https://github.com/elastic/eui/pull/8105))\r\n- Fixed an `EuiSuperDatePicker` bug where inputs would overflow out of\r\nsmaller widths instead of truncating\r\n([#8109](https://github.com/elastic/eui/pull/8109))\r\n- Fixed a bug with `EuiPageHeader`'s `rightSideItems` responsiveness\r\nwhere single items could overflow past the intended max width\r\n([#8110](https://github.com/elastic/eui/pull/8110))","sha":"4e65ae9b1e69fc92341de99078bde179708b3394"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/199186","number":199186,"mergeCommit":{"message":"Upgrade EUI to v97.3.1 (#199186)\n\n`v97.3.0`⏩`v97.3.1`\r\n\r\n_[Questions? Please see our Kibana upgrade\r\nFAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)_\r\n\r\n---\r\n\r\n## [`v97.3.1`](https://github.com/elastic/eui/releases/v97.3.1)\r\n\r\n**Bug fixes**\r\n\r\n- Fixed an `EuiComboBox` bug where Enter keypresses were not working\r\ncorrectly on selection clear buttons\r\n([#8105](https://github.com/elastic/eui/pull/8105))\r\n- Fixed an `EuiSuperDatePicker` bug where inputs would overflow out of\r\nsmaller widths instead of truncating\r\n([#8109](https://github.com/elastic/eui/pull/8109))\r\n- Fixed a bug with `EuiPageHeader`'s `rightSideItems` responsiveness\r\nwhere single items could overflow past the intended max width\r\n([#8110](https://github.com/elastic/eui/pull/8110))","sha":"4e65ae9b1e69fc92341de99078bde179708b3394"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->