### PR TITLE
Skip Serverless Transaction groups alerts when data is loaded with avg transaction duration alerts returns the correct number of alert counts

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/transactions_groups_alerts.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/transactions_groups_alerts.spec.ts
@@ -73,7 +73,10 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     return response.body as TransactionsGroupsMainStatistics;
   }
 
-  describe('Transaction groups alerts', () => {
+  describe('Transaction groups alerts', function () {
+    // fails on MKI, see https://github.com/elastic/kibana/issues/201531
+    this.tags(['failsOnMKI']);
+
     describe('when data is loaded', () => {
       const transactions = [
         {
@@ -208,9 +211,6 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         });
 
         it('returns the correct number of alert counts', async () => {
-          // fails on MKI, see https://github.com/elastic/kibana/issues/201531
-          // @ts-expect-error
-          this.tags(['failsOnMKI']);
           const txGroupsTypeRequest = await getTransactionGroups({
             query: { transactionType: 'request' },
           });

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/transactions_groups_alerts.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/transactions_groups_alerts.spec.ts
@@ -208,6 +208,9 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         });
 
         it('returns the correct number of alert counts', async () => {
+          // fails on MKI, see https://github.com/elastic/kibana/issues/201531
+          // @ts-expect-error
+          this.tags(['failsOnMKI']);
           const txGroupsTypeRequest = await getTransactionGroups({
             query: { transactionType: 'request' },
           });


### PR DESCRIPTION
## Summary
Related to https://github.com/elastic/kibana/issues/201531

This PR skips `Transaction groups alerts when data is loaded with avg transaction duration alerts returns the correct number of alert counts`, which is inside `x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/transactions/transactions_groups_alerts.spec.ts` file, as it's failing on MKI.

A proper fix will be implemented soon in the issue.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->