### PR TITLE
Revert "[APM] Set explicit access options for APM public APIs (#197435)"

### DIFF
--- a/x-pack/plugins/observability_solution/apm/server/routes/agent_keys/route.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/agent_keys/route.ts
@@ -91,10 +91,7 @@ const invalidateAgentKeyRoute = createApmServerRoute({
 
 const createAgentKeyRoute = createApmServerRoute({
   endpoint: 'POST /api/apm/agent_keys 2023-10-31',
-  options: {
-    tags: ['access:apm', 'access:apm_settings_write', 'oas-tag:APM agent keys'],
-    access: 'public',
-  },
+  options: { tags: ['access:apm', 'access:apm_settings_write', 'oas-tag:APM agent keys'] },
   params: t.type({
     body: t.type({
       name: t.string,

--- a/x-pack/plugins/observability_solution/apm/server/routes/fleet/route.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/fleet/route.ts
@@ -65,7 +65,7 @@ const fleetAgentsRoute = createApmServerRoute({
 
 const saveApmServerSchemaRoute = createApmServerRoute({
   endpoint: 'POST /api/apm/fleet/apm_server_schema 2023-10-31',
-  options: { tags: ['access:apm', 'access:apm_write'], access: 'public' },
+  options: { tags: ['access:apm', 'access:apm_write'] },
   params: t.type({
     body: t.type({
       schema: t.record(t.string, t.unknown),

--- a/x-pack/plugins/observability_solution/apm/server/routes/services/route.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/services/route.ts
@@ -395,7 +395,7 @@ const serviceAnnotationsRoute = createApmServerRoute({
     }),
     query: t.intersection([environmentRt, rangeRt]),
   }),
-  options: { tags: ['access:apm', 'oas-tag:APM annotations'], access: 'public' },
+  options: { tags: ['access:apm', 'oas-tag:APM annotations'] },
   handler: async (resources): Promise<ServiceAnnotationResponse> => {
     const apmEventClient = await getApmEventClient(resources);
     const { params, plugins, context, request, logger, config } = resources;
@@ -440,7 +440,6 @@ const serviceAnnotationsCreateRoute = createApmServerRoute({
   endpoint: 'POST /api/apm/services/{serviceName}/annotation 2023-10-31',
   options: {
     tags: ['access:apm', 'access:apm_write', 'oas-tag:APM annotations'],
-    access: 'public',
   },
   params: t.type({
     path: t.type({

--- a/x-pack/plugins/observability_solution/apm/server/routes/settings/agent_configuration/route.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/settings/agent_configuration/route.ts
@@ -39,7 +39,7 @@ function throwNotFoundIfAgentConfigNotAvailable(featureFlags: ApmFeatureFlags): 
 // get list of configurations
 const agentConfigurationRoute = createApmServerRoute({
   endpoint: 'GET /api/apm/settings/agent-configuration 2023-10-31',
-  options: { tags: ['access:apm'], access: 'public' },
+  options: { tags: ['access:apm'] },
   handler: async (
     resources
   ): Promise<{
@@ -68,7 +68,7 @@ const getSingleAgentConfigurationRoute = createApmServerRoute({
   params: t.partial({
     query: serviceRt,
   }),
-  options: { tags: ['access:apm'], access: 'public' },
+  options: { tags: ['access:apm'] },
   handler: async (resources): Promise<AgentConfiguration> => {
     throwNotFoundIfAgentConfigNotAvailable(resources.featureFlags);
 
@@ -100,7 +100,6 @@ const deleteAgentConfigurationRoute = createApmServerRoute({
   endpoint: 'DELETE /api/apm/settings/agent-configuration 2023-10-31',
   options: {
     tags: ['access:apm', 'access:apm_settings_write'],
-    access: 'public',
   },
   params: t.type({
     body: t.type({
@@ -157,7 +156,6 @@ const createOrUpdateAgentConfigurationRoute = createApmServerRoute({
   endpoint: 'PUT /api/apm/settings/agent-configuration 2023-10-31',
   options: {
     tags: ['access:apm', 'access:apm_settings_write'],
-    access: 'public',
   },
   params: t.intersection([
     t.partial({ query: t.partial({ overwrite: toBooleanRt }) }),
@@ -226,7 +224,7 @@ const agentConfigurationSearchRoute = createApmServerRoute({
   params: t.type({
     body: searchParamsRt,
   }),
-  options: { tags: ['access:apm'], disableTelemetry: true, access: 'public' },
+  options: { tags: ['access:apm'], disableTelemetry: true },
   handler: async (
     resources
   ): Promise<SearchHit<AgentConfiguration, undefined, undefined> | null> => {
@@ -288,7 +286,7 @@ const listAgentConfigurationEnvironmentsRoute = createApmServerRoute({
   params: t.partial({
     query: t.partial({ serviceName: t.string }),
   }),
-  options: { tags: ['access:apm'], access: 'public' },
+  options: { tags: ['access:apm'] },
   handler: async (
     resources
   ): Promise<{
@@ -329,7 +327,7 @@ const agentConfigurationAgentNameRoute = createApmServerRoute({
   params: t.type({
     query: t.type({ serviceName: t.string }),
   }),
-  options: { tags: ['access:apm'], access: 'public' },
+  options: { tags: ['access:apm'] },
   handler: async (resources): Promise<{ agentName: string | undefined }> => {
     throwNotFoundIfAgentConfigNotAvailable(resources.featureFlags);
 

--- a/x-pack/plugins/observability_solution/apm/server/routes/source_maps/route.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/source_maps/route.ts
@@ -49,7 +49,7 @@ function throwNotImplementedIfSourceMapNotAvailable(featureFlags: ApmFeatureFlag
 
 const listSourceMapRoute = createApmServerRoute({
   endpoint: 'GET /api/apm/sourcemaps 2023-10-31',
-  options: { tags: ['access:apm'], access: 'public' },
+  options: { tags: ['access:apm'] },
   params: t.partial({
     query: t.partial({
       page: toNumberRt,
@@ -87,7 +87,6 @@ const uploadSourceMapRoute = createApmServerRoute({
   options: {
     tags: ['access:apm', 'access:apm_write'],
     body: { accepts: ['multipart/form-data'] },
-    access: 'public',
   },
   params: t.type({
     body: t.type({
@@ -160,7 +159,7 @@ const uploadSourceMapRoute = createApmServerRoute({
 
 const deleteSourceMapRoute = createApmServerRoute({
   endpoint: 'DELETE /api/apm/sourcemaps/{id} 2023-10-31',
-  options: { tags: ['access:apm', 'access:apm_write'], access: 'public' },
+  options: { tags: ['access:apm', 'access:apm_write'] },
   params: t.type({
     path: t.type({
       id: t.string,


### PR DESCRIPTION
closes #200742

This PR reverts changes introduced in [PR](https://github.com/elastic/kibana/pull/197435) to avoid duplicating logic. 





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->