### PR TITLE
[Docs] Add release notes for 8.16.1

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -10,6 +10,7 @@
 
 Review important information about the {kib} 8.x releases.
 
+* <<release-notes-8.16.1>>
 * <<release-notes-8.16.0>>
 * <<release-notes-8.15.4>>
 * <<release-notes-8.15.3>>
@@ -78,6 +79,27 @@ Review important information about the {kib} 8.x releases.
 
 
 include::upgrade-notes.asciidoc[]
+
+
+[[release-notes-8.16.1]]
+== {kib} 8.16.1
+
+The 8.16.1 release includes the following bug fixes.
+
+[float]
+[[fixes-v8.16.1]]
+=== Bug fixes
+Dashboards & Visualizations::
+* Fixes an issue preventing a custom panel title from being saved correctly ({kibana-pull}200548[#200548]).
+Elastic Observability solution::
+* Changes the order of the errors shown on Infrastructure applications to be more relevant ({kibana-pull}200531[#200531]).
+* Fixes the summary calculation for a calendar-aligned and occurrences-based SLO ({kibana-pull}199873[#199873]).
+* Fixes the `kustomize` command ({kibana-pull}199758[#199758]).
+Elastic Security solution::
+For the Elastic Security 8.16.1 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
+Platform::
+* Fixes an issue with duplicate references to objects when copying saved objects to other spaces ({kibana-pull}200053[#200053]).
+* Fixes button colors in the "Share data view to spaces" flyout ({kibana-pull}196004[#196004]).
 
 
 [[release-notes-8.16.0]]


### PR DESCRIPTION
This PR adds release notes for the 8.16.1 release of Kibana.

Closes: https://github.com/elastic/platform-docs-team/issues/566
Rel: https://github.com/elastic/dev/issues/2884

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->