### PR TITLE
[Dashboards] [Embeddables] Allow embeddables to register a panel config schema

### DIFF
--- a/src/plugins/dashboard/server/api/register_routes.ts
+++ b/src/plugins/dashboard/server/api/register_routes.ts
@@ -12,6 +12,7 @@ import type { ContentManagementServerSetup } from '@kbn/content-management-plugi
 import type { HttpServiceSetup } from '@kbn/core/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import type { Logger } from '@kbn/logging';
+import type { EmbeddableStart } from '@kbn/embeddable-plugin/server';
 
 import { CONTENT_ID } from '../../common/content_management';
 import {
@@ -20,10 +21,10 @@ import {
   PUBLIC_API_CONTENT_MANAGEMENT_VERSION,
 } from './constants';
 import {
-  dashboardAttributesSchema,
-  dashboardGetResultSchema,
-  dashboardCreateResultSchema,
-  dashboardSearchResultsSchema,
+  getDashboardAttributesSchema,
+  getDashboardGetResultSchema,
+  getDashboardCreateResultSchema,
+  getDashboardSearchResultsSchema,
   referenceSchema,
 } from '../content_management/v3';
 
@@ -32,6 +33,7 @@ interface RegisterAPIRoutesArgs {
   contentManagement: ContentManagementServerSetup;
   restCounter?: UsageCounter;
   logger: Logger;
+  embeddable: EmbeddableStart;
 }
 
 const TECHNICAL_PREVIEW_WARNING =
@@ -40,6 +42,7 @@ const TECHNICAL_PREVIEW_WARNING =
 export function registerAPIRoutes({
   http,
   contentManagement,
+  embeddable,
   restCounter,
   logger,
 }: RegisterAPIRoutesArgs) {
@@ -65,14 +68,14 @@ export function registerAPIRoutes({
             id: schema.maybe(schema.string()),
           }),
           body: schema.object({
-            attributes: dashboardAttributesSchema,
+            attributes: getDashboardAttributesSchema(embeddable),
             references: schema.maybe(schema.arrayOf(referenceSchema)),
             spaces: schema.maybe(schema.arrayOf(schema.string())),
           }),
         },
         response: {
           200: {
-            body: () => dashboardCreateResultSchema,
+            body: () => getDashboardCreateResultSchema(embeddable),
           },
         },
       },
@@ -131,13 +134,13 @@ export function registerAPIRoutes({
             id: schema.string(),
           }),
           body: schema.object({
-            attributes: dashboardAttributesSchema,
+            attributes: getDashboardAttributesSchema(embeddable),
             references: schema.maybe(schema.arrayOf(referenceSchema)),
           }),
         },
         response: {
           200: {
-            body: () => dashboardCreateResultSchema,
+            body: () => getDashboardCreateResultSchema(embeddable),
           },
         },
       },
