### PR TITLE
[8.15] [UII] Allow to create integration policy with no agent policies (#201051)

### DIFF
--- a/x-pack/plugins/fleet/cypress/e2e/package_policy.cy.ts
+++ b/x-pack/plugins/fleet/cypress/e2e/package_policy.cy.ts
@@ -4,36 +4,46 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { EXISTING_HOSTS_TAB } from '../screens/fleet';
+import {
+  ADD_INTEGRATION_POLICY_BTN,
+  CREATE_PACKAGE_POLICY_SAVE_BTN,
+  POLICY_EDITOR,
+} from '../screens/integrations';
+import { CONFIRM_MODAL } from '../screens/navigation';
 import { login } from '../tasks/login';
 
-describe('Edit package policy', () => {
-  const policyConfig = {
-    id: 'policy-1',
-    name: 'fleet_server-1',
-    namespace: 'default',
-    package: { name: 'fleet_server', title: 'Fleet Server', version: '1.1.0' },
-    enabled: true,
-    policy_id: 'fleet-server-policy',
-    policy_ids: ['fleet-server-policy'],
-    output_id: 'fleet-default-output',
-    inputs: [
-      {
-        type: 'fleet-server',
-        policy_template: 'fleet_server',
-        enabled: true,
-        streams: [],
-        vars: {
-          host: { value: ['0.0.0.0'], type: 'text' },
-          port: { value: [8220], type: 'integer' },
-          max_connections: { type: 'integer' },
-          custom: { value: '', type: 'yaml' },
-        },
-        compiled_input: { server: { port: 8220, host: '0.0.0.0' } },
-      },
-    ],
-  };
+describe('Package policy', () => {
   beforeEach(() => {
     login();
+  });
+
+  it('should edit package policy', () => {
+    const policyConfig = {
+      id: 'policy-1',
+      name: 'fleet_server-1',
+      namespace: 'default',
+      package: { name: 'fleet_server', title: 'Fleet Server', version: '1.1.0' },
+      enabled: true,
+      policy_id: 'fleet-server-policy',
+      policy_ids: ['fleet-server-policy'],
+      output_id: 'fleet-default-output',
+      inputs: [
+        {
+          type: 'fleet-server',
+          policy_template: 'fleet_server',
+          enabled: true,
+          streams: [],
+          vars: {
+            host: { value: ['0.0.0.0'], type: 'text' },
+            port: { value: [8220], type: 'integer' },
+            max_connections: { type: 'integer' },
+            custom: { value: '', type: 'yaml' },
+          },
+          compiled_input: { server: { port: 8220, host: '0.0.0.0' } },
+        },
+      ],
+    };
 
     cy.intercept('/api/fleet/package_policies/policy-1', {
       item: policyConfig,
@@ -111,9 +121,7 @@ describe('Edit package policy', () => {
         status: 'not_installed',
       },
     });
-  });
 
-  it('should edit package policy', () => {
     cy.visit('/app/fleet/policies/fleet-server-policy/edit-integration/policy-1');
     cy.getBySel('packagePolicyDescriptionInput').clear().type('desc');
 
@@ -126,6 +134,29 @@ describe('Edit package policy', () => {
 
     cy.wait('@updatePackagePolicy').then((interception) => {
       expect(interception.request.body.description).to.equal('desc');
+    });
+  });
+
+  it('should create a new orphaned package policy', () => {
+    cy.visit('/app/integrations/detail/system');
+    cy.getBySel(ADD_INTEGRATION_POLICY_BTN).click();
+    cy.getBySel(EXISTING_HOSTS_TAB).click();
+    cy.getBySel(POLICY_EDITOR.AGENT_POLICY_SELECT).should('exist');
+    cy.getBySel(POLICY_EDITOR.AGENT_POLICY_CLEAR).should('not.exist');
+    cy.getBySel(POLICY_EDITOR.POLICY_NAME_INPUT).clear().type('system-orphaned-test');
+
+    cy.intercept({
+      method: 'POST',
+      url: '/api/fleet/package_policies',
+    }).as('createPackagePolicy');
+
+    cy.getBySel(CREATE_PACKAGE_POLICY_SAVE_BTN).should('be.enabled').click();
+    cy.getBySel(CONFIRM_MODAL.CONFIRM_BUTTON).click();
+
+    cy.wait('@createPackagePolicy').then((interception) => {
+      expect(interception.request.body.name).to.equal('system-orphaned-test');
+      expect(interception.request.body.policy_id).to.equal(undefined);
+      expect(interception.request.body.policy_ids).to.deep.equal([]);
     });
   });
 });

--- a/x-pack/plugins/fleet/cypress/screens/integrations.ts
+++ b/x-pack/plugins/fleet/cypress/screens/integrations.ts
@@ -38,7 +38,8 @@ export const SETTINGS = {
 export const POLICY_EDITOR = {
   POLICY_NAME_INPUT: 'packagePolicyNameInput',
   DATASET_SELECT: 'datasetComboBox',
-  AGENT_POLICY_SELECT: 'agentPolicySelect',
+  AGENT_POLICY_SELECT: 'agentPolicyMultiSelect',
+  AGENT_POLICY_CLEAR: 'comboBoxClearButton',
   INSPECT_PIPELINES_BTN: 'datastreamInspectPipelineBtn',
   EDIT_MAPPINGS_BTN: 'datastreamEditMappingsBtn',
   CREATE_MAPPINGS_BTN: 'datastreamAddCustomComponentTemplateBtn',

--- a/x-pack/plugins/fleet/cypress/screens/integrations.ts
+++ b/x-pack/plugins/fleet/cypress/screens/integrations.ts
@@ -38,8 +38,7 @@ export const SETTINGS = {
 export const POLICY_EDITOR = {
   POLICY_NAME_INPUT: 'packagePolicyNameInput',
   DATASET_SELECT: 'datasetComboBox',
-  AGENT_POLICY_SELECT: 'agentPolicyMultiSelect',
-  AGENT_POLICY_CLEAR: 'comboBoxClearButton',
+  AGENT_POLICY_SELECT: 'agentPolicySelect',
   INSPECT_PIPELINES_BTN: 'datastreamInspectPipelineBtn',
   EDIT_MAPPINGS_BTN: 'datastreamEditMappingsBtn',
   CREATE_MAPPINGS_BTN: 'datastreamAddCustomComponentTemplateBtn',

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.test.tsx
@@ -112,7 +112,8 @@ describe('StepSelectHosts', () => {
     waitFor(() => {
       expect(renderResult.getByText('Agent policy 1')).toBeInTheDocument();
     });
-    expect(renderResult.queryByRole('tablist')).not.toBeInTheDocument();
+    expect(renderResult.queryByRole('tablist')).toBeInTheDocument();
+    expect(renderResult.getByText('Create agent policy')).toBeInTheDocument();
   });
 
   it('should display tabs with New hosts selected when agent policies exist', () => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_select_hosts.tsx
@@ -121,7 +121,7 @@ export const StepSelectHosts: React.FunctionComponent<Props> = ({
   const handleOnTabClick = (tab: EuiTabbedContentTab) =>
     updateSelectedTab(tab.id as SelectedPolicyTab);
 
-  return existingAgentPolicies.length > 0 ? (
+  return (
     <StyledEuiTabbedContent
       initialSelectedTab={
         initialSelectedTabIndex
@@ -132,14 +132,6 @@ export const StepSelectHosts: React.FunctionComponent<Props> = ({
       }
       tabs={tabs}
       onTabClick={handleOnTabClick}
-    />
-  ) : (
-    <AgentPolicyIntegrationForm
-      agentPolicy={newAgentPolicy}
-      updateAgentPolicy={updateNewAgentPolicy}
-      withSysMonitoring={withSysMonitoring}
-      updateSysMonitoring={updateSysMonitoring}
-      validation={validation}
     />
   );
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -279,7 +279,7 @@ export function useOnSubmit({
 
   useEffect(() => {
     if (
-      agentPolicies.length > 0 &&
+      (canUseMultipleAgentPolicies || agentPolicies.length > 0) &&
       !isEqual(
         agentPolicies.map((policy) => policy.id),
         packagePolicy.policy_ids
@@ -289,7 +289,7 @@ export function useOnSubmit({
         policy_ids: agentPolicies.map((policy) => policy.id),
       });
     }
-  }, [packagePolicy, agentPolicies, updatePackagePolicy]);
+  }, [packagePolicy, agentPolicies, updatePackagePolicy, canUseMultipleAgentPolicies]);
 
   const onSaveNavigate = useOnSaveNavigate({
     packagePolicy,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -25,6 +25,7 @@ import {
   sendCreatePackagePolicy,
   sendBulkInstallPackages,
   sendGetPackagePolicies,
+  useMultipleAgentPolicies,
 } from '../../../../../hooks';
 import { isVerificationError, packageToPackagePolicy } from '../../../../../services';
 import {
@@ -152,6 +153,8 @@ export function useOnSubmit({
 }) {
   const { notifications } = useStartServices();
   const confirmForceInstall = useConfirmForceInstall();
+  const { canUseMultipleAgentPolicies } = useMultipleAgentPolicies();
+
   // only used to store the resulting package policy once saved
   const [savedPackagePolicy, setSavedPackagePolicy] = useState<PackagePolicy>();
   // Form state

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/services/devtools_request.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/services/devtools_request.tsx
@@ -18,6 +18,7 @@ import type {
   UpdatePackagePolicy,
   UpdateAgentPolicyRequest,
 } from '../../../types';
+import { canUseMultipleAgentPolicies } from '../../../hooks';
 
 function generateKibanaDevToolsRequest(method: string, path: string, body: any) {
   return `${method} kbn:${path}\n${JSON.stringify(body, null, 2)}\n`;
@@ -49,9 +50,13 @@ export function generateCreateAgentPolicyDevToolsRequest(
 export function generateCreatePackagePolicyDevToolsRequest(
   packagePolicy: NewPackagePolicy & { force?: boolean }
 ) {
+  const canHaveNoAgentPolicies = canUseMultipleAgentPolicies();
+
   return generateKibanaDevToolsRequest('POST', packagePolicyRouteService.getCreatePath(), {
     policy_ids:
-      packagePolicy.policy_ids.length > 0 ? packagePolicy.policy_ids : ['<agent_policy_id>'],
+      packagePolicy.policy_ids.length > 0 || canHaveNoAgentPolicies
+        ? packagePolicy.policy_ids
+        : ['<agent_policy_id>'],
     package: formatPackage(packagePolicy.package),
     ...omit(packagePolicy, 'policy_ids', 'package', 'enabled'),
     inputs: formatInputs(packagePolicy.inputs),

--- a/x-pack/plugins/fleet/public/hooks/use_multiple_agent_policies.ts
+++ b/x-pack/plugins/fleet/public/hooks/use_multiple_agent_policies.ts
@@ -7,17 +7,18 @@
 
 import { ExperimentalFeaturesService } from '../services';
 
-import { useLicense } from './use_license';
+import { licenseService } from './use_license';
 
 export const LICENCE_FOR_MULTIPLE_AGENT_POLICIES = 'enterprise';
 
 export function useMultipleAgentPolicies() {
-  const licenseService = useLicense();
+  return { canUseMultipleAgentPolicies: canUseMultipleAgentPolicies() };
+}
+
+export function canUseMultipleAgentPolicies() {
   const { enableReusableIntegrationPolicies } = ExperimentalFeaturesService.get();
 
   const hasEnterpriseLicence = licenseService.hasAtLeast(LICENCE_FOR_MULTIPLE_AGENT_POLICIES);
 
-  const canUseMultipleAgentPolicies = enableReusableIntegrationPolicies && hasEnterpriseLicence;
-
-  return { canUseMultipleAgentPolicies };
+  return Boolean(enableReusableIntegrationPolicies && hasEnterpriseLicence);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.15`:
 - [[UII] Allow to create integration policy with no agent policies (#201051)](https://github.com/elastic/kibana/pull/201051)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2024-11-22T00:57:06Z","message":"[UII] Allow to create integration policy with no agent policies (#201051)\n\n## Summary\r\n\r\nResolves #198165. This PR fixes an issue where `policy_ids` array was\r\nnot able to be cleared behind the scenes to create an orphaned\r\nintegration policy, even when cluster is able to use the multiple agent\r\npolicies feature.","sha":"3952dea3962c52dbd8d0cf01f7966670a64639d4","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","v9.0.0","backport:prev-major","v8.17.0","v8.18.0"],"number":201051,"url":"https://github.com/elastic/kibana/pull/201051","mergeCommit":{"message":"[UII] Allow to create integration policy with no agent policies (#201051)\n\n## Summary\r\n\r\nResolves #198165. This PR fixes an issue where `policy_ids` array was\r\nnot able to be cleared behind the scenes to create an orphaned\r\nintegration policy, even when cluster is able to use the multiple agent\r\npolicies feature.","sha":"3952dea3962c52dbd8d0cf01f7966670a64639d4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/201051","number":201051,"mergeCommit":{"message":"[UII] Allow to create integration policy with no agent policies (#201051)\n\n## Summary\r\n\r\nResolves #198165. This PR fixes an issue where `policy_ids` array was\r\nnot able to be cleared behind the scenes to create an orphaned\r\nintegration policy, even when cluster is able to use the multiple agent\r\npolicies feature.","sha":"3952dea3962c52dbd8d0cf01f7966670a64639d4"}},{"branch":"8.17","label":"v8.17.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201305","number":201305,"state":"MERGED","mergeCommit":{"sha":"8eb67bd1883aad804d5c33df61d065f01f4398ca","message":"[8.17] [UII] Allow to create integration policy with no agent policies (#201051) (#201305)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.17`:\n- [[UII] Allow to create integration policy with no agent policies\n(#201051)](https://github.com/elastic/kibana/pull/201051)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jen\nHuang\",\"email\":\"its.jenetic@gmail.com\"},\"sourceCommit\":{\"committedDate\":\"2024-11-22T00:57:06Z\",\"message\":\"[UII]\nAllow to create integration policy with no agent policies\n(#201051)\\n\\n## Summary\\r\\n\\r\\nResolves #198165. This PR fixes an issue\nwhere `policy_ids` array was\\r\\nnot able to be cleared behind the scenes\nto create an orphaned\\r\\nintegration policy, even when cluster is able\nto use the multiple agent\\r\\npolicies\nfeature.\",\"sha\":\"3952dea3962c52dbd8d0cf01f7966670a64639d4\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:fix\",\"Team:Fleet\",\"v9.0.0\",\"backport:prev-major\"],\"title\":\"[UII]\nAllow to create integration policy with no agent\npolicies\",\"number\":201051,\"url\":\"https://github.com/elastic/kibana/pull/201051\",\"mergeCommit\":{\"message\":\"[UII]\nAllow to create integration policy with no agent policies\n(#201051)\\n\\n## Summary\\r\\n\\r\\nResolves #198165. This PR fixes an issue\nwhere `policy_ids` array was\\r\\nnot able to be cleared behind the scenes\nto create an orphaned\\r\\nintegration policy, even when cluster is able\nto use the multiple agent\\r\\npolicies\nfeature.\",\"sha\":\"3952dea3962c52dbd8d0cf01f7966670a64639d4\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/201051\",\"number\":201051,\"mergeCommit\":{\"message\":\"[UII]\nAllow to create integration policy with no agent policies\n(#201051)\\n\\n## Summary\\r\\n\\r\\nResolves #198165. This PR fixes an issue\nwhere `policy_ids` array was\\r\\nnot able to be cleared behind the scenes\nto create an orphaned\\r\\nintegration policy, even when cluster is able\nto use the multiple agent\\r\\npolicies\nfeature.\",\"sha\":\"3952dea3962c52dbd8d0cf01f7966670a64639d4\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Jen Huang <its.jenetic@gmail.com>"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201306","number":201306,"state":"MERGED","mergeCommit":{"sha":"19059ee9c2d90d1da7cc21ce05c7c34e6a5b0578","message":"[8.x] [UII] Allow to create integration policy with no agent policies (#201051) (#201306)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[UII] Allow to create integration policy with no agent policies\n(#201051)](https://github.com/elastic/kibana/pull/201051)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jen\nHuang\",\"email\":\"its.jenetic@gmail.com\"},\"sourceCommit\":{\"committedDate\":\"2024-11-22T00:57:06Z\",\"message\":\"[UII]\nAllow to create integration policy with no agent policies\n(#201051)\\n\\n## Summary\\r\\n\\r\\nResolves #198165. This PR fixes an issue\nwhere `policy_ids` array was\\r\\nnot able to be cleared behind the scenes\nto create an orphaned\\r\\nintegration policy, even when cluster is able\nto use the multiple agent\\r\\npolicies\nfeature.\",\"sha\":\"3952dea3962c52dbd8d0cf01f7966670a64639d4\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:fix\",\"Team:Fleet\",\"v9.0.0\",\"backport:prev-major\"],\"title\":\"[UII]\nAllow to create integration policy with no agent\npolicies\",\"number\":201051,\"url\":\"https://github.com/elastic/kibana/pull/201051\",\"mergeCommit\":{\"message\":\"[UII]\nAllow to create integration policy with no agent policies\n(#201051)\\n\\n## Summary\\r\\n\\r\\nResolves #198165. This PR fixes an issue\nwhere `policy_ids` array was\\r\\nnot able to be cleared behind the scenes\nto create an orphaned\\r\\nintegration policy, even when cluster is able\nto use the multiple agent\\r\\npolicies\nfeature.\",\"sha\":\"3952dea3962c52dbd8d0cf01f7966670a64639d4\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/201051\",\"number\":201051,\"mergeCommit\":{\"message\":\"[UII]\nAllow to create integration policy with no agent policies\n(#201051)\\n\\n## Summary\\r\\n\\r\\nResolves #198165. This PR fixes an issue\nwhere `policy_ids` array was\\r\\nnot able to be cleared behind the scenes\nto create an orphaned\\r\\nintegration policy, even when cluster is able\nto use the multiple agent\\r\\npolicies\nfeature.\",\"sha\":\"3952dea3962c52dbd8d0cf01f7966670a64639d4\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Jen Huang <its.jenetic@gmail.com>"}}]}] BACKPORT-->