### PR TITLE
[Entity Analytics][API] Changes for preview-risk-scores API to accept new params 

### DIFF
--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/preview_route.gen.ts
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/preview_route.gen.ts
@@ -58,9 +58,11 @@ export const RiskScoresPreviewRequest = z.object({
   /**
    * A list of alert statuses to exclude from the risk score calculation. If unspecified, all alert statuses are included.
    */
-  excludeAlertStatuses: z
-    .array(z.enum(['open', 'closed', 'in-progress', 'acknowledged']))
-    .optional(),
+  exclude_alert_statuses: z.array(z.string()).optional(),
+  /**
+   * A list of alert tags to exclude from the risk score calculation. If unspecified, all alert tags are included.
+   */
+  exclude_alert_tags: z.array(z.string()).optional(),
 });
 
 export type RiskScoresPreviewResponse = z.infer<typeof RiskScoresPreviewResponse>;

--- a/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/preview_route.schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/entity_analytics/risk_engine/preview_route.schema.yaml
@@ -58,16 +58,16 @@ components:
           description: Defines the time period over which scores will be evaluated. If unspecified, a range of `[now, now-30d]` will be used.
         weights:
           $ref: '../common/common.schema.yaml#/components/schemas/RiskScoreWeights'
-        excludeAlertStatuses:
+        exclude_alert_statuses:
           description: A list of alert statuses to exclude from the risk score calculation. If unspecified, all alert statuses are included.
           type: array
           items:
             type: string
-            enum:
-              - open
-              - closed
-              - in-progress
-              - acknowledged
+        exclude_alert_tags:
+          description: A list of alert tags to exclude from the risk score calculation. If unspecified, all alert tags are included.
+          type: array
+          items:
+            type: string
           
 
     RiskScoresPreviewResponse:

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/preview.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/preview.test.ts
@@ -250,5 +250,35 @@ describe('POST risk_engine/preview route', () => {
         expect(result.ok).toHaveBeenCalledWith(expect.objectContaining({ after_keys: {} }));
       });
     });
+
+    describe('exclude_alert_statuses', () => {
+      it('respects the provided exclude_alert_statuses', async () => {
+        const request = buildRequest({
+          exclude_alert_statuses: ['open'],
+        });
+
+        const response = await server.inject(request, requestContextMock.convertContext(context));
+
+        expect(response.status).toEqual(200);
+        expect(mockRiskScoreService.calculateScores).toHaveBeenCalledWith(
+          expect.objectContaining({ excludeAlertStatuses: ['open'] })
+        );
+      });
+    });
+
+    describe('exclude_alert_tags', () => {
+      it('respects the provided exclude_alert_tags', async () => {
+        const request = buildRequest({
+          exclude_alert_tags: ['tag1'],
+        });
+
+        const response = await server.inject(request, requestContextMock.convertContext(context));
+
+        expect(response.status).toEqual(200);
+        expect(mockRiskScoreService.calculateScores).toHaveBeenCalledWith(
+          expect.objectContaining({ excludeAlertTags: ['tag1'] })
+        );
+      });
+    });
   });
 });

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/preview.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/risk_score/routes/preview.ts
@@ -65,7 +65,8 @@ export const riskScorePreviewRoute = (
           filter,
           range: userRange,
           weights,
-          excludeAlertStatuses,
+          exclude_alert_statuses: excludedStatuses,
+          exclude_alert_tags: excludedTags,
         } = request.body;
 
         const entityAnalyticsConfig = await riskScoreService.getConfigurationWithDefaults(
@@ -84,6 +85,8 @@ export const riskScorePreviewRoute = (
           const afterKeys = userAfterKeys ?? {};
           const range = userRange ?? { start: 'now-15d', end: 'now' };
           const pageSize = userPageSize ?? DEFAULT_RISK_SCORE_PAGE_SIZE;
+          const excludeAlertStatuses = excludedStatuses || ['closed'];
+          const excludeAlertTags = excludedTags || [];
 
           const result = await riskScoreService.calculateScores({
             afterKeys,
@@ -97,6 +100,7 @@ export const riskScorePreviewRoute = (
             weights,
             alertSampleSizePerShard,
             excludeAlertStatuses,
+            excludeAlertTags,
           });
 
           securityContext.getAuditLogger()?.log({

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/types.ts
@@ -86,6 +86,7 @@ export interface CalculateScoresParams {
   weights?: RiskScoreWeights;
   alertSampleSizePerShard?: number;
   excludeAlertStatuses?: string[];
+  excludeAlertTags?: string[];
 }
 
 export interface CalculateAndPersistScoresParams {


### PR DESCRIPTION
## Summary

This pull request introduces several changes to the risk score calculation functionality in the `x-pack/plugins/security_solution` plugin. The main updates include adding support for excluding alerts based on tags and renaming some fields for consistency. Here are the most important changes:

### Enhancements to Risk Score Calculation:

* Updated the `calculateRiskScores` function to handle the new `excludeAlertTags` parameter and include it in the filter logic.

### Test Coverage:

* Added unit tests to verify that the `exclude_alert_statuses` and `exclude_alert_tags` parameters are respected in the risk score calculation.

These changes enhance the flexibility of the risk score calculation by allowing more granular exclusions and ensure consistency and reliability across the codebase.

**Note : Above summary generated by Copilot, not bad** 👍🏼 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