@@ -193,7 +196,7 @@ export function registerAPIRoutes({
           200: {
             body: () =>
               schema.object({
-                items: schema.arrayOf(dashboardSearchResultsSchema),
+                items: schema.arrayOf(getDashboardSearchResultsSchema(embeddable)),
                 total: schema.number(),
               }),
           },
@@ -247,7 +250,7 @@ export function registerAPIRoutes({
         },
         response: {
           200: {
-            body: () => dashboardGetResultSchema,
+            body: () => getDashboardGetResultSchema(embeddable),
           },
         },
       },

--- a/src/plugins/dashboard/server/api/register_routes.ts
+++ b/src/plugins/dashboard/server/api/register_routes.ts
@@ -62,7 +62,7 @@ export function registerAPIRoutes({
   createRoute.addVersion(
     {
       version: PUBLIC_API_VERSION,
-      validate: {
+      validate: () => ({
         request: {
           params: schema.object({
             id: schema.maybe(schema.string()),
@@ -78,7 +78,7 @@ export function registerAPIRoutes({
             body: () => getDashboardCreateResultSchema(embeddable),
           },
         },
-      },
+      }),
     },
     async (ctx, req, res) => {
       const { id } = req.params;

--- a/src/plugins/dashboard/server/content_management/cm_services.ts
+++ b/src/plugins/dashboard/server/content_management/cm_services.ts
@@ -11,16 +11,19 @@ import type {
   ContentManagementServicesDefinition as ServicesDefinition,
   Version,
 } from '@kbn/object-versioning';
+import { EmbeddableStart } from '@kbn/embeddable-plugin/server';
 
 // We export the versioned service definition from this file and not the barrel to avoid adding
 // the schemas in the "public" js bundle
 
 import { serviceDefinition as v1 } from './v1';
 import { serviceDefinition as v2 } from './v2';
-import { serviceDefinition as v3 } from './v3';
+import { getServiceDefinition as v3 } from './v3';
 
-export const cmServicesDefinition: { [version: Version]: ServicesDefinition } = {
+export const getCmServicesDefinition = (
+  embeddable: EmbeddableStart
+): { [version: Version]: ServicesDefinition } => ({
   1: v1,
   2: v2,
-  3: v3,
-};
+  3: v3(embeddable),
+});

--- a/src/plugins/dashboard/server/content_management/v3/cm_services.ts
+++ b/src/plugins/dashboard/server/content_management/v3/cm_services.ts
@@ -8,7 +8,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { schema, Type } from '@kbn/config-schema';
+import { ObjectType, schema, Type } from '@kbn/config-schema';
 import { createOptionsSchemas, updateOptionsSchema } from '@kbn/content-management-utils';
 import type { ContentManagementServicesDefinition as ServicesDefinition } from '@kbn/object-versioning';
 import {
@@ -27,6 +27,8 @@ import {
 } from '@kbn/controls-plugin/common';
 import { FilterStateStore } from '@kbn/es-query';
 import { SortDirection } from '@kbn/data-plugin/common/search';
+import { ViewMode } from '@kbn/embeddable-plugin/common';
+import type { EmbeddableStart } from '@kbn/embeddable-plugin/server';
 import {
   DASHBOARD_GRID_COLUMN_COUNT,
   DEFAULT_PANEL_HEIGHT,
@@ -249,56 +251,88 @@ export const gridDataSchema = schema.object({
   }),
 });
 
-export const panelSchema = schema.object({
-  panelConfig: schema.object(
+const genericPanelConfig = schema.object(
+  {
+    type: schema.maybe(schema.string()),
+    version: schema.maybe(
+      schema.string({
+        meta: { description: 'The version of the embeddable in the panel.' },
+      })
+    ),
+    viewMode: schema.maybe(
+      schema.oneOf(
+        Object.values(ViewMode)
+          .filter((value): value is ViewMode => typeof value === 'string')
+          .map((value) => schema.literal(value)) as [Type<ViewMode>]
+      )
+    ),
+    title: schema.maybe(schema.string({ meta: { description: 'The title of the panel' } })),
+    description: schema.maybe(
+      schema.string({ meta: { description: 'The description of the panel' } })
+    ),
+    savedObjectId: schema.maybe(
+      schema.string({
+        meta: {
+          description: 'The unique id of the library item to construct the embeddable.',
+        },
+      })
+    ),
+    hidePanelTitles: schema.maybe(
+      schema.boolean({
+        defaultValue: false,
+        meta: { description: 'Set to true to hide the panel title in its container.' },
+      })
+    ),
+    enhancements: schema.maybe(schema.recordOf(schema.string(), schema.any())),
+    disabledActions: schema.maybe(schema.arrayOf(schema.string())),
+    disableTriggers: schema.maybe(schema.boolean()),
+    timeRange: schema.maybe(schema.object({ from: schema.string(), to: schema.string() })),
+  },
+  {
+    unknowns: 'allow',
+  }
+);
+
+export const getPanelSchema = (embeddable: EmbeddableStart) =>
+  schema.object(
     {
+      panelConfig: genericPanelConfig,
+      id: schema.maybe(
+        schema.string({ meta: { description: 'The saved object id for by reference panels' } })
+      ),
+      type: schema.string({ meta: { description: 'The embeddable type' } }),
+      panelRefName: schema.maybe(schema.string()),
+      gridData: gridDataSchema,
+      panelIndex: schema.string({
+        meta: { description: 'The unique ID of the panel.' },
+        defaultValue: schema.siblingRef('gridData.i'),
+      }),
+      title: schema.maybe(schema.string({ meta: { description: 'The title of the panel' } })),
       version: schema.maybe(
         schema.string({
-          meta: { description: 'The version of the embeddable in the panel.' },
+          meta: {
+            description:
+              "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
+            deprecated: true,
+          },
         })
       ),
-      title: schema.maybe(schema.string({ meta: { description: 'The title of the panel' } })),
-      description: schema.maybe(
-        schema.string({ meta: { description: 'The description of the panel' } })
-      ),
-      savedObjectId: schema.maybe(
-        schema.string({
-          meta: { description: 'The unique id of the library item to construct the embeddable.' },
-        })
-      ),
-      hidePanelTitles: schema.maybe(
-        schema.boolean({
-          defaultValue: false,
-          meta: { description: 'Set to true to hide the panel title in its container.' },
-        })
-      ),
-      enhancements: schema.maybe(schema.recordOf(schema.string(), schema.any())),
     },
     {
-      unknowns: 'allow',
-    }
-  ),
-  id: schema.maybe(
-    schema.string({ meta: { description: 'The saved object id for by reference panels' } })
-  ),
-  type: schema.string({ meta: { description: 'The embeddable type' } }),
-  panelRefName: schema.maybe(schema.string()),
-  gridData: gridDataSchema,
-  panelIndex: schema.string({
-    meta: { description: 'The unique ID of the panel.' },
-    defaultValue: schema.siblingRef('gridData.i'),
-  }),
-  title: schema.maybe(schema.string({ meta: { description: 'The title of the panel' } })),
-  version: schema.maybe(
-    schema.string({
-      meta: {
-        description:
-          "The version was used to store Kibana version information from versions 7.3.0 -> 8.11.0. As of version 8.11.0, the versioning information is now per-embeddable-type and is stored on the embeddable's input. (panelConfig in this type).",
-        deprecated: true,
+      validate(value) {
+        const { type, panelConfig } = value;
+        const getConfigSchema = embeddable.getValidationSchema(
+          type
+        ) as unknown as () => ObjectType<any>;
+        if (getConfigSchema) {
+          const configSchema = getConfigSchema();
+          const panelConfigSchema = schema.intersection([genericPanelConfig, configSchema]);
+          return panelConfigSchema.validate(panelConfig);
+        }
+        return value;
       },
-    })
-  ),
-});
+    }
+  );
 
 export const optionsSchema = schema.object({
   hidePanelTitles: schema.boolean({
@@ -333,72 +367,73 @@ export const searchResultsAttributesSchema = schema.object({
   }),
 });
 
-export const dashboardAttributesSchema = searchResultsAttributesSchema.extends({
-  // Search
-  kibanaSavedObjectMeta: schema.object(
-    {
-      searchSource: schema.maybe(searchSourceSchema),
-    },
-    {
-      meta: {
-        description: 'A container for various metadata',
-      },
-      defaultValue: {},
-    }
-  ),
-  // Time
-  timeFrom: schema.maybe(
-    schema.string({ meta: { description: 'An ISO string indicating when to restore time from' } })
-  ),
-  timeTo: schema.maybe(
-    schema.string({ meta: { description: 'An ISO string indicating when to restore time from' } })
-  ),
-  refreshInterval: schema.maybe(
-    schema.object(
+export const getDashboardAttributesSchema = (embeddable: EmbeddableStart) =>
+  searchResultsAttributesSchema.extends({
+    // Search
+    kibanaSavedObjectMeta: schema.object(
       {
-        pause: schema.boolean({
-          meta: {
-            description:
-              'Whether the refresh interval is set to be paused while viewing the dashboard.',
-          },
-        }),
-        value: schema.number({
-          meta: {
-            description: 'A numeric value indicating refresh frequency in milliseconds.',
-          },
-        }),
-        display: schema.maybe(
-          schema.string({
-            meta: {
-              description:
-                'A human-readable string indicating the refresh frequency. No longer used.',
-              deprecated: true,
-            },
-          })
-        ),
-        section: schema.maybe(
-          schema.number({
-            meta: {
-              description: 'No longer used.', // TODO what is this legacy property?
-              deprecated: true,
-            },
-          })
-        ),
+        searchSource: schema.maybe(searchSourceSchema),
       },
       {
         meta: {
-          description: 'A container for various refresh interval settings',
+          description: 'A container for various metadata',
         },
+        defaultValue: {},
       }
-    )
-  ),
+    ),
+    // Time
+    timeFrom: schema.maybe(
+      schema.string({ meta: { description: 'An ISO string indicating when to restore time from' } })
+    ),
+    timeTo: schema.maybe(
+      schema.string({ meta: { description: 'An ISO string indicating when to restore time from' } })
+    ),
+    refreshInterval: schema.maybe(
+      schema.object(
+        {
+          pause: schema.boolean({
+            meta: {
+              description:
+                'Whether the refresh interval is set to be paused while viewing the dashboard.',
+            },
+          }),
+          value: schema.number({
+            meta: {
+              description: 'A numeric value indicating refresh frequency in milliseconds.',
+            },
+          }),
+          display: schema.maybe(
+            schema.string({
+              meta: {
+                description:
+                  'A human-readable string indicating the refresh frequency. No longer used.',
+                deprecated: true,
+              },
+            })
+          ),
+          section: schema.maybe(
+            schema.number({
+              meta: {
+                description: 'No longer used.', // TODO what is this legacy property?
+                deprecated: true,
+              },
+            })
+          ),
+        },
+        {
+          meta: {
+            description: 'A container for various refresh interval settings',
+          },
+        }
+      )
+    ),
 
-  // Dashboard Content
-  controlGroupInput: schema.maybe(controlGroupInputSchema),
-  panels: schema.arrayOf(panelSchema, { defaultValue: [] }),
-  options: optionsSchema,
-  version: schema.maybe(schema.number({ meta: { deprecated: true } })),
-});
+    // Dashboard Content
+    controlGroupInput: schema.maybe(controlGroupInputSchema),
+    panels: schema.arrayOf(getPanelSchema(embeddable), { defaultValue: [] }),
+    options: optionsSchema,
+    version: schema.maybe(schema.number({ meta: { deprecated: true } })),
+  });
 
 export const referenceSchema = schema.object(
   {
@@ -409,28 +444,30 @@ export const referenceSchema = schema.object(
   { unknowns: 'forbid' }
 );
 
-export const dashboardItemSchema = schema.object(
-  {
-    id: schema.string(),
-    type: schema.string(),
-    version: schema.maybe(schema.string()),
-    createdAt: schema.maybe(schema.string()),
-    updatedAt: schema.maybe(schema.string()),
-    createdBy: schema.maybe(schema.string()),
-    updatedBy: schema.maybe(schema.string()),
-    managed: schema.maybe(schema.boolean()),
-    error: schema.maybe(apiError),
-    attributes: dashboardAttributesSchema,
-    references: schema.arrayOf(referenceSchema),
-    namespaces: schema.maybe(schema.arrayOf(schema.string())),
-    originId: schema.maybe(schema.string()),
-  },
-  { unknowns: 'allow' }
-);
+export const getDashboardItemSchema = (embeddable: EmbeddableStart) =>
+  schema.object(
+    {
+      id: schema.string(),
+      type: schema.string(),
+      version: schema.maybe(schema.string()),
+      createdAt: schema.maybe(schema.string()),
+      updatedAt: schema.maybe(schema.string()),
+      createdBy: schema.maybe(schema.string()),
+      updatedBy: schema.maybe(schema.string()),
+      managed: schema.maybe(schema.boolean()),
+      error: schema.maybe(apiError),
+      attributes: getDashboardAttributesSchema(embeddable),
+      references: schema.arrayOf(referenceSchema),
+      namespaces: schema.maybe(schema.arrayOf(schema.string())),
+      originId: schema.maybe(schema.string()),
+    },
+    { unknowns: 'allow' }
+  );
 
-export const dashboardSearchResultsSchema = dashboardItemSchema.extends({
-  attributes: searchResultsAttributesSchema,
-});
+export const getDashboardSearchResultsSchema = (embeddable: EmbeddableStart) =>
+  getDashboardItemSchema(embeddable).extends({
+    attributes: searchResultsAttributesSchema,
+  });
 
 export const dashboardSearchOptionsSchema = schema.maybe(
   schema.object(
@@ -457,42 +494,44 @@ export const dashboardUpdateOptionsSchema = schema.object({
   mergeAttributes: schema.maybe(updateOptionsSchema.mergeAttributes),
 });
 
-export const dashboardGetResultSchema = schema.object(
-  {
-    item: dashboardItemSchema,
-    meta: schema.object(
-      {
-        outcome: schema.oneOf([
-          schema.literal('exactMatch'),
-          schema.literal('aliasMatch'),
-          schema.literal('conflict'),
-        ]),
-        aliasTargetId: schema.maybe(schema.string()),
-        aliasPurpose: schema.maybe(
-          schema.oneOf([
-            schema.literal('savedObjectConversion'),
-            schema.literal('savedObjectImport'),
-          ])
-        ),
-      },
-      { unknowns: 'forbid' }
-    ),
-  },
-  { unknowns: 'forbid' }
-);
+export const getDashboardGetResultSchema = (embeddable: EmbeddableStart) =>
+  schema.object(
+    {
+      item: getDashboardItemSchema(embeddable),
+      meta: schema.object(
+        {
+          outcome: schema.oneOf([
+            schema.literal('exactMatch'),
+            schema.literal('aliasMatch'),
+            schema.literal('conflict'),
+          ]),
+          aliasTargetId: schema.maybe(schema.string()),
+          aliasPurpose: schema.maybe(
+            schema.oneOf([
+              schema.literal('savedObjectConversion'),
+              schema.literal('savedObjectImport'),
+            ])
+          ),
+        },
+        { unknowns: 'forbid' }
+      ),
+    },
+    { unknowns: 'forbid' }
+  );
 
-export const dashboardCreateResultSchema = schema.object(
-  {
-    item: dashboardItemSchema,
-  },
-  { unknowns: 'forbid' }
-);
+export const getDashboardCreateResultSchema = (embeddable: EmbeddableStart) =>
+  schema.object(
+    {
+      item: getDashboardItemSchema(embeddable),
+    },
+    { unknowns: 'forbid' }
+  );
 
-export const serviceDefinition: ServicesDefinition = {
+export const getServiceDefinition = (embeddable: EmbeddableStart): ServicesDefinition => ({
   get: {
     out: {
       result: {
-        schema: dashboardGetResultSchema,
+        schema: getDashboardGetResultSchema(embeddable),
         down: getResultV3ToV2,
       },
     },
@@ -503,12 +542,12 @@ export const serviceDefinition: ServicesDefinition = {
         schema: dashboardCreateOptionsSchema,
       },
       data: {
-        schema: dashboardAttributesSchema,
+        schema: getDashboardAttributesSchema(embeddable),
       },
     },
     out: {
       result: {
-        schema: dashboardCreateResultSchema,
+        schema: getDashboardCreateResultSchema(embeddable),
       },
     },
   },
@@ -518,7 +557,7 @@ export const serviceDefinition: ServicesDefinition = {
         schema: dashboardUpdateOptionsSchema,
       },
       data: {
-        schema: dashboardAttributesSchema,
+        schema: getDashboardAttributesSchema(embeddable),
       },
     },
   },
@@ -532,8 +571,8 @@ export const serviceDefinition: ServicesDefinition = {
   mSearch: {
     out: {
       result: {
-        schema: dashboardItemSchema,
+        schema: getDashboardItemSchema(embeddable),
       },
     },
   },
-};
+});

--- a/src/plugins/dashboard/server/content_management/v3/index.ts
+++ b/src/plugins/dashboard/server/content_management/v3/index.ts
@@ -27,12 +27,12 @@ export type {
   DashboardOptions,
 } from './types';
 export {
-  serviceDefinition,
-  dashboardAttributesSchema,
-  dashboardGetResultSchema,
-  dashboardCreateResultSchema,
-  dashboardItemSchema,
-  dashboardSearchResultsSchema,
+  getServiceDefinition,
+  getDashboardAttributesSchema,
+  getDashboardGetResultSchema,
+  getDashboardCreateResultSchema,
+  getDashboardItemSchema,
+  getDashboardSearchResultsSchema,
   referenceSchema,
 } from './cm_services';
 export {

--- a/src/plugins/dashboard/server/content_management/v3/types.ts
+++ b/src/plugins/dashboard/server/content_management/v3/types.ts
@@ -17,18 +17,18 @@ import {
 } from '@kbn/content-management-plugin/common';
 import { SavedObjectReference } from '@kbn/core-saved-objects-api-server';
 import {
-  dashboardItemSchema,
   controlGroupInputSchema,
-  gridDataSchema,
-  panelSchema,
-  dashboardAttributesSchema,
+  getDashboardAttributesSchema,
   dashboardCreateOptionsSchema,
-  dashboardCreateResultSchema,
-  dashboardGetResultSchema,
+  getDashboardCreateResultSchema,
+  getDashboardGetResultSchema,
+  getDashboardItemSchema,
   dashboardSearchOptionsSchema,
-  dashboardSearchResultsSchema,
+  getDashboardSearchResultsSchema,
   dashboardUpdateOptionsSchema,
+  gridDataSchema,
   optionsSchema,
+  getPanelSchema,
 } from './cm_services';
 import { CONTENT_ID } from '../../../common/content_management';
 import { DashboardSavedObjectAttributes } from '../../dashboard_saved_object';
@@ -38,14 +38,17 @@ export type DashboardOptions = TypeOf<typeof optionsSchema>;
 // Panel config has some defined types but also allows for custom keys added by embeddables
 // The schema uses "unknowns: 'allow'" to permit any other keys, but the TypeOf helper does not
 // recognize this, so we need to manually extend the type here.
-export type DashboardPanel = Omit<TypeOf<typeof panelSchema>, 'panelConfig'> & {
-  panelConfig: TypeOf<typeof panelSchema>['panelConfig'] & { [key: string]: any };
+export type DashboardPanel = Omit<TypeOf<ReturnType<typeof getPanelSchema>>, 'panelConfig'> & {
+  panelConfig: TypeOf<ReturnType<typeof getPanelSchema>>['panelConfig'] & { [key: string]: any };
 };
-export type DashboardAttributes = Omit<TypeOf<typeof dashboardAttributesSchema>, 'panels'> & {
+export type DashboardAttributes = Omit<
+  TypeOf<ReturnType<typeof getDashboardAttributesSchema>>,
+  'panels'
+> & {
   panels: DashboardPanel[];
 };
 
-export type DashboardItem = TypeOf<typeof dashboardItemSchema>;
+export type DashboardItem = TypeOf<ReturnType<typeof getDashboardItemSchema>>;
 export type PartialDashboardItem = Omit<DashboardItem, 'attributes' | 'references'> & {
   attributes: Partial<DashboardAttributes>;
   references: SavedObjectReference[] | undefined;
@@ -55,19 +58,21 @@ export type ControlGroupAttributes = TypeOf<typeof controlGroupInputSchema>;
 export type GridData = TypeOf<typeof gridDataSchema>;
 
 export type DashboardGetIn = GetIn<typeof CONTENT_ID>;
-export type DashboardGetOut = TypeOf<typeof dashboardGetResultSchema>;
+export type DashboardGetOut = TypeOf<ReturnType<typeof getDashboardGetResultSchema>>;
 
 export type DashboardCreateIn = CreateIn<typeof CONTENT_ID, DashboardAttributes>;
-export type DashboardCreateOut = TypeOf<typeof dashboardCreateResultSchema>;
+export type DashboardCreateOut = TypeOf<ReturnType<typeof getDashboardCreateResultSchema>>;
 export type DashboardCreateOptions = TypeOf<typeof dashboardCreateOptionsSchema>;
 
 export type DashboardUpdateIn = UpdateIn<typeof CONTENT_ID, Partial<DashboardAttributes>>;
-export type DashboardUpdateOut = TypeOf<typeof dashboardCreateResultSchema>;
+export type DashboardUpdateOut = TypeOf<ReturnType<typeof getDashboardCreateResultSchema>>;
 export type DashboardUpdateOptions = TypeOf<typeof dashboardUpdateOptionsSchema>;
 
 export type DashboardSearchIn = SearchIn<typeof CONTENT_ID>;
 export type DashboardSearchOptions = TypeOf<typeof dashboardSearchOptionsSchema>;
-export type DashboardSearchOut = SearchResult<TypeOf<typeof dashboardSearchResultsSchema>>;
+export type DashboardSearchOut = SearchResult<
+  TypeOf<ReturnType<typeof getDashboardSearchResultsSchema>>
+>;
 
 export type SavedObjectToItemReturn<T> =
   | {

--- a/src/plugins/dashboard/server/plugin.ts
+++ b/src/plugins/dashboard/server/plugin.ts
@@ -11,7 +11,7 @@ import {
   TaskManagerSetupContract,
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
-import { EmbeddableSetup } from '@kbn/embeddable-plugin/server';
+import { EmbeddableSetup, EmbeddableStart } from '@kbn/embeddable-plugin/server';
 import { UsageCollectionSetup, UsageCollectionStart } from '@kbn/usage-collection-plugin/server';
 import { ContentManagementServerSetup } from '@kbn/content-management-plugin/server';
 import { PluginInitializerContext, CoreSetup, CoreStart, Plugin, Logger } from '@kbn/core/server';
@@ -42,6 +42,7 @@ interface SetupDeps {
 interface StartDeps {
   taskManager: TaskManagerStartContract;
   usageCollection?: UsageCollectionStart;
+  embeddable: EmbeddableStart;
 }
 
 export class DashboardPlugin
@@ -63,10 +64,10 @@ export class DashboardPlugin
         },
       })
     );
-
     plugins.contentManagement.register({
       id: CONTENT_ID,
       storage: new DashboardStorage({
+        core,
         throwOnResultValidationError: this.initializerContext.env.mode.dev,
         logger: this.logger.get('storage'),
       }),
@@ -112,10 +113,13 @@ export class DashboardPlugin
 
     core.uiSettings.register(getUISettings());
 
-    registerAPIRoutes({
-      http: core.http,
-      contentManagement: plugins.contentManagement,
-      logger: this.logger,
+    core.getStartServices().then(([_, { embeddable }]) => {
+      registerAPIRoutes({
+        http: core.http,
+        contentManagement: plugins.contentManagement,
+        logger: this.logger,
+        embeddable,
+      });
     });
 
     return {};

--- a/src/plugins/embeddable/common/types.ts
+++ b/src/plugins/embeddable/common/types.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Type } from '@kbn/config-schema';
 import type { SerializableRecord } from '@kbn/utility-types';
 import type { KibanaExecutionContext } from '@kbn/core/public';
 import type {
@@ -92,6 +93,7 @@ export interface EmbeddableRegistryDefinition<
   P extends EmbeddableStateWithType = EmbeddableStateWithType
 > extends PersistableStateDefinition<P> {
   id: string;
+  getSchema: () => Type<any>;
 }
 
 export type EmbeddablePersistableStateService = PersistableStateService<EmbeddableStateWithType>;

--- a/src/plugins/embeddable/server/plugin.ts
+++ b/src/plugins/embeddable/server/plugin.ts
@@ -97,6 +97,13 @@ export class EmbeddableServerPlugin implements Plugin<EmbeddableSetup, Embeddabl
         }
         return factory.getSchema;
       },
+      getAllValidationSchemas: () => {
+        const schemas = Array.from(this.embeddableFactories.values())
+          .filter((factory) => factory.getSchema)
+          .map((factory) => factory.getSchema);
+        return schemas;
+      },
+      getRegisteredEmbeddableFactories: () => Array.from(this.embeddableFactories.keys()),
     };
   }
 

--- a/src/plugins/embeddable/server/types.ts
+++ b/src/plugins/embeddable/server/types.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Type } from '@kbn/config-schema';
 import type { SerializableRecord } from '@kbn/utility-types';
 import { PersistableState, PersistableStateDefinition } from '@kbn/kibana-utils-plugin/common';
 import { EmbeddableStateWithType } from '../common/types';
@@ -27,4 +28,5 @@ export interface EnhancementRegistryItem<P extends SerializableRecord = Serializ
 export interface EmbeddableRegistryItem<P extends EmbeddableStateWithType = EmbeddableStateWithType>
   extends PersistableState<P> {
   id: string;
+  getSchema?: () => Type<any>;
 }

--- a/src/plugins/kibana_utils/common/persistable_state/types.ts
+++ b/src/plugins/kibana_utils/common/persistable_state/types.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { Type } from '@kbn/config-schema';
 import type { SerializableRecord, Serializable } from '@kbn/utility-types';
 import { SavedObjectReference } from '@kbn/core/types';
 

--- a/x-pack/plugins/lens/server/embeddable/make_lens_embeddable_factory.ts
+++ b/x-pack/plugins/lens/server/embeddable/make_lens_embeddable_factory.ts
@@ -52,6 +52,7 @@ import {
   XYVisState850,
 } from '../migrations/types';
 import { extract, inject } from '../../common/embeddable_factory';
+import { getSchema } from './schema';
 
 export const makeLensEmbeddableFactory =
   (
@@ -186,5 +187,6 @@ export const makeLensEmbeddableFactory =
         ),
       extract,
       inject,
+      getSchema,
     };
   };

--- a/x-pack/plugins/lens/server/embeddable/schema/index.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { getSchema } from './latest';

--- a/x-pack/plugins/lens/server/embeddable/schema/latest.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/latest.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './v1';

--- a/x-pack/plugins/lens/server/embeddable/schema/v1/common.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/v1/common.ts
@@ -178,8 +178,7 @@ export const sortingStateSchema = schema.object({
 });
 
 export const lensGenericAttributesSchema = schema.object({
-  type: schema.maybe(schema.string()),
-  visualizationType: schema.nullable(schema.string()),
+  visualizationType: schema.string(),
   title: schema.maybe(schema.string()),
   description: schema.maybe(schema.string()),
   state: lensGenericAttributesStateSchema,

--- a/x-pack/plugins/lens/server/embeddable/schema/v1/common.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/v1/common.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ObjectType, schema } from '@kbn/config-schema';
+import { KBN_FIELD_TYPES } from '@kbn/field-types';
+
+import { FilterStateStore } from '@kbn/es-query';
+import { formBasedLayerSchema } from './data_sources/form_based';
+
+const referenceSchema = schema.object(
+  {
+    name: schema.string(),
+    type: schema.string(),
+    id: schema.string(),
+  },
+  { unknowns: 'forbid' }
+);
+
+const lensGenericAttributesStateSchema = schema.object({
+  datasourceStates: schema.recordOf(schema.string(), schema.any()),
+  visualization: schema.any(),
+  query: schema.object({
+    query: schema.oneOf([
+      schema.string({
+        meta: {
+          description:
+            'A text-based query such as Kibana Query Language (KQL) or Lucene query language.',
+        },
+      }),
+      schema.recordOf(schema.string(), schema.any()),
+    ]),
+    language: schema.string({
+      meta: { description: 'The query language such as KQL or Lucene.' },
+    }),
+  }),
+  globalPalette: schema.maybe(
+    schema.object({
+      activePaletteId: schema.string(),
+      state: schema.maybe(schema.any()),
+    })
+  ),
+  filters: schema.arrayOf(
+    schema.object(
+      {
+        meta: schema.object(
+          {
+            alias: schema.maybe(schema.nullable(schema.string())),
+            disabled: schema.maybe(schema.boolean()),
+            negate: schema.maybe(schema.boolean()),
+            controlledBy: schema.maybe(schema.string()),
+            group: schema.maybe(schema.string()),
+            index: schema.maybe(schema.string()),
+            isMultiIndex: schema.maybe(schema.boolean()),
+            type: schema.maybe(schema.string()),
+            key: schema.maybe(schema.string()),
+            params: schema.maybe(schema.any()),
+            value: schema.maybe(schema.string()),
+            field: schema.maybe(schema.string()),
+          },
+          { unknowns: 'allow' }
+        ),
+        query: schema.maybe(schema.recordOf(schema.string(), schema.any())),
+        $state: schema.maybe(
+          schema.object({
+            store: schema.oneOf(
+              [
+                schema.literal(FilterStateStore.APP_STATE),
+                schema.literal(FilterStateStore.GLOBAL_STATE),
+              ],
+              {
+                meta: {
+                  description:
+                    "Denote whether a filter is specific to an application's context (e.g. 'appState') or whether it should be applied globally (e.g. 'globalState').",
+                },
+              }
+            ),
+          })
+        ),
+      },
+      { meta: { description: 'A filter for the search source.' } }
+    )
+  ),
+  adHocDataViews: schema.maybe(schema.recordOf(schema.string(), schema.any())),
+  internalReferences: schema.maybe(schema.arrayOf(referenceSchema)),
+});
+
+const metaType = (Object.keys(KBN_FIELD_TYPES) as Array<keyof typeof KBN_FIELD_TYPES>).map((key) =>
+  schema.literal(KBN_FIELD_TYPES[key])
+);
+
+const datatableColumnSchema = schema.object({
+  id: schema.string(),
+  name: schema.string(),
+  meta: schema.object({
+    type: schema.oneOf(metaType as [(typeof metaType)[number]]),
+    esType: schema.maybe(schema.string()),
+    field: schema.maybe(schema.string()),
+    index: schema.maybe(schema.string()),
+    dimensionName: schema.maybe(schema.string()),
+    params: schema.maybe(schema.any()),
+    source: schema.maybe(schema.string()),
+    sourceParams: schema.maybe(
+      schema.object({
+        id: schema.maybe(schema.string()),
+        params: schema.maybe(schema.recordOf(schema.string(), schema.any())),
+      })
+    ),
+  }),
+  isNull: schema.maybe(schema.boolean()),
+});
+
+const paletteSchema = schema.object({
+  type: schema.oneOf([schema.literal('palette'), schema.literal('system_palette')]),
+  name: schema.string(),
+  params: schema.maybe(schema.any()),
+});
+
+export const columnStateSchema = schema.object({
+  columnId: schema.string(),
+  width: schema.maybe(schema.number()),
+  hidden: schema.maybe(schema.boolean()),
+  oneClickFilter: schema.maybe(schema.boolean()),
+  isTransposed: schema.maybe(schema.boolean()),
+  transposable: schema.maybe(schema.boolean()),
+  originalColumnId: schema.maybe(schema.string()),
+  originalName: schema.maybe(schema.string()),
+  bucketValues: schema.maybe(
+    schema.arrayOf(
+      schema.object({
+        originalBucketColumn: datatableColumnSchema,
+        value: schema.any(),
+      })
+    )
+  ),
+  alignment: schema.maybe(
+    schema.oneOf([schema.literal('left'), schema.literal('right'), schema.literal('center')])
+  ),
+  palette: schema.maybe(paletteSchema),
+  colorMapping: schema.maybe(schema.any()),
+  colorMode: schema.maybe(
+    schema.oneOf([schema.literal('none'), schema.literal('cell'), schema.literal('text')])
+  ),
+  summaryRow: schema.maybe(
+    schema.oneOf([
+      schema.literal('none'),
+      schema.literal('sum'),
+      schema.literal('avg'),
+      schema.literal('count'),
+      schema.literal('min'),
+      schema.literal('max'),
+    ])
+  ),
+  summaryLabel: schema.maybe(schema.string()),
+  collapseFn: schema.maybe(
+    schema.oneOf([
+      schema.literal('sum'),
+      schema.literal('avg'),
+      schema.literal('min'),
+      schema.literal('max'),
+    ])
+  ),
+  isMetric: schema.maybe(schema.boolean()),
+});
+
+export const rowHeightModeSchema = schema.oneOf([
+  schema.literal('auto'),
+  schema.literal('single'),
+  schema.literal('custom'),
+]);
+
+export const sortingStateSchema = schema.object({
+  columnId: schema.maybe(schema.string()),
+  direction: schema.oneOf([schema.literal('asc'), schema.literal('desc'), schema.literal('none')]),
+});
+
+export const lensGenericAttributesSchema = schema.object({
+  type: schema.maybe(schema.string()),
+  visualizationType: schema.nullable(schema.string()),
+  title: schema.maybe(schema.string()),
+  description: schema.maybe(schema.string()),
+  state: lensGenericAttributesStateSchema,
+  references: schema.arrayOf(referenceSchema),
+});
+
+export const getLensAttributesSchema = (visType: string, visState: ObjectType) =>
+  lensGenericAttributesSchema.extends({
+    visualizationType: schema.literal(visType),
+    state: lensGenericAttributesStateSchema.extends({
+      datasourceStates: schema.object({
+        formBased: schema.maybe(
+          schema.object({
+            layers: schema.recordOf(schema.string(), formBasedLayerSchema),
+          })
+        ),
+        textBased: schema.maybe(
+          schema.object({
+            // TODO add schema for text based datasource to ./text_based.ts
+            layers: schema.recordOf(schema.string(), schema.any()),
+            initialContext: schema.maybe(schema.any()),
+          })
+        ),
+      }),
+      visualization: visState,
+    }),
+  });

--- a/x-pack/plugins/lens/server/embeddable/schema/v1/common.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/v1/common.ts
@@ -9,7 +9,7 @@ import { ObjectType, schema } from '@kbn/config-schema';
 import { KBN_FIELD_TYPES } from '@kbn/field-types';
 
 import { FilterStateStore } from '@kbn/es-query';
-import { formBasedLayerSchema } from './data_sources/form_based';
+import { formBasedLayerSchema } from './data_sources';
 
 const referenceSchema = schema.object(
   {
@@ -178,16 +178,17 @@ export const sortingStateSchema = schema.object({
 });
 
 export const lensGenericAttributesSchema = schema.object({
-  visualizationType: schema.string(),
   title: schema.maybe(schema.string()),
+  type: schema.maybe(schema.string()),
   description: schema.maybe(schema.string()),
-  state: lensGenericAttributesStateSchema,
   references: schema.arrayOf(referenceSchema),
 });
 
 export const getLensAttributesSchema = (visType: string, visState: ObjectType) =>
   lensGenericAttributesSchema.extends({
-    visualizationType: schema.literal(visType),
+    visualizationType: schema.oneOf([schema.literal(visType)], {
+      meta: { description: 'The type of visualization.' },
+    }),
     state: lensGenericAttributesStateSchema.extends({
       datasourceStates: schema.object({
         formBased: schema.maybe(

--- a/x-pack/plugins/lens/server/embeddable/schema/v1/data_sources/form_based.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/v1/data_sources/form_based.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+const fieldOnlyDataTypeSchema = schema.oneOf([
+  schema.literal('document'),
+  schema.literal('ip'),
+  schema.literal('histogram'),
+  schema.literal('geo_point'),
+  schema.literal('geo_shape'),
+  schema.literal('counter'),
+  schema.literal('gauge'),
+  schema.literal('murmur3'),
+]);
+
+const dataTypeSchema = schema.oneOf([
+  schema.literal('string'),
+  schema.literal('number'),
+  schema.literal('date'),
+  schema.literal('boolean'),
+  fieldOnlyDataTypeSchema,
+]);
+
+const operationMetadataSchema = schema.object({
+  interval: schema.maybe(schema.string()),
+  dataType: dataTypeSchema,
+  isBucketed: schema.boolean(),
+  scale: schema.maybe(
+    schema.oneOf([schema.literal('ordinal'), schema.literal('interval'), schema.literal('ratio')])
+  ),
+  isStaticValue: schema.maybe(schema.boolean()),
+});
+
+const operationSchema = operationMetadataSchema.extends({
+  label: schema.maybe(schema.string()),
+  sortingHint: schema.maybe(schema.string()),
+});
+
+const baseIndexPatternColumnSchema = operationSchema.extends({
+  operationType: schema.string(),
+  customLabel: schema.maybe(schema.string()),
+  timeScale: schema.maybe(schema.any()),
+  filter: schema.maybe(schema.any()),
+  reducedTimeRange: schema.maybe(schema.string()),
+  timeShift: schema.maybe(schema.string()),
+});
+
+const valueFormatConfigSchema = schema.object({
+  id: schema.string(),
+  params: schema.maybe(
+    schema.object({
+      decimals: schema.number(),
+      suffix: schema.maybe(schema.string()),
+      compact: schema.maybe(schema.boolean()),
+      pattern: schema.maybe(schema.string()),
+      fromUnit: schema.maybe(schema.string()),
+      toUnit: schema.maybe(schema.string()),
+    })
+  ),
+});
+
+const fieldBasedIndexPatternColumnSchema = baseIndexPatternColumnSchema.extends({
+  sourceField: schema.string(),
+});
+
+const formattedIndexPatternColumnSchema = baseIndexPatternColumnSchema.extends({
+  params: schema.maybe(
+    schema.object({
+      format: schema.maybe(valueFormatConfigSchema),
+    })
+  ),
+});
+
+const termsIndexPatternColumnSchema = fieldBasedIndexPatternColumnSchema.extends({
+  operationType: schema.literal('terms'),
+  params: schema.object({
+    size: schema.number(),
+    accuracyMode: schema.maybe(schema.boolean()),
+    include: schema.maybe(schema.arrayOf(schema.oneOf([schema.string(), schema.number()]))),
+    exclude: schema.maybe(schema.arrayOf(schema.oneOf([schema.string(), schema.number()]))),
+    includeIsRegex: schema.maybe(schema.boolean()),
+    excludeIsRegex: schema.maybe(schema.boolean()),
+    orderBy: schema.oneOf([
+      schema.object({
+        type: schema.literal('alphabetical'),
+        fallback: schema.maybe(schema.boolean()),
+      }),
+      schema.object({
+        type: schema.literal('rare'),
+        maxDocCount: schema.number(),
+      }),
+      schema.literal('significant'),
+      schema.object({
+        type: schema.literal('column'),
+        columnId: schema.string(),
+      }),
+      schema.literal('custom'),
+    ]),
+    orderAgg: schema.maybe(fieldBasedIndexPatternColumnSchema),
+    orderDirection: schema.maybe(schema.oneOf([schema.literal('asc'), schema.literal('desc')])),
+    otherBucket: schema.maybe(schema.boolean()),
+    missingBucket: schema.maybe(schema.boolean()),
+    secondaryFields: schema.maybe(schema.arrayOf(schema.string())),
+    format: schema.maybe(valueFormatConfigSchema),
+    parentFormat: schema.maybe(schema.object({ id: schema.string() })),
+  }),
+});
+
+const referenceBasedIndexPatternColumnSchema = formattedIndexPatternColumnSchema.extends({
+  references: schema.arrayOf(schema.string()),
+});
+
+const genericIndexPatternColumnSchema = schema.oneOf([
+  baseIndexPatternColumnSchema,
+  fieldBasedIndexPatternColumnSchema,
+  referenceBasedIndexPatternColumnSchema,
+]);
+
+const incompleteColumnSchema = schema.object({
+  operationType: schema.maybe(schema.string()),
+  sourceField: schema.maybe(schema.string()),
+});
+
+export const formBasedLayerSchema = schema.object({
+  columnOrder: schema.arrayOf(schema.string()),
+  columns: schema.recordOf(
+    schema.string(),
+    schema.oneOf([termsIndexPatternColumnSchema, genericIndexPatternColumnSchema])
+  ),
+  // TODO indexPatternId should be required, but we make it optional since it might be
+  // specified in the state.references array via the HTTP endpoint.
+  indexPatternId: schema.maybe(schema.string()),
+  linkToLayers: schema.maybe(schema.arrayOf(schema.string())),
+  incompleteColumns: schema.maybe(
+    schema.recordOf(schema.string(), schema.maybe(incompleteColumnSchema))
+  ),
+  sampling: schema.maybe(schema.number()),
+  ignoreGlobalFilters: schema.maybe(schema.boolean()),
+});

--- a/x-pack/plugins/lens/server/embeddable/schema/v1/data_sources/form_based.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/v1/data_sources/form_based.ts
@@ -68,6 +68,32 @@ const fieldBasedIndexPatternColumnSchema = baseIndexPatternColumnSchema.extends(
   sourceField: schema.string(),
 });
 
+const countIndexPatternColumnSchema = fieldBasedIndexPatternColumnSchema.extends({
+  operationType: schema.literal('count'),
+  params: schema.object({
+    emptyAsNull: schema.maybe(schema.boolean()),
+    format: schema.maybe(valueFormatConfigSchema),
+  }),
+});
+
+const getMetricColumnSchema = (operationType: string) =>
+  fieldBasedIndexPatternColumnSchema.extends({
+    operationType: schema.literal(operationType),
+    params: schema.maybe(
+      schema.object({
+        emptyAsNull: schema.maybe(schema.boolean()),
+        format: schema.maybe(valueFormatConfigSchema),
+      })
+    ),
+  });
+
+const sumIndexPatternColumnSchema = getMetricColumnSchema('sum');
+const avgIndexPatternColumnSchema = getMetricColumnSchema('average');
+const minIndexPatternColumnSchema = getMetricColumnSchema('min');
+const maxIndexPatternColumnSchema = getMetricColumnSchema('max');
+const medianIndexPatternColumnSchema = getMetricColumnSchema('median');
+const standardDeviationIndexPatternColumnSchema = getMetricColumnSchema('standard_deviation');
+
 const formattedIndexPatternColumnSchema = baseIndexPatternColumnSchema.extends({
   params: schema.maybe(
     schema.object({
@@ -130,7 +156,17 @@ export const formBasedLayerSchema = schema.object({
   columnOrder: schema.arrayOf(schema.string()),
   columns: schema.recordOf(
     schema.string(),
-    schema.oneOf([termsIndexPatternColumnSchema, genericIndexPatternColumnSchema])
+    schema.oneOf([
+      termsIndexPatternColumnSchema,
+      countIndexPatternColumnSchema,
+      sumIndexPatternColumnSchema,
+      avgIndexPatternColumnSchema,
+      minIndexPatternColumnSchema,
+      maxIndexPatternColumnSchema,
+      medianIndexPatternColumnSchema,
+      standardDeviationIndexPatternColumnSchema,
+      genericIndexPatternColumnSchema,
+    ])
   ),
   // TODO indexPatternId should be required, but we make it optional since it might be
   // specified in the state.references array via the HTTP endpoint.

--- a/x-pack/plugins/lens/server/embeddable/schema/v1/data_sources/index.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/v1/data_sources/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { formBasedLayerSchema } from './form_based';
+export { indexPatternSchema } from './index_pattern';

--- a/x-pack/plugins/lens/server/embeddable/schema/v1/data_sources/index_pattern.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/v1/data_sources/index_pattern.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { formBasedLayerSchema } from './form_based';
+
+export const indexPatternSchema = formBasedLayerSchema.extends({
+  indexPatternId: undefined,
+});

--- a/x-pack/plugins/lens/server/embeddable/schema/v1/data_sources/text_based.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/v1/data_sources/text_based.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// TODO

--- a/x-pack/plugins/lens/server/embeddable/schema/v1/index.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/v1/index.ts
@@ -13,6 +13,6 @@ export const getSchema = () =>
   schema.object({
     attributes: schema.oneOf([
       getLensAttributesSchema('lnsDatatable', datatableVisualizationStateSchema),
-      lensGenericAttributesSchema,
+      // lensGenericAttributesSchema,
     ]),
   });

--- a/x-pack/plugins/lens/server/embeddable/schema/v1/index.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/v1/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { datatableVisualizationStateSchema } from './visualization_state/data_table';
+import { getLensAttributesSchema, lensGenericAttributesSchema } from './common';
+
+export const getSchema = () =>
+  schema.object({
+    attributes: schema.oneOf([
+      getLensAttributesSchema('lnsDatatable', datatableVisualizationStateSchema),
+      lensGenericAttributesSchema,
+    ]),
+  });

--- a/x-pack/plugins/lens/server/embeddable/schema/v1/visualization_state/data_table.ts
+++ b/x-pack/plugins/lens/server/embeddable/schema/v1/visualization_state/data_table.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Type, schema } from '@kbn/config-schema';
+import { columnStateSchema, rowHeightModeSchema, sortingStateSchema } from '../common';
+import { LayerType } from '../../../../../common/types';
+import { layerTypes } from '../../../../../common/layer_types';
+
+const pagingStateSchema = schema.object({
+  size: schema.number(),
+  enabled: schema.boolean(),
+});
+
+export const datatableVisualizationStateSchema = schema.object({
+  columns: schema.arrayOf(columnStateSchema),
+  layerId: schema.string(),
+  layerType: schema.oneOf(
+    Object.values(layerTypes).map((value) => schema.literal(value)) as [Type<LayerType>]
+  ),
+  sorting: schema.maybe(sortingStateSchema),
+  rowHeight: schema.maybe(rowHeightModeSchema),
+  headerRowHeight: schema.maybe(rowHeightModeSchema),
+  rowHeightLines: schema.maybe(schema.number()),
+  headerRowHeightLines: schema.maybe(schema.number()),
+  paging: schema.maybe(pagingStateSchema),
+});


### PR DESCRIPTION
This is a WIP example for allowing embeddables to register a panel config schema that allows the Dashboard to validate panel content via the public HTTP or internal RPC CRUD endpoints.


Initially, this adds validation for Lens data table charts. An example of a chart that gets validated against the schema is below. Other Lens charts will be validated against a generic schema. Embeddables that do not register a schema are not validated.

```
curl --request POST \
  --url http://localhost:5601/api/dashboards/dashboard \
  --header 'accept: application/json' \
  --header 'authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \
  --header 'elastic-api-version: 2023-10-31' \
  --header 'kbn-xsrf: true' \
  --data '{"attributes": {"title": "a table lens panel","panels": [{"type": "lens","gridData": {"x": 0,"y": 0,"w": 24,"h": 15},"panelIndex": "666ba2ac-babb-4226-ad8b-9e30fec7dd74","panelConfig": {"attributes": {"visualizationType": "lnsDatatable","title": "my data table","state": {"datasourceStates": {"formBased": {"layers": {"53c6e98c-6267-4d97-876b-29f5df00e39b": {"columns": {"963714a8-b8a2-4e7d-889e-3851c74a0212": {"dataType": "string","isBucketed": true,"operationType": "terms","sourceField": "machine.os.keyword","params": {"size": 5,"orderBy": {"type": "alphabetical"}}},"627d787d-f907-46d2-861f-7752cd1001b9": {"dataType": "number","isBucketed": false,"label": "Count of records","operationType": "count","sourceField": "___records___"}},"columnOrder": ["963714a8-b8a2-4e7d-889e-3851c74a0212","627d787d-f907-46d2-861f-7752cd1001b9"]}}}},"visualization": {"layerId": "53c6e98c-6267-4d97-876b-29f5df00e39b","layerType": "data","columns": [{"columnId": "627d787d-f907-46d2-861f-7752cd1001b9"},{"columnId": "963714a8-b8a2-4e7d-889e-3851c74a0212"}]},"query": {"query": "","language": "kuery"},"filters": []},"references": [{"type": "index-pattern","id": "90943e30-9a47-11e8-b64d-95841ca0b247","name": "indexpattern-datasource-layer-53c6e98c-6267-4d97-876b-29f5df00e39b"}]}}}]},"references": [{"type": "index-pattern","id": "90943e30-9a47-11e8-b64d-95841ca0b247","name": "666ba2ac-babb-4226-ad8b-9e30fec7dd74:indexpattern-datasource-layer-53c6e98c-6267-4d97-876b-29f5df00e39b"}]}'
```


## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



