### PR TITLE
[FTR] Cleaned up removed apm_user role

### DIFF
--- a/x-pack/test/accessibility/apps/group1/users.ts
+++ b/x-pack/test/accessibility/apps/group1/users.ts
@@ -62,7 +62,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         confirm_password: 'password',
         full_name: 'a11y user',
         email: 'example@example.com',
-        roles: ['apm_user'],
+        roles: ['editor'],
       });
       await testSubjects.click('rolesDropdown');
       await a11y.testAppSnapshot();
@@ -75,7 +75,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         confirm_password: 'password',
         full_name: 'DeleteA11y user',
         email: 'example@example.com',
-        roles: ['apm_user'],
+        roles: ['editor'],
       });
       await testSubjects.click('checkboxSelectRow-deleteA11y');
       await a11y.testAppSnapshot();


### PR DESCRIPTION
## Summary

Cleaned up check for removed `apm_user` role, see https://github.com/elastic/elasticsearch/pull/116712


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_node:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


__Closes:  https://github.com/elastic/kibana/issues/200667__