### PR TITLE
Remove Container Workload Protection link from Assets page

### DIFF
--- a/x-pack/plugins/security_solution/public/app/solution_navigation/links/sections/assets_links.ts
+++ b/x-pack/plugins/security_solution/public/app/solution_navigation/links/sections/assets_links.ts
@@ -34,7 +34,7 @@ const assetsCloudDefendAppLink: LinkItem = {
   landingIcon: IconEcctlLazy,
   isBeta: true,
   hideTimeline: true,
-  links: [], // cloudDefendPolicies link is added in createAssetsLinkFromManage
+  links: [],
 };
 
 export const createAssetsLinkFromManage = (manageLink: LinkItem): LinkItem => {
@@ -54,13 +54,7 @@ export const createAssetsLinkFromManage = (manageLink: LinkItem): LinkItem => {
     assetsSubLinks.push({ ...endpointsLink, links: endpointsSubLinks });
   }
 
-  const cloudPoliciesLink = manageLink.links?.find(
-    ({ id }) => id === SecurityPageName.cloudDefendPolicies
-  );
-  if (cloudPoliciesLink) {
-    // Add cloud defend policies link as cloud defend sub link
-    assetsSubLinks.push({ ...assetsCloudDefendAppLink, links: [cloudPoliciesLink] });
-  }
+  assetsSubLinks.push(assetsCloudDefendAppLink);
 
   return {
     ...assetsAppLink,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/security-team/issues/10741.

As the name suggests, it simply removes the link to the "Container Workload Protection" link from the Cloud section in the Assets page. The Cloud section is kept though, since the screenshot in the ticket doesn't highlight it.

### Testing

> [!NOTE]
>  Note this page is only accessible in Serverless.

Authenticate to Docker Registry with
```bash
docker login -u <YOUR_USER> -p <YOUR_PASSWORD> docker.elastic.co
```

Then run ES with

```bash
yarn es serverless --projectType security --kill
```

Alternatively, run Kibana with
```bash
yarn serverless-security
```

### Screenshot

Link removed, but Cloud section is kept:

<details><summary>Before</summary>
<img width="2043" alt="before" src="https://github.com/user-attachments/assets/e0421c83-6f62-49f9-bb46-26e8e828f10b">
</details> 

<details><summary>After</summary>
<img width="2514" alt="Screenshot 2024-11-20 at 12 05 01" src="https://github.com/user-attachments/assets/51ac7f1f-086a-4fe2-846a-5511fc8e0f82">
</details> 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR description includes the appropriate Release Notes section, and the correct `release_node:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)




<!--ONMERGE {"backportTargets":["8.18","8.x"]} ONMERGE-->