### PR TITLE
[React18] Migrate test suites to account for testing library upgrades kibana-data-discovery,security-threat-hunting-investigations

### DIFF
--- a/packages/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_cell_value.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_cell_value.test.tsx
@@ -11,8 +11,7 @@ import { EuiDataGridCellValueElementProps, EuiDataGridSetCellProps } from '@elas
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import { generateEsHits, additionalFieldGroups } from '@kbn/discover-utils/src/__mocks__';
 import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
-import { render, screen } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { render, screen, renderHook } from '@testing-library/react';
 import React from 'react';
 import { ReactNode, useState } from 'react';
 import { dataViewWithTimefieldMock } from '../../../../__mocks__/data_view_with_timefield';

--- a/packages/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_columns.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_columns.test.tsx
@@ -13,9 +13,8 @@ import {
   FIELD_COLUMN_WIDTH,
   useComparisonColumns,
 } from './use_comparison_columns';
-import { renderHook } from '@testing-library/react-hooks';
 import type { EuiDataGridColumn, EuiDataGridColumnActions } from '@elastic/eui';
-import { render, screen } from '@testing-library/react';
+import { render, screen, renderHook } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { generateEsHits } from '@kbn/discover-utils/src/__mocks__';

--- a/packages/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_css.test.ts
+++ b/packages/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_css.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useComparisonCss } from './use_comparison_css';
 
 describe('useComparisonCss', () => {

--- a/packages/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_fields.test.ts
+++ b/packages/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_fields.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import {
   MAX_COMPARISON_FIELDS,

--- a/packages/kbn-unified-data-table/src/hooks/use_data_grid_columns.test.tsx
+++ b/packages/kbn-unified-data-table/src/hooks/use_data_grid_columns.test.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useColumns } from './use_data_grid_columns';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import { configMock } from '../../__mocks__/config';

--- a/packages/kbn-unified-data-table/src/hooks/use_data_grid_density.test.tsx
+++ b/packages/kbn-unified-data-table/src/hooks/use_data_grid_density.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useDataGridDensity } from './use_data_grid_density';
 import { DATA_GRID_STYLE_EXPANDED, DataGridDensity } from '../constants';
 

--- a/packages/kbn-unified-data-table/src/hooks/use_full_screen_watcher.test.ts
+++ b/packages/kbn-unified-data-table/src/hooks/use_full_screen_watcher.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { act, renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import {
   EUI_DATA_GRID_FULL_SCREEN_CLASS,
   UNIFIED_DATA_TABLE_FULL_SCREEN_CLASS,
@@ -40,7 +40,7 @@ const nextTick = () => {
   return act(() => {
     return new Promise((resolve) =>
       requestAnimationFrame(() => {
-        resolve();
+        resolve(null);
       })
     );
   });

--- a/packages/kbn-unified-data-table/src/hooks/use_row_height.test.tsx
+++ b/packages/kbn-unified-data-table/src/hooks/use_row_height.test.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { createLocalStorageMock } from '../../__mocks__/local_storage_mock';
 import { useRowHeight } from './use_row_height';
 import { RowHeightMode } from '../components/row_height_settings';

--- a/packages/kbn-unified-data-table/src/hooks/use_row_heights_options.test.ts
+++ b/packages/kbn-unified-data-table/src/hooks/use_row_heights_options.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useRowHeightsOptions } from './use_row_heights_options';
 
 describe('useRowHeightsOptions', () => {

--- a/packages/kbn-unified-data-table/src/hooks/use_selected_docs.test.ts
+++ b/packages/kbn-unified-data-table/src/hooks/use_selected_docs.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { act, renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import { useSelectedDocs } from './use_selected_docs';
 import { generateEsHits } from '@kbn/discover-utils/src/__mocks__';


### PR DESCRIPTION
This PR migrates test suites that use `renderHook` from the library `@testing-library/react-hooks` to adopt the equivalent and replacement of `renderHook` from the export that is now available from
`@testing-library/react`. This work is required for the planned migration to react18. 

##  Context

In this PR, usages of `waitForNextUpdate` that previously could have been destructured from `renderHook` are now been replaced with `waitFor` exported from `@testing-library/react`, furthermore `waitFor` 
that would also have been destructured from the same renderHook result is now been replaced with `waitFor` from the export of `@testing-library/react`.

***Why is `waitFor` a sufficient enough replacement for `waitForNextUpdate`, and better for testing values subject to async computations?***

WaitFor will retry the provided callback if an error is returned, till the configured timeout elapses. By default the retry interval is `50ms` with a timeout value of `1000ms` that 
effectively translates to at least 20 retries for assertions placed within waitFor. See https://testing-library.com/docs/dom-testing-library/api-async/#waitfor for more information.
This however means that for person's writing tests, said person has to be explicit about expectations that describe the internal state of the hook being tested. 
This implies checking for instance when a react query hook is being rendered, there's an assertion that said hook isn't loading anymore.

In this PR you'd notice that this pattern has been adopted, with most existing assertions following an invocation of `waitForNextUpdate` being placed within a `waitFor` 
invocation. In some cases the replacement is simply a `waitFor(() => new Promise((resolve) => resolve(null)))` (many thanks to @kapral18, for point out exactly why this works),
 where this suffices the assertions that follow aren't placed within a waitFor so this PR doesn't get larger than it needs to be.

It's also worth pointing out this PR might also contain changes to test and application code to improve said existing test.

### What to do next?
1. Review the changes in this PR.
2. If you think the changes are correct, approve the PR.

## Any questions?
If you have any questions or need help with this PR, please leave comments in this PR.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->