### PR TITLE
[8.16] [Securitysolution] Add Risk score missing privileges callout to enablement flyout (#199804)

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
@@ -28,6 +28,10 @@ import {
   ENABLEMENT_DESCRIPTION_RISK_ENGINE_ONLY,
   ENABLEMENT_DESCRIPTION_ENTITY_STORE_ONLY,
 } from '../translations';
+import { useEntityEnginePrivileges } from '../hooks/use_entity_engine_privileges';
+import { MissingPrivilegesCallout } from './missing_privileges_callout';
+import { useMissingRiskEnginePrivileges } from '../../../hooks/use_missing_risk_engine_privileges';
+import { RiskEnginePrivilegesCallOut } from '../../risk_engine_privileges_callout';
 
 export interface Enablements {
   riskScore: boolean;
@@ -59,6 +63,10 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
     riskScore: !!riskScore.checked,
     entityStore: !!entityStore.checked,
   });
+  const { data: entityEnginePrivileges, isLoading: isLoadingEntityEnginePrivileges } =
+    useEntityEnginePrivileges();
+  const riskEnginePrivileges = useMissingRiskEnginePrivileges();
+  const enablementOptions = enablements.riskScore || enablements.entityStore;
 
   if (!visible) {
     return null;
@@ -85,15 +93,22 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
                 />
               }
               checked={enablements.riskScore}
-              disabled={riskScore.disabled || false}
+              disabled={
+                riskScore.disabled ||
+                (!riskEnginePrivileges.isLoading && !riskEnginePrivileges?.hasAllRequiredPrivileges)
+              }
               onChange={() => setEnablements((prev) => ({ ...prev, riskScore: !prev.riskScore }))}
             />
           </EuiFlexItem>
+          {!riskEnginePrivileges.isLoading && !riskEnginePrivileges.hasAllRequiredPrivileges && (
+            <EuiFlexItem>
+              <RiskEnginePrivilegesCallOut privileges={riskEnginePrivileges} />
+            </EuiFlexItem>
+          )}
           <EuiFlexItem>
             <EuiText>{ENABLEMENT_DESCRIPTION_RISK_ENGINE_ONLY}</EuiText>
           </EuiFlexItem>
           <EuiHorizontalRule margin="none" />
-
           <EuiFlexItem>
             <EuiFlexGroup justifyContent="flexStart">
               <EuiSwitch
@@ -104,7 +119,10 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
                   />
                 }
                 checked={enablements.entityStore}
-                disabled={entityStore.disabled || false}
+                disabled={
+                  entityStore.disabled ||
+                  (!isLoadingEntityEnginePrivileges && !entityEnginePrivileges?.has_all_required)
+                }
                 onChange={() =>
                   setEnablements((prev) => ({ ...prev, entityStore: !prev.entityStore }))
                 }
@@ -114,6 +132,11 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
               </EuiToolTip>
             </EuiFlexGroup>
           </EuiFlexItem>
+          {!entityEnginePrivileges || entityEnginePrivileges.has_all_required ? null : (
+            <EuiFlexItem>
+              <MissingPrivilegesCallout privileges={entityEnginePrivileges} />
+            </EuiFlexItem>
+          )}
           <EuiFlexItem>
             <EuiText>{ENABLEMENT_DESCRIPTION_ENTITY_STORE_ONLY}</EuiText>
           </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
@@ -28,8 +28,6 @@ import {
   ENABLEMENT_DESCRIPTION_RISK_ENGINE_ONLY,
   ENABLEMENT_DESCRIPTION_ENTITY_STORE_ONLY,
 } from '../translations';
-import { useEntityEnginePrivileges } from '../hooks/use_entity_engine_privileges';
-import { MissingPrivilegesCallout } from './missing_privileges_callout';
 import { useMissingRiskEnginePrivileges } from '../../../hooks/use_missing_risk_engine_privileges';
 import { RiskEnginePrivilegesCallOut } from '../../risk_engine_privileges_callout';
 
@@ -63,10 +61,7 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
     riskScore: !!riskScore.checked,
     entityStore: !!entityStore.checked,
   });
-  const { data: entityEnginePrivileges, isLoading: isLoadingEntityEnginePrivileges } =
-    useEntityEnginePrivileges();
   const riskEnginePrivileges = useMissingRiskEnginePrivileges();
