### PR TITLE
[8.17] [Inventory] Fix the link to discover test (#201197)

### DIFF
--- a/x-pack/plugins/observability_solution/inventory/e2e/cypress/e2e/home.cy.ts
+++ b/x-pack/plugins/observability_solution/inventory/e2e/cypress/e2e/home.cy.ts
@@ -225,7 +225,7 @@ describe('Home page', () => {
         cy.getByTestSubj('inventoryEntityActionOpenInDiscover').click();
         cy.url().should(
           'include',
-          "query:'container.id:%20foo%20AND%20entity.definition_id%20:%20builtin*"
+          "query:'container.id:%20%22foo%22%20AND%20entity.definition_id%20:%20builtin*"
         );
       });
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Inventory] Fix the link to discover test (#201197)](https://github.com/elastic/kibana/pull/201197)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2024-11-21T17:14:43Z","message":"[Inventory] Fix the link to discover test (#201197)\n\nCloses #201189\r\n\r\n## Summary\r\n\r\nAfter this fix was added in\r\nhttps://github.com/elastic/kibana/pull/200984 the test started failing\r\nas it was verifying the previous kuery value - it was missing the `\" \"`\r\nso after this bug was fixed the test should be updated as well\r\n(basically changing `container.id:foo` with `container.id:\"foo\"`) and\r\nthis PR updates the test.\r\n\r\nI checked locally and the test is passing now.","sha":"74cf5d45784b9f633decae428c61ff96281dcc4b","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor","ci:project-deploy-observability","Team:obs-ux-infra_services","v8.18.0"],"number":201197,"url":"https://github.com/elastic/kibana/pull/201197","mergeCommit":{"message":"[Inventory] Fix the link to discover test (#201197)\n\nCloses #201189\r\n\r\n## Summary\r\n\r\nAfter this fix was added in\r\nhttps://github.com/elastic/kibana/pull/200984 the test started failing\r\nas it was verifying the previous kuery value - it was missing the `\" \"`\r\nso after this bug was fixed the test should be updated as well\r\n(basically changing `container.id:foo` with `container.id:\"foo\"`) and\r\nthis PR updates the test.\r\n\r\nI checked locally and the test is passing now.","sha":"74cf5d45784b9f633decae428c61ff96281dcc4b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/201197","number":201197,"mergeCommit":{"message":"[Inventory] Fix the link to discover test (#201197)\n\nCloses #201189\r\n\r\n## Summary\r\n\r\nAfter this fix was added in\r\nhttps://github.com/elastic/kibana/pull/200984 the test started failing\r\nas it was verifying the previous kuery value - it was missing the `\" \"`\r\nso after this bug was fixed the test should be updated as well\r\n(basically changing `container.id:foo` with `container.id:\"foo\"`) and\r\nthis PR updates the test.\r\n\r\nI checked locally and the test is passing now.","sha":"74cf5d45784b9f633decae428c61ff96281dcc4b"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201252","number":201252,"state":"MERGED","mergeCommit":{"sha":"b342de58951e78ad8921704499231a9d78100ca9","message":"[8.x] [Inventory] Fix the link to discover test (#201197) (#201252)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Inventory] Fix the link to discover test\n(#201197)](https://github.com/elastic/kibana/pull/201197)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT\n[{\"author\":{\"name\":\"jennypavlova\",\"email\":\"dzheni.pavlova@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-11-21T17:14:43Z\",\"message\":\"[Inventory]\nFix the link to discover test (#201197)\\n\\nCloses #201189\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nAfter this fix was added\nin\\r\\nhttps://github.com/elastic/kibana/pull/200984 the test started\nfailing\\r\\nas it was verifying the previous kuery value - it was missing\nthe `\\\" \\\"`\\r\\nso after this bug was fixed the test should be updated as\nwell\\r\\n(basically changing `container.id:foo` with\n`container.id:\\\"foo\\\"`) and\\r\\nthis PR updates the test.\\r\\n\\r\\nI\nchecked locally and the test is passing\nnow.\",\"sha\":\"74cf5d45784b9f633decae428c61ff96281dcc4b\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"backport:prev-minor\",\"ci:project-deploy-observability\",\"Team:obs-ux-infra_services\"],\"title\":\"[Inventory]\nFix the link to discover\ntest\",\"number\":201197,\"url\":\"https://github.com/elastic/kibana/pull/201197\",\"mergeCommit\":{\"message\":\"[Inventory]\nFix the link to discover test (#201197)\\n\\nCloses #201189\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nAfter this fix was added\nin\\r\\nhttps://github.com/elastic/kibana/pull/200984 the test started\nfailing\\r\\nas it was verifying the previous kuery value - it was missing\nthe `\\\" \\\"`\\r\\nso after this bug was fixed the test should be updated as\nwell\\r\\n(basically changing `container.id:foo` with\n`container.id:\\\"foo\\\"`) and\\r\\nthis PR updates the test.\\r\\n\\r\\nI\nchecked locally and the test is passing\nnow.\",\"sha\":\"74cf5d45784b9f633decae428c61ff96281dcc4b\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/201197\",\"number\":201197,\"mergeCommit\":{\"message\":\"[Inventory]\nFix the link to discover test (#201197)\\n\\nCloses #201189\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nAfter this fix was added\nin\\r\\nhttps://github.com/elastic/kibana/pull/200984 the test started\nfailing\\r\\nas it was verifying the previous kuery value - it was missing\nthe `\\\" \\\"`\\r\\nso after this bug was fixed the test should be updated as\nwell\\r\\n(basically changing `container.id:foo` with\n`container.id:\\\"foo\\\"`) and\\r\\nthis PR updates the test.\\r\\n\\r\\nI\nchecked locally and the test is passing\nnow.\",\"sha\":\"74cf5d45784b9f633decae428c61ff96281dcc4b\"}}]}] BACKPORT-->\n\nCo-authored-by: jennypavlova <dzheni.pavlova@elastic.co>"}}]}] BACKPORT-->