### PR TITLE
[StdPerf] Add Telemetry for Alert related pages

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/application/index.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/application/index.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PerformanceContextProvider } from '@kbn/ebt-tools';
 import { i18n } from '@kbn/i18n';
 import { Router, Routes, Route } from '@kbn/shared-ux-router';
 import { AppMountParameters, APP_WRAPPER_CLASS, CoreStart } from '@kbn/core/public';
@@ -111,10 +112,12 @@ export const renderApp = ({
                 <Router history={history}>
                   <EuiThemeProvider darkMode={isDarkMode}>
                     <RedirectAppLinks coreStart={core} data-test-subj="observabilityMainContainer">
-                      <QueryClientProvider client={queryClient}>
-                        <App />
-                        <HideableReactQueryDevTools />
-                      </QueryClientProvider>
+                      <PerformanceContextProvider>
+                        <QueryClientProvider client={queryClient}>
+                          <App />
+                          <HideableReactQueryDevTools />
+                        </QueryClientProvider>
+                      </PerformanceContextProvider>
                     </RedirectAppLinks>
                   </EuiThemeProvider>
                 </Router>

--- a/x-pack/plugins/observability_solution/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/pages/alert_details/alert_details.tsx
@@ -7,6 +7,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
@@ -84,6 +85,7 @@ export const getPageTitle = (ruleCategory: string) => {
 };
 
 export function AlertDetails() {
+  const { onPageReady } = usePerformanceContext();
   const {
     cases: {
       helpers: { canUseCases },
@@ -180,6 +182,12 @@ export function AlertDetails() {
   const onUntrackAlert = () => {
     setAlertStatus(ALERT_STATUS_UNTRACKED);
   };
+
+  useEffect(() => {
+    if (onPageReady && !isLoading && alertDetail !== undefined && activeTabId === OVERVIEW_TAB_ID) {
+      onPageReady();
+    }
+  }, [onPageReady, alertDetail, isLoading, activeTabId]);
 
   if (isLoading) {
     return <CenterJustifiedSpinner />;


### PR DESCRIPTION
## Summary

This PR adds StdPerf to the alert details page. For now, I only added this metric for the overview tab.

---

Resolves https://github.com/elastic/observability-dev/issues/3559

