### PR TITLE
Update outlook configurable fields

### DIFF
--- a/packages/kbn-search-connectors/types/native_connectors.ts
+++ b/packages/kbn-search-connectors/types/native_connectors.ts
@@ -3375,6 +3375,30 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         validations: [],
         value: '',
       },
+      client_emails: {
+        default_value: null,
+        depends_on: [
+          {
+            'field': 'data_source',
+            'value': 'outlook_cloud'
+          }
+        ],
+        display: TEXTBOX,
+        label: translate('searchConnectors.nativeConnectors.outlook.client_emails.label', {
+          defaultMessage: 'Client Email Addresses (comma-separated)',
+        }),
+        options: [],
+        order: 5,
+        required: false,
+        sensitive: false,
+        tooltip: translate('searchConnectors.nativeConnectors.outlook.client_emails.tooltip', {
+          defaultMessage: 'Specify the email addresses to limit data fetching to specific clients. If set to *, data will be fetched for all users.',
+        }),
+        type: LIST,
+        ui_restrictions: [],
+        validations: [],
+        value: '*',
+      },
       exchange_server: {
         default_value: null,
         depends_on: [
@@ -3388,7 +3412,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
           defaultMessage: 'Exchange Server',
         }),
         options: [],
-        order: 5,
+        order: 6,
         required: true,
         sensitive: false,
         tooltip: translate('searchConnectors.nativeConnectors.outlook.exchange_server.tooltip', {
@@ -3415,7 +3439,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
           }
         ),
         options: [],
-        order: 6,
+        order: 7,
         required: true,
         sensitive: false,
         tooltip: translate(
@@ -3442,7 +3466,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
           defaultMessage: 'Exchange server username',
         }),
         options: [],
-        order: 7,
+        order: 8,
         required: true,
         sensitive: false,
         tooltip: null,
@@ -3464,7 +3488,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
           defaultMessage: 'Exchange server password',
         }),
         options: [],
-        order: 8,
+        order: 9,
         required: true,
         sensitive: true,
         tooltip: null,
@@ -3486,7 +3510,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
           defaultMessage: 'Exchange server domain name',
         }),
         options: [],
-        order: 9,
+        order: 10,
         required: true,
         sensitive: false,
         tooltip: translate('searchConnectors.nativeConnectors.outlook.domain.tooltip', {
@@ -3510,7 +3534,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
           defaultMessage: 'Enable SSL',
         }),
         options: [],
-        order: 10,
+        order: 11,
         required: true,
         sensitive: false,
         tooltip: null,
@@ -3536,7 +3560,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
           defaultMessage: 'SSL certificate',
         }),
         options: [],
-        order: 11,
+        order: 12,
         required: true,
         sensitive: false,
         tooltip: null,
@@ -3556,7 +3580,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
           }
         ),
         options: [],
-        order: 12,
+        order: 13,
         required: true,
         sensitive: false,
         tooltip: translate(
@@ -3577,7 +3601,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         display: TOGGLE,
         label: ENABLE_DOCUMENT_LEVEL_SECURITY_LABEL,
         options: [],
-        order: 13,
+        order: 14,
         required: true,
         sensitive: false,
         tooltip: getEnableDocumentLevelSecurityTooltip(

--- a/packages/kbn-search-connectors/types/native_connectors.ts
+++ b/packages/kbn-search-connectors/types/native_connectors.ts
@@ -3379,9 +3379,9 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         default_value: null,
         depends_on: [
           {
-            'field': 'data_source',
-            'value': 'outlook_cloud'
-          }
+            field: 'data_source',
+            value: 'outlook_cloud',
+          },
         ],
         display: TEXTBOX,
         label: translate('searchConnectors.nativeConnectors.outlook.client_emails.label', {
@@ -3392,7 +3392,8 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
         required: false,
         sensitive: false,
         tooltip: translate('searchConnectors.nativeConnectors.outlook.client_emails.tooltip', {
-          defaultMessage: 'Specify the email addresses to limit data fetching to specific clients. If set to *, data will be fetched for all users.',
+          defaultMessage:
+            'Specify the email addresses to limit data fetching to specific clients. If set to *, data will be fetched for all users.',
         }),
         type: LIST,
         ui_restrictions: [],


### PR DESCRIPTION
## Summary

This PR updates native outlook connector configurable fields to match changes in https://github.com/elastic/connectors/pull/2844/files:

- Adds new `client_emails` field
- Updates order of fields below it


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_node:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


