### PR TITLE
fix: switch MockIdP plugin from using IdP-initiated login to SP-initiated one

### DIFF
--- a/packages/kbn-mock-idp-plugin/public/login_page.tsx
+++ b/packages/kbn-mock-idp-plugin/public/login_page.tsx
@@ -47,6 +47,7 @@ export const LoginPage = () => {
         full_name: values.full_name,
         email: sanitizeEmail(values.full_name),
         roles: [values.role],
+        urlWithSAMLRequest: location.href,
       });
     },
   });

--- a/packages/kbn-mock-idp-plugin/server/plugin.ts
+++ b/packages/kbn-mock-idp-plugin/server/plugin.ts
@@ -18,7 +18,12 @@ import {
   SERVERLESS_ROLES_ROOT_PATH,
   STATEFUL_ROLES_ROOT_PATH,
 } from '@kbn/es';
-import { createSAMLResponse, MOCK_IDP_LOGIN_PATH, MOCK_IDP_LOGOUT_PATH } from '@kbn/mock-idp-utils';
+import {
+  createSAMLResponse,
+  getSAMLRequestId,
+  MOCK_IDP_LOGIN_PATH,
+  MOCK_IDP_LOGOUT_PATH,
+} from '@kbn/mock-idp-utils';
 
 export interface PluginSetupDependencies {
   cloud: CloudSetup;
@@ -29,6 +34,7 @@ const createSAMLResponseSchema = schema.object({
   full_name: schema.maybe(schema.nullable(schema.string())),
   email: schema.maybe(schema.nullable(schema.string())),
   roles: schema.arrayOf(schema.string()),
+  urlWithSAMLRequest: schema.maybe(schema.string()),
 });
 
 const projectToAlias = new Map<string, string>([
@@ -119,6 +125,9 @@ export const plugin: PluginInitializer<
               full_name: request.body.full_name ?? undefined,
               email: request.body.email ?? undefined,
               roles: request.body.roles,
+              authnRequestId: request.body.urlWithSAMLRequest
+                ? await getSAMLRequestId(request.body.urlWithSAMLRequest)
+                : undefined,
             }),
           },
         });

--- a/packages/kbn-mock-idp-utils/src/index.ts
+++ b/packages/kbn-mock-idp-utils/src/index.ts
@@ -20,4 +20,9 @@ export {
   MOCK_IDP_ATTRIBUTE_NAME,
 } from './constants';
 
-export { createMockIdpMetadata, createSAMLResponse, ensureSAMLRoleMapping } from './utils';
+export {
+  createMockIdpMetadata,
+  createSAMLResponse,
+  ensureSAMLRoleMapping,
+  getSAMLRequestId,
+} from './utils';

--- a/packages/kbn-mock-idp-utils/src/utils.ts
+++ b/packages/kbn-mock-idp-utils/src/utils.ts
@@ -10,7 +10,11 @@
 import type { Client } from '@elastic/elasticsearch';
 import { X509Certificate } from 'crypto';
 import { readFile } from 'fs/promises';
+import url from 'url';
+import { promisify } from 'util';
 import { SignedXml } from 'xml-crypto';
+import { parseString } from 'xml2js';
+import zlib from 'zlib';
 
 import { KBN_CERT_PATH, KBN_KEY_PATH } from '@kbn/dev-utils';
 
@@ -25,6 +29,9 @@ import {
   MOCK_IDP_REALM_NAME,
   MOCK_IDP_ROLE_MAPPING_NAME,
 } from './constants';
+
+const inflateRawAsync = promisify(zlib.inflateRaw);
+const parseStringAsync = promisify(parseString);
 
 /**
  * Creates XML metadata for our mock identity provider.
@@ -204,4 +211,16 @@ export async function ensureSAMLRoleMapping(client: Client) {
       },
     },
   });
+}
+
+export async function getSAMLRequestId(urlWithSAMLRequestId: string) {
+  const inflatedSAMLRequest = (await inflateRawAsync(
+    Buffer.from(
+      url.parse(urlWithSAMLRequestId, true /* parseQueryString */).query.SAMLRequest as string,
+      'base64'
+    )
+  )) as Buffer;
+
+  const parsedSAMLRequest = (await parseStringAsync(inflatedSAMLRequest.toString())) as any;
+  return parsedSAMLRequest['saml2p:AuthnRequest'].$.ID;
 }

--- a/x-pack/plugins/security/server/authentication/providers/saml.ts
+++ b/x-pack/plugins/security/server/authentication/providers/saml.ts
@@ -353,6 +353,12 @@ export class SAMLAuthenticationProvider extends BaseAuthenticationProvider {
         : 'Login has been initiated by Identity Provider.'
     );
 
+    this.logger.debug(
+      `SAML RESPONSE: ${samlResponse}:::${JSON.stringify(
+        !isIdPInitiatedLogin ? [stateRequestId] : []
+      )}`
+    );
+
     const providerRealm = this.realm || stateRealm;
 
     let result: {


### PR DESCRIPTION
## Summary

Switch MockIdP plugin from using IdP-initiated login to SP-initiated one.

