### PR TITLE
[Dataset Quality] Fix loading on dataset quality summary

### DIFF
--- a/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_summary_panel.ts
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_summary_panel.ts
@@ -14,8 +14,12 @@ import { filterInactiveDatasets } from '../utils';
 
 const useSummaryPanel = () => {
   const { service } = useDatasetQualityContext();
-  const { filteredItems, canUserMonitorDataset, canUserMonitorAnyDataStream, loading } =
-    useDatasetQualityTable();
+  const {
+    filteredItems,
+    canUserMonitorDataset,
+    canUserMonitorAnyDataStream,
+    loading: isTableLoading,
+  } = useDatasetQualityTable();
 
   const { timeRange } = useSelector(service, (state) => state.context.filters);
 
@@ -27,9 +31,10 @@ const useSummaryPanel = () => {
     percentages: filteredItems.map((item) => item.degradedDocs.percentage),
   };
 
-  const isDatasetsQualityLoading = useSelector(service, (state) =>
+  const isDegradedDocsLoading = useSelector(service, (state) =>
     state.matches('stats.degradedDocs.fetching')
   );
+  const isDatasetsQualityLoading = isDegradedDocsLoading || isTableLoading;
 
   /*
     User Authorization
@@ -38,7 +43,7 @@ const useSummaryPanel = () => {
     (item) => item.userPrivileges?.canMonitor ?? true
   );
 
-  const isUserAuthorizedForDataset = !loading
+  const isUserAuthorizedForDataset = !isTableLoading
     ? canUserMonitorDataset && canUserMonitorAnyDataStream && canUserMonitorAllFilteredDataStreams
     : true;
 

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_details.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_details.ts
@@ -423,7 +423,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
           );
         });
 
-        countColumn.sort('ascending');
+        await countColumn.sort('ascending');
 
         await retry.tryForTime(5000, async () => {
           const currentUrl = await browser.getCurrentUrl();

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_summary.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_summary.ts
@@ -47,7 +47,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
     ]);
   };
 
-  describe.only('Dataset quality summary', () => {
+  describe('Dataset quality summary', () => {
     afterEach(async () => {
       await synthtrace.clean();
     });

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_summary.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_summary.ts
@@ -19,7 +19,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
   const synthtrace = getService('logSynthtraceEsClient');
   const to = '2024-01-01T12:00:00.000Z';
 
-  const ingestDataForSummary = async () => {
+  const ingestDataForSummary = () => {
     // Ingest documents for 3 type of datasets
     return synthtrace.index([
       // Ingest good data to all 3 datasets
@@ -47,17 +47,15 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
     ]);
   };
 
-  describe('Dataset quality summary', () => {
-    before(async () => {
-      await synthtrace.index(getInitialTestLogs({ to, count: 4 }));
-      await PageObjects.datasetQuality.navigateTo();
-    });
-
+  describe.only('Dataset quality summary', () => {
     afterEach(async () => {
       await synthtrace.clean();
     });
 
     it('shows poor, degraded and good count as 0 and all dataset as healthy', async () => {
+      await synthtrace.index(getInitialTestLogs({ to, count: 4 }));
+      await PageObjects.datasetQuality.navigateTo();
+
       const summary = await PageObjects.datasetQuality.parseSummaryPanel();
       expect(summary).to.eql({
         datasetHealthPoor: '0',
@@ -70,7 +68,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
     it('shows updated count for poor, degraded and good datasets, estimated size and updates active datasets', async () => {
       await ingestDataForSummary();
-      await PageObjects.datasetQuality.refreshTable();
+      await PageObjects.datasetQuality.navigateTo();
 
       const summary = await PageObjects.datasetQuality.parseSummaryPanel();
       const { estimatedData, ...restOfSummary } = summary;


### PR DESCRIPTION
## 📓 Summary

Closes #186549 

Refreshing the page didn't give enough time for the data ingestion to process correctly, hopefully navigating to the page, which is gated by an assertion on loading indicators, should check that data is loaded correctly.

Also, running the test in isolation raised a bug in the code, where the loading of the summary details was not synced with the loaded data from the table. This resulted in the summary always being 0 at first load, and then immediately update once the table is ready, which broke the test. Syncing their loading indicators fixed the issue and tests passes in isolation too.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->