### PR TITLE
[A11y][Crawler] Define radiogroups correctly in extraction rules flyout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/extraction_rules/edit_field_rule_flyout.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_domain_detail/extraction_rules/edit_field_rule_flyout.tsx
@@ -199,6 +199,7 @@ export const EditFieldRuleFlyout: React.FC<EditFieldRuleFlyoutProps> = ({
                   >
                     <EuiRadioGroup
                       data-telemetry-id="entSearchContent-crawler-domainDetail-extractionRules-editContentRuleSource"
+                      name="source_type_radiogroup"
                       options={[
                         {
                           id: FieldType.HTML,
@@ -361,6 +362,7 @@ export const EditFieldRuleFlyout: React.FC<EditFieldRuleFlyoutProps> = ({
                   >
                     <EuiRadioGroup
                       data-telemetry-id="entSearchContent-crawler-domainDetail-extractionRules-editContentRuleExtraction"
+                      name="content_from.value_type_radiogroup"
                       options={[
                         {
                           id: ContentFrom.EXTRACTED,
@@ -408,6 +410,7 @@ export const EditFieldRuleFlyout: React.FC<EditFieldRuleFlyoutProps> = ({
                           >
                             <EuiRadioGroup
                               data-telemetry-id="entSearchContent-crawler-domainDetail-extractionRules-editContentRuleMultipleObjects"
+                              name="multiple_objects_handling_radiogroup"
                               options={[
                                 {
                                   id: MultipleObjectsHandling.STRING,


### PR DESCRIPTION
## Summary

The issue: keyboard nav with tab doesn't jump between radiogroups correctly, instead skips some.

Fix the issue with radiogroups selection with `TAB`, following the EUI docs:
https://eui.elastic.co/#/forms/selection-controls#radio-group

We need to
> Pass a single `name` property to define the group.

Tested locally that this is the culprit of issues when rendering multiple radio groups in the same flyout. 


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->