### PR TITLE
[Reporting] Remove "download CSV" export type functionality, Part 2

### DIFF
--- a/docs/settings/reporting-settings.asciidoc
+++ b/docs/settings/reporting-settings.asciidoc
@@ -302,11 +302,5 @@ Enables a check that warns you when there's a potential formula included in the 
 `xpack.reporting.csv.escapeFormulaValues`::
 Escape formula values in cells with a `'`. See OWASP: https://www.owasp.org/index.php/CSV_Injection. Defaults to `true`.
 
-`xpack.reporting.csv.enablePanelActionDownload`::
-deprecated:[8.14.0,This setting will be removed in an upcoming version of {kib}.] When `true`, this
-setting enables a deprecated feature which allows users to download a CSV export from a saved search
-panel on a dashboard. When `false`, users can generate regular CSV reports from a saved search panel on a
-dashboard and later download them in *Stack Management > Reporting*. Defaults to `false`.
-
 `xpack.reporting.csv.useByteOrderMarkEncoding`::
 Adds a byte order mark (`\ufeff`) at the beginning of the CSV file. Defaults to `false`.

--- a/packages/kbn-generate-csv/src/generate_csv.test.ts
+++ b/packages/kbn-generate-csv/src/generate_csv.test.ts
@@ -47,7 +47,6 @@ const getMockConfig = (opts: Partial<CsvConfigType> = {}): CsvConfigType => ({
   maxSizeBytes: 180000,
   useByteOrderMarkEncoding: false,
   scroll: { size: 500, duration: '30s', strategy: 'pit' },
-  enablePanelActionDownload: false,
   maxConcurrentShardRequests: 5,
   ...opts,
 });

