### PR TITLE
[Entity Analytics][Bug] Only refresh the asset criticality index after bulk upload

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/asset_criticality/asset_criticality_data_client.ts
@@ -301,7 +301,7 @@ export class AssetCriticalityDataClient {
       index: this.getIndex(),
       flushBytes,
       retries,
-      refreshOnCompletion: true, // refresh the index after all records are processed
+      refreshOnCompletion: this.getIndex(),
       onDocument: ({ record }) => [
         { update: { _id: createId(record) } },
         {


### PR DESCRIPTION
## Summary

We were unintentionally refreshing all indices after an asset criticality bulk upload was performed, this fix makes it so we only refresh the asset criticality index.

backporting to all 8.x versions

## Test steps

- 1. I created an index by uploading a document, the content isn't important:
```
POST /logs-test-hello/_doc
{
  "host" : {
    "name" : "my_host",
    "domain" : "my_domain",
    "ip" : ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
  }
}
```

- 2. I then used the refresh stats API to see how many refreshes have happened on that index:

```
GET /_stats/refresh

// lots ommited here:

    ".ds-logs-test-hello-2024.11.20-000001": {
      "uuid": "DRxQd3rgQC2YSMIahzDCrw",
      "health": "yellow",
      "status": "open",
      "primaries": {
        "refresh": {
          "total": 10,
          "total_time_in_millis": 66,
          "external_total": 9,
          "external_total_time_in_millis": 67,
          "listeners": 0
        }
      },
      "total": {
        "refresh": {
          "total": 10, // <--------------------------------- Index has had 10 refreshes
          "total_time_in_millis": 66,
          "external_total": 9,
          "external_total_time_in_millis": 67,
          "listeners": 0
        }
      }
    },
```
3. perform an asset criticality bulk upload
4. call the `GET /_stats/refresh` API again, before the fix notice the number has gone up on the logs index (I did this a few times just to make sure) OR after the fix, this number does not go up.



<!--ONMERGE {"backportTargets":["8.15","8.16","8.18","8.x"]} ONMERGE-->