### PR TITLE
[Dashboard] Only run setters on changed state on reset

### DIFF
--- a/packages/presentation/presentation_containers/interfaces/unsaved_changes/initialize_unsaved_changes.ts
+++ b/packages/presentation/presentation_containers/interfaces/unsaved_changes/initialize_unsaved_changes.ts
@@ -95,9 +95,12 @@ export const initializeUnsavedChanges = <RuntimeState extends {} = {}>(
       unsavedChanges,
       resetUnsavedChanges: () => {
         const lastSaved = lastSavedState$.getValue();
+        const unsavedChangesKeys = Object.keys(unsavedChanges.getValue() ?? {});
         for (const key of comparatorKeys) {
-          const setter = comparators[key][1]; // setter function is the 1st element of the tuple
-          setter(lastSaved?.[key] as RuntimeState[typeof key]);
+          if (key in unsavedChangesKeys) {
+            const setter = comparators[key][1]; // setter function is the 1st element of the tuple
+            setter(lastSaved?.[key] as RuntimeState[typeof key]);
+          }
         }
       },
       snapshotRuntimeState,


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/197870. 

The bug in #197870 was a side effect of the setter for `dynamicActionsState$` being called with an empty object whenever any unsaved changes were reset on the dashboard, even when drilldowns didn't change. This changes `resetUnsavedChanges` to only call the setters for the parts of dashboard state that had unsaved changes, so we don't unnecessarily alter parts of the embeddable state that didn't have any changes.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_node:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



