### PR TITLE
[8.x] [ResponseOps] [Cases] Attach file to case API (#198377)

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -163,7 +163,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -262,7 +262,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -354,7 +354,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -440,7 +440,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -562,7 +562,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -658,7 +658,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -750,7 +750,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -838,7 +838,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response.
+                      omitted from the response. 
                     type: boolean
                   is_system_action:
                     description: >-
@@ -19491,7 +19491,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded.  Errors pertaining to individual
-            objects will be returned in the response body.
+            objects will be returned in the response body. 
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -19525,7 +19525,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded. Errors pertaining to individual
-            objects will be returned in the response body.
+            objects will be returned in the response body. 
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -21081,7 +21081,7 @@ paths:
                               members have read access to. A document within the
                               specified data streams and indices must match this
                               query in order for it to be accessible by the role
-                              members.
+                              members. 
                             type: string
                         required:
                           - clusters
@@ -21360,7 +21360,7 @@ paths:
                                     document within the specified data streams
                                     and indices must match this query in order
                                     for it to be accessible by the role
-                                    members.
+                                    members. 
                                   type: string
                               required:
                                 - clusters
@@ -24437,7 +24437,7 @@ components:
           runtimeFieldMap:
             runtime_shape_name:
               script:
-                source: "emit(doc['shape_name'].value)"
+                source: 'emit(doc[''shape_name''].value)'
               type: keyword
           title: logstash-*
     Data_views_create_runtime_field_request:
@@ -25757,7 +25757,7 @@ components:
               readFromDocValues: false
               runtimeField:
                 script:
-                  source: "emit(doc['timestamp'].value.getHour());"
+                  source: 'emit(doc[''timestamp''].value.getHour());'
                 type: long
               scripted: false
               searchable: true
@@ -25882,7 +25882,7 @@ components:
           runtimeFieldMap:
             hour_of_day:
               script:
-                source: "emit(doc['timestamp'].value.getHour());"
+                source: 'emit(doc[''timestamp''].value.getHour());'
               type: long
           sourceFilters: []
           timeFieldName: timestamp
@@ -25897,7 +25897,7 @@ components:
             readFromDocValues: false
             runtimeField:
               script:
-                source: "emit(doc['timestamp'].value.getHour());"
+                source: 'emit(doc[''timestamp''].value.getHour());'
               type: long
             scripted: false
             searchable: true
@@ -26667,7 +26667,7 @@ components:
           description: >
             The scaling factor to use when encoding values. This property is
             applicable when `type` is `scaled_float`. Values will be multiplied
-            by this factor at index time and rounded to the closest long value.
+            by this factor at index time and rounded to the closest long value. 
           type: integer
         type:
           description: Specifies the data type for the field.
@@ -42450,7 +42450,7 @@ components:
           example: Bad Request
           type: string
         message:
-          example: "Invalid value 'foo' supplied to: [...]"
+          example: 'Invalid value ''foo'' supplied to: [...]'
           type: string
         statusCode:
           example: 400
@@ -43417,7 +43417,7 @@ components:
             - $ref: '#/components/schemas/SLOs_indicator_properties_histogram'
             - $ref: '#/components/schemas/SLOs_indicator_properties_timeslice_metric'
         instanceId:
-          description: "the value derived from the groupBy field, if present, otherwise '*'"
+          description: 'the value derived from the groupBy field, if present, otherwise ''*'''
           example: host-abcde
           type: string
         name:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -7764,7 +7764,47 @@ paths:
       summary: Push a case to an external service
       tags:
         - cases
-  '/api/cases/{caseId}/user_actions':
+  /api/cases/{caseId}/files:
+    post:
+      description: >
+        Attach a file to a case. You must have `all` privileges for the
+        **Cases** feature in the **Management**, **Observability**, or
+        **Security** section of the Kibana feature privileges, depending on the
+        owner of the case you're updating. The request must include:
+
+        - The `Content-Type: multipart/form-data` HTTP header.
+
+        - The location of the file that is being uploaded.
+      operationId: addCaseFileDefaultSpace
+      parameters:
+        - $ref: '#/components/parameters/Cases_kbn_xsrf'
+        - $ref: '#/components/parameters/Cases_case_id'
+      requestBody:
+        content:
+          multipart/form-data; Elastic-Api-Version=2023-10-31:
+            schema:
+              $ref: '#/components/schemas/Cases_add_case_file_request'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              examples:
+                addCaseFileResponse:
+                  $ref: '#/components/examples/Cases_add_comment_response'
+              schema:
+                $ref: '#/components/schemas/Cases_case_response_properties'
+          description: Indicates a successful call.
+        '401':
+          content:
+            application/json; Elastic-Api-Version=2023-10-31:
+              schema:
+                $ref: '#/components/schemas/Cases_4xx_response'
+          description: Authorization information is missing or invalid.
+      summary: Attach a file to a case
+      tags:
+        - cases
+  /api/cases/{caseId}/user_actions:
     get:
       deprecated: true
       description: >
@@ -27174,6 +27214,25 @@ components:
         - $ref: '#/components/schemas/Cases_add_alert_comment_request_properties'
         - $ref: '#/components/schemas/Cases_add_user_comment_request_properties'
       title: Add case comment request
+    Cases_add_case_file_request:
+      description: >-
+        Defines the file that will be attached to the case. Optional parameters
+        will be generated automatically from the file metadata if not defined.
+      type: object
+      properties:
+        file:
+          description: The file being attached to the case.
+          format: binary
+          type: string
+        filename:
+          description: >-
+            The desired name of the file being attached to the case, it can be
+            different than the name of the file in the filesystem. **This should
+            not include the file extension.**
+          type: string
+      required:
+        - file
+      title: Add case file request properties
     Cases_add_user_comment_request_properties:
       description: Defines properties for case comment requests when type is user.
       properties:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -163,7 +163,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -262,7 +262,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -354,7 +354,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -440,7 +440,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -562,7 +562,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -658,7 +658,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -750,7 +750,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -838,7 +838,7 @@ paths:
                     description: >-
                       Indicates whether the connector is preconfigured. If true,
                       the `config` and `is_missing_secrets` properties are
-                      omitted from the response. 
+                      omitted from the response.
                     type: boolean
                   is_system_action:
                     description: >-
@@ -7764,7 +7764,7 @@ paths:
       summary: Push a case to an external service
       tags:
         - cases
-  /api/cases/{caseId}/files:
+  '/api/cases/{caseId}/files':
     post:
       description: >
         Attach a file to a case. You must have `all` privileges for the
@@ -7804,7 +7804,7 @@ paths:
       summary: Attach a file to a case
       tags:
         - cases
-  /api/cases/{caseId}/user_actions:
+  '/api/cases/{caseId}/user_actions':
     get:
       deprecated: true
       description: >
@@ -19491,7 +19491,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded.  Errors pertaining to individual
-            objects will be returned in the response body. 
+            objects will be returned in the response body.
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -19525,7 +19525,7 @@ paths:
           description: >
             Indicates a successful call. NOTE: This HTTP response code indicates
             that the bulk operation succeeded. Errors pertaining to individual
-            objects will be returned in the response body. 
+            objects will be returned in the response body.
         '400':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
@@ -21081,7 +21081,7 @@ paths:
                               members have read access to. A document within the
                               specified data streams and indices must match this
                               query in order for it to be accessible by the role
-                              members. 
+                              members.
                             type: string
                         required:
                           - clusters
@@ -21360,7 +21360,7 @@ paths:
                                     document within the specified data streams
                                     and indices must match this query in order
                                     for it to be accessible by the role
-                                    members. 
+                                    members.
                                   type: string
                               required:
                                 - clusters
@@ -24437,7 +24437,7 @@ components:
           runtimeFieldMap:
             runtime_shape_name:
               script:
-                source: 'emit(doc[''shape_name''].value)'
+                source: "emit(doc['shape_name'].value)"
               type: keyword
           title: logstash-*
     Data_views_create_runtime_field_request:
@@ -25757,7 +25757,7 @@ components:
               readFromDocValues: false
               runtimeField:
                 script:
-                  source: 'emit(doc[''timestamp''].value.getHour());'
+                  source: "emit(doc['timestamp'].value.getHour());"
                 type: long
               scripted: false
               searchable: true
@@ -25882,7 +25882,7 @@ components:
           runtimeFieldMap:
             hour_of_day:
               script:
-                source: 'emit(doc[''timestamp''].value.getHour());'
+                source: "emit(doc['timestamp'].value.getHour());"
               type: long
           sourceFilters: []
           timeFieldName: timestamp
@@ -25897,7 +25897,7 @@ components:
             readFromDocValues: false
             runtimeField:
               script:
-                source: 'emit(doc[''timestamp''].value.getHour());'
+                source: "emit(doc['timestamp'].value.getHour());"
               type: long
             scripted: false
             searchable: true
@@ -26667,7 +26667,7 @@ components:
           description: >
             The scaling factor to use when encoding values. This property is
             applicable when `type` is `scaled_float`. Values will be multiplied
-            by this factor at index time and rounded to the closest long value. 
+            by this factor at index time and rounded to the closest long value.
           type: integer
         type:
           description: Specifies the data type for the field.
@@ -42450,7 +42450,7 @@ components:
           example: Bad Request
           type: string
         message:
-          example: 'Invalid value ''foo'' supplied to: [...]'
+          example: "Invalid value 'foo' supplied to: [...]"
           type: string
         statusCode:
           example: 400
@@ -43417,7 +43417,7 @@ components:
             - $ref: '#/components/schemas/SLOs_indicator_properties_histogram'
             - $ref: '#/components/schemas/SLOs_indicator_properties_timeslice_metric'
         instanceId:
-          description: 'the value derived from the groupBy field, if present, otherwise ''*'''
+          description: "the value derived from the groupBy field, if present, otherwise '*'"
           example: host-abcde
           type: string
         name:

--- a/x-pack/plugins/cases/common/constants/index.ts
+++ b/x-pack/plugins/cases/common/constants/index.ts
@@ -62,6 +62,8 @@ export const CASE_FIND_USER_ACTIONS_URL = `${CASE_USER_ACTIONS_URL}/_find` as co
 export const CASE_ALERTS_URL = `${CASES_URL}/alerts/{alert_id}` as const;
 export const CASE_DETAILS_ALERTS_URL = `${CASE_DETAILS_URL}/alerts` as const;
 
+export const CASE_FILES_URL = `${CASE_DETAILS_URL}/files` as const;
+
 /**
  * Internal routes
  */
@@ -139,6 +141,7 @@ export const MAX_TEMPLATE_DESCRIPTION_LENGTH = 1000 as const;
 export const MAX_TEMPLATES_LENGTH = 10 as const;
 export const MAX_TEMPLATE_TAG_LENGTH = 50 as const;
 export const MAX_TAGS_PER_TEMPLATE = 10 as const;
+export const MAX_FILENAME_LENGTH = 160 as const;
 
 /**
  * Cases features

--- a/x-pack/plugins/cases/common/schema/index.test.ts
+++ b/x-pack/plugins/cases/common/schema/index.test.ts
@@ -11,6 +11,7 @@ import {
   limitedArraySchema,
   limitedNumberSchema,
   limitedStringSchema,
+  mimeTypeString,
   NonEmptyString,
   paginationSchema,
   limitedNumberAsIntegerSchema,
@@ -321,14 +322,32 @@ describe('schema', () => {
     });
   });
 
+  describe('mimeTypeString', () => {
+    it('works correctly when the value is an allowed mime type', () => {
+      expect(PathReporter.report(mimeTypeString.decode('image/jpx'))).toMatchInlineSnapshot(`
+        Array [
+          "No errors!",
+        ]
+      `);
+    });
+
+    it('fails when the value is not an allowed mime type', () => {
+      expect(PathReporter.report(mimeTypeString.decode('foo/bar'))).toMatchInlineSnapshot(`
+        Array [
+          "The mime type field value foo/bar is not allowed.",
+        ]
+      `);
+    });
+  });
+
   describe('limitedNumberAsIntegerSchema', () => {
     it('works correctly the number is safe integer', () => {
       expect(PathReporter.report(limitedNumberAsIntegerSchema({ fieldName: 'foo' }).decode(1)))
         .toMatchInlineSnapshot(`
-          Array [
-            "No errors!",
-          ]
-        `);
+        Array [
+          "No errors!",
+        ]
+      `);
     });
 
     it('fails when given a number that is lower than the minimum', () => {

--- a/x-pack/plugins/cases/common/schema/index.ts
+++ b/x-pack/plugins/cases/common/schema/index.ts
@@ -11,6 +11,7 @@ import { either } from 'fp-ts/lib/Either';
 import { MAX_DOCS_PER_PAGE } from '../constants';
 import type { PartialPaginationType } from './types';
 import { PaginationSchemaRt } from './types';
+import { ALLOWED_MIME_TYPES } from '../constants/mime_types';
 
 export interface LimitedSchemaType {
   fieldName: string;
@@ -194,3 +195,17 @@ export const regexStringRt = ({ codec, pattern, message }: RegexStringSchemaType
       }),
     rt.identity
   );
+
+export const mimeTypeString = new rt.Type<string, string, unknown>(
+  'mimeTypeString',
+  rt.string.is,
+  (input, context) =>
+    either.chain(rt.string.validate(input, context), (s) => {
+      if (!ALLOWED_MIME_TYPES.includes(s)) {
+        return rt.failure(input, context, `The mime type field value ${s} is not allowed.`);
+      }
+
+      return rt.success(s);
+    }),
+  rt.identity
+);

--- a/x-pack/plugins/cases/common/types/api/attachment/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/attachment/v1.ts
@@ -12,6 +12,7 @@ import {
   MAX_COMMENTS_PER_PAGE,
   MAX_COMMENT_LENGTH,
   MAX_DELETE_FILES,
+  MAX_FILENAME_LENGTH,
 } from '../../../constants';
 import {
   limitedArraySchema,
@@ -47,7 +48,23 @@ export const BulkDeleteFileAttachmentsRequestRt = rt.strict({
   }),
 });
 
+export const PostFileAttachmentRequestRt = rt.intersection([
+  rt.strict({
+    file: rt.unknown,
+  }),
+  rt.exact(
+    rt.partial({
+      filename: limitedStringSchema({ fieldName: 'filename', min: 1, max: MAX_FILENAME_LENGTH }),
+    })
+  ),
+]);
+
 export type BulkDeleteFileAttachmentsRequest = rt.TypeOf<typeof BulkDeleteFileAttachmentsRequestRt>;
+export type PostFileAttachmentRequest = rt.TypeOf<typeof PostFileAttachmentRequestRt>;
+
+/**
+ * Attachments
+ */
 
 const BasicAttachmentRequestRt = rt.union([
   UserCommentAttachmentPayloadRt,

--- a/x-pack/plugins/cases/common/types/domain/attachment/v1.ts
+++ b/x-pack/plugins/cases/common/types/domain/attachment/v1.ts
@@ -6,8 +6,10 @@
  */
 
 import * as rt from 'io-ts';
+import { limitedStringSchema, mimeTypeString } from '../../../schema';
 import { jsonValueRt } from '../../../api';
 import { UserRt } from '../user/v1';
+import { MAX_FILENAME_LENGTH } from '../../../constants';
 
 /**
  * Files
@@ -33,6 +35,11 @@ export const AttachmentAttributesBasicRt = rt.strict({
   pushed_by: rt.union([UserRt, rt.null]),
   updated_at: rt.union([rt.string, rt.null]),
   updated_by: rt.union([UserRt, rt.null]),
+});
+
+export const FileAttachmentMetadataPayloadRt = rt.strict({
+  mimeType: mimeTypeString,
+  filename: limitedStringSchema({ fieldName: 'filename', min: 1, max: MAX_FILENAME_LENGTH }),
 });
 
 /**

--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -1869,6 +1869,61 @@
           }
         }
       }
+    },
+    "/api/cases/{caseId}/files": {
+      "post": {
+        "summary": "Attach a file to a case",
+        "operationId": "addCaseFileDefaultSpace",
+        "description": "Attach a file to a case. You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're updating. The request must include:\n- The `Content-Type: multipart/form-data` HTTP header.\n- The location of the file that is being uploaded.\n",
+        "tags": [
+          "cases"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          },
+          {
+            "$ref": "#/components/parameters/case_id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/add_case_file_request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/case_response_properties"
+                },
+                "examples": {
+                  "addCaseFileResponse": {
+                    "$ref": "#/components/examples/add_comment_response"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/4xx_response"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -4796,6 +4851,25 @@
               "severity"
             ],
             "example": "create_case"
+          }
+        }
+      },
+      "add_case_file_request": {
+        "title": "Add case file request properties",
+        "required": [
+          "file"
+        ],
+        "description": "Defines the file that will be attached to the case. Optional parameters will be generated automatically from the file metadata if not defined.",
+        "type": "object",
+        "properties": {
+          "file": {
+            "description": "The file being attached to the case.",
+            "type": "string",
+            "format": "binary"
+          },
+          "filename": {
+            "description": "The desired name of the file being attached to the case, it can be different than the name of the file in the filesystem. **This should not include the file extension.**",
+            "type": "string"
           }
         }
       }

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -1208,6 +1208,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/4xx_response'
+  /api/cases/{caseId}/files:
+    post:
+      summary: Attach a file to a case
+      operationId: addCaseFileDefaultSpace
+      description: |
+        Attach a file to a case. You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're updating. The request must include:
+        - The `Content-Type: multipart/form-data` HTTP header.
+        - The location of the file that is being uploaded.
+      tags:
+        - cases
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+        - $ref: '#/components/parameters/case_id'
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/add_case_file_request'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/case_response_properties'
+              examples:
+                addCaseFileResponse:
+                  $ref: '#/components/examples/add_comment_response'
+        '401':
+          description: Authorization information is missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/4xx_response'
 components:
   parameters:
     kbn_xsrf:
@@ -3331,6 +3366,20 @@ components:
             - settings
             - severity
           example: create_case
+    add_case_file_request:
+      title: Add case file request properties
+      required:
+        - file
+      description: Defines the file that will be attached to the case. Optional parameters will be generated automatically from the file metadata if not defined.
+      type: object
+      properties:
+        file:
+          description: The file being attached to the case.
+          type: string
+          format: binary
+        filename:
+          description: The desired name of the file being attached to the case, it can be different than the name of the file in the filesystem. **This should not include the file extension.**
+          type: string
   examples:
     create_case_request:
       summary: Create a security case that uses a Jira connector.

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/add_case_file_request.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/add_case_file_request.yaml
@@ -1,0 +1,13 @@
+title: Add case file request properties
+required:
+  - file
+description: Defines the file that will be attached to the case. Optional parameters will be generated automatically from the file metadata if not defined.
+type: object
+properties:
+  file:
+    description: The file being attached to the case.
+    type: string
+    format: binary
+  filename:
+    description: The desired name of the file being attached to the case, it can be different than the name of the file in the filesystem. **This should not include the file extension.**
+    type: string

--- a/x-pack/plugins/cases/docs/openapi/entrypoint.yaml
+++ b/x-pack/plugins/cases/docs/openapi/entrypoint.yaml
@@ -14,7 +14,7 @@ tags:
 servers:
   - url: /
 paths:
-# Paths in the default space
+  # Paths in the default space
   '/api/cases':
     $ref: 'paths/api@cases.yaml'
   '/api/cases/_find':
@@ -49,41 +49,43 @@ paths:
     $ref: 'paths/api@cases@{caseid}@user_actions@_find.yaml'
   '/api/cases/configure/connectors/_find':
     $ref: paths/api@cases@configure@connectors@_find.yaml
+  '/api/cases/{caseId}/files':
+    $ref: 'paths/api@cases@{caseid}@files.yaml'
 # Paths with space identifiers
-  # '/s/{spaceId}/api/cases':
-  #   $ref: 'paths/s@{spaceid}@api@cases.yaml'
-  # '/s/{spaceId}/api/cases/_find':
-  #   $ref: 'paths/s@{spaceid}@api@cases@_find.yaml'
-  # '/s/{spaceId}/api/cases/alerts/{alertId}':
-  #   $ref: 'paths/s@{spaceid}@api@cases@alerts@{alertid}.yaml'
-  # '/s/{spaceId}/api/cases/configure':
-  #   $ref: paths/s@{spaceid}@api@cases@configure.yaml
-  # '/s/{spaceId}/api/cases/configure/{configurationId}':
-  #   $ref: paths/s@{spaceid}@api@cases@configure@{configurationid}.yaml
-  # '/s/{spaceId}/api/cases/configure/connectors/_find':
-  #   $ref: paths/s@{spaceid}@api@cases@configure@connectors@_find.yaml
-  # '/s/{spaceId}/api/cases/reporters':
-  #   $ref: 'paths/s@{spaceid}@api@cases@reporters.yaml'
-  # '/s/{spaceId}/api/cases/status':
-  #   $ref: 'paths/s@{spaceid}@api@cases@status.yaml'
-  # '/s/{spaceId}/api/cases/tags':
-  #   $ref: 'paths/s@{spaceid}@api@cases@tags.yaml'
-  # '/s/{spaceId}/api/cases/{caseId}':
-  #   $ref: 'paths/s@{spaceid}@api@cases@{caseid}.yaml'
-  # '/s/{spaceId}/api/cases/{caseId}/alerts':
-  #   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@alerts.yaml'
-  # '/s/{spaceId}/api/cases/{caseId}/comments':
-  #   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@comments.yaml'
-  # '/s/{spaceId}/api/cases/{caseId}/comments/_find':
-  #   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@comments@_find.yaml'
-  # '/s/{spaceId}/api/cases/{caseId}/comments/{commentId}':
-  #   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@comments@{commentid}.yaml'
-  # '/s/{spaceId}/api/cases/{caseId}/connector/{connectorId}/_push':
-  #   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@connector@{connectorid}@_push.yaml'
-  # '/s/{spaceId}/api/cases/{caseId}/user_actions':
-  #   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@user_actions.yaml'
-  # '/s/{spaceId}/api/cases/{caseId}/user_actions/_find':
-  #   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@user_actions@_find.yaml'
+# '/s/{spaceId}/api/cases':
+#   $ref: 'paths/s@{spaceid}@api@cases.yaml'
+# '/s/{spaceId}/api/cases/_find':
+#   $ref: 'paths/s@{spaceid}@api@cases@_find.yaml'
+# '/s/{spaceId}/api/cases/alerts/{alertId}':
+#   $ref: 'paths/s@{spaceid}@api@cases@alerts@{alertid}.yaml'
+# '/s/{spaceId}/api/cases/configure':
+#   $ref: paths/s@{spaceid}@api@cases@configure.yaml
+# '/s/{spaceId}/api/cases/configure/{configurationId}':
+#   $ref: paths/s@{spaceid}@api@cases@configure@{configurationid}.yaml
+# '/s/{spaceId}/api/cases/configure/connectors/_find':
+#   $ref: paths/s@{spaceid}@api@cases@configure@connectors@_find.yaml
+# '/s/{spaceId}/api/cases/reporters':
+#   $ref: 'paths/s@{spaceid}@api@cases@reporters.yaml'
+# '/s/{spaceId}/api/cases/status':
+#   $ref: 'paths/s@{spaceid}@api@cases@status.yaml'
+# '/s/{spaceId}/api/cases/tags':
+#   $ref: 'paths/s@{spaceid}@api@cases@tags.yaml'
+# '/s/{spaceId}/api/cases/{caseId}':
+#   $ref: 'paths/s@{spaceid}@api@cases@{caseid}.yaml'
+# '/s/{spaceId}/api/cases/{caseId}/alerts':
+#   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@alerts.yaml'
+# '/s/{spaceId}/api/cases/{caseId}/comments':
+#   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@comments.yaml'
+# '/s/{spaceId}/api/cases/{caseId}/comments/_find':
+#   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@comments@_find.yaml'
+# '/s/{spaceId}/api/cases/{caseId}/comments/{commentId}':
+#   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@comments@{commentid}.yaml'
+# '/s/{spaceId}/api/cases/{caseId}/connector/{connectorId}/_push':
+#   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@connector@{connectorid}@_push.yaml'
+# '/s/{spaceId}/api/cases/{caseId}/user_actions':
+#   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@user_actions.yaml'
+# '/s/{spaceId}/api/cases/{caseId}/user_actions/_find':
+#   $ref: 'paths/s@{spaceid}@api@cases@{caseid}@user_actions@_find.yaml'
 # components:
 #   securitySchemes:
 #     basicAuth:

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@files.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@files.yaml
@@ -1,0 +1,40 @@
+post:
+  summary: Attach a file to a case
+  operationId: addCaseFileDefaultSpace
+  description: >
+    Attach a file to a case.
+    You must have `all` privileges for the **Cases** feature in the
+    **Management**, **Observability**, or **Security** section of the Kibana
+    feature privileges, depending on the owner of the case you're updating.
+    The request must include:
+
+    - The `Content-Type: multipart/form-data` HTTP header.
+
+    - The location of the file that is being uploaded.
+  tags:
+    - cases
+  parameters:
+    - $ref: '../components/headers/kbn_xsrf.yaml'
+    - $ref: '../components/parameters/case_id.yaml'
+  requestBody:
+    required: true
+    content:
+      multipart/form-data:
+        schema:
+          $ref: '../components/schemas/add_case_file_request.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/case_response_properties.yaml'
+          examples:
+            addCaseFileResponse:
+              $ref: '../components/examples/add_comment_response.yaml'
+    '401':
+      description: Authorization information is missing or invalid.
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/4xx_response.yaml'

--- a/x-pack/plugins/cases/server/client/attachments/add_file.test.ts
+++ b/x-pack/plugins/cases/server/client/attachments/add_file.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Readable } from 'stream';
+import type { File } from '@kbn/files-plugin/common';
+
+import type { Case } from '../../../common';
+import { MAX_USER_ACTIONS_PER_CASE } from '../../../common/constants';
+import { createUserActionServiceMock } from '../../services/mocks';
+import { createCasesClientMock, createCasesClientMockArgs } from '../mocks';
+import { addFile } from './add_file';
+import { buildAttachmentRequestFromFileJSON } from '../utils';
+
+jest.mock('../utils');
+
+const buildAttachmentRequestFromFileJSONMock = buildAttachmentRequestFromFileJSON as jest.Mock;
+
+describe('addFile', () => {
+  const caseId = 'test-case';
+  const file = new Readable();
+  file.push('theFile');
+  file.push(null);
+  const owner = 'cases';
+
+  const clientArgs = createCasesClientMockArgs();
+  const casesClient = createCasesClientMock();
+  const userActionService = createUserActionServiceMock();
+
+  clientArgs.services.userActionService = userActionService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue({});
+    casesClient.cases.get.mockResolvedValue({ id: caseId, owner } as unknown as Case);
+  });
+
+  it('throws an error if the filename is missing', async () => {
+    await expect(
+      addFile(
+        // @ts-expect-error
+        { caseId, fileRequest: { file, mimeType: 'text/plain' } },
+        clientArgs,
+        casesClient
+      )
+    ).rejects.toThrow(`Invalid value "undefined" supplied to "filename"`);
+  });
+
+  it('throws an error if the mimeType is not part of the allowed mime types', async () => {
+    await expect(
+      addFile({ caseId, file, filename: 'foobar', mimeType: 'foo/bar' }, clientArgs, casesClient)
+    ).rejects.toThrow('The mime type field value foo/bar is not allowed.');
+  });
+
+  it(`throws an error when the case user actions become > ${MAX_USER_ACTIONS_PER_CASE}`, async () => {
+    userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue({
+      [caseId]: MAX_USER_ACTIONS_PER_CASE,
+    });
+
+    await expect(
+      addFile({ caseId, file, filename: 'foobar', mimeType: 'text/plain' }, clientArgs, casesClient)
+    ).rejects.toThrow(
+      `The case with id ${caseId} has reached the limit of ${MAX_USER_ACTIONS_PER_CASE} user actions.`
+    );
+  });
+
+  it('calls fileService.delete when an error is thrown after the file was created', async () => {
+    const id = 'file-id';
+
+    clientArgs.fileService.create.mockResolvedValue({
+      id,
+      uploadContent: jest.fn(),
+      toJSON: () => {
+        throw new Error(); // ensures an error is thrown after file creation
+      },
+    } as unknown as File);
+
+    await expect(
+      addFile(
+        {
+          caseId,
+          file,
+          filename: 'foobar',
+          mimeType: 'text/plain',
+        },
+        clientArgs,
+        casesClient
+      )
+    ).rejects.toThrowError();
+    expect(clientArgs.fileService.delete).toHaveBeenCalledWith({ id });
+  });
+
+  it('calls buildAttachmentRequestFromFileJSON with the correct params', async () => {
+    const fileMetadata = {
+      id: 'file-id',
+      created: 'created',
+      extension: 'jpg',
+      mimeType: 'image/jpeg',
+      name: 'foobar',
+    };
+
+    clientArgs.fileService.create.mockResolvedValue({
+      id: fileMetadata.id,
+      uploadContent: jest.fn(),
+      toJSON: () => fileMetadata,
+    } as unknown as File);
+
+    buildAttachmentRequestFromFileJSONMock.mockImplementation(() => {
+      throw new Error(); // ensures the test finishes early
+    });
+
+    await expect(
+      addFile(
+        {
+          caseId,
+          file,
+          filename: fileMetadata.name,
+          mimeType: fileMetadata.mimeType,
+        },
+        clientArgs,
+        casesClient
+      )
+    ).rejects.toThrowError();
+    expect(buildAttachmentRequestFromFileJSONMock).toHaveBeenCalledWith({ owner, fileMetadata });
+  });
+});

--- a/x-pack/plugins/cases/server/client/attachments/add_file.ts
+++ b/x-pack/plugins/cases/server/client/attachments/add_file.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SavedObjectsUtils } from '@kbn/core/server';
+
+import type { Owner } from '../../../common/constants/types';
+import { FileAttachmentMetadataPayloadRt, type Case } from '../../../common/types/domain';
+import type { CasesClient, CasesClientArgs } from '..';
+import type { AddFileArgs } from './types';
+
+import { CaseCommentModel } from '../../common/models';
+import { createCaseError } from '../../common/error';
+import { validateMaxUserActions } from '../../common/validators';
+import { constructFileKindIdByOwner } from '../../../common/files';
+import { Operations } from '../../authorization';
+import { validateRegisteredAttachments } from './validators';
+import { buildAttachmentRequestFromFileJSON } from '../utils';
+import { decodeWithExcessOrThrow } from '../../common/runtime_types';
+
+/**
+ * Create a file attachment to a case.
+ */
+export const addFile = async (
+  addFileArgs: AddFileArgs,
+  clientArgs: CasesClientArgs,
+  casesClient: CasesClient
+): Promise<Case> => {
+  const { caseId, file, filename, mimeType, $abort } = addFileArgs;
+  const {
+    logger,
+    authorization,
+    persistableStateAttachmentTypeRegistry,
+    externalReferenceAttachmentTypeRegistry,
+    services: { userActionService },
+    fileService,
+  } = clientArgs;
+
+  let createdFile;
+
+  try {
+    decodeWithExcessOrThrow(FileAttachmentMetadataPayloadRt)({
+      filename,
+      mimeType,
+    });
+
+    // This will perform an authorization check to ensure the user has access to the parent case
+    const theCase = await casesClient.cases.get({
+      id: caseId,
+      includeComments: false,
+    });
+
+    const owner = theCase.owner;
+
+    await validateMaxUserActions({ caseId, userActionService, userActionsToAdd: 1 });
+
+    const savedObjectID = SavedObjectsUtils.generateId();
+
+    await authorization.ensureAuthorized({
+      operation: Operations.createComment,
+      entities: [{ owner, id: savedObjectID }],
+    });
+
+    createdFile = await fileService.create({
+      name: filename,
+      mime: mimeType,
+      fileKind: constructFileKindIdByOwner(owner as Owner),
+      meta: { caseIds: [caseId], owner: [owner] },
+    });
+
+    await createdFile.uploadContent(file, $abort);
+
+    const commentReq = buildAttachmentRequestFromFileJSON({
+      owner,
+      fileMetadata: createdFile.toJSON(),
+    });
+
+    validateRegisteredAttachments({
+      query: commentReq,
+      persistableStateAttachmentTypeRegistry,
+      externalReferenceAttachmentTypeRegistry,
+    });
+
+    const createdDate = new Date().toISOString();
+
+    const model = await CaseCommentModel.create(caseId, clientArgs);
+
+    const updatedModel = await model.createComment({
+      createdDate,
+      commentReq,
+      id: savedObjectID,
+    });
+
+    return await updatedModel.encodeWithComments();
+  } catch (error) {
+    if (createdFile?.id) {
+      await fileService.delete({ id: createdFile.id });
+    }
+
+    throw createCaseError({
+      message: `Failed while adding a comment to case id: ${caseId} error: ${error}`,
+      error,
+      logger,
+    });
+  }
+};

--- a/x-pack/plugins/cases/server/client/attachments/client.ts
+++ b/x-pack/plugins/cases/server/client/attachments/client.ts
@@ -28,6 +28,7 @@ import type {
   UpdateArgs,
   BulkGetArgs,
   BulkDeleteFileArgs,
+  AddFileArgs,
 } from './types';
 import { bulkCreate } from './bulk_create';
 import { deleteAll, deleteComment } from './delete';
@@ -35,6 +36,7 @@ import { find, get, getAll, getAllAlertsAttachToCase } from './get';
 import { bulkGet } from './bulk_get';
 import { update } from './update';
 import { bulkDeleteFileAttachments } from './bulk_delete';
+import { addFile } from './add_file';
 
 /**
  * API for interacting with the attachments to a case.
@@ -77,6 +79,10 @@ export interface AttachmentsSubClient {
    * The request must include all fields for the attachment. Even the fields that are not changing.
    */
   update(updateArgs: UpdateArgs): Promise<Case>;
+  /**
+   * Adds a file attachment to a case. Returns the case with comments.
+   */
+  addFile(params: AddFileArgs): Promise<Case>;
 }
 
 /**
@@ -102,6 +108,7 @@ export const createAttachmentsSubClient = (
     getAll: (params) => getAll(params, clientArgs),
     get: (params) => get(params, clientArgs),
     update: (params) => update(params, clientArgs),
+    addFile: (params: AddFileArgs) => addFile(params, clientArgs, casesClient),
   };
 
   return Object.freeze(attachmentSubClient);

--- a/x-pack/plugins/cases/server/client/attachments/types.ts
+++ b/x-pack/plugins/cases/server/client/attachments/types.ts
@@ -4,7 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import type { Readable } from 'stream';
+import type { ReplaySubject } from 'rxjs';
 import type {
   BulkCreateAttachmentsRequest,
   AttachmentPatchRequest,
@@ -131,4 +132,37 @@ export interface UpdateArgs {
    * The full attachment request with the fields updated with appropriate values
    */
   updateRequest: AttachmentPatchRequest;
+}
+
+export interface HapiReadableStream extends Readable {
+  hapi: {
+    filename: string;
+    headers: Record<string, string>;
+  };
+}
+
+/**
+ * The arguments needed for attaching a file to a case.
+ */
+export interface AddFileArgs {
+  /**
+   * The case ID that this attachment will be associated with
+   */
+  caseId: string;
+  /**
+   * The file to upload
+   */
+  file: Readable;
+  /**
+   * The name of the file to upload
+   */
+  filename: string;
+  /**
+   * The mime type of the file to upload
+   */
+  mimeType?: string;
+  /**
+   * An observable that can be used to abort the upload at any time.
+   */
+  $abort?: ReplaySubject<unknown>;
 }

--- a/x-pack/plugins/cases/server/client/mocks.ts
+++ b/x-pack/plugins/cases/server/client/mocks.ts
@@ -91,6 +91,7 @@ const createAttachmentsSubClientMock = (): AttachmentsSubClientMock => {
   return {
     bulkGet: jest.fn(),
     add: jest.fn(),
+    addFile: jest.fn(),
     bulkCreate: jest.fn(),
     delete: jest.fn(),
     deleteAll: jest.fn(),

--- a/x-pack/plugins/cases/server/client/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/utils.test.ts
@@ -14,6 +14,7 @@ import { toElasticsearchQuery, toKqlExpression } from '@kbn/es-query';
 import { createSavedObjectsSerializerMock } from './mocks';
 import {
   arraysDifference,
+  buildAttachmentRequestFromFileJSON,
   buildFilter,
   buildRangeFilter,
   constructQueryOptions,
@@ -24,6 +25,7 @@ import {
 import { CasePersistedSeverity, CasePersistedStatus } from '../common/types/case';
 import type { CustomFieldsConfiguration } from '../../common/types/domain';
 import { CaseSeverity, CaseStatuses, CustomFieldTypes } from '../../common/types/domain';
+import type { FileJSON } from '@kbn/shared-ux-file-types';
 
 describe('utils', () => {
   describe('buildFilter', () => {
@@ -1574,6 +1576,42 @@ describe('utils', () => {
       });
 
       expect(res).toEqual([]);
+    });
+  });
+
+  describe('buildAttachmentRequestFromFileJSON', () => {
+    it('builds attachment request correctly', () => {
+      expect(
+        buildAttachmentRequestFromFileJSON({
+          owner: 'theOwner',
+          fileMetadata: {
+            id: 'file-id',
+            created: 'created',
+            extension: 'jpg',
+            mimeType: 'image/jpeg',
+            name: 'foobar',
+          } as FileJSON,
+        })
+      ).toStrictEqual({
+        externalReferenceAttachmentTypeId: '.files',
+        externalReferenceId: 'file-id',
+        externalReferenceMetadata: {
+          files: [
+            {
+              created: 'created',
+              extension: 'jpg',
+              mimeType: 'image/jpeg',
+              name: 'foobar',
+            },
+          ],
+        },
+        externalReferenceStorage: {
+          soType: 'file',
+          type: 'savedObject',
+        },
+        owner: 'theOwner',
+        type: 'externalReference',
+      });
     });
   });
 });

--- a/x-pack/plugins/cases/server/client/utils.ts
+++ b/x-pack/plugins/cases/server/client/utils.ts
@@ -16,6 +16,8 @@ import type { KueryNode } from '@kbn/es-query';
 import { nodeBuilder, fromKueryExpression, escapeKuery } from '@kbn/es-query';
 import { spaceIdToNamespace } from '@kbn/spaces-plugin/server/lib/utils/namespace';
 
+import type { FileJSON } from '@kbn/shared-ux-file-types';
+import { FILE_SO_TYPE } from '@kbn/files-plugin/common/constants';
 import type {
   CaseCustomField,
   CaseSeverity,
@@ -28,6 +30,7 @@ import type {
 import {
   ActionsAttachmentPayloadRt,
   AlertAttachmentPayloadRt,
+  AttachmentType,
   ExternalReferenceNoSOAttachmentPayloadRt,
   ExternalReferenceSOAttachmentPayloadRt,
   ExternalReferenceStorageType,
@@ -40,6 +43,7 @@ import type { CasesSearchParams } from './types';
 import { decodeWithExcessOrThrow } from '../common/runtime_types';
 import {
   CASE_SAVED_OBJECT,
+  FILE_ATTACHMENT_TYPE,
   NO_ASSIGNEES_FILTERING_KEYWORD,
   OWNER_FIELD,
 } from '../../common/constants';
@@ -660,3 +664,30 @@ export const transformTemplateCustomFields = ({
     };
   });
 };
+
+export const buildAttachmentRequestFromFileJSON = ({
+  owner,
+  fileMetadata,
+}: {
+  owner: string;
+  fileMetadata: FileJSON;
+}): AttachmentRequest => ({
+  owner,
+  type: AttachmentType.externalReference,
+  externalReferenceId: fileMetadata.id,
+  externalReferenceStorage: {
+    type: ExternalReferenceStorageType.savedObject,
+    soType: FILE_SO_TYPE,
+  },
+  externalReferenceAttachmentTypeId: FILE_ATTACHMENT_TYPE,
+  externalReferenceMetadata: {
+    files: [
+      {
+        name: fileMetadata.name,
+        extension: fileMetadata.extension ?? 'txt',
+        mimeType: fileMetadata.mimeType ?? 'text/plain',
+        created: fileMetadata.created,
+      },
+    ],
+  },
+});

--- a/x-pack/plugins/cases/server/routes/api/files/post_file.test.ts
+++ b/x-pack/plugins/cases/server/routes/api/files/post_file.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createCasesClientMock } from '../../../client/mocks';
+import { postFileRoute } from './post_file';
+
+describe('getCaseRoute', () => {
+  const casesClientMock = createCasesClientMock();
+  const response = { ok: jest.fn() };
+  const context = { cases: { getCasesClient: jest.fn().mockResolvedValue(casesClientMock) } };
+  const sub = { unsubscribe: jest.fn() };
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('extracts the file metadata from hapi as expected', async () => {
+    const request = {
+      body: { file: { hapi: { filename: 'foobar.txt' } } },
+      events: { aborted$: { subscribe: jest.fn().mockReturnValue(sub) } },
+      params: { case_id: 'bar' },
+    };
+
+    // @ts-ignore
+    await postFileRoute.handler({ context, request, response });
+
+    expect(casesClientMock.attachments.addFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        caseId: 'bar',
+        file: {
+          hapi: {
+            filename: 'foobar.txt',
+          },
+        },
+        filename: 'foobar',
+        mimeType: 'text/plain',
+      })
+    );
+
+    expect(sub.unsubscribe).toHaveBeenCalled();
+  });
+
+  it('filename in body takes precedence over metadata', async () => {
+    const request = {
+      body: { file: { hapi: { filename: 'foobar.txt' } }, filename: 'foo' },
+      events: { aborted$: { subscribe: jest.fn().mockReturnValue(sub) } },
+      params: { case_id: 'bar' },
+    };
+
+    // @ts-ignore
+    await postFileRoute.handler({ context, request, response });
+
+    expect(casesClientMock.attachments.addFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        caseId: 'bar',
+        file: {
+          hapi: {
+            filename: 'foobar.txt',
+          },
+        },
+        filename: 'foo',
+        mimeType: 'text/plain',
+      })
+    );
+
+    expect(sub.unsubscribe).toHaveBeenCalled();
+  });
+
+  it('unrecognized mimetype will be sent as undefined', async () => {
+    const request = {
+      body: { file: { hapi: { filename: 'foobar.foobar' } } },
+      events: { aborted$: { subscribe: jest.fn().mockReturnValue(sub) } },
+      params: { case_id: 'bar' },
+    };
+
+    // @ts-ignore
+    await postFileRoute.handler({ context, request, response });
+
+    expect(casesClientMock.attachments.addFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        caseId: 'bar',
+        file: {
+          hapi: {
+            filename: 'foobar.foobar',
+          },
+        },
+      })
+    );
+
+    expect(sub.unsubscribe).toHaveBeenCalled();
+  });
+
+  it('missing hapi will not throw an error', async () => {
+    const request = {
+      body: { file: {} },
+      events: { aborted$: { subscribe: jest.fn().mockReturnValue(sub) } },
+      params: { case_id: 'bar' },
+    };
+
+    // @ts-ignore
+    await postFileRoute.handler({ context, request, response });
+
+    expect(casesClientMock.attachments.addFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        caseId: 'bar',
+        file: {},
+        filename: '',
+      })
+    );
+
+    expect(sub.unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/cases/server/routes/api/files/post_file.ts
+++ b/x-pack/plugins/cases/server/routes/api/files/post_file.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import Boom from '@hapi/boom';
+import mime from 'mime-types';
+import { parse } from 'path';
+
+import { schema } from '@kbn/config-schema';
+import { ReplaySubject } from 'rxjs';
+
+import { AbortedUploadError } from '@kbn/files-plugin/server/file/errors';
+import type { HapiReadableStream } from '../../../client/attachments/types';
+import type { attachmentApiV1 } from '../../../../common/types/api';
+
+import { CASE_FILES_URL } from '../../../../common/constants';
+import { createCaseError } from '../../../common/error';
+import { createCasesRoute } from '../create_cases_route';
+import type { caseDomainV1 } from '../../../../common/types/domain';
+
+export const postFileRoute = createCasesRoute({
+  method: 'post',
+  path: CASE_FILES_URL,
+  params: {
+    params: schema.object({
+      case_id: schema.string(),
+    }),
+  },
+  routerOptions: {
+    access: 'public',
+    summary: 'Attach a file to a case',
+    tags: ['oas-tag:cases'],
+    body: {
+      // This is set to 10 GiB as an upper boundary on the size of the HTTP request body.
+      // The file service will throw 413 errors if the file size is larger than expected.
+      maxBytes: 10 * 1024 * 1024 * 1024,
+      output: 'stream',
+      parse: true,
+      accepts: 'multipart/form-data',
+    },
+  },
+  handler: async ({ context, request, response }) => {
+    const $abort = new ReplaySubject();
+    const sub = request.events.aborted$.subscribe($abort);
+
+    try {
+      const caseContext = await context.cases;
+      const casesClient = await caseContext.getCasesClient();
+
+      const fileRequest = request.body as attachmentApiV1.PostFileAttachmentRequest;
+      const file = fileRequest.file as HapiReadableStream;
+
+      let filename = fileRequest.filename;
+      let mimeType;
+
+      if (file.hapi != null) {
+        const parsedFilename = parse(file.hapi.filename);
+
+        filename ??= parsedFilename.name;
+        mimeType = mime.lookup(parsedFilename.ext.toLowerCase()) || undefined;
+      }
+
+      const res: caseDomainV1.Case = await casesClient.attachments.addFile({
+        file,
+        filename: filename ?? '',
+        mimeType,
+        caseId: request.params.case_id,
+        $abort,
+      });
+
+      return response.ok({
+        body: res,
+      });
+    } catch (error) {
+      if (error instanceof AbortedUploadError) {
+        throw new Boom.Boom(error, {
+          statusCode: 499,
+          message: error.message,
+        });
+      }
+      throw createCaseError({
+        message: `Failed to attach file to case in route: ${error}`,
+        error,
+      });
+    } finally {
+      sub.unsubscribe();
+    }
+  },
+});

--- a/x-pack/plugins/cases/server/routes/api/get_external_routes.ts
+++ b/x-pack/plugins/cases/server/routes/api/get_external_routes.ts
@@ -30,6 +30,7 @@ import { patchCaseConfigureRoute } from './configure/patch_configure';
 import { postCaseConfigureRoute } from './configure/post_configure';
 import { getAllAlertsAttachedToCaseRoute } from './comments/get_alerts';
 import { findUserActionsRoute } from './user_actions/find_user_actions';
+import { postFileRoute } from './files/post_file';
 
 export const getExternalRoutes = ({ isServerless }: { isServerless?: boolean }) =>
   [
@@ -58,4 +59,5 @@ export const getExternalRoutes = ({ isServerless }: { isServerless?: boolean }) 
     patchCaseConfigureRoute,
     postCaseConfigureRoute,
     getAllAlertsAttachedToCaseRoute,
+    postFileRoute,
   ] as CaseRoute[];

--- a/x-pack/test/cases_api_integration/common/lib/api/attachments.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/attachments.ts
@@ -18,6 +18,7 @@ import {
   BulkCreateAttachmentsRequest,
   AttachmentPatchRequest,
   AttachmentsFindResponse,
+  PostFileAttachmentRequest,
 } from '@kbn/cases-plugin/common/types/api';
 import { Attachments, Attachment } from '@kbn/cases-plugin/common/types/domain';
 import { User } from '../authentication/types';
@@ -74,6 +75,33 @@ export const createComment = async ({
     .set('kbn-xsrf', 'true')
     .set(headers)
     .send(params)
+    .expect(expectedHttpCode);
+
+  return theCase;
+};
+
+export const createFileAttachment = async ({
+  supertest,
+  caseId,
+  params,
+  auth = { user: superUser, space: null },
+  expectedHttpCode = 200,
+  headers = {},
+}: {
+  supertest: SuperTest.Agent;
+  caseId: string;
+  params: PostFileAttachmentRequest;
+  auth?: { user: User; space: string | null } | null;
+  expectedHttpCode?: number;
+  headers?: Record<string, string | string[]>;
+}): Promise<Case> => {
+  const apiCall = supertest.post(`${getSpaceUrlPrefix(auth?.space)}${CASES_URL}/${caseId}/files`);
+  void setupAuth({ apiCall, headers, auth });
+
+  const { body: theCase } = await apiCall
+    .set('kbn-xsrf', 'true')
+    .set(headers)
+    .attach('file', Buffer.from(params.file as unknown as string), params.filename)
     .expect(expectedHttpCode);
 
   return theCase;

--- a/x-pack/test/cases_api_integration/common/lib/mock.ts
+++ b/x-pack/test/cases_api_integration/common/lib/mock.ts
@@ -20,7 +20,10 @@ import {
   PersistableStateAttachmentPayload,
   Attachment,
 } from '@kbn/cases-plugin/common/types/domain';
-import type { CasePostRequest } from '@kbn/cases-plugin/common/types/api';
+import type {
+  CasePostRequest,
+  PostFileAttachmentRequest,
+} from '@kbn/cases-plugin/common/types/api';
 import { FILE_ATTACHMENT_TYPE } from '@kbn/cases-plugin/common/constants';
 import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
 import { FILE_SO_TYPE } from '@kbn/files-plugin/common';
@@ -62,6 +65,11 @@ export const postCommentUserReq: UserCommentAttachmentPayload = {
   comment: 'This is a cool comment',
   type: AttachmentType.user,
   owner: 'securitySolutionFixture',
+};
+
+export const postFileReq: PostFileAttachmentRequest = {
+  file: 'This is a file, a buffer will be created from this string.',
+  filename: 'foobar.txt',
 };
 
 export const postCommentAlertReq: AlertAttachmentPayload = {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/delete_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/delete_cases.ts
@@ -79,6 +79,9 @@ export default ({ getService }: FtrProviderContext): void => {
 
   describe('delete_cases', () => {
     afterEach(async () => {
+      await deleteAllFiles({
+        supertest,
+      });
       await deleteAllCaseItems(es);
     });
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/files/post_file.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/files/post_file.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { ExternalReferenceAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
+import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common';
+import {
+  globalRead,
+  noKibanaPrivileges,
+  obsOnly,
+  obsOnlyRead,
+  obsSecRead,
+  secOnly,
+  secOnlyRead,
+  superUser,
+} from '../../../../common/lib/authentication/users';
+import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+
+import { defaultUser, postCaseReq, postFileReq } from '../../../../common/lib/mock';
+import {
+  createCase,
+  createFileAttachment,
+  removeServerGeneratedPropertiesFromSavedObject,
+  getAuthWithSuperUser,
+  deleteAllCaseItems,
+  superUserSpace1Auth,
+  deleteAllFiles,
+} from '../../../../common/lib/api';
+
+// eslint-disable-next-line import/no-default-export
+export default ({ getService }: FtrProviderContext): void => {
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const authSpace1 = getAuthWithSuperUser();
+  const caseRequest = { ...postCaseReq, owner: SECURITY_SOLUTION_OWNER };
+
+  describe('post_file', () => {
+    afterEach(async () => {
+      await deleteAllCaseItems(es);
+    });
+
+    describe('happy path', () => {
+      afterEach(async () => {
+        await deleteAllFiles({
+          supertest,
+          auth: authSpace1,
+        });
+      });
+
+      it('should post a file in space1', async () => {
+        const postedCase = await createCase(supertest, caseRequest, 200, authSpace1);
+        const patchedCase = await createFileAttachment({
+          supertest,
+          caseId: postedCase.id,
+          params: postFileReq,
+          auth: authSpace1,
+        });
+
+        const attachedFileComment = removeServerGeneratedPropertiesFromSavedObject(
+          patchedCase.comments![0]
+        ) as ExternalReferenceAttachmentAttributes;
+        // @ts-ignore
+        const fileMetadata = attachedFileComment.externalReferenceMetadata?.files[0];
+
+        expect(attachedFileComment.owner).to.be('securitySolution');
+        expect(attachedFileComment.externalReferenceId).to.be.ok(); // truthy
+        expect(attachedFileComment.externalReferenceAttachmentTypeId).to.be('.files');
+        expect(attachedFileComment.externalReferenceStorage).to.eql({
+          soType: 'file',
+          type: 'savedObject',
+        });
+        expect(fileMetadata.name).to.be('foobar');
+        expect(fileMetadata.mimeType).to.be('text/plain');
+        expect(fileMetadata.extension).to.be('txt');
+
+        // updates the case correctly after adding a comment
+        expect(patchedCase.totalComment).to.eql(patchedCase.comments!.length);
+        expect(patchedCase.updated_by).to.eql(defaultUser);
+      });
+    });
+
+    describe('unhappy path', () => {
+      it('should return a 400 when posting a file without a filename', async () => {
+        const postedCase = await createCase(supertest, caseRequest, 200, authSpace1);
+        await createFileAttachment({
+          supertest,
+          caseId: postedCase.id,
+          params: { ...postFileReq, filename: '' },
+          auth: authSpace1,
+          expectedHttpCode: 400,
+        });
+      });
+
+      it('should return a 400 when posting a file with a filename that is too long', async () => {
+        const longFilename = Array(161).fill('a').toString();
+
+        const postedCase = await createCase(supertest, caseRequest, 200, authSpace1);
+        await createFileAttachment({
+          supertest,
+          caseId: postedCase.id,
+          params: { ...postFileReq, filename: longFilename },
+          auth: authSpace1,
+          expectedHttpCode: 400,
+        });
+      });
+
+      it('should return a 400 when posting a file with an invalid mime type', async () => {
+        const postedCase = await createCase(supertest, caseRequest, 200, authSpace1);
+        await createFileAttachment({
+          supertest,
+          caseId: postedCase.id,
+          params: { ...postFileReq, filename: 'foobar.124zas' },
+          auth: authSpace1,
+          expectedHttpCode: 400,
+        });
+      });
+    });
+
+    describe('rbac', () => {
+      const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+      afterEach(async () => {
+        await deleteAllCaseItems(es);
+      });
+
+      it('should not post a file when the user does not have permissions for that owner', async () => {
+        const postedCase = await createCase(supertest, caseRequest, 200, authSpace1);
+
+        await createFileAttachment({
+          supertest: supertestWithoutAuth,
+          caseId: postedCase.id,
+          params: postFileReq,
+          auth: { user: obsOnly, space: 'space1' },
+          expectedHttpCode: 403,
+        });
+      });
+
+      for (const user of [globalRead, secOnlyRead, obsOnlyRead, obsSecRead, noKibanaPrivileges]) {
+        it(`User ${
+          user.username
+        } with role(s) ${user.roles.join()} - should not post a file`, async () => {
+          const postedCase = await createCase(
+            supertestWithoutAuth,
+            caseRequest,
+            200,
+            superUserSpace1Auth
+          );
+
+          await createFileAttachment({
+            supertest: supertestWithoutAuth,
+            caseId: postedCase.id,
+            params: postFileReq,
+            auth: { user, space: 'space1' },
+            expectedHttpCode: 403,
+          });
+        });
+      }
+
+      it('should not post a file in a space the user does not have permissions for', async () => {
+        const postedCase = await createCase(supertestWithoutAuth, caseRequest, 200, {
+          user: superUser,
+          space: 'space2',
+        });
+
+        await createFileAttachment({
+          supertest: supertestWithoutAuth,
+          caseId: postedCase.id,
+          params: postFileReq,
+          auth: { user: secOnly, space: 'space2' },
+          expectedHttpCode: 403,
+        });
+      });
+    });
+  });
+};

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/index.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/index.ts
@@ -21,6 +21,7 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
     loadTestFile(require.resolve('./comments/get_all_comments'));
     loadTestFile(require.resolve('./comments/patch_comment'));
     loadTestFile(require.resolve('./comments/post_comment'));
+    loadTestFile(require.resolve('./files/post_file'));
     loadTestFile(require.resolve('./alerts/get_cases'));
     loadTestFile(require.resolve('./alerts/get_alerts_attached_to_case'));
     loadTestFile(require.resolve('./cases/delete_cases'));

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/files/post_file.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/files/post_file.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { ExternalReferenceAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
+import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common';
+import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+
+import { nullUser, postCaseReq, postFileReq } from '../../../../common/lib/mock';
+import {
+  createCase,
+  createFileAttachment,
+  removeServerGeneratedPropertiesFromSavedObject,
+  getAuthWithSuperUser,
+  deleteAllCaseItems,
+  deleteAllFiles,
+} from '../../../../common/lib/api';
+
+// eslint-disable-next-line import/no-default-export
+export default ({ getService }: FtrProviderContext): void => {
+  // const supertest = getService('supertest');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+  const es = getService('es');
+  const authSpace1 = getAuthWithSuperUser();
+
+  describe('post_file', () => {
+    afterEach(async () => {
+      await deleteAllFiles({
+        supertest: supertestWithoutAuth,
+        auth: authSpace1,
+      });
+      await deleteAllCaseItems(es);
+    });
+
+    it('should post a file in space1', async () => {
+      const postedCase = await createCase(
+        supertestWithoutAuth,
+        { ...postCaseReq, owner: SECURITY_SOLUTION_OWNER },
+        200,
+        authSpace1
+      );
+      const patchedCase = await createFileAttachment({
+        supertest: supertestWithoutAuth,
+        caseId: postedCase.id,
+        params: postFileReq,
+        auth: authSpace1,
+      });
+
+      const attachedFileComment = removeServerGeneratedPropertiesFromSavedObject(
+        patchedCase.comments![0]
+      ) as ExternalReferenceAttachmentAttributes;
+      // @ts-ignore
+      const fileMetadata = attachedFileComment.externalReferenceMetadata?.files[0];
+
+      expect(attachedFileComment.owner).to.be('securitySolution');
+      expect(attachedFileComment.externalReferenceId).to.be.ok(); // truthy
+      expect(attachedFileComment.externalReferenceAttachmentTypeId).to.be('.files');
+      expect(attachedFileComment.externalReferenceStorage).to.eql({
+        soType: 'file',
+        type: 'savedObject',
+      });
+      expect(fileMetadata.name).to.be('foobar');
+      expect(fileMetadata.mimeType).to.be('text/plain');
+      expect(fileMetadata.extension).to.be('txt');
+
+      // updates the case correctly after adding a comment
+      expect(patchedCase.totalComment).to.eql(patchedCase.comments!.length);
+      expect(patchedCase.updated_by).to.eql(nullUser);
+    });
+
+    it('should not post a file on a case in a different space', async () => {
+      const postedCase = await createCase(supertestWithoutAuth, postCaseReq, 200, authSpace1);
+      await createFileAttachment({
+        supertest: supertestWithoutAuth,
+        caseId: postedCase.id,
+        params: postFileReq,
+        auth: getAuthWithSuperUser('space2'),
+        expectedHttpCode: 404,
+      });
+    });
+  });
+};

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/index.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/index.ts
@@ -17,6 +17,7 @@ export default ({ loadTestFile }: FtrProviderContext): void => {
     loadTestFile(require.resolve('./comments/get_all_comments'));
     loadTestFile(require.resolve('./comments/patch_comment'));
     loadTestFile(require.resolve('./comments/post_comment'));
+    loadTestFile(require.resolve('./files/post_file'));
     loadTestFile(require.resolve('./cases/delete_cases'));
     loadTestFile(require.resolve('./cases/find_cases'));
     loadTestFile(require.resolve('./cases/get_case'));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ResponseOps] [Cases] Attach file to case API (#198377)](https://github.com/elastic/kibana/pull/198377)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Antonio","email":"antonio.coelho@elastic.co"},"sourceCommit":{"committedDate":"2024-11-14T17:05:11Z","message":"[ResponseOps] [Cases] Attach file to case API (#198377)\n\nFixes #22832\r\n\r\n## Summary\r\n\r\nThis PR adds the possibility of adding Files/Attachments to Case in\r\nKibana via an API call.\r\n\r\n### How to test\r\n\r\nThe new API URL is `https://localhost:5601/api/cases/<CASE_ID>/files`.\r\nYou can either use postman or curl to test.\r\n\r\n1. Start by creating a case.\r\n2. Call the new API\r\n```\r\ncurl --location 'https://localhost:5601/api/cases/<CASE_ID>/files' \\\r\n--header 'kbn-xsrf: true' \\\r\n--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \\\r\n--form 'filename=\"Notice\"' \\\r\n--form 'mimeType=\"text/plain\"' \\\r\n--form 'file=@\"<FULL_PATH_TO_THE_FILE_YOU_WANT_TO_UPLOAD>\"'\r\n```\r\n<img width=\"1090\" alt=\"Screenshot 2024-10-30 at 15 41 26\"\r\nsrc=\"https://github.com/user-attachments/assets/b018f92d-2603-4bf1-ac12-f01452f35303\">\r\n\r\n3. Confirm the user action was created.\r\n<img width=\"383\" alt=\"Screenshot 2024-10-30 at 15 48 45\"\r\nsrc=\"https://github.com/user-attachments/assets/04952b8f-e8fb-4f19-a72f-54030f496fe9\">\r\n\r\n4. Confirm the file exists in the case and:\r\n    - it can be downloaded as expected.\r\n    - it can be previewed as expected(not every MIME type allows this).\r\n\r\n\r\n### Release Notes\r\n\r\nFiles can now be attached to cases directly via API.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: lcawl <lcawley@elastic.co>","sha":"e2702ff5912ec440060d62fb323a9a03c4881143","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:ResponseOps","v9.0.0","Feature:Cases","release_note:feature","backport:prev-minor","v8.17.0"],"number":198377,"url":"https://github.com/elastic/kibana/pull/198377","mergeCommit":{"message":"[ResponseOps] [Cases] Attach file to case API (#198377)\n\nFixes #22832\r\n\r\n## Summary\r\n\r\nThis PR adds the possibility of adding Files/Attachments to Case in\r\nKibana via an API call.\r\n\r\n### How to test\r\n\r\nThe new API URL is `https://localhost:5601/api/cases/<CASE_ID>/files`.\r\nYou can either use postman or curl to test.\r\n\r\n1. Start by creating a case.\r\n2. Call the new API\r\n```\r\ncurl --location 'https://localhost:5601/api/cases/<CASE_ID>/files' \\\r\n--header 'kbn-xsrf: true' \\\r\n--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \\\r\n--form 'filename=\"Notice\"' \\\r\n--form 'mimeType=\"text/plain\"' \\\r\n--form 'file=@\"<FULL_PATH_TO_THE_FILE_YOU_WANT_TO_UPLOAD>\"'\r\n```\r\n<img width=\"1090\" alt=\"Screenshot 2024-10-30 at 15 41 26\"\r\nsrc=\"https://github.com/user-attachments/assets/b018f92d-2603-4bf1-ac12-f01452f35303\">\r\n\r\n3. Confirm the user action was created.\r\n<img width=\"383\" alt=\"Screenshot 2024-10-30 at 15 48 45\"\r\nsrc=\"https://github.com/user-attachments/assets/04952b8f-e8fb-4f19-a72f-54030f496fe9\">\r\n\r\n4. Confirm the file exists in the case and:\r\n    - it can be downloaded as expected.\r\n    - it can be previewed as expected(not every MIME type allows this).\r\n\r\n\r\n### Release Notes\r\n\r\nFiles can now be attached to cases directly via API.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: lcawl <lcawley@elastic.co>","sha":"e2702ff5912ec440060d62fb323a9a03c4881143"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/198377","number":198377,"mergeCommit":{"message":"[ResponseOps] [Cases] Attach file to case API (#198377)\n\nFixes #22832\r\n\r\n## Summary\r\n\r\nThis PR adds the possibility of adding Files/Attachments to Case in\r\nKibana via an API call.\r\n\r\n### How to test\r\n\r\nThe new API URL is `https://localhost:5601/api/cases/<CASE_ID>/files`.\r\nYou can either use postman or curl to test.\r\n\r\n1. Start by creating a case.\r\n2. Call the new API\r\n```\r\ncurl --location 'https://localhost:5601/api/cases/<CASE_ID>/files' \\\r\n--header 'kbn-xsrf: true' \\\r\n--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \\\r\n--form 'filename=\"Notice\"' \\\r\n--form 'mimeType=\"text/plain\"' \\\r\n--form 'file=@\"<FULL_PATH_TO_THE_FILE_YOU_WANT_TO_UPLOAD>\"'\r\n```\r\n<img width=\"1090\" alt=\"Screenshot 2024-10-30 at 15 41 26\"\r\nsrc=\"https://github.com/user-attachments/assets/b018f92d-2603-4bf1-ac12-f01452f35303\">\r\n\r\n3. Confirm the user action was created.\r\n<img width=\"383\" alt=\"Screenshot 2024-10-30 at 15 48 45\"\r\nsrc=\"https://github.com/user-attachments/assets/04952b8f-e8fb-4f19-a72f-54030f496fe9\">\r\n\r\n4. Confirm the file exists in the case and:\r\n    - it can be downloaded as expected.\r\n    - it can be previewed as expected(not every MIME type allows this).\r\n\r\n\r\n### Release Notes\r\n\r\nFiles can now be attached to cases directly via API.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: lcawl <lcawley@elastic.co>","sha":"e2702ff5912ec440060d62fb323a9a03c4881143"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->