### PR TITLE
[ML] Trained Models: fix `NaN` in a progress bar during the download task initialization 

### DIFF
--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -697,8 +697,7 @@ export const ModelsList: FC<Props> = ({
                     <>
                       {downloadState
                         ? (
-                            (downloadState.downloaded_parts / downloadState.total_parts) *
-                            100
+                            (downloadState.downloaded_parts / downloadState.total_parts || -1) * 100
                           ).toFixed(0) + '%'
                         : '100%'}
                     </>

--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -697,7 +697,8 @@ export const ModelsList: FC<Props> = ({
                     <>
                       {downloadState
                         ? (
-                            (downloadState.downloaded_parts / downloadState.total_parts || -1) * 100
+                            (downloadState.downloaded_parts / (downloadState.total_parts || -1)) *
+                            100
                           ).toFixed(0) + '%'
                         : '100%'}
                     </>


### PR DESCRIPTION
## Summary

When we request a status of the download task right after initializing a download, `total_parts` might be returned with a `0` value, hence dividing by 0 for the progress bar causing in `NaN%` value rendered. This PR adds a fallback to `-1` for that, to make sure we render 0%. 

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->