### PR TITLE
[8.15] Unskips api key functional tests in MKI (#196572)

### DIFF
--- a/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_table.tsx
+++ b/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_table.tsx
@@ -230,7 +230,7 @@ export const ApiKeysTable: FunctionComponent<ApiKeysTableProps> = ({
           color: 'danger',
           onClick: (item) => onDelete([item]),
           available: deletable,
-          'data-test-subj': 'apiKeysTableDeleteAction',
+          'data-test-subj': (item) => `apiKeysTableDeleteAction-${item.name}`,
         },
       ],
     });

--- a/x-pack/test/functional/page_objects/api_keys_page.ts
+++ b/x-pack/test/functional/page_objects/api_keys_page.ts
@@ -78,15 +78,25 @@ export function ApiKeysPageProvider({ getService }: FtrProviderContext) {
       return euiCallOutHeader.getVisibleText();
     },
 
+    async isPromptPage() {
+      return await testSubjects.exists('apiKeysCreatePromptButton');
+    },
+
     async getApiKeysFirstPromptTitle() {
       const titlePromptElem = await find.byCssSelector('.euiEmptyPrompt .euiTitle');
       return await titlePromptElem.getVisibleText();
     },
 
+    async deleteApiKeyByName(apiKeyName: string) {
+      await testSubjects.click(`apiKeysTableDeleteAction-${apiKeyName}`);
+      await testSubjects.click('confirmModalConfirmButton');
+      await testSubjects.waitForDeleted(`apiKeyRowName-${apiKeyName}`);
+    },
+
     async deleteAllApiKeyOneByOne() {
-      const hasApiKeysToDelete = await testSubjects.exists('apiKeysTableDeleteAction');
+      const hasApiKeysToDelete = await testSubjects.exists('*apiKeysTableDeleteAction');
       if (hasApiKeysToDelete) {
-        const apiKeysToDelete = await testSubjects.findAll('apiKeysTableDeleteAction');
+        const apiKeysToDelete = await testSubjects.findAll('*apiKeysTableDeleteAction');
         for (const element of apiKeysToDelete) {
           await element.click();
           await testSubjects.click('confirmModalConfirmButton');
@@ -111,6 +121,10 @@ export function ApiKeysPageProvider({ getService }: FtrProviderContext) {
 
     async ensureApiKeyExists(apiKeyName: string) {
       await testSubjects.existOrFail(`apiKeyRowName-${apiKeyName}`);
+    },
+
+    async doesApiKeyExist(apiKeyName: string) {
+      return await testSubjects.exists(`apiKeyRowName-${apiKeyName}`);
     },
 
     async getMetadataSwitch() {

--- a/x-pack/test_serverless/functional/test_suites/common/platform_security/api_keys.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/platform_security/api_keys.ts
@@ -6,10 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import { Client } from '@elastic/elasticsearch';
-import { ToolingLog } from '@kbn/tooling-log';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
+<<<<<<< HEAD
 async function clearAllApiKeys(esClient: Client, logger: ToolingLog) {
   const existingKeys = await esClient.security.queryApiKeys();
   if (existingKeys.count > 0) {
@@ -23,21 +22,15 @@ async function clearAllApiKeys(esClient: Client, logger: ToolingLog) {
   }
 }
 
+=======
+>>>>>>> 492a9a4643b (Unskips api key functional tests in MKI (#196572))
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const pageObjects = getPageObjects(['common', 'svlCommonPage', 'apiKeys']);
   const browser = getService('browser');
-  const es = getService('es');
-  const log = getService('log');
 
   describe('API keys', function () {
-    // TimeoutError: Waiting for element to be located By(css selector, [data-test-subj="apiKeysCreatePromptButton"]) Wait timed out after 10028ms
-    this.tags(['failsOnMKI']);
     before(async () => {
       await pageObjects.svlCommonPage.loginAsAdmin();
-    });
-
-    after(async () => {
-      await clearAllApiKeys(es, log);
     });
 
     it('should create and delete API keys correctly', async () => {
@@ -45,8 +38,15 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         shouldUseHashForSubUrl: false,
       });
 
-      const apiKeyName = 'Happy API Key';
-      await pageObjects.apiKeys.clickOnPromptCreateApiKey();
+      // name needs to be unique because we will confirm deletion by name
+      const apiKeyName = `API Key ${Date.now()}`;
+
+      // If there are any existing API keys (e.g. will occur on projects created with QAF),
+      // the table will be displayed. Otherwise, the empty prompt is displayed.
+      const isPromptPage = await pageObjects.apiKeys.isPromptPage();
+      if (isPromptPage) await pageObjects.apiKeys.clickOnPromptCreateApiKey();
+      else await pageObjects.apiKeys.clickOnTableCreateApiKey();
+
       expect(await browser.getCurrentUrl()).to.contain('app/management/security/api_keys/create');
       expect(await pageObjects.apiKeys.getFlyoutTitleText()).to.be('Create API key');
 
@@ -61,7 +61,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       expect(await pageObjects.apiKeys.isApiKeyModalExists()).to.be(false);
       expect(newApiKeyCreation).to.be(`Created API key '${apiKeyName}'`);
 
-      await pageObjects.apiKeys.deleteAllApiKeyOneByOne();
+      await pageObjects.apiKeys.ensureApiKeyExists(apiKeyName);
+      await pageObjects.apiKeys.deleteApiKeyByName(apiKeyName);
+      expect(await pageObjects.apiKeys.doesApiKeyExist(apiKeyName)).to.be(false);
     });
   });
 };

--- a/x-pack/test_serverless/functional/test_suites/common/platform_security/api_keys.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/platform_security/api_keys.ts
@@ -8,19 +8,6 @@
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
-async function clearAllApiKeys(esClient: Client, logger: ToolingLog) {
-  const existingKeys = await esClient.security.queryApiKeys();
-  if (existingKeys.count > 0) {
-    await Promise.all(
-      existingKeys.api_keys.map(async (key) => {
-        esClient.security.invalidateApiKey({ ids: [key.id] });
-      })
-    );
-  } else {
-    logger.debug('No API keys to delete.');
-  }
-}
-
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const pageObjects = getPageObjects(['common', 'svlCommonPage', 'apiKeys']);
   const browser = getService('browser');

--- a/x-pack/test_serverless/functional/test_suites/common/platform_security/api_keys.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/platform_security/api_keys.ts
@@ -8,7 +8,6 @@
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
-<<<<<<< HEAD
 async function clearAllApiKeys(esClient: Client, logger: ToolingLog) {
   const existingKeys = await esClient.security.queryApiKeys();
   if (existingKeys.count > 0) {
@@ -22,8 +21,6 @@ async function clearAllApiKeys(esClient: Client, logger: ToolingLog) {
   }
 }
 
-=======
->>>>>>> 492a9a4643b (Unskips api key functional tests in MKI (#196572))
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const pageObjects = getPageObjects(['common', 'svlCommonPage', 'apiKeys']);
   const browser = getService('browser');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [Unskips api key functional tests in MKI (#196572)](https://github.com/elastic/kibana/pull/196572)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2024-10-21T12:33:34Z","message":"Unskips api key functional tests in MKI (#196572)\n\nCloses #186619\r\n\r\n## Summary\r\n\r\nTested against a new QA project, the platform security api key\r\nfunctional test now passes as expected.\r\n\r\nUpdate: the serverless functional UI API key test has also been modified\r\nto account for a non-empty start state, and to be non-destructive. If\r\nany API keys exist prior to running this test, they will not interfere\r\nwith the test and they will remain after the test completes.\r\n\r\nFlaky test runners:\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\r\n- Security re-run\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195","sha":"492a9a4643b37d2bf393a3d549c50dcfba16907f","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","v9.0.0","backport:prev-major","v8.17.0","v8.18.0","v8.16.2"],"number":196572,"url":"https://github.com/elastic/kibana/pull/196572","mergeCommit":{"message":"Unskips api key functional tests in MKI (#196572)\n\nCloses #186619\r\n\r\n## Summary\r\n\r\nTested against a new QA project, the platform security api key\r\nfunctional test now passes as expected.\r\n\r\nUpdate: the serverless functional UI API key test has also been modified\r\nto account for a non-empty start state, and to be non-destructive. If\r\nany API keys exist prior to running this test, they will not interfere\r\nwith the test and they will remain after the test completes.\r\n\r\nFlaky test runners:\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\r\n- Security re-run\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195","sha":"492a9a4643b37d2bf393a3d549c50dcfba16907f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/196572","number":196572,"mergeCommit":{"message":"Unskips api key functional tests in MKI (#196572)\n\nCloses #186619\r\n\r\n## Summary\r\n\r\nTested against a new QA project, the platform security api key\r\nfunctional test now passes as expected.\r\n\r\nUpdate: the serverless functional UI API key test has also been modified\r\nto account for a non-empty start state, and to be non-destructive. If\r\nany API keys exist prior to running this test, they will not interfere\r\nwith the test and they will remain after the test completes.\r\n\r\nFlaky test runners:\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\r\n- Security re-run\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195","sha":"492a9a4643b37d2bf393a3d549c50dcfba16907f"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201395","number":201395,"state":"MERGED","mergeCommit":{"sha":"ec39ce4966c14468b7684719324881e419791aa9","message":"[8.x] Unskips api key functional tests in MKI (#196572) (#201395)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [Unskips api key functional tests in MKI\n(#196572)](https://github.com/elastic/kibana/pull/196572)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jeramy\nSoucy\",\"email\":\"jeramy.soucy@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-10-21T12:33:34Z\",\"message\":\"Unskips\napi key functional tests in MKI (#196572)\\n\\nCloses #186619\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nTested against a new QA project, the platform security\napi key\\r\\nfunctional test now passes as expected.\\r\\n\\r\\nUpdate: the\nserverless functional UI API key test has also been modified\\r\\nto\naccount for a non-empty start state, and to be non-destructive.\nIf\\r\\nany API keys exist prior to running this test, they will not\ninterfere\\r\\nwith the test and they will remain after the test\ncompletes.\\r\\n\\r\\nFlaky test\nrunners:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\\r\\n-\nSecurity\nre-run\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195\",\"sha\":\"492a9a4643b37d2bf393a3d549c50dcfba16907f\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Team:Security\",\"release_note:skip\",\"v9.0.0\",\"backport:prev-major\"],\"title\":\"Unskips\napi key functional tests in\nMKI\",\"number\":196572,\"url\":\"https://github.com/elastic/kibana/pull/196572\",\"mergeCommit\":{\"message\":\"Unskips\napi key functional tests in MKI (#196572)\\n\\nCloses #186619\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nTested against a new QA project, the platform security\napi key\\r\\nfunctional test now passes as expected.\\r\\n\\r\\nUpdate: the\nserverless functional UI API key test has also been modified\\r\\nto\naccount for a non-empty start state, and to be non-destructive.\nIf\\r\\nany API keys exist prior to running this test, they will not\ninterfere\\r\\nwith the test and they will remain after the test\ncompletes.\\r\\n\\r\\nFlaky test\nrunners:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\\r\\n-\nSecurity\nre-run\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195\",\"sha\":\"492a9a4643b37d2bf393a3d549c50dcfba16907f\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/196572\",\"number\":196572,\"mergeCommit\":{\"message\":\"Unskips\napi key functional tests in MKI (#196572)\\n\\nCloses #186619\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nTested against a new QA project, the platform security\napi key\\r\\nfunctional test now passes as expected.\\r\\n\\r\\nUpdate: the\nserverless functional UI API key test has also been modified\\r\\nto\naccount for a non-empty start state, and to be non-destructive.\nIf\\r\\nany API keys exist prior to running this test, they will not\ninterfere\\r\\nwith the test and they will remain after the test\ncompletes.\\r\\n\\r\\nFlaky test\nrunners:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\\r\\n-\nSecurity\nre-run\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195\",\"sha\":\"492a9a4643b37d2bf393a3d549c50dcfba16907f\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.16","label":"v8.16.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201393","number":201393,"state":"MERGED","mergeCommit":{"sha":"b938b43a5fdc2d091c02a4c54ad0485cb119c680","message":"[8.16] Unskips api key functional tests in MKI (#196572) (#201393)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.16`:\n- [Unskips api key functional tests in MKI\n(#196572)](https://github.com/elastic/kibana/pull/196572)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jeramy\nSoucy\",\"email\":\"jeramy.soucy@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-10-21T12:33:34Z\",\"message\":\"Unskips\napi key functional tests in MKI (#196572)\\n\\nCloses #186619\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nTested against a new QA project, the platform security\napi key\\r\\nfunctional test now passes as expected.\\r\\n\\r\\nUpdate: the\nserverless functional UI API key test has also been modified\\r\\nto\naccount for a non-empty start state, and to be non-destructive.\nIf\\r\\nany API keys exist prior to running this test, they will not\ninterfere\\r\\nwith the test and they will remain after the test\ncompletes.\\r\\n\\r\\nFlaky test\nrunners:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\\r\\n-\nSecurity\nre-run\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195\",\"sha\":\"492a9a4643b37d2bf393a3d549c50dcfba16907f\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Team:Security\",\"release_note:skip\",\"v9.0.0\",\"backport:prev-major\"],\"title\":\"Unskips\napi key functional tests in\nMKI\",\"number\":196572,\"url\":\"https://github.com/elastic/kibana/pull/196572\",\"mergeCommit\":{\"message\":\"Unskips\napi key functional tests in MKI (#196572)\\n\\nCloses #186619\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nTested against a new QA project, the platform security\napi key\\r\\nfunctional test now passes as expected.\\r\\n\\r\\nUpdate: the\nserverless functional UI API key test has also been modified\\r\\nto\naccount for a non-empty start state, and to be non-destructive.\nIf\\r\\nany API keys exist prior to running this test, they will not\ninterfere\\r\\nwith the test and they will remain after the test\ncompletes.\\r\\n\\r\\nFlaky test\nrunners:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\\r\\n-\nSecurity\nre-run\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195\",\"sha\":\"492a9a4643b37d2bf393a3d549c50dcfba16907f\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/196572\",\"number\":196572,\"mergeCommit\":{\"message\":\"Unskips\napi key functional tests in MKI (#196572)\\n\\nCloses #186619\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nTested against a new QA project, the platform security\napi key\\r\\nfunctional test now passes as expected.\\r\\n\\r\\nUpdate: the\nserverless functional UI API key test has also been modified\\r\\nto\naccount for a non-empty start state, and to be non-destructive.\nIf\\r\\nany API keys exist prior to running this test, they will not\ninterfere\\r\\nwith the test and they will remain after the test\ncompletes.\\r\\n\\r\\nFlaky test\nrunners:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\\r\\n-\nSecurity\nre-run\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195\",\"sha\":\"492a9a4643b37d2bf393a3d549c50dcfba16907f\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>"}},{"url":"https://github.com/elastic/kibana/pull/201394","number":201394,"branch":"8.17","state":"MERGED","mergeCommit":{"sha":"3e09ffc239215999f28bed0d3f7a7cebf4a92657","message":"[8.17] Unskips api key functional tests in MKI (#196572) (#201394)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.17`:\n- [Unskips api key functional tests in MKI\n(#196572)](https://github.com/elastic/kibana/pull/196572)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jeramy\nSoucy\",\"email\":\"jeramy.soucy@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-10-21T12:33:34Z\",\"message\":\"Unskips\napi key functional tests in MKI (#196572)\\n\\nCloses #186619\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nTested against a new QA project, the platform security\napi key\\r\\nfunctional test now passes as expected.\\r\\n\\r\\nUpdate: the\nserverless functional UI API key test has also been modified\\r\\nto\naccount for a non-empty start state, and to be non-destructive.\nIf\\r\\nany API keys exist prior to running this test, they will not\ninterfere\\r\\nwith the test and they will remain after the test\ncompletes.\\r\\n\\r\\nFlaky test\nrunners:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\\r\\n-\nSecurity\nre-run\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195\",\"sha\":\"492a9a4643b37d2bf393a3d549c50dcfba16907f\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Team:Security\",\"release_note:skip\",\"v9.0.0\",\"backport:prev-major\"],\"title\":\"Unskips\napi key functional tests in\nMKI\",\"number\":196572,\"url\":\"https://github.com/elastic/kibana/pull/196572\",\"mergeCommit\":{\"message\":\"Unskips\napi key functional tests in MKI (#196572)\\n\\nCloses #186619\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nTested against a new QA project, the platform security\napi key\\r\\nfunctional test now passes as expected.\\r\\n\\r\\nUpdate: the\nserverless functional UI API key test has also been modified\\r\\nto\naccount for a non-empty start state, and to be non-destructive.\nIf\\r\\nany API keys exist prior to running this test, they will not\ninterfere\\r\\nwith the test and they will remain after the test\ncompletes.\\r\\n\\r\\nFlaky test\nrunners:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\\r\\n-\nSecurity\nre-run\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195\",\"sha\":\"492a9a4643b37d2bf393a3d549c50dcfba16907f\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/196572\",\"number\":196572,\"mergeCommit\":{\"message\":\"Unskips\napi key functional tests in MKI (#196572)\\n\\nCloses #186619\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nTested against a new QA project, the platform security\napi key\\r\\nfunctional test now passes as expected.\\r\\n\\r\\nUpdate: the\nserverless functional UI API key test has also been modified\\r\\nto\naccount for a non-empty start state, and to be non-destructive.\nIf\\r\\nany API keys exist prior to running this test, they will not\ninterfere\\r\\nwith the test and they will remain after the test\ncompletes.\\r\\n\\r\\nFlaky test\nrunners:\\r\\n-\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7184\\r\\n-\nSecurity\nre-run\\r\\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7195\",\"sha\":\"492a9a4643b37d2bf393a3d549c50dcfba16907f\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>"}}]}] BACKPORT-->