### PR TITLE
[8.16] [Security Solution] Migration of Alert Page controls for non-default Spaces. (#200058)

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/index.ts
+++ b/x-pack/plugins/security_solution/public/detections/index.ts
@@ -12,6 +12,7 @@ import { getDataTablesInStorageByIds } from '../timelines/containers/local_stora
 import { routes } from './routes';
 import type { SecuritySubPlugin } from '../app/types';
 import { runDetectionMigrations } from './migrations';
+import type { StartPlugins } from '../types';
 
 export const DETECTIONS_TABLE_IDS: TableIdLiteral[] = [
   TableId.alertsOnRuleDetailsPage,
@@ -21,8 +22,8 @@ export const DETECTIONS_TABLE_IDS: TableIdLiteral[] = [
 export class Detections {
   public setup() {}
 
-  public start(storage: Storage): SecuritySubPlugin {
-    runDetectionMigrations();
+  public async start(storage: Storage, plugins: StartPlugins): Promise<SecuritySubPlugin> {
+    await runDetectionMigrations(storage, plugins);
 
     return {
       storageDataTables: {

--- a/x-pack/plugins/security_solution/public/detections/migrations.ts
+++ b/x-pack/plugins/security_solution/public/detections/migrations.ts
@@ -5,16 +5,21 @@
  * 2.0.
  */
 
-import { Storage } from '@kbn/kibana-utils-plugin/public';
+import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import { migrateAlertPageControlsTo816 } from '../timelines/containers/local_storage/migrate_alert_page_controls';
+import type { StartPlugins } from '../types';
 
-type LocalStorageMigrator = (storage: Storage) => void;
+/* Migrator could be sync or async */
+type LocalStorageMigrator = (storage: Storage, plugins: StartPlugins) => void | Promise<void>;
 
-const runLocalStorageMigration = (fn: LocalStorageMigrator) => {
-  const storage = new Storage(localStorage);
-  fn(storage);
+const getLocalStorageMigrationRunner = (storage: Storage, plugins: StartPlugins) => {
+  const runLocalStorageMigration = async (fn: LocalStorageMigrator) => {
+    await fn(storage, plugins);
+  };
+  return runLocalStorageMigration;
 };
 
-export const runDetectionMigrations = () => {
-  runLocalStorageMigration(migrateAlertPageControlsTo816);
+export const runDetectionMigrations = async (storage: Storage, plugins: StartPlugins) => {
+  const runLocalStorageMigration = getLocalStorageMigrationRunner(storage, plugins);
+  await runLocalStorageMigration(migrateAlertPageControlsTo816);
 };

--- a/x-pack/plugins/security_solution/public/plugin.tsx
+++ b/x-pack/plugins/security_solution/public/plugin.tsx
@@ -256,8 +256,9 @@ export class Plugin implements IPlugin<PluginSetup, PluginStart, SetupPlugins, S
     plugins: StartPlugins
   ): Promise<StartedSubPlugins> {
     const subPlugins = await this.createSubPlugins();
+    const alerts = await subPlugins.alerts.start(storage, plugins);
     return {
-      alerts: subPlugins.alerts.start(storage),
+      alerts,
       attackDiscovery: subPlugins.attackDiscovery.start(),
       cases: subPlugins.cases.start(),
       cloudDefend: subPlugins.cloudDefend.start(),

--- a/x-pack/plugins/security_solution/public/timelines/containers/local_storage/migrate_alert_page_controls.ts
+++ b/x-pack/plugins/security_solution/public/timelines/containers/local_storage/migrate_alert_page_controls.ts
@@ -7,8 +7,10 @@
 
 import type { DefaultControlState, ControlGroupRuntimeState } from '@kbn/controls-plugin/common';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
+import type { StartPlugins } from '../../../types';
 
-export const PAGE_FILTER_STORAGE_KEY = 'siem.default.pageFilters';
+export const GET_PAGE_FILTER_STORAGE_KEY = (spaceId: string = 'default') =>
+  `siem.${spaceId}.pageFilters`;
 
 interface OldFormat {
   viewMode: string;
@@ -96,8 +98,11 @@ interface NewFormatExplicitInput {
  * This migration script is to migrate the old format to the new format.
  *
  */
-export function migrateAlertPageControlsTo816(storage: Storage) {
-  const oldFormat: OldFormat = storage.get(PAGE_FILTER_STORAGE_KEY);
+export async function migrateAlertPageControlsTo816(storage: Storage, plugins: StartPlugins) {
+  const space = await plugins.spaces?.getActiveSpace();
+  const spaceId = space?.id ?? 'default';
+  const storageKey = GET_PAGE_FILTER_STORAGE_KEY(spaceId);
+  const oldFormat: OldFormat = storage.get(GET_PAGE_FILTER_STORAGE_KEY(spaceId));
   if (oldFormat && Object.keys(oldFormat).includes('panels')) {
     // Only run when it is old format
     const newFormat: ControlGroupRuntimeState<NewFormatExplicitInput & DefaultControlState> = {
@@ -131,6 +136,6 @@ export function migrateAlertPageControlsTo816(storage: Storage) {
       };
     }
 
-    storage.set(PAGE_FILTER_STORAGE_KEY, newFormat);
+    storage.set(storageKey, newFormat);
   }
 }

--- a/x-pack/plugins/security_solution/public/types.ts
+++ b/x-pack/plugins/security_solution/public/types.ts
@@ -248,7 +248,7 @@ export interface SubPlugins {
 // TODO: find a better way to defined these types
 export interface StartedSubPlugins {
   [CASES_SUB_PLUGIN_KEY]: ReturnType<Cases['start']>;
-  alerts: ReturnType<Detections['start']>;
+  alerts: Awaited<ReturnType<Detections['start']>>;
   attackDiscovery: ReturnType<AttackDiscovery['start']>;
   cloudDefend: ReturnType<CloudDefend['start']>;
   cloudSecurityPosture: ReturnType<CloudSecurityPosture['start']>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Security Solution] Migration of Alert Page controls for non-default Spaces. (#200058)](https://github.com/elastic/kibana/pull/200058)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2024-11-13T20:52:00Z","message":"[Security Solution] Migration of Alert Page controls for non-default Spaces. (#200058)\n\n## Summary\r\n\r\nRecently, we created a PR to migrate the alert page filters controls to\r\n`8.16`. Unfortunately, it does not do migration for non-default spaces\r\nso any users upgrading to `8.16` will face the issue where Alert page\r\nerrors out as shown in below screenshot.\r\n\r\n\r\n![grafik](https://github.com/user-attachments/assets/ffee1c2d-4aa2-44a4-96c9-68053fb1cf63)\r\n\r\n\r\n## Desk Testing\r\n\r\n1. Checkout to `v8.15` branch by running `git checkout 8.15`. \r\n2. Create a new space and go to that space.\r\n3. Go to the alert page and do some modifications to the page controls.\r\nThis store `v8.15` page controls in local storage.\r\n    - You can, for example, delete one page control.\r\n    - Change selected value for one page control.\r\n    - Additionally, you can also add a custom control.\r\n4. Checkout `main` now and repeat the above steps.\r\n5. Your changes should be retained on the alert page and there should\r\nnot be any error.","sha":"b7ca7228315393c6672f638982dbac5196c9ad90","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","v9.0.0","Team:Threat Hunting:Investigations","backport:prev-minor","v8.17.0","v8.16.1"],"number":200058,"url":"https://github.com/elastic/kibana/pull/200058","mergeCommit":{"message":"[Security Solution] Migration of Alert Page controls for non-default Spaces. (#200058)\n\n## Summary\r\n\r\nRecently, we created a PR to migrate the alert page filters controls to\r\n`8.16`. Unfortunately, it does not do migration for non-default spaces\r\nso any users upgrading to `8.16` will face the issue where Alert page\r\nerrors out as shown in below screenshot.\r\n\r\n\r\n![grafik](https://github.com/user-attachments/assets/ffee1c2d-4aa2-44a4-96c9-68053fb1cf63)\r\n\r\n\r\n## Desk Testing\r\n\r\n1. Checkout to `v8.15` branch by running `git checkout 8.15`. \r\n2. Create a new space and go to that space.\r\n3. Go to the alert page and do some modifications to the page controls.\r\nThis store `v8.15` page controls in local storage.\r\n    - You can, for example, delete one page control.\r\n    - Change selected value for one page control.\r\n    - Additionally, you can also add a custom control.\r\n4. Checkout `main` now and repeat the above steps.\r\n5. Your changes should be retained on the alert page and there should\r\nnot be any error.","sha":"b7ca7228315393c6672f638982dbac5196c9ad90"}},"sourceBranch":"main","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/200058","number":200058,"mergeCommit":{"message":"[Security Solution] Migration of Alert Page controls for non-default Spaces. (#200058)\n\n## Summary\r\n\r\nRecently, we created a PR to migrate the alert page filters controls to\r\n`8.16`. Unfortunately, it does not do migration for non-default spaces\r\nso any users upgrading to `8.16` will face the issue where Alert page\r\nerrors out as shown in below screenshot.\r\n\r\n\r\n![grafik](https://github.com/user-attachments/assets/ffee1c2d-4aa2-44a4-96c9-68053fb1cf63)\r\n\r\n\r\n## Desk Testing\r\n\r\n1. Checkout to `v8.15` branch by running `git checkout 8.15`. \r\n2. Create a new space and go to that space.\r\n3. Go to the alert page and do some modifications to the page controls.\r\nThis store `v8.15` page controls in local storage.\r\n    - You can, for example, delete one page control.\r\n    - Change selected value for one page control.\r\n    - Additionally, you can also add a custom control.\r\n4. Checkout `main` now and repeat the above steps.\r\n5. Your changes should be retained on the alert page and there should\r\nnot be any error.","sha":"b7ca7228315393c6672f638982dbac5196c9ad90"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/200093","number":200093,"state":"MERGED","mergeCommit":{"sha":"255086dc66b19be0f879f5797660f3ddf1339d93","message":"[8.x] [Security Solution] Migration of Alert Page controls for non-default Spaces. (#200058) (#200093)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Security Solution] Migration of Alert Page controls for non-default\nSpaces. (#200058)](https://github.com/elastic/kibana/pull/200058)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jatin\nKathuria\",\"email\":\"jatin.kathuria@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-11-13T20:52:00Z\",\"message\":\"[Security\nSolution] Migration of Alert Page controls for non-default Spaces.\n(#200058)\\n\\n## Summary\\r\\n\\r\\nRecently, we created a PR to migrate the\nalert page filters controls to\\r\\n`8.16`. Unfortunately, it does not do\nmigration for non-default spaces\\r\\nso any users upgrading to `8.16`\nwill face the issue where Alert page\\r\\nerrors out as shown in below\nscreenshot.\\r\\n\\r\\n\\r\\n![grafik](https://github.com/user-attachments/assets/ffee1c2d-4aa2-44a4-96c9-68053fb1cf63)\\r\\n\\r\\n\\r\\n##\nDesk Testing\\r\\n\\r\\n1. Checkout to `v8.15` branch by running `git\ncheckout 8.15`. \\r\\n2. Create a new space and go to that space.\\r\\n3. Go\nto the alert page and do some modifications to the page\ncontrols.\\r\\nThis store `v8.15` page controls in local storage.\\r\\n -\nYou can, for example, delete one page control.\\r\\n - Change selected\nvalue for one page control.\\r\\n - Additionally, you can also add a\ncustom control.\\r\\n4. Checkout `main` now and repeat the above\nsteps.\\r\\n5. Your changes should be retained on the alert page and there\nshould\\r\\nnot be any\nerror.\",\"sha\":\"b7ca7228315393c6672f638982dbac5196c9ad90\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"Team:Threat\nHunting:Investigations\",\"backport:prev-minor\"],\"title\":\"[Security\nSolution] Migration of Alert Page controls for non-default\nSpaces.\",\"number\":200058,\"url\":\"https://github.com/elastic/kibana/pull/200058\",\"mergeCommit\":{\"message\":\"[Security\nSolution] Migration of Alert Page controls for non-default Spaces.\n(#200058)\\n\\n## Summary\\r\\n\\r\\nRecently, we created a PR to migrate the\nalert page filters controls to\\r\\n`8.16`. Unfortunately, it does not do\nmigration for non-default spaces\\r\\nso any users upgrading to `8.16`\nwill face the issue where Alert page\\r\\nerrors out as shown in below\nscreenshot.\\r\\n\\r\\n\\r\\n![grafik](https://github.com/user-attachments/assets/ffee1c2d-4aa2-44a4-96c9-68053fb1cf63)\\r\\n\\r\\n\\r\\n##\nDesk Testing\\r\\n\\r\\n1. Checkout to `v8.15` branch by running `git\ncheckout 8.15`. \\r\\n2. Create a new space and go to that space.\\r\\n3. Go\nto the alert page and do some modifications to the page\ncontrols.\\r\\nThis store `v8.15` page controls in local storage.\\r\\n -\nYou can, for example, delete one page control.\\r\\n - Change selected\nvalue for one page control.\\r\\n - Additionally, you can also add a\ncustom control.\\r\\n4. Checkout `main` now and repeat the above\nsteps.\\r\\n5. Your changes should be retained on the alert page and there\nshould\\r\\nnot be any\nerror.\",\"sha\":\"b7ca7228315393c6672f638982dbac5196c9ad90\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/200058\",\"number\":200058,\"mergeCommit\":{\"message\":\"[Security\nSolution] Migration of Alert Page controls for non-default Spaces.\n(#200058)\\n\\n## Summary\\r\\n\\r\\nRecently, we created a PR to migrate the\nalert page filters controls to\\r\\n`8.16`. Unfortunately, it does not do\nmigration for non-default spaces\\r\\nso any users upgrading to `8.16`\nwill face the issue where Alert page\\r\\nerrors out as shown in below\nscreenshot.\\r\\n\\r\\n\\r\\n![grafik](https://github.com/user-attachments/assets/ffee1c2d-4aa2-44a4-96c9-68053fb1cf63)\\r\\n\\r\\n\\r\\n##\nDesk Testing\\r\\n\\r\\n1. Checkout to `v8.15` branch by running `git\ncheckout 8.15`. \\r\\n2. Create a new space and go to that space.\\r\\n3. Go\nto the alert page and do some modifications to the page\ncontrols.\\r\\nThis store `v8.15` page controls in local storage.\\r\\n -\nYou can, for example, delete one page control.\\r\\n - Change selected\nvalue for one page control.\\r\\n - Additionally, you can also add a\ncustom control.\\r\\n4. Checkout `main` now and repeat the above\nsteps.\\r\\n5. Your changes should be retained on the alert page and there\nshould\\r\\nnot be any\nerror.\",\"sha\":\"b7ca7228315393c6672f638982dbac5196c9ad90\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Jatin Kathuria <jatin.kathuria@elastic.co>"}},{"branch":"8.16","label":"v8.16.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->