### PR TITLE
[Security Solution] Remove a blog post callout from rule management page

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/index.tsx
@@ -22,7 +22,6 @@ import { SpyRoute } from '../../../../common/utils/route/spy_routes';
 import { MissingPrivilegesCallOut } from '../../../../detections/components/callouts/missing_privileges_callout';
 import { MlJobCompatibilityCallout } from '../../../../detections/components/callouts/ml_job_compatibility_callout';
 import { NeedAdminForUpdateRulesCallOut } from '../../../../detections/components/callouts/need_admin_for_update_callout';
-import { BlogPostDetectionEngineeringCallout } from '../../../../detections/components/callouts/blog_post_detection_engineering_callout';
 import { AddElasticRulesButton } from '../../../../detections/components/rules/pre_packaged_rules/add_elastic_rules_button';
 import { ValueListsFlyout } from '../../../../detections/components/value_lists_management_flyout';
 import { useUserData } from '../../../../detections/components/user_info';
@@ -173,7 +172,6 @@ const RulesPageComponent: React.FC = () => {
             kibanaServices={kibanaServices}
             categories={[DEFAULT_APP_CATEGORIES.security.id]}
           />
-          <BlogPostDetectionEngineeringCallout />
           <AllRules data-test-subj="all-rules" />
         </SecuritySolutionPageWrapper>
       </RulesTableContextProvider>


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/197024**

## Summary

PR https://github.com/elastic/kibana/pull/195943 added a callout banner to the 8.x branch. This banner was intended to be displayed only in ESS v8.16. We are now removing it to ensure it does not appear in v8.17.0.

## Screenshots

**Before**
<img width="1840" alt="Scherm­afbeelding 2024-11-18 om 21 14 22" src="https://github.com/user-attachments/assets/46ad45af-c058-4379-8651-43954801b3a1">

**After**
<img width="1840" alt="Scherm­afbeelding 2024-11-18 om 21 14 41" src="https://github.com/user-attachments/assets/181d0b95-4486-43ab-be08-35ae91759660">


