### PR TITLE
[8.16] [Stack Monitoring / Logs] Fix Stack Monitoring logs links (#200043)

### DIFF
--- a/x-pack/plugins/monitoring/kibana.jsonc
+++ b/x-pack/plugins/monitoring/kibana.jsonc
@@ -15,7 +15,8 @@
       "observability",
       "observabilityShared",
       "dataViews",
-      "unifiedSearch"
+      "unifiedSearch",
+      "share"
     ],
     "optionalPlugins": [
       "infra",
@@ -30,6 +31,11 @@
       "dashboard",
       "fleet"
     ],
-    "requiredBundles": ["kibanaUtils", "alerting", "kibanaReact"]
+    "requiredBundles": [
+      "kibanaUtils",
+      "alerting",
+      "kibanaReact",
+      "logsShared"
+    ]
   }
 }

--- a/x-pack/plugins/monitoring/public/components/logs/logs.js
+++ b/x-pack/plugins/monitoring/public/components/logs/logs.js
@@ -10,11 +10,12 @@ import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import { upperFirst } from 'lodash';
 import { Legacy } from '../../legacy_shims';
 import { EuiBasicTable, EuiTitle, EuiSpacer, EuiText, EuiCallOut, EuiLink } from '@elastic/eui';
-import { INFRA_SOURCE_ID } from '../../../common/constants';
 import { formatDateTimeLocal } from '../../../common/formatting';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { Reason } from './reason';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { getLogsLocatorsFromUrlService } from '@kbn/logs-shared-plugin/common';
 
 const getFormattedDateTimeLocal = (timestamp) => {
   const timezone = Legacy.shims.uiSettings?.get('dateFormat:tz');
@@ -110,7 +111,7 @@ const clusterColumns = [
   },
 ];
 