--- a/packages/kbn-generate-csv/src/generate_csv_esql.test.ts
+++ b/packages/kbn-generate-csv/src/generate_csv_esql.test.ts
@@ -98,7 +98,6 @@ describe('CsvESQLGenerator', () => {
       maxSizeBytes: 180000,
       useByteOrderMarkEncoding: false,
       scroll: { size: 500, duration: '30s', strategy: 'pit' },
-      enablePanelActionDownload: false,
       maxConcurrentShardRequests: 5,
     };
 
@@ -569,7 +568,6 @@ describe('CsvESQLGenerator', () => {
         maxSizeBytes: 180000,
         useByteOrderMarkEncoding: false,
         scroll: { size: 500, duration: '30s', strategy: 'pit' },
-        enablePanelActionDownload: false,
         maxConcurrentShardRequests: 5,
       };
       mockSearchResponse({

--- a/packages/kbn-generate-csv/src/lib/get_export_settings.test.ts
+++ b/packages/kbn-generate-csv/src/lib/get_export_settings.test.ts
@@ -39,7 +39,6 @@ describe('getExportSettings', () => {
       scroll: { size: 500, duration: '30s', strategy: 'pit' },
       useByteOrderMarkEncoding: false,
       maxConcurrentShardRequests: 5,
-      enablePanelActionDownload: false,
     };
 
     taskInstanceFields = { startedAt: null, retryAt: null };

--- a/packages/kbn-reporting/server/__snapshots__/config_schema.test.ts.snap
+++ b/packages/kbn-reporting/server/__snapshots__/config_schema.test.ts.snap
@@ -7,7 +7,6 @@ Object {
   },
   "csv": Object {
     "checkForFormulas": true,
-    "enablePanelActionDownload": false,
     "escapeFormulaValues": false,
     "maxConcurrentShardRequests": 5,
     "maxSizeBytes": ByteSizeValue {
@@ -70,7 +69,6 @@ Object {
   },
   "csv": Object {
     "checkForFormulas": true,
-    "enablePanelActionDownload": false,
     "escapeFormulaValues": false,
     "maxConcurrentShardRequests": 5,
     "maxSizeBytes": ByteSizeValue {

--- a/packages/kbn-reporting/server/config_schema.ts
+++ b/packages/kbn-reporting/server/config_schema.ts
@@ -60,7 +60,7 @@ const CaptureSchema = schema.object({
 const CsvSchema = schema.object({
   checkForFormulas: schema.boolean({ defaultValue: true }),
   escapeFormulaValues: schema.boolean({ defaultValue: false }),
-  enablePanelActionDownload: schema.boolean({ defaultValue: false }), // unused as of 9.0
+  enablePanelActionDownload: schema.maybe(schema.boolean({ defaultValue: false })), // unused as of 9.0
   maxSizeBytes: schema.oneOf([schema.number(), schema.byteSize()], {
     defaultValue: ByteSizeValue.parse('250mb'),
   }),

--- a/x-pack/plugins/reporting/server/config/index.test.ts
+++ b/x-pack/plugins/reporting/server/config/index.test.ts
@@ -54,19 +54,8 @@ describe('deprecations', () => {
     `);
   });
 
-  it('logs a warning if csv.enablePanelActionDownload: true is set', () => {
-    const { messages } = applyReportingDeprecations({ csv: { enablePanelActionDownload: true } });
-    expect(messages).toMatchInlineSnapshot(`
-      Array [
-        "The default mechanism for Reporting privileges will work differently in future versions, which will affect the behavior of this cluster. Set \\"xpack.reporting.roles.enabled\\" to \\"false\\" to adopt the future behavior before upgrading.",
-        "The \\"xpack.reporting.csv.enablePanelActionDownload\\" setting is deprecated.",
-      ]
-    `);
-  });
-
   it('does not log a warning recommended settings are used', () => {
     const { messages } = applyReportingDeprecations({
-      csv: { enablePanelActionDownload: false },
       roles: { enabled: false },
     });
     expect(messages).toMatchInlineSnapshot(`Array []`);

--- a/x-pack/plugins/reporting/server/config/index.ts
+++ b/x-pack/plugins/reporting/server/config/index.ts
@@ -13,10 +13,7 @@ import { ConfigSchema, ReportingConfigType } from '@kbn/reporting-server';
 
 export const config: PluginConfigDescriptor<ReportingConfigType> = {
   exposeToBrowser: {
-    csv: {
-      enablePanelActionDownload: true,
-      scroll: true,
-    },
+    csv: { scroll: true },
     poll: true,
     roles: true,
     export_types: true,
@@ -69,44 +66,11 @@ export const config: PluginConfigDescriptor<ReportingConfigType> = {
           },
         });
       }
-
-      if (reporting?.csv?.enablePanelActionDownload === true) {
-        addDeprecation({
-          configPath: `${fromPath}.csv.enablePanelActionDownload`,
-          title: i18n.translate('xpack.reporting.deprecations.csvPanelActionDownload.title', {
-            defaultMessage:
-              'The setting to enable CSV Download from saved search panels in dashboards is deprecated.',
-          }),
-          level: 'warning',
-          message: i18n.translate('xpack.reporting.deprecations.csvPanelActionDownload.message', {
-            defaultMessage: `The "{enablePanelActionDownload}" setting is deprecated.`,
-            values: {
-              enablePanelActionDownload: `${fromPath}.csv.enablePanelActionDownload`,
-            },
-          }),
-          correctiveActions: {
-            manualSteps: [
-              i18n.translate('xpack.reporting.deprecations.csvPanelActionDownload.manualStep1', {
-                defaultMessage:
-                  'Remove "{enablePanelActionDownload}" from `kibana.yml` or change the setting to `false`.',
-                values: {
-                  enablePanelActionDownload: `${fromPath}.csv.enablePanelActionDownload`,
-                },
-              }),
-              i18n.translate('xpack.reporting.deprecations.csvPanelActionDownload.manualStep2', {
-                defaultMessage:
-                  'Use the replacement panel action to generate CSV reports from saved search panels in the Dashboard application.',
-              }),
-            ],
-          },
-        });
-      }
     },
   ],
   exposeToUsage: {
     capture: { maxAttempts: true },
     csv: {
-      enablePanelActionDownload: true,
       maxSizeBytes: true,
       scroll: { size: true, duration: true },
     },


### PR DESCRIPTION
Follows #199033

## Summary

This PR further removes logic that uses `xpack.reporting.csv.enablePanelActionDownload`, and removes references of that setting from our documentation. See https://github.com/elastic/kibana/pull/199033 for the **release note**.

### Changes
1. `enablePanelActionDownload` exists as an **optional** setting in `packages/kbn-reporting/server/config_schema.ts`
2. The only reference to this setting marks it as unused in `x-pack/plugins/reporting/server/config/index.ts`
3. Removes the detection of the setting from the Upgrade Assistant integration

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.


