### PR TITLE
[8.17] Preconfigured Endpoints in Semantic_text field (#200659)

### DIFF
--- a/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
+++ b/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
@@ -55,7 +55,7 @@ it('builds a generated plugin into a viable archive', async () => {
   };
 
   expect(filterLogs(generateProc.all)).toMatchInlineSnapshot(`
-    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/current/production.html#openssl-legacy-provider
+    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/8.17/production.html#openssl-legacy-provider
      succ 🎉
 
           Your plugin has been created in plugins/foo_test_plugin
@@ -75,7 +75,7 @@ it('builds a generated plugin into a viable archive', async () => {
   );
 
   expect(filterLogs(buildProc.all)).toMatchInlineSnapshot(`
-    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/current/production.html#openssl-legacy-provider
+    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/8.17/production.html#openssl-legacy-provider
      info deleting the build and target directories
      info run bazel and build required artifacts for the optimizer
      succ bazel run successfully and artifacts were created

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/index_details_page.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/index_details_page.test.tsx
@@ -836,7 +836,6 @@ describe('<IndexDetailsPage />', () => {
           testBed.actions.mappings.isReferenceFieldVisible();
           testBed.actions.mappings.selectInferenceIdButtonExists();
           testBed.actions.mappings.openSelectInferencePopover();
-          testBed.actions.mappings.expectDefaultInferenceModelToExists();
           testBed.actions.mappings.expectCustomInferenceModelToExists(
             `custom-inference_${customInferenceModel}`
           );

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -71,6 +71,8 @@ jest.mock('../../../public/application/components/mappings_editor/mappings_state
 jest.mock('../../../public/application/services/api', () => ({
   useLoadInferenceEndpoints: jest.fn().mockReturnValue({
     data: [
+      { inference_id: '.preconfigured-elser', task_type: 'sparse_embedding' },
+      { inference_id: '.preconfigured-e5', task_type: 'text_embedding' },
       { inference_id: 'endpoint-1', task_type: 'text_embedding' },
       { inference_id: 'endpoint-2', task_type: 'sparse_embedding' },
       { inference_id: 'endpoint-3', task_type: 'completion' },
@@ -83,7 +85,7 @@ jest.mock('../../../public/application/services/api', () => ({
 function getTestForm(Component: React.FC<SelectInferenceIdProps>) {
   return (defaultProps: SelectInferenceIdProps) => {
     const { form } = useForm();
-    form.setFieldValue('inference_id', 'elser_model_2');
+    form.setFieldValue('inference_id', '.preconfigured-elser');
     return (
       <Form form={form}>
         <Component {...(defaultProps as any)} />
@@ -125,8 +127,8 @@ describe('SelectInferenceId', () => {
 
   it('should display the inference endpoints in the combo', () => {
     find('inferenceIdButton').simulate('click');
-    expect(find('data-inference-endpoint-list').contains('e5')).toBe(true);
-    expect(find('data-inference-endpoint-list').contains('elser_model_2')).toBe(true);
+    expect(find('data-inference-endpoint-list').contains('.preconfigured-elser')).toBe(true);
+    expect(find('data-inference-endpoint-list').contains('.preconfigured-e5')).toBe(true);
     expect(find('data-inference-endpoint-list').contains('endpoint-1')).toBe(true);
     expect(find('data-inference-endpoint-list').contains('endpoint-2')).toBe(true);
     expect(find('data-inference-endpoint-list').contains('endpoint-3')).toBe(false);

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -52,15 +52,6 @@ type SelectInferenceIdContentProps = SelectInferenceIdProps & {
   value: string;
 };
 
-const defaultEndpoints = [
-  {
-    inference_id: 'elser_model_2',
-  },
-  {
-    inference_id: 'e5',
-  },
-];
-
 export const SelectInferenceId: React.FC<SelectInferenceIdProps> = ({
   createInferenceEndpoint,
   'data-test-subj': dataTestSubj,
@@ -134,13 +125,7 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
         endpoint.task_type === 'text_embedding' || endpoint.task_type === 'sparse_embedding'
     );
 
-    const missingDefaultEndpoints = defaultEndpoints.filter(
-      (endpoint) => !(filteredEndpoints || []).find((e) => e.inference_id === endpoint.inference_id)
-    );
-    const newOptions: EuiSelectableOption[] = [
-      ...(filteredEndpoints || []),
-      ...missingDefaultEndpoints,
-    ].map((endpoint) => ({
+    const newOptions: EuiSelectableOption[] = [...(filteredEndpoints || [])].map((endpoint) => ({
       label: endpoint.inference_id,
       'data-test-subj': `custom-inference_${endpoint.inference_id}`,
       checked: value === endpoint.inference_id ? 'on' : undefined,

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/semantic_text/use_semantic_text.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/semantic_text/use_semantic_text.ts
@@ -19,6 +19,8 @@ import { useMLModelNotificationToasts } from '../../../../../../../../hooks/use_
 
 import { getInferenceEndpoints } from '../../../../../../../services/api';
 import { getFieldByPathName } from '../../../../../lib/utils';
+import { ELSER_PRECONFIGURED_ENDPOINTS } from '../../../../../constants';
+
 interface UseSemanticTextProps {
   form: FormHook<Field, Field>;
   ml?: MlPluginStart;
@@ -62,7 +64,7 @@ export function useSemanticText(props: UseSemanticTextProps) {
         form.setFieldValue('reference_field', referenceField);
       }
       if (!form.getFormData().inference_id) {
-        form.setFieldValue('inference_id', 'elser_model_2');
+        form.setFieldValue('inference_id', ELSER_PRECONFIGURED_ENDPOINTS);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
@@ -19,7 +19,11 @@ import { i18n } from '@kbn/i18n';
 
 import { NormalizedField, NormalizedFields, State } from '../../../types';
 import { getTypeLabelFromField } from '../../../lib';
-import { CHILD_FIELD_INDENT_SIZE, LEFT_PADDING_SIZE_FIELD_ITEM_WRAPPER } from '../../../constants';
+import {
+  CHILD_FIELD_INDENT_SIZE,
+  ELSER_PRECONFIGURED_ENDPOINTS,
+  LEFT_PADDING_SIZE_FIELD_ITEM_WRAPPER,
+} from '../../../constants';
 
 import { FieldsList } from './fields_list';
 import { CreateField } from './create_field';
@@ -105,6 +109,7 @@ function FieldListItemComponent(
   const indent = treeDepth * CHILD_FIELD_INDENT_SIZE - substractIndentAmount;
 
   const isSemanticText = source.type === 'semantic_text';
+  const inferenceId: string = (source.inference_id as string) ?? ELSER_PRECONFIGURED_ENDPOINTS;
 
   const indentCreateField =
     (treeDepth + 1) * CHILD_FIELD_INDENT_SIZE +
@@ -293,7 +298,7 @@ function FieldListItemComponent(
 
             {isSemanticText && (
               <EuiFlexItem grow={false}>
-                <EuiBadge color="hollow">{source.inference_id as string}</EuiBadge>
+                <EuiBadge color="hollow">{inferenceId}</EuiBadge>
               </EuiFlexItem>
             )}
 

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/constants/default_values.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/constants/default_values.ts
@@ -13,3 +13,9 @@
 export const INDEX_DEFAULT = 'index_default';
 
 export const STANDARD = 'standard';
+
+/*  
+  This will be repalce once we add default elser inference_id 
+  with the index mapping response.
+*/
+export const ELSER_PRECONFIGURED_ENDPOINTS = '.elser-2-elasticsearch';

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -62,6 +62,8 @@ import { SemanticTextBanner } from './semantic_text_banner';
 import { TrainedModelsDeploymentModal } from './trained_models_deployment_modal';
 import { parseMappings } from '../../../../shared/parse_mappings';
 
+const isInferencePreconfigured = (inferenceId: string) => inferenceId.startsWith('.');
+
 export const DetailsPageMappingsContent: FunctionComponent<{
   index: Index;
   data: string;
@@ -233,7 +235,8 @@ export const DetailsPageMappingsContent: FunctionComponent<{
               .filter(
                 (inferenceId: string) =>
                   inferenceToModelIdMap?.[inferenceId].trainedModelId && // third-party inference models don't have trainedModelId
-                  !inferenceToModelIdMap?.[inferenceId].isDeployed
+                  !inferenceToModelIdMap?.[inferenceId].isDeployed &&
+                  !isInferencePreconfigured(inferenceId)
               );
         setHasSavedFields(true);
         if (inferenceIdsInPendingList.length === 0) {

--- a/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/constants.ts
+++ b/x-pack/plugins/search_inference_endpoints/public/components/all_inference_endpoints/constants.ts
@@ -34,8 +34,3 @@ export const DEFAULT_INFERENCE_ENDPOINTS_TABLE_STATE: AllInferenceEndpointsTable
 };
 
 export const PIPELINE_URL = 'ingest/ingest_pipelines';
-
-export const PRECONFIGURED_ENDPOINTS = {
-  ELSER: '.elser-2-elasticsearch',
-  E5: '.multilingual-e5-small-elasticsearch',
-};

--- a/x-pack/plugins/search_inference_endpoints/public/utils/preconfigured_endpoint_helper.test.ts
+++ b/x-pack/plugins/search_inference_endpoints/public/utils/preconfigured_endpoint_helper.test.ts
@@ -5,16 +5,15 @@
  * 2.0.
  */
 
-import { PRECONFIGURED_ENDPOINTS } from '../components/all_inference_endpoints/constants';
 import { isEndpointPreconfigured } from './preconfigured_endpoint_helper';
 
 describe('Preconfigured Endpoint helper', () => {
   it('return true for preconfigured elser', () => {
-    expect(isEndpointPreconfigured(PRECONFIGURED_ENDPOINTS.ELSER)).toEqual(true);
+    expect(isEndpointPreconfigured('.preconfigured_elser')).toEqual(true);
   });
 
   it('return true for preconfigured e5', () => {
-    expect(isEndpointPreconfigured(PRECONFIGURED_ENDPOINTS.E5)).toEqual(true);
+    expect(isEndpointPreconfigured('.preconfigured_e5')).toEqual(true);
   });
 
   it('return false for other endpoints', () => {

--- a/x-pack/plugins/search_inference_endpoints/public/utils/preconfigured_endpoint_helper.ts
+++ b/x-pack/plugins/search_inference_endpoints/public/utils/preconfigured_endpoint_helper.ts
@@ -5,7 +5,4 @@
  * 2.0.
  */
 
-import { PRECONFIGURED_ENDPOINTS } from '../components/all_inference_endpoints/constants';
-
-export const isEndpointPreconfigured = (endpoint: string) =>
-  Object.values(PRECONFIGURED_ENDPOINTS).includes(endpoint);
+export const isEndpointPreconfigured = (endpoint: string) => endpoint.startsWith('.');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Preconfigured Endpoints in Semantic_text field (#200659)](https://github.com/elastic/kibana/pull/200659)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Samiul Monir","email":"150824886+Samiul-TheSoccerFan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-11-21T00:48:56Z","message":"Preconfigured Endpoints in Semantic_text field (#200659)\n\n## Summary\r\n\r\n1. Removed default endpoints from the `Select inference id` dropdown\r\n2. Linked preconfigured endpoints properly with fields.\r\n3. Added support to remove `index` errors regarding models.\r\n\r\n### ESS:\r\n\r\nhttps://github.com/user-attachments/assets/4c13f5b3-a00a-4aac-a1c2-ca94e5b2c293\r\n\r\n### ES3\r\n\r\n\r\nhttps://github.com/user-attachments/assets/83f1bd74-0973-4225-907b-89e7c372fa5f\r\n\r\n### ingest and data with the preconfigured endpoint:\r\n```\r\nPOST /search-jmo0/_doc\r\n{\r\n    \"content\": \"park_rocky-mountain\"\r\n}\r\n```\r\n```\r\nGET /search-jmo0/_search\r\n```\r\n\r\nwill return something like this:\r\n\r\n```\r\n{\r\n  \"took\": 3,\r\n  \"timed_out\": false,\r\n  \"_shards\": {\r\n    \"total\": 3,\r\n    \"successful\": 3,\r\n    \"skipped\": 0,\r\n    \"failed\": 0\r\n  },\r\n  \"hits\": {\r\n    \"total\": {\r\n      \"value\": 1,\r\n      \"relation\": \"eq\"\r\n    },\r\n    \"max_score\": 1,\r\n    \"hits\": [\r\n      {\r\n        \"_index\": \"search-jmo0\",\r\n        \"_id\": \"712LRpMBqdKCj6yG9iFJ\",\r\n        \"_score\": 1,\r\n        \"_source\": {\r\n          \"openai_semantic_text\": {\r\n            \"inference\": {\r\n              \"inference_id\": \"my-test-1-openai-endpoint\",\r\n              \"model_settings\": {\r\n                \"task_type\": \"text_embedding\",\r\n                \"dimensions\": 1536,\r\n                \"similarity\": \"dot_product\",\r\n                \"element_type\": \"float\"\r\n              },\r\n              \"chunks\": [\r\n                {\r\n                  \"text\": \"park_rocky-mountain\",\r\n                  \"embeddings\": [...]\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"elser_semantic_text\": {\r\n            \"inference\": {\r\n              \"inference_id\": \".elser-2-elasticsearch\",\r\n              \"model_settings\": {\r\n                \"task_type\": \"sparse_embedding\"\r\n              },\r\n              \"chunks\": [\r\n                {\r\n                  \"text\": \"park_rocky-mountain\",\r\n                  \"embeddings\": {...}\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"e5_semantic_text\": {\r\n            \"inference\": {\r\n              \"inference_id\": \".multilingual-e5-small-elasticsearch\",\r\n              \"model_settings\": {\r\n                \"task_type\": \"text_embedding\",\r\n                \"dimensions\": 384,\r\n                \"similarity\": \"cosine\",\r\n                \"element_type\": \"float\"\r\n              },\r\n              \"chunks\": [\r\n                {\r\n                  \"text\": \"park_rocky-mountain\",\r\n                  \"embeddings\": [...]\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"content\": \"park_rocky-mountain\"\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}\r\n```\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [X] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"052f527ee7acf3393a0b9bfa2ad2f41de29015a9","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Search","ci:project-deploy-elasticsearch","backport:version","v8.17.0"],"number":200659,"url":"https://github.com/elastic/kibana/pull/200659","mergeCommit":{"message":"Preconfigured Endpoints in Semantic_text field (#200659)\n\n## Summary\r\n\r\n1. Removed default endpoints from the `Select inference id` dropdown\r\n2. Linked preconfigured endpoints properly with fields.\r\n3. Added support to remove `index` errors regarding models.\r\n\r\n### ESS:\r\n\r\nhttps://github.com/user-attachments/assets/4c13f5b3-a00a-4aac-a1c2-ca94e5b2c293\r\n\r\n### ES3\r\n\r\n\r\nhttps://github.com/user-attachments/assets/83f1bd74-0973-4225-907b-89e7c372fa5f\r\n\r\n### ingest and data with the preconfigured endpoint:\r\n```\r\nPOST /search-jmo0/_doc\r\n{\r\n    \"content\": \"park_rocky-mountain\"\r\n}\r\n```\r\n```\r\nGET /search-jmo0/_search\r\n```\r\n\r\nwill return something like this:\r\n\r\n```\r\n{\r\n  \"took\": 3,\r\n  \"timed_out\": false,\r\n  \"_shards\": {\r\n    \"total\": 3,\r\n    \"successful\": 3,\r\n    \"skipped\": 0,\r\n    \"failed\": 0\r\n  },\r\n  \"hits\": {\r\n    \"total\": {\r\n      \"value\": 1,\r\n      \"relation\": \"eq\"\r\n    },\r\n    \"max_score\": 1,\r\n    \"hits\": [\r\n      {\r\n        \"_index\": \"search-jmo0\",\r\n        \"_id\": \"712LRpMBqdKCj6yG9iFJ\",\r\n        \"_score\": 1,\r\n        \"_source\": {\r\n          \"openai_semantic_text\": {\r\n            \"inference\": {\r\n              \"inference_id\": \"my-test-1-openai-endpoint\",\r\n              \"model_settings\": {\r\n                \"task_type\": \"text_embedding\",\r\n                \"dimensions\": 1536,\r\n                \"similarity\": \"dot_product\",\r\n                \"element_type\": \"float\"\r\n              },\r\n              \"chunks\": [\r\n                {\r\n                  \"text\": \"park_rocky-mountain\",\r\n                  \"embeddings\": [...]\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"elser_semantic_text\": {\r\n            \"inference\": {\r\n              \"inference_id\": \".elser-2-elasticsearch\",\r\n              \"model_settings\": {\r\n                \"task_type\": \"sparse_embedding\"\r\n              },\r\n              \"chunks\": [\r\n                {\r\n                  \"text\": \"park_rocky-mountain\",\r\n                  \"embeddings\": {...}\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"e5_semantic_text\": {\r\n            \"inference\": {\r\n              \"inference_id\": \".multilingual-e5-small-elasticsearch\",\r\n              \"model_settings\": {\r\n                \"task_type\": \"text_embedding\",\r\n                \"dimensions\": 384,\r\n                \"similarity\": \"cosine\",\r\n                \"element_type\": \"float\"\r\n              },\r\n              \"chunks\": [\r\n                {\r\n                  \"text\": \"park_rocky-mountain\",\r\n                  \"embeddings\": [...]\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"content\": \"park_rocky-mountain\"\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}\r\n```\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [X] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"052f527ee7acf3393a0b9bfa2ad2f41de29015a9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/200659","number":200659,"mergeCommit":{"message":"Preconfigured Endpoints in Semantic_text field (#200659)\n\n## Summary\r\n\r\n1. Removed default endpoints from the `Select inference id` dropdown\r\n2. Linked preconfigured endpoints properly with fields.\r\n3. Added support to remove `index` errors regarding models.\r\n\r\n### ESS:\r\n\r\nhttps://github.com/user-attachments/assets/4c13f5b3-a00a-4aac-a1c2-ca94e5b2c293\r\n\r\n### ES3\r\n\r\n\r\nhttps://github.com/user-attachments/assets/83f1bd74-0973-4225-907b-89e7c372fa5f\r\n\r\n### ingest and data with the preconfigured endpoint:\r\n```\r\nPOST /search-jmo0/_doc\r\n{\r\n    \"content\": \"park_rocky-mountain\"\r\n}\r\n```\r\n```\r\nGET /search-jmo0/_search\r\n```\r\n\r\nwill return something like this:\r\n\r\n```\r\n{\r\n  \"took\": 3,\r\n  \"timed_out\": false,\r\n  \"_shards\": {\r\n    \"total\": 3,\r\n    \"successful\": 3,\r\n    \"skipped\": 0,\r\n    \"failed\": 0\r\n  },\r\n  \"hits\": {\r\n    \"total\": {\r\n      \"value\": 1,\r\n      \"relation\": \"eq\"\r\n    },\r\n    \"max_score\": 1,\r\n    \"hits\": [\r\n      {\r\n        \"_index\": \"search-jmo0\",\r\n        \"_id\": \"712LRpMBqdKCj6yG9iFJ\",\r\n        \"_score\": 1,\r\n        \"_source\": {\r\n          \"openai_semantic_text\": {\r\n            \"inference\": {\r\n              \"inference_id\": \"my-test-1-openai-endpoint\",\r\n              \"model_settings\": {\r\n                \"task_type\": \"text_embedding\",\r\n                \"dimensions\": 1536,\r\n                \"similarity\": \"dot_product\",\r\n                \"element_type\": \"float\"\r\n              },\r\n              \"chunks\": [\r\n                {\r\n                  \"text\": \"park_rocky-mountain\",\r\n                  \"embeddings\": [...]\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"elser_semantic_text\": {\r\n            \"inference\": {\r\n              \"inference_id\": \".elser-2-elasticsearch\",\r\n              \"model_settings\": {\r\n                \"task_type\": \"sparse_embedding\"\r\n              },\r\n              \"chunks\": [\r\n                {\r\n                  \"text\": \"park_rocky-mountain\",\r\n                  \"embeddings\": {...}\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"e5_semantic_text\": {\r\n            \"inference\": {\r\n              \"inference_id\": \".multilingual-e5-small-elasticsearch\",\r\n              \"model_settings\": {\r\n                \"task_type\": \"text_embedding\",\r\n                \"dimensions\": 384,\r\n                \"similarity\": \"cosine\",\r\n                \"element_type\": \"float\"\r\n              },\r\n              \"chunks\": [\r\n                {\r\n                  \"text\": \"park_rocky-mountain\",\r\n                  \"embeddings\": [...]\r\n                }\r\n              ]\r\n            }\r\n          },\r\n          \"content\": \"park_rocky-mountain\"\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}\r\n```\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [X] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"052f527ee7acf3393a0b9bfa2ad2f41de29015a9"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201063","number":201063,"state":"MERGED","mergeCommit":{"sha":"10db504da848eccc464735ca2b8c665915009bbb","message":"[8.x] Preconfigured Endpoints in Semantic_text field (#200659) (#201063)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [Preconfigured Endpoints in Semantic_text field\n(#200659)](https://github.com/elastic/kibana/pull/200659)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Samiul\nMonir\",\"email\":\"150824886+Samiul-TheSoccerFan@users.noreply.github.com\"},\"sourceCommit\":{\"committedDate\":\"2024-11-21T00:48:56Z\",\"message\":\"Preconfigured\nEndpoints in Semantic_text field (#200659)\\n\\n## Summary\\r\\n\\r\\n1.\nRemoved default endpoints from the `Select inference id` dropdown\\r\\n2.\nLinked preconfigured endpoints properly with fields.\\r\\n3. Added support\nto remove `index` errors regarding models.\\r\\n\\r\\n###\nESS:\\r\\n\\r\\nhttps://github.com/user-attachments/assets/4c13f5b3-a00a-4aac-a1c2-ca94e5b2c293\\r\\n\\r\\n###\nES3\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/83f1bd74-0973-4225-907b-89e7c372fa5f\\r\\n\\r\\n###\ningest and data with the preconfigured endpoint:\\r\\n```\\r\\nPOST\n/search-jmo0/_doc\\r\\n{\\r\\n \\\"content\\\":\n\\\"park_rocky-mountain\\\"\\r\\n}\\r\\n```\\r\\n```\\r\\nGET\n/search-jmo0/_search\\r\\n```\\r\\n\\r\\nwill return something like\nthis:\\r\\n\\r\\n```\\r\\n{\\r\\n \\\"took\\\": 3,\\r\\n \\\"timed_out\\\": false,\\r\\n\n\\\"_shards\\\": {\\r\\n \\\"total\\\": 3,\\r\\n \\\"successful\\\": 3,\\r\\n \\\"skipped\\\":\n0,\\r\\n \\\"failed\\\": 0\\r\\n },\\r\\n \\\"hits\\\": {\\r\\n \\\"total\\\": {\\r\\n\n\\\"value\\\": 1,\\r\\n \\\"relation\\\": \\\"eq\\\"\\r\\n },\\r\\n \\\"max_score\\\": 1,\\r\\n\n\\\"hits\\\": [\\r\\n {\\r\\n \\\"_index\\\": \\\"search-jmo0\\\",\\r\\n \\\"_id\\\":\n\\\"712LRpMBqdKCj6yG9iFJ\\\",\\r\\n \\\"_score\\\": 1,\\r\\n \\\"_source\\\": {\\r\\n\n\\\"openai_semantic_text\\\": {\\r\\n \\\"inference\\\": {\\r\\n \\\"inference_id\\\":\n\\\"my-test-1-openai-endpoint\\\",\\r\\n \\\"model_settings\\\": {\\r\\n\n\\\"task_type\\\": \\\"text_embedding\\\",\\r\\n \\\"dimensions\\\": 1536,\\r\\n\n\\\"similarity\\\": \\\"dot_product\\\",\\r\\n \\\"element_type\\\": \\\"float\\\"\\r\\n\n},\\r\\n \\\"chunks\\\": [\\r\\n {\\r\\n \\\"text\\\": \\\"park_rocky-mountain\\\",\\r\\n\n\\\"embeddings\\\": [...]\\r\\n }\\r\\n ]\\r\\n }\\r\\n },\\r\\n\n\\\"elser_semantic_text\\\": {\\r\\n \\\"inference\\\": {\\r\\n \\\"inference_id\\\":\n\\\".elser-2-elasticsearch\\\",\\r\\n \\\"model_settings\\\": {\\r\\n \\\"task_type\\\":\n\\\"sparse_embedding\\\"\\r\\n },\\r\\n \\\"chunks\\\": [\\r\\n {\\r\\n \\\"text\\\":\n\\\"park_rocky-mountain\\\",\\r\\n \\\"embeddings\\\": {...}\\r\\n }\\r\\n ]\\r\\n }\\r\\n\n},\\r\\n \\\"e5_semantic_text\\\": {\\r\\n \\\"inference\\\": {\\r\\n\n\\\"inference_id\\\": \\\".multilingual-e5-small-elasticsearch\\\",\\r\\n\n\\\"model_settings\\\": {\\r\\n \\\"task_type\\\": \\\"text_embedding\\\",\\r\\n\n\\\"dimensions\\\": 384,\\r\\n \\\"similarity\\\": \\\"cosine\\\",\\r\\n\n\\\"element_type\\\": \\\"float\\\"\\r\\n },\\r\\n \\\"chunks\\\": [\\r\\n {\\r\\n \\\"text\\\":\n\\\"park_rocky-mountain\\\",\\r\\n \\\"embeddings\\\": [...]\\r\\n }\\r\\n ]\\r\\n }\\r\\n\n},\\r\\n \\\"content\\\": \\\"park_rocky-mountain\\\"\\r\\n }\\r\\n }\\r\\n ]\\r\\n\n}\\r\\n}\\r\\n```\\r\\n\\r\\n### Checklist\\r\\n\\r\\nCheck the PR satisfies\nfollowing conditions. \\r\\n\\r\\nReviewers should verify this PR satisfies\nthis list as well.\\r\\n\\r\\n- [X] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"052f527ee7acf3393a0b9bfa2ad2f41de29015a9\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"Team:Search\",\"ci:project-deploy-elasticsearch\",\"backport:version\",\"v8.17.0\"],\"title\":\"Preconfigured\nEndpoints in Semantic_text\nfield\",\"number\":200659,\"url\":\"https://github.com/elastic/kibana/pull/200659\",\"mergeCommit\":{\"message\":\"Preconfigured\nEndpoints in Semantic_text field (#200659)\\n\\n## Summary\\r\\n\\r\\n1.\nRemoved default endpoints from the `Select inference id` dropdown\\r\\n2.\nLinked preconfigured endpoints properly with fields.\\r\\n3. Added support\nto remove `index` errors regarding models.\\r\\n\\r\\n###\nESS:\\r\\n\\r\\nhttps://github.com/user-attachments/assets/4c13f5b3-a00a-4aac-a1c2-ca94e5b2c293\\r\\n\\r\\n###\nES3\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/83f1bd74-0973-4225-907b-89e7c372fa5f\\r\\n\\r\\n###\ningest and data with the preconfigured endpoint:\\r\\n```\\r\\nPOST\n/search-jmo0/_doc\\r\\n{\\r\\n \\\"content\\\":\n\\\"park_rocky-mountain\\\"\\r\\n}\\r\\n```\\r\\n```\\r\\nGET\n/search-jmo0/_search\\r\\n```\\r\\n\\r\\nwill return something like\nthis:\\r\\n\\r\\n```\\r\\n{\\r\\n \\\"took\\\": 3,\\r\\n \\\"timed_out\\\": false,\\r\\n\n\\\"_shards\\\": {\\r\\n \\\"total\\\": 3,\\r\\n \\\"successful\\\": 3,\\r\\n \\\"skipped\\\":\n0,\\r\\n \\\"failed\\\": 0\\r\\n },\\r\\n \\\"hits\\\": {\\r\\n \\\"total\\\": {\\r\\n\n\\\"value\\\": 1,\\r\\n \\\"relation\\\": \\\"eq\\\"\\r\\n },\\r\\n \\\"max_score\\\": 1,\\r\\n\n\\\"hits\\\": [\\r\\n {\\r\\n \\\"_index\\\": \\\"search-jmo0\\\",\\r\\n \\\"_id\\\":\n\\\"712LRpMBqdKCj6yG9iFJ\\\",\\r\\n \\\"_score\\\": 1,\\r\\n \\\"_source\\\": {\\r\\n\n\\\"openai_semantic_text\\\": {\\r\\n \\\"inference\\\": {\\r\\n \\\"inference_id\\\":\n\\\"my-test-1-openai-endpoint\\\",\\r\\n \\\"model_settings\\\": {\\r\\n\n\\\"task_type\\\": \\\"text_embedding\\\",\\r\\n \\\"dimensions\\\": 1536,\\r\\n\n\\\"similarity\\\": \\\"dot_product\\\",\\r\\n \\\"element_type\\\": \\\"float\\\"\\r\\n\n},\\r\\n \\\"chunks\\\": [\\r\\n {\\r\\n \\\"text\\\": \\\"park_rocky-mountain\\\",\\r\\n\n\\\"embeddings\\\": [...]\\r\\n }\\r\\n ]\\r\\n }\\r\\n },\\r\\n\n\\\"elser_semantic_text\\\": {\\r\\n \\\"inference\\\": {\\r\\n \\\"inference_id\\\":\n\\\".elser-2-elasticsearch\\\",\\r\\n \\\"model_settings\\\": {\\r\\n \\\"task_type\\\":\n\\\"sparse_embedding\\\"\\r\\n },\\r\\n \\\"chunks\\\": [\\r\\n {\\r\\n \\\"text\\\":\n\\\"park_rocky-mountain\\\",\\r\\n \\\"embeddings\\\": {...}\\r\\n }\\r\\n ]\\r\\n }\\r\\n\n},\\r\\n \\\"e5_semantic_text\\\": {\\r\\n \\\"inference\\\": {\\r\\n\n\\\"inference_id\\\": \\\".multilingual-e5-small-elasticsearch\\\",\\r\\n\n\\\"model_settings\\\": {\\r\\n \\\"task_type\\\": \\\"text_embedding\\\",\\r\\n\n\\\"dimensions\\\": 384,\\r\\n \\\"similarity\\\": \\\"cosine\\\",\\r\\n\n\\\"element_type\\\": \\\"float\\\"\\r\\n },\\r\\n \\\"chunks\\\": [\\r\\n {\\r\\n \\\"text\\\":\n\\\"park_rocky-mountain\\\",\\r\\n \\\"embeddings\\\": [...]\\r\\n }\\r\\n ]\\r\\n }\\r\\n\n},\\r\\n \\\"content\\\": \\\"park_rocky-mountain\\\"\\r\\n }\\r\\n }\\r\\n ]\\r\\n\n}\\r\\n}\\r\\n```\\r\\n\\r\\n### Checklist\\r\\n\\r\\nCheck the PR satisfies\nfollowing conditions. \\r\\n\\r\\nReviewers should verify this PR satisfies\nthis list as well.\\r\\n\\r\\n- [X] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"052f527ee7acf3393a0b9bfa2ad2f41de29015a9\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.x\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/200659\",\"number\":200659,\"mergeCommit\":{\"message\":\"Preconfigured\nEndpoints in Semantic_text field (#200659)\\n\\n## Summary\\r\\n\\r\\n1.\nRemoved default endpoints from the `Select inference id` dropdown\\r\\n2.\nLinked preconfigured endpoints properly with fields.\\r\\n3. Added support\nto remove `index` errors regarding models.\\r\\n\\r\\n###\nESS:\\r\\n\\r\\nhttps://github.com/user-attachments/assets/4c13f5b3-a00a-4aac-a1c2-ca94e5b2c293\\r\\n\\r\\n###\nES3\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/83f1bd74-0973-4225-907b-89e7c372fa5f\\r\\n\\r\\n###\ningest and data with the preconfigured endpoint:\\r\\n```\\r\\nPOST\n/search-jmo0/_doc\\r\\n{\\r\\n \\\"content\\\":\n\\\"park_rocky-mountain\\\"\\r\\n}\\r\\n```\\r\\n```\\r\\nGET\n/search-jmo0/_search\\r\\n```\\r\\n\\r\\nwill return something like\nthis:\\r\\n\\r\\n```\\r\\n{\\r\\n \\\"took\\\": 3,\\r\\n \\\"timed_out\\\": false,\\r\\n\n\\\"_shards\\\": {\\r\\n \\\"total\\\": 3,\\r\\n \\\"successful\\\": 3,\\r\\n \\\"skipped\\\":\n0,\\r\\n \\\"failed\\\": 0\\r\\n },\\r\\n \\\"hits\\\": {\\r\\n \\\"total\\\": {\\r\\n\n\\\"value\\\": 1,\\r\\n \\\"relation\\\": \\\"eq\\\"\\r\\n },\\r\\n \\\"max_score\\\": 1,\\r\\n\n\\\"hits\\\": [\\r\\n {\\r\\n \\\"_index\\\": \\\"search-jmo0\\\",\\r\\n \\\"_id\\\":\n\\\"712LRpMBqdKCj6yG9iFJ\\\",\\r\\n \\\"_score\\\": 1,\\r\\n \\\"_source\\\": {\\r\\n\n\\\"openai_semantic_text\\\": {\\r\\n \\\"inference\\\": {\\r\\n \\\"inference_id\\\":\n\\\"my-test-1-openai-endpoint\\\",\\r\\n \\\"model_settings\\\": {\\r\\n\n\\\"task_type\\\": \\\"text_embedding\\\",\\r\\n \\\"dimensions\\\": 1536,\\r\\n\n\\\"similarity\\\": \\\"dot_product\\\",\\r\\n \\\"element_type\\\": \\\"float\\\"\\r\\n\n},\\r\\n \\\"chunks\\\": [\\r\\n {\\r\\n \\\"text\\\": \\\"park_rocky-mountain\\\",\\r\\n\n\\\"embeddings\\\": [...]\\r\\n }\\r\\n ]\\r\\n }\\r\\n },\\r\\n\n\\\"elser_semantic_text\\\": {\\r\\n \\\"inference\\\": {\\r\\n \\\"inference_id\\\":\n\\\".elser-2-elasticsearch\\\",\\r\\n \\\"model_settings\\\": {\\r\\n \\\"task_type\\\":\n\\\"sparse_embedding\\\"\\r\\n },\\r\\n \\\"chunks\\\": [\\r\\n {\\r\\n \\\"text\\\":\n\\\"park_rocky-mountain\\\",\\r\\n \\\"embeddings\\\": {...}\\r\\n }\\r\\n ]\\r\\n }\\r\\n\n},\\r\\n \\\"e5_semantic_text\\\": {\\r\\n \\\"inference\\\": {\\r\\n\n\\\"inference_id\\\": \\\".multilingual-e5-small-elasticsearch\\\",\\r\\n\n\\\"model_settings\\\": {\\r\\n \\\"task_type\\\": \\\"text_embedding\\\",\\r\\n\n\\\"dimensions\\\": 384,\\r\\n \\\"similarity\\\": \\\"cosine\\\",\\r\\n\n\\\"element_type\\\": \\\"float\\\"\\r\\n },\\r\\n \\\"chunks\\\": [\\r\\n {\\r\\n \\\"text\\\":\n\\\"park_rocky-mountain\\\",\\r\\n \\\"embeddings\\\": [...]\\r\\n }\\r\\n ]\\r\\n }\\r\\n\n},\\r\\n \\\"content\\\": \\\"park_rocky-mountain\\\"\\r\\n }\\r\\n }\\r\\n ]\\r\\n\n}\\r\\n}\\r\\n```\\r\\n\\r\\n### Checklist\\r\\n\\r\\nCheck the PR satisfies\nfollowing conditions. \\r\\n\\r\\nReviewers should verify this PR satisfies\nthis list as well.\\r\\n\\r\\n- [X] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"052f527ee7acf3393a0b9bfa2ad2f41de29015a9\"}},{\"branch\":\"8.x\",\"label\":\"v8.17.0\",\"branchLabelMappingKey\":\"^v8.17.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Samiul Monir <150824886+Samiul-TheSoccerFan@users.noreply.github.com>"}}]}] BACKPORT-->