### PR TITLE
[8.15] [Infra] Change order of the errors shown on Infra pages (#200531)

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/page_template.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/page_template.tsx
@@ -95,12 +95,12 @@ export const MetricsPageTemplate: React.FC<LazyObservabilityPageTemplateProps> =
 
   if (isLoading && !source) return <SourceLoadingPage />;
 
-  if (!remoteClustersExist) {
-    return <NoRemoteCluster />;
+  if (sourceError) {
+    return <SourceErrorPage errorMessage={sourceError} retry={loadSource} />;
   }
 
-  if (sourceError) {
-    <SourceErrorPage errorMessage={sourceError} retry={loadSource} />;
+  if (!isLoading && !remoteClustersExist) {
+    return <NoRemoteCluster />;
   }
 
   if (dataViewLoadError) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Infra] Change order of the errors shown on Infra pages (#200531)](https://github.com/elastic/kibana/pull/200531)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2024-11-18T12:30:32Z","message":"[Infra] Change order of the errors shown on Infra pages (#200531)\n\nCloses #200190 \r\n\r\n## Summary\r\n\r\nThis PR fixes the issue with the errors shown on the metrics explorer\r\npage - when the metrics indices can't be fetched we should show the\r\nerror returned and if there is no fetch error and a remote cluster\r\nconfigured but no connection is possible we should show the remote\r\ncluster error:\r\n\r\n- Example with 504 error \r\n\r\n![image](https://github.com/user-attachments/assets/65cd8226-8c81-4c64-b043-c9db5a93d3e0)\r\n\r\n- Example with remote cluster error\r\n\r\n![image](https://github.com/user-attachments/assets/e024a3f8-76e0-4ad7-8aa6-e35ad5c1112a)\r\n\r\n\r\n## Testing\r\nCouldn't find a way to reproduce this so I \"faked\" the API response to\r\nbe an error and checked several cases\r\n- API returns an error, we should show the error:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/c1086b22-1ff5-4333-97a5-b3d1dca16afe\r\n\r\n\r\n- API doesn't return an error but the remote cluster connection wasn't\r\npossible, we should show the remote cluster error:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/151b3ae4-5ca1-4d54-bd58-2729db202cdb\r\n\r\n\r\n- If no remote cluster is used/or a remote cluster is connected and the\r\nAPI response is not returning an error the page should load correctly:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/f9ef1066-3dfd-4957-8b46-878bf58d2f1c","sha":"46d4c84f2cb3f778d3b0eca83d0cfa4f25a602c4","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","backport:prev-major","ci:project-deploy-observability","Team:obs-ux-infra_services"],"number":200531,"url":"https://github.com/elastic/kibana/pull/200531","mergeCommit":{"message":"[Infra] Change order of the errors shown on Infra pages (#200531)\n\nCloses #200190 \r\n\r\n## Summary\r\n\r\nThis PR fixes the issue with the errors shown on the metrics explorer\r\npage - when the metrics indices can't be fetched we should show the\r\nerror returned and if there is no fetch error and a remote cluster\r\nconfigured but no connection is possible we should show the remote\r\ncluster error:\r\n\r\n- Example with 504 error \r\n\r\n![image](https://github.com/user-attachments/assets/65cd8226-8c81-4c64-b043-c9db5a93d3e0)\r\n\r\n- Example with remote cluster error\r\n\r\n![image](https://github.com/user-attachments/assets/e024a3f8-76e0-4ad7-8aa6-e35ad5c1112a)\r\n\r\n\r\n## Testing\r\nCouldn't find a way to reproduce this so I \"faked\" the API response to\r\nbe an error and checked several cases\r\n- API returns an error, we should show the error:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/c1086b22-1ff5-4333-97a5-b3d1dca16afe\r\n\r\n\r\n- API doesn't return an error but the remote cluster connection wasn't\r\npossible, we should show the remote cluster error:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/151b3ae4-5ca1-4d54-bd58-2729db202cdb\r\n\r\n\r\n- If no remote cluster is used/or a remote cluster is connected and the\r\nAPI response is not returning an error the page should load correctly:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/f9ef1066-3dfd-4957-8b46-878bf58d2f1c","sha":"46d4c84f2cb3f778d3b0eca83d0cfa4f25a602c4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/200531","number":200531,"mergeCommit":{"message":"[Infra] Change order of the errors shown on Infra pages (#200531)\n\nCloses #200190 \r\n\r\n## Summary\r\n\r\nThis PR fixes the issue with the errors shown on the metrics explorer\r\npage - when the metrics indices can't be fetched we should show the\r\nerror returned and if there is no fetch error and a remote cluster\r\nconfigured but no connection is possible we should show the remote\r\ncluster error:\r\n\r\n- Example with 504 error \r\n\r\n![image](https://github.com/user-attachments/assets/65cd8226-8c81-4c64-b043-c9db5a93d3e0)\r\n\r\n- Example with remote cluster error\r\n\r\n![image](https://github.com/user-attachments/assets/e024a3f8-76e0-4ad7-8aa6-e35ad5c1112a)\r\n\r\n\r\n## Testing\r\nCouldn't find a way to reproduce this so I \"faked\" the API response to\r\nbe an error and checked several cases\r\n- API returns an error, we should show the error:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/c1086b22-1ff5-4333-97a5-b3d1dca16afe\r\n\r\n\r\n- API doesn't return an error but the remote cluster connection wasn't\r\npossible, we should show the remote cluster error:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/151b3ae4-5ca1-4d54-bd58-2729db202cdb\r\n\r\n\r\n- If no remote cluster is used/or a remote cluster is connected and the\r\nAPI response is not returning an error the page should load correctly:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/f9ef1066-3dfd-4957-8b46-878bf58d2f1c","sha":"46d4c84f2cb3f778d3b0eca83d0cfa4f25a602c4"}},{"url":"https://github.com/elastic/kibana/pull/200553","number":200553,"branch":"8.16","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/200554","number":200554,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->