### PR TITLE
[Connector] Checkout to right version

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_from_source_step.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/components/run_from_source_step.tsx
@@ -36,6 +36,7 @@ export interface RunFromSourceStepProps {
   connectorId?: string;
   isWaitingForConnector: boolean;
   serviceType: string;
+  connectorVersion: string;
 }
 
 export const RunFromSourceStep: React.FC<RunFromSourceStepProps> = ({
@@ -43,6 +44,7 @@ export const RunFromSourceStep: React.FC<RunFromSourceStepProps> = ({
   connectorId,
   isWaitingForConnector,
   serviceType,
+  connectorVersion,
 }) => {
   const [isOpen, setIsOpen] = React.useState<EuiAccordionProps['forceState']>('open');
   useEffect(() => {
@@ -125,7 +127,7 @@ export const RunFromSourceStep: React.FC<RunFromSourceStepProps> = ({
         <CodeBox
           showTopBar={false}
           languageType="bash"
-          codeSnippet="cd connectors && touch config.yml"
+          codeSnippet={`cd connectors && git checkout ${connectorVersion} && touch config.yml`}
         />
         <EuiSpacer size="s" />
         <EuiText size="s">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/deployment.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/deployment.tsx
@@ -193,6 +193,7 @@ export const ConnectorDeployment: React.FC = () => {
                           serviceType={connector.service_type ?? ''}
                           apiKeyData={apiKey}
                           isWaitingForConnector={isWaitingForConnector}
+                          connectorVersion={kibanaVersion ? `v${kibanaVersion}` : 'main'}
                         />
                       ) : (
                         <DockerInstructionsStep


### PR DESCRIPTION
## Summary

When running `connectors` from sources let's checkout to the right git tag. If version is not provided use `main` branch as default value.

If version is provided use git tag e.g. `v8.16.0` to checkout to right version of connectors repo.

This fixes the bug when running `9.0` (main branch by default) connectors from source against <9.0 stack what causes issues.

Similar logic to how we handle versioning docker images https://github.com/elastic/kibana/blob/main/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/deployment.tsx#L204

### Screenshots

<img width="947" alt="Screenshot 2024-11-18 at 18 31 58" src="https://github.com/user-attachments/assets/1f21393d-3cb0-4516-b1de-38c0d853c7b2">


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->