### PR TITLE
chore(slo): Migrate deprecated access tag

### DIFF
--- a/x-pack/plugins/observability_solution/slo/server/routes/slo/route.ts
+++ b/x-pack/plugins/observability_solution/slo/server/routes/slo/route.ts
@@ -79,9 +79,11 @@ const getSpaceId = async (plugins: SLORoutesDependencies['plugins'], request: Ki
 
 const createSLORoute = createSloServerRoute({
   endpoint: 'POST /api/observability/slos 2023-10-31',
-  options: {
-    tags: ['access:slo_write'],
-    access: 'public',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_write'],
+    },
   },
   params: createSLOParamsSchema,
   handler: async ({ context, response, params, logger, request, plugins, corePlugins }) => {
@@ -134,9 +136,11 @@ const createSLORoute = createSloServerRoute({
 
 const inspectSLORoute = createSloServerRoute({
   endpoint: 'POST /internal/observability/slos/_inspect',
-  options: {
-    tags: ['access:slo_write'],
-    access: 'internal',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_write'],
+    },
   },
   params: createSLOParamsSchema,
   handler: async ({ context, params, logger, request, plugins, corePlugins }) => {
@@ -186,9 +190,11 @@ const inspectSLORoute = createSloServerRoute({
 
 const updateSLORoute = createSloServerRoute({
   endpoint: 'PUT /api/observability/slos/{id} 2023-10-31',
-  options: {
-    tags: ['access:slo_write'],
-    access: 'public',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_write'],
+    },
   },
   params: updateSLOParamsSchema,
   handler: async ({ context, request, params, logger, plugins, corePlugins }) => {
@@ -239,9 +245,11 @@ const updateSLORoute = createSloServerRoute({
 
 const deleteSLORoute = createSloServerRoute({
   endpoint: 'DELETE /api/observability/slos/{id} 2023-10-31',
-  options: {
-    tags: ['access:slo_write'],
-    access: 'public',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_write'],
+    },
   },
   params: deleteSLOParamsSchema,
   handler: async ({ request, response, context, params, logger, plugins }) => {
@@ -295,9 +303,11 @@ const deleteSLORoute = createSloServerRoute({
 
 const getSLORoute = createSloServerRoute({
   endpoint: 'GET /api/observability/slos/{id} 2023-10-31',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'public',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   params: getSLOParamsSchema,
   handler: async ({ request, context, params, logger, plugins }) => {
@@ -321,9 +331,11 @@ const getSLORoute = createSloServerRoute({
 
 const enableSLORoute = createSloServerRoute({
   endpoint: 'POST /api/observability/slos/{id}/enable 2023-10-31',
-  options: {
-    tags: ['access:slo_write'],
-    access: 'public',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_write'],
+    },
   },
   params: manageSLOParamsSchema,
   handler: async ({ request, response, context, params, logger, plugins }) => {
@@ -366,9 +378,11 @@ const enableSLORoute = createSloServerRoute({
 
 const disableSLORoute = createSloServerRoute({
   endpoint: 'POST /api/observability/slos/{id}/disable 2023-10-31',
-  options: {
-    tags: ['access:slo_write'],
-    access: 'public',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_write'],
+    },
   },
   params: manageSLOParamsSchema,
   handler: async ({ response, request, context, params, logger, plugins }) => {
@@ -410,9 +424,11 @@ const disableSLORoute = createSloServerRoute({
 
 const resetSLORoute = createSloServerRoute({
   endpoint: 'POST /api/observability/slos/{id}/_reset 2023-10-31',
-  options: {
-    tags: ['access:slo_write'],
-    access: 'public',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_write'],
+    },
   },
   params: resetSLOParamsSchema,
   handler: async ({ context, request, params, logger, plugins, corePlugins }) => {
@@ -463,9 +479,11 @@ const resetSLORoute = createSloServerRoute({
 
 const findSLORoute = createSloServerRoute({
   endpoint: 'GET /api/observability/slos 2023-10-31',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'public',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   params: findSLOParamsSchema,
   handler: async ({ context, request, params, logger, plugins }) => {
@@ -485,9 +503,11 @@ const findSLORoute = createSloServerRoute({
 
 const findSLOGroupsRoute = createSloServerRoute({
   endpoint: 'GET /internal/observability/slos/_groups',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'internal',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   params: findSLOGroupsParamsSchema,
   handler: async ({ context, request, params, logger, plugins }) => {
@@ -504,9 +524,11 @@ const findSLOGroupsRoute = createSloServerRoute({
 
 const getSLOSuggestionsRoute = createSloServerRoute({
   endpoint: 'GET /internal/observability/slos/suggestions',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'internal',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   handler: async ({ context, plugins }) => {
     await assertPlatinumLicense(plugins);
@@ -519,9 +541,11 @@ const getSLOSuggestionsRoute = createSloServerRoute({
 
 const deleteSloInstancesRoute = createSloServerRoute({
   endpoint: 'POST /api/observability/slos/_delete_instances 2023-10-31',
-  options: {
-    tags: ['access:slo_write'],
-    access: 'public',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_write'],
+    },
   },
   params: deleteSLOInstancesParamsSchema,
   handler: async ({ response, context, params, plugins }) => {
@@ -537,9 +561,11 @@ const deleteSloInstancesRoute = createSloServerRoute({
 
 const findSloDefinitionsRoute = createSloServerRoute({
   endpoint: 'GET /api/observability/slos/_definitions 2023-10-31',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'public',
+  options: { access: 'public' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   params: findSloDefinitionsParamsSchema,
   handler: async ({ context, params, logger, plugins }) => {
@@ -555,9 +581,11 @@ const findSloDefinitionsRoute = createSloServerRoute({
 
 const fetchHistoricalSummary = createSloServerRoute({
   endpoint: 'POST /internal/observability/slos/_historical_summary',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'internal',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   params: fetchHistoricalSummaryParamsSchema,
   handler: async ({ context, params, plugins }) => {
@@ -572,9 +600,11 @@ const fetchHistoricalSummary = createSloServerRoute({
 
 const getSLOInstancesRoute = createSloServerRoute({
   endpoint: 'GET /internal/observability/slos/{id}/_instances',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'internal',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   params: getSLOInstancesParamsSchema,
   handler: async ({ context, params, logger, plugins }) => {
@@ -591,9 +621,12 @@ const getSLOInstancesRoute = createSloServerRoute({
 
 const getDiagnosisRoute = createSloServerRoute({
   endpoint: 'GET /internal/observability/slos/_diagnosis',
-  options: {
-    tags: [],
-    access: 'internal',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      enabled: false,
+      reason: 'The endpoint is used to diagnose SLOs and does not require any specific privileges.',
+    },
   },
   params: undefined,
   handler: async ({ context, plugins }) => {
@@ -614,9 +647,11 @@ const getDiagnosisRoute = createSloServerRoute({
 
 const fetchSloHealthRoute = createSloServerRoute({
   endpoint: 'POST /internal/observability/slos/_health',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'internal',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   params: fetchSLOHealthParamsSchema,
   handler: async ({ context, params, logger, plugins }) => {
@@ -636,9 +671,11 @@ const fetchSloHealthRoute = createSloServerRoute({
 
 const getSloBurnRates = createSloServerRoute({
   endpoint: 'POST /internal/observability/slos/{id}/_burn_rates',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'internal',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   params: getSLOBurnRatesParamsSchema,
   handler: async ({ request, context, params, logger, plugins }) => {
@@ -669,9 +706,11 @@ const getSloBurnRates = createSloServerRoute({
 
 const getPreviewData = createSloServerRoute({
   endpoint: 'POST /internal/observability/slos/_preview',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'internal',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   params: getPreviewDataParamsSchema,
   handler: async ({ request, context, params, plugins }) => {
@@ -690,9 +729,11 @@ const getPreviewData = createSloServerRoute({
 
 const getSloSettingsRoute = createSloServerRoute({
   endpoint: 'GET /internal/slo/settings',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'internal',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   handler: async ({ context, plugins }) => {
     await assertPlatinumLicense(plugins);
@@ -706,9 +747,11 @@ const getSloSettingsRoute = createSloServerRoute({
 const putSloSettings = (isServerless?: boolean) =>
   createSloServerRoute({
     endpoint: 'PUT /internal/slo/settings',
-    options: {
-      tags: ['access:slo_write'],
-      access: 'internal',
+    options: { access: 'internal' },
+    security: {
+      authz: {
+        requiredPrivileges: ['slo_write'],
+      },
     },
     params: isServerless ? putSLOServerlessSettingsParamsSchema : putSLOSettingsParamsSchema,
     handler: async ({ context, params, plugins }) => {
@@ -723,9 +766,11 @@ const putSloSettings = (isServerless?: boolean) =>
 
 const getSLOsOverview = createSloServerRoute({
   endpoint: 'GET /internal/observability/slos/overview',
-  options: {
-    tags: ['access:slo_read'],
-    access: 'internal',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      requiredPrivileges: ['slo_read'],
+    },
   },
   params: getOverviewParamsSchema,
   handler: async ({ context, params, request, logger, plugins }) => {


### PR DESCRIPTION
### 🍒 Summary

This PR removes the deprecated previous way of managing route authentication, and replaces them with the new `security.authz` configuration

### 🧪 Manual testing

- Create two roles: one without any permission on Kibana SLO and one with Read permission only.
- Create two users associated to these roles
- Assert the role without read access can't access SLO pages
- Assert the role with read only cannot create/edit/reset/delete SLOs

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->