### PR TITLE
fix(slo): Add missing new context providers around burn rate editor

### DIFF
--- a/x-pack/plugins/observability_solution/slo/public/rules/register_burn_rate_rule_type.ts
+++ b/x-pack/plugins/observability_solution/slo/public/rules/register_burn_rate_rule_type.ts
@@ -67,7 +67,9 @@ export const registerBurnRateRuleType = (
     documentationUrl(docLinks) {
       return `${docLinks.links.observability.sloBurnRateRule}`;
     },
-    ruleParamsExpression: lazy(() => import('../components/burn_rate_rule_editor')),
+    ruleParamsExpression: lazyWithContextProviders(
+      lazy(() => import('../components/burn_rate_rule_editor'))
+    ),
     validate: validateBurnRateRule,
     requiresAppContext: false,
     defaultActionMessage: sloBurnRateDefaultActionMessage,


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/issues/198683


### 🍒 Summary

This PR addresses an issue with the burn rate editor registration. We forgot to wrap this component with the new context providers introduced while migrating to the new router. 
This was making the editor fails when opened from outside the SLO page.


### 🧬 Testing

Make sure you can create/edit an SLO burn rate rule from the `Observability > Rules` page

<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->