### PR TITLE
Improve retry logic in licensing with exponential backoff

### DIFF
--- a/x-pack/plugins/licensing/common/license_update.test.ts
+++ b/x-pack/plugins/licensing/common/license_update.test.ts
@@ -221,7 +221,7 @@ describe('licensing update', () => {
       expect(fetcher).toHaveBeenCalledTimes(expectedCallCount);
     };
 
-    it('fetcher has no calls innitially', async () => {
+    it('fetcher has no calls initially, async () => {
       expect(fetcher).not.toHaveBeenCalled();
     });
 

--- a/x-pack/plugins/licensing/common/license_update.test.ts
+++ b/x-pack/plugins/licensing/common/license_update.test.ts
@@ -42,7 +42,13 @@ describe('licensing update', () => {
     const trigger$ = new Subject<void>();
 
     const fetcher = jest.fn().mockResolvedValue(fetchedLicense);
-    const { license$ } = createLicenseUpdate(trigger$, stop$, fetcher, maxRetryDelay, initialLicense);
+    const { license$ } = createLicenseUpdate(
+      trigger$,
+      stop$,
+      fetcher,
+      maxRetryDelay,
+      initialLicense
+    );
     trigger$.next();
     const [first, second] = await firstValueFrom(license$.pipe(take(2), toArray()));
 
@@ -68,7 +74,7 @@ describe('licensing update', () => {
     expect(first.type).toBe('basic');
 
     trigger$.next();
-   
+
     await Promise.resolve();
     trigger$.next();
 
@@ -85,9 +91,9 @@ describe('licensing update', () => {
 
     const { license$ } = createLicenseUpdate(trigger$, stop$, fetcher, maxRetryDelay);
 
-    license$.subscribe(() => { });
-    license$.subscribe(() => { });
-    license$.subscribe(() => { });
+    license$.subscribe(() => {});
+    license$.subscribe(() => {});
+    license$.subscribe(() => {});
     trigger$.next();
 
     expect(fetcher).toHaveBeenCalledTimes(1);
@@ -161,7 +167,12 @@ describe('licensing update', () => {
         return secondLicense;
       });
 
-    const { license$, refreshManually } = createLicenseUpdate(trigger$, stop$, fetcher, maxRetryDelay);
+    const { license$, refreshManually } = createLicenseUpdate(
+      trigger$,
+      stop$,
+      fetcher,
+      maxRetryDelay
+    );
     let fromObservable;
     license$.subscribe((license) => (fromObservable = license));
 
@@ -191,7 +202,9 @@ describe('licensing update', () => {
       license = licenseMock.createLicense({ license: { type: 'basic' } });
       values = [];
 
-      const fetcherFuncWithError = async () => { throw Error("forced error"); };
+      const fetcherFuncWithError = async () => {
+        throw Error('forced error');
+      };
       fetcher = jest.fn().mockImplementation(fetcherFuncWithError);
 
       const result = createLicenseUpdate(trigger$, stop$, fetcher, maxRetryDelay);

--- a/x-pack/plugins/licensing/common/license_update.test.ts
+++ b/x-pack/plugins/licensing/common/license_update.test.ts
@@ -91,9 +91,9 @@ describe('licensing update', () => {
 
     const { license$ } = createLicenseUpdate(trigger$, stop$, fetcher, maxRetryDelay);
 
-    license$.subscribe(() => { });
-    license$.subscribe(() => { });
-    license$.subscribe(() => { });
+    license$.subscribe(() => {});
+    license$.subscribe(() => {});
+    license$.subscribe(() => {});
     trigger$.next();
 
     expect(fetcher).toHaveBeenCalledTimes(1);

--- a/x-pack/plugins/licensing/common/license_update.ts
+++ b/x-pack/plugins/licensing/common/license_update.ts
@@ -18,7 +18,7 @@ import {
   finalize,
   startWith,
   retry,
-  timer
+  timer,
 } from 'rxjs';
 import { hasLicenseInfoChanged } from './has_license_info_changed';
 import type { ILicense } from './types';
@@ -37,8 +37,9 @@ export function createLicenseUpdate(
     exhaustMap(() =>
       defer(() => fetcher()).pipe(
         retry({
-          delay: (_, retryCount) => timer(Math.min(maxRetryDelay, 1000 * Math.pow(2, retryCount - 1))),
-          resetOnSuccess: true
+          delay: (_, retryCount) =>
+            timer(Math.min(maxRetryDelay, 1000 * Math.pow(2, retryCount - 1))),
+          resetOnSuccess: true,
         })
       )
     ),

--- a/x-pack/plugins/licensing/common/license_update.ts
+++ b/x-pack/plugins/licensing/common/license_update.ts
@@ -39,7 +39,7 @@ export function createLicenseUpdate(
         retry({
           delay: (_, retryCount) =>
             maxRetryDelay > Math.pow(2, retryCount - 1) * 1000
-              ? timer(Math.pow(2, retryCount - 1) * 1000) 
+              ? timer(Math.pow(2, retryCount - 1) * 1000)
               : EMPTY,
           resetOnSuccess: true,
         })

--- a/x-pack/plugins/licensing/common/license_update.ts
+++ b/x-pack/plugins/licensing/common/license_update.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { type Observable, Subject, merge, firstValueFrom, defer } from 'rxjs';
+import { type Observable, Subject, merge, firstValueFrom, defer, EMPTY } from 'rxjs';
 
 import {
   filter,
@@ -38,7 +38,9 @@ export function createLicenseUpdate(
       defer(() => fetcher()).pipe(
         retry({
           delay: (_, retryCount) =>
-            timer(Math.min(maxRetryDelay, 1000 * Math.pow(2, retryCount - 1))),
+            maxRetryDelay > Math.pow(2, retryCount - 1) * 1000
+              ? timer(Math.pow(2, retryCount - 1) * 1000) 
+              : EMPTY,
           resetOnSuccess: true,
         })
       )

--- a/x-pack/plugins/licensing/public/plugin.ts
+++ b/x-pack/plugins/licensing/public/plugin.ts
@@ -17,6 +17,8 @@ import { FeatureUsageService } from './services';
 import type { PublicLicenseJSON } from '../common/types';
 import { registerAnalyticsContextProvider } from '../common/register_analytics_context_provider';
 
+const MAX_RETRY_DELAY = 30 * 1000;
+
 export const licensingSessionStorageKey = 'xpack.licensing';
 
 /**
@@ -75,13 +77,12 @@ export class LicensingPlugin implements Plugin<LicensingPluginSetup, LicensingPl
 
   public setup(core: CoreSetup) {
     const signatureUpdated$ = new Subject<void>();
-    const maxRetryDelay = 30 * 1000;
 
     const { license$, refreshManually } = createLicenseUpdate(
       signatureUpdated$,
       this.stop$,
       () => this.fetchLicense(core),
-      maxRetryDelay,
+      MAX_RETRY_DELAY,
       this.getSaved()
     );
 

--- a/x-pack/plugins/licensing/public/plugin.ts
+++ b/x-pack/plugins/licensing/public/plugin.ts
@@ -75,11 +75,13 @@ export class LicensingPlugin implements Plugin<LicensingPluginSetup, LicensingPl
 
   public setup(core: CoreSetup) {
     const signatureUpdated$ = new Subject<void>();
+    const maxRetryDelay = 30 * 1000;
 
     const { license$, refreshManually } = createLicenseUpdate(
       signatureUpdated$,
       this.stop$,
       () => this.fetchLicense(core),
+      maxRetryDelay,
       this.getSaved()
     );
 

--- a/x-pack/plugins/licensing/server/plugin.ts
+++ b/x-pack/plugins/licensing/server/plugin.ts
@@ -131,7 +131,7 @@ export class LicensingPlugin implements Plugin<LicensingPluginSetup, LicensingPl
       intervalRefresh$,
       this.stop$,
       licenseFetcher,
-      pollingFrequency 
+      pollingFrequency
     );
 
     this.loggingSubscription = license$.subscribe((license) =>

--- a/x-pack/plugins/licensing/server/plugin.ts
+++ b/x-pack/plugins/licensing/server/plugin.ts
@@ -130,7 +130,8 @@ export class LicensingPlugin implements Plugin<LicensingPluginSetup, LicensingPl
     const { license$, refreshManually } = createLicenseUpdate(
       intervalRefresh$,
       this.stop$,
-      licenseFetcher
+      licenseFetcher,
+      pollingFrequency 
     );
 
     this.loggingSubscription = license$.subscribe((license) =>


### PR DESCRIPTION
## Summary

Added an exponential backoff logic to the licensing retry. 

In the server it was easy to adapt since we can use the pollingFrequency as the maxRetryDelay as you can see [here](https://github.com/elastic/kibana/blob/bbd5bf60fdf6e0f1ec9fad03e09a49e1f8bd18cb/x-pack/plugins/licensing/server/plugin.ts#L130C1-L135C7).

In the UI it was more complicated since there were multiple options:
- The first option was to pass the config from server to public and use the config's polling frequency as the maxRetryDelay.
- The second option was to use a constant value as the maxRetryDelay.
- The third option was to use a constant value and avoid using the exponential backoff when calling from the UI.
- The fourth option was to not retry and just let the user do manual refreshes.

I went for the [second option](https://github.com/jesuswr/kibana/blob/569bb0aaa5f937d39f89002af37499c92a63406e/x-pack/plugins/licensing/public/plugin.ts#L76C1-L86C7) because:
- We aren't actually doing any polling when calling from the UI, so it seemed weird to export and use the polling frequency config.
- I didn't want to remove the retry or the exponential backoff since it adds one more case that adds a bit of complexity and doesn't offer a really clear benefit.

If you have another option or feel like one of the other 3 options is better, please let me know


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



