### PR TITLE
[Security Solution] - enable running threat hunting investigations api integration tests in QA quality gate

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/investigation/saved_objects/tests/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/investigation/saved_objects/tests/index.ts
@@ -8,7 +8,7 @@
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('@ess @serverless SecuritySolution Saved Objects', () => {
+  describe('@ess @serverless @serverlessQA SecuritySolution Saved Objects', () => {
     loadTestFile(require.resolve('./notes'));
     loadTestFile(require.resolve('./pinned_events'));
     loadTestFile(require.resolve('./timeline'));

--- a/x-pack/test/security_solution_api_integration/test_suites/investigation/timeline/tests/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/investigation/timeline/tests/index.ts
@@ -8,7 +8,7 @@
 import { FtrProviderContextWithSpaces } from '../../../../ftr_provider_context_with_spaces';
 
 export default function ({ loadTestFile }: FtrProviderContextWithSpaces) {
-  describe('@ess @serverless SecuritySolution Timeline', () => {
+  describe('@ess @serverless @serverlessQA SecuritySolution Timeline', () => {
     loadTestFile(require.resolve('./events'));
     loadTestFile(require.resolve('./timeline_details'));
     loadTestFile(require.resolve('./timeline'));


### PR DESCRIPTION
## Summary

This PR enables the Threat Hunting Investigations api integration tests to the release quality gate.

https://github.com/elastic/kibana/issues/181687



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->