### PR TITLE
[Fleet] Fix agent dashboard link accross multiple space

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_dashboard_link.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_details_page/components/agent_dashboard_link.test.tsx
@@ -21,6 +21,7 @@ jest.mock('../../../../../../hooks/use_fleet_status', () => ({
   FleetStatusProvider: (props: any) => {
     return props.children;
   },
+  useFleetStatus: jest.fn().mockReturnValue({ spaceId: 'default' }),
 }));
 
 jest.mock('../../../../../../hooks/use_request/epm');
@@ -30,7 +31,7 @@ jest.mock('../../../../../../hooks/use_locator', () => {
     useDashboardLocator: jest.fn().mockImplementation(() => {
       return {
         id: 'DASHBOARD_APP_LOCATOR',
-        getRedirectUrl: jest.fn().mockResolvedValue('app/dashboards#/view/elastic_agent-a0001'),
+        getRedirectUrl: jest.fn().mockReturnValue('app/dashboards#/view/elastic_agent-a0001'),
       };
     }),
   };
@@ -43,6 +44,10 @@ describe('AgentDashboardLink', () => {
       data: {
         item: {
           status: 'installed',
+          installationInfo: {
+            install_status: 'installed',
+            installed_kibana_space_id: 'default',
+          },
         },
       },
     } as ReturnType<typeof useGetPackageInfoByKeyQuery>);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/services/dashboard_helper.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/services/dashboard_helper.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { GetInfoResponse } from '../../../../../../common';
+
+import { getDashboardIdForSpace } from './dashboard_helpers';
+
+const PKG_INFO = {
+  item: {
+    status: 'installed',
+    installationInfo: {
+      install_status: 'installed',
+      installed_kibana_space_id: 'default',
+      additional_spaces_installed_kibana: {
+        test: [
+          {
+            id: 'test-destination-1',
+            originId: 'test-id-1',
+          },
+        ],
+      },
+    },
+  },
+} as unknown as GetInfoResponse;
+
+describe('getDashboardIdForSpace', () => {
+  it('return the same id if package is installed in the same space', () => {
+    expect(() => getDashboardIdForSpace('default', PKG_INFO, 'test-id-1'));
+  });
+
+  it('return the destination ID if package is installed in an additionnal space', () => {
+    expect(() => getDashboardIdForSpace('test', PKG_INFO, 'test-id-1'));
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/services/dashboard_helpers.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/services/dashboard_helpers.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
+
+import type { GetInfoResponse } from '../../../../../../common';
+
+export function getDashboardIdForSpace(
+  spaceId: string = DEFAULT_SPACE_ID,
+  res: GetInfoResponse | undefined,
+  dashboardId: string
+) {
+  if (res?.item?.status !== 'installed') {
+    return dashboardId;
+  }
+
+  const installationInfo = res.item.installationInfo;
+
+  if (!installationInfo || installationInfo?.installed_kibana_space_id === spaceId) {
+    return dashboardId;
+  }
+
+  return (
+    installationInfo.additional_spaces_installed_kibana?.[spaceId]?.find(
+      ({ originId }) => originId === dashboardId
+    )?.id ?? dashboardId
+  );
+}


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/193664

Fix agent dashboard link when the integration is installed in multiple space, we now can install kibana assets in multiple space, but the dashboard link was using the hardcoded id of the dashboard, when installing in a new space the dashboard id is different that PR fix that by using the correct dashboard id when available.

## Test

How to test? with space awareness enabled (feature flag + api call)

Create multiple space and add agent to those space

Check the dashboard link is visible and working when kibana assets are installed in the space
<img width="700" alt="Screenshot 2024-11-21 at 3 16 18 PM" src="https://github.com/user-attachments/assets/5c2e7255-3e9f-4660-b628-e26042ab7363">


<img width="600" alt="Screenshot 2024-11-21 at 2 26 16 PM" src="https://github.com/user-attachments/assets/52495957-8164-4685-9ca5-83158d454ba8">
<img width="900" alt="Screenshot 2024-11-21 at 3 17 25 PM" src="https://github.com/user-attachments/assets/a2ddbb21-c789-44d1-b749-6710e966eda2">
<img width="700" alt="Screenshot 2024-11-21 at 3 19 10 PM" src="https://github.com/user-attachments/assets/aba2c0c4-f84d-4cc3-a828-b1f872f90317">



 

<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->