### PR TITLE
[8.17] Remove hardcoded preconfigured ELSER endpoint (#201300)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_error.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_error.tsx
@@ -31,15 +31,10 @@ export interface IndexErrorProps {
 }
 
 interface SemanticTextProperty extends MappingPropertyBase {
-  inference_id?: string;
+  inference_id: string;
   type: 'semantic_text';
 }
 
-/*  
-  This will be repalce once we add default elser inference_id 
-  with the index mapping response.
-*/
-const ELSER_PRECONFIGURED_ENDPOINTS = '.elser-2-elasticsearch';
 const isInferencePreconfigured = (inferenceId: string) => inferenceId.startsWith('.');
 
 const parseMapping = (mappings: MappingTypeMapping) => {
@@ -56,11 +51,6 @@ const getSemanticTextFields = (
 ): Array<{ path: string; source: SemanticTextProperty }> => {
   return Object.entries(fields).flatMap(([key, value]) => {
     const currentPath: string = path ? `${path}.${key}` : key;
-    if (value.type === 'semantic_text') {
-      value = value.inference_id
-        ? value
-        : { ...value, inference_id: ELSER_PRECONFIGURED_ENDPOINTS };
-    }
     const currentField: Array<{ path: string; source: SemanticTextProperty }> =
       value.type === 'semantic_text' ? [{ path: currentPath, source: value }] : [];
     if (hasProperties(value)) {

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/select_inference_id.test.tsx
@@ -9,7 +9,7 @@ import {
   Form,
   useForm,
 } from '../../../public/application/components/mappings_editor/shared_imports';
-import { registerTestBed } from '@kbn/test-jest-helpers';
+import { findTestSubject, registerTestBed } from '@kbn/test-jest-helpers';
 import { act } from 'react-dom/test-utils';
 import {
   SelectInferenceId,
@@ -151,5 +151,35 @@ describe('SelectInferenceId', () => {
     expect(find('data-inference-endpoint-list').contains('endpoint-1')).toBe(true);
     expect(find('data-inference-endpoint-list').contains('endpoint-2')).toBe(true);
     expect(find('data-inference-endpoint-list').contains('endpoint-3')).toBe(false);
+  });
+
+  it('select the first endpoint by default', () => {
+    find('inferenceIdButton').simulate('click');
+    const defaultElser = findTestSubject(
+      find('data-inference-endpoint-list'),
+      'custom-inference_.preconfigured-elser'
+    );
+    expect(defaultElser.prop('aria-checked')).toEqual(true);
+  });
+
+  it('does not select the other endpoints by default', () => {
+    find('inferenceIdButton').simulate('click');
+    const defaultE5 = findTestSubject(
+      find('data-inference-endpoint-list'),
+      'custom-inference_.preconfigured-e5'
+    );
+    expect(defaultE5.prop('aria-checked')).toEqual(false);
+
+    const endpoint1 = findTestSubject(
+      find('data-inference-endpoint-list'),
+      'custom-inference_endpoint-1'
+    );
+    expect(endpoint1.prop('aria-checked')).toEqual(false);
+
+    const endpoint2 = findTestSubject(
+      find('data-inference-endpoint-list'),
+      'custom-inference_endpoint-2'
+    );
+    expect(endpoint2.prop('aria-checked')).toEqual(false);
   });
 });

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/select_inference_id.tsx
@@ -132,6 +132,14 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
       'data-test-subj': `custom-inference_${endpoint.inference_id}`,
       checked: value === endpoint.inference_id ? 'on' : undefined,
     }));
+    /**
+     * Adding this check to ensure we have the preconfigured elser endpoint selected by default.
+     */
+    const hasInferenceSelected = newOptions.some((option) => option.checked === 'on');
+    if (!hasInferenceSelected && newOptions.length > 0) {
+      newOptions[0].checked = 'on';
+    }
+
     if (value && !newOptions.find((option) => option.label === value)) {
       // Sometimes we create a new endpoint but the backend is slow in updating so we need to optimistically update
       const newOption: EuiSelectableOption = {
@@ -273,6 +281,7 @@ const SelectInferenceIdContent: React.FC<SelectInferenceIdContentProps> = ({
           searchable
           isLoading={isLoading}
           singleSelection="always"
+          defaultChecked
           searchProps={{
             compressed: true,
             placeholder: i18n.translate(

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/semantic_text/use_semantic_text.test.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/semantic_text/use_semantic_text.test.ts
@@ -13,15 +13,15 @@ import { act } from 'react-dom/test-utils';
 jest.mock('../../../../../../../../hooks/use_details_page_mappings_model_management', () => ({
   useDetailsPageMappingsModelManagement: () => ({
     fetchInferenceToModelIdMap: () => ({
-      e5: {
-        isDeployed: false,
-        isDeployable: true,
-        trainedModelId: '.multilingual-e5-small',
-      },
-      elser_model_2: {
+      '.preconfigured_elser': {
         isDeployed: false,
         isDeployable: true,
         trainedModelId: '.elser_model_2',
+      },
+      '.preconfigured_e5': {
+        isDeployed: false,
+        isDeployable: true,
+        trainedModelId: '.multilingual-e5-small',
       },
       openai: {
         isDeployed: false,
@@ -49,13 +49,13 @@ const mockField: Record<string, SemanticTextField> = {
   elser_model_2: {
     name: 'name',
     type: 'semantic_text',
-    inference_id: 'elser_model_2',
+    inference_id: '.preconfigured_elser',
     reference_field: 'title',
   },
   e5: {
     name: 'name',
     type: 'semantic_text',
-    inference_id: 'e5',
+    inference_id: '.preconfigured_e5',
     reference_field: 'title',
   },
   openai: {
@@ -100,15 +100,15 @@ const mockDispatch = jest.fn();
 jest.mock('../../../../../mappings_state_context', () => ({
   useMappingsState: jest.fn().mockReturnValue({
     inferenceToModelIdMap: {
-      e5: {
-        isDeployed: false,
-        isDeployable: true,
-        trainedModelId: '.multilingual-e5-small',
-      },
-      elser_model_2: {
+      '.preconfigured_elser': {
         isDeployed: false,
         isDeployable: true,
         trainedModelId: '.elser_model_2',
+      },
+      '.preconfigured_e5': {
+        isDeployed: false,
+        isDeployable: true,
+        trainedModelId: '.multilingual-e5-small',
       },
       openai: {
         isDeployed: false,
@@ -142,7 +142,7 @@ jest.mock('../../../../../../../services/api', () => ({
   getInferenceEndpoints: jest.fn().mockResolvedValue({
     data: [
       {
-        inference_id: 'e5',
+        inference_id: '.preconfigured_e5',
         task_type: 'text_embedding',
         service: 'elasticsearch',
         service_settings: {
@@ -212,28 +212,6 @@ describe('useSemanticText', () => {
       mockConfig.openai.modelConfig
     );
   });
-  it('should handle semantic text with inference endpoint created from flyout correctly', async () => {
-    const { result } = renderHook(() =>
-      useSemanticText({
-        form: mockForm.elasticModelEndpointCreatedfromFlyout,
-        setErrorsInTrainedModelDeployment: jest.fn(),
-        ml: mlMock,
-      })
-    );
-    await act(async () => {
-      result.current.handleSemanticText(mockField.my_elser_endpoint, mockConfig.elser);
-    });
-
-    expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'field.add',
-      value: mockField.my_elser_endpoint,
-    });
-    expect(mlMock.mlApi.inferenceModels.createInferenceEndpoint).toHaveBeenCalledWith(
-      'my_elser_endpoint',
-      'sparse_embedding',
-      mockConfig.elser.modelConfig
-    );
-  });
 
   it('should handle semantic text correctly', async () => {
     const { result } = renderHook(() =>
@@ -252,20 +230,6 @@ describe('useSemanticText', () => {
       type: 'field.add',
       value: mockField.elser_model_2,
     });
-    expect(mlMock.mlApi.inferenceModels.createInferenceEndpoint).toHaveBeenCalledWith(
-      'elser_model_2',
-      'sparse_embedding',
-      {
-        service: 'elser',
-        service_settings: {
-          adaptive_allocations: {
-            enabled: true,
-          },
-          num_threads: 1,
-          model_id: '.elser_model_2',
-        },
-      }
-    );
   });
   it('does not call create inference endpoint api, if default endpoint already exists', async () => {
     const { result } = renderHook(() =>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/semantic_text/use_semantic_text.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/semantic_text/use_semantic_text.ts
@@ -19,7 +19,6 @@ import { useMLModelNotificationToasts } from '../../../../../../../../hooks/use_
 
 import { getInferenceEndpoints } from '../../../../../../../services/api';
 import { getFieldByPathName } from '../../../../../lib/utils';
-import { ELSER_PRECONFIGURED_ENDPOINTS } from '../../../../../constants';
 
 interface UseSemanticTextProps {
   form: FormHook<Field, Field>;
@@ -62,9 +61,6 @@ export function useSemanticText(props: UseSemanticTextProps) {
       }
       if (!form.getFormData().reference_field) {
         form.setFieldValue('reference_field', referenceField);
-      }
-      if (!form.getFormData().inference_id) {
-        form.setFieldValue('inference_id', ELSER_PRECONFIGURED_ENDPOINTS);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
@@ -19,11 +19,7 @@ import { i18n } from '@kbn/i18n';
 
 import { NormalizedField, NormalizedFields, State } from '../../../types';
 import { getTypeLabelFromField } from '../../../lib';
-import {
-  CHILD_FIELD_INDENT_SIZE,
-  ELSER_PRECONFIGURED_ENDPOINTS,
-  LEFT_PADDING_SIZE_FIELD_ITEM_WRAPPER,
-} from '../../../constants';
+import { CHILD_FIELD_INDENT_SIZE, LEFT_PADDING_SIZE_FIELD_ITEM_WRAPPER } from '../../../constants';
 
 import { FieldsList } from './fields_list';
 import { CreateField } from './create_field';
@@ -109,7 +105,6 @@ function FieldListItemComponent(
   const indent = treeDepth * CHILD_FIELD_INDENT_SIZE - substractIndentAmount;
 
   const isSemanticText = source.type === 'semantic_text';
-  const inferenceId: string = (source.inference_id as string) ?? ELSER_PRECONFIGURED_ENDPOINTS;
 
   const indentCreateField =
     (treeDepth + 1) * CHILD_FIELD_INDENT_SIZE +
@@ -298,7 +293,7 @@ function FieldListItemComponent(
 
             {isSemanticText && (
               <EuiFlexItem grow={false}>
-                <EuiBadge color="hollow">{inferenceId}</EuiBadge>
+                <EuiBadge color="hollow">{source.inference_id as string}</EuiBadge>
               </EuiFlexItem>
             )}
 

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/constants/default_values.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/constants/default_values.ts
@@ -13,9 +13,3 @@
 export const INDEX_DEFAULT = 'index_default';
 
 export const STANDARD = 'standard';
-
-/*  
-  This will be repalce once we add default elser inference_id 
-  with the index mapping response.
-*/
-export const ELSER_PRECONFIGURED_ENDPOINTS = '.elser-2-elasticsearch';

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/constants/parameters_definition.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/constants/parameters_definition.tsx
@@ -1126,22 +1126,10 @@ export const PARAMETERS_DEFINITION: { [key in ParameterName]: ParameterDefinitio
   },
   inference_id: {
     fieldConfig: {
-      defaultValue: 'elser_model_2',
+      defaultValue: '',
       label: i18n.translate('xpack.idxMgmt.mappingsEditor.parameters.inferenceIdLabel', {
         defaultMessage: 'Select an inference endpoint:',
       }),
-      validations: [
-        {
-          validator: emptyField(
-            i18n.translate(
-              'xpack.idxMgmt.mappingsEditor.parameters.validations.inferenceIdIsRequiredErrorMessage',
-              {
-                defaultMessage: 'Inference ID is required.',
-              }
-            )
-          ),
-        },
-      ],
     },
     schema: t.string,
   },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Remove hardcoded preconfigured ELSER endpoint (#201300)](https://github.com/elastic/kibana/pull/201300)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Samiul Monir","email":"150824886+Samiul-TheSoccerFan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-11-26T14:42:20Z","message":"Remove hardcoded preconfigured ELSER endpoint (#201300)\n\n## Summary\r\n\r\nThe Index mapping will have access to default elser inference endpoint\r\nso we do not need to hardcode endpoint names in the Kibana.\r\n\r\nThis needs to go after\r\n#https://github.com/elastic/elasticsearch/pull/117294 merges in `8.17`\r\nand further.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/4a786fde-e250-440d-a9d7-2256dacc8edd\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b3d638b7cf3022fbe1e0fb019462ad9df6d52f25","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Search","backport:version","v8.17.0","v8.18.0"],"number":201300,"url":"https://github.com/elastic/kibana/pull/201300","mergeCommit":{"message":"Remove hardcoded preconfigured ELSER endpoint (#201300)\n\n## Summary\r\n\r\nThe Index mapping will have access to default elser inference endpoint\r\nso we do not need to hardcode endpoint names in the Kibana.\r\n\r\nThis needs to go after\r\n#https://github.com/elastic/elasticsearch/pull/117294 merges in `8.17`\r\nand further.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/4a786fde-e250-440d-a9d7-2256dacc8edd\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b3d638b7cf3022fbe1e0fb019462ad9df6d52f25"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/201300","number":201300,"mergeCommit":{"message":"Remove hardcoded preconfigured ELSER endpoint (#201300)\n\n## Summary\r\n\r\nThe Index mapping will have access to default elser inference endpoint\r\nso we do not need to hardcode endpoint names in the Kibana.\r\n\r\nThis needs to go after\r\n#https://github.com/elastic/elasticsearch/pull/117294 merges in `8.17`\r\nand further.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/4a786fde-e250-440d-a9d7-2256dacc8edd\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b3d638b7cf3022fbe1e0fb019462ad9df6d52f25"}},{"branch":"8.17","label":"v8.17.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201811","number":201811,"state":"OPEN"}]}] BACKPORT-->