### PR TITLE
[Fleet] Revert enrollment api key list removal

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -16951,6 +16951,49 @@
                       },
                       "type": "array"
                     },
+                    "list": {
+                      "deprecated": true,
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "active": {
+                            "description": "When false, the enrollment API key is revoked and cannot be used for enrolling Elastic Agents.",
+                            "type": "boolean"
+                          },
+                          "api_key": {
+                            "description": "The enrollment API key (token) used for enrolling Elastic Agents.",
+                            "type": "string"
+                          },
+                          "api_key_id": {
+                            "description": "The ID of the API key in the Security API.",
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The name of the enrollment API key.",
+                            "type": "string"
+                          },
+                          "policy_id": {
+                            "description": "The ID of the agent policy the Elastic Agent will be enrolled in.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "api_key_id",
+                          "api_key",
+                          "active",
+                          "created_at"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
                     "page": {
                       "type": "number"
                     },
@@ -16965,7 +17008,8 @@
                     "items",
                     "total",
                     "page",
-                    "perPage"
+                    "perPage",
+                    "list"
                   ],
                   "type": "object"
                 }

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -16951,6 +16951,49 @@
                       },
                       "type": "array"
                     },
+                    "list": {
+                      "deprecated": true,
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "active": {
+                            "description": "When false, the enrollment API key is revoked and cannot be used for enrolling Elastic Agents.",
+                            "type": "boolean"
+                          },
+                          "api_key": {
+                            "description": "The enrollment API key (token) used for enrolling Elastic Agents.",
+                            "type": "string"
+                          },
+                          "api_key_id": {
+                            "description": "The ID of the API key in the Security API.",
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The name of the enrollment API key.",
+                            "type": "string"
+                          },
+                          "policy_id": {
+                            "description": "The ID of the agent policy the Elastic Agent will be enrolled in.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "api_key_id",
+                          "api_key",
+                          "active",
+                          "created_at"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
                     "page": {
                       "type": "number"
                     },
@@ -16965,7 +17008,8 @@
                     "items",
                     "total",
                     "page",
-                    "perPage"
+                    "perPage",
+                    "list"
                   ],
                   "type": "object"
                 }

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -17704,6 +17704,44 @@ paths:
                         - active
                         - created_at
                     type: array
+                  list:
+                    deprecated: true
+                    items:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        active:
+                          description: >-
+                            When false, the enrollment API key is revoked and
+                            cannot be used for enrolling Elastic Agents.
+                          type: boolean
+                        api_key:
+                          description: >-
+                            The enrollment API key (token) used for enrolling
+                            Elastic Agents.
+                          type: string
+                        api_key_id:
+                          description: The ID of the API key in the Security API.
+                          type: string
+                        created_at:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          description: The name of the enrollment API key.
+                          type: string
+                        policy_id:
+                          description: >-
+                            The ID of the agent policy the Elastic Agent will be
+                            enrolled in.
+                          type: string
+                      required:
+                        - id
+                        - api_key_id
+                        - api_key
+                        - active
+                        - created_at
+                    type: array
                   page:
                     type: number
                   perPage:
@@ -17715,6 +17753,7 @@ paths:
                   - total
                   - page
                   - perPage
+                  - list
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -21023,6 +21023,44 @@ paths:
                         - active
                         - created_at
                     type: array
+                  list:
+                    deprecated: true
+                    items:
+                      additionalProperties: false
+                      type: object
+                      properties:
+                        active:
+                          description: >-
+                            When false, the enrollment API key is revoked and
+                            cannot be used for enrolling Elastic Agents.
+                          type: boolean
+                        api_key:
+                          description: >-
+                            The enrollment API key (token) used for enrolling
+                            Elastic Agents.
+                          type: string
+                        api_key_id:
+                          description: The ID of the API key in the Security API.
+                          type: string
+                        created_at:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          description: The name of the enrollment API key.
+                          type: string
+                        policy_id:
+                          description: >-
+                            The ID of the agent policy the Elastic Agent will be
+                            enrolled in.
+                          type: string
+                      required:
+                        - id
+                        - api_key_id
+                        - api_key
+                        - active
+                        - created_at
+                    type: array
                   page:
                     type: number
                   perPage:
@@ -21034,6 +21072,7 @@ paths:
                   - total
                   - page
                   - perPage
+                  - list
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:

--- a/x-pack/plugins/fleet/common/types/rest_spec/enrollment_api_key.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/enrollment_api_key.ts
@@ -13,7 +13,10 @@ export interface GetEnrollmentAPIKeysRequest {
   query: ListWithKuery;
 }
 
-export type GetEnrollmentAPIKeysResponse = ListResult<EnrollmentAPIKey>;
+export type GetEnrollmentAPIKeysResponse = ListResult<EnrollmentAPIKey> & {
+  // deprecated in 8.x
+  list?: EnrollmentAPIKey[];
+};
 
 export interface GetOneEnrollmentAPIKeyRequest {
   params: {

--- a/x-pack/plugins/fleet/server/routes/enrollment_api_key/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/enrollment_api_key/handler.ts
@@ -43,6 +43,7 @@ export const getEnrollmentApiKeysHandler: RequestHandler<
       spaceId: useSpaceAwareness ? getCurrentNamespace(soClient) : undefined,
     });
     const body: GetEnrollmentAPIKeysResponse = {
+      list: items, // deprecated
       items,
       total,
       page,

--- a/x-pack/plugins/fleet/server/routes/enrollment_api_key/index.ts
+++ b/x-pack/plugins/fleet/server/routes/enrollment_api_key/index.ts
@@ -111,7 +111,10 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
           request: GetEnrollmentAPIKeysRequestSchema,
           response: {
             200: {
-              body: () => ListResponseSchema(EnrollmentAPIKeySchema),
+              body: () =>
+                ListResponseSchema(EnrollmentAPIKeySchema).extends({
+                  list: schema.arrayOf(EnrollmentAPIKeySchema, { meta: { deprecated: true } }),
+                }),
             },
             400: {
               body: genericErrorResponse,

--- a/x-pack/test/fleet_api_integration/apis/enrollment_api_keys/crud.ts
+++ b/x-pack/test/fleet_api_integration/apis/enrollment_api_keys/crud.ts
@@ -43,6 +43,8 @@ export default function (providerContext: FtrProviderContext) {
 
         expect(apiResponse.total).to.be(2);
         expect(apiResponse.items[0]).to.have.keys('id', 'api_key_id', 'name');
+        // Deprecated property list
+        expect(apiResponse.list[0]).to.have.keys('id', 'api_key_id', 'name');
         expect(apiResponse).to.have.keys('items');
       });
 


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/ingest-dev/issues/4459

Revert the removal of the deprecated property `list` in `GET /api/fleet/enrollment_api_keys`  API as it used by elastic-package for testing.