### PR TITLE
[Inventory] Fix the link to discover test

### DIFF
--- a/x-pack/plugins/observability_solution/inventory/e2e/cypress/e2e/home.cy.ts
+++ b/x-pack/plugins/observability_solution/inventory/e2e/cypress/e2e/home.cy.ts
@@ -225,7 +225,7 @@ describe('Home page', () => {
         cy.getByTestSubj('inventoryEntityActionOpenInDiscover').click();
         cy.url().should(
           'include',
-          "query:'container.id:%20foo%20AND%20entity.definition_id%20:%20builtin*"
+          "query:'container.id:%20%22foo%22%20AND%20entity.definition_id%20:%20builtin*"
         );
       });
     });


### PR DESCRIPTION
Closes #201189

## Summary

After this fix was added in https://github.com/elastic/kibana/pull/200984 the test started failing as it was verifying the previous kuery value - it was missing the `" "` so after this bug was fixed the test should be updated as well (basically changing `container.id:foo` with `container.id:"foo"`)  and this PR updates the test.

I checked locally and the test is passing now.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->