### PR TITLE
[Security Solution] Fix an error with nested fields being treated as keyword

### DIFF
--- a/x-pack/plugins/timelines/server/search_strategy/timeline/factory/helpers/format_timeline_data.ts
+++ b/x-pack/plugins/timelines/server/search_strategy/timeline/factory/helpers/format_timeline_data.ts
@@ -34,7 +34,7 @@ const createBaseTimelineEdges = (): TimelineEdges => ({
 
 function deepMerge(target: EventSource, source: EventSource) {
   for (const key in source) {
-    if (source[key] instanceof Object && key in target) {
+    if (source && source[key] instanceof Object && target && target[key] instanceof Object) {
       deepMerge(target[key], source[key]);
     } else {
       target[key] = source[key];


### PR DESCRIPTION
## Summary
When formatting elasticsearch responses for the frontend, the timelines search strategies will treat unmapped fields as type: keyword. If the underlying field is actually an object, but is seen as a string in the code, this for (key in source) loop will fail, as it's trying to loop over a string. Fix below should have minimal effect as the data is accessible at the further nested keys.



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios







<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.x"]} ONMERGE-->