### PR TITLE
Add retry logic to license fetcher

### DIFF
--- a/x-pack/plugins/licensing/server/license_fetcher.test.ts
+++ b/x-pack/plugins/licensing/server/license_fetcher.test.ts
@@ -162,7 +162,7 @@ describe('LicenseFetcher', () => {
     expect(clusterClient.asInternalUser.xpack.info).toBeCalledTimes(1);
 
     const licensePromise = fetcher();
-    jest.advanceTimersByTimeAsync(sumOfRetryTimes);
+    await jest.advanceTimersByTimeAsync(sumOfRetryTimes);
     license = await licensePromise;
     expect(license.uid).toEqual('license-1');
     // should be called once in the successful mock, once in the error mock

--- a/x-pack/plugins/licensing/server/license_fetcher.test.ts
+++ b/x-pack/plugins/licensing/server/license_fetcher.test.ts
@@ -50,7 +50,7 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
-      maxRetryDelay
+      maxRetryDelay,
     });
 
     const license = await fetcher();
@@ -76,7 +76,7 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
-      maxRetryDelay
+      maxRetryDelay,
     });
 
     let license = await fetcher();
@@ -96,7 +96,7 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
-      maxRetryDelay
+      maxRetryDelay,
     });
 
     const licensePromise = fetcher();
@@ -125,7 +125,7 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
-      maxRetryDelay
+      maxRetryDelay,
     });
 
     const licensePromise = fetcher();
@@ -148,13 +148,13 @@ describe('LicenseFetcher', () => {
       } as any)
       .mockResponseImplementation(() => {
         throw new Error('woups');
-      })
+      });
 
     const fetcher = getLicenseFetcher({
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
-      maxRetryDelay
+      maxRetryDelay,
     });
 
     let license = await fetcher();
@@ -181,13 +181,13 @@ describe('LicenseFetcher', () => {
       } as any)
       .mockResponseImplementation(() => {
         throw new Error('woups');
-      })
+      });
 
     const fetcher = getLicenseFetcher({
       logger,
       clusterClient,
       cacheDurationMs: 1,
-      maxRetryDelay
+      maxRetryDelay,
     });
 
     let license = await fetcher();
@@ -209,7 +209,7 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
-      maxRetryDelay
+      maxRetryDelay,
     });
 
     const license = await fetcher();
@@ -233,7 +233,7 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
-      maxRetryDelay
+      maxRetryDelay,
     });
 
     const license = await fetcher();
@@ -255,7 +255,7 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
-      maxRetryDelay: 10 * 1000
+      maxRetryDelay: 10 * 1000,
     });
     const sumOfRetryTimesUntilTen = (1 + 2 + 4 + 8) * 1000;
 

--- a/x-pack/plugins/licensing/server/license_fetcher.test.ts
+++ b/x-pack/plugins/licensing/server/license_fetcher.test.ts
@@ -12,7 +12,8 @@ import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 
 type EsLicense = estypes.XpackInfoMinimalLicenseInformation;
 
