### PR TITLE
[ResponseOps] Use the feature ID to get connector types for the stack management rule form

### DIFF
--- a/packages/kbn-alerts-ui-shared/src/common/hooks/use_load_connector_types.test.tsx
+++ b/packages/kbn-alerts-ui-shared/src/common/hooks/use_load_connector_types.test.tsx
@@ -48,6 +48,7 @@ describe('useLoadConnectorTypes', () => {
         useLoadConnectorTypes({
           http,
           includeSystemActions: true,
+          featureId: 'alerting',
         }),
       { wrapper }
     );
@@ -68,6 +69,11 @@ describe('useLoadConnectorTypes', () => {
         supportedFeatureIds: ['alerting'],
       },
     ]);
+    expect(http.get).toHaveBeenCalledWith('/internal/actions/connector_types', {
+      query: {
+        feature_id: 'alerting',
+      },
+    });
   });
 
   test('should call the correct endpoint if system actions is true', async () => {

--- a/packages/kbn-alerts-ui-shared/src/common/hooks/use_load_connector_types.ts
+++ b/packages/kbn-alerts-ui-shared/src/common/hooks/use_load_connector_types.ts
@@ -15,17 +15,18 @@ export interface UseLoadConnectorTypesProps {
   http: HttpStart;
   includeSystemActions?: boolean;
   enabled?: boolean;
+  featureId?: string;
 }
 
 export const useLoadConnectorTypes = (props: UseLoadConnectorTypesProps) => {
-  const { http, includeSystemActions, enabled = true } = props;
+  const { http, includeSystemActions, enabled = true, featureId } = props;
 
   const queryFn = () => {
-    return fetchConnectorTypes({ http, includeSystemActions });
+    return fetchConnectorTypes({ http, featureId, includeSystemActions });
   };
 
   const { data, isLoading, isFetching, isInitialLoading } = useQuery({
-    queryKey: ['useLoadConnectorTypes', includeSystemActions],
+    queryKey: ['useLoadConnectorTypes', includeSystemActions, featureId],
     queryFn,
     refetchOnWindowFocus: false,
     enabled,

--- a/packages/kbn-alerts-ui-shared/src/rule_form/create_rule_form.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/create_rule_form.tsx
@@ -36,6 +36,7 @@ export interface CreateRuleFormProps {
   ruleTypeId: string;
   plugins: RuleFormPlugins;
   consumer?: string;
+  connectorFeatureId?: string;
   multiConsumerSelection?: RuleCreationValidConsumer | null;
   hideInterval?: boolean;
   validConsumers?: RuleCreationValidConsumer[];
@@ -52,6 +53,7 @@ export const CreateRuleForm = (props: CreateRuleFormProps) => {
     ruleTypeId,
     plugins,
     consumer = 'alerts',
+    connectorFeatureId = 'alerting',
     multiConsumerSelection,
     validConsumers = DEFAULT_VALID_CONSUMERS,
     filteredRuleTypes = [],
@@ -107,6 +109,7 @@ export const CreateRuleForm = (props: CreateRuleFormProps) => {
     consumer,
     validConsumers,
     filteredRuleTypes,
+    connectorFeatureId,
   });
 
   const onSave = useCallback(

--- a/packages/kbn-alerts-ui-shared/src/rule_form/edit_rule_form.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/edit_rule_form.tsx
@@ -31,12 +31,20 @@ export interface EditRuleFormProps {
   id: string;
   plugins: RuleFormPlugins;
   showMustacheAutocompleteSwitch?: boolean;
+  connectorFeatureId?: string;
   onCancel?: () => void;
   onSubmit?: (ruleId: string) => void;
 }
 
 export const EditRuleForm = (props: EditRuleFormProps) => {
-  const { id, plugins, showMustacheAutocompleteSwitch = false, onCancel, onSubmit } = props;
+  const {
+    id,
+    plugins,
+    showMustacheAutocompleteSwitch = false,
+    connectorFeatureId = 'alerting',
+    onCancel,
+    onSubmit,
+  } = props;
   const { http, notifications, docLinks, ruleTypeRegistry, i18n, theme, application } = plugins;
   const { toasts } = notifications;
 
@@ -80,6 +88,7 @@ export const EditRuleForm = (props: EditRuleFormProps) => {
     capabilities: plugins.application.capabilities,
     ruleTypeRegistry,
     id,
+    connectorFeatureId,
   });
 
   const onSave = useCallback(

--- a/packages/kbn-alerts-ui-shared/src/rule_form/hooks/use_load_dependencies.ts
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/hooks/use_load_dependencies.ts
@@ -35,6 +35,7 @@ export interface UseLoadDependencies {
   ruleTypeId?: string;
   validConsumers?: RuleCreationValidConsumer[];
   filteredRuleTypes?: string[];
+  connectorFeatureId?: string;
 }
 
 export const useLoadDependencies = (props: UseLoadDependencies) => {
@@ -46,6 +47,7 @@ export const useLoadDependencies = (props: UseLoadDependencies) => {
     ruleTypeId,
     capabilities,
     filteredRuleTypes = [],
+    connectorFeatureId,
   } = props;
 
   const canReadConnectors = !!capabilities.actions?.show;
@@ -113,6 +115,7 @@ export const useLoadDependencies = (props: UseLoadDependencies) => {
     http,
     includeSystemActions: true,
     enabled: canReadConnectors,
+    featureId: connectorFeatureId,
   });
 
   const {


### PR DESCRIPTION
## Summary

This PR reinstates the `featureId` parameter in requests to the connector type API within the new stack management rule form.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### To verify

1. Create a connector with supportedFeatureIds that does not include AlertingConnectorFeatureId (e.g., the SentinelOne connector).
2. Use the new rule form to create a rule.
3. Confirm that the SentinelOne connector is not displayed in the rule form as an available option.


<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.x"]} ONMERGE-->