-function getLogsUiLink(clusterUuid, nodeId, indexUuid) {
+function getLogsUiLink(clusterUuid, nodeId, indexUuid, sharePlugin) {
   const params = [];
   if (clusterUuid) {
     params.push(`elasticsearch.cluster.uuid:${clusterUuid}`);
@@ -122,15 +123,23 @@ function getLogsUiLink(clusterUuid, nodeId, indexUuid) {
     params.push(`elasticsearch.index.name:${indexUuid}`);
   }
 
-  const base = Legacy.shims.infra.locators.logsLocator.getRedirectUrl({
-    logView: { logViewId: INFRA_SOURCE_ID, type: 'log-view-reference' },
-    ...(params.length ? { filter: params.join(' and ') } : {}),
+  const filter = params.join(' and ');
+  const { logsLocator } = getLogsLocatorsFromUrlService(sharePlugin.url);
+
+  const base = logsLocator.getRedirectUrl({
+    filter,
   });
 
   return base;
 }
 
-export class Logs extends PureComponent {
+export const Logs = (props) => {
+  const {
+    services: { share },
+  } = useKibana();
+  return <LogsContent sharePlugin={share} {...props} />;
+};
+export class LogsContent extends PureComponent {
   renderLogs() {
     const {
       logs: { enabled, logs },
@@ -165,7 +174,9 @@ export class Logs extends PureComponent {
       nodeId,
       clusterUuid,
       indexUuid,
+      sharePlugin,
     } = this.props;
+
     if (!enabled || !show) {
       return null;
     }
@@ -184,7 +195,7 @@ export class Logs extends PureComponent {
             defaultMessage="Visit {link} to dive deeper."
             values={{
               link: (
-                <EuiLink href={getLogsUiLink(clusterUuid, nodeId, indexUuid)}>
+                <EuiLink href={getLogsUiLink(clusterUuid, nodeId, indexUuid, sharePlugin)}>
                   {i18n.translate('xpack.monitoring.logs.listing.calloutLinkText', {
                     defaultMessage: 'Logs',
                   })}

--- a/x-pack/plugins/monitoring/public/components/logs/logs.test.js
+++ b/x-pack/plugins/monitoring/public/components/logs/logs.test.js
@@ -7,7 +7,18 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Logs } from './logs';
+import { LogsContent } from './logs';
+import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
+
+const sharePlugin = sharePluginMock.createStartContract();
+
+jest.mock('@kbn/logs-shared-plugin/common', () => {
+  return {
+    getLogsLocatorsFromUrlService: jest.fn().mockReturnValue({
+      logsLocator: { getRedirectUrl: jest.fn(() => '') },
+    }),
+  };
+});
 
 jest.mock('../../legacy_shims', () => ({
   Legacy: {
@@ -123,32 +134,40 @@ const logs = {
 
 describe('Logs', () => {
   it('should render normally', () => {
-    const component = shallow(<Logs logs={logs} />);
+    const component = shallow(<LogsContent sharePlugin={sharePlugin} logs={logs} />);
     expect(component).toMatchSnapshot();
   });
 
   it('should render fewer columns for node or index view', () => {
-    const component = shallow(<Logs logs={logs} nodeId="12345" />);
+    const component = shallow(<LogsContent sharePlugin={sharePlugin} logs={logs} nodeId="12345" />);
     expect(component.find('EuiBasicTable').prop('columns')).toMatchSnapshot();
   });
 
   it('should render a link to filter by cluster uuid', () => {
-    const component = shallow(<Logs logs={logs} clusterUuid="12345" />);
+    const component = shallow(
+      <LogsContent sharePlugin={sharePlugin} logs={logs} clusterUuid="12345" />
+    );
     expect(component.find('EuiCallOut')).toMatchSnapshot();
   });
 
   it('should render a link to filter by cluster uuid and node uuid', () => {
-    const component = shallow(<Logs logs={logs} clusterUuid="12345" nodeId="6789" />);
+    const component = shallow(
+      <LogsContent sharePlugin={sharePlugin} logs={logs} clusterUuid="12345" nodeId="6789" />
+    );
     expect(component.find('EuiCallOut')).toMatchSnapshot();
   });
 
   it('should render a link to filter by cluster uuid and index uuid', () => {
-    const component = shallow(<Logs logs={logs} clusterUuid="12345" indexUuid="6789" />);
+    const component = shallow(
+      <LogsContent sharePlugin={sharePlugin} logs={logs} clusterUuid="12345" indexUuid="6789" />
+    );
     expect(component.find('EuiCallOut')).toMatchSnapshot();
   });
 
   it('should render a reason if the logs are disabled', () => {
-    const component = shallow(<Logs logs={{ enabled: false, limit: 15, reason: {} }} />);
+    const component = shallow(
+      <LogsContent sharePlugin={sharePlugin} logs={{ enabled: false, limit: 15, reason: {} }} />
+    );
     expect(component).toMatchSnapshot();
   });
 });

--- a/x-pack/plugins/monitoring/public/plugin.ts
+++ b/x-pack/plugins/monitoring/public/plugin.ts
@@ -101,6 +101,7 @@ export class MonitoringPlugin
           element: params.element,
           core: coreStart,
           data: pluginsStart.data,
+          share: pluginsStart.share,
           isCloud: Boolean(plugins.cloud?.isCloudEnabled),
           pluginInitializerContext: this.initializerContext,
           externalConfig,
@@ -124,6 +125,7 @@ export class MonitoringPlugin
           appMountParameters: deps.appMountParameters,
           dataViews: deps.dataViews,
           infra: deps.infra,
+          share: deps.share,
         });
 
         const config = Object.fromEntries(externalConfig);

--- a/x-pack/plugins/monitoring/public/types.ts
+++ b/x-pack/plugins/monitoring/public/types.ts
@@ -16,6 +16,7 @@ import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { DashboardStart } from '@kbn/dashboard-plugin/public';
 import { FleetStart } from '@kbn/fleet-plugin/public';
 import type { InfraClientStartExports } from '@kbn/infra-plugin/public';
+import { SharePluginStart } from '@kbn/share-plugin/public';
 
 export interface MonitoringStartPluginDependencies {
   navigation: NavigationStart;
@@ -26,6 +27,7 @@ export interface MonitoringStartPluginDependencies {
   dashboard?: DashboardStart;
   fleet?: FleetStart;
   infra?: InfraClientStartExports;
+  share: SharePluginStart;
 }
 
 interface LegacyStartDependencies {

--- a/x-pack/plugins/monitoring/tsconfig.json
+++ b/x-pack/plugins/monitoring/tsconfig.json
@@ -49,6 +49,7 @@
     "@kbn/flot-charts",
     "@kbn/ui-theme",
     "@kbn/core-elasticsearch-server",
+    "@kbn/share-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Stack Monitoring / Logs] Fix Stack Monitoring logs links (#200043)](https://github.com/elastic/kibana/pull/200043)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kerry Gallagher","email":"kerry.gallagher@elastic.co"},"sourceCommit":{"committedDate":"2024-11-14T17:26:24Z","message":"[Stack Monitoring / Logs] Fix Stack Monitoring logs links (#200043)\n\n## Summary\r\n\r\nFixes\r\nhttps://github.com/elastic/kibana/issues/199902#issuecomment-2474040264.\r\n\r\nThis was missed in https://github.com/elastic/kibana/pull/190835 due to\r\nStack Monitoring's lack of type checking in certain files. `infra` no\r\nlonger exposes `logsLocators`.\r\n\r\nThis uses `getLogsLocatorsFromUrlService`, technically we could go to\r\nDiscover now knowing that Logs Explorer will be deprecated in the\r\nfuture. But it will make more sense to convert\r\n`getLogsLocatorsFromUrlService` over to using the Discover locators in\r\none when that happens. This puts us on the same page as\r\nhttps://github.com/elastic/kibana/pull/190835.\r\n\r\nThis link should now work, and have the correct filters applied.\r\n\r\n![Screenshot 2024-11-13 at 16 09\r\n15](https://github.com/user-attachments/assets/e1f8fd18-ac73-4179-af4c-1727a2afeeec)\r\n\r\n---------\r\n\r\nCo-authored-by: mohamedhamed-ahmed <mohamed.ahmed@elastic.co>","sha":"4e852ea041b63e3e3ad918ceee1bc3861dd1e519","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","ci:cloud-deploy","Team:obs-ux-logs","backport:version","v8.17.0","v8.16.1"],"number":200043,"url":"https://github.com/elastic/kibana/pull/200043","mergeCommit":{"message":"[Stack Monitoring / Logs] Fix Stack Monitoring logs links (#200043)\n\n## Summary\r\n\r\nFixes\r\nhttps://github.com/elastic/kibana/issues/199902#issuecomment-2474040264.\r\n\r\nThis was missed in https://github.com/elastic/kibana/pull/190835 due to\r\nStack Monitoring's lack of type checking in certain files. `infra` no\r\nlonger exposes `logsLocators`.\r\n\r\nThis uses `getLogsLocatorsFromUrlService`, technically we could go to\r\nDiscover now knowing that Logs Explorer will be deprecated in the\r\nfuture. But it will make more sense to convert\r\n`getLogsLocatorsFromUrlService` over to using the Discover locators in\r\none when that happens. This puts us on the same page as\r\nhttps://github.com/elastic/kibana/pull/190835.\r\n\r\nThis link should now work, and have the correct filters applied.\r\n\r\n![Screenshot 2024-11-13 at 16 09\r\n15](https://github.com/user-attachments/assets/e1f8fd18-ac73-4179-af4c-1727a2afeeec)\r\n\r\n---------\r\n\r\nCo-authored-by: mohamedhamed-ahmed <mohamed.ahmed@elastic.co>","sha":"4e852ea041b63e3e3ad918ceee1bc3861dd1e519"}},"sourceBranch":"main","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/200043","number":200043,"mergeCommit":{"message":"[Stack Monitoring / Logs] Fix Stack Monitoring logs links (#200043)\n\n## Summary\r\n\r\nFixes\r\nhttps://github.com/elastic/kibana/issues/199902#issuecomment-2474040264.\r\n\r\nThis was missed in https://github.com/elastic/kibana/pull/190835 due to\r\nStack Monitoring's lack of type checking in certain files. `infra` no\r\nlonger exposes `logsLocators`.\r\n\r\nThis uses `getLogsLocatorsFromUrlService`, technically we could go to\r\nDiscover now knowing that Logs Explorer will be deprecated in the\r\nfuture. But it will make more sense to convert\r\n`getLogsLocatorsFromUrlService` over to using the Discover locators in\r\none when that happens. This puts us on the same page as\r\nhttps://github.com/elastic/kibana/pull/190835.\r\n\r\nThis link should now work, and have the correct filters applied.\r\n\r\n![Screenshot 2024-11-13 at 16 09\r\n15](https://github.com/user-attachments/assets/e1f8fd18-ac73-4179-af4c-1727a2afeeec)\r\n\r\n---------\r\n\r\nCo-authored-by: mohamedhamed-ahmed <mohamed.ahmed@elastic.co>","sha":"4e852ea041b63e3e3ad918ceee1bc3861dd1e519"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/200227","number":200227,"state":"OPEN"},{"branch":"8.16","label":"v8.16.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->