### PR TITLE
[Logs Shared] Update deprecated Kibana usages

### DIFF
--- a/x-pack/plugins/observability_solution/logs_shared/common/log_views/resolved_log_view.ts
+++ b/x-pack/plugins/observability_solution/logs_shared/common/log_views/resolved_log_view.ts
@@ -106,7 +106,7 @@ const resolveDataViewReference = async (
   });
 
   return {
-    indices: dataView.title,
+    indices: dataView.getIndexPattern(),
     timestampField: dataView.timeFieldName ?? TIMESTAMP_FIELD,
     tiebreakerField: TIEBREAKER_FIELD,
     messageField: ['message'],

--- a/x-pack/plugins/observability_solution/logs_shared/server/saved_objects/log_view/log_view_saved_object.ts
+++ b/x-pack/plugins/observability_solution/logs_shared/server/saved_objects/log_view/log_view_saved_object.ts
@@ -40,5 +40,4 @@ export const logViewSavedObjectType: SavedObjectsType = {
       },
     },
   },
-  migrations: {},
 };


### PR DESCRIPTION
## 📓 Summary

The `logs_shared` plugin was still relying on internal [deprecated kibana APIs](https://docs.elastic.dev/kibana-dev-docs/api-meta/deprecated-api-list-by-plugin#logsshared).
These changes update the usage with the related recommendation.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->