### PR TITLE
[Fleet] Fix settings response when space awareness enabled

### DIFF
--- a/x-pack/plugins/fleet/server/services/settings.test.ts
+++ b/x-pack/plugins/fleet/server/services/settings.test.ts
@@ -143,6 +143,42 @@ describe('getSettings', () => {
 
     await getSettings(soClient);
   });
+
+  it('should handle null values for space awareness migration fields', async () => {
+    const soClient = savedObjectsClientMock.create();
+
+    soClient.find.mockResolvedValueOnce({
+      saved_objects: [
+        {
+          id: GLOBAL_SETTINGS_ID,
+          attributes: {
+            use_space_awareness_migration_status: null,
+            use_space_awareness_migration_started_at: null,
+          },
+          references: [],
+          type: GLOBAL_SETTINGS_SAVED_OBJECT_TYPE,
+          score: 0,
+        },
+      ],
+      page: 1,
+      per_page: 10,
+      total: 1,
+    });
+
+    const settings = await getSettings(soClient);
+    expect(settings).toEqual({
+      delete_unenrolled_agents: undefined,
+      has_seen_add_data_notice: undefined,
+      id: 'fleet-default-settings',
+      output_secret_storage_requirements_met: undefined,
+      preconfigured_fields: [],
+      prerelease_integrations_enabled: undefined,
+      secret_storage_requirements_met: undefined,
+      use_space_awareness_migration_started_at: undefined,
+      use_space_awareness_migration_status: undefined,
+      version: undefined,
+    });
+  });
 });
 
 describe('saveSettings', () => {


### PR DESCRIPTION
## Summary

When investigating space awareness performance issue I found that the settings response is not valid (see screenshot), and because of react query retry retries feature it was causing some delay before rendering the page, that PR fix that.

<img width="600" alt="Screenshot 2024-11-22 at 9 08 12 AM" src="https://github.com/user-attachments/assets/fd256c0b-25b7-496b-8784-29c4f9ddd143">


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->