### PR TITLE
Dependency ownership for QA team

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -4,11 +4,15 @@
       "repoOwner": "elastic",
       "repoName": "kibana",
       "pipelineSlug": "kibana-pull-request",
-
       "enabled": true,
       "allow_org_users": true,
-      "allowed_repo_permissions": ["admin", "write"],
-      "allowed_list": ["elastic-vault-github-plugin-prod[bot]"],
+      "allowed_repo_permissions": [
+        "admin",
+        "write"
+      ],
+      "allowed_list": [
+        "elastic-vault-github-plugin-prod[bot]"
+      ],
       "set_commit_status": true,
       "commit_status_context": "kibana-ci",
       "build_on_commit": true,
@@ -17,8 +21,14 @@
       "build_on_ready": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^\\/ci$",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^\\/ci$",
-      "skip_ci_labels": ["skip-ci"],
-      "skip_target_branches": ["6.8", "7.11", "7.12"],
+      "skip_ci_labels": [
+        "skip-ci"
+      ],
+      "skip_target_branches": [
+        "6.8",
+        "7.11",
+        "7.12"
+      ],
       "enable_skippable_commits": true,
       "skip_ci_on_only_changed": [
         "^docs/",
@@ -29,7 +39,8 @@
         "^\\.backportrc\\.json$",
         "^src/dev/prs/kibana_qa_pr_list\\.json$",
         "^\\.buildkite/pull_requests\\.json$",
-        "^\\.devcontainer/"
+        "^\\.devcontainer/",
+        "^renovate\.json$",
       ],
       "always_require_ci_on_changed": [
         "^docs/developer/plugin-list.asciidoc$",
@@ -38,7 +49,10 @@
       ],
       "kibana_versions_check": true,
       "kibana_build_reuse": true,
-      "kibana_build_reuse_pipeline_slugs": ["kibana-pull-request", "kibana-on-merge"],
+      "kibana_build_reuse_pipeline_slugs": [
+        "kibana-pull-request",
+        "kibana-on-merge"
+      ],
       "kibana_build_reuse_regexes": [
         "^test/",
         "^x-pack/test/",
@@ -53,8 +67,13 @@
       "skip_ci_labels": [],
       "enabled": true,
       "allow_org_users": true,
-      "allowed_repo_permissions": ["admin", "write"],
-      "allowed_list": ["elastic-vault-github-plugin-prod[bot]"],
+      "allowed_repo_permissions": [
+        "admin",
+        "write"
+      ],
+      "allowed_list": [
+        "elastic-vault-github-plugin-prod[bot]"
+      ],
       "set_commit_status": true,
       "commit_status_context": "kibana-deploy-project-from-pr",
       "build_on_commit": false,
@@ -63,7 +82,11 @@
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:deploy)\\W+(?:project))$",
       "kibana_versions_check": true,
       "kibana_build_reuse": true,
