### PR TITLE
[8.17] [EEM] Add built in definitions for core Kubernetes entities (#196916)

### DIFF
--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/index.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/index.ts
@@ -10,10 +10,13 @@ import { builtInServicesFromEcsEntityDefinition } from './services_from_ecs_data
 import { builtInHostsFromEcsEntityDefinition } from './hosts_from_ecs_data';
 import { builtInContainersFromEcsEntityDefinition } from './containers_from_ecs_data';
 
+import * as kubernetes from './kubernetes';
+
 export { BUILT_IN_ID_PREFIX } from './constants';
 
 export const builtInDefinitions: EntityDefinition[] = [
   builtInServicesFromEcsEntityDefinition,
   builtInHostsFromEcsEntityDefinition,
   builtInContainersFromEcsEntityDefinition,
+  ...Object.values(kubernetes),
 ];

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/common/ecs_index_patterns.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/common/ecs_index_patterns.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const commonEcsIndexPatterns = ['metrics-kubernetes*', 'logs-*'];

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/common/ecs_metadata.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/common/ecs_metadata.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MetadataField } from '@kbn/entities-schema';
+import { globalMetadata } from './global_metadata';
+
+export const commonEcsMetadata: MetadataField[] = [
+  ...globalMetadata,
+  {
+    source: 'orchestrator.namespace',
+    destination: 'orchestrator.namespace',
+    aggregation: { type: 'terms', limit: 10 },
+  },
+  {
+    source: 'orchestrator.cluster_ip',
+    destination: 'orchestrator.cluster_id',
+    aggregation: { type: 'top_value', sort: { '@timestamp': 'desc' } },
+  },
+  {
+    source: 'orchestrator.cluster_name',
+    destination: 'orchestrator.cluster_name',
+    aggregation: { type: 'top_value', sort: { '@timestamp': 'desc' } },
+  },
+];

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/common/global_metadata.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/common/global_metadata.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MetadataField } from '@kbn/entities-schema';
+
+export const globalMetadata: MetadataField[] = [
+  {
+    source: '_index',
+    destination: 'source_index',
+    aggregation: { type: 'top_value', sort: { '@timestamp': 'desc' } },
+  },
+  {
+    source: 'data_stream.type',
+    destination: 'source_data_stream.type',
+    aggregation: { type: 'top_value', sort: { '@timestamp': 'desc' } },
+  },
+  {
+    source: 'data_stream.dataset',
+    destination: 'source_data_stream.dataset',
+    aggregation: { type: 'top_value', sort: { '@timestamp': 'desc' } },
+  },
+];

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/common/otel_index_patterns.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/common/otel_index_patterns.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const commonOtelIndexPatterns = ['metrics-*otel*', 'logs-*'];

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/common/otel_metadata.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/common/otel_metadata.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MetadataField } from '@kbn/entities-schema';
+import { globalMetadata } from './global_metadata';
+
+export const commonOtelMetadata: MetadataField[] = [
+  ...globalMetadata,
+  {
+    source: 'k8s.namespace.name',
+    destination: 'k8s.namespace.name',
+    aggregation: { type: 'terms', limit: 10 },
+  },
+  {
+    source: 'k8s.cluster.name',
+    destination: 'k8s.cluster.name',
+    aggregation: { type: 'top_value', sort: { '@timestamp': 'desc' } },
+  },
+];

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/cluster.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/cluster.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonEcsIndexPatterns } from '../common/ecs_index_patterns';
+import { globalMetadata } from '../common/global_metadata';
+
+export const builtInKubernetesClusterEcsEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_cluster_ecs`,
+    filter: 'orchestrator.cluster.name: *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes Clusters from ECS data',
+    description:
+      'This definition extracts Kubernetes cluster entities from the Kubernetes integration data streams',
+    type: 'k8s.cluster.ecs',
+    indexPatterns: commonEcsIndexPatterns,
+    identityFields: ['orchestrator.cluster.name'],
+    displayNameTemplate: '{{orchestrator.cluster.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: [
+      ...globalMetadata,
+      {
+        source: 'orchestrator.namespace',
+        destination: 'orchestrator.namespace',
+        aggregation: { type: 'terms', limit: 10 },
+      },
+      {
+        source: 'orchestrator.cluster_ip',
+        destination: 'orchestrator.cluster_id',
+        aggregation: { type: 'top_value', sort: { '@timestamp': 'desc' } },
+      },
+    ],
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/cron_job.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/cron_job.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonEcsIndexPatterns } from '../common/ecs_index_patterns';
+import { commonEcsMetadata } from '../common/ecs_metadata';
+
+export const builtInKubernetesCronJobEcsEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_cron_job_ecs`,
+    filter: 'kubernetes.cronjob.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes CronJob from ECS data',
+    description:
+      'This definition extracts Kubernetes cron job entities from the Kubernetes integration data streams',
+    type: 'k8s.cronjob.ecs',
+    indexPatterns: commonEcsIndexPatterns,
+    identityFields: ['kubernetes.cronjob.uid'],
+    displayNameTemplate: '{{kubernetes.cronjob.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonEcsMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/daemon_set.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/daemon_set.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonEcsIndexPatterns } from '../common/ecs_index_patterns';
+import { commonEcsMetadata } from '../common/ecs_metadata';
+
+export const builtInKubernetesDaemonSetEcsEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_daemon_set_ecs`,
+    filter: 'kubernetes.daemonset.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes DaemonSet from ECS data',
+    description:
+      'This definition extracts Kubernetes daemon set entities from the Kubernetes integration data streams',
+    type: 'k8s.daemonset.ecs',
+    indexPatterns: commonEcsIndexPatterns,
+    identityFields: ['kubernetes.daemonset.name'],
+    displayNameTemplate: '{{kubernetes.daemonset.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonEcsMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/deployment.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/deployment.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonEcsMetadata } from '../common/ecs_metadata';
+import { commonEcsIndexPatterns } from '../common/ecs_index_patterns';
+
+export const builtInKubernetesDeploymentEcsEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_deployment_ecs`,
+    filter: 'kubernetes.deployment.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes Deployment from ECS data',
+    description:
+      'This definition extracts Kubernetes deployment entities from the Kubernetes integration data streams',
+    type: 'k8s.deployment.ecs',
+    indexPatterns: commonEcsIndexPatterns,
+    identityFields: ['kubernetes.deployment.uid'],
+    displayNameTemplate: '{{kubernetes.deployment.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonEcsMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/index.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { builtInKubernetesClusterEcsEntityDefinition } from './cluster';
+export { builtInKubernetesNodeEcsEntityDefinition } from './node';
+export { builtInKubernetesPodEcsEntityDefinition } from './pod';
+export { builtInKubernetesReplicaSetEcsEntityDefinition } from './replica_set';
+export { builtInKubernetesDeploymentEcsEntityDefinition } from './deployment';
+export { builtInKubernetesStatefulSetEcsEntityDefinition } from './stateful_set';
+export { builtInKubernetesDaemonSetEcsEntityDefinition } from './daemon_set';
+export { builtInKubernetesJobEcsEntityDefinition } from './job';
+export { builtInKubernetesCronJobEcsEntityDefinition } from './cron_job';
+export { builtInKubernetesServiceEcsEntityDefinition } from './service';

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/job.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/job.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonEcsIndexPatterns } from '../common/ecs_index_patterns';
+import { commonEcsMetadata } from '../common/ecs_metadata';
+
+export const builtInKubernetesJobEcsEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_job_ecs`,
+    filter: 'kubernetes.job.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes Job from ECS data',
+    description:
+      'This definition extracts Kubernetes job entities from the Kubernetes integration data streams',
+    type: 'k8s.job.ecs',
+    indexPatterns: commonEcsIndexPatterns,
+    identityFields: ['kubernetes.job.uid'],
+    displayNameTemplate: '{{kubernetes.job.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonEcsMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/node.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/node.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonEcsIndexPatterns } from '../common/ecs_index_patterns';
+import { commonEcsMetadata } from '../common/ecs_metadata';
+
+export const builtInKubernetesNodeEcsEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_node_ecs`,
+    filer: 'kubernetes.node.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes Node from ECS data',
+    description:
+      'This definition extracts Kubernetes node entities from the Kubernetes integration data streams',
+    type: 'k8s.node.ecs',
+    indexPatterns: commonEcsIndexPatterns,
+    identityFields: ['kubernetes.node.uid'],
+    displayNameTemplate: '{{kubernetes.node.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonEcsMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/pod.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/pod.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonEcsMetadata } from '../common/ecs_metadata';
+import { commonEcsIndexPatterns } from '../common/ecs_index_patterns';
+
+export const builtInKubernetesPodEcsEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_pod_ecs`,
+    filter: 'kubernetes.pod.uid: *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes Pod from ECS data',
+    description:
+      'This definition extracts Kubernetes pod entities from the Kubernetes integration data streams',
+    type: 'k8s.pod.ecs',
+    indexPatterns: commonEcsIndexPatterns,
+    identityFields: ['kubernetes.pod.name'],
+    displayNameTemplate: '{{kubernetes.pod.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonEcsMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/replica_set.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/replica_set.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonEcsMetadata } from '../common/ecs_metadata';
+import { commonEcsIndexPatterns } from '../common/ecs_index_patterns';
+
+export const builtInKubernetesReplicaSetEcsEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_replica_set_ecs`,
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes ReplicaSet from ECS data',
+    description:
+      'This definition extracts Kubernetes replica set entities from the Kubernetes integration data streams',
+    type: 'k8s.replicaset.ecs',
+    indexPatterns: commonEcsIndexPatterns,
+    identityFields: ['kubernetes.replicaset.uid'],
+    displayNameTemplate: '{{kubernetes.replicaset.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonEcsMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/service.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/service.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonEcsMetadata } from '../common/ecs_metadata';
+import { commonEcsIndexPatterns } from '../common/ecs_index_patterns';
+
+export const builtInKubernetesServiceEcsEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_service_ecs`,
+    filter: 'kubernetes.service.name: *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes Services from ECS data',
+    description:
+      'This definition extracts Kubernetes service entities from the Kubernetes integration data streams',
+    type: 'k8s.service.ecs',
+    indexPatterns: commonEcsIndexPatterns,
+    identityFields: ['kubernetes.service.name'],
+    displayNameTemplate: '{{kubernetes.service.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonEcsMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/stateful_set.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/ecs/stateful_set.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonEcsMetadata } from '../common/ecs_metadata';
+import { commonEcsIndexPatterns } from '../common/ecs_index_patterns';
+
+export const builtInKubernetesStatefulSetEcsEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_stateful_set_ecs`,
+    filter: 'kubernetes.statefulset.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes StatefulSet from ECS data',
+    description:
+      'This definition extracts Kubernetes stateful set entities from the Kubernetes integration data streams',
+    type: 'k8s.statefulset.ecs',
+    indexPatterns: commonEcsIndexPatterns,
+    identityFields: ['kubernetes.statefulset.uid'],
+    displayNameTemplate: '{{kubernetes.statefulset.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonEcsMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/index.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './ecs';
+export * from './semconv';

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/cluster.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/cluster.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonOtelIndexPatterns } from '../common/otel_index_patterns';
+import { commonOtelMetadata } from '../common/otel_metadata';
+
+export const builtInKubernetesClusterSemConvEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_cluster_semconv`,
+    filter: 'k8s.cluster.uid: *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes Clusters from SemConv data',
+    description:
+      'This definition extracts Kubernetes cluster entities using data collected with OpenTelemetry',
+    type: 'kubernetes_cluster_semconv',
+    indexPatterns: commonOtelIndexPatterns,
+    identityFields: ['k8s.cluster.uid'],
+    displayNameTemplate: '{{k8s.cluster.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonOtelMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/cron_job.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/cron_job.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonOtelIndexPatterns } from '../common/otel_index_patterns';
+import { commonOtelMetadata } from '../common/otel_metadata';
+
+export const builtInKubernetesCronJobSemConvEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_cron_job_semconv`,
+    filter: 'k8s.cronjob.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes CronJob from SemConv data',
+    description:
+      'This definition extracts Kubernetes cron job entities using data collected with OpenTelemetry',
+    type: 'k8s.cronjob.otel',
+    indexPatterns: commonOtelIndexPatterns,
+    identityFields: ['k8s.cronjob.uid'],
+    displayNameTemplate: '{{k8s.cronjob.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonOtelMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/daemon_set.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/daemon_set.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonOtelIndexPatterns } from '../common/otel_index_patterns';
+import { commonOtelMetadata } from '../common/otel_metadata';
+
+export const builtInKubernetesDaemonSetSemConvEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_daemon_set_semconv`,
+    filter: 'k8s.daemonset.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes DaemonSet from SemConv data',
+    description:
+      'This definition extracts Kubernetes daemon set entities using data collected with OpenTelemetry',
+    type: 'k8s.daemonset.otel',
+    indexPatterns: commonOtelIndexPatterns,
+    identityFields: ['k8s.daemonset.uid'],
+    displayNameTemplate: '{{k8s.daemonset.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonOtelMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/deployment.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/deployment.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonOtelMetadata } from '../common/otel_metadata';
+import { commonOtelIndexPatterns } from '../common/otel_index_patterns';
+
+export const builtInKubernetesDeploymentSemConvEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_deployment_semconv`,
+    filter: 'k8s.deployment.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes Deployment from SemConv data',
+    description:
+      'This definition extracts Kubernetes deployment entities using data collected with OpenTelemetry',
+    type: 'k8s.deployment.otel',
+    indexPatterns: commonOtelIndexPatterns,
+    identityFields: ['k8s.deployment.uid'],
+    displayNameTemplate: '{{k8s.deployment.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonOtelMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/index.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { builtInKubernetesClusterSemConvEntityDefinition } from './cluster';
+export { builtInKubernetesNodeSemConvEntityDefinition } from './node';
+export { builtInKubernetesPodSemConvEntityDefinition } from './pod';
+export { builtInKubernetesReplicaSetSemConvEntityDefinition } from './replica_set';
+export { builtInKubernetesDeploymentSemConvEntityDefinition } from './deployment';
+export { builtInKubernetesStatefulSetSemConvEntityDefinition } from './stateful_set';
+export { builtInKubernetesDaemonSetSemConvEntityDefinition } from './daemon_set';
+export { builtInKubernetesJobSemConvEntityDefinition } from './job';
+export { builtInKubernetesCronJobSemConvEntityDefinition } from './cron_job';

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/job.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/job.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonOtelIndexPatterns } from '../common/otel_index_patterns';
+import { commonOtelMetadata } from '../common/otel_metadata';
+
+export const builtInKubernetesJobSemConvEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_job_semconv`,
+    filter: 'k8s.job.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes Job from SemConv data',
+    description:
+      'This definition extracts Kubernetes job entities using data collected with OpenTelemetry',
+    type: 'k8s.job.otel',
+    indexPatterns: commonOtelIndexPatterns,
+    identityFields: ['k8s.job.uid'],
+    displayNameTemplate: '{{k8s.job.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonOtelMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/node.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/node.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonOtelIndexPatterns } from '../common/otel_index_patterns';
+import { commonOtelMetadata } from '../common/otel_metadata';
+
+export const builtInKubernetesNodeSemConvEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_node_semconv`,
+    filter: 'k8s.node.uid: *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes Node from SemConv data',
+    description:
+      'This definition extracts Kubernetes node entities using data collected with OpenTelemetry',
+    type: 'k8s.node.otel',
+    indexPatterns: commonOtelIndexPatterns,
+    identityFields: ['k8s.node.uid'],
+    displayNameTemplate: '{{k8s.node.uid}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonOtelMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/pod.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/pod.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonOtelMetadata } from '../common/otel_metadata';
+import { commonOtelIndexPatterns } from '../common/otel_index_patterns';
+
+export const builtInKubernetesPodSemConvEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_pod_semconv`,
+    filter: 'k8s.pod.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes Pod from SemConv data',
+    description:
+      'This definition extracts Kubernetes pod entities using data collected with OpenTelemetry',
+    type: 'k8s.pod.otel',
+    indexPatterns: commonOtelIndexPatterns,
+    identityFields: ['k8s.pod.uid'],
+    displayNameTemplate: '{{k8s.pod.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonOtelMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/replica_set.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/replica_set.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonOtelMetadata } from '../common/otel_metadata';
+import { commonOtelIndexPatterns } from '../common/otel_index_patterns';
+
+export const builtInKubernetesReplicaSetSemConvEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_replica_set_semconv`,
+    filter: 'k8s.replicaset.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes ReplicaSet from SemConv data',
+    description:
+      'This definition extracts Kubernetes replica set entities using data collected with OpenTelemetry',
+    type: 'kubernetes_replica_set_semconv',
+    indexPatterns: commonOtelIndexPatterns,
+    identityFields: ['k8s.replicaset.name'],
+    displayNameTemplate: '{{k8s.replicaset.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonOtelMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/stateful_set.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/built_in/kubernetes/semconv/stateful_set.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EntityDefinition, entityDefinitionSchema } from '@kbn/entities-schema';
+import { BUILT_IN_ID_PREFIX } from '../../constants';
+import { commonOtelMetadata } from '../common/otel_metadata';
+import { commonOtelIndexPatterns } from '../common/otel_index_patterns';
+
+export const builtInKubernetesStatefulSetSemConvEntityDefinition: EntityDefinition =
+  entityDefinitionSchema.parse({
+    id: `${BUILT_IN_ID_PREFIX}kubernetes_stateful_set_semconv`,
+    filter: 'k8s.statefulset.uid : *',
+    managed: true,
+    version: '0.1.0',
+    name: 'Kubernetes StatefulSet from SemConv data',
+    description:
+      'This definition extracts Kubernetes stateful set entities using data collected with OpenTelemetry',
+    type: 'k8s.statefulset.otel',
+    indexPatterns: commonOtelIndexPatterns,
+    identityFields: ['k8s.statefulset.uid'],
+    displayNameTemplate: '{{k8s.statefulset.name}}',
+    latest: {
+      timestampField: '@timestamp',
+      lookbackPeriod: '10m',
+      settings: {
+        frequency: '5m',
+      },
+    },
+    metadata: commonOtelMetadata,
+  });

