### PR TITLE
Stabilize inference endpoint svl search tests for MKI

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/search/inference_management.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/inference_management.ts
@@ -16,6 +16,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     'svlCommonPage',
     'embeddedConsole',
     'svlSearchInferenceManagementPage',
+    'header',
   ]);
   const svlSearchNavigation = getService('svlSearchNavigation');
   const browser = getService('browser');
@@ -66,6 +67,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       beforeEach(async () => {
         await ml.api.createInferenceEndpoint(endpoint, taskType, modelConfig);
         await browser.refresh();
+        await pageObjects.header.waitUntilLoadingHasFinished();
       });
 
       after(async () => {


### PR DESCRIPTION
## Summary

This PR stabilizes the inference endpoint serverless earch UI tests for MKI runs by waiting for loading to finish after refreshing the page.


<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->