### PR TITLE
[Security KB] Fix setup KB

### DIFF
--- a/x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
@@ -212,7 +212,7 @@ export class AIAssistantKnowledgeBaseDataClient extends AIAssistantDataClient {
         },
       });
 
-      // await for the model to be deployed 
+      // await for the model to be deployed
       await this.isInferenceEndpointExists();
     } catch (error) {
       this.options.logger.error(

--- a/x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
@@ -178,9 +178,22 @@ export class AIAssistantKnowledgeBaseDataClient extends AIAssistantDataClient {
   public createInferenceEndpoint = async () => {
     const elserId = await this.options.getElserId();
     this.options.logger.debug(`Deploying ELSER model '${elserId}'...`);
-    try {
-      const esClient = await this.options.elasticsearchClientPromise;
+    const esClient = await this.options.elasticsearchClientPromise;
 
+    try {
+      await esClient.inference.delete({
+        inference_id: ASSISTANT_ELSER_INFERENCE_ID,
+        // it's being used in the mapping so we need to force delete
+        force: true,
+      });
+      this.options.logger.debug(`Deleted existing inference endpoint for ELSER model '${elserId}'`);
+    } catch (error) {
+      this.options.logger.error(
+        `Error deleting inference endpoint for ELSER model '${elserId}':\n${error}`
+      );
+    }
+
+    try {
       await esClient.inference.put({
         task_type: 'sparse_embedding',
         inference_id: ASSISTANT_ELSER_INFERENCE_ID,
@@ -198,6 +211,9 @@ export class AIAssistantKnowledgeBaseDataClient extends AIAssistantDataClient {
           task_settings: {},
         },
       });
+
+      // await for the model to be deployed 
+      await this.isInferenceEndpointExists();
     } catch (error) {
       this.options.logger.error(
         `Error creating inference endpoint for ELSER model '${elserId}':\n${error}`


### PR DESCRIPTION
## Summary

Fix an issue with auto-recovery of Knowledge Base setup. 

When the KB setup was initialized on an undersized cluster, the model failed to deploy correctly. This resulted in the KB ending up in a broken state, repeatedly displaying the Setup KB button.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->