### PR TITLE
[Session management] update cleanup to allow partial search results for PIT query

### DIFF
--- a/x-pack/plugins/security/server/session_management/session_index.test.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.test.ts
@@ -473,6 +473,7 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.search).toHaveBeenCalledTimes(1);
       expect(mockElasticsearchClient.search).toHaveBeenCalledWith({
         _source_includes: 'usernameHash,provider',
+        allow_partial_search_results: true,
         sort: '_shard_doc',
         track_total_hits: false,
         search_after: undefined,
@@ -555,6 +556,7 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.search).toHaveBeenCalledTimes(1);
       expect(mockElasticsearchClient.search).toHaveBeenCalledWith({
         _source_includes: 'usernameHash,provider',
+        allow_partial_search_results: true,
         sort: '_shard_doc',
         track_total_hits: false,
         search_after: undefined,
@@ -649,6 +651,7 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.search).toHaveBeenCalledTimes(1);
       expect(mockElasticsearchClient.search).toHaveBeenCalledWith({
         _source_includes: 'usernameHash,provider',
+        allow_partial_search_results: true,
         sort: '_shard_doc',
         track_total_hits: false,
         search_after: undefined,
@@ -737,6 +740,7 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.search).toHaveBeenCalledTimes(1);
       expect(mockElasticsearchClient.search).toHaveBeenCalledWith({
         _source_includes: 'usernameHash,provider',
+        allow_partial_search_results: true,
         sort: '_shard_doc',
         track_total_hits: false,
         search_after: undefined,
@@ -850,6 +854,7 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.search).toHaveBeenCalledTimes(1);
       expect(mockElasticsearchClient.search).toHaveBeenCalledWith({
         _source_includes: 'usernameHash,provider',
+        allow_partial_search_results: true,
         sort: '_shard_doc',
         track_total_hits: false,
         search_after: undefined,

--- a/x-pack/plugins/security/server/session_management/session_index.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.ts
@@ -857,6 +857,7 @@ export class SessionIndex {
           size: SESSION_INDEX_CLEANUP_BATCH_SIZE,
           sort: '_shard_doc',
           track_total_hits: false, // for performance
+          allow_partial_search_results: true,
         });
         const { hits } = searchResponse.hits;
         if (hits.length > 0) {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/200008

## Summary
This PR updates the session cleanup task to allow partial results in the point in time query used to delete any invalid sessions. 


### Notes
Using a [recently introduced option by ES](https://github.com/elastic/elasticsearch/pull/111516), the session cleanup now allows the PIT to run over partial results. This should reduce the noise we see around session_cleanup errors in our logs.


### Release notes
Fixes error with opening point in time query for session deletion by now accounting for partial results. 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_node:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.x"]} ONMERGE-->