--- a/x-pack/plugins/entity_manager/server/lib/entities/uninstall_entity_definition.ts
+++ b/x-pack/plugins/entity_manager/server/lib/entities/uninstall_entity_definition.ts
@@ -47,7 +47,10 @@ export async function uninstallBuiltInEntityDefinitions({
   entityClient: EntityClient;
   deleteData?: boolean;
 }): Promise<EntityDefinition[]> {
-  const { definitions } = await entityClient.getEntityDefinitions({ builtIn: true });
+  const { definitions } = await entityClient.getEntityDefinitions({
+    builtIn: true,
+    perPage: 1000,
+  });
 
   await Promise.all(
     definitions.map(async ({ id }) => {

--- a/x-pack/test/api_integration/apis/entity_manager/helpers/request.ts
+++ b/x-pack/test/api_integration/apis/entity_manager/helpers/request.ts
@@ -16,12 +16,12 @@ export interface Auth {
 
 export const getInstalledDefinitions = async (
   supertest: Agent,
-  params: { auth?: Auth; id?: string; includeState?: boolean } = {}
+  params: { auth?: Auth; id?: string; includeState?: boolean; perPage?: number } = {}
 ): Promise<{ definitions: EntityDefinitionWithState[] }> => {
-  const { auth, id, includeState = true } = params;
+  const { auth, id, includeState = true, perPage = 1000 } = params;
   let req = supertest
     .get(`/internal/entities/definition${id ? `/${id}` : ''}`)
-    .query({ includeState })
+    .query({ includeState, perPage })
     .set('kbn-xsrf', 'xxx');
   if (auth) {
     req = req.auth(auth.username, auth.password);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[EEM] Add built in definitions for core Kubernetes entities (#196916)](https://github.com/elastic/kibana/pull/196916)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Milton Hultgren","email":"milton.hultgren@elastic.co"},"sourceCommit":{"committedDate":"2024-11-19T21:23:52Z","message":"[EEM] Add built in definitions for core Kubernetes entities (#196916)\n\n## 🍒 Summary\r\n\r\nThis PR adds the OTEL and ECS entity definition for Kubernetes. This\r\ncovers the following datasets:\r\n- Cluster\r\n- Service (ECS Only)\r\n- Pod\r\n- ReplicaSet\r\n- Deployment\r\n- Statefulset\r\n- DaemonSet\r\n- Job\r\n- CronJob\r\n- Node\r\n\r\nThis PR does not include Container per @roshan-elastic \r\n\r\n### ✅ TODO\r\n- [X] Use correct index pattern for SemConv data\r\n(`metrics-k8sclusterreceiver.otel-default`,\r\n`metrics-kubeletstatsreceiver.otel-default`)\r\nUse global IDs instead of local IDs\r\n- [X] Add minimal list of labels to track beyond what was already added\r\n(wildcards are not supported, example `container.image.name` for\r\ncontainers to allow to find all \"redis\" containers)\r\n- [ ] Test with ECS data, SemConv data and mixed data (to check if we\r\nget duplicates, with the container definition for example).\r\n\r\n### 🐴 Follow up EEM features \r\nhttps://github.com/elastic/elastic-entity-model/issues/170 (Add\r\ndedicated aggregation for display name and use that instead to provide a\r\nbetter label than the global ID)\r\nhttps://github.com/elastic/elastic-entity-model/issues/193 (Add entity\r\ntype display label to allow UI to not hard code a user friendly label)\r\n\r\n---------\r\n\r\nCo-authored-by: Chris Cowan <chris@elastic.co>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"080d0ff97f00bf564dedfd8fd37cdac0370e1349","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport:skip","v9.0.0","release_note:feature","v8.17.0"],"number":196916,"url":"https://github.com/elastic/kibana/pull/196916","mergeCommit":{"message":"[EEM] Add built in definitions for core Kubernetes entities (#196916)\n\n## 🍒 Summary\r\n\r\nThis PR adds the OTEL and ECS entity definition for Kubernetes. This\r\ncovers the following datasets:\r\n- Cluster\r\n- Service (ECS Only)\r\n- Pod\r\n- ReplicaSet\r\n- Deployment\r\n- Statefulset\r\n- DaemonSet\r\n- Job\r\n- CronJob\r\n- Node\r\n\r\nThis PR does not include Container per @roshan-elastic \r\n\r\n### ✅ TODO\r\n- [X] Use correct index pattern for SemConv data\r\n(`metrics-k8sclusterreceiver.otel-default`,\r\n`metrics-kubeletstatsreceiver.otel-default`)\r\nUse global IDs instead of local IDs\r\n- [X] Add minimal list of labels to track beyond what was already added\r\n(wildcards are not supported, example `container.image.name` for\r\ncontainers to allow to find all \"redis\" containers)\r\n- [ ] Test with ECS data, SemConv data and mixed data (to check if we\r\nget duplicates, with the container definition for example).\r\n\r\n### 🐴 Follow up EEM features \r\nhttps://github.com/elastic/elastic-entity-model/issues/170 (Add\r\ndedicated aggregation for display name and use that instead to provide a\r\nbetter label than the global ID)\r\nhttps://github.com/elastic/elastic-entity-model/issues/193 (Add entity\r\ntype display label to allow UI to not hard code a user friendly label)\r\n\r\n---------\r\n\r\nCo-authored-by: Chris Cowan <chris@elastic.co>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"080d0ff97f00bf564dedfd8fd37cdac0370e1349"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/196916","number":196916,"mergeCommit":{"message":"[EEM] Add built in definitions for core Kubernetes entities (#196916)\n\n## 🍒 Summary\r\n\r\nThis PR adds the OTEL and ECS entity definition for Kubernetes. This\r\ncovers the following datasets:\r\n- Cluster\r\n- Service (ECS Only)\r\n- Pod\r\n- ReplicaSet\r\n- Deployment\r\n- Statefulset\r\n- DaemonSet\r\n- Job\r\n- CronJob\r\n- Node\r\n\r\nThis PR does not include Container per @roshan-elastic \r\n\r\n### ✅ TODO\r\n- [X] Use correct index pattern for SemConv data\r\n(`metrics-k8sclusterreceiver.otel-default`,\r\n`metrics-kubeletstatsreceiver.otel-default`)\r\nUse global IDs instead of local IDs\r\n- [X] Add minimal list of labels to track beyond what was already added\r\n(wildcards are not supported, example `container.image.name` for\r\ncontainers to allow to find all \"redis\" containers)\r\n- [ ] Test with ECS data, SemConv data and mixed data (to check if we\r\nget duplicates, with the container definition for example).\r\n\r\n### 🐴 Follow up EEM features \r\nhttps://github.com/elastic/elastic-entity-model/issues/170 (Add\r\ndedicated aggregation for display name and use that instead to provide a\r\nbetter label than the global ID)\r\nhttps://github.com/elastic/elastic-entity-model/issues/193 (Add entity\r\ntype display label to allow UI to not hard code a user friendly label)\r\n\r\n---------\r\n\r\nCo-authored-by: Chris Cowan <chris@elastic.co>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"080d0ff97f00bf564dedfd8fd37cdac0370e1349"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->