### PR TITLE
[React18] Migrate test suites to account for testing library upgrades appex-sharedux

### DIFF
--- a/packages/shared-ux/modal/tabbed/src/context/index.test.tsx
+++ b/packages/shared-ux/modal/tabbed/src/context/index.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { type ComponentProps, type ComponentType } from 'react';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import { useModalContext, ModalContextProvider } from '.';
 
 type ModalContextProviderProps = ComponentProps<typeof ModalContextProvider>;

--- a/packages/shared-ux/table_persist/src/use_table_persist.test.ts
+++ b/packages/shared-ux/table_persist/src/use_table_persist.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { CriteriaWithPagination } from '@elastic/eui';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import { useEuiTablePersist } from './use_table_persist';
 import { createStorage } from './storage'; // Mock this if it's external
 

--- a/src/plugins/content_management/public/content_client/content_client_mutation_hooks.test.tsx
+++ b/src/plugins/content_management/public/content_client/content_client_mutation_hooks.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { FC, PropsWithChildren } from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { ContentClientProvider } from './content_client_context';
 import { ContentClient } from './content_client';
 import { createCrudClientMock } from '../crud_client/crud_client.mock';
@@ -46,12 +46,10 @@ describe('useCreateContentMutation', () => {
     const input: CreateIn = { contentTypeId: 'testType', data: { foo: 'bar' }, version: 2 };
     const output = { test: 'test' };
     crudClient.create.mockResolvedValueOnce(output);
-    const { result, waitFor } = renderHook(() => useCreateContentMutation(), { wrapper: Wrapper });
+    const { result } = renderHook(() => useCreateContentMutation(), { wrapper: Wrapper });
     result.current.mutate(input);
 
-    await waitFor(() => result.current.isSuccess);
-
-    expect(result.current.data).toEqual(output);
+    await waitFor(() => expect(result.current.data).toEqual(output));
   });
 });
 
@@ -66,12 +64,10 @@ describe('useUpdateContentMutation', () => {
     };
     const output = { test: 'test' };
     crudClient.update.mockResolvedValueOnce(output);
-    const { result, waitFor } = renderHook(() => useUpdateContentMutation(), { wrapper: Wrapper });
+    const { result } = renderHook(() => useUpdateContentMutation(), { wrapper: Wrapper });
     result.current.mutate(input);
 
-    await waitFor(() => result.current.isSuccess);
-
-    expect(result.current.data).toEqual(output);
+    await waitFor(() => expect(result.current.data).toEqual(output));
   });
 });
 
@@ -81,11 +77,9 @@ describe('useDeleteContentMutation', () => {
     const input: DeleteIn = { contentTypeId: 'testType', id: 'test', version: 2 };
     const output = { test: 'test' };
     crudClient.delete.mockResolvedValueOnce(output);
-    const { result, waitFor } = renderHook(() => useDeleteContentMutation(), { wrapper: Wrapper });
+    const { result } = renderHook(() => useDeleteContentMutation(), { wrapper: Wrapper });
     result.current.mutate(input);
 
-    await waitFor(() => result.current.isSuccess);
-
-    expect(result.current.data).toEqual(output);
+    await waitFor(() => expect(result.current.data).toEqual(output));
   });
 });

--- a/src/plugins/content_management/public/content_client/content_client_query_hooks.test.tsx
+++ b/src/plugins/content_management/public/content_client/content_client_query_hooks.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { FC, PropsWithChildren } from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { ContentClientProvider } from './content_client_context';
 import { ContentClient } from './content_client';
 import { createCrudClientMock } from '../crud_client/crud_client.mock';
@@ -42,9 +42,8 @@ describe('useGetContentQuery', () => {
     const input: GetIn = { id: 'test', contentTypeId: 'testType', version: 2 };
     const output = { test: 'test' };
     crudClient.get.mockResolvedValueOnce(output);
-    const { result, waitFor } = renderHook(() => useGetContentQuery(input), { wrapper: Wrapper });
-    await waitFor(() => result.current.isSuccess);
-    expect(result.current.data).toEqual(output);
+    const { result } = renderHook(() => useGetContentQuery(input), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current.data).toEqual(output));
   });
 });
 
@@ -54,10 +53,9 @@ describe('useSearchContentQuery', () => {
     const input: SearchIn = { contentTypeId: 'testType', query: {}, version: 2 };
     const output = { hits: [{ id: 'test' }] };
     crudClient.search.mockResolvedValueOnce(output);
-    const { result, waitFor } = renderHook(() => useSearchContentQuery(input), {
+    const { result } = renderHook(() => useSearchContentQuery(input), {
       wrapper: Wrapper,
     });
-    await waitFor(() => result.current.isSuccess);
-    expect(result.current.data).toEqual(output);
+    await waitFor(() => expect(result.current.data).toEqual(output));
   });
 });


### PR DESCRIPTION

This PR migrates test suites that use `renderHook` from the library `@testing-library/react-hooks` to adopt the equivalent and replacement of `renderHook` from the export that is now available from
`@testing-library/react`. This work is required for the planned migration to react18. 

##  Context

In this PR, usages of `waitForNextUpdate` that previously could have been destructured from `renderHook` are now been replaced with `waitFor` exported from `@testing-library/react`, furthermore `waitFor` 
that would also have been destructured from the same renderHook result is now been replaced with `waitFor` from the export of `@testing-library/react`.

***Why is `waitFor` a sufficient enough replacement for `waitForNextUpdate`, and better for testing values subject to async computations?***

WaitFor will retry the provided callback if an error is returned, till the configured timeout elapses. By default the retry interval is `50ms` with a timeout value of `1000ms` that 
effectively translates to at least 20 retries for assertions placed within waitFor. See https://testing-library.com/docs/dom-testing-library/api-async/#waitfor for more information.
This however means that for person's writing tests, said person has to be explicit about expectations that describe the internal state of the hook being tested. 
This implies checking for instance when a react query hook is being rendered, there's an assertion that said hook isn't loading anymore.

In this PR you'd notice that this pattern has been adopted, with most existing assertions following an invocation of `waitForNextUpdate` being placed within a `waitFor` 
invocation. In some cases the replacement is simply a `waitFor(() => new Promise((resolve) => resolve(null)))` (many thanks to @kapral18, for point out exactly why this works),
 where this suffices the assertions that follow aren't placed within a waitFor so this PR doesn't get larger than it needs to be.

It's also worth pointing out this PR might also contain changes to test and application code to improve said existing test.

### What to do next?
1. Review the changes in this PR.
2. If you think the changes are correct, approve the PR.

## Any questions?
If you have any questions or need help with this PR, please leave comments in this PR.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->