### PR TITLE
[ML] Single metric viewer: Explorer chart label prop types fix 

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/explorer_charts/components/explorer_chart_label/explorer_chart_label.js
+++ b/x-pack/plugins/ml/public/application/explorer/explorer_charts/components/explorer_chart_label/explorer_chart_label.js
@@ -94,7 +94,7 @@ export function ExplorerChartLabel({
 }
 ExplorerChartLabel.propTypes = {
   detectorLabel: PropTypes.object.isRequired,
-  isEmbeddable: PropTypes.boolean,
+  isEmbeddable: PropTypes.bool,
   entityFields: PropTypes.arrayOf(ExplorerChartLabelBadge.propTypes.entity),
   infoTooltip: PropTypes.object.isRequired,
   wrapLabel: PropTypes.bool,


### PR DESCRIPTION
## Summary

Currently, on the dashboards page, if an explorer charts embeddable is attached, an error appears in the console:
![Screenshot 2024-11-21 at 13 06 37](https://github.com/user-attachments/assets/978d254c-d971-46c6-b79d-b912d2fa35ae)

This issue occurs due to a PropTypes typo: `boolean` instead of `bool`.




<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->