### PR TITLE
[CI] Fix on-merge pipeline syntax

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -502,7 +502,7 @@ steps:
       machineType: n2-standard-2
       preemptible: true
     timeout_in_minutes: 60
-    continue_on_failure: true
+    soft_fail: true
     retry:
       automatic:
         - exit_status: '-1'


### PR DESCRIPTION
## Summary

use soft_fail instead of continue_on_failure, as this setting doesn't exist on command steps (https://buildkite.com/docs/pipelines/command-step) - introduced in https://github.com/elastic/kibana/pull/197482


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->