### PR TITLE
Enable cert validation on Fleet Server health check

### DIFF
--- a/x-pack/plugins/fleet/server/routes/health_check/index.ts
+++ b/x-pack/plugins/fleet/server/routes/health_check/index.ts
@@ -4,7 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import https from 'https';
 
 import type { TypeOf } from '@kbn/config-schema';
 import fetch from 'node-fetch';
@@ -83,9 +82,6 @@ export const postHealthCheckHandler: FleetRequestHandler<
         accept: '*/*',
       },
       method: 'GET',
-      agent: new https.Agent({
-        rejectUnauthorized: false,
-      }),
       signal: abortController.signal,
     });
     const bodyRes = await res.json();


### PR DESCRIPTION
## Summary

Manual backport of https://github.com/elastic/kibana/commit/6bfe8a7a9ee93ced88d182ba46d5632cf4ee5074 to 8.x

