### PR TITLE
chore(NA): update pipeline resource definitions after bump 8.15.6

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
@@ -22,7 +22,7 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 8.x 8.17 8.16 8.15 7.17
+      branch_configuration: main 8.x 8.17 8.16 7.17
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/build.yml
@@ -60,10 +60,6 @@ spec:
           cronline: 0 22 * * * America/New_York
           message: Daily build
           branch: '8.16'
-        Daily build (8.15):
-          cronline: 0 22 * * * America/New_York
-          message: Daily build
-          branch: '8.15'
         Daily build (7.17):
           cronline: 0 20 * * * America/New_York
           message: Daily build
@@ -95,7 +91,7 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 8.x 8.17 8.16 8.15 7.17
+      branch_configuration: main 8.x 8.17 8.16 7.17
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/promote.yml
@@ -144,7 +140,7 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         REPORT_FAILED_TESTS_TO_GITHUB: 'true'
       allow_rebuilds: true
-      branch_configuration: main 8.x 8.17 8.16 8.15 7.17
+      branch_configuration: main 8.x 8.17 8.16 7.17
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/verify.yml

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml
@@ -22,7 +22,7 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-unsupported-ftrs-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 8.x 8.17 8.16 8.15 7.17
+      branch_configuration: main 8.x 8.17 8.16 7.17
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/on_merge_unsupported_ftrs.yml

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
@@ -25,7 +25,7 @@ spec:
         REPORT_FAILED_TESTS_TO_GITHUB: 'true'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 8.x 8.17 8.16 8.15 7.17
+      branch_configuration: main 8.x 8.17 8.16 7.17
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/on_merge.yml


### PR DESCRIPTION
This PR updates the pipeline resource definitions after the 8.15.6 release.