### PR TITLE
[Search][a11y] Fixing wrong navigation sequence after Reset or Save Default Settings

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/default_settings_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/default_settings_flyout.tsx
@@ -56,7 +56,8 @@ export const DefaultSettingsFlyout: React.FC<DefaultSettingsFlyoutProps> = ({ cl
     reduce_whitespace: reduceWhitespace,
     run_ml_inference: runMLInference,
   } = pipelineState;
-  const elementRef = useRef<HTMLAnchorElement>(null);
+  // Reference the first focusable element in the flyout for accessibility on click or Enter key action either Reset or Save button
+  const firstFocusInFlyoutRef = useRef<HTMLAnchorElement>(null);
   return (
     <EuiFlyout onClose={closeFlyout} size="s" paddingSize="l">
       <EuiFlyoutHeader hasBorder>
@@ -82,7 +83,7 @@ export const DefaultSettingsFlyout: React.FC<DefaultSettingsFlyoutProps> = ({ cl
                     data-telemetry-id="entSearchContent-defaultSettingsFlyout-ingestPipelinesLink"
                     href={docLinks.ingestPipelines}
                     target="_blank"
-                    ref={elementRef}
+                    ref={firstFocusInFlyoutRef}
                   >
                     {i18n.translate(
                       'xpack.enterpriseSearch.defaultSettingsFlyout.body.description.ingestPipelinesLink.link',
@@ -208,7 +209,7 @@ export const DefaultSettingsFlyout: React.FC<DefaultSettingsFlyoutProps> = ({ cl
                   isLoading={isLoading}
                   onClick={() => {
                     setPipeline(defaultPipeline);
-                    elementRef.current?.focus();
+                    firstFocusInFlyoutRef.current?.focus();
                   }}
                   data-test-subj={'entSearchContentSettingsResetButton'}
                 >
@@ -225,7 +226,7 @@ export const DefaultSettingsFlyout: React.FC<DefaultSettingsFlyoutProps> = ({ cl
                   isLoading={isLoading}
                   onClick={() => {
                     makeRequest(pipelineState);
-                    elementRef.current?.focus();
+                    firstFocusInFlyoutRef.current?.focus();
                   }}
                   data-test-subj={'entSearchContentSettingsSaveButton'}
                 >

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/default_settings_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/default_settings_flyout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { useValues, useActions } from 'kea';
 
@@ -31,6 +31,7 @@ import { docLinks } from '../../../shared/doc_links';
 
 import { SettingsLogic } from './settings_logic';
 import { SettingsPanel } from './settings_panel';
+import { element } from 'prop-types';
 
 export interface DefaultSettingsFlyoutProps {
   closeFlyout: () => void;
@@ -56,6 +57,7 @@ export const DefaultSettingsFlyout: React.FC<DefaultSettingsFlyoutProps> = ({ cl
     reduce_whitespace: reduceWhitespace,
     run_ml_inference: runMLInference,
   } = pipelineState;
+  const elementRef = useRef(null);
   return (
     <EuiFlyout onClose={closeFlyout} size="s" paddingSize="l">
       <EuiFlyoutHeader hasBorder>
@@ -81,6 +83,7 @@ export const DefaultSettingsFlyout: React.FC<DefaultSettingsFlyoutProps> = ({ cl
                     data-telemetry-id="entSearchContent-defaultSettingsFlyout-ingestPipelinesLink"
                     href={docLinks.ingestPipelines}
                     target="_blank"
+                    ref={elementRef}
                   >
                     {i18n.translate(
                       'xpack.enterpriseSearch.defaultSettingsFlyout.body.description.ingestPipelinesLink.link',
@@ -204,7 +207,10 @@ export const DefaultSettingsFlyout: React.FC<DefaultSettingsFlyoutProps> = ({ cl
                   color="primary"
                   disabled={hasNoChanges}
                   isLoading={isLoading}
-                  onClick={() => setPipeline(defaultPipeline)}
+                  onClick={() => {
+                    elementRef.current?.focus();
+                    setPipeline(defaultPipeline);
+                  }}
                   data-test-subj={'entSearchContentSettingsResetButton'}
                 >
                   {i18n.translate('xpack.enterpriseSearch.content.settings.resetButtonLabel', {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/default_settings_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/settings/default_settings_flyout.tsx
@@ -31,7 +31,6 @@ import { docLinks } from '../../../shared/doc_links';
 
 import { SettingsLogic } from './settings_logic';
 import { SettingsPanel } from './settings_panel';
-import { element } from 'prop-types';
 
 export interface DefaultSettingsFlyoutProps {
   closeFlyout: () => void;
@@ -57,7 +56,7 @@ export const DefaultSettingsFlyout: React.FC<DefaultSettingsFlyoutProps> = ({ cl
     reduce_whitespace: reduceWhitespace,
     run_ml_inference: runMLInference,
   } = pipelineState;
-  const elementRef = useRef(null);
+  const elementRef = useRef<HTMLAnchorElement>(null);
   return (
     <EuiFlyout onClose={closeFlyout} size="s" paddingSize="l">
       <EuiFlyoutHeader hasBorder>
@@ -208,8 +207,8 @@ export const DefaultSettingsFlyout: React.FC<DefaultSettingsFlyoutProps> = ({ cl
                   disabled={hasNoChanges}
                   isLoading={isLoading}
                   onClick={() => {
-                    elementRef.current?.focus();
                     setPipeline(defaultPipeline);
+                    elementRef.current?.focus();
                   }}
                   data-test-subj={'entSearchContentSettingsResetButton'}
                 >
@@ -224,7 +223,10 @@ export const DefaultSettingsFlyout: React.FC<DefaultSettingsFlyoutProps> = ({ cl
                   fill
                   disabled={hasNoChanges}
                   isLoading={isLoading}
-                  onClick={() => makeRequest(pipelineState)}
+                  onClick={() => {
+                    makeRequest(pipelineState);
+                    elementRef.current?.focus();
+                  }}
                   data-test-subj={'entSearchContentSettingsSaveButton'}
                 >
                   {i18n.translate('xpack.enterpriseSearch.content.settings.saveButtonLabel', {


### PR DESCRIPTION
## Summary

This PR solves the issues https://github.com/elastic/kibana/issues/195951 and https://github.com/elastic/kibana/issues/195942 getting the focus on the first interactive element as suggested which is the _ingest pipelines_ external link after pressing enter using the keyboard navigation either the _Reset_ or _Save_ buttons. With this the screen reader announces the  _ingest pipelines_ content after any of those previous events.

![CleanShot 2024-11-22 at 10 16 08](https://github.com/user-attachments/assets/ca8d5739-fcea-42da-af14-031989a84bac)




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->