### PR TITLE
[Entity Analytics] Sort asset criticality by `@timestamp` by default + unskip serverless tests

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
@@ -97,7 +97,7 @@ export class AssetCriticalityDataClient {
     query,
     size = DEFAULT_CRITICALITY_RESPONSE_SIZE,
     from,
-    sort = ['@timestamp'],
+    sort = ['@timestamp'], // without a default sort order the results are not deterministic which makes testing hard
   }: {
     query: ESFilter;
     size?: number;

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
@@ -97,7 +97,7 @@ export class AssetCriticalityDataClient {
     query,
     size = DEFAULT_CRITICALITY_RESPONSE_SIZE,
     from,
-    sort,
+    sort = ['@timestamp'],
   }: {
     query: ESFilter;
     size?: number;

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/asset_criticality.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/asset_criticality.ts
@@ -224,7 +224,7 @@ export default ({ getService }: FtrProviderContext) => {
 
       const createRecords = () => createAssetCriticalityRecords(records, es);
 
-      it('@skipInServerless should return the first 10 asset criticality records if no args provided', async () => {
+      it(' should return the first 10 asset criticality records if no args provided', async () => {
         await createRecords();
 
         const { body } = await assetCriticalityRoutes.list();
@@ -259,7 +259,7 @@ export default ({ getService }: FtrProviderContext) => {
         );
       });
 
-      it('@skipInServerless should only return 1 asset criticality record if per_page=1', async () => {
+      it('should only return 1 asset criticality record if per_page=1', async () => {
         await createRecords();
 
         const { body } = await assetCriticalityRoutes.list({ per_page: 1 });
@@ -273,7 +273,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(body.records[0].id_value).to.eql(records[0].id_value);
       });
 
-      it('@skipInServerless should return the next 10 asset criticality records if page=2', async () => {
+      it('should return the next 10 asset criticality records if page=2', async () => {
         await createRecords();
 
         const { body } = await assetCriticalityRoutes.list({ page: 2 });

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution.ts
@@ -103,7 +103,7 @@ export default ({ getService }: FtrProviderContext): void => {
             );
           });
 
-          it('@skipInServerlessMKI @skipInServerless starts the latest transform', async () => {
+          it.only('@skipInServerlessMKI starts the latest transform', async () => {
             // Transform states that indicate the transform is running happily
             const TRANSFORM_STARTED_STATES = ['started', 'indexing'];
 

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/risk_scoring_task/task_execution.ts
@@ -103,7 +103,7 @@ export default ({ getService }: FtrProviderContext): void => {
             );
           });
 
-          it.only('@skipInServerlessMKI starts the latest transform', async () => {
+          it('@skipInServerlessMKI starts the latest transform', async () => {
             // Transform states that indicate the transform is running happily
             const TRANSFORM_STARTED_STATES = ['started', 'indexing'];
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/189067

These asset criticality tests were failing in serverless because it seems queries without a specified sort order behave differently in serverless vs ESS.

I have made it so that asset criticality sorts by timestamp by default, this makes serverless the same as ESS.

I have backported to 8.16 as I think the more tests that run, the better.



<!--ONMERGE {"backportTargets":["8.16","8.18","8.x"]} ONMERGE-->