### PR TITLE
[Authz] Removed security property from route.options types

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/router.test.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.test.ts
@@ -305,6 +305,23 @@ describe('Router', () => {
       );
     });
 
+    it('throws if route has security declared wrong', () => {
+      const router = new Router('', logger, enhanceWithContext, routerOptions);
+      expect(() =>
+        router.get(
+          // we use 'any' because validate requires valid Type or function usage
+          {
+            path: '/',
+            validate: false,
+            options: { security: { authz: { requiredPrivileges: [] } } } as any,
+          },
+          (context, req, res) => res.ok({})
+        )
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"\`options.security\` is not allowed in route config. Use \`security\` instead."`
+      );
+    });
+
     it('throws if options.body.output is not a valid value', () => {
       const router = new Router('', logger, enhanceWithContext, routerOptions);
       expect(() =>

--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -115,6 +115,11 @@ function validOptions(
     );
   }
 
+  // @ts-expect-error to eliminate problems with `security` in the options for route factories abstractions
+  if (options.security) {
+    throw new Error('`options.security` is not allowed in route config. Use `security` instead.');
+  }
+
   const body = shouldNotHavePayload
     ? undefined
     : {

--- a/packages/core/http/core-http-server/src/router/request.ts
+++ b/packages/core/http/core-http-server/src/router/request.ts
@@ -52,7 +52,7 @@ export type KibanaRequestRouteOptions<Method extends RouteMethod> = (Method exte
   | 'get'
   | 'options'
   ? Required<Omit<RouteConfigOptions<Method>, 'body'>>
-  : Required<RouteConfigOptions<Method>>) & { security: RouteSecurity };
+  : Required<RouteConfigOptions<Method>>) & { security?: RouteSecurity };
 
 /**
  * Request specific route information exposed to a handler.

--- a/packages/core/http/core-http-server/src/router/request.ts
+++ b/packages/core/http/core-http-server/src/router/request.ts
@@ -48,9 +48,11 @@ export interface KibanaRequestState extends RequestApplicationState {
  * Route options: If 'GET' or 'OPTIONS' method, body options won't be returned.
  * @public
  */
-export type KibanaRequestRouteOptions<Method extends RouteMethod> = Method extends 'get' | 'options'
+export type KibanaRequestRouteOptions<Method extends RouteMethod> = (Method extends
+  | 'get'
+  | 'options'
   ? Required<Omit<RouteConfigOptions<Method>, 'body'>>
-  : Required<RouteConfigOptions<Method>>;
+  : Required<RouteConfigOptions<Method>>) & { security: RouteSecurity };
 
 /**
  * Request specific route information exposed to a handler.

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -516,7 +516,7 @@ export interface RouteConfig<P, Q, B, Method extends RouteMethod> {
   /**
    * Additional route options {@link RouteConfigOptions}.
    */
-  options?: Omit<RouteConfigOptions<Method>, 'security'>;
+  options?: RouteConfigOptions<Method>;
 }
 
 /**

--- a/packages/core/http/core-http-server/src/router/route.ts
+++ b/packages/core/http/core-http-server/src/router/route.ts
@@ -399,13 +399,6 @@ export interface RouteConfigOptions<Method extends RouteMethod> {
   discontinued?: string;
 
   /**
-   * Defines the security requirements for a route, including authorization and authentication.
-   *
-   * @remarks This will be surfaced in OAS documentation.
-   */
-  security?: RouteSecurity;
-
-  /**
    * Whether this endpoint is being used to serve generated or static HTTP resources
    * like JS, CSS or HTML. _Do not set to `true` for HTTP APIs._
    *
@@ -523,7 +516,7 @@ export interface RouteConfig<P, Q, B, Method extends RouteMethod> {
   /**
    * Additional route options {@link RouteConfigOptions}.
    */
-  options?: RouteConfigOptions<Method>;
+  options?: Omit<RouteConfigOptions<Method>, 'security'>;
 }
 
 /**

--- a/packages/core/http/core-http-server/src/versioning/types.ts
+++ b/packages/core/http/core-http-server/src/versioning/types.ts
@@ -19,6 +19,7 @@ import type {
   RequestHandlerContextBase,
   RouteValidationFunction,
   LazyValidator,
+  RouteSecurity,
 } from '../..';
 import type { RouteDeprecationInfo } from '../router/route';
 type RqCtx = RequestHandlerContextBase;
@@ -40,7 +41,7 @@ export type VersionedRouteConfig<Method extends RouteMethod> = Omit<
   /** See {@link RouteConfigOptions<RouteMethod>['access']} */
   access: Exclude<RouteConfigOptions<Method>['access'], undefined>;
   /** See {@link RouteConfigOptions<RouteMethod>['security']} */
-  security?: Exclude<RouteConfigOptions<Method>['security'], undefined>;
+  security?: RouteSecurity;
   /**
    * When enabled, the router will also check for the presence of an `apiVersion`
    * query parameter to determine the route version to resolve to:
@@ -337,7 +338,7 @@ export interface AddVersionOpts<P, Q, B> {
    */
   validate: false | VersionedRouteValidation<P, Q, B> | (() => VersionedRouteValidation<P, Q, B>); // Provide a way to lazily load validation schemas
 
-  security?: Exclude<RouteConfigOptions<RouteMethod>['security'], undefined>;
+  security?: RouteSecurity;
 
   options?: {
     deprecated?: RouteDeprecationInfo;

--- a/packages/core/http/core-http-server/src/versioning/types.ts
+++ b/packages/core/http/core-http-server/src/versioning/types.ts
@@ -36,7 +36,7 @@ export type VersionedRouteConfig<Method extends RouteMethod> = Omit<
 > & {
   options?: Omit<
     RouteConfigOptions<Method>,
-    'access' | 'description' | 'summary' | 'deprecated' | 'discontinued' | 'security'
+    'access' | 'description' | 'summary' | 'deprecated' | 'discontinued'
   >;
   /** See {@link RouteConfigOptions<RouteMethod>['access']} */
   access: Exclude<RouteConfigOptions<Method>['access'], undefined>;

--- a/packages/kbn-server-route-repository-utils/src/typings.ts
+++ b/packages/kbn-server-route-repository-utils/src/typings.ts
@@ -15,6 +15,7 @@ import type {
   Logger,
   RequestHandlerContext,
   RouteConfigOptions,
+  RouteSecurity,
   RouteMethod,
 } from '@kbn/core/server';
 import type { ServerSentEvent } from '@kbn/sse-utils';
@@ -277,5 +278,5 @@ export interface DefaultRouteHandlerResources extends CoreRouteHandlerResources 
 }
 
 export interface DefaultRouteCreateOptions {
-  options?: RouteConfigOptions<RouteMethod>;
+  options?: RouteConfigOptions<RouteMethod> & { security?: RouteSecurity };
 }

--- a/packages/kbn-server-route-repository/src/register_routes.ts
+++ b/packages/kbn-server-route-repository/src/register_routes.ts
@@ -137,11 +137,14 @@ export function registerRoutes<TDependencies extends Record<string, any>>({
       validationObject = passThroughValidationObject;
     }
 
+    const { security, ...restOptions } = options ?? {};
+
     if (!version) {
       router[method](
         {
           path: pathname,
-          options,
+          security,
+          options: restOptions,
           validate: validationObject,
         },
         wrappedHandler
@@ -150,7 +153,8 @@ export function registerRoutes<TDependencies extends Record<string, any>>({
       router.versioned[method]({
         path: pathname,
         access: pathname.startsWith('/internal/') ? 'internal' : 'public',
-        options,
+        options: restOptions,
+        security,
       }).addVersion(
         {
           version,

--- a/x-pack/plugins/ai_infra/product_doc_base/server/routes/installation.ts
+++ b/x-pack/plugins/ai_infra/product_doc_base/server/routes/installation.ts
@@ -29,10 +29,10 @@ export const registerInstallationRoutes = ({
       validate: false,
       options: {
         access: 'internal',
-        security: {
-          authz: {
-            requiredPrivileges: ['manage_llm_product_doc'],
-          },
+      },
+      security: {
+        authz: {
+          requiredPrivileges: ['manage_llm_product_doc'],
         },
       },
     },
@@ -56,12 +56,12 @@ export const registerInstallationRoutes = ({
       validate: false,
       options: {
         access: 'internal',
-        security: {
-          authz: {
-            requiredPrivileges: ['manage_llm_product_doc'],
-          },
-        },
         timeout: { idleSocket: 20 * 60 * 1000 }, // install can take time.
+      },
+      security: {
+        authz: {
+          requiredPrivileges: ['manage_llm_product_doc'],
+        },
       },
     },
     async (ctx, req, res) => {
@@ -90,10 +90,10 @@ export const registerInstallationRoutes = ({
       validate: false,
       options: {
         access: 'internal',
-        security: {
-          authz: {
-            requiredPrivileges: ['manage_llm_product_doc'],
-          },
+      },
+      security: {
+        authz: {
+          requiredPrivileges: ['manage_llm_product_doc'],
         },
       },
     },


### PR DESCRIPTION
## Summary

Removed `security` property from `route.options` types, `security` should exist only as a top level property. 
Fixed routes with incorrect config accordingly.


## Routes Impacted
Routes with disabled authorization (impact can be considered negligible)
```
/internal/entities/managed/enablement
/internal/entities/managed/enablement
/internal/entities/managed/enablement
/internal/entities/definition
/internal/entities/definition/{id}
/internal/entities/definition/{id?}
/internal/entities/definition/{id}/_reset
/internal/entities/definition/{id}
/api/streams/_enable
/api/streams/_resync
/api/streams/{id}/_fork
/api/streams/{id}
/api/streams/{id}
/api/streams/{id}
/api/streams 
```

Routes with authorization (will be backported to `8.17.0`)

```
/internal/product_doc_base/status
/internal/product_doc_base/install
/internal/product_doc_base/uninstall
```



__Fixes: https://github.com/elastic/kibana/issues/201347__




<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->