-      "kibana_build_reuse_pipeline_slugs": ["kibana-pull-request", "kibana-on-merge", "kibana-deploy-project-from-pr"],
+      "kibana_build_reuse_pipeline_slugs": [
+        "kibana-pull-request",
+        "kibana-on-merge",
+        "kibana-deploy-project-from-pr"
+      ],
       "kibana_build_reuse_regexes": [
         "^test/",
         "^x-pack/test/",

--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -4,15 +4,11 @@
       "repoOwner": "elastic",
       "repoName": "kibana",
       "pipelineSlug": "kibana-pull-request",
+
       "enabled": true,
       "allow_org_users": true,
-      "allowed_repo_permissions": [
-        "admin",
-        "write"
-      ],
-      "allowed_list": [
-        "elastic-vault-github-plugin-prod[bot]"
-      ],
+      "allowed_repo_permissions": ["admin", "write"],
+      "allowed_list": ["elastic-vault-github-plugin-prod[bot]"],
       "set_commit_status": true,
       "commit_status_context": "kibana-ci",
       "build_on_commit": true,
@@ -21,14 +17,8 @@
       "build_on_ready": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^\\/ci$",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^\\/ci$",
-      "skip_ci_labels": [
-        "skip-ci"
-      ],
-      "skip_target_branches": [
-        "6.8",
-        "7.11",
-        "7.12"
-      ],
+      "skip_ci_labels": ["skip-ci"],
+      "skip_target_branches": ["6.8", "7.11", "7.12"],
       "enable_skippable_commits": true,
       "skip_ci_on_only_changed": [
         "^docs/",
@@ -39,8 +29,7 @@
         "^\\.backportrc\\.json$",
         "^src/dev/prs/kibana_qa_pr_list\\.json$",
         "^\\.buildkite/pull_requests\\.json$",
-        "^\\.devcontainer/",
-        "^renovate\.json$",
+        "^\\.devcontainer/"
       ],
       "always_require_ci_on_changed": [
         "^docs/developer/plugin-list.asciidoc$",
@@ -49,10 +38,7 @@
       ],
       "kibana_versions_check": true,
       "kibana_build_reuse": true,
-      "kibana_build_reuse_pipeline_slugs": [
-        "kibana-pull-request",
-        "kibana-on-merge"
-      ],
+      "kibana_build_reuse_pipeline_slugs": ["kibana-pull-request", "kibana-on-merge"],
       "kibana_build_reuse_regexes": [
         "^test/",
         "^x-pack/test/",
@@ -67,13 +53,8 @@
       "skip_ci_labels": [],
       "enabled": true,
       "allow_org_users": true,
-      "allowed_repo_permissions": [
-        "admin",
-        "write"
-      ],
-      "allowed_list": [
-        "elastic-vault-github-plugin-prod[bot]"
-      ],
+      "allowed_repo_permissions": ["admin", "write"],
+      "allowed_list": ["elastic-vault-github-plugin-prod[bot]"],
       "set_commit_status": true,
       "commit_status_context": "kibana-deploy-project-from-pr",
       "build_on_commit": false,
@@ -82,11 +63,7 @@
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:deploy)\\W+(?:project))$",
       "kibana_versions_check": true,
       "kibana_build_reuse": true,
-      "kibana_build_reuse_pipeline_slugs": [
-        "kibana-pull-request",
-        "kibana-on-merge",
-        "kibana-deploy-project-from-pr"
-      ],
+      "kibana_build_reuse_pipeline_slugs": ["kibana-pull-request", "kibana-on-merge", "kibana-deploy-project-from-pr"],
       "kibana_build_reuse_regexes": [
         "^test/",
         "^x-pack/test/",

--- a/renovate.json
+++ b/renovate.json
@@ -100,7 +100,7 @@
       "enabled": true
     },
     {
-      "groupName": "@elastic/appex-ai-infra",
+      "groupName": "@elastic/appex-ai-infra dependencies",
       "matchDepNames": [
         "@aws-crypto/sha256-js",
         "@aws-crypto/util",
@@ -128,6 +128,45 @@
       ],
       "labels": [
         "Team:AI Infra",
+        "release_note:skip",
+        "backport:all-open"
+      ],
+      "enabled": true
+    },
+    {
+      "groupName": "@elastic/appex-qa dependencies",
+      "matchDepNames": [
+        "cheerio",
+        "@istanbuljs/nyc-config-typescript",
+        "@istanbuljs/schema",
+        "@types/enzyme",
+        "@types/faker",
+        "@types/pixelmatch",
+        "@types/pngjs",
+        "@types/supertest",
+        "@wojtekmaj/enzyme-adapter-react-17",
+        "babel-plugin-istanbul",
+        "enzyme",
+        "enzyme-to-json",
+        "faker",
+        "nyc",
+        "oboe",
+        "pixelmatch",
+        "playwright",
+        "pngjs",
+        "sharp",
+        "superagent",
+        "supertest",
+        "xmlbuilder"
+      ],
+      "reviewers": [
+        "team:appex-qa"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "labels": [
+        "Team:QA",
         "release_note:skip",
         "backport:all-open"
       ],


### PR DESCRIPTION
## Summary

This updates our `renovate.json` configuration to mark the QA team as owners of their set of dependencies.