-  const enablementOptions = enablements.riskScore || enablements.entityStore;
 
   if (!visible) {
     return null;
@@ -119,10 +114,7 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
                   />
                 }
                 checked={enablements.entityStore}
-                disabled={
-                  entityStore.disabled ||
-                  (!isLoadingEntityEnginePrivileges && !entityEnginePrivileges?.has_all_required)
-                }
+                disabled={entityStore.disabled}
                 onChange={() =>
                   setEnablements((prev) => ({ ...prev, entityStore: !prev.entityStore }))
                 }
@@ -132,11 +124,6 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
               </EuiToolTip>
             </EuiFlexGroup>
           </EuiFlexItem>
-          {!entityEnginePrivileges || entityEnginePrivileges.has_all_required ? null : (
-            <EuiFlexItem>
-              <MissingPrivilegesCallout privileges={entityEnginePrivileges} />
-            </EuiFlexItem>
-          )}
           <EuiFlexItem>
             <EuiText>{ENABLEMENT_DESCRIPTION_ENTITY_STORE_ONLY}</EuiText>
           </EuiFlexItem>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Securitysolution] Add Risk score missing privileges callout to enablement flyout (#199804)](https://github.com/elastic/kibana/pull/199804)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2024-11-14T08:40:27Z","message":"[Securitysolution] Add Risk score missing privileges callout to enablement flyout (#199804)\n\n## Summary\r\n\r\nThe entity analytics enablement model doesn't show the missing\r\nprivileges warning for the Entity Risk score.\r\n\r\nTo fix it, I added to the model the same callout we display on the risk\r\nengine page.\r\n\r\n### What is not included\r\n* Improvement to the risk engine callout\r\n* Fix risk engine callout bugs\r\nhttps://github.com/elastic/security-team/issues/11138\r\n\r\n### How to test it\r\n* Create a user with no privileges except to the security solution app\r\nand the `logs*` index\r\n* Login and open the entity analytics page with the non-privileged user\r\n* Click enable and check if the model displays the missing privileges\r\ncallout for the risk engine\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"54c6144bbc9e041dad5c2fd9f296ea7d838cc614","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team: SecuritySolution","Theme: entity_analytics","Feature:Entity Analytics","Team:Entity Analytics","backport:version","v8.17.0","v8.16.1"],"number":199804,"url":"https://github.com/elastic/kibana/pull/199804","mergeCommit":{"message":"[Securitysolution] Add Risk score missing privileges callout to enablement flyout (#199804)\n\n## Summary\r\n\r\nThe entity analytics enablement model doesn't show the missing\r\nprivileges warning for the Entity Risk score.\r\n\r\nTo fix it, I added to the model the same callout we display on the risk\r\nengine page.\r\n\r\n### What is not included\r\n* Improvement to the risk engine callout\r\n* Fix risk engine callout bugs\r\nhttps://github.com/elastic/security-team/issues/11138\r\n\r\n### How to test it\r\n* Create a user with no privileges except to the security solution app\r\nand the `logs*` index\r\n* Login and open the entity analytics page with the non-privileged user\r\n* Click enable and check if the model displays the missing privileges\r\ncallout for the risk engine\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"54c6144bbc9e041dad5c2fd9f296ea7d838cc614"}},"sourceBranch":"main","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/199804","number":199804,"mergeCommit":{"message":"[Securitysolution] Add Risk score missing privileges callout to enablement flyout (#199804)\n\n## Summary\r\n\r\nThe entity analytics enablement model doesn't show the missing\r\nprivileges warning for the Entity Risk score.\r\n\r\nTo fix it, I added to the model the same callout we display on the risk\r\nengine page.\r\n\r\n### What is not included\r\n* Improvement to the risk engine callout\r\n* Fix risk engine callout bugs\r\nhttps://github.com/elastic/security-team/issues/11138\r\n\r\n### How to test it\r\n* Create a user with no privileges except to the security solution app\r\nand the `logs*` index\r\n* Login and open the entity analytics page with the non-privileged user\r\n* Click enable and check if the model displays the missing privileges\r\ncallout for the risk engine\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"54c6144bbc9e041dad5c2fd9f296ea7d838cc614"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/200123","number":200123,"state":"MERGED","mergeCommit":{"sha":"6e7d4362ac3e661f061c852c587ba95ebbc565b2","message":"[8.x] [Securitysolution] Add Risk score missing privileges callout to enablement flyout (#199804) (#200123)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Securitysolution] Add Risk score missing privileges callout to\nenablement flyout\n(#199804)](https://github.com/elastic/kibana/pull/199804)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Pablo\nMachado\",\"email\":\"pablo.nevesmachado@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-11-14T08:40:27Z\",\"message\":\"[Securitysolution]\nAdd Risk score missing privileges callout to enablement flyout\n(#199804)\\n\\n## Summary\\r\\n\\r\\nThe entity analytics enablement model\ndoesn't show the missing\\r\\nprivileges warning for the Entity Risk\nscore.\\r\\n\\r\\nTo fix it, I added to the model the same callout we\ndisplay on the risk\\r\\nengine page.\\r\\n\\r\\n### What is not included\\r\\n*\nImprovement to the risk engine callout\\r\\n* Fix risk engine callout\nbugs\\r\\nhttps://github.com/elastic/security-team/issues/11138\\r\\n\\r\\n###\nHow to test it\\r\\n* Create a user with no privileges except to the\nsecurity solution app\\r\\nand the `logs*` index\\r\\n* Login and open the\nentity analytics page with the non-privileged user\\r\\n* Click enable and\ncheck if the model displays the missing privileges\\r\\ncallout for the\nrisk engine\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"54c6144bbc9e041dad5c2fd9f296ea7d838cc614\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"Team:\nSecuritySolution\",\"Theme: entity_analytics\",\"Feature:Entity\nAnalytics\",\"Team:Entity\nAnalytics\",\"backport:version\",\"v8.17.0\",\"v8.16.1\"],\"title\":\"[Securitysolution]\nAdd Risk score missing privileges callout to enablement\nflyout\",\"number\":199804,\"url\":\"https://github.com/elastic/kibana/pull/199804\",\"mergeCommit\":{\"message\":\"[Securitysolution]\nAdd Risk score missing privileges callout to enablement flyout\n(#199804)\\n\\n## Summary\\r\\n\\r\\nThe entity analytics enablement model\ndoesn't show the missing\\r\\nprivileges warning for the Entity Risk\nscore.\\r\\n\\r\\nTo fix it, I added to the model the same callout we\ndisplay on the risk\\r\\nengine page.\\r\\n\\r\\n### What is not included\\r\\n*\nImprovement to the risk engine callout\\r\\n* Fix risk engine callout\nbugs\\r\\nhttps://github.com/elastic/security-team/issues/11138\\r\\n\\r\\n###\nHow to test it\\r\\n* Create a user with no privileges except to the\nsecurity solution app\\r\\nand the `logs*` index\\r\\n* Login and open the\nentity analytics page with the non-privileged user\\r\\n* Click enable and\ncheck if the model displays the missing privileges\\r\\ncallout for the\nrisk engine\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"54c6144bbc9e041dad5c2fd9f296ea7d838cc614\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.x\",\"8.16\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/199804\",\"number\":199804,\"mergeCommit\":{\"message\":\"[Securitysolution]\nAdd Risk score missing privileges callout to enablement flyout\n(#199804)\\n\\n## Summary\\r\\n\\r\\nThe entity analytics enablement model\ndoesn't show the missing\\r\\nprivileges warning for the Entity Risk\nscore.\\r\\n\\r\\nTo fix it, I added to the model the same callout we\ndisplay on the risk\\r\\nengine page.\\r\\n\\r\\n### What is not included\\r\\n*\nImprovement to the risk engine callout\\r\\n* Fix risk engine callout\nbugs\\r\\nhttps://github.com/elastic/security-team/issues/11138\\r\\n\\r\\n###\nHow to test it\\r\\n* Create a user with no privileges except to the\nsecurity solution app\\r\\nand the `logs*` index\\r\\n* Login and open the\nentity analytics page with the non-privileged user\\r\\n* Click enable and\ncheck if the model displays the missing privileges\\r\\ncallout for the\nrisk engine\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"54c6144bbc9e041dad5c2fd9f296ea7d838cc614\"}},{\"branch\":\"8.x\",\"label\":\"v8.17.0\",\"branchLabelMappingKey\":\"^v8.17.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.16\",\"label\":\"v8.16.1\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Pablo Machado <pablo.nevesmachado@elastic.co>"}},{"branch":"8.16","label":"v8.16.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->