### PR TITLE
[Security Solution][Document Flyout] Fix toggle column missing in timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/components/cell_actions.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/components/cell_actions.tsx
@@ -9,7 +9,6 @@ import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import { useDocumentDetailsContext } from '../context';
 import { getSourcererScopeId } from '../../../../helpers';
-import { useBasicDataFromDetailsData } from '../hooks/use_basic_data_from_details_data';
 import { SecurityCellActionType } from '../../../../app/actions/constants';
 import {
   CellActionsMode,
@@ -40,12 +39,7 @@ interface CellActionsProps {
  * Security cell action wrapper for document details flyout
  */
 export const CellActions: FC<CellActionsProps> = ({ field, value, isObjectArray, children }) => {
-  const { dataFormattedForFieldBrowser, scopeId, isPreview } = useDocumentDetailsContext();
-  const { isAlert } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
-
-  const triggerId = isAlert
-    ? SecurityCellActionsTrigger.DETAILS_FLYOUT
-    : SecurityCellActionsTrigger.DEFAULT;
+  const { scopeId, isPreview } = useDocumentDetailsContext();
 
   const data = useMemo(() => ({ field, value }), [field, value]);
   const metadata = useMemo(() => ({ scopeId, isObjectArray }), [scopeId, isObjectArray]);
@@ -58,7 +52,7 @@ export const CellActions: FC<CellActionsProps> = ({ field, value, isObjectArray,
     <SecurityCellActions
       data={data}
       mode={CellActionsMode.HOVER_DOWN}
-      triggerId={triggerId}
+      triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
       visibleCellActions={6}
       sourcererScopeId={getSourcererScopeId(scopeId)}
       metadata={metadata}


### PR DESCRIPTION
## Summary

Related: https://github.com/elastic/kibana/issues/200046

Reenabling toggle columns for events. It was mistakenly excluded in [this refactor](https://github.com/elastic/kibana/pull/190560/files#diff-d9edcdb9ad0f231269f791e8392d2d0fe1d10105c223c89d9f86e546972bc342)

![image](https://github.com/user-attachments/assets/e787c227-f167-4f3a-a0e0-d1ac1ad45670)


<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->