### PR TITLE
[Dataset Quality] Fix Privilege Failing Test

### DIFF
--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_privileges.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_privileges.ts
@@ -146,7 +146,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
           const datasetWithMonitorPrivilege = apacheAccessDatasetHumanName;
           const datasetWithoutMonitorPrivilege = 'synth.1';
 
-          await retry.tryForTime(5000, async () => {
+          await retry.tryForTime(10000, async () => {
             // "Size" should be available for `apacheAccessDatasetName`
             await testSubjects.missingOrFail(
               `${PageObjects.datasetQuality.testSubjectSelectors.datasetQualityInsufficientPrivileges}-sizeBytes-${datasetWithMonitorPrivilege}`


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/198865

<!--ONMERGE {"backportTargets":["8.16","8.x"]} ONMERGE-->