### PR TITLE
[Execution Context] Update on URL change

### DIFF
--- a/packages/core/execution-context/core-execution-context-browser-internal/src/execution_context_service.ts
+++ b/packages/core/execution-context/core-execution-context-browser-internal/src/execution_context_service.ts
@@ -8,6 +8,7 @@
  */
 
 import { compact, isEqual, isUndefined, omitBy } from 'lodash';
+import type { History } from 'history';
 import type { Observable } from 'rxjs';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { map } from 'rxjs';
@@ -18,7 +19,6 @@ import type {
   ExecutionContextSetup,
   ExecutionContextStart,
 } from '@kbn/core-execution-context-browser';
-import type { InternalApplicationStart } from '@kbn/core-application-browser-internal';
 
 // Should be exported from elastic/apm-rum
 export type LabelValue = string | number | boolean;
@@ -33,7 +33,7 @@ export interface SetupDeps {
 
 export interface StartDeps {
   curApp$: Observable<string | undefined>;
-  history: InternalApplicationStart['history'];
+  history: History<unknown>;
 }
 
 /** @internal */

--- a/packages/core/execution-context/core-execution-context-browser-internal/tsconfig.json
+++ b/packages/core/execution-context/core-execution-context-browser-internal/tsconfig.json
@@ -15,7 +15,9 @@
     "@kbn/core-analytics-browser",
     "@kbn/core-analytics-browser-mocks",
     "@kbn/core-execution-context-common",
-    "@kbn/core-execution-context-browser"
+    "@kbn/core-execution-context-browser",
+    "@kbn/core-application-browser-mocks",
+    "@kbn/core-application-browser-internal"
   ],
   "exclude": [
     "target/**/*",

--- a/packages/core/root/core-root-browser-internal/src/core_system.ts
+++ b/packages/core/root/core-root-browser-internal/src/core_system.ts
@@ -339,6 +339,7 @@ export class CoreSystem {
 
       const executionContext = this.executionContext.start({
         curApp$: application.currentAppId$,
+        history: application.history,
       });
 
       const chrome = await this.chrome.start({


### PR DESCRIPTION
## Summary

Resolves #195778

This PR attempts to fix #195778 and https://github.com/elastic/observability-dev/issues/3776 by calling `executionContext.set({ url })` whenever we identify the pathname has changed (using the `history` module for that).

Hopefully, this will remove the need of plugins explicitly calling the execution context to update the path when their internal `Router` applies any changes.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

- [ ] **The solution is using `executionContext.set` instead of `executionContext.clear`.** The difference is that any previous contextual information will be kept. When switching apps, we clear every previous context. However, when inside the same app, it didn't feel right to clear everything. Should it?




