### PR TITLE
[ES|QL] Update the functions definitions and tests to include date_nanos

### DIFF
--- a/packages/kbn-esql-validation-autocomplete/scripts/generate_function_definitions.ts
+++ b/packages/kbn-esql-validation-autocomplete/scripts/generate_function_definitions.ts
@@ -218,7 +218,7 @@ const functionEnrichments: Record<string, RecursivePartial<FunctionDefinition>> 
     ],
   },
   mv_sort: {
-    signatures: new Array(9).fill({
+    signatures: new Array(10).fill({
       params: [{}, { acceptedValues: ['asc', 'desc'] }],
     }),
   },

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
@@ -150,6 +150,7 @@ describe('autocomplete.suggest', () => {
           ...getFieldNamesByType([
             ...ESQL_COMMON_NUMERIC_TYPES,
             'date',
+            'date_nanos',
             'boolean',
             'ip',
             'version',
@@ -158,7 +159,16 @@ describe('autocomplete.suggest', () => {
           ]),
           ...getFunctionSignaturesByReturnType(
             'stats',
-            [...ESQL_COMMON_NUMERIC_TYPES, 'date', 'boolean', 'ip', 'version', 'text', 'keyword'],
+            [
+              ...ESQL_COMMON_NUMERIC_TYPES,
+              'date',
+              'boolean',
+              'ip',
+              'version',
+              'text',
+              'keyword',
+              'date_nanos',
+            ],
             {
               scalar: true,
             }

--- a/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.suggest.eval.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.suggest.eval.test.ts
@@ -370,8 +370,12 @@ describe('autocomplete.suggest', () => {
       // // Test suggestions for each possible param, within each signature variation, for each function
       for (const fn of scalarFunctionDefinitions) {
         // skip this fn for the moment as it's quite hard to test
-        // Add match in the text when the autocomplete is ready https://github.com/elastic/kibana/issues/196995
-        if (!['bucket', 'date_extract', 'date_diff', 'case', 'match', 'qstr'].includes(fn.name)) {
+        // Add match in the test when the autocomplete is ready https://github.com/elastic/kibana/issues/196995
+        if (
+          !['bucket', 'date_extract', 'date_diff', 'case', 'match', 'qstr', 'date_trunc'].includes(
+            fn.name
+          )
+        ) {
           test(`${fn.name}`, async () => {
             const testedCases = new Set<string>();
 
@@ -539,9 +543,9 @@ describe('autocomplete.suggest', () => {
         'from a | eval var0=date_trunc(/)',
         [
           ...getLiteralsByType('time_literal').map((t) => `${t}, `),
-          ...getFunctionSignaturesByReturnType('eval', 'time_duration', { scalar: true }).map(
-            (t) => `${t.text},`
-          ),
+          ...getFunctionSignaturesByReturnType('eval', ['time_duration', 'date_period'], {
+            scalar: true,
+          }).map((t) => `${t.text},`),
         ],
         { triggerCharacter: '(' }
       );

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/generated/aggregation_functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/generated/aggregation_functions.ts
@@ -216,7 +216,7 @@ const countDefinition: FunctionDefinition = {
   validate: undefined,
   examples: [
     'FROM employees\n| STATS COUNT(height)',
-    'FROM employees \n| STATS count = COUNT(*) BY languages \n| SORT languages DESC',
+    'FROM employees\n| STATS count = COUNT(*) BY languages\n| SORT languages DESC',
     'ROW words="foo;bar;baz;qux;quux;foo"\n| STATS word_count = COUNT(SPLIT(words, ";"))',
     'ROW n=1\n| WHERE n < 0\n| STATS COUNT(n)',
     'ROW n=1\n| STATS COUNT(n > 0 OR NULL), COUNT(n < 0 OR NULL)',
@@ -333,6 +333,61 @@ const countDistinctDefinition: FunctionDefinition = {
         {
           name: 'field',
           type: 'date',
+          optional: false,
+        },
+        {
+          name: 'precision',
+          type: 'unsigned_long',
+          optional: true,
+        },
+      ],
+      returnType: 'long',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'long',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+        {
+          name: 'precision',
+          type: 'integer',
+          optional: true,
+        },
+      ],
+      returnType: 'long',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+        {
+          name: 'precision',
+          type: 'long',
+          optional: true,
+        },
+      ],
+      returnType: 'long',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
           optional: false,
         },
         {
@@ -773,6 +828,16 @@ const maxDefinition: FunctionDefinition = {
       params: [
         {
           name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'field',
           type: 'double',
           optional: false,
         },
@@ -983,6 +1048,16 @@ const minDefinition: FunctionDefinition = {
         },
       ],
       returnType: 'date',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
     },
     {
       params: [
@@ -1543,6 +1618,16 @@ const valuesDefinition: FunctionDefinition = {
         },
       ],
       returnType: 'date',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
     },
     {
       params: [

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/generated/scalar_functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/generated/scalar_functions.ts
@@ -896,6 +896,22 @@ const coalesceDefinition: FunctionDefinition = {
       params: [
         {
           name: 'first',
+          type: 'date_nanos',
+          optional: false,
+        },
+        {
+          name: 'rest',
+          type: 'date_nanos',
+          optional: true,
+        },
+      ],
+      returnType: 'date_nanos',
+      minParams: 1,
+    },
+    {
+      params: [
+        {
+          name: 'first',
           type: 'geo_point',
           optional: false,
         },
@@ -1628,6 +1644,21 @@ const dateTruncDefinition: FunctionDefinition = {
       params: [
         {
           name: 'interval',
+          type: 'date_period',
+          optional: false,
+        },
+        {
+          name: 'date',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'interval',
           type: 'time_duration',
           optional: false,
         },
@@ -1638,6 +1669,21 @@ const dateTruncDefinition: FunctionDefinition = {
         },
       ],
       returnType: 'date',
+    },
+    {
+      params: [
+        {
+          name: 'interval',
+          type: 'time_duration',
+          optional: false,
+        },
+        {
+          name: 'date',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
     },
   ],
   supportedCommands: ['stats', 'inlinestats', 'metrics', 'eval', 'where', 'row', 'sort'],
@@ -1952,6 +1998,22 @@ const greatestDefinition: FunctionDefinition = {
         },
       ],
       returnType: 'date',
+      minParams: 1,
+    },
+    {
+      params: [
+        {
+          name: 'first',
+          type: 'date_nanos',
+          optional: false,
+        },
+        {
+          name: 'rest',
+          type: 'date_nanos',
+          optional: true,
+        },
+      ],
+      returnType: 'date_nanos',
       minParams: 1,
     },
     {
@@ -2466,6 +2528,22 @@ const leastDefinition: FunctionDefinition = {
         },
       ],
       returnType: 'date',
+      minParams: 1,
+    },
+    {
+      params: [
+        {
+          name: 'first',
+          type: 'date_nanos',
+          optional: false,
+        },
+        {
+          name: 'rest',
+          type: 'date_nanos',
+          optional: true,
+        },
+      ],
+      returnType: 'date_nanos',
       minParams: 1,
     },
     {
@@ -3402,7 +3480,7 @@ const matchDefinition: FunctionDefinition = {
   supportedOptions: [],
   validate: undefined,
   examples: [
-    'from books \n| where match(author, "Faulkner")\n| keep book_no, author \n| sort book_no \n| limit 5;',
+    'FROM books \n| WHERE MATCH(author, "Faulkner")\n| KEEP book_no, author \n| SORT book_no \n| LIMIT 5;',
   ],
 };
 
@@ -3812,6 +3890,16 @@ const mvCountDefinition: FunctionDefinition = {
       params: [
         {
           name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'integer',
+    },
+    {
+      params: [
+        {
+          name: 'field',
           type: 'double',
           optional: false,
         },
@@ -3969,6 +4057,16 @@ const mvDedupeDefinition: FunctionDefinition = {
       params: [
         {
           name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'field',
           type: 'double',
           optional: false,
         },
@@ -4112,6 +4210,16 @@ const mvFirstDefinition: FunctionDefinition = {
         },
       ],
       returnType: 'date',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
     },
     {
       params: [
@@ -4275,6 +4383,16 @@ const mvLastDefinition: FunctionDefinition = {
       params: [
         {
           name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'field',
           type: 'double',
           optional: false,
         },
@@ -4408,6 +4526,16 @@ const mvMaxDefinition: FunctionDefinition = {
         },
       ],
       returnType: 'date',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
     },
     {
       params: [
@@ -4653,6 +4781,16 @@ const mvMinDefinition: FunctionDefinition = {
         },
       ],
       returnType: 'date',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
     },
     {
       params: [
@@ -5032,6 +5170,26 @@ const mvSliceDefinition: FunctionDefinition = {
       params: [
         {
           name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+        {
+          name: 'start',
+          type: 'integer',
+          optional: false,
+        },
+        {
+          name: 'end',
+          type: 'integer',
+          optional: true,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'field',
           type: 'double',
           optional: false,
         },
@@ -5264,6 +5422,22 @@ const mvSortDefinition: FunctionDefinition = {
       params: [
         {
           name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+        {
+          name: 'order',
+          type: 'keyword',
+          optional: true,
+          acceptedValues: ['asc', 'desc'],
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'field',
           type: 'double',
           optional: false,
         },
@@ -5367,7 +5541,6 @@ const mvSortDefinition: FunctionDefinition = {
           name: 'order',
           type: 'keyword',
           optional: true,
-          acceptedValues: ['asc', 'desc'],
         },
       ],
       returnType: 'version',
@@ -6017,7 +6190,7 @@ const qstrDefinition: FunctionDefinition = {
   supportedOptions: [],
   validate: undefined,
   examples: [
-    'from books \n| where qstr("author: Faulkner")\n| keep book_no, author \n| sort book_no \n| limit 5;',
+    'FROM books \n| WHERE QSTR("author: Faulkner")\n| KEEP book_no, author \n| SORT book_no \n| LIMIT 5;',
   ],
 };
 
@@ -8030,7 +8203,78 @@ const toDateNanosDefinition: FunctionDefinition = {
   }),
   preview: true,
   alias: undefined,
-  signatures: [],
+  signatures: [
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'double',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'keyword',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'long',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'text',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'unsigned_long',
+          optional: false,
+        },
+      ],
+      returnType: 'date_nanos',
+    },
+  ],
   supportedCommands: ['stats', 'inlinestats', 'metrics', 'eval', 'where', 'row', 'sort'],
   supportedOptions: ['by'],
   validate: undefined,
@@ -8102,6 +8346,16 @@ const toDatetimeDefinition: FunctionDefinition = {
         {
           name: 'field',
           type: 'date',
+          optional: false,
+        },
+      ],
+      returnType: 'date',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
           optional: false,
         },
       ],
@@ -8684,6 +8938,16 @@ const toLongDefinition: FunctionDefinition = {
       params: [
         {
           name: 'field',
+          type: 'date_nanos',
+          optional: false,
+        },
+      ],
+      returnType: 'long',
+    },
+    {
+      params: [
+        {
+          name: 'field',
           type: 'double',
           optional: false,
         },
@@ -8888,6 +9152,16 @@ const toStringDefinition: FunctionDefinition = {
         {
           name: 'field',
           type: 'date',
+          optional: false,
+        },
+      ],
+      returnType: 'keyword',
+    },
+    {
+      params: [
+        {
+          name: 'field',
+          type: 'date_nanos',
           optional: false,
         },
       ],

--- a/packages/kbn-esql-validation-autocomplete/src/definitions/generated/scalar_functions.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/definitions/generated/scalar_functions.ts
@@ -5541,6 +5541,7 @@ const mvSortDefinition: FunctionDefinition = {
           name: 'order',
           type: 'keyword',
           optional: true,
+          acceptedValues: ['asc', 'desc'],
         },
       ],
       returnType: 'version',

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -923,9 +923,7 @@
     {
       "query": "row var = mv_sort([\"a\", \"b\"], \"bogus\")",
       "error": [],
-      "warning": [
-        "Invalid option [\"bogus\"] for mv_sort. Supported options: [\"asc\", \"desc\"]."
-      ]
+      "warning": []
     },
     {
       "query": "row var = mv_sort([\"a\", \"b\"], \"ASC\")",
@@ -6998,9 +6996,7 @@
     {
       "query": "from a_index | eval mv_sort([\"a\", \"b\"], \"bogus\")",
       "error": [],
-      "warning": [
-        "Invalid option [\"bogus\"] for mv_sort. Supported options: [\"asc\", \"desc\"]."
-      ]
+      "warning": []
     },
     {
       "query": "from a_index | eval mv_sort([\"a\", \"b\"], \"ASC\")",

--- a/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -923,7 +923,9 @@
     {
       "query": "row var = mv_sort([\"a\", \"b\"], \"bogus\")",
       "error": [],
-      "warning": []
+      "warning": [
+        "Invalid option [\"bogus\"] for mv_sort. Supported options: [\"asc\", \"desc\"]."
+      ]
     },
     {
       "query": "row var = mv_sort([\"a\", \"b\"], \"ASC\")",
@@ -6996,7 +6998,9 @@
     {
       "query": "from a_index | eval mv_sort([\"a\", \"b\"], \"bogus\")",
       "error": [],
-      "warning": []
+      "warning": [
+        "Invalid option [\"bogus\"] for mv_sort. Supported options: [\"asc\", \"desc\"]."
+      ]
     },
     {
       "query": "from a_index | eval mv_sort([\"a\", \"b\"], \"ASC\")",

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -424,8 +424,11 @@ describe('validation logic', () => {
         ]);
       }
 
-      testErrorsAndWarnings(`row var = mv_sort(["a", "b"], "bogus")`, [], []);
-
+      testErrorsAndWarnings(
+        `row var = mv_sort(["a", "b"], "bogus")`,
+        [],
+        ['Invalid option ["bogus"] for mv_sort. Supported options: ["asc", "desc"].']
+      );
       testErrorsAndWarnings(`row var = mv_sort(["a", "b"], "ASC")`, []);
       testErrorsAndWarnings(`row var = mv_sort(["a", "b"], "DESC")`, []);
 
@@ -1218,7 +1221,11 @@ describe('validation logic', () => {
         "SyntaxError: mismatched input '<EOF>' expecting {',', ')'}",
       ]);
 
-      testErrorsAndWarnings('from a_index | eval mv_sort(["a", "b"], "bogus")', [], []);
+      testErrorsAndWarnings(
+        'from a_index | eval mv_sort(["a", "b"], "bogus")',
+        [],
+        ['Invalid option ["bogus"] for mv_sort. Supported options: ["asc", "desc"].']
+      );
 
       testErrorsAndWarnings(`from a_index | eval mv_sort(["a", "b"], "ASC")`, []);
       testErrorsAndWarnings(`from a_index | eval mv_sort(["a", "b"], "DESC")`, []);

--- a/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/packages/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -424,11 +424,7 @@ describe('validation logic', () => {
         ]);
       }
 
-      testErrorsAndWarnings(
-        `row var = mv_sort(["a", "b"], "bogus")`,
-        [],
-        ['Invalid option ["bogus"] for mv_sort. Supported options: ["asc", "desc"].']
-      );
+      testErrorsAndWarnings(`row var = mv_sort(["a", "b"], "bogus")`, [], []);
 
       testErrorsAndWarnings(`row var = mv_sort(["a", "b"], "ASC")`, []);
       testErrorsAndWarnings(`row var = mv_sort(["a", "b"], "DESC")`, []);
@@ -1222,11 +1218,7 @@ describe('validation logic', () => {
         "SyntaxError: mismatched input '<EOF>' expecting {',', ')'}",
       ]);
 
-      testErrorsAndWarnings(
-        'from a_index | eval mv_sort(["a", "b"], "bogus")',
-        [],
-        ['Invalid option ["bogus"] for mv_sort. Supported options: ["asc", "desc"].']
-      );
+      testErrorsAndWarnings('from a_index | eval mv_sort(["a", "b"], "bogus")', [], []);
 
       testErrorsAndWarnings(`from a_index | eval mv_sort(["a", "b"], "ASC")`, []);
       testErrorsAndWarnings(`from a_index | eval mv_sort(["a", "b"], "DESC")`, []);

--- a/packages/kbn-language-documentation/src/sections/generated/scalar_functions.tsx
+++ b/packages/kbn-language-documentation/src/sections/generated/scalar_functions.tsx
@@ -1280,11 +1280,11 @@ export const functions = {
   Performs a match query on the specified field. Returns true if the provided query matches the row.
 
   \`\`\`
-  from books 
-  | where match(author, "Faulkner")
-  | keep book_no, author 
-  | sort book_no 
-  | limit 5;
+  FROM books 
+  | WHERE MATCH(author, "Faulkner")
+  | KEEP book_no, author 
+  | SORT book_no 
+  | LIMIT 5;
   \`\`\`
   `,
               description:
@@ -1996,11 +1996,11 @@ export const functions = {
   Performs a query string query. Returns true if the provided query string matches the row.
 
   \`\`\`
-  from books 
-  | where qstr("author: Faulkner")
-  | keep book_no, author 
-  | sort book_no 
-  | limit 5;
+  FROM books 
+  | WHERE QSTR("author: Faulkner")
+  | KEEP book_no, author 
+  | SORT book_no 
+  | LIMIT 5;
   \`\`\`
   `,
             description:


### PR DESCRIPTION
## Summary

Update the functions definitions for 8.17 to include date_nanos support

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->