### PR TITLE
[ML] AiOps: Change point detection - Remove unnecessary theme provider

### DIFF
--- a/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_root.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_root.tsx
@@ -10,7 +10,6 @@ import React, { useMemo } from 'react';
 import type { Observable } from 'rxjs';
 import { map } from 'rxjs';
 import { pick } from 'lodash';
-import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
 import { EuiSpacer } from '@elastic/eui';
 
 import type { DataView } from '@kbn/data-views-plugin/common';

--- a/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_root.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/change_point_detection_root.tsx
@@ -86,30 +86,28 @@ export const ChangePointDetectionAppState: FC<ChangePointDetectionAppStateProps>
   const casesPermissions = appContextValue.cases?.helpers.canUseCases();
 
   return (
-    <KibanaThemeProvider theme={appContextValue.theme}>
-      <CasesContext owner={[]} permissions={casesPermissions!}>
-        <AiopsAppContext.Provider value={appContextValue}>
-          <UrlStateProvider>
-            <DataSourceContext.Provider value={{ dataView, savedSearch }}>
-              <StorageContextProvider storage={localStorage} storageKeys={AIOPS_STORAGE_KEYS}>
-                <DatePickerContextProvider {...datePickerDeps}>
-                  <PageHeader />
-                  <EuiSpacer />
-                  <ReloadContextProvider reload$={reload$}>
-                    <FilterQueryContextProvider>
-                      <ChangePointDetectionContextProvider>
-                        <ChangePointDetectionControlsContextProvider>
-                          <ChangePointDetectionPage />
-                        </ChangePointDetectionControlsContextProvider>
-                      </ChangePointDetectionContextProvider>
-                    </FilterQueryContextProvider>
-                  </ReloadContextProvider>
-                </DatePickerContextProvider>
-              </StorageContextProvider>
-            </DataSourceContext.Provider>
-          </UrlStateProvider>
-        </AiopsAppContext.Provider>
-      </CasesContext>
-    </KibanaThemeProvider>
+    <CasesContext owner={[]} permissions={casesPermissions!}>
+      <AiopsAppContext.Provider value={appContextValue}>
+        <UrlStateProvider>
+          <DataSourceContext.Provider value={{ dataView, savedSearch }}>
+            <StorageContextProvider storage={localStorage} storageKeys={AIOPS_STORAGE_KEYS}>
+              <DatePickerContextProvider {...datePickerDeps}>
+                <PageHeader />
+                <EuiSpacer />
+                <ReloadContextProvider reload$={reload$}>
+                  <FilterQueryContextProvider>
+                    <ChangePointDetectionContextProvider>
+                      <ChangePointDetectionControlsContextProvider>
+                        <ChangePointDetectionPage />
+                      </ChangePointDetectionControlsContextProvider>
+                    </ChangePointDetectionContextProvider>
+                  </FilterQueryContextProvider>
+                </ReloadContextProvider>
+              </DatePickerContextProvider>
+            </StorageContextProvider>
+          </DataSourceContext.Provider>
+        </UrlStateProvider>
+      </AiopsAppContext.Provider>
+    </CasesContext>
   );
 };

--- a/x-pack/plugins/aiops/tsconfig.json
+++ b/x-pack/plugins/aiops/tsconfig.json
@@ -63,7 +63,6 @@
     "@kbn/presentation-containers",
     "@kbn/presentation-publishing",
     "@kbn/presentation-util-plugin",
-    "@kbn/react-kibana-context-theme",
     "@kbn/react-kibana-mount",
     "@kbn/rison",
     "@kbn/saved-search-plugin",


### PR DESCRIPTION
## Summary


Recently, an error started appearing on the Change Point Detection page:
![image](https://github.com/user-attachments/assets/d802fe26-0222-4286-b32e-c967cadcd466)
This occurred because we had a duplicate Theme provider in the component tree.
After removing the duplicate:


https://github.com/user-attachments/assets/81568e67-93dc-4c01-9db6-26c57a4c2b52


