### PR TITLE
[React18] Migrate test suites to account for testing library upgrades observability-ui

### DIFF
--- a/x-pack/plugins/observability_solution/observability_shared/public/hooks/use_breadcrumbs.test.tsx
+++ b/x-pack/plugins/observability_solution/observability_shared/public/hooks/use_breadcrumbs.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
-import React, { ReactNode } from 'react';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { CoreStart } from '@kbn/core/public';
 import { createKibanaReactContext } from '@kbn/kibana-react-plugin/public';
@@ -28,7 +28,7 @@ const kibanaServices = {
 } as unknown as Partial<CoreStart>;
 const KibanaContext = createKibanaReactContext(kibanaServices);
 
-function Wrapper({ children }: { children?: ReactNode }) {
+function Wrapper({ children }: React.PropsWithChildren) {
   return (
     <MemoryRouter>
       <KibanaContext.Provider>{children}</KibanaContext.Provider>
@@ -38,18 +38,20 @@ function Wrapper({ children }: { children?: ReactNode }) {
 
 describe('useBreadcrumbs', () => {
   afterEach(() => {
-    setBreadcrumbs.mockClear();
-    setTitle.mockClear();
+    jest.clearAllMocks();
   });
 
   describe('when setBreadcrumbs and setTitle are not defined', () => {
     it('does not set breadcrumbs or the title', () => {
       renderHook(() => useBreadcrumbs([]), {
-        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+        wrapper: ({ children }: React.PropsWithChildren) => (
           <MemoryRouter>
             <KibanaContext.Provider
               services={
-                { ...kibanaServices, chrome: { docTitle: {} } } as unknown as Partial<CoreStart>
+                {
+                  ...kibanaServices,
+                  chrome: { ...kibanaServices.chrome, docTitle: {}, setBreadcrumbs: null },
+                } as unknown as Partial<CoreStart>
               }
             >
               {children}

--- a/x-pack/plugins/observability_solution/observability_shared/public/hooks/use_breadcrumbs.ts
+++ b/x-pack/plugins/observability_solution/observability_shared/public/hooks/use_breadcrumbs.ts
@@ -97,7 +97,7 @@ export const useBreadcrumbs = (
   const setBreadcrumbs = useMemo(() => {
     if (!serverless?.setBreadcrumbs) {
       return (breadcrumbs: ChromeBreadcrumb[]) =>
-        chromeSetBreadcrumbs(
+        chromeSetBreadcrumbs?.(
           breadcrumbs,
           !classicOnly
             ? {

--- a/x-pack/plugins/observability_solution/observability_shared/public/hooks/use_link_props.test.tsx
+++ b/x-pack/plugins/observability_solution/observability_shared/public/hooks/use_link_props.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import React, { PropsWithChildren } from 'react';
 import { Router } from '@kbn/shared-ux-router';


### PR DESCRIPTION

This PR migrates test suites that use `renderHook` from the library `@testing-library/react-hooks` to adopt the equivalent and replacement of `renderHook` from the export that is now available from
`@testing-library/react`. This work is required for the planned migration to react18. 

##  Context

In this PR, usages of `waitForNextUpdate` that previously could have been destructured from `renderHook` are now been replaced with `waitFor` exported from `@testing-library/react`, furthermore `waitFor` 
that would also have been destructured from the same renderHook result is now been replaced with `waitFor` from the export of `@testing-library/react`.

***Why is `waitFor` a sufficient enough replacement for `waitForNextUpdate`, and better for testing values subject to async computations?***

WaitFor will retry the provided callback if an error is returned, till the configured timeout elapses. By default the retry interval is `50ms` with a timeout value of `1000ms` that 
effectively translates to at least 20 retries for assertions placed within waitFor. See https://testing-library.com/docs/dom-testing-library/api-async/#waitfor for more information.
This however means that for person's writing tests, said person has to be explicit about expectations that describe the internal state of the hook being tested. 
This implies checking for instance when a react query hook is being rendered, there's an assertion that said hook isn't loading anymore.

In this PR you'd notice that this pattern has been adopted, with most existing assertions following an invocation of `waitForNextUpdate` being placed within a `waitFor` 
invocation. In some cases the replacement is simply a `waitFor(() => new Promise((resolve) => resolve(null)))` (many thanks to @kapral18, for point out exactly why this works),
 where this suffices the assertions that follow aren't placed within a waitFor so this PR doesn't get larger than it needs to be.

It's also worth pointing out this PR might also contain changes to test and application code to improve said existing test.

### What to do next?
1. Review the changes in this PR.
2. If you think the changes are correct, approve the PR.

## Any questions?
If you have any questions or need help with this PR, please leave comments in this PR.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->