### PR TITLE
[Automatic Import] remove duplicate preserve flag from http_endpoint

### DIFF
--- a/x-pack/plugins/integration_assistant/server/templates/manifest/http_endpoint_manifest.yml.njk
+++ b/x-pack/plugins/integration_assistant/server/templates/manifest/http_endpoint_manifest.yml.njk
@@ -42,12 +42,6 @@
         The Ingest Node pipeline ID to be used by the integration.
       required: false
       show_user: true
-    - name: preserve_original_event
-      type: bool
-      title: Preserve Original Event
-      description: This option copies the raw unmodified body of the incoming request to the event.original field as a string before sending the event to Elasticsearch.
-      required: false
-      show_user: true
     - name: prefix
       type: text
       title: Prefix


### PR DESCRIPTION
## Release Notes

Removes an erroneous duplicate `Preserve Original Event` flag as we additionally add one from the common settings file.

## Summary

Removes an erroneous duplicate `Preserve Original Event` flag as we additionally add one from the common settings file.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->