### PR TITLE
[Fleet] Fail gracefully on agent count retrieval

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/confirm_update.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/confirm_update.tsx
@@ -72,7 +72,7 @@ export async function confirmUpdate(
 ) {
   const { agentCount, agentPolicyCount } = await getCountsForDownloadSource(downloadSource).catch(
     () => ({
-      //  Fail gracefully when count are not avaiable
+      //  Fail gracefully when counts are not avaiable
       agentCount: undefined,
       agentPolicyCount: undefined,
     })

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/confirm_update.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/confirm_update.tsx
@@ -15,52 +15,68 @@ import { getCountsForDownloadSource } from './services/get_count';
 
 interface ConfirmDescriptionProps {
   downloadSource: DownloadSource;
-  agentCount: number;
-  agentPolicyCount: number;
+  agentCount?: number;
+  agentPolicyCount?: number;
 }
 
 const ConfirmDescription: React.FunctionComponent<ConfirmDescriptionProps> = ({
   downloadSource,
   agentCount,
   agentPolicyCount,
-}) => (
-  <FormattedMessage
-    id="xpack.fleet.settings.updateDownloadSourceModal.confirmModalText"
-    data-test-subj="editDownloadSourcesConfirmModal.confirmModalText"
-    defaultMessage="This action will update {downloadSourceName} agent binary source. It will update {policies} and {agents}. This action can not be undone. Are you sure you wish to continue?"
-    values={{
-      downloadSourceName: <strong>{downloadSource.name}</strong>,
-      agents: (
-        <strong>
-          <FormattedMessage
-            id="xpack.fleet.settings.updateDownloadSourceModal.agentsCount"
-            defaultMessage="{agentCount, plural, one {# agent} other {# agents}}"
-            values={{
-              agentCount,
-            }}
-          />
-        </strong>
-      ),
-      policies: (
-        <strong>
-          <FormattedMessage
-            id="xpack.fleet.settings.updateDownloadSourceModal.agentPolicyCount"
-            defaultMessage="{agentPolicyCount, plural, one {# agent policy} other {# agent policies}}"
-            values={{
-              agentPolicyCount,
-            }}
-          />
-        </strong>
-      ),
-    }}
-  />
-);
+}) =>
+  agentCount !== undefined && agentPolicyCount !== undefined ? (
+    <FormattedMessage
+      id="xpack.fleet.settings.updateDownloadSourceModal.confirmModalText"
+      data-test-subj="editDownloadSourcesConfirmModal.confirmModalText"
+      defaultMessage="This action will update {downloadSourceName} agent binary source. It will update {policies} and {agents}. This action can not be undone. Are you sure you wish to continue?"
+      values={{
+        downloadSourceName: <strong>{downloadSource.name}</strong>,
+        agents: (
+          <strong>
+            <FormattedMessage
+              id="xpack.fleet.settings.updateDownloadSourceModal.agentsCount"
+              defaultMessage="{agentCount, plural, one {# agent} other {# agents}}"
+              values={{
+                agentCount,
+              }}
+            />
+          </strong>
+        ),
+        policies: (
+          <strong>
+            <FormattedMessage
+              id="xpack.fleet.settings.updateDownloadSourceModal.agentPolicyCount"
+              defaultMessage="{agentPolicyCount, plural, one {# agent policy} other {# agent policies}}"
+              values={{
+                agentPolicyCount,
+              }}
+            />
+          </strong>
+        ),
+      }}
+    />
+  ) : (
+    <FormattedMessage
+      id="xpack.fleet.settings.updateDownloadSourceModal.confirmModalTextWithoutCount"
+      data-test-subj="editDownloadSourcesConfirmModal.confirmModalText"
+      defaultMessage="This action will update {downloadSourceName} agent binary source. It will update related policies and agents. This action can not be undone. Are you sure you wish to continue?"
+      values={{
+        downloadSourceName: <strong>{downloadSource.name}</strong>,
+      }}
+    />
+  );
 
 export async function confirmUpdate(
   downloadSource: DownloadSource,
   confirm: ReturnType<typeof useConfirmModal>['confirm']
 ) {
-  const { agentCount, agentPolicyCount } = await getCountsForDownloadSource(downloadSource);
+  const { agentCount, agentPolicyCount } = await getCountsForDownloadSource(downloadSource).catch(
+    () => ({
+      //  Fail gracefully when count are not avaiable
+      agentCount: undefined,
+      agentPolicyCount: undefined,
+    })
+  );
   return confirm(
     <FormattedMessage
       id="xpack.fleet.settings.updateDownloadSourceModal.confirmModalTitle"

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_delete_download_source.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_delete_download_source.tsx
@@ -67,7 +67,7 @@ const ConfirmDeleteDescription: React.FunctionComponent<ConfirmDeleteDescription
   ) : (
     <FormattedMessage
       id="xpack.fleet.settings.deleteDowloadSource.confirmModalTextWithoutCount"
-      defaultMessage="This action will delete {downloadSourceName} agent binary source. It will update related policies and agents. This action can not be undone. Are you sure you wish to continue?"
+      defaultMessage="This action will delete {downloadSourceName} agent binary sourceand it will update its related policies and agents. This action can not be undone. Are you sure you wish to continue?"
       values={{
         downloadSourceName: <strong>{downloadSource.name}</strong>,
       }}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_delete_download_source.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_delete_download_source.tsx
@@ -25,45 +25,54 @@ const ConfirmTitle = () => (
 
 interface ConfirmDeleteDescriptionProps {
   downloadSource: DownloadSource;
-  agentCount: number;
-  agentPolicyCount: number;
+  agentCount?: number;
+  agentPolicyCount?: number;
 }
 
 const ConfirmDeleteDescription: React.FunctionComponent<ConfirmDeleteDescriptionProps> = ({
   downloadSource,
   agentCount,
   agentPolicyCount,
-}) => (
-  <FormattedMessage
-    id="xpack.fleet.settings.deleteDowloadSource.confirmModalText"
-    defaultMessage="This action will delete {downloadSourceName} agent binary source. It will update {policies} and {agents}. This action can not be undone. Are you sure you wish to continue?"
-    values={{
-      downloadSourceName: <strong>{downloadSource.name}</strong>,
-      agents: (
-        <strong>
-          <FormattedMessage
-            id="xpack.fleet.settings.deleteDowloadSource.agentsCount"
-            defaultMessage="{agentCount, plural, one {# agent} other {# agents}}"
-            values={{
-              agentCount,
-            }}
-          />
-        </strong>
-      ),
-      policies: (
-        <strong>
-          <FormattedMessage
-            id="xpack.fleet.settings.deleteDowloadSource.agentPolicyCount"
-            defaultMessage="{agentPolicyCount, plural, one {# agent policy} other {# agent policies}}"
-            values={{
-              agentPolicyCount,
-            }}
-          />
-        </strong>
-      ),
-    }}
-  />
-);
+}) =>
+  agentCount !== undefined && agentPolicyCount !== undefined ? (
+    <FormattedMessage
+      id="xpack.fleet.settings.deleteDowloadSource.confirmModalText"
+      defaultMessage="This action will delete {downloadSourceName} agent binary source. It will update {policies} and {agents}. This action can not be undone. Are you sure you wish to continue?"
+      values={{
+        downloadSourceName: <strong>{downloadSource.name}</strong>,
+        agents: (
+          <strong>
+            <FormattedMessage
+              id="xpack.fleet.settings.deleteDowloadSource.agentsCount"
+              defaultMessage="{agentCount, plural, one {# agent} other {# agents}}"
+              values={{
+                agentCount,
+              }}
+            />
+          </strong>
+        ),
+        policies: (
+          <strong>
+            <FormattedMessage
+              id="xpack.fleet.settings.deleteDowloadSource.agentPolicyCount"
+              defaultMessage="{agentPolicyCount, plural, one {# agent policy} other {# agent policies}}"
+              values={{
+                agentPolicyCount,
+              }}
+            />
+          </strong>
+        ),
+      }}
+    />
+  ) : (
+    <FormattedMessage
+      id="xpack.fleet.settings.deleteDowloadSource.confirmModalTextWithoutCount"
+      defaultMessage="This action will delete {downloadSourceName} agent binary source. It will update related policies and agents. This action can not be undone. Are you sure you wish to continue?"
+      values={{
+        downloadSourceName: <strong>{downloadSource.name}</strong>,
+      }}
+    />
+  );
 
 export function useDeleteDownloadSource(onSuccess: () => void) {
   const { confirm } = useConfirmModal();
@@ -71,7 +80,10 @@ export function useDeleteDownloadSource(onSuccess: () => void) {
   const deleteDownloadSource = useCallback(
     async (downloadSource: DownloadSource) => {
       try {
-        const { agentCount, agentPolicyCount } = await getCountsForDownloadSource(downloadSource);
+        const { agentCount, agentPolicyCount } = await getCountsForDownloadSource(
+          downloadSource
+          // Fail gracefully when counts are not available
+        ).catch(() => ({ agentCount: undefined, agentPolicyCount: undefined }));
 
         const isConfirmed = await confirm(
           <ConfirmTitle />,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_delete_download_source.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/download_source_flyout/use_delete_download_source.tsx
@@ -67,7 +67,7 @@ const ConfirmDeleteDescription: React.FunctionComponent<ConfirmDeleteDescription
   ) : (
     <FormattedMessage
       id="xpack.fleet.settings.deleteDowloadSource.confirmModalTextWithoutCount"
-      defaultMessage="This action will delete {downloadSourceName} agent binary sourceand it will update its related policies and agents. This action can not be undone. Are you sure you wish to continue?"
+      defaultMessage="This action will delete {downloadSourceName} agent binary source and it will update its related policies and agents. This action can not be undone. Are you sure you wish to continue?"
       values={{
         downloadSourceName: <strong>{downloadSource.name}</strong>,
       }}


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/192056 

When a user do not have the permissions to read agent or agents policies we cannot retrieve the agent count, because of that we were not able to show the confirm modal when updating/delating outputs/binary source. That PR fix that by failing gracefully when we are not able to retrieve that count.

## UI Changes


<img width="1470" alt="Screenshot 2024-11-18 at 10 20 54 AM" src="https://github.com/user-attachments/assets/619c9953-32a5-4995-bbfa-6ebbea24e1d6">
<img width="1417" alt="Screenshot 2024-11-18 at 10 25 19 AM" src="https://github.com/user-attachments/assets/e26b7205-fe5f-4d52-a57e-0cf1f32bf858">
<img width="1469" alt="Screenshot 2024-11-18 at 10 28 09 AM" src="https://github.com/user-attachments/assets/dc06b2eb-2208-42a7-a7f8-dd2739754cc0">


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->