### PR TITLE
[8.x] [Fleet] Use metering API in serverless (#200063)

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -7,6 +7,7 @@ xpack.fleet.internal.disableILMPolicies: true
 xpack.fleet.internal.activeAgentsSoftLimit: 25000
 xpack.fleet.internal.onlyAllowAgentUpgradeToKnownVersions: true
 xpack.fleet.internal.retrySetupOnBoot: true
+xpack.fleet.internal.useMeteringApi: true
 
 ## Fine-tune the feature privileges.
 xpack.features.overrides:

--- a/x-pack/plugins/fleet/common/types/index.ts
+++ b/x-pack/plugins/fleet/common/types/index.ts
@@ -65,6 +65,7 @@ export interface FleetConfigType {
     disableBundledPackagesCache?: boolean;
   };
   internal?: {
+    useMeteringApi?: boolean;
     disableILMPolicies: boolean;
     fleetServerStandalone: boolean;
     onlyAllowAgentUpgradeToKnownVersions: boolean;

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -203,6 +203,9 @@ export const config: PluginConfigDescriptor = {
 
       internal: schema.maybe(
         schema.object({
+          useMeteringApi: schema.boolean({
+            defaultValue: false,
+          }),
           disableILMPolicies: schema.boolean({
             defaultValue: false,
           }),

--- a/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { Dictionary } from 'lodash';
 import { keyBy, keys, merge } from 'lodash';
 import type { RequestHandler } from '@kbn/core/server';
 import pMap from 'p-map';
@@ -13,9 +14,13 @@ import { KibanaSavedObjectType } from '../../../common/types';
 import type { GetDataStreamsResponse } from '../../../common/types';
 import { getPackageSavedObjects } from '../../services/epm/packages/get';
 import { defaultFleetErrorHandler } from '../../errors';
+import type { MeteringStats } from '../../services/data_streams';
 import { dataStreamService } from '../../services/data_streams';
 
 import { getDataStreamsQueryMetadata } from './get_data_streams_query_metadata';
+import type { IndicesDataStreamsStatsDataStreamsStatsItem } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { ByteSizeValue } from '@kbn/config-schema';
+import { appContextService } from '../../services';
 
 const MANAGED_BY = 'fleet';
 const LEGACY_MANAGED_BY = 'ingest-manager';
@@ -51,10 +56,22 @@ export const getListHandler: RequestHandler = async (context, request, response)
   };
 
   try {
+    const useMeteringApi = appContextService.getConfig()?.internal?.useMeteringApi;
+
     // Get matching data streams, their stats, and package SOs
-    const [dataStreamsInfo, dataStreamStats, packageSavedObjects] = await Promise.all([
+    const [
+      dataStreamsInfo,
+      dataStreamStatsOrUndefined,
+      dataStreamMeteringStatsorUndefined,
+      packageSavedObjects,
+    ] = await Promise.all([
       dataStreamService.getAllFleetDataStreams(esClient),
-      dataStreamService.getAllFleetDataStreamsStats(esClient),
+      useMeteringApi
+        ? undefined
+        : dataStreamService.getAllFleetDataStreamsStats(elasticsearch.client.asSecondaryAuthUser),
+      useMeteringApi
+        ? dataStreamService.getAllFleetMeteringStats(elasticsearch.client.asSecondaryAuthUser)
+        : undefined,
       getPackageSavedObjects(savedObjects.client),
     ]);
 
@@ -67,13 +84,24 @@ export const getListHandler: RequestHandler = async (context, request, response)
 
     const dataStreamsInfoByName = keyBy<ESDataStreamInfo>(filteredDataStreamsInfo, 'name');
 
-    const filteredDataStreamsStats = dataStreamStats.filter(
-      (dss) => !!dataStreamsInfoByName[dss.data_stream]
-    );
-    const dataStreamsStatsByName = keyBy(filteredDataStreamsStats, 'data_stream');
+    let dataStreamsStatsByName: Dictionary<IndicesDataStreamsStatsDataStreamsStatsItem> = {};
+    if (dataStreamStatsOrUndefined) {
+      const filteredDataStreamsStats = dataStreamStatsOrUndefined.filter(
+        (dss) => !!dataStreamsInfoByName[dss.data_stream]
+      );
+      dataStreamsStatsByName = keyBy(filteredDataStreamsStats, 'data_stream');
+    }
+    let dataStreamsMeteringStatsByName: Dictionary<MeteringStats> = {};
+    if (dataStreamMeteringStatsorUndefined) {
+      dataStreamsMeteringStatsByName = keyBy(dataStreamMeteringStatsorUndefined, 'name');
+    }
 
     // Combine data stream info
-    const dataStreams = merge(dataStreamsInfoByName, dataStreamsStatsByName);
+    const dataStreams = merge(
+      dataStreamsInfoByName,
+      dataStreamsStatsByName,
+      dataStreamsMeteringStatsByName
+    );
     const dataStreamNames = keys(dataStreams);
 
     // Map package SOs
@@ -132,10 +160,14 @@ export const getListHandler: RequestHandler = async (context, request, response)
         package: dataStream._meta?.package?.name || '',
         package_version: '',
         last_activity_ms: dataStream.maximum_timestamp, // overridden below if maxIngestedTimestamp agg returns a result
-        size_in_bytes: dataStream.store_size_bytes,
+        size_in_bytes: dataStream.store_size_bytes || dataStream.size_in_bytes,
         // `store_size` should be available from ES due to ?human=true flag
         // but fallback to bytes just in case
-        size_in_bytes_formatted: dataStream.store_size || `${dataStream.store_size_bytes}b`,
+        size_in_bytes_formatted:
+          dataStream.store_size ||
+          new ByteSizeValue(
+            dataStream.store_size_bytes || dataStream.size_in_bytes || 0
+          ).toString(),
         dashboards: [],
         serviceDetails: null,
       };

--- a/x-pack/plugins/fleet/server/services/data_streams.ts
+++ b/x-pack/plugins/fleet/server/services/data_streams.ts
@@ -10,6 +10,15 @@ import type { ElasticsearchClient } from '@kbn/core/server';
 
 const DATA_STREAM_INDEX_PATTERN = 'logs-*-*,metrics-*-*,traces-*-*,synthetics-*-*,profiling-*';
 
+export interface MeteringStatsResponse {
+  datastreams: MeteringStats[];
+}
+export interface MeteringStats {
+  name: string;
+  num_docs: number;
+  size_in_bytes: number;
+}
+
 class DataStreamService {
   public async getAllFleetDataStreams(esClient: ElasticsearchClient) {
     const { data_streams: dataStreamsInfo } = await esClient.indices.getDataStream({
@@ -17,6 +26,18 @@ class DataStreamService {
     });
 
     return dataStreamsInfo;
+  }
+
+  public async getAllFleetMeteringStats(esClient: ElasticsearchClient) {
+    const res = await esClient.transport.request<MeteringStatsResponse>({
+      path: `/_metering/stats`,
+      method: 'GET',
+      querystring: {
+        human: true,
+      },
+    });
+
+    return res.datastreams ?? [];
   }
 
   public async getAllFleetDataStreamsStats(esClient: ElasticsearchClient) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Fleet] Use metering API in serverless (#200063)](https://github.com/elastic/kibana/pull/200063)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2024-11-18T21:36:27Z","message":"[Fleet] Use metering API in serverless (#200063)","sha":"1fd3f412e13ed234524915cc87d058f05b840528","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Fleet","v9.0.0","backport:prev-minor"],"number":200063,"url":"https://github.com/elastic/kibana/pull/200063","mergeCommit":{"message":"[Fleet] Use metering API in serverless (#200063)","sha":"1fd3f412e13ed234524915cc87d058f05b840528"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/200063","number":200063,"mergeCommit":{"message":"[Fleet] Use metering API in serverless (#200063)","sha":"1fd3f412e13ed234524915cc87d058f05b840528"}}]}] BACKPORT-->