### PR TITLE
chore(NA): update versions after v8.18.0 bump

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -8,10 +8,15 @@
       "currentMinor": true
     },
     {
-      "version": "8.17.0",
+      "version": "8.18.0",
       "branch": "8.x",
       "previousMajor": true,
       "previousMinor": true
+    },
+    {
+      "version": "8.17.0",
+      "branch": "8.17",
+      "previousMajor": true
     },
     {
       "version": "8.16.1",


### PR DESCRIPTION
This PR is a simple update of our versions file after the recent bumps.