### PR TITLE
feat(reporting,security): generate a dedicated API key for the reporting job for interactive users relying on the token based authentication

### DIFF
--- a/x-pack/plugins/security/server/authentication/http_authentication/http_authorization_header.ts
+++ b/x-pack/plugins/security/server/authentication/http_authentication/http_authorization_header.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { KibanaRequest } from '@kbn/core/server';
+import type { ScopeableRequest } from '@kbn/core/server';
 
 export class HTTPAuthorizationHeader {
   /**
@@ -30,7 +30,7 @@ export class HTTPAuthorizationHeader {
    * @param [headerName] Optional name of the HTTP header to extract authentication information from. By default, the
    * authentication information is extracted from the `Authorization` HTTP header.
    */
-  static parseFromRequest(request: KibanaRequest, headerName = 'authorization') {
+  static parseFromRequest(request: ScopeableRequest, headerName = 'authorization') {
     const authorizationHeaderValue = request.headers[headerName.toLowerCase()];
     if (!authorizationHeaderValue || typeof authorizationHeaderValue !== 'string') {
       return null;


### PR DESCRIPTION
## Summary

>[!CAUTION]
> This is a proof-of-concept only, not a fully functional solution.

In this PR, reporting generates a dedicated short-lived API key for the reporting job if all of the following requirements are met:

- API keys are enabled in the deployment
- The report is being generated by the interactive user who relies on token-based authentication

The API key should be invalidated after report is complete (partially implemented)

## How to test

- Enable debug logs for Security and Reporting to have more visibility into what's happening under the hood:
```yaml
logging:
  loggers:
    - name: plugins.security
      level: debug
    - name: plugins.reporting
      level: debug
```

- Run Elasticsearch Serverless locally with this command to use very short access token expiration:
```shell
yarn es serverless --projectType=security -E xpack.security.authc.token.timeout=5s
```
- Run Kibana Serverless locally with this command:
```shell
yarn start --serverless=security
```
- Log in via "Mock IdP" SAML login page as an `admin`
- Generate a sample data and try to generate report of any size, observe logs and see that report is generated successfully:
```
[2024-11-26T12:54:40.734+01:00][DEBUG][plugins.security.authentication.api-key] Testing if API Keys are enabled by attempting to invalidate a non-existant key: kibana-api-key-service-test
[2024-11-26T12:54:40.744+01:00][DEBUG][plugins.security.authentication.api-key] Trying to grant an API key
[2024-11-26T12:54:40.981+01:00][DEBUG][plugins.security.authentication.api-key] API key was granted successfully
[2024-11-26T12:54:40.982+01:00][DEBUG][plugins.reporting] Successfully replaced user bearer token with an API key for the reporting job.
```

__Fixes: https://github.com/elastic/kibana/issues/71866__