### PR TITLE
[Security Solution] Fix Auto-grow behaviour of Filter Page Controls

### DIFF
--- a/packages/kbn-alerts-ui-shared/src/alert_filter_controls/constants.ts
+++ b/packages/kbn-alerts-ui-shared/src/alert_filter_controls/constants.ts
@@ -70,6 +70,7 @@ export const COMMON_OPTIONS_LIST_CONTROL_INPUTS: Partial<OptionsListControlState
   hideSort: true,
   placeholder: '',
   width: 'small',
+  grow: true,
 };
 
 export const TIMEOUTS = {


### PR DESCRIPTION
## Summary

PR : https://github.com/elastic/kibana/pull/199408 disables `auto` grow behaviour page filters controls which has been default behavior for some time. 

It causes issue on the page filters of Security and probably Observability as well since Page Filter controls do not grow anymore.

|Correct in 8.16| Broken in 8.17/9.0.0|
|---|---|
|![image](https://github.com/user-attachments/assets/cc120c75-971c-44e6-bd63-65e5193cc0e5)|![image](https://github.com/user-attachments/assets/9a83a75d-70e2-4543-b9db-d0cbee24a404)|  



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->