### PR TITLE
[8.16] [OpenAPI] Fix fleet filepath API parameter (#199538)

### DIFF
--- a/packages/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
+++ b/packages/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
@@ -228,7 +228,7 @@ OK response oas-test-version-2",
         "x-discontinued": "route discontinued version or date",
       },
     },
-    "/foo/{id}/{path*}": Object {
+    "/foo/{id}/{path}": Object {
       "delete": Object {
         "description": "route description",
         "operationId": "delete-foo-id-path",
@@ -570,7 +570,7 @@ OK response oas-test-version-2",
         ],
       },
     },
-    "/no-xsrf/{id}/{path*}": Object {
+    "/no-xsrf/{id}/{path}": Object {
       "post": Object {
         "operationId": "post-no-xsrf-id-path-2",
         "parameters": Array [

--- a/packages/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
+++ b/packages/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
@@ -151,7 +151,7 @@ export const sharedOas = {
         tags: ['versioned'],
       },
     },
-    '/foo/{id}/{path*}': {
+    '/foo/{id}/{path}': {
       get: {
         description: 'route description',
         operationId: 'get-foo-id-path',

--- a/packages/kbn-router-to-openapispec/src/generate_oas.test.ts
+++ b/packages/kbn-router-to-openapispec/src/generate_oas.test.ts
@@ -312,9 +312,9 @@ describe('generateOpenApiDocument', () => {
         }
       );
       // router paths
-      expect(result.paths['/1-1/{id}/{path*}']!.get!.tags).toEqual(['1', '2']);
-      expect(result.paths['/1-2/{id}/{path*}']!.get!.tags).toEqual(['1']);
-      expect(result.paths['/2-1/{id}/{path*}']!.get!.tags).toEqual([]);
+      expect(result.paths['/1-1/{id}/{path}']!.get!.tags).toEqual(['1', '2']);
+      expect(result.paths['/1-2/{id}/{path}']!.get!.tags).toEqual(['1']);
+      expect(result.paths['/2-1/{id}/{path}']!.get!.tags).toEqual([]);
       // versioned router paths
       expect(result.paths['/v1-1']!.get!.tags).toEqual(['v1']);
       expect(result.paths['/v1-2']!.get!.tags).toEqual(['v2', 'v3']);
@@ -390,17 +390,17 @@ describe('generateOpenApiDocument', () => {
       );
 
       // router paths
-      expect(result.paths['/1-1/{id}/{path*}']!.get).toMatchObject({
+      expect(result.paths['/1-1/{id}/{path}']!.get).toMatchObject({
         'x-state': 'Technical Preview',
       });
-      expect(result.paths['/1-2/{id}/{path*}']!.get).toMatchObject({
+      expect(result.paths['/1-2/{id}/{path}']!.get).toMatchObject({
         'x-state': 'Beta',
       });
 
-      expect(result.paths['/1-3/{id}/{path*}']!.get).not.toMatchObject({
+      expect(result.paths['/1-3/{id}/{path}']!.get).not.toMatchObject({
         'x-state': expect.any(String),
       });
-      expect(result.paths['/2-1/{id}/{path*}']!.get).not.toMatchObject({
+      expect(result.paths['/2-1/{id}/{path}']!.get).not.toMatchObject({
         'x-state': expect.any(String),
       });
 

--- a/packages/kbn-router-to-openapispec/src/util.test.ts
+++ b/packages/kbn-router-to-openapispec/src/util.test.ts
@@ -17,8 +17,9 @@ import {
   getPathParameters,
   createOpIdGenerator,
   GetOpId,
+  assignToPaths,
+  extractTags,
 } from './util';
-import { assignToPaths, extractTags } from './util';
 
 describe('extractTags', () => {
   test.each([
@@ -115,9 +116,11 @@ describe('assignToPaths', () => {
     const paths = {};
     assignToPaths(paths, '/foo', {});
     assignToPaths(paths, '/bar/{id?}', {});
+    assignToPaths(paths, '/bar/file/{path*}', {});
     expect(paths).toEqual({
       '/foo': {},
       '/bar/{id}': {},
+      '/bar/file/{path}': {},
     });
   });
 });
@@ -320,7 +323,7 @@ describe('createOpIdGenerator', () => {
     {
       input: {
         method: 'get',
-        path: '/api/my/resource/{path*}',
+        path: '/api/my/resource/{path}',
       },
       output: 'get-my-resource-path',
     },

--- a/packages/kbn-router-to-openapispec/src/util.ts
+++ b/packages/kbn-router-to-openapispec/src/util.ts
@@ -132,7 +132,7 @@ export const assignToPaths = (
   path: string,
   pathObject: OpenAPIV3.PathItemObject
 ): void => {
-  const pathName = path.replace('?', '');
+  const pathName = path.replace(/[\?\*]/, '');
   paths[pathName] = { ...paths[pathName], ...pathObject };
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[OpenAPI] Fix fleet filepath API parameter (#199538)](https://github.com/elastic/kibana/pull/199538)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2024-11-14T22:05:39Z","message":"[OpenAPI] Fix fleet filepath API parameter (#199538)","sha":"ba6ffec9e769669bce8a265cfb55fc142471fbe0","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","docs","backport:version","v8.17.0","v8.16.1"],"number":199538,"url":"https://github.com/elastic/kibana/pull/199538","mergeCommit":{"message":"[OpenAPI] Fix fleet filepath API parameter (#199538)","sha":"ba6ffec9e769669bce8a265cfb55fc142471fbe0"}},"sourceBranch":"main","suggestedTargetBranches":["8.x","8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/199538","number":199538,"mergeCommit":{"message":"[OpenAPI] Fix fleet filepath API parameter (#199538)","sha":"ba6ffec9e769669bce8a265cfb55fc142471fbe0"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.16","label":"v8.16.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->