### PR TITLE
[ES|QL] An attempt to resolve flaky statuses of ES|QL history items

### DIFF
--- a/test/functional/apps/discover/esql/_esql_view.ts
+++ b/test/functional/apps/discover/esql/_esql_view.ts
@@ -41,7 +41,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     defaultIndex: 'logstash-*',
     enableESQL: true,
   };
-
   describe('discover esql view', function () {
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/196866
- Previous attempt https://github.com/elastic/kibana/pull/200928

## Summary

This PR is to resolve a race condition in adding items to ES|QL query history.

From the CI failure: should be an error icon for the first history item but it's a green checkmark.
![discoveresql discover esql view query history should add a failed query to the h-68a6114f2a586841f7eee1bfb901cac4bcdc7a2cd577786fd85d6851b6dfbd8b](https://github.com/user-attachments/assets/176d4d4d-0a06-4c3a-91b8-92142213124a)


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


