### PR TITLE
[8.16] [Discover] Unskip Discover-Lens functional test suite  (#200687)

### DIFF
--- a/test/functional/apps/discover/group3/_lens_vis.ts
+++ b/test/functional/apps/discover/group3/_lens_vis.ts
@@ -110,8 +110,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     return seriesType;
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/184600
-  describe.skip('discover lens vis', function () {
+  describe('discover lens vis', function () {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
@@ -655,8 +654,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await discover.waitUntilSearchingHasFinished();
       await testSubjects.missingOrFail('unsavedChangesBadge');
 
-      await discover.chooseLensSuggestion('pie');
-      expect(await getCurrentVisTitle()).to.be('Pie');
+      await discover.chooseLensSuggestion('waffle');
+      expect(await getCurrentVisTitle()).to.be('Waffle');
       await testSubjects.existOrFail('partitionVisChart');
       expect(await discover.getVisContextSuggestionType()).to.be('lensSuggestion');
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Discover] Unskip Discover-Lens functional test suite  (#200687)](https://github.com/elastic/kibana/pull/200687)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Matthias Wilhelm","email":"ankertal@gmail.com"},"sourceCommit":{"committedDate":"2024-11-20T17:38:05Z","message":"[Discover] Unskip Discover-Lens functional test suite  (#200687)\n\nCatching an invalid state of properties propagated to the UnifiedHistogram which is using the Lens embeddable in Discover, that causes a rendering error when e.g. ad hoc data views are being edited. Therefore the skipped testview can be unskipped.","sha":"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:skip","v9.0.0","Team:DataDiscovery","backport:prev-major","v8.17.0"],"number":200687,"url":"https://github.com/elastic/kibana/pull/200687","mergeCommit":{"message":"[Discover] Unskip Discover-Lens functional test suite  (#200687)\n\nCatching an invalid state of properties propagated to the UnifiedHistogram which is using the Lens embeddable in Discover, that causes a rendering error when e.g. ad hoc data views are being edited. Therefore the skipped testview can be unskipped.","sha":"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/200687","number":200687,"mergeCommit":{"message":"[Discover] Unskip Discover-Lens functional test suite  (#200687)\n\nCatching an invalid state of properties propagated to the UnifiedHistogram which is using the Lens embeddable in Discover, that causes a rendering error when e.g. ad hoc data views are being edited. Therefore the skipped testview can be unskipped.","sha":"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201013","number":201013,"state":"MERGED","mergeCommit":{"sha":"e2c0c94b52a4fe3486a0e85b84e9856821c27afc","message":"[8.x] [Discover] Unskip Discover-Lens functional test suite  (#200687) (#201013)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Discover] Unskip Discover-Lens functional test suite\n(#200687)](https://github.com/elastic/kibana/pull/200687)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Matthias\nWilhelm\",\"email\":\"ankertal@gmail.com\"},\"sourceCommit\":{\"committedDate\":\"2024-11-20T17:38:05Z\",\"message\":\"[Discover]\nUnskip Discover-Lens functional test suite (#200687)\\n\\nCatching an\ninvalid state of properties propagated to the UnifiedHistogram which is\nusing the Lens embeddable in Discover, that causes a rendering error\nwhen e.g. ad hoc data views are being edited. Therefore the skipped\ntestview can be\nunskipped.\",\"sha\":\"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Feature:Discover\",\"release_note:skip\",\"v9.0.0\",\"Team:DataDiscovery\",\"backport:prev-major\"],\"title\":\"[Discover]\nUnskip Discover-Lens functional test suite\n\",\"number\":200687,\"url\":\"https://github.com/elastic/kibana/pull/200687\",\"mergeCommit\":{\"message\":\"[Discover]\nUnskip Discover-Lens functional test suite (#200687)\\n\\nCatching an\ninvalid state of properties propagated to the UnifiedHistogram which is\nusing the Lens embeddable in Discover, that causes a rendering error\nwhen e.g. ad hoc data views are being edited. Therefore the skipped\ntestview can be\nunskipped.\",\"sha\":\"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/200687\",\"number\":200687,\"mergeCommit\":{\"message\":\"[Discover]\nUnskip Discover-Lens functional test suite (#200687)\\n\\nCatching an\ninvalid state of properties propagated to the UnifiedHistogram which is\nusing the Lens embeddable in Discover, that causes a rendering error\nwhen e.g. ad hoc data views are being edited. Therefore the skipped\ntestview can be\nunskipped.\",\"sha\":\"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Matthias Wilhelm <ankertal@gmail.com>"}}]}] BACKPORT-->