### PR TITLE
[Inventory][ECO] Fix asKqlFilter

### DIFF
--- a/x-pack/plugins/entity_manager/public/lib/entity_client.test.ts
+++ b/x-pack/plugins/entity_manager/public/lib/entity_client.test.ts
@@ -39,7 +39,22 @@ describe('EntityClient', () => {
       };
 
       const result = entityClient.asKqlFilter(entityLatest);
-      expect(result).toEqual('service.name: my-service');
+      expect(result).toEqual('service.name: "my-service"');
+    });
+
+    it('should return the kql filter when an indentity field value contain special characters', () => {
+      const entityLatest: EntityInstance = {
+        entity: {
+          ...commonEntityFields.entity,
+          identity_fields: ['host.name', 'foo.bar'],
+        },
+        host: {
+          name: 'my-host:some-value:some-other-value',
+        },
+      };
+
+      const result = entityClient.asKqlFilter(entityLatest);
+      expect(result).toEqual('host.name: "my-host:some-value:some-other-value"');
     });
 
     it('should return the kql filter when indentity_fields is composed by multiple fields', () => {
@@ -56,7 +71,7 @@ describe('EntityClient', () => {
       };
 
       const result = entityClient.asKqlFilter(entityLatest);
-      expect(result).toEqual('(service.name: my-service AND service.environment: staging)');
+      expect(result).toEqual('(service.name: "my-service" AND service.environment: "staging")');
     });
 
     it('should ignore fields that are not present in the entity', () => {
@@ -71,7 +86,7 @@ describe('EntityClient', () => {
       };
 
       const result = entityClient.asKqlFilter(entityLatest);
-      expect(result).toEqual('host.name: my-host');
+      expect(result).toEqual('host.name: "my-host"');
     });
   });
 

--- a/x-pack/plugins/entity_manager/public/lib/entity_client.ts
+++ b/x-pack/plugins/entity_manager/public/lib/entity_client.ts
@@ -95,7 +95,7 @@ export class EntityClient {
     const identityFieldsValue = this.getIdentityFieldsValue(entityInstance);
 
     const nodes: KueryNode[] = Object.entries(identityFieldsValue).map(([identityField, value]) => {
-      return nodeTypes.function.buildNode('is', identityField, value);
+      return nodeTypes.function.buildNode('is', identityField, `"${value}"`);
     });
 
     if (nodes.length === 0) return '';


### PR DESCRIPTION
fixes [#200981](https://github.com/elastic/kibana/issues/200981)

## Summary

This PR fixes a problem with the asKqlFilter throwing an error when building filters with string containing special characters.





<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.x"]} ONMERGE-->