### PR TITLE
[8.x] [One Discover] Add app menu actions for Observability projects (#198987)

### DIFF
--- a/src/plugins/discover/kibana.jsonc
+++ b/src/plugins/discover/kibana.jsonc
@@ -15,6 +15,7 @@
       "charts",
       "data",
       "dataViews",
+      "discoverShared",
       "embeddable",
       "inspector",
       "fieldFormats",
@@ -30,7 +31,7 @@
       "unifiedDocViewer",
       "unifiedSearch",
       "unifiedHistogram",
-      "contentManagement"
+      "contentManagement",
     ],
     "optionalPlugins": [
       "dataVisualizer",
@@ -46,7 +47,7 @@
       "observabilityAIAssistant",
       "aiops",
       "fieldsMetadata",
-      "logsDataAccess"
+      "logsDataAccess",
     ],
     "requiredBundles": [
       "kibanaUtils",

--- a/src/plugins/discover/public/build_services.ts
+++ b/src/plugins/discover/public/build_services.ts
@@ -59,6 +59,7 @@ import type { AiopsPluginStart } from '@kbn/aiops-plugin/public';
 import type { DataVisualizerPluginStart } from '@kbn/data-visualizer-plugin/public';
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/public';
+import { DiscoverSharedPublicStart } from '@kbn/discover-shared-plugin/public';
 import type { DiscoverStartPlugins } from './types';
 import type { DiscoverContextAppLocator } from './application/context/services/locator';
 import type { DiscoverSingleDocLocator } from './application/doc/locator';
@@ -89,6 +90,7 @@ export interface DiscoverServices {
   chrome: ChromeStart;
   core: CoreStart;
   data: DataPublicPluginStart;
+  discoverShared: DiscoverSharedPublicStart;
   docLinks: DocLinksStart;
   embeddable: EmbeddableStart;
   history: History<HistoryLocationState>;
@@ -178,6 +180,7 @@ export const buildServices = memoize(
       core,
       data: plugins.data,
       dataVisualizer: plugins.dataVisualizer,
+      discoverShared: plugins.discoverShared,
       docLinks: core.docLinks,
       embeddable: plugins.embeddable,
       i18n: core.i18n,

--- a/src/plugins/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_app_menu.ts
+++ b/src/plugins/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/get_app_menu.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { AppMenuActionId, AppMenuActionType, AppMenuRegistry } from '@kbn/discover-utils';
+import { DATA_QUALITY_LOCATOR_ID, DataQualityLocatorParams } from '@kbn/deeplinks-observability';
+import { OBSERVABILITY_THRESHOLD_RULE_TYPE_ID } from '@kbn/rule-data-utils';
+import { isOfQueryType } from '@kbn/es-query';
+import { i18n } from '@kbn/i18n';
+import { AppMenuExtensionParams } from '../../../..';
+import type { RootProfileProvider } from '../../../../profiles';
+import { ProfileProviderServices } from '../../../profile_provider_services';
+
+export const createGetAppMenu =
+  (services: ProfileProviderServices): RootProfileProvider['profile']['getAppMenu'] =>
+  (prev) =>
+  (params) => {
+    const prevValue = prev(params);
+
+    return {
+      appMenuRegistry: (registry) => {
+        // Register custom link actions
+        registerDatasetQualityLink(registry, services);
+        // Register alerts sub menu actions
+        registerCreateSLOAction(registry, services, params);
+        registerCustomThresholdRuleAction(registry, services, params);
+
+        return prevValue.appMenuRegistry(registry);
+      },
+    };
+  };
+
+const registerDatasetQualityLink = (
+  registry: AppMenuRegistry,
+  { share, timefilter }: ProfileProviderServices
+) => {
+  const dataQualityLocator =
+    share?.url.locators.get<DataQualityLocatorParams>(DATA_QUALITY_LOCATOR_ID);
+
+  if (dataQualityLocator) {
+    registry.registerCustomAction({
+      id: 'dataset-quality-link',
+      type: AppMenuActionType.custom,
+      controlProps: {
+        label: i18n.translate('discover.observabilitySolution.appMenu.datasets', {
+          defaultMessage: 'Data sets',
+        }),
+        testId: 'discoverAppMenuDatasetQualityLink',
+        onClick: ({ onFinishAction }) => {
+          const refresh = timefilter.getRefreshInterval();
+          const { from, to } = timefilter.getTime();
+
+          dataQualityLocator.navigate({
+            filters: {
+              timeRange: {
+                from: from ?? 'now-24h',
+                to: to ?? 'now',
+                refresh,
+              },
+            },
+          });
+
+          onFinishAction();
+        },
+      },
+    });
+  }
+};
+
+const registerCustomThresholdRuleAction = (
+  registry: AppMenuRegistry,
+  { data, triggersActionsUi }: ProfileProviderServices,
+  { dataView }: AppMenuExtensionParams
+) => {
+  registry.registerCustomActionUnderSubmenu(AppMenuActionId.alerts, {
+    id: AppMenuActionId.createRule,
+    type: AppMenuActionType.custom,
+    order: 101,
+    controlProps: {
+      label: i18n.translate('discover.observabilitySolution.appMenu.customThresholdRule', {
+        defaultMessage: 'Create custom threshold rule',
+      }),
+      iconType: 'visGauge',
+      testId: 'discoverAppMenuCustomThresholdRule',
+      onClick: ({ onFinishAction }) => {
+        const index = dataView?.toMinimalSpec();
+        const { filters, query } = data.query.getState();
+
+        return triggersActionsUi.getAddRuleFlyout({
+          consumer: 'logs',
+          ruleTypeId: OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
+          canChangeTrigger: false,
+          initialValues: {
+            params: {
+              searchConfiguration: {
+                index,
+                query,
+                filter: filters,
+              },
+            },
+          },
+          onClose: onFinishAction,
+        });
+      },
+    },
+  });
+};
+
+const registerCreateSLOAction = (
+  registry: AppMenuRegistry,
+  { data, discoverShared }: ProfileProviderServices,
+  { dataView, isEsqlMode }: AppMenuExtensionParams
+) => {
+  const sloFeature = discoverShared.features.registry.getById('observability-create-slo');
+
+  if (sloFeature) {
+    registry.registerCustomActionUnderSubmenu(AppMenuActionId.alerts, {
+      id: 'create-slo',
+      type: AppMenuActionType.custom,
+      order: 102,
+      controlProps: {
+        label: i18n.translate('discover.observabilitySolution.appMenu.slo', {
+          defaultMessage: 'Create SLO',
+        }),
+        iconType: 'bell',
+        testId: 'discoverAppMenuCreateSlo',
+        onClick: ({ onFinishAction }) => {
+          const index = dataView?.getIndexPattern();
+          const timestampField = dataView?.timeFieldName;
+          const { filters, query: kqlQuery } = data.query.getState();
+
+          const filter = isEsqlMode
+            ? {}
+            : {
+                kqlQuery: isOfQueryType(kqlQuery) ? kqlQuery.query : '',
+                filters: filters?.map(({ meta, query }) => ({ meta, query })),
+              };
+
+          return sloFeature.createSLOFlyout({
+            initialValues: {
+              indicator: {
+                type: 'sli.kql.custom',
+                params: {
+                  index,
+                  timestampField,
+                  filter,
+                },
+              },
+            },
+            onClose: onFinishAction,
+          });
+        },
+      },
+    });
+  }
+};

--- a/src/plugins/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/index.ts
+++ b/src/plugins/discover/public/context_awareness/profile_providers/observability/observability_root_profile/accessors/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { createGetAppMenu } from './get_app_menu';

--- a/src/plugins/discover/public/context_awareness/profile_providers/observability/observability_root_profile/index.ts
+++ b/src/plugins/discover/public/context_awareness/profile_providers/observability/observability_root_profile/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { createObservabilityRootProfileProvider } from './profile';

--- a/src/plugins/discover/public/context_awareness/profile_providers/observability/observability_root_profile/profile.test.ts
+++ b/src/plugins/discover/public/context_awareness/profile_providers/observability/observability_root_profile/profile.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { SolutionType } from '../../../profiles';
+import { createContextAwarenessMocks } from '../../../__mocks__';
+import { createObservabilityRootProfileProvider } from './profile';
+
+const mockServices = createContextAwarenessMocks().profileProviderServices;
+
+describe('observabilityRootProfileProvider', () => {
+  const observabilityRootProfileProvider = createObservabilityRootProfileProvider(mockServices);
+  const RESOLUTION_MATCH = {
+    isMatch: true,
+    context: { solutionType: SolutionType.Observability },
+  };
+  const RESOLUTION_MISMATCH = {
+    isMatch: false,
+  };
+
+  it('should match when the solution project is observability', () => {
+    expect(
+      observabilityRootProfileProvider.resolve({
+        solutionNavId: SolutionType.Observability,
+      })
+    ).toEqual(RESOLUTION_MATCH);
+  });
+
+  it('should NOT match when the solution project anything but observability', () => {
+    expect(
+      observabilityRootProfileProvider.resolve({
+        solutionNavId: SolutionType.Default,
+      })
+    ).toEqual(RESOLUTION_MISMATCH);
+    expect(
+      observabilityRootProfileProvider.resolve({
+        solutionNavId: SolutionType.Search,
+      })
+    ).toEqual(RESOLUTION_MISMATCH);
+    expect(
+      observabilityRootProfileProvider.resolve({
+        solutionNavId: SolutionType.Security,
+      })
+    ).toEqual(RESOLUTION_MISMATCH);
+  });
+});

--- a/src/plugins/discover/public/context_awareness/profile_providers/observability/observability_root_profile/profile.tsx
+++ b/src/plugins/discover/public/context_awareness/profile_providers/observability/observability_root_profile/profile.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { RootProfileProvider, SolutionType } from '../../../profiles';
+import { ProfileProviderServices } from '../../profile_provider_services';
+import { createGetAppMenu } from './accessors';
+
+export const createObservabilityRootProfileProvider = (
+  services: ProfileProviderServices
+): RootProfileProvider => ({
+  profileId: 'observability-root-profile',
+  profile: {
+    getAppMenu: createGetAppMenu(services),
+  },
+  resolve: (params) => {
+    if (params.solutionNavId === SolutionType.Observability) {
+      return { isMatch: true, context: { solutionType: SolutionType.Observability } };
+    }
+
+    return { isMatch: false };
+  },
+});

--- a/src/plugins/discover/public/context_awareness/profile_providers/register_profile_providers.ts
+++ b/src/plugins/discover/public/context_awareness/profile_providers/register_profile_providers.ts
@@ -27,6 +27,7 @@ import {
   ProfileProviderServices,
 } from './profile_provider_services';
 import type { DiscoverServices } from '../../build_services';
+import { createObservabilityRootProfileProvider } from './observability/observability_root_profile';
 
 /**
  * Register profile providers for root, data source, and document contexts to the profile profile services
@@ -122,6 +123,7 @@ const createRootProfileProviders = (providerServices: ProfileProviderServices) =
   createExampleRootProfileProvider(),
   createExampleSolutionViewRootProfileProvider(),
   createSecurityRootProfileProvider(providerServices),
+  createObservabilityRootProfileProvider(providerServices),
 ];
 
 /**

--- a/src/plugins/discover/public/types.ts
+++ b/src/plugins/discover/public/types.ts
@@ -42,6 +42,7 @@ import type { AiopsPluginStart } from '@kbn/aiops-plugin/public';
 import type { DataVisualizerPluginStart } from '@kbn/data-visualizer-plugin/public';
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import type { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/public';
+import { DiscoverSharedPublicStart } from '@kbn/discover-shared-plugin/public';
 import { DiscoverAppLocator } from '../common';
 import { DiscoverCustomizationContext } from './customizations';
 import { type DiscoverContainerProps } from './components/discover_container';
@@ -151,6 +152,7 @@ export interface DiscoverStartPlugins {
   dataViewFieldEditor: IndexPatternFieldEditorStart;
   dataViews: DataViewsServicePublic;
   dataVisualizer?: DataVisualizerPluginStart;
+  discoverShared: DiscoverSharedPublicStart;
   embeddable: EmbeddableStart;
   expressions: ExpressionsStart;
   fieldFormats: FieldFormatsStart;

--- a/src/plugins/discover/tsconfig.json
+++ b/src/plugins/discover/tsconfig.json
@@ -98,7 +98,8 @@
     "@kbn/logs-data-access-plugin",
     "@kbn/core-lifecycle-browser",
     "@kbn/discover-contextual-components",
-    "@kbn/esql-ast"
+    "@kbn/esql-ast",
+    "@kbn/discover-shared-plugin"
   ],
   "exclude": [
     "target/**/*"

--- a/src/plugins/discover_shared/public/services/discover_features/types.ts
+++ b/src/plugins/discover_shared/public/services/discover_features/types.ts
@@ -30,8 +30,16 @@ export interface ObservabilityLogsAIAssistantFeature {
   render: (deps: ObservabilityLogsAIAssistantFeatureRenderDeps) => JSX.Element;
 }
 
+export interface ObservabilityCreateSLOFeature {
+  id: 'observability-create-slo';
+  createSLOFlyout: (props: {
+    onClose: () => void;
+    initialValues: Record<string, unknown>;
+  }) => React.ReactNode;
+}
+
 // This should be a union of all the available client features.
-export type DiscoverFeature = ObservabilityLogsAIAssistantFeature;
+export type DiscoverFeature = ObservabilityLogsAIAssistantFeature | ObservabilityCreateSLOFeature;
 
 /**
  * Service types

--- a/x-pack/plugins/observability_solution/slo/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/slo/kibana.jsonc
@@ -22,6 +22,7 @@
       "dashboard",
       "data",
       "dataViews",
+      "discoverShared",
       "lens",
       "dataViewEditor",
       "dataViewFieldEditor",

--- a/x-pack/plugins/observability_solution/slo/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/slo/public/plugin.ts
@@ -176,17 +176,25 @@ export class SloPlugin
 
   public start(coreStart: CoreStart, pluginsStart: SloPublicPluginsStart) {
     const kibanaVersion = this.initContext.env.packageInfo.version;
+
+    const getCreateSLOFlyout = getCreateSLOFlyoutLazy({
+      core: coreStart,
+      isDev: this.initContext.env.mode.dev,
+      kibanaVersion,
+      observabilityRuleTypeRegistry: pluginsStart.observability.observabilityRuleTypeRegistry,
+      ObservabilityPageTemplate: pluginsStart.observabilityShared.navigation.PageTemplate,
+      plugins: pluginsStart,
+      isServerless: !!pluginsStart.serverless,
+      experimentalFeatures: this.experimentalFeatures,
+    })
+
+    pluginsStart.discoverShared.features.registry.register({
+      id: 'observability-create-slo',
+      createSLOFlyout: getCreateSLOFlyout,
+    });
+
     return {
-      getCreateSLOFlyout: getCreateSLOFlyoutLazy({
-        core: coreStart,
-        isDev: this.initContext.env.mode.dev,
-        kibanaVersion,
-        observabilityRuleTypeRegistry: pluginsStart.observability.observabilityRuleTypeRegistry,
-        ObservabilityPageTemplate: pluginsStart.observabilityShared.navigation.PageTemplate,
-        plugins: pluginsStart,
-        isServerless: !!pluginsStart.serverless,
-        experimentalFeatures: this.experimentalFeatures,
-      }),
+      getCreateSLOFlyout,
     };
   }
 

--- a/x-pack/plugins/observability_solution/slo/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/slo/public/plugin.ts
@@ -186,7 +186,7 @@ export class SloPlugin
       plugins: pluginsStart,
       isServerless: !!pluginsStart.serverless,
       experimentalFeatures: this.experimentalFeatures,
-    })
+    });
 
     pluginsStart.discoverShared.features.registry.register({
       id: 'observability-create-slo',

--- a/x-pack/plugins/observability_solution/slo/public/types.ts
+++ b/x-pack/plugins/observability_solution/slo/public/types.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { DiscoverSharedPublicStart } from '@kbn/discover-shared-plugin/public';
 import {
   ObservabilityPublicSetup,
   ObservabilityPublicStart,
@@ -70,6 +71,7 @@ export interface SloPublicPluginsStart {
   cloud?: CloudStart;
   dashboard: DashboardStart;
   dataViewEditor: DataViewEditorStart;
+  discoverShared: DiscoverSharedPublicStart;
   fieldFormats: FieldFormatsStart;
   observability: ObservabilityPublicStart;
   observabilityShared: ObservabilitySharedPluginStart;

--- a/x-pack/plugins/observability_solution/slo/tsconfig.json
+++ b/x-pack/plugins/observability_solution/slo/tsconfig.json
@@ -95,6 +95,7 @@
     "@kbn/core-application-browser",
     "@kbn/core-theme-browser",
     "@kbn/ebt-tools",
-    "@kbn/observability-alerting-rule-utils"
+    "@kbn/observability-alerting-rule-utils",
+    "@kbn/discover-shared-plugin"
   ]
 }

--- a/x-pack/test_serverless/functional/test_suites/common/discover_ml_uptime/discover/search_source_alert.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover_ml_uptime/discover/search_source_alert.ts
@@ -365,7 +365,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     expect(await titleElem.getAttribute('value')).to.equal(dataView);
   };
 
-  describe('Search source Alert', () => {
+  describe('Search source Alert', function () {
+    // see details: https://github.com/elastic/kibana/issues/193842
+    this.tags(['failsOnMKI', 'skipSvlOblt']);
     before(async () => {
       await security.testUser.setRoles(['discover_alert']);
       await PageObjects.svlCommonPage.loginAsAdmin();

--- a/x-pack/test_serverless/functional/test_suites/observability/discover/context_awareness/_get_app_menu.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/discover/context_awareness/_get_app_menu.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import kbnRison from '@kbn/rison';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const { common, svlCommonPage } = getPageObjects([
+    'common',
+    'timePicker',
+    'discover',
+    'header',
+    'timePicker',
+    'svlCommonPage',
+  ]);
+  const browser = getService('browser');
+  const esArchiver = getService('esArchiver');
+  const retry = getService('retry');
+  const testSubjects = getService('testSubjects');
+
+  describe('extension getAppMenu', () => {
+    before(async () => {
+      await svlCommonPage.loginAsAdmin();
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
+    });
+
+    after(async () => {
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
+    });
+
+    beforeEach(async () => {
+      const state = kbnRison.encode({
+        dataSource: { type: 'esql' },
+        query: { esql: 'from logstash* | sort @timestamp desc' },
+      });
+      await common.navigateToActualUrl('discover', `?_a=${state}`, {
+        ensureCurrentUrl: false,
+      });
+    });
+
+    it('should display a "Add data" link to navigate to the onboading page', async () => {
+      const link = await testSubjects.find('discoverAppMenuDatasetQualityLink');
+      await link.click();
+
+      await retry.try(async () => {
+        const url = await browser.getCurrentUrl();
+        expect(url).to.contain(`/app/management/data/data_quality`);
+      });
+    });
+
+    it('should display a "Create custom threshold rule" action under the Alerts menu to create an o11y alert', async () => {
+      const alertsButton = await testSubjects.find('discoverAlertsButton');
+      await alertsButton.click();
+
+      const createRuleButton = await testSubjects.find('discoverAppMenuCustomThresholdRule');
+      await createRuleButton.click();
+
+      const ruleTitleElement = await testSubjects.find('selectedRuleTypeTitle');
+
+      await retry.try(async () => {
+        expect(await ruleTitleElement.getVisibleText()).to.equal('Custom threshold');
+      });
+    });
+
+    it('should display a "Create SLO" action under the Alerts menu to create an o11y alert', async () => {
+      const alertsButton = await testSubjects.find('discoverAlertsButton');
+      await alertsButton.click();
+
+      const createSLOButton = await testSubjects.find('discoverAppMenuCreateSlo');
+      await createSLOButton.click();
+
+      const sloTitleElement = await testSubjects.find('addSLOFlyoutTitle');
+      expect(await sloTitleElement.getVisibleText()).to.equal('Create SLO');
+    });
+  });
+}

--- a/x-pack/test_serverless/functional/test_suites/observability/discover/context_awareness/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/discover/context_awareness/index.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ getService, getPageObjects, loadTestFile }: FtrProviderContext) {
+  const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
+  const PageObjects = getPageObjects(['timePicker', 'svlCommonPage']);
+  const from = '2024-06-10T14:00:00.000Z';
+  const to = '2024-06-10T16:30:00.000Z';
+
+  describe('discover/observabilitySolution/context_awareness', function () {
+    this.tags(['esGate']);
+
+    before(async () => {
+      await esArchiver.load('test/functional/fixtures/es_archiver/discover/context_awareness');
+      await kibanaServer.importExport.load(
+        'test/functional/fixtures/kbn_archiver/discover/context_awareness'
+      );
+      await kibanaServer.uiSettings.update({
+        'timepicker:timeDefaults': `{ "from": "${from}", "to": "${to}"}`,
+      });
+    });
+
+    after(async () => {
+      await esArchiver.unload('test/functional/fixtures/es_archiver/discover/context_awareness');
+      await kibanaServer.importExport.unload(
+        'test/functional/fixtures/kbn_archiver/discover/context_awareness'
+      );
+      await PageObjects.timePicker.resetDefaultAbsoluteRangeViaUiSettings();
+    });
+
+    loadTestFile(require.resolve('./_get_app_menu'));
+  });
+}

--- a/x-pack/test_serverless/functional/test_suites/observability/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/index.ts
@@ -15,6 +15,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./navigation'));
     loadTestFile(require.resolve('./observability_logs_explorer'));
     loadTestFile(require.resolve('./dataset_quality'));
+    loadTestFile(require.resolve('./discover/context_awareness'));
     loadTestFile(require.resolve('./onboarding'));
     loadTestFile(require.resolve('./rules/rules_list'));
     loadTestFile(require.resolve('./cases'));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[One Discover] Add app menu actions for Observability projects (#198987)](https://github.com/elastic/kibana/pull/198987)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Marco Antonio Ghiani","email":"marcoantonio.ghiani01@gmail.com"},"sourceCommit":{"committedDate":"2024-11-14T10:00:38Z","message":"[One Discover] Add app menu actions for Observability projects (#198987)\n\n## 📓 Summary\r\n\r\nCloses #182230 \r\n\r\nThis work introduces a new observability root profile and uses the new\r\nextension point to register custom actions on the app menu.\r\nThe registered actions and link will appear only with the new project\r\nnavigation enabled on an Observability project:\r\n- A link to the data sets quality page\r\n- On the alerts sub menu...\r\n- replace the default search rule creation with the observability custom\r\nthreshold rule\r\n  - add an entry to directly create an SLO for the current search\r\n\r\nTo access the SLO capabilities without breaking the dependencies\r\nhierarchy of the new sustainable architecture, the feature is registered\r\nby the common plugin `discover-shared` in SLO and consumed then by\r\nDiscover using the IoC principle.\r\n\r\n## 🖼️ Screenshots\r\n\r\n### Observability project solution - show new menu\r\n\r\n<img width=\"3004\" alt=\"Screenshot 2024-11-06 at 12 37 02\"\r\nsrc=\"https://github.com/user-attachments/assets/d70b532d-1889-4d5b-b2ee-de2f048560f4\">\r\n\r\n### Search project solution - hide new menu\r\n\r\n<img width=\"3006\" alt=\"Screenshot 2024-11-06 at 12 36 19\"\r\nsrc=\"https://github.com/user-attachments/assets/660893c3-f6b5-4b06-b8de-50a61a6bdb98\">\r\n\r\n### Default navigation mode - hide new menu\r\n\r\n<img width=\"3002\" alt=\"Screenshot 2024-11-06 at 12 35 43\"\r\nsrc=\"https://github.com/user-attachments/assets/674c5a08-0084-40e5-ae34-a56c363cacce\">\r\n\r\n## 🎥  Demo\r\n\r\n\r\nhttps://github.com/user-attachments/assets/104e6074-0401-4fd2-a8e6-8b05f2c070d7\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9d38922401d0bbd0d95d750f68fec77ca22758fb","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor","ci:project-deploy-observability","Team:obs-ux-logs","Team:obs-ux-management","Project:OneDiscover"],"number":198987,"url":"https://github.com/elastic/kibana/pull/198987","mergeCommit":{"message":"[One Discover] Add app menu actions for Observability projects (#198987)\n\n## 📓 Summary\r\n\r\nCloses #182230 \r\n\r\nThis work introduces a new observability root profile and uses the new\r\nextension point to register custom actions on the app menu.\r\nThe registered actions and link will appear only with the new project\r\nnavigation enabled on an Observability project:\r\n- A link to the data sets quality page\r\n- On the alerts sub menu...\r\n- replace the default search rule creation with the observability custom\r\nthreshold rule\r\n  - add an entry to directly create an SLO for the current search\r\n\r\nTo access the SLO capabilities without breaking the dependencies\r\nhierarchy of the new sustainable architecture, the feature is registered\r\nby the common plugin `discover-shared` in SLO and consumed then by\r\nDiscover using the IoC principle.\r\n\r\n## 🖼️ Screenshots\r\n\r\n### Observability project solution - show new menu\r\n\r\n<img width=\"3004\" alt=\"Screenshot 2024-11-06 at 12 37 02\"\r\nsrc=\"https://github.com/user-attachments/assets/d70b532d-1889-4d5b-b2ee-de2f048560f4\">\r\n\r\n### Search project solution - hide new menu\r\n\r\n<img width=\"3006\" alt=\"Screenshot 2024-11-06 at 12 36 19\"\r\nsrc=\"https://github.com/user-attachments/assets/660893c3-f6b5-4b06-b8de-50a61a6bdb98\">\r\n\r\n### Default navigation mode - hide new menu\r\n\r\n<img width=\"3002\" alt=\"Screenshot 2024-11-06 at 12 35 43\"\r\nsrc=\"https://github.com/user-attachments/assets/674c5a08-0084-40e5-ae34-a56c363cacce\">\r\n\r\n## 🎥  Demo\r\n\r\n\r\nhttps://github.com/user-attachments/assets/104e6074-0401-4fd2-a8e6-8b05f2c070d7\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9d38922401d0bbd0d95d750f68fec77ca22758fb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/198987","number":198987,"mergeCommit":{"message":"[One Discover] Add app menu actions for Observability projects (#198987)\n\n## 📓 Summary\r\n\r\nCloses #182230 \r\n\r\nThis work introduces a new observability root profile and uses the new\r\nextension point to register custom actions on the app menu.\r\nThe registered actions and link will appear only with the new project\r\nnavigation enabled on an Observability project:\r\n- A link to the data sets quality page\r\n- On the alerts sub menu...\r\n- replace the default search rule creation with the observability custom\r\nthreshold rule\r\n  - add an entry to directly create an SLO for the current search\r\n\r\nTo access the SLO capabilities without breaking the dependencies\r\nhierarchy of the new sustainable architecture, the feature is registered\r\nby the common plugin `discover-shared` in SLO and consumed then by\r\nDiscover using the IoC principle.\r\n\r\n## 🖼️ Screenshots\r\n\r\n### Observability project solution - show new menu\r\n\r\n<img width=\"3004\" alt=\"Screenshot 2024-11-06 at 12 37 02\"\r\nsrc=\"https://github.com/user-attachments/assets/d70b532d-1889-4d5b-b2ee-de2f048560f4\">\r\n\r\n### Search project solution - hide new menu\r\n\r\n<img width=\"3006\" alt=\"Screenshot 2024-11-06 at 12 36 19\"\r\nsrc=\"https://github.com/user-attachments/assets/660893c3-f6b5-4b06-b8de-50a61a6bdb98\">\r\n\r\n### Default navigation mode - hide new menu\r\n\r\n<img width=\"3002\" alt=\"Screenshot 2024-11-06 at 12 35 43\"\r\nsrc=\"https://github.com/user-attachments/assets/674c5a08-0084-40e5-ae34-a56c363cacce\">\r\n\r\n## 🎥  Demo\r\n\r\n\r\nhttps://github.com/user-attachments/assets/104e6074-0401-4fd2-a8e6-8b05f2c070d7\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"9d38922401d0bbd0d95d750f68fec77ca22758fb"}}]}] BACKPORT-->