### PR TITLE
[8.15] [Discover] Unskip Discover-Lens functional test suite  (#200687)

### DIFF
--- a/src/plugins/unified_histogram/public/chart/histogram.tsx
+++ b/src/plugins/unified_histogram/public/chart/histogram.tsx
@@ -58,6 +58,32 @@ export interface HistogramProps {
   withDefaultActions: EmbeddableComponentProps['withDefaultActions'];
 }
 
+/**
+ * To prevent flakiness in the chart, we need to ensure that the data view config is valid.
+ * This requires that there are not multiple different data view ids in the given configuration.
+ * @param dataView
+ * @param visContext
+ * @param adHocDataViews
+ */
+const checkValidDataViewConfig = (
+  dataView: DataView,
+  visContext: UnifiedHistogramVisContext,
+  adHocDataViews: { [key: string]: DataViewSpec } | undefined
+) => {
+  if (!dataView.id) {
+    return false;
+  }
+
+  if (!dataView.isPersisted() && !adHocDataViews?.[dataView.id]) {
+    return false;
+  }
+
+  if (dataView.id !== visContext.requestData.dataViewId) {
+    return false;
+  }
+  return true;
+};
+
 const computeTotalHits = (
   hasLensSuggestions: boolean,
   adapterTables:
@@ -213,6 +239,10 @@ export function Histogram({
       transform: translate(-50%, -50%);
     }
   `;
+
+  if (!checkValidDataViewConfig(dataView, visContext, lensProps.attributes.state.adHocDataViews)) {
+    return <></>;
+  }
 
   return (
     <>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[Discover] Unskip Discover-Lens functional test suite  (#200687)](https://github.com/elastic/kibana/pull/200687)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Matthias Wilhelm","email":"ankertal@gmail.com"},"sourceCommit":{"committedDate":"2024-11-20T17:38:05Z","message":"[Discover] Unskip Discover-Lens functional test suite  (#200687)\n\nCatching an invalid state of properties propagated to the UnifiedHistogram which is using the Lens embeddable in Discover, that causes a rendering error when e.g. ad hoc data views are being edited. Therefore the skipped testview can be unskipped.","sha":"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:skip","v9.0.0","Team:DataDiscovery","backport:prev-major","v8.17.0"],"number":200687,"url":"https://github.com/elastic/kibana/pull/200687","mergeCommit":{"message":"[Discover] Unskip Discover-Lens functional test suite  (#200687)\n\nCatching an invalid state of properties propagated to the UnifiedHistogram which is using the Lens embeddable in Discover, that causes a rendering error when e.g. ad hoc data views are being edited. Therefore the skipped testview can be unskipped.","sha":"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/200687","number":200687,"mergeCommit":{"message":"[Discover] Unskip Discover-Lens functional test suite  (#200687)\n\nCatching an invalid state of properties propagated to the UnifiedHistogram which is using the Lens embeddable in Discover, that causes a rendering error when e.g. ad hoc data views are being edited. Therefore the skipped testview can be unskipped.","sha":"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201013","number":201013,"state":"MERGED","mergeCommit":{"sha":"e2c0c94b52a4fe3486a0e85b84e9856821c27afc","message":"[8.x] [Discover] Unskip Discover-Lens functional test suite  (#200687) (#201013)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Discover] Unskip Discover-Lens functional test suite\n(#200687)](https://github.com/elastic/kibana/pull/200687)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Matthias\nWilhelm\",\"email\":\"ankertal@gmail.com\"},\"sourceCommit\":{\"committedDate\":\"2024-11-20T17:38:05Z\",\"message\":\"[Discover]\nUnskip Discover-Lens functional test suite (#200687)\\n\\nCatching an\ninvalid state of properties propagated to the UnifiedHistogram which is\nusing the Lens embeddable in Discover, that causes a rendering error\nwhen e.g. ad hoc data views are being edited. Therefore the skipped\ntestview can be\nunskipped.\",\"sha\":\"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Feature:Discover\",\"release_note:skip\",\"v9.0.0\",\"Team:DataDiscovery\",\"backport:prev-major\"],\"title\":\"[Discover]\nUnskip Discover-Lens functional test suite\n\",\"number\":200687,\"url\":\"https://github.com/elastic/kibana/pull/200687\",\"mergeCommit\":{\"message\":\"[Discover]\nUnskip Discover-Lens functional test suite (#200687)\\n\\nCatching an\ninvalid state of properties propagated to the UnifiedHistogram which is\nusing the Lens embeddable in Discover, that causes a rendering error\nwhen e.g. ad hoc data views are being edited. Therefore the skipped\ntestview can be\nunskipped.\",\"sha\":\"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/200687\",\"number\":200687,\"mergeCommit\":{\"message\":\"[Discover]\nUnskip Discover-Lens functional test suite (#200687)\\n\\nCatching an\ninvalid state of properties propagated to the UnifiedHistogram which is\nusing the Lens embeddable in Discover, that causes a rendering error\nwhen e.g. ad hoc data views are being edited. Therefore the skipped\ntestview can be\nunskipped.\",\"sha\":\"e082cd1dfaa79c6fdfc5d7f1d2842b6ca0a5db6c\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Matthias Wilhelm <ankertal@gmail.com>"}}]}] BACKPORT-->