### PR TITLE
[8.17] [Docs] Add deprecation notice for MacOS x86_64 builds (#201329)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -150,12 +150,37 @@ For more information, refer to {kibana-issue}199891[#199891] and {kibana-issue}1
 ====
 
 [float]
+[[breaking-changes-8.16.0]]
+=== Breaking changes
+
+Breaking changes can prevent your application from optimal operation and performance.
+Before you upgrade to 8.16.0, review the breaking changes, then mitigate the impact to your application.
+
+[discrete]
+.Updated request processing during shutdown.
+[%collapsible]
+====
+*Details* +
+During shutdown, {kib} now waits for all the ongoing requests to complete according to the `server.shutdownTimeout` setting. During that period, the incoming socket is closed and any new incoming requests are rejected. Before this update, new incoming requests received a response with the status code 503 and body `{"message": "Kibana is shutting down and not accepting new incoming requests"}`. For more information, refer to {kibana-pull}180986[#180986].
+==== 
+
+[float]
 [[deprecations-8.16.0]]
 === Deprecations
 
 The following functionality is deprecated in 8.16.0, and will be removed in 9.0.0.
 Deprecated functionality does not have an immediate impact on your application, but we strongly recommend
 you make the necessary updates after you upgrade to 8.16.0.
+
+[discrete]
+.New versions of Kibana for macOS x86_64 will end after 8.17.
+[%collapsible]
+====
+*Details* +
+New versions of Kibana builds for macOS x86_64 are deprecated and will no longer be released after 8.17.  Kibana for macOS AArch64 is unaffected. 
+
+Use Docker to run new versions of Kibana on macOS 86x_64.
+====
 
 [discrete]
 .The Logs Stream is now hidden by default in favor of the Logs Explorer app.
@@ -179,20 +204,6 @@ The Observability AI Assistant specific advanced setting for Logs index patterns
 //!!TODO!!
 ====
 
-[float]
-[[breaking-changes-8.16.0]]
-=== Breaking changes
-
-Breaking changes can prevent your application from optimal operation and performance.
-Before you upgrade to 8.16.0, review the breaking changes, then mitigate the impact to your application.
-
-[discrete]
-.Updated request processing during shutdown.
-[%collapsible]
-====
-*Details* +
-During shutdown, {kib} now waits for all the ongoing requests to complete according to the `server.shutdownTimeout` setting. During that period, the incoming socket is closed and any new incoming requests are rejected. Before this update, new incoming requests received a response with the status code 503 and body `{"message": "Kibana is shutting down and not accepting new incoming requests"}`. For more information, refer to {kibana-pull}180986[#180986].
-==== 
   
 [float]
 [[features-8.16.0]]

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -1618,6 +1618,18 @@ The following security_linux and security_windows job configurations are updated
 ** v3_windows_rare_user_type10_remote_login
 ====
 
+// Setup
+
+[discrete]
+[[deprecation-macos-x8664]]
+.[Setup] New versions of Kibana for macOS x86_64 will end after 8.17.
+[%collapsible]
+====
+*Details* +
+New versions of Kibana builds for macOS x86_64 are deprecated and will no longer be released after 8.17.  Kibana for macOS AArch64 is unaffected. 
+
+Use Docker to run new versions of Kibana on macOS 86x_64.
+====
 
 // Sharing & Reporting
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.17`:
 - [[Docs] Add deprecation notice for MacOS x86_64 builds (#201329)](https://github.com/elastic/kibana/pull/201329)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"florent-leborgne","email":"florent.leborgne@elastic.co"},"sourceCommit":{"committedDate":"2024-11-22T09:59:37Z","message":"[Docs] Add deprecation notice for MacOS x86_64 builds (#201329)\n\nThis PR adds a deprecation notice to the release and upgrade notes\r\nregarding macOS x86_64 builds.\r\n\r\n+a small fix of reordering deprecation and breaking changes correctly in\r\n8.16 release notes","sha":"4ad0c2d4f74541bd680bb51755fbefd2a12b2383","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","v8.16.0","backport:version","v8.17.0","v8.18.0"],"number":201329,"url":"https://github.com/elastic/kibana/pull/201329","mergeCommit":{"message":"[Docs] Add deprecation notice for MacOS x86_64 builds (#201329)\n\nThis PR adds a deprecation notice to the release and upgrade notes\r\nregarding macOS x86_64 builds.\r\n\r\n+a small fix of reordering deprecation and breaking changes correctly in\r\n8.16 release notes","sha":"4ad0c2d4f74541bd680bb51755fbefd2a12b2383"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.16","8.17"],"targetPullRequestStates":[{"branch":"main","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->