### PR TITLE
[a11y][connectors] Fix connector configuration tooltips

### DIFF
--- a/packages/kbn-search-connectors/components/configuration/connector_configuration_field.tsx
+++ b/packages/kbn-search-connectors/components/configuration/connector_configuration_field.tsx
@@ -20,7 +20,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiButtonIcon,
-  EuiIcon,
+  EuiIconTip,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
@@ -110,7 +110,7 @@ export const ConfigSensitiveTextArea: React.FC<ConfigInputFieldProps> = ({
               <p>{label}</p>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiIcon type="questionInCircle" />
+              <EuiIconTip content={tooltip} />
             </EuiFlexItem>
           </EuiFlexGroup>
         ) : (
@@ -228,7 +228,7 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
                   <EuiSwitch
                     checked={ensureBooleanType(value)}
                     disabled={isLoading || !hasPlatinumLicense}
-                    label={<p>{label}</p>}
+                    label={label}
                     onChange={(event) => {
                       validateAndSetConfigValue(event.target.checked);
                     }}
@@ -263,27 +263,21 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
         );
       }
       return (
-        <EuiSwitch
-          checked={ensureBooleanType(value)}
-          disabled={isLoading}
-          label={
-            tooltip ? (
-              <EuiFlexGroup gutterSize="xs">
-                <EuiFlexItem>
-                  <p>{label}</p>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiIcon type="questionInCircle" />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            ) : (
-              <p>{label}</p>
-            )
-          }
-          onChange={(event) => {
-            validateAndSetConfigValue(event.target.checked);
-          }}
-        />
+        <EuiFlexGroup direction="row" gutterSize="xs">
+          <EuiSwitch
+            checked={ensureBooleanType(value)}
+            disabled={isLoading}
+            label={label}
+            onChange={(event) => {
+              validateAndSetConfigValue(event.target.checked);
+            }}
+          />
+          {tooltip && (
+            <EuiFlexItem grow={false}>
+              <EuiIconTip content={tooltip} />
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
       );
 
     default:

--- a/packages/kbn-search-connectors/components/configuration/connector_configuration_form_items.tsx
+++ b/packages/kbn-search-connectors/components/configuration/connector_configuration_form_items.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 
-import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiIcon, EuiPanel, EuiToolTip } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiIconTip, EuiPanel } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
@@ -66,7 +66,7 @@ export const ConnectorConfigurationFormItems: React.FC<ConnectorConfigurationFor
                 <p>{label}</p>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiIcon type="questionInCircle" />
+                <EuiIconTip content={tooltip} />
               </EuiFlexItem>
             </EuiFlexGroup>
           ) : (
@@ -77,46 +77,42 @@ export const ConnectorConfigurationFormItems: React.FC<ConnectorConfigurationFor
           return (
             <EuiFlexItem key={key}>
               <EuiPanel color="subdued" borderRadius="none">
-                <EuiToolTip content={tooltip}>
-                  <EuiFormRow
-                    label={rowLabel}
-                    helpText={helpText}
-                    error={validationErrors}
-                    isInvalid={!isValid}
-                    data-test-subj={`entSearchContent-connector-configuration-formrow-${key}`}
-                  >
-                    <ConnectorConfigurationField
-                      configEntry={configEntry}
-                      isLoading={isLoading}
-                      setConfigValue={(value) => {
-                        setConfigEntry(configEntry.key, value);
-                      }}
-                    />
-                  </EuiFormRow>
-                </EuiToolTip>
+                <EuiFormRow
+                  label={rowLabel}
+                  helpText={helpText}
+                  error={validationErrors}
+                  isInvalid={!isValid}
+                  data-test-subj={`entSearchContent-connector-configuration-formrow-${key}`}
+                >
+                  <ConnectorConfigurationField
+                    configEntry={configEntry}
+                    isLoading={isLoading}
+                    setConfigValue={(value) => {
+                      setConfigEntry(configEntry.key, value);
+                    }}
+                  />
+                </EuiFormRow>
               </EuiPanel>
             </EuiFlexItem>
           );
         }
         return (
           <EuiFlexItem key={key}>
-            <EuiToolTip content={tooltip}>
-              <EuiFormRow
-                label={rowLabel}
-                helpText={helpText}
-                error={validationErrors}
-                isInvalid={!isValid}
-                data-test-subj={`entSearchContent-connector-configuration-formrow-${key}`}
-              >
-                <ConnectorConfigurationField
-                  configEntry={configEntry}
-                  isLoading={isLoading}
-                  setConfigValue={(value) => {
-                    setConfigEntry(configEntry.key, value);
-                  }}
-                />
-              </EuiFormRow>
-            </EuiToolTip>
+            <EuiFormRow
+              label={rowLabel}
+              helpText={helpText}
+              error={validationErrors}
+              isInvalid={!isValid}
+              data-test-subj={`entSearchContent-connector-configuration-formrow-${key}`}
+            >
+              <ConnectorConfigurationField
+                configEntry={configEntry}
+                isLoading={isLoading}
+                setConfigValue={(value) => {
+                  setConfigEntry(configEntry.key, value);
+                }}
+              />
+            </EuiFormRow>
           </EuiFlexItem>
         );
       })}

--- a/packages/kbn-search-connectors/components/configuration/connector_configuration_form_items.tsx
+++ b/packages/kbn-search-connectors/components/configuration/connector_configuration_form_items.tsx
@@ -66,7 +66,9 @@ export const ConnectorConfigurationFormItems: React.FC<ConnectorConfigurationFor
                 <p>{label}</p>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiIconTip content={tooltip} />
+                <div role="tooltip">
+                  <EuiIconTip content={tooltip} />
+                </div>
               </EuiFlexItem>
             </EuiFlexGroup>
           ) : (


### PR DESCRIPTION
## Summary

Use proper tooltip EUI elem, before you could not navigate on those elements with keyboard `TAB` key as we were just rendering icon image on the side of label. 

Now it's possible to reach each (?) with keyboard navigation and it's possible to read the tooltip with screenreader. 

See:

https://github.com/user-attachments/assets/4b50a70c-d153-432f-9093-70ba6dffa9d9




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->