### PR TITLE
Limit bytesizevalue length for 8.x/7.x

### DIFF
--- a/packages/kbn-config-schema/src/byte_size_value/index.test.ts
+++ b/packages/kbn-config-schema/src/byte_size_value/index.test.ts
@@ -36,9 +36,26 @@ describe('parsing units', () => {
     expect(ByteSizeValue.parse('1Mb').getValueInBytes()).toBe(1024 * 1024);
   });
 
+  test('parses the max safe integer', () => {
+    expect(ByteSizeValue.parse('9007199254740991').getValueInBytes()).toBe(9007199254740991);
+    expect(ByteSizeValue.parse('9007199254740991b').getValueInBytes()).toBe(9007199254740991);
+  });
+
   test('throws an error when unsupported unit specified', () => {
     expect(() => ByteSizeValue.parse('1tb')).toThrowErrorMatchingInlineSnapshot(
       `"Failed to parse value as byte value. Value must be either number of bytes, or follow the format <count>[b|kb|mb|gb] (e.g., '1024kb', '200mb', '1gb'), where the number is a safe positive integer."`
+    );
+  });
+
+  test('throws an error when unsafe integer', () => {
+    expect(() => ByteSizeValue.parse('9007199254740992')).toThrowErrorMatchingInlineSnapshot(
+      `"Value in bytes is expected to be a safe positive integer."`
+    );
+  });
+
+  test('throws an error on unusually long input', () => {
+    expect(() => ByteSizeValue.parse('19007199254740991kb')).toThrowErrorMatchingInlineSnapshot(
+      `"Value in bytes is expected to be a safe positive integer."`
     );
   });
 });

--- a/packages/kbn-config-schema/src/byte_size_value/index.ts
+++ b/packages/kbn-config-schema/src/byte_size_value/index.ts
@@ -23,6 +23,10 @@ function renderUnit(value: number, unit: string) {
 
 export class ByteSizeValue {
   public static parse(text: string): ByteSizeValue {
+    if (text.length > 18) {
+      // Exit early on large input where <count> uses more than 16 digits and is therefore larger than Number.MAX_SAFE_INTEGER
+      throw new Error('Value in bytes is expected to be a safe positive integer.');
+    }
     const match = /([1-9][0-9]*)(b|kb|mb|gb)/i.exec(text);
     if (!match) {
       const number = Number(text);


### PR DESCRIPTION
## Summary

Inspired by https://github.com/elastic/kibana/pull/193529 but does not change the regular expression, it only limits the string length which is anyway the biggest performance improvement. This makes it a lot safer to backport since it's less likely that we could break existing kibana configurations that had typos.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_node:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



