### PR TITLE
[ResponseOps][Connectors] Show a licensing message if the user does not have the sufficient license for system actions.

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/system_action_type_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/system_action_type_form.tsx
@@ -28,6 +28,7 @@ import { isEmpty, partition, some } from 'lodash';
 import { ActionVariable, RuleActionParam } from '@kbn/alerting-plugin/common';
 import { ActionGroupWithMessageVariables } from '@kbn/triggers-actions-ui-types';
 import { transformActionVariables } from '@kbn/alerts-ui-shared/src/action_variables/transforms';
+import { checkActionFormActionTypeEnabled } from '@kbn/alerts-ui-shared/src/rule_form/utils/check_action_type_enabled';
 import { TECH_PREVIEW_DESCRIPTION, TECH_PREVIEW_LABEL } from '../translations';
 import {
   IErrorObject,
@@ -167,8 +168,12 @@ export const SystemActionTypeForm = ({
   };
 
   const ParamsFieldsComponent = actionTypeRegistered.actionParamsFields;
+  const checkEnabledResult = checkActionFormActionTypeEnabled(
+    actionTypesIndex[actionConnector.actionTypeId],
+    []
+  );
 
-  const accordionContent = (
+  const accordionContent = checkEnabledResult.isEnabled ? (
     <>
       <EuiSplitPanel.Inner color="plain">
         {ParamsFieldsComponent ? (
@@ -212,6 +217,8 @@ export const SystemActionTypeForm = ({
         ) : null}
       </EuiSplitPanel.Inner>
     </>
+  ) : (
+    checkEnabledResult.messageCard
   );
 
   return (


### PR DESCRIPTION
If a user does not have a sufficient license for a connector and the rule is already configured with such a connector we show the following message:

<img width="1026" alt="Screenshot 2024-11-22 at 1 48 10 PM" src="https://github.com/user-attachments/assets/4b3d7197-ff3c-4673-9b37-9ca627dab0db">

This PR does the same for system actions.

<img width="1162" alt="Screenshot 2024-11-22 at 1 03 06 PM" src="https://github.com/user-attachments/assets/d1cbd479-ff65-453d-889a-ae7f5cd2b63b">

## Testing

1. Create a rule with a case action in Platinum license
2. Downgrade to basic
3. Verify that a licensing message is showing for the case action. Verify in all solutions.

Issue: https://github.com/elastic/kibana/issues/189978

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->