-const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
+const maxRetryDelay = 30 * 1000;
+const sumOfRetryTimes = (1 + 2 + 4 + 8 + 16) * 1000;
 
 function buildRawLicense(options: Partial<EsLicense> = {}): EsLicense {
   return {
@@ -33,6 +34,9 @@ describe('LicenseFetcher', () => {
     logger = loggerMock.create();
     clusterClient = elasticsearchServiceMock.createClusterClient();
   });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 
   it('returns the license for successful calls', async () => {
     clusterClient.asInternalUser.xpack.info.mockResponse({
@@ -46,6 +50,7 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
+      maxRetryDelay
     });
 
     const license = await fetcher();
@@ -71,6 +76,7 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
+      maxRetryDelay
     });
 
     let license = await fetcher();
@@ -81,6 +87,7 @@ describe('LicenseFetcher', () => {
   });
 
   it('returns an error license in case of error', async () => {
+    jest.useFakeTimers();
     clusterClient.asInternalUser.xpack.info.mockResponseImplementation(() => {
       throw new Error('woups');
     });
@@ -89,13 +96,20 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
+      maxRetryDelay
     });
 
-    const license = await fetcher();
+    const licensePromise = fetcher();
+    await jest.advanceTimersByTimeAsync(sumOfRetryTimes);
+    const license = await licensePromise;
+
     expect(license.error).toEqual('woups');
+    // should be called once to start and then in the retries after 1s, 2s, 4s, 8s and 16s
+    expect(clusterClient.asInternalUser.xpack.info).toHaveBeenCalledTimes(6);
   });
 
   it('returns a license successfully fetched after an error', async () => {
+    jest.useFakeTimers();
     clusterClient.asInternalUser.xpack.info
       .mockResponseImplementationOnce(() => {
         throw new Error('woups');
@@ -111,15 +125,20 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
+      maxRetryDelay
     });
 
-    let license = await fetcher();
-    expect(license.error).toEqual('woups');
-    license = await fetcher();
+    const licensePromise = fetcher();
+    // wait one minute since we mocked only one error
+    await jest.advanceTimersByTimeAsync(1000);
+    const license = await licensePromise;
+
     expect(license.uid).toEqual('license-1');
+    expect(clusterClient.asInternalUser.xpack.info).toBeCalledTimes(2);
   });
 
   it('returns the latest fetched license after an error within the cache duration period', async () => {
+    jest.useFakeTimers();
     clusterClient.asInternalUser.xpack.info
       .mockResponseOnce({
         license: buildRawLicense({
@@ -127,23 +146,32 @@ describe('LicenseFetcher', () => {
         }),
         features: {},
       } as any)
-      .mockResponseImplementationOnce(() => {
+      .mockResponseImplementation(() => {
         throw new Error('woups');
-      });
+      })
 
     const fetcher = getLicenseFetcher({
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
+      maxRetryDelay
     });
 
     let license = await fetcher();
     expect(license.uid).toEqual('license-1');
-    license = await fetcher();
+    expect(clusterClient.asInternalUser.xpack.info).toBeCalledTimes(1);
+
+    const licensePromise = fetcher();
+    jest.advanceTimersByTimeAsync(sumOfRetryTimes);
+    license = await licensePromise;
     expect(license.uid).toEqual('license-1');
+    // should be called once in the successful mock, once in the error mock
+    // and then in the retries after 1s, 2s, 4s, 8s and 16s
+    expect(clusterClient.asInternalUser.xpack.info).toBeCalledTimes(7);
   });
 
   it('returns an error license after an error exceeding the cache duration period', async () => {
+    jest.useFakeTimers();
     clusterClient.asInternalUser.xpack.info
       .mockResponseOnce({
         license: buildRawLicense({
@@ -151,22 +179,23 @@ describe('LicenseFetcher', () => {
         }),
         features: {},
       } as any)
-      .mockResponseImplementationOnce(() => {
+      .mockResponseImplementation(() => {
         throw new Error('woups');
-      });
+      })
 
     const fetcher = getLicenseFetcher({
       logger,
       clusterClient,
       cacheDurationMs: 1,
+      maxRetryDelay
     });
 
     let license = await fetcher();
     expect(license.uid).toEqual('license-1');
 
-    await delay(50);
-
-    license = await fetcher();
+    const licensePromise = fetcher();
+    await jest.advanceTimersByTimeAsync(sumOfRetryTimes);
+    license = await licensePromise;
     expect(license.error).toEqual('woups');
   });
 
@@ -180,6 +209,7 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
+      maxRetryDelay
     });
 
     const license = await fetcher();
@@ -203,6 +233,7 @@ describe('LicenseFetcher', () => {
       logger,
       clusterClient,
       cacheDurationMs: 50_000,
+      maxRetryDelay
     });
 
     const license = await fetcher();
@@ -212,5 +243,28 @@ describe('LicenseFetcher', () => {
         "License information fetched from Elasticsearch, but no license is available",
       ]
     `);
+  });
+
+  it('testing the fetcher retry with a different maxRetryDelay using only errors', async () => {
+    jest.useFakeTimers();
+    clusterClient.asInternalUser.xpack.info.mockResponseImplementation(() => {
+      throw new Error('woups');
+    });
+
+    const fetcher = getLicenseFetcher({
+      logger,
+      clusterClient,
+      cacheDurationMs: 50_000,
+      maxRetryDelay: 10 * 1000
+    });
+    const sumOfRetryTimesUntilTen = (1 + 2 + 4 + 8) * 1000;
+
+    const licensePromise = fetcher();
+    await jest.advanceTimersByTimeAsync(sumOfRetryTimesUntilTen);
+    const license = await licensePromise;
+
+    expect(license.error).toEqual('woups');
+    // should be called once to start and then in the retries after 1s, 2s, 4s and 8s
+    expect(clusterClient.asInternalUser.xpack.info).toHaveBeenCalledTimes(5);
   });
 });

--- a/x-pack/plugins/licensing/server/license_fetcher.ts
+++ b/x-pack/plugins/licensing/server/license_fetcher.ts
@@ -26,7 +26,7 @@ export const getLicenseFetcher = ({
   clusterClient,
   logger,
   cacheDurationMs,
-  maxRetryDelay 
+  maxRetryDelay,
 }: {
   clusterClient: MaybePromise<IClusterClient>;
   logger: Logger;
@@ -40,7 +40,9 @@ export const getLicenseFetcher = ({
   return async () => {
     const client = isPromise(clusterClient) ? await clusterClient : clusterClient;
     try {
-      const response = await pRetry(() => client.asInternalUser.xpack.info(), {retries: maxRetries});
+      const response = await pRetry(() => client.asInternalUser.xpack.info(), {
+        retries: maxRetries,
+      });
       const normalizedLicense =
         response.license && response.license.type !== 'missing'
           ? normalizeServerLicense(response.license)
@@ -69,7 +71,7 @@ export const getLicenseFetcher = ({
       return currentLicense;
     } catch (err) {
       const error = err.originalError ?? err;
-      
+
       logger.warn(
         `License information could not be obtained from Elasticsearch due to ${error} error`
       );

--- a/x-pack/plugins/licensing/server/plugin.ts
+++ b/x-pack/plugins/licensing/server/plugin.ts
@@ -125,7 +125,7 @@ export class LicensingPlugin implements Plugin<LicensingPluginSetup, LicensingPl
       clusterClient,
       logger: this.logger,
       cacheDurationMs: this.config.license_cache_duration.asMilliseconds(),
-      maxRetryDelay: pollingFrequency
+      maxRetryDelay: pollingFrequency,
     });
 
     const { license$, refreshManually } = createLicenseUpdate(

--- a/x-pack/plugins/licensing/server/plugin.ts
+++ b/x-pack/plugins/licensing/server/plugin.ts
@@ -125,6 +125,7 @@ export class LicensingPlugin implements Plugin<LicensingPluginSetup, LicensingPl
       clusterClient,
       logger: this.logger,
       cacheDurationMs: this.config.license_cache_duration.asMilliseconds(),
+      maxRetryDelay: pollingFrequency
     });
 
     const { license$, refreshManually } = createLicenseUpdate(


### PR DESCRIPTION
## Summary

Added some retry logic to the license fetcher function and updated tests to match this new behavior.

Resolves: https://github.com/elastic/kibana/issues/197074 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)







<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->