### PR TITLE
[Inventory][ECO] APM url generated with invalid environment

### DIFF
--- a/x-pack/plugins/observability_solution/inventory/common/utils/entity_type_guards.ts
+++ b/x-pack/plugins/observability_solution/inventory/common/utils/entity_type_guards.ts
@@ -13,7 +13,7 @@ interface BuiltinEntityMap {
   container: InventoryEntity & { cloud?: { provider?: string[] } };
   service: InventoryEntity & {
     agent?: { name: AgentName[] };
-    service?: { environment?: string };
+    service?: { environment?: string | string[] | null };
   };
 }
 

--- a/x-pack/plugins/observability_solution/inventory/e2e/cypress/e2e/home.cy.ts
+++ b/x-pack/plugins/observability_solution/inventory/e2e/cypress/e2e/home.cy.ts
@@ -110,6 +110,18 @@ describe('Home page', () => {
         cy.url().should('include', '/app/apm/services/synth-node-trace-logs/overview');
       });
 
+      it('Navigates to apm when clicking on a logs only service', () => {
+        cy.intercept('GET', '/internal/entities/managed/enablement', {
+          fixture: 'eem_enabled.json',
+        }).as('getEEMStatus');
+        cy.visitKibana('/app/inventory');
+        cy.wait('@getEEMStatus');
+        cy.contains('service').click();
+        cy.contains('service-logs-only').click();
+        cy.url().should('include', '/app/apm/services/service-logs-only/overview');
+        cy.contains('Detect and resolve issues faster with deep visibility into your application');
+      });
+
       it('Navigates to hosts when clicking on a host type entity', () => {
         cy.intercept('GET', '/internal/entities/managed/enablement', {
           fixture: 'eem_enabled.json',

--- a/x-pack/plugins/observability_solution/inventory/public/hooks/use_detail_view_redirect.ts
+++ b/x-pack/plugins/observability_solution/inventory/public/hooks/use_detail_view_redirect.ts
@@ -61,7 +61,9 @@ export const useDetailViewRedirect = () => {
       if (isBuiltinEntityOfType('service', entity)) {
         return serviceOverviewLocator?.getRedirectUrl({
           serviceName: identityFieldsValue[identityFields[0]],
-          environment: entity.service?.environment,
+          environment: entity.service?.environment
+            ? castArray(entity.service?.environment)[0]
+            : undefined,
         });
       }
 


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/200913

The service environment can be `null`, when that's the case we should not pass it to the service locator, we must instead pass `undefined`.

<img width="1238" alt="Screenshot 2024-11-20 at 16 26 18" src="https://github.com/user-attachments/assets/ced1f3c2-b7e2-4acf-8d87-4e4caa01095c">


<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->