### PR TITLE
[APM] Unskip feature flag test

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/observability/apm_api_integration/common/apm_api_supertest.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/apm_api_integration/common/apm_api_supertest.ts
@@ -46,7 +46,7 @@ export function createApmApiClient(st: supertest.Agent) {
         .set('Content-type', 'multipart/form-data');
 
       for (const field of fields) {
-        await formDataRequest.field(field[0], field[1]);
+        void formDataRequest.field(field[0], field[1]);
       }
 
       res = await formDataRequest;

--- a/x-pack/test_serverless/api_integration/test_suites/observability/apm_api_integration/feature_flags.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/apm_api_integration/feature_flags.ts
@@ -77,9 +77,7 @@ export default function ({ getService }: APMFtrContextProvider) {
   const svlUserManager = getService('svlUserManager');
   const svlCommonApi = getService('svlCommonApi');
 
-  // https://github.com/elastic/kibana/pull/190690
-  // skipping since "rejects requests to list source maps" fails with 400
-  describe.skip('apm feature flags', () => {
+  describe('apm feature flags', () => {
     let roleAuthc: RoleCredentials;
     let internalReqHeader: InternalRequestHeader;
 


### PR DESCRIPTION
closes [#198998](https://github.com/elastic/kibana/issues/198998)

## Summary

Just unskips he APM feature flag serverless tests.





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->