### PR TITLE
[8.16] [Security Solution][Data Quality Dashboard][Serverless] Fix fetchAvailableIndices in get_index_stats (#197065)

### DIFF
--- a/x-pack/plugins/ecs_data_quality_dashboard/server/lib/fetch_available_indices.test.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/lib/fetch_available_indices.test.ts
@@ -1,0 +1,454 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient } from '@kbn/core/server';
+import moment from 'moment-timezone';
+
+import type {
+  FetchAvailableCatIndicesResponseRequired,
+  IndexSearchAggregationResponse,
+} from './fetch_available_indices';
+import { fetchAvailableIndices } from './fetch_available_indices';
+
+function getEsClientMock() {
+  return {
+    search: jest.fn().mockResolvedValue({
+      aggregations: {
+        index: {
+          buckets: [],
+        },
+      },
+    }),
+    cat: {
+      indices: jest.fn().mockResolvedValue([]),
+    },
+  } as unknown as ElasticsearchClient & {
+    cat: {
+      indices: jest.Mock<Promise<FetchAvailableCatIndicesResponseRequired>>;
+    };
+    search: jest.Mock<Promise<{ aggregations: IndexSearchAggregationResponse }>>;
+  };
+}
+
+// fixing timezone for both Date and moment
+// so when tests are run in different timezones, the results are consistent
+process.env.TZ = 'UTC';
+moment.tz.setDefault('UTC');
+
+const DAY_IN_MILLIS = 24 * 60 * 60 * 1000;
+
+// We assume that the dates are in UTC, because es is using UTC
+// It also diminishes difference date parsing by Date and moment constructors
+// in different timezones, i.e. short ISO format '2021-10-01' is parsed as local
+// date by moment and as UTC date by Date, whereas long ISO format '2021-10-01T00:00:00Z'
+// is parsed as UTC date by both
+const startDateString: string = '2021-10-01T00:00:00Z';
+const endDateString: string = '2021-10-07T00:00:00Z';
+
+const startDateMillis: number = new Date(startDateString).getTime();
+const endDateMillis: number = new Date(endDateString).getTime();
+
+describe('fetchAvailableIndices', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('aggregate search given index by startDate and endDate', async () => {
+    const esClientMock = getEsClientMock();
+
+    await fetchAvailableIndices(esClientMock, {
+      indexPattern: 'logs-*',
+      startDate: startDateString,
+      endDate: endDateString,
+    });
+
+    expect(esClientMock.search).toHaveBeenCalledWith({
+      query: {
+        bool: {
+          filter: [
+            {
+              range: {
+                '@timestamp': {
+                  format: 'strict_date_optional_time',
+                  gte: startDateString,
+                  lte: endDateString,
+                },
+              },
+            },
+          ],
+          must: [],
+          must_not: [],
+          should: [],
+        },
+      },
+      index: 'logs-*',
+      size: 0,
+      aggs: {
+        index: {
+          terms: {
+            field: '_index',
+          },
+        },
+      },
+    });
+  });
+
+  it('should call esClient.cat.indices for given index', async () => {
+    const esClientMock = getEsClientMock();
+
+    await fetchAvailableIndices(esClientMock, {
+      indexPattern: 'logs-*',
+      startDate: startDateString,
+      endDate: endDateString,
+    });
+
+    expect(esClientMock.cat.indices).toHaveBeenCalledWith({
+      index: 'logs-*',
+      format: 'json',
+      h: 'index,creation.date',
+    });
+  });
+
+  describe('when indices are created within the date range', () => {
+    it('returns indices within the date range', async () => {
+      const esClientMock = getEsClientMock();
+
+      esClientMock.cat.indices.mockResolvedValue([
+        {
+          index: 'logs-2021.10.01',
+          'creation.date': `${startDateMillis}`,
+        },
+        {
+          index: 'logs-2021.10.05',
+          'creation.date': `${startDateMillis + 4 * DAY_IN_MILLIS}`,
+        },
+        {
+          index: 'logs-2021.09.30',
+          'creation.date': `${startDateMillis - DAY_IN_MILLIS}`,
+        },
+      ]);
+
+      const result = await fetchAvailableIndices(esClientMock, {
+        indexPattern: 'logs-*',
+        startDate: startDateString,
+        endDate: endDateString,
+      });
+
+      expect(result).toEqual(['logs-2021.10.01', 'logs-2021.10.05']);
+
+      expect(esClientMock.cat.indices).toHaveBeenCalledWith({
+        index: 'logs-*',
+        format: 'json',
+        h: 'index,creation.date',
+      });
+    });
+  });
+
+  describe('when indices are outside the date range', () => {
+    it('returns an empty list', async () => {
+      const esClientMock = getEsClientMock();
+
+      esClientMock.cat.indices.mockResolvedValue([
+        {
+          index: 'logs-2021.09.30',
+          'creation.date': `${startDateMillis - DAY_IN_MILLIS}`,
+        },
+        {
+          index: 'logs-2021.10.08',
+          'creation.date': `${endDateMillis + DAY_IN_MILLIS}`,
+        },
+      ]);
+
+      const result = await fetchAvailableIndices(esClientMock, {
+        indexPattern: 'logs-*',
+        startDate: startDateString,
+        endDate: endDateString,
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('when no indices match the index pattern', () => {
+    it('returns empty list', async () => {
+      const esClientMock = getEsClientMock();
+
+      esClientMock.cat.indices.mockResolvedValue([]);
+
+      const result = await fetchAvailableIndices(esClientMock, {
+        indexPattern: 'nonexistent-*',
+        startDate: startDateString,
+        endDate: endDateString,
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('when indices have data in the date range', () => {
+    it('returns indices with data in the date range', async () => {
+      const esClientMock = getEsClientMock();
+
+      // esClient.cat.indices returns no indices
+      esClientMock.cat.indices.mockResolvedValue([]);
+
+      // esClient.search returns indices with data in the date range
+      esClientMock.search.mockResolvedValue({
+        aggregations: {
+          index: {
+            buckets: [
+              { key: 'logs-2021.10.02', doc_count: 100 },
+              { key: 'logs-2021.10.03', doc_count: 150 },
+            ],
+          },
+        },
+      });
+
+      const result = await fetchAvailableIndices(esClientMock, {
+        indexPattern: 'logs-*',
+        startDate: startDateString,
+        endDate: endDateString,
+      });
+
+      expect(result).toEqual(['logs-2021.10.02', 'logs-2021.10.03']);
+    });
+
+    it('combines indices from both methods without duplicates', async () => {
+      const esClientMock = getEsClientMock();
+
+      esClientMock.cat.indices.mockResolvedValue([
+        {
+          index: 'logs-2021.10.01',
+          'creation.date': `${startDateMillis}`,
+        },
+        {
+          index: 'logs-2021.10.03',
+          'creation.date': `${startDateMillis + 2 * DAY_IN_MILLIS}`,
+        },
+      ]);
+
+      esClientMock.search.mockResolvedValue({
+        aggregations: {
+          index: {
+            buckets: [
+              { key: 'logs-2021.10.03', doc_count: 150 },
+              { key: 'logs-2021.10.04', doc_count: 200 },
+            ],
+          },
+        },
+      });
+
+      const result = await fetchAvailableIndices(esClientMock, {
+        indexPattern: 'logs-*',
+        startDate: startDateString,
+        endDate: endDateString,
+      });
+
+      expect(result).toEqual(['logs-2021.10.01', 'logs-2021.10.03', 'logs-2021.10.04']);
+    });
+  });
+
+  describe('edge cases for creation dates', () => {
+    it('includes indices with creation date exactly at startDate and endDate', async () => {
+      const esClientMock = getEsClientMock();
+
+      esClientMock.cat.indices.mockResolvedValue([
+        {
+          index: 'logs-2021.10.01',
+          'creation.date': `${startDateMillis}`,
+        },
+        {
+          index: 'logs-2021.10.07',
+          'creation.date': `${endDateMillis}`,
+        },
+      ]);
+
+      const result = await fetchAvailableIndices(esClientMock, {
+        indexPattern: 'logs-*',
+        startDate: startDateString,
+        endDate: endDateString,
+      });
+
+      expect(result).toEqual(['logs-2021.10.01', 'logs-2021.10.07']);
+    });
+  });
+
+  describe('when esClient.search rejects', () => {
+    it('throws an error', async () => {
+      const esClientMock = getEsClientMock();
+
+      esClientMock.search.mockRejectedValue(new Error('Elasticsearch search error'));
+
+      await expect(
+        fetchAvailableIndices(esClientMock, {
+          indexPattern: 'logs-*',
+          startDate: startDateString,
+          endDate: endDateString,
+        })
+      ).rejects.toThrow('Elasticsearch search error');
+    });
+  });
+
+  describe('when both esClient.cat.indices and esClient.search return empty', () => {
+    it('returns an empty list', async () => {
+      const esClientMock = getEsClientMock();
+
+      esClientMock.cat.indices.mockResolvedValue([]);
+      esClientMock.search.mockResolvedValue({
+        aggregations: {
+          index: {
+            buckets: [],
+          },
+        },
+      });
+
+      const result = await fetchAvailableIndices(esClientMock, {
+        indexPattern: 'logs-*',
+        startDate: startDateString,
+        endDate: endDateString,
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('when indices are returned with both methods and have duplicates', () => {
+    it('does not duplicate indices in the result', async () => {
+      const esClientMock = getEsClientMock();
+
+      esClientMock.cat.indices.mockResolvedValue([
+        {
+          index: 'logs-2021.10.05',
+          'creation.date': `${startDateMillis + 4 * DAY_IN_MILLIS}`,
+        },
+      ]);
+
+      esClientMock.search.mockResolvedValue({
+        aggregations: {
+          index: {
+            buckets: [{ key: 'logs-2021.10.05', doc_count: 100 }],
+          },
+        },
+      });
+
+      const result = await fetchAvailableIndices(esClientMock, {
+        indexPattern: 'logs-*',
+        startDate: startDateString,
+        endDate: endDateString,
+      });
+
+      expect(result).toEqual(['logs-2021.10.05']);
+    });
+  });
+
+  describe('given keyword dates', () => {
+    describe('given 7 days range', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2021-10-07T00:00:00Z').getTime());
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it('finds indices created within the date range', async () => {
+        const esClientMock = getEsClientMock();
+
+        esClientMock.cat.indices.mockResolvedValue([
+          {
+            index: 'logs-2021.10.01',
+            'creation.date': `${startDateMillis}`,
+          },
+          {
+            index: 'logs-2021.10.05',
+            'creation.date': `${startDateMillis + 4 * DAY_IN_MILLIS}`,
+          },
+        ]);
+
+        const results = await fetchAvailableIndices(esClientMock, {
+          indexPattern: 'logs-*',
+          startDate: 'now-7d/d',
+          endDate: 'now/d',
+        });
+
+        expect(results).toEqual(['logs-2021.10.01', 'logs-2021.10.05']);
+      });
+
+      it('finds indices with end date rounded up to the end of the day', async () => {
+        const esClientMock = getEsClientMock();
+
+        esClientMock.cat.indices.mockResolvedValue([
+          {
+            index: 'logs-2021.10.06',
+            'creation.date': `${new Date('2021-10-06T23:59:59Z').getTime()}`,
+          },
+        ]);
+
+        const results = await fetchAvailableIndices(esClientMock, {
+          indexPattern: 'logs-*',
+          startDate: 'now-7d/d',
+          endDate: 'now-1d/d',
+        });
+
+        expect(results).toEqual(['logs-2021.10.06']);
+      });
+    });
+  });
+
+  describe('rejections', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+    describe('when esClient.cat.indices rejects', () => {
+      it('throws an error', async () => {
+        const esClientMock = getEsClientMock();
+
+        esClientMock.cat.indices.mockRejectedValue(new Error('Elasticsearch error'));
+
+        await expect(
+          fetchAvailableIndices(esClientMock, {
+            indexPattern: 'logs-*',
+            startDate: startDateString,
+            endDate: endDateString,
+          })
+        ).rejects.toThrow('Elasticsearch error');
+      });
+    });
+
+    describe('when startDate is invalid', () => {
+      it('throws an error', async () => {
+        const esClientMock = getEsClientMock();
+
+        await expect(
+          fetchAvailableIndices(esClientMock, {
+            indexPattern: 'logs-*',
+            startDate: 'invalid-date',
+            endDate: endDateString,
+          })
+        ).rejects.toThrow('Invalid date format: invalid-date');
+      });
+    });
+
+    describe('when endDate is invalid', () => {
+      it('throws an error', async () => {
+        const esClientMock = getEsClientMock();
+
+        await expect(
+          fetchAvailableIndices(esClientMock, {
+            indexPattern: 'logs-*',
+            startDate: startDateString,
+            endDate: 'invalid-date',
+          })
+        ).rejects.toThrow('Invalid date format: invalid-date');
+      });
+    });
+  });
+});

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/lib/fetch_available_indices.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/lib/fetch_available_indices.ts
@@ -4,18 +4,72 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import type { ElasticsearchClient } from '@kbn/core/server';
+import type { CatIndicesIndicesRecord } from '@elastic/elasticsearch/lib/api/types';
+import dateMath from '@kbn/datemath';
+
 import { getRequestBody } from '../helpers/get_available_indices';
 
+export type FetchAvailableCatIndicesResponseRequired = Array<
+  Required<Pick<CatIndicesIndicesRecord, 'index' | 'creation.date'>>
+>;
+
 type AggregateName = 'index';
-interface Result {
+export interface IndexSearchAggregationResponse {
   index: {
-    buckets: Array<{ key: string }>;
-    doc_count: number;
+    buckets: Array<{ key: string; doc_count: number }>;
   };
 }
 
-export const fetchAvailableIndices = (
+const getParsedDateMs = (dateStr: string, roundUp = false) => {
+  const date = dateMath.parse(dateStr, roundUp ? { roundUp: true } : undefined);
+  if (!date?.isValid()) {
+    throw new Error(`Invalid date format: ${dateStr}`);
+  }
+  return date.valueOf();
+};
+
+export const fetchAvailableIndices = async (
   esClient: ElasticsearchClient,
   params: { indexPattern: string; startDate: string; endDate: string }
-) => esClient.search<AggregateName, Result>(getRequestBody(params));
+): Promise<string[]> => {
+  const { indexPattern, startDate, endDate } = params;
+
+  const startDateMs = getParsedDateMs(startDate);
+  const endDateMs = getParsedDateMs(endDate, true);
+
+  const indicesCats = (await esClient.cat.indices({
+    index: indexPattern,
+    format: 'json',
+    h: 'index,creation.date',
+  })) as FetchAvailableCatIndicesResponseRequired;
+
+  const indicesCatsInRange = indicesCats.filter((indexInfo) => {
+    const creationDateMs = parseInt(indexInfo['creation.date'], 10);
+    return creationDateMs >= startDateMs && creationDateMs <= endDateMs;
+  });
+
+  const timeSeriesIndicesWithDataInRangeSearchResult = await esClient.search<
+    AggregateName,
+    IndexSearchAggregationResponse
+  >(getRequestBody(params));
+
+  const timeSeriesIndicesWithDataInRange =
+    timeSeriesIndicesWithDataInRangeSearchResult.aggregations?.index.buckets.map(
+      (bucket) => bucket.key
+    ) || [];
+
+  // Combine indices from both sources removing duplicates
+  const resultingIndices = new Set<string>();
+
+  for (const indicesCat of indicesCatsInRange) {
+    resultingIndices.add(indicesCat.index);
+  }
+
+  for (const timeSeriesIndex of timeSeriesIndicesWithDataInRange) {
+    resultingIndices.add(timeSeriesIndex);
+  }
+
+  return Array.from(resultingIndices);
+};

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/lib/fetch_stats.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/lib/fetch_stats.ts
@@ -57,16 +57,16 @@ export const parseMeteringStats = (meteringStatsIndices: MeteringStatsIndex[]) =
   }, {});
 
 export const pickAvailableMeteringStats = (
-  indicesBuckets: Array<{ key: string }>,
+  indicesBuckets: string[],
   meteringStatsIndices: Record<string, MeteringStatsIndex>
 ) =>
-  indicesBuckets.reduce((acc: Record<string, MeteringStatsIndex>, { key }: { key: string }) => {
-    if (meteringStatsIndices?.[key]) {
-      acc[key] = {
-        name: meteringStatsIndices?.[key].name,
-        num_docs: meteringStatsIndices?.[key].num_docs,
+  indicesBuckets.reduce((acc: Record<string, MeteringStatsIndex>, indexName: string) => {
+    if (meteringStatsIndices?.[indexName]) {
+      acc[indexName] = {
+        name: meteringStatsIndices?.[indexName].name,
+        num_docs: meteringStatsIndices?.[indexName].num_docs,
         size_in_bytes: null, // We don't have size_in_bytes intentionally when ILM is not available
-        data_stream: meteringStatsIndices?.[key].data_stream,
+        data_stream: meteringStatsIndices?.[indexName].data_stream,
       };
     }
     return acc;

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.test.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.test.ts
@@ -152,17 +152,7 @@ describe('getIndexStatsRoute route', () => {
       },
     };
     (fetchMeteringStats as jest.Mock).mockResolvedValue(mockMeteringStatsIndex);
-    (fetchAvailableIndices as jest.Mock).mockResolvedValue({
-      aggregations: {
-        index: {
-          buckets: [
-            {
-              key: 'my-index-000001',
-            },
-          ],
-        },
-      },
-    });
+    (fetchAvailableIndices as jest.Mock).mockResolvedValue(['my-index-000001']);
 
     const response = await server.inject(request, requestContextMock.convertContext(context));
     expect(response.status).toEqual(200);
@@ -198,7 +188,7 @@ describe('getIndexStatsRoute route', () => {
     );
   });
 
-  test('returns an empty object when "availableIndices" indices are not available', async () => {
+  test('returns an empty object when "availableIndices" indices are empty', async () => {
     const request = requestMock.create({
       method: 'get',
       path: GET_INDEX_STATS,
@@ -214,9 +204,7 @@ describe('getIndexStatsRoute route', () => {
 
     const mockIndices = {};
     (fetchMeteringStats as jest.Mock).mockResolvedValue(mockMeteringStatsIndex);
-    (fetchAvailableIndices as jest.Mock).mockResolvedValue({
-      aggregations: undefined,
-    });
+    (fetchAvailableIndices as jest.Mock).mockResolvedValue([]);
 
     const response = await server.inject(request, requestContextMock.convertContext(context));
     expect(response.status).toEqual(200);

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
@@ -86,7 +86,7 @@ export const getIndexStatsRoute = (router: IRouter, logger: Logger) => {
               endDate: decodedEndDate,
             });
 
-            if (!availableIndices.aggregations?.index?.buckets) {
+            if (availableIndices.length === 0) {
               logger.warn(
                 `No available indices found under pattern: ${decodedIndexName}, in the given date range: ${decodedStartDate} - ${decodedEndDate}`
               );
@@ -95,10 +95,7 @@ export const getIndexStatsRoute = (router: IRouter, logger: Logger) => {
               });
             }
 
-            const indices = pickAvailableMeteringStats(
-              availableIndices.aggregations.index.buckets,
-              meteringStatsIndices
-            );
+            const indices = pickAvailableMeteringStats(availableIndices, meteringStatsIndices);
 
             return response.ok({
               body: indices,

--- a/x-pack/plugins/ecs_data_quality_dashboard/tsconfig.json
+++ b/x-pack/plugins/ecs_data_quality_dashboard/tsconfig.json
@@ -26,6 +26,7 @@
     "@kbn/core-elasticsearch-server-mocks",
     "@kbn/core-elasticsearch-server",
     "@kbn/core-security-common",
+    "@kbn/datemath",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Security Solution][Data Quality Dashboard][Serverless] Fix fetchAvailableIndices in get_index_stats (#197065)](https://github.com/elastic/kibana/pull/197065)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Karen Grigoryan","email":"karen.grigoryan@elastic.co"},"sourceCommit":{"committedDate":"2024-10-31T13:07:36Z","message":"[Security Solution][Data Quality Dashboard][Serverless] Fix fetchAvailableIndices in get_index_stats (#197065)\n\naddresses #196528\r\n\r\n- Remove unused get_available_indices.ts params helper file.\r\n- Change fetchAvailableIndices to use creation_date from _cat api\r\ninstead of targeting @timestamp field of indices\r\n\r\n## UI Changes:\r\n\r\nBefore:\r\n\r\n![image](https://github.com/user-attachments/assets/1954a8b6-1760-4ec7-b3d3-167b724f8b3c)\r\nAfter:\r\n\r\n![image](https://github.com/user-attachments/assets/232674a1-9691-4d49-862e-99873f22c3cf)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ac013b4a99d68ac1596a19d94a7094b4284a200a","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Threat Hunting","Team:Threat Hunting:Explore","backport:prev-minor","ci:project-deploy-security","v8.17.0"],"number":197065,"url":"https://github.com/elastic/kibana/pull/197065","mergeCommit":{"message":"[Security Solution][Data Quality Dashboard][Serverless] Fix fetchAvailableIndices in get_index_stats (#197065)\n\naddresses #196528\r\n\r\n- Remove unused get_available_indices.ts params helper file.\r\n- Change fetchAvailableIndices to use creation_date from _cat api\r\ninstead of targeting @timestamp field of indices\r\n\r\n## UI Changes:\r\n\r\nBefore:\r\n\r\n![image](https://github.com/user-attachments/assets/1954a8b6-1760-4ec7-b3d3-167b724f8b3c)\r\nAfter:\r\n\r\n![image](https://github.com/user-attachments/assets/232674a1-9691-4d49-862e-99873f22c3cf)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ac013b4a99d68ac1596a19d94a7094b4284a200a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/197065","number":197065,"mergeCommit":{"message":"[Security Solution][Data Quality Dashboard][Serverless] Fix fetchAvailableIndices in get_index_stats (#197065)\n\naddresses #196528\r\n\r\n- Remove unused get_available_indices.ts params helper file.\r\n- Change fetchAvailableIndices to use creation_date from _cat api\r\ninstead of targeting @timestamp field of indices\r\n\r\n## UI Changes:\r\n\r\nBefore:\r\n\r\n![image](https://github.com/user-attachments/assets/1954a8b6-1760-4ec7-b3d3-167b724f8b3c)\r\nAfter:\r\n\r\n![image](https://github.com/user-attachments/assets/232674a1-9691-4d49-862e-99873f22c3cf)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ac013b4a99d68ac1596a19d94a7094b4284a200a"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/198525","number":198525,"state":"MERGED","mergeCommit":{"sha":"0a561873792de54c5266884a47a0e0819dc7aea3","message":"[8.x] [Security Solution][Data Quality Dashboard][Serverless] Fix fetchAvailableIndices in get_index_stats (#197065) (#198525)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Security Solution][Data Quality Dashboard][Serverless] Fix\nfetchAvailableIndices in get_index_stats\n(#197065)](https://github.com/elastic/kibana/pull/197065)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Karen\nGrigoryan\",\"email\":\"karen.grigoryan@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-10-31T13:07:36Z\",\"message\":\"[Security\nSolution][Data Quality Dashboard][Serverless] Fix fetchAvailableIndices\nin get_index_stats (#197065)\\n\\naddresses #196528\\r\\n\\r\\n- Remove unused\nget_available_indices.ts params helper file.\\r\\n- Change\nfetchAvailableIndices to use creation_date from _cat api\\r\\ninstead of\ntargeting @timestamp field of indices\\r\\n\\r\\n## UI\nChanges:\\r\\n\\r\\nBefore:\\r\\n\\r\\n![image](https://github.com/user-attachments/assets/1954a8b6-1760-4ec7-b3d3-167b724f8b3c)\\r\\nAfter:\\r\\n\\r\\n![image](https://github.com/user-attachments/assets/232674a1-9691-4d49-862e-99873f22c3cf)\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"ac013b4a99d68ac1596a19d94a7094b4284a200a\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"Team:Threat\nHunting\",\"Team:Threat\nHunting:Explore\",\"backport:prev-minor\",\"ci:project-deploy-security\"],\"title\":\"[Security\nSolution][Data Quality Dashboard][Serverless] Fix fetchAvailableIndices\nin\nget_index_stats\",\"number\":197065,\"url\":\"https://github.com/elastic/kibana/pull/197065\",\"mergeCommit\":{\"message\":\"[Security\nSolution][Data Quality Dashboard][Serverless] Fix fetchAvailableIndices\nin get_index_stats (#197065)\\n\\naddresses #196528\\r\\n\\r\\n- Remove unused\nget_available_indices.ts params helper file.\\r\\n- Change\nfetchAvailableIndices to use creation_date from _cat api\\r\\ninstead of\ntargeting @timestamp field of indices\\r\\n\\r\\n## UI\nChanges:\\r\\n\\r\\nBefore:\\r\\n\\r\\n![image](https://github.com/user-attachments/assets/1954a8b6-1760-4ec7-b3d3-167b724f8b3c)\\r\\nAfter:\\r\\n\\r\\n![image](https://github.com/user-attachments/assets/232674a1-9691-4d49-862e-99873f22c3cf)\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"ac013b4a99d68ac1596a19d94a7094b4284a200a\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/197065\",\"number\":197065,\"mergeCommit\":{\"message\":\"[Security\nSolution][Data Quality Dashboard][Serverless] Fix fetchAvailableIndices\nin get_index_stats (#197065)\\n\\naddresses #196528\\r\\n\\r\\n- Remove unused\nget_available_indices.ts params helper file.\\r\\n- Change\nfetchAvailableIndices to use creation_date from _cat api\\r\\ninstead of\ntargeting @timestamp field of indices\\r\\n\\r\\n## UI\nChanges:\\r\\n\\r\\nBefore:\\r\\n\\r\\n![image](https://github.com/user-attachments/assets/1954a8b6-1760-4ec7-b3d3-167b724f8b3c)\\r\\nAfter:\\r\\n\\r\\n![image](https://github.com/user-attachments/assets/232674a1-9691-4d49-862e-99873f22c3cf)\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"ac013b4a99d68ac1596a19d94a7094b4284a200a\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Karen Grigoryan <karen.grigoryan@elastic.co>"}}]}] BACKPORT-->