### PR TITLE
[ResponseOps][Cases] Remove deprecated date format from telemetry

### DIFF
--- a/x-pack/plugins/cases/server/telemetry/queries/alerts.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/alerts.test.ts
@@ -62,6 +62,7 @@ describe('alerts', () => {
           counts: {
             date_range: {
               field: 'cases-comments.attributes.created_at',
+              format: 'dd/MM/yyyy',
               ranges: [
                 {
                   from: 'now-1d',

--- a/x-pack/plugins/cases/server/telemetry/queries/alerts.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/alerts.test.ts
@@ -62,7 +62,6 @@ describe('alerts', () => {
           counts: {
             date_range: {
               field: 'cases-comments.attributes.created_at',
-              format: 'dd/MM/YYYY',
               ranges: [
                 {
                   from: 'now-1d',

--- a/x-pack/plugins/cases/server/telemetry/queries/cases.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/cases.test.ts
@@ -469,7 +469,6 @@ describe('getCasesTelemetryData', () => {
                 "counts": Object {
                   "date_range": Object {
                     "field": "cases.attributes.created_at",
-                    "format": "dd/MM/YYYY",
                     "ranges": Array [
                       Object {
                         "from": "now-1d",
@@ -501,7 +500,6 @@ describe('getCasesTelemetryData', () => {
             "counts": Object {
               "date_range": Object {
                 "field": "cases.attributes.created_at",
-                "format": "dd/MM/YYYY",
                 "ranges": Array [
                   Object {
                     "from": "now-1d",
@@ -547,7 +545,6 @@ describe('getCasesTelemetryData', () => {
                 "counts": Object {
                   "date_range": Object {
                     "field": "cases.attributes.created_at",
-                    "format": "dd/MM/YYYY",
                     "ranges": Array [
                       Object {
                         "from": "now-1d",
@@ -605,7 +602,6 @@ describe('getCasesTelemetryData', () => {
                 "counts": Object {
                   "date_range": Object {
                     "field": "cases.attributes.created_at",
-                    "format": "dd/MM/YYYY",
                     "ranges": Array [
                       Object {
                         "from": "now-1d",

--- a/x-pack/plugins/cases/server/telemetry/queries/cases.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/cases.test.ts
@@ -469,6 +469,7 @@ describe('getCasesTelemetryData', () => {
                 "counts": Object {
                   "date_range": Object {
                     "field": "cases.attributes.created_at",
+                    "format": "dd/MM/yyyy",
                     "ranges": Array [
                       Object {
                         "from": "now-1d",
@@ -500,6 +501,7 @@ describe('getCasesTelemetryData', () => {
             "counts": Object {
               "date_range": Object {
                 "field": "cases.attributes.created_at",
+                "format": "dd/MM/yyyy",
                 "ranges": Array [
                   Object {
                     "from": "now-1d",
@@ -545,6 +547,7 @@ describe('getCasesTelemetryData', () => {
                 "counts": Object {
                   "date_range": Object {
                     "field": "cases.attributes.created_at",
+                    "format": "dd/MM/yyyy",
                     "ranges": Array [
                       Object {
                         "from": "now-1d",
@@ -602,6 +605,7 @@ describe('getCasesTelemetryData', () => {
                 "counts": Object {
                   "date_range": Object {
                     "field": "cases.attributes.created_at",
+                    "format": "dd/MM/yyyy",
                     "ranges": Array [
                       Object {
                         "from": "now-1d",

--- a/x-pack/plugins/cases/server/telemetry/queries/comments.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/comments.test.ts
@@ -62,6 +62,7 @@ describe('comments', () => {
           counts: {
             date_range: {
               field: 'cases-comments.attributes.created_at',
+              format: 'dd/MM/yyyy',
               ranges: [
                 {
                   from: 'now-1d',

--- a/x-pack/plugins/cases/server/telemetry/queries/comments.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/comments.test.ts
@@ -62,7 +62,6 @@ describe('comments', () => {
           counts: {
             date_range: {
               field: 'cases-comments.attributes.created_at',
-              format: 'dd/MM/YYYY',
               ranges: [
                 {
                   from: 'now-1d',

--- a/x-pack/plugins/cases/server/telemetry/queries/user_actions.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/user_actions.test.ts
@@ -62,7 +62,6 @@ describe('user_actions', () => {
           counts: {
             date_range: {
               field: 'cases-user-actions.attributes.created_at',
-              format: 'dd/MM/YYYY',
               ranges: [
                 {
                   from: 'now-1d',

--- a/x-pack/plugins/cases/server/telemetry/queries/user_actions.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/user_actions.test.ts
@@ -62,6 +62,7 @@ describe('user_actions', () => {
           counts: {
             date_range: {
               field: 'cases-user-actions.attributes.created_at',
+              format: 'dd/MM/yyyy',
               ranges: [
                 {
                   from: 'now-1d',

--- a/x-pack/plugins/cases/server/telemetry/queries/utils.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/utils.test.ts
@@ -817,6 +817,7 @@ describe('utils', () => {
         counts: {
           date_range: {
             field: 'test.attributes.created_at',
+            format: 'dd/MM/yyyy',
             ranges: [
               { from: 'now-1d', to: 'now' },
               { from: 'now-1w', to: 'now' },
@@ -1131,6 +1132,7 @@ describe('utils', () => {
           counts: {
             date_range: {
               field: 'test.attributes.created_at',
+              format: 'dd/MM/yyyy',
               ranges: [
                 {
                   from: 'now-1d',
@@ -1259,6 +1261,7 @@ describe('utils', () => {
           counts: {
             date_range: {
               field: 'cases-comments.attributes.created_at',
+              format: 'dd/MM/yyyy',
               ranges: [
                 {
                   from: 'now-1d',

--- a/x-pack/plugins/cases/server/telemetry/queries/utils.test.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/utils.test.ts
@@ -817,7 +817,6 @@ describe('utils', () => {
         counts: {
           date_range: {
             field: 'test.attributes.created_at',
-            format: 'dd/MM/YYYY',
             ranges: [
               { from: 'now-1d', to: 'now' },
               { from: 'now-1w', to: 'now' },
@@ -1132,7 +1131,6 @@ describe('utils', () => {
           counts: {
             date_range: {
               field: 'test.attributes.created_at',
-              format: 'dd/MM/YYYY',
               ranges: [
                 {
                   from: 'now-1d',
@@ -1261,7 +1259,6 @@ describe('utils', () => {
           counts: {
             date_range: {
               field: 'cases-comments.attributes.created_at',
-              format: 'dd/MM/YYYY',
               ranges: [
                 {
                   from: 'now-1d',

--- a/x-pack/plugins/cases/server/telemetry/queries/utils.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/utils.ts
@@ -38,7 +38,6 @@ export const getCountsAggregationQuery = (savedObjectType: string) => ({
   counts: {
     date_range: {
       field: `${savedObjectType}.attributes.created_at`,
-      format: 'dd/MM/YYYY',
       ranges: [
         { from: 'now-1d', to: 'now' },
         { from: 'now-1w', to: 'now' },
@@ -52,7 +51,6 @@ export const getAlertsCountsAggregationQuery = () => ({
   counts: {
     date_range: {
       field: `${CASE_COMMENT_SAVED_OBJECT}.attributes.created_at`,
-      format: 'dd/MM/YYYY',
       ranges: [
         { from: 'now-1d', to: 'now' },
         { from: 'now-1w', to: 'now' },

--- a/x-pack/plugins/cases/server/telemetry/queries/utils.ts
+++ b/x-pack/plugins/cases/server/telemetry/queries/utils.ts
@@ -38,6 +38,7 @@ export const getCountsAggregationQuery = (savedObjectType: string) => ({
   counts: {
     date_range: {
       field: `${savedObjectType}.attributes.created_at`,
+      format: 'dd/MM/yyyy',
       ranges: [
         { from: 'now-1d', to: 'now' },
         { from: 'now-1w', to: 'now' },
@@ -51,6 +52,7 @@ export const getAlertsCountsAggregationQuery = () => ({
   counts: {
     date_range: {
       field: `${CASE_COMMENT_SAVED_OBJECT}.attributes.created_at`,
+      format: 'dd/MM/yyyy',
       ranges: [
         { from: 'now-1d', to: 'now' },
         { from: 'now-1w', to: 'now' },

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/telemetry.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/telemetry.ts
@@ -52,7 +52,7 @@ export default ({ getService }: FtrProviderContext): void => {
       });
     });
 
-    it('should return the corect total number of alerts attached to cases', async () => {
+    it('should return the correct total number of alerts attached to cases', async () => {
       const firstCase = await createCase(supertest, getPostCaseRequest());
       const secondCase = await createCase(supertest, getPostCaseRequest());
 


### PR DESCRIPTION
## Summary

The Cases telemetry uses a deprecated date format that will not be supported in 9.0. This PR changes the format of the date set in the `format` field as suggested here https://www.elastic.co/blog/locale-changes-elasticsearch-8-16-jdk-23. Specifically, it changes `Y` to `y`. From the docs:

> In particular, if you are using the Y specifier as part of a calendar date format, you are probably using it erroneously; Joda time uses Y to represent year-of-era, but the JDK uses Y to represent week-years. You need to modify your format to use y instead, or change to a built-in format.

Fixes: https://github.com/elastic/kibana-team/issues/1188

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.18","8.x"]} ONMERGE-->