### PR TITLE
[Discover] mailto links in data view urls

### DIFF
--- a/src/plugins/field_formats/common/converters/url.test.ts
+++ b/src/plugins/field_formats/common/converters/url.test.ts
@@ -19,6 +19,14 @@ describe('UrlFormat', () => {
     );
   });
 
+  test('outputs a mailto: link when URL starts with mailto:', () => {
+    const url = new UrlFormat({});
+
+    expect(url.convert('mailto:test@example.com', HTML_CONTEXT_TYPE)).toBe(
+      '<a href="mailto:test@example.com" target="_blank" rel="noopener noreferrer">mailto:test@example.com</a>'
+    );
+  });
+
   test('outputs an <audio> if type === "audio"', () => {
     const url = new UrlFormat({ type: 'audio' });
 

--- a/src/plugins/field_formats/common/converters/url.ts
+++ b/src/plugins/field_formats/common/converters/url.ts
@@ -21,7 +21,7 @@ import {
 } from '../types';
 
 const templateMatchRE = /{{([\s\S]+?)}}/g;
-const allowedUrlSchemes = ['http://', 'https://'];
+const allowedUrlSchemes = ['http://', 'https://', 'mailto:'];
 
 const URL_TYPES = [
   {


### PR DESCRIPTION
## Summary

Adds `mailto:` as an allowed URL Url formatters in data views.

Resolves papercut: https://github.com/elastic/kibana/issues/179773

Example:

<img width="963" alt="image" src="https://github.com/user-attachments/assets/2e851311-496c-4904-a138-96624a594e2c">


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#_add_your_labels)
- [ ] This will appear in the **Release Notes** and follow the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

