### PR TITLE
Sustainable Kibana Architecture: Temporarily allow non-snake case package names

### DIFF
--- a/src/dev/run_check_file_casing.ts
+++ b/src/dev/run_check_file_casing.ts
@@ -26,6 +26,12 @@ run(async ({ log }) => {
       // so it's still super slow. This prevents loading the files
       // and still relies on gitignore to final ignores
       '**/node_modules',
+      // temporarily allow non-snake case for module names
+      // during relocation packages and plugins
+      // in the context of Sustainable Kibana Architecture
+      'src/platform/**',
+      'x-pack/platform/**',
+      'x-pack/solutions/**',
     ],
   });
 


### PR DESCRIPTION
## Summary

In the context of _Sustainable Kibana Architecture_, we want to relocate plugins and packages to dedicated solutions folders.
Current CI checks enforce snake case for new package names, and we cannot afford the extra churn of renaming all packages' folders during relocation.

The PR aims at relaxing this constraint, only for the target folders of the relocation.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->