### PR TITLE
[8.x] [React18] Migrate test suites to account for testing library upgrades security-threat-hunting-investigations (#201145)

### DIFF
--- a/packages/kbn-expandable-flyout/src/hooks/use_initialize_from_local_storage.test.ts
+++ b/packages/kbn-expandable-flyout/src/hooks/use_initialize_from_local_storage.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useInitializeFromLocalStorage } from './use_initialize_from_local_storage';
 import { localStorageMock } from '../../__mocks__';
 import {

--- a/packages/kbn-expandable-flyout/src/hooks/use_sections.test.tsx
+++ b/packages/kbn-expandable-flyout/src/hooks/use_sections.test.tsx
@@ -8,8 +8,7 @@
  */
 
 import React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
-import type { RenderHookResult } from '@testing-library/react-hooks';
+import { renderHook, RenderHookResult } from '@testing-library/react';
 import type { UseSectionsParams, UseSectionsResult } from './use_sections';
 import { useSections } from './use_sections';
 import { useExpandableFlyoutState } from '../..';
@@ -17,7 +16,7 @@ import { useExpandableFlyoutState } from '../..';
 jest.mock('../..');
 
 describe('useSections', () => {
-  let hookResult: RenderHookResult<UseSectionsParams, UseSectionsResult>;
+  let hookResult: RenderHookResult<UseSectionsResult, UseSectionsParams>;
 
   it('should return undefined for all values if no registeredPanels', () => {
     (useExpandableFlyoutState as jest.Mock).mockReturnValue({

--- a/packages/kbn-expandable-flyout/src/hooks/use_window_width.test.ts
+++ b/packages/kbn-expandable-flyout/src/hooks/use_window_width.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import {
   FULL_WIDTH_PADDING,
   MAX_RESOLUTION_BREAKPOINT,

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_data_providers.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_data_providers.test.ts
@@ -4,13 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { renderHook } from '@testing-library/react-hooks';
-import type { UseInsightDataProvidersProps, Provider } from './use_insight_data_providers';
+
+import { renderHook } from '@testing-library/react';
+import type { Provider } from './use_insight_data_providers';
 import type { TimelineEventsDetailsItem } from '../../../../../../common/search_strategy';
-import {
-  useInsightDataProviders,
-  type UseInsightDataProvidersResult,
-} from './use_insight_data_providers';
+import { useInsightDataProviders } from './use_insight_data_providers';
 import { mockAlertDetailsData } from '../../../event_details/mocks';
 
 const mockAlertDetailsDataWithIsObject = mockAlertDetailsData.map((detail) => {
@@ -103,7 +101,7 @@ const providerWithRange: Provider[][] = [
 
 describe('useInsightDataProviders', () => {
   it('should return 2 data providers, 1 with a nested provider ANDed to it', () => {
-    const { result } = renderHook<UseInsightDataProvidersProps, UseInsightDataProvidersResult>(() =>
+    const { result } = renderHook(() =>
       useInsightDataProviders({
         providers: nestedAndProvider,
         alertData: mockAlertDetailsDataWithIsObject,
@@ -117,7 +115,7 @@ describe('useInsightDataProviders', () => {
   });
 
   it('should return 3 data providers without any containing nested ANDs', () => {
-    const { result } = renderHook<UseInsightDataProvidersProps, UseInsightDataProvidersResult>(() =>
+    const { result } = renderHook(() =>
       useInsightDataProviders({
         providers: topLevelOnly,
         alertData: mockAlertDetailsDataWithIsObject,
@@ -130,7 +128,7 @@ describe('useInsightDataProviders', () => {
   });
 
   it('should use the string literal if no field in the alert matches a bracketed value', () => {
-    const { result } = renderHook<UseInsightDataProvidersProps, UseInsightDataProvidersResult>(() =>
+    const { result } = renderHook(() =>
       useInsightDataProviders({
         providers: nonExistantField,
         alertData: mockAlertDetailsDataWithIsObject,
@@ -145,7 +143,7 @@ describe('useInsightDataProviders', () => {
   });
 
   it('should use template data providers when called without alertData', () => {
-    const { result } = renderHook<UseInsightDataProvidersProps, UseInsightDataProvidersResult>(() =>
+    const { result } = renderHook(() =>
       useInsightDataProviders({
         providers: nestedAndProvider,
       })
@@ -159,7 +157,7 @@ describe('useInsightDataProviders', () => {
   });
 
   it('should return an empty array of dataProviders and populated filters if a provider contains a range type', () => {
-    const { result } = renderHook<UseInsightDataProvidersProps, UseInsightDataProvidersResult>(() =>
+    const { result } = renderHook(() =>
       useInsightDataProviders({
         providers: providerWithRange,
       })

--- a/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.test.ts
+++ b/x-pack/plugins/security_solution/public/common/components/markdown_editor/plugins/insight/use_insight_query.test.ts
@@ -4,13 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import type { QueryOperator } from '@kbn/timelines-plugin/common';
 import { DataProviderTypeEnum } from '../../../../../../common/api/timeline';
 import { useInsightQuery } from './use_insight_query';
 import { TestProviders } from '../../../../mock';
-import type { UseInsightQuery, UseInsightQueryResult } from './use_insight_query';
 import { IS_OPERATOR } from '../../../../../timelines/components/timeline/data_providers/data_provider';
 
 const mockProvider = {
@@ -30,7 +28,7 @@ const mockProvider = {
 
 describe('useInsightQuery', () => {
   it('should return renderable defaults', () => {
-    const { result } = renderHook<React.PropsWithChildren<UseInsightQuery>, UseInsightQueryResult>(
+    const { result } = renderHook(
       () =>
         useInsightQuery({
           dataProviders: [mockProvider],

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data.test.tsx
@@ -5,11 +5,10 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
-import type { PropsWithChildren } from 'react';
+import { renderHook } from '@testing-library/react';
 import { TestProviders } from '../../../../common/mock';
 import { ALERTS_QUERY_NAMES } from '../../../containers/detection_engine/alerts/constants';
-import type { UseAlerts, UseAlertsQueryProps } from './use_summary_chart_data';
+import type { UseAlertsQueryProps } from './use_summary_chart_data';
 import { useSummaryChartData, getAlertsQuery } from './use_summary_chart_data';
 import * as aggregations from './aggregations';
 import * as severityMock from '../severity_level_panel/mock_data';
@@ -76,7 +75,7 @@ describe('getAlertsQuery', () => {
 
 // helper function to render the hook
 const renderUseSummaryChartData = (props: Partial<UseAlertsQueryProps> = {}) =>
-  renderHook<PropsWithChildren<UseAlertsQueryProps>, ReturnType<UseAlerts>>(
+  renderHook(
     () =>
       useSummaryChartData({
         aggregations: aggregations.severityAggregations,

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/alerts_local_storage/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/alerts_local_storage/index.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import React from 'react';
 
 import { useAlertsLocalStorage } from '.';

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import type { FieldSpec } from '@kbn/data-plugin/common';
 
 import type { GetAggregatableFields, UseInspectButtonParams } from './hooks';
@@ -120,7 +120,7 @@ describe('hooks', () => {
       jest.clearAllMocks();
     });
     it('returns only aggregateable fields', () => {
-      const wrapper = ({ children }: { children: JSX.Element }) => (
+      const wrapper = ({ children }: React.PropsWithChildren) => (
         <TestProviders>{children}</TestProviders>
       );
       const { result, unmount } = renderHook(() => useStackByFields(), { wrapper });
@@ -137,7 +137,7 @@ describe('hooks', () => {
         browserFields: { base: mockBrowserFields.base },
       });
 
-      const wrapper = ({ children }: { children: JSX.Element }) => (
+      const wrapper = ({ children }: React.PropsWithChildren) => (
         <TestProviders>{children}</TestProviders>
       );
       const useLensCompatibleFields = true;
@@ -155,7 +155,7 @@ describe('hooks', () => {
         browserFields: { nestedField: mockBrowserFields.nestedField },
       });
 
-      const wrapper = ({ children }: { children: JSX.Element }) => (
+      const wrapper = ({ children }: React.PropsWithChildren) => (
         <TestProviders>{children}</TestProviders>
       );
       const useLensCompatibleFields = true;

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/investigate_in_resolver.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/investigate_in_resolver.test.tsx
@@ -7,7 +7,7 @@
 
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { useIsInvestigateInResolverActionEnabled } from './investigate_in_resolver';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { TestProviders } from '../../../../common/mock';
 
 describe('InvestigateInResolverAction', () => {

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_to_case_actions.test.tsx
@@ -7,8 +7,7 @@
 
 import React from 'react';
 import { EuiContextMenu, EuiPopover } from '@elastic/eui';
-import { act, renderHook } from '@testing-library/react-hooks';
-import { render, screen } from '@testing-library/react';
+import { render, screen, renderHook, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useAddToCaseActions } from './use_add_to_case_actions';
 import { TestProviders } from '../../../../common/mock';

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_assignees_actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_assignees_actions.test.tsx
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
 import type { UseAlertAssigneesActionsProps } from './use_alert_assignees_actions';
 import { useAlertAssigneesActions } from './use_alert_assignees_actions';
 import { useAlertsPrivileges } from '../../../containers/detection_engine/alerts/use_alerts_privileges';
 import type { AlertTableContextMenuItem } from '../types';
-import { render } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
 import React from 'react';
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiPopover, EuiContextMenu } from '@elastic/eui';

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_tags_actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_tags_actions.test.tsx
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
 import type { UseAlertTagsActionsProps } from './use_alert_tags_actions';
 import { useAlertTagsActions } from './use_alert_tags_actions';
 import { useAlertsPrivileges } from '../../../containers/detection_engine/alerts/use_alerts_privileges';
 import type { AlertTableContextMenuItem } from '../types';
-import { render } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
 import React from 'react';
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiPopover, EuiContextMenu } from '@elastic/eui';

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_investigate_in_timeline.test.tsx
@@ -4,8 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { renderHook, act } from '@testing-library/react-hooks';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+
+import { fireEvent, render, waitFor, renderHook, act } from '@testing-library/react';
 import { of } from 'rxjs';
 import { TestProviders } from '../../../../common/mock';
 import { useKibana } from '../../../../common/lib/kibana';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/hooks/use_fetch_alerts.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/hooks/use_fetch_alerts.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useKibana } from '../../../../common/lib/kibana';
 import { createFindAlerts } from '../services/find_alerts';
 import { useFetchAlerts, type UseAlertsQueryParams } from './use_fetch_alerts';
@@ -41,15 +41,14 @@ describe('useFetchAlerts', () => {
       sort: [{ '@timestamp': 'desc' }],
     };
 
-    const { result, waitFor } = renderHook(() => useFetchAlerts(params), {
+    const { result } = renderHook(() => useFetchAlerts(params), {
       wrapper: createReactQueryWrapper(),
     });
 
     expect(result.current.loading).toBe(true);
 
-    await waitFor(() => !result.current.loading);
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(result.current.loading).toBe(false);
     expect(result.current.error).toBe(false);
     expect(result.current.totalItemCount).toBe(10);
     expect(result.current.data).toEqual(['alert1', 'alert2', 'alert3']);
@@ -70,13 +69,13 @@ describe('useFetchAlerts', () => {
       sort: [{ '@timestamp': 'desc' }],
     };
 
-    const { result, waitFor } = renderHook(() => useFetchAlerts(params), {
+    const { result } = renderHook(() => useFetchAlerts(params), {
       wrapper: createReactQueryWrapper(),
     });
 
     expect(result.current.loading).toBe(true);
 
-    await waitFor(() => !result.current.loading);
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBe(true);

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/hooks/use_response_actions_view.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/hooks/use_response_actions_view.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useResponseActionsView } from './use_response_actions_view';
 import { mockSearchHit } from '../../shared/mocks/mock_search_hit';
 import { mockDataAsNestedObject } from '../../shared/mocks/mock_data_as_nested_object';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/hooks/use_threat_intelligence_details.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { useThreatIntelligenceDetails } from './use_threat_intelligence_details';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { SecurityPageName } from '@kbn/deeplinks-security';
 import { useTimelineEventsDetails } from '../../../../timelines/containers/details';
 import { useSourcererDataView } from '../../../../sourcerer/containers';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_accordion_state.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_accordion_state.test.ts
@@ -7,14 +7,14 @@
 
 import type { ToggleReducerAction, UseAccordionStateValue } from './use_accordion_state';
 import { useAccordionState, toggleReducer } from './use_accordion_state';
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { FLYOUT_STORAGE_KEYS } from '../../shared/constants/local_storage';
 
 const mockSet = jest.fn();
 
 describe('useAccordionState', () => {
-  let hookResult: RenderHookResult<boolean, UseAccordionStateValue>;
+  let hookResult: RenderHookResult<UseAccordionStateValue, boolean>;
 
   it('should return initial value', () => {
     hookResult = renderHook((props: boolean) => useAccordionState(props), {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_assistant.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_assistant.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type { UseAssistantParams, UseAssistantResult } from './use_assistant';
 import { useAssistant } from './use_assistant';
 import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_formatted_for_field_browser';
@@ -25,7 +25,7 @@ const renderUseAssistant = () =>
   });
 
 describe('useAssistant', () => {
-  let hookResult: RenderHookResult<UseAssistantParams, UseAssistantResult>;
+  let hookResult: RenderHookResult<UseAssistantResult, UseAssistantParams>;
 
   it(`should return showAssistant true and a value for promptContextId`, () => {
     jest.mocked(useAssistantAvailability).mockReturnValue({

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_expand_section.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_expand_section.test.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type { UseExpandSectionParams } from './use_expand_section';
 import { useExpandSection } from './use_expand_section';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -14,7 +14,7 @@ import { useKibana } from '../../../../common/lib/kibana';
 jest.mock('../../../../common/lib/kibana');
 
 describe('useExpandSection', () => {
-  let hookResult: RenderHookResult<UseExpandSectionParams, boolean>;
+  let hookResult: RenderHookResult<boolean, UseExpandSectionParams>;
 
   it('should return default value if nothing in localStorage', () => {
     (useKibana as jest.Mock).mockReturnValue({

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_fetch_threat_intelligence.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_fetch_threat_intelligence.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type {
   UseThreatIntelligenceParams,
   UseThreatIntelligenceResult,
@@ -41,7 +41,7 @@ const dataFormattedForFieldBrowser = [
 ];
 
 describe('useFetchThreatIntelligence', () => {
-  let hookResult: RenderHookResult<UseThreatIntelligenceParams, UseThreatIntelligenceResult>;
+  let hookResult: RenderHookResult<UseThreatIntelligenceResult, UseThreatIntelligenceParams>;
 
   it('return render 1 match detected and 1 field enriched', () => {
     (useInvestigationTimeEnrichment as jest.Mock).mockReturnValue({

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_flyout_is_expandable.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_flyout_is_expandable.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useFlyoutIsExpandable } from './use_flyout_is_expandable';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_get_flyout_link.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_get_flyout_link.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useGetFlyoutLink } from './use_get_flyout_link';
 import { useGetAppUrl } from '@kbn/security-solution-navigation';
 import { ALERT_DETAILS_REDIRECT_PATH } from '../../../../../common/constants';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_graph_preview.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_graph_preview.test.tsx
@@ -5,15 +5,15 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type { UseGraphPreviewParams, UseGraphPreviewResult } from './use_graph_preview';
 import { useGraphPreview } from './use_graph_preview';
 import type { GetFieldsData } from '../../shared/hooks/use_get_fields_data';
 import { mockFieldData } from '../../shared/mocks/mock_get_fields_data';
 
 describe('useGraphPreview', () => {
-  let hookResult: RenderHookResult<UseGraphPreviewParams, UseGraphPreviewResult>;
+  let hookResult: RenderHookResult<UseGraphPreviewResult, UseGraphPreviewParams>;
 
   it(`should return false when missing actor`, () => {
     const getFieldsData: GetFieldsData = (field: string) => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_process_data.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_process_data.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { getUserDisplayName, useProcessData } from './use_process_data';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import type { FC, PropsWithChildren } from 'react';
 import { DocumentDetailsContext } from '../../shared/context';
 import React from 'react';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_session_preview.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_session_preview.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type { UseSessionPreviewParams } from './use_session_preview';
 import { useSessionPreview } from './use_session_preview';
 import type { SessionViewConfig } from '@kbn/securitysolution-data-table/common/types';
@@ -15,7 +15,7 @@ import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_f
 import { mockFieldData, mockGetFieldsData } from '../../shared/mocks/mock_get_fields_data';
 
 describe('useSessionPreview', () => {
-  let hookResult: RenderHookResult<UseSessionPreviewParams, SessionViewConfig | null>;
+  let hookResult: RenderHookResult<SessionViewConfig | null, UseSessionPreviewParams>;
 
   it(`should return a session view config object if alert ancestor index is available`, () => {
     const getFieldsData: GetFieldsData = (field: string) => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_tabs.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_tabs.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type { UseTabsParams, UseTabsResult } from './use_tabs';
 import { allThreeTabs, twoTabs, useTabs } from './use_tabs';
 
@@ -26,7 +26,7 @@ jest.mock('../../../../common/lib/kibana', () => {
 });
 
 describe('useTabs', () => {
-  let hookResult: RenderHookResult<UseTabsParams, UseTabsResult>;
+  let hookResult: RenderHookResult<UseTabsResult, UseTabsParams>;
 
   it('should return 3 tabs to render and the one from path as selected', () => {
     const initialProps: UseTabsParams = {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_alert_document_analyzer_schema.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_alert_document_analyzer_schema.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { useQuery } from '@tanstack/react-query';
 import type {
   UseAlertDocumentAnalyzerSchemaParams,
@@ -20,8 +20,8 @@ jest.mock('@tanstack/react-query');
 
 describe('useAlertPrevalenceFromProcessTree', () => {
   let hookResult: RenderHookResult<
-    UseAlertDocumentAnalyzerSchemaParams,
-    UseAlertDocumentAnalyzerSchemaResult
+    UseAlertDocumentAnalyzerSchemaResult,
+    UseAlertDocumentAnalyzerSchemaParams
   >;
 
   beforeEach(() => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_alert_prevalence.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_alert_prevalence.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { ALERT_PREVALENCE_AGG, useAlertPrevalence } from './use_alert_prevalence';
 import type { UseAlertPrevalenceParams, UserAlertPrevalenceResult } from './use_alert_prevalence';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
@@ -18,7 +18,7 @@ jest.mock('../../../../common/hooks/use_selector');
 jest.mock('../../../../detections/containers/detection_engine/alerts/use_query');
 
 describe('useAlertPrevalence', () => {
-  let hookResult: RenderHookResult<UseAlertPrevalenceParams, UserAlertPrevalenceResult>;
+  let hookResult: RenderHookResult<UserAlertPrevalenceResult, UseAlertPrevalenceParams>;
 
   beforeEach(() => {
     (useDeepEqualSelector as jest.Mock).mockReturnValue({

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_alert_prevalence_from_process_tree.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_alert_prevalence_from_process_tree.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type {
   UseAlertPrevalenceFromProcessTreeParams,
   UserAlertPrevalenceFromProcessTreeResult,
@@ -25,8 +25,8 @@ jest.mock('@tanstack/react-query');
 
 describe('useAlertPrevalenceFromProcessTree', () => {
   let hookResult: RenderHookResult<
-    UseAlertPrevalenceFromProcessTreeParams,
-    UserAlertPrevalenceFromProcessTreeResult
+    UserAlertPrevalenceFromProcessTreeResult,
+    UseAlertPrevalenceFromProcessTreeParams
   >;
 
   beforeEach(() => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_basic_data_from_details_data.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_basic_data_from_details_data.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useBasicDataFromDetailsData } from './use_basic_data_from_details_data';
 import { mockDataFormattedForFieldBrowser } from '../mocks/mock_data_formatted_for_field_browser';
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_event_details.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type { UseEventDetailsParams, UseEventDetailsResult } from './use_event_details';
 import { getAlertIndexAlias, useEventDetails } from './use_event_details';
 import { useSpaceId } from '../../../../common/hooks/use_space_id';
@@ -45,7 +45,7 @@ describe('getAlertIndexAlias', () => {
 });
 
 describe('useEventDetails', () => {
-  let hookResult: RenderHookResult<UseEventDetailsParams, UseEventDetailsResult>;
+  let hookResult: RenderHookResult<UseEventDetailsResult, UseEventDetailsParams>;
 
   it('should return all properties', () => {
     jest.mocked(useSpaceId).mockReturnValue('default');

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_fetch_related_alerts_by_ancestry.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_fetch_related_alerts_by_ancestry.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type {
   UseFetchRelatedAlertsByAncestryParams,
   UseFetchRelatedAlertsByAncestryResult,
@@ -22,8 +22,8 @@ const scopeId = 'scopeId';
 
 describe('useFetchRelatedAlertsByAncestry', () => {
   let hookResult: RenderHookResult<
-    UseFetchRelatedAlertsByAncestryParams,
-    UseFetchRelatedAlertsByAncestryResult
+    UseFetchRelatedAlertsByAncestryResult,
+    UseFetchRelatedAlertsByAncestryParams
   >;
 
   it('should return loading true while data is loading', () => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_fetch_related_alerts_by_same_source_event.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_fetch_related_alerts_by_same_source_event.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type {
   UseFetchRelatedAlertsBySameSourceEventParams,
   UseFetchRelatedAlertsBySameSourceEventResult,
@@ -21,8 +21,8 @@ const scopeId = 'scopeId';
 
 describe('useFetchRelatedAlertsBySameSourceEvent', () => {
   let hookResult: RenderHookResult<
-    UseFetchRelatedAlertsBySameSourceEventParams,
-    UseFetchRelatedAlertsBySameSourceEventResult
+    UseFetchRelatedAlertsBySameSourceEventResult,
+    UseFetchRelatedAlertsBySameSourceEventParams
   >;
 
   it('should return loading true while data is loading', () => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_fetch_related_alerts_by_session.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_fetch_related_alerts_by_session.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
 import type {
   UseFetchRelatedAlertsBySessionParams,
@@ -22,8 +22,8 @@ const scopeId = 'scopeId';
 
 describe('useFetchRelatedAlertsBySession', () => {
   let hookResult: RenderHookResult<
-    UseFetchRelatedAlertsBySessionParams,
-    UseFetchRelatedAlertsBySessionResult
+    UseFetchRelatedAlertsBySessionResult,
+    UseFetchRelatedAlertsBySessionParams
   >;
 
   it('should return loading true while data is loading', () => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_fetch_related_cases.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_fetch_related_cases.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { createReactQueryWrapper } from '../../../../common/mock';
 import { useFetchRelatedCases } from './use_fetch_related_cases';
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_get_fields_data.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_get_fields_data.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { mockSearchHit } from '../mocks/mock_search_hit';
 import type { UseGetFieldsDataParams, UseGetFieldsDataResult } from './use_get_fields_data';
 import { useGetFieldsData } from './use_get_fields_data';
@@ -17,7 +17,7 @@ const fieldsData = {
 };
 
 describe('useGetFieldsData', () => {
-  let hookResult: RenderHookResult<UseGetFieldsDataParams, UseGetFieldsDataResult>;
+  let hookResult: RenderHookResult<UseGetFieldsDataResult, UseGetFieldsDataParams>;
 
   it('should return the value for a field', () => {
     hookResult = renderHook(() => useGetFieldsData({ fieldsData }));

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_highlighted_fields.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_highlighted_fields.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 
 import {
   mockDataFormattedForFieldBrowser,

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_investigation_enrichment.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_investigation_enrichment.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useInvestigationTimeEnrichment } from './use_investigation_enrichment';
 import {
   DEFAULT_EVENT_ENRICHMENT_FROM,

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_investigation_guide.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_investigation_guide.test.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type {
   UseInvestigationGuideParams,
   UseInvestigationGuideResult,
@@ -22,7 +22,7 @@ jest.mock('../../../../detection_engine/rule_management/logic/use_rule_with_fall
 const dataFormattedForFieldBrowser = mockDataFormattedForFieldBrowser;
 
 describe('useInvestigationGuide', () => {
-  let hookResult: RenderHookResult<UseInvestigationGuideParams, UseInvestigationGuideResult>;
+  let hookResult: RenderHookResult<UseInvestigationGuideResult, UseInvestigationGuideParams>;
 
   it('should return loading true', () => {
     (useBasicDataFromDetailsData as jest.Mock).mockReturnValue({ ruleId: 'ruleId' });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_analyzer.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_analyzer.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useNavigateToAnalyzer } from './use_navigate_to_analyzer';
 import { mockFlyoutApi } from '../mocks/mock_flyout_context';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_session_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_session_view.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { useNavigateToSessionView } from './use_navigate_to_session_view';
 import { mockFlyoutApi } from '../mocks/mock_flyout_context';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_prevalence.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_prevalence.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 
 import { usePrevalence } from './use_prevalence';
 import { mockDataFormattedForFieldBrowser } from '../mocks/mock_data_formatted_for_field_browser';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_rule_details_link.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_rule_details_link.test.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type { UseRuleDetailsLinkParams } from './use_rule_details_link';
 import { useRuleDetailsLink } from './use_rule_details_link';
 
@@ -24,7 +24,7 @@ jest.mock('../../../../common/components/link_to', () => ({
 }));
 
 describe('useRuleDetailsLink', () => {
-  let hookResult: RenderHookResult<UseRuleDetailsLinkParams, string | null>;
+  let hookResult: RenderHookResult<string | null, UseRuleDetailsLinkParams>;
 
   it('should return null if the ruleId prop is null', () => {
     const initialProps: UseRuleDetailsLinkParams = {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_ancestry.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_ancestry.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type {
   UseShowRelatedAlertsByAncestryParams,
   UseShowRelatedAlertsByAncestryResult,
@@ -36,8 +36,8 @@ const dataAsNestedObject = mockDataAsNestedObject;
 
 describe('useShowRelatedAlertsByAncestry', () => {
   let hookResult: RenderHookResult<
-    UseShowRelatedAlertsByAncestryParams,
-    UseShowRelatedAlertsByAncestryResult
+    UseShowRelatedAlertsByAncestryResult,
+    UseShowRelatedAlertsByAncestryParams
   >;
 
   it('should return false if Process Entity Info is not available', () => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_same_source_event.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_same_source_event.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
 import type {
   ShowRelatedAlertsBySameSourceEventParams,
@@ -18,8 +18,8 @@ const eventId = 'eventId';
 
 describe('useShowRelatedAlertsBySameSourceEvent', () => {
   let hookResult: RenderHookResult<
-    ShowRelatedAlertsBySameSourceEventParams,
-    ShowRelatedAlertsBySameSourceEventResult
+    ShowRelatedAlertsBySameSourceEventResult,
+    ShowRelatedAlertsBySameSourceEventParams
   >;
 
   it('should return eventId if getFieldsData returns null', () => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_session.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_alerts_by_session.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
 import type {
   UseShowRelatedAlertsBySessionParams,
@@ -16,8 +16,8 @@ import { useShowRelatedAlertsBySession } from './use_show_related_alerts_by_sess
 
 describe('useShowRelatedAlertsBySession', () => {
   let hookResult: RenderHookResult<
-    UseShowRelatedAlertsBySessionParams,
-    UseShowRelatedAlertsBySessionResult
+    UseShowRelatedAlertsBySessionResult,
+    UseShowRelatedAlertsBySessionParams
   >;
 
   it('should return false if getFieldsData returns null', () => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_cases.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_related_cases.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 
 import { useKibana as mockUseKibana } from '../../../../common/lib/kibana/__mocks__';
 import { useShowRelatedCases } from './use_show_related_cases';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_suppressed_alerts.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_show_suppressed_alerts.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import type {
   ShowSuppressedAlertsParams,
   ShowSuppressedAlertsResult,
@@ -14,7 +14,7 @@ import type {
 import { useShowSuppressedAlerts } from './use_show_suppressed_alerts';
 
 describe('useShowSuppressedAlerts', () => {
-  let hookResult: RenderHookResult<ShowSuppressedAlertsParams, ShowSuppressedAlertsResult>;
+  let hookResult: RenderHookResult<ShowSuppressedAlertsResult, ShowSuppressedAlertsParams>;
 
   it('should return false if getFieldsData returns null', () => {
     const getFieldsData = () => null;

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_which_flyout.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/hooks/use_which_flyout.test.tsx
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { useWhichFlyout } from './use_which_flyout';
 import { Flyouts } from '../constants/flyouts';
 
 describe('useWhichFlyout', () => {
-  let hookResult: RenderHookResult<{}, string | null>;
+  let hookResult: RenderHookResult<string | null, unknown>;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_on_expandable_flyout_close.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_on_expandable_flyout_close.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useWhichFlyout } from '../../document_details/shared/hooks/use_which_flyout';
 import { useOnExpandableFlyoutClose } from './use_on_expandable_flyout_close';
 import { Flyouts } from '../../document_details/shared/constants/flyouts';

--- a/x-pack/plugins/security_solution/public/notes/hooks/use_fetch_notes.test.ts
+++ b/x-pack/plugins/security_solution/public/notes/hooks/use_fetch_notes.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useDispatch } from 'react-redux';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { fetchNotesByDocumentIds } from '../store/notes.slice';

--- a/x-pack/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.test.ts
+++ b/x-pack/plugins/security_solution/public/sourcerer/components/use_get_sourcerer_data_view.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { DataView } from '@kbn/data-views-plugin/common';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useSourcererDataView } from '../containers';
 import { mockSourcererScope } from '../containers/mocks';
 import { SourcererScopeName } from '../store/model';
@@ -14,14 +14,11 @@ import type { UseGetScopedSourcererDataViewArgs } from './use_get_sourcerer_data
 import { useGetScopedSourcererDataView } from './use_get_sourcerer_data_view';
 
 const renderHookCustom = (args: UseGetScopedSourcererDataViewArgs) => {
-  return renderHook<UseGetScopedSourcererDataViewArgs, DataView | undefined>(
-    ({ sourcererScope }) => useGetScopedSourcererDataView({ sourcererScope }),
-    {
-      initialProps: {
-        ...args,
-      },
-    }
-  );
+  return renderHook(({ sourcererScope }) => useGetScopedSourcererDataView({ sourcererScope }), {
+    initialProps: {
+      ...args,
+    },
+  });
 };
 
 jest.mock('../containers');

--- a/x-pack/plugins/security_solution/public/sourcerer/components/use_update_data_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/sourcerer/components/use_update_data_view.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useUpdateDataView } from './use_update_data_view';
 import { useKibana as mockUseKibana } from '../../common/lib/kibana/__mocks__';
 import * as i18n from './translations';

--- a/x-pack/plugins/security_solution/public/sourcerer/containers/hooks.test.tsx
+++ b/x-pack/plugins/security_solution/public/sourcerer/containers/hooks.test.tsx
@@ -6,8 +6,7 @@
  */
 
 import React from 'react';
-import { act, renderHook } from '@testing-library/react-hooks';
-import { waitFor } from '@testing-library/react';
+import { act, waitFor, renderHook } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
 import { useSourcererDataView } from '.';
@@ -137,8 +136,12 @@ jest.mock('../../common/lib/kibana', () => ({
                     type: 'keyword',
                   },
                 }),
+                toSpec: () => ({
+                  id: dataViewId,
+                }),
               })
           ),
+          getExistingIndices: jest.fn(() => [] as string[]),
         },
         indexPatterns: {
           getTitles: jest.fn().mockImplementation(() => Promise.resolve(mockPatterns)),
@@ -153,34 +156,35 @@ jest.mock('../../common/lib/kibana', () => ({
 describe('Sourcerer Hooks', () => {
   let store = createMockStore();
 
+  const StoreProvider: React.FC<React.PropsWithChildren> = ({ children }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  const Wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+    <TestProviders>{children}</TestProviders>
+  );
+
   beforeEach(() => {
     jest.clearAllMocks();
     store = createMockStore();
     mockUseUserInfo.mockImplementation(() => userInfoState);
   });
   it('initializes loading default and timeline index patterns', async () => {
-    await act(async () => {
-      const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-        () => useInitSourcerer(),
-        {
-          wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-        }
-      );
-      await waitForNextUpdate();
-      rerender();
-      expect(mockDispatch).toBeCalledTimes(3);
-      expect(mockDispatch.mock.calls[0][0]).toEqual({
-        type: 'x-pack/security_solution/local/sourcerer/SET_DATA_VIEW_LOADING',
-        payload: { id: 'security-solution', loading: true },
-      });
-      expect(mockDispatch.mock.calls[1][0]).toEqual({
-        type: 'x-pack/security_solution/local/sourcerer/SET_SELECTED_DATA_VIEW',
-        payload: {
-          id: 'timeline',
-          selectedDataViewId: 'security-solution',
-          selectedPatterns: ['.siem-signals-spacename', ...DEFAULT_INDEX_PATTERN],
-        },
-      });
+    const { rerender } = renderHook(() => useInitSourcerer(), {
+      wrapper: StoreProvider,
+    });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender();
+    expect(mockDispatch.mock.calls[0][0]).toEqual({
+      type: 'x-pack/security_solution/local/sourcerer/SET_DATA_VIEW_LOADING',
+      payload: { id: 'security-solution', loading: true },
+    });
+    expect(mockDispatch.mock.calls[1][0]).toEqual({
+      type: 'x-pack/security_solution/local/sourcerer/SET_SELECTED_DATA_VIEW',
+      payload: {
+        id: 'timeline',
+        selectedDataViewId: 'security-solution',
+        selectedPatterns: ['.siem-signals-spacename', ...DEFAULT_INDEX_PATTERN],
+      },
     });
   });
   it('sets signal index name', async () => {
@@ -202,47 +206,42 @@ describe('Sourcerer Hooks', () => {
         },
       },
     });
-    await act(async () => {
-      mockUseUserInfo.mockImplementation(() => ({
-        ...userInfoState,
-        loading: false,
-        signalIndexName: mockSourcererState.signalIndexName,
-      }));
-      const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-        () => useInitSourcerer(),
-        {
-          wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-        }
-      );
-      await waitForNextUpdate();
-      rerender();
-      await waitFor(() => {
-        expect(mockDispatch.mock.calls[3][0]).toEqual({
-          type: 'x-pack/security_solution/local/sourcerer/SET_SOURCERER_SCOPE_LOADING',
-          payload: { loading: true },
-        });
-        expect(mockDispatch.mock.calls[4][0]).toEqual({
-          type: 'x-pack/security_solution/local/sourcerer/SET_SIGNAL_INDEX_NAME',
-          payload: { signalIndexName: mockSourcererState.signalIndexName },
-        });
-        expect(mockDispatch.mock.calls[5][0]).toEqual({
-          type: 'x-pack/security_solution/local/sourcerer/SET_DATA_VIEW_LOADING',
-          payload: {
-            id: mockSourcererState.defaultDataView.id,
-            loading: true,
-          },
-        });
-        expect(mockDispatch.mock.calls[6][0]).toEqual({
-          type: 'x-pack/security_solution/local/sourcerer/SET_SOURCERER_DATA_VIEWS',
-          payload: mockNewDataViews,
-        });
-        expect(mockDispatch.mock.calls[7][0]).toEqual({
-          type: 'x-pack/security_solution/local/sourcerer/SET_SOURCERER_SCOPE_LOADING',
-          payload: { loading: false },
-        });
-        expect(mockDispatch).toHaveBeenCalledTimes(8);
-        expect(mockSearch).toHaveBeenCalledTimes(2);
+    mockUseUserInfo.mockImplementation(() => ({
+      ...userInfoState,
+      loading: false,
+      signalIndexName: mockSourcererState.signalIndexName,
+    }));
+    const { rerender } = renderHook(useInitSourcerer, {
+      wrapper: StoreProvider,
+    });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender();
+    await waitFor(() => {
+      expect(mockDispatch.mock.calls[3][0]).toEqual({
+        type: 'x-pack/security_solution/local/sourcerer/SET_SOURCERER_SCOPE_LOADING',
+        payload: { loading: true },
       });
+      expect(mockDispatch.mock.calls[4][0]).toEqual({
+        type: 'x-pack/security_solution/local/sourcerer/SET_SIGNAL_INDEX_NAME',
+        payload: { signalIndexName: mockSourcererState.signalIndexName },
+      });
+      expect(mockDispatch.mock.calls[5][0]).toEqual({
+        type: 'x-pack/security_solution/local/sourcerer/SET_DATA_VIEW_LOADING',
+        payload: {
+          id: mockSourcererState.defaultDataView.id,
+          loading: true,
+        },
+      });
+      expect(mockDispatch.mock.calls[6][0]).toEqual({
+        type: 'x-pack/security_solution/local/sourcerer/SET_SOURCERER_DATA_VIEWS',
+        payload: mockNewDataViews,
+      });
+      expect(mockDispatch.mock.calls[7][0]).toEqual({
+        type: 'x-pack/security_solution/local/sourcerer/SET_SOURCERER_SCOPE_LOADING',
+        payload: { loading: false },
+      });
+
+      expect(mockSearch).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -258,8 +257,8 @@ describe('Sourcerer Hooks', () => {
       })
     );
 
-    renderHook<React.PropsWithChildren<{}>, void>(() => useInitSourcerer(), {
-      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    renderHook(() => useInitSourcerer(), {
+      wrapper: Wrapper,
     });
 
     expect(mockDispatch).toHaveBeenCalledWith(
@@ -278,8 +277,8 @@ describe('Sourcerer Hooks', () => {
       onInitialize(null)
     );
 
-    renderHook<React.PropsWithChildren<{}>, void>(() => useInitSourcerer(), {
-      wrapper: ({ children }) => <TestProviders>{children}</TestProviders>,
+    renderHook(() => useInitSourcerer(), {
+      wrapper: Wrapper,
     });
 
     expect(updateUrlParam).toHaveBeenCalledWith({
@@ -302,16 +301,14 @@ describe('Sourcerer Hooks', () => {
         },
       },
     });
-    await act(async () => {
-      renderHook<React.PropsWithChildren<{}>, void>(() => useInitSourcerer(), {
-        wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-      });
+    renderHook(() => useInitSourcerer(), {
+      wrapper: StoreProvider,
+    });
 
-      await waitFor(() => {
-        expect(mockAddWarning).toHaveBeenNthCalledWith(1, {
-          text: 'Users with write permission need to access the Elastic Security app to initialize the app source data.',
-          title: 'Write role required to generate data',
-        });
+    await waitFor(() => {
+      expect(mockAddWarning).toHaveBeenNthCalledWith(1, {
+        text: 'Users with write permission need to access the Elastic Security app to initialize the app source data.',
+        title: 'Write role required to generate data',
       });
     });
   });
@@ -333,27 +330,25 @@ describe('Sourcerer Hooks', () => {
         },
       },
     });
-    await act(async () => {
-      mockUseUserInfo.mockImplementation(() => ({
-        ...userInfoState,
-        loading: false,
-        signalIndexName: mockSourcererState.signalIndexName,
-      }));
-      const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-        () => useInitSourcerer(),
-        {
-          wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-        }
-      );
 
-      await waitForNextUpdate();
-      rerender();
+    mockUseUserInfo.mockImplementation(() => ({
+      ...userInfoState,
+      loading: false,
+      signalIndexName: mockSourcererState.signalIndexName,
+    }));
 
-      await waitFor(() => {
-        expect(mockCreateSourcererDataView).toHaveBeenCalled();
-        expect(mockAddError).not.toHaveBeenCalled();
-      });
+    const { rerender } = renderHook(() => useInitSourcerer(), {
+      wrapper: StoreProvider,
     });
+
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+
+    rerender();
+
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+
+    expect(mockCreateSourcererDataView).toHaveBeenCalled();
+    expect(mockAddError).not.toHaveBeenCalled();
   });
 
   it('does call addError if updateSourcererDataView receives a non-abort error', async () => {
@@ -375,66 +370,51 @@ describe('Sourcerer Hooks', () => {
         },
       },
     });
-    await act(async () => {
-      mockUseUserInfo.mockImplementation(() => ({
-        ...userInfoState,
-        loading: false,
-        signalIndexName: mockSourcererState.signalIndexName,
-      }));
-      const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-        () => useInitSourcerer(),
-        {
-          wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-        }
-      );
+    mockUseUserInfo.mockImplementation(() => ({
+      ...userInfoState,
+      loading: false,
+      signalIndexName: mockSourcererState.signalIndexName,
+    }));
+    const { rerender } = renderHook(() => useInitSourcerer(), {
+      wrapper: StoreProvider,
+    });
 
-      await waitForNextUpdate();
-      rerender();
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender();
 
-      await waitFor(() => {
-        expect(mockAddError).toHaveBeenCalled();
-      });
+    await waitFor(() => {
+      expect(mockAddError).toHaveBeenCalled();
     });
   });
 
   it('handles detections page', async () => {
-    await act(async () => {
-      mockUseUserInfo.mockImplementation(() => ({
-        ...userInfoState,
-        signalIndexName: mockSourcererState.signalIndexName,
-        isSignalIndexExists: true,
-      }));
-      const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-        () => useInitSourcerer(SourcererScopeName.detections),
-        {
-          wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-        }
-      );
-      await waitForNextUpdate();
-      rerender();
-      expect(mockDispatch.mock.calls[3][0]).toEqual({
-        type: 'x-pack/security_solution/local/sourcerer/SET_SELECTED_DATA_VIEW',
-        payload: {
-          id: 'detections',
-          selectedDataViewId: mockSourcererState.defaultDataView.id,
-          selectedPatterns: [mockSourcererState.signalIndexName],
-        },
-      });
+    mockUseUserInfo.mockImplementation(() => ({
+      ...userInfoState,
+      signalIndexName: mockSourcererState.signalIndexName,
+      isSignalIndexExists: true,
+    }));
+    const { rerender } = renderHook(() => useInitSourcerer(SourcererScopeName.detections), {
+      wrapper: StoreProvider,
+    });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender();
+    expect(mockDispatch.mock.calls[3][0]).toEqual({
+      type: 'x-pack/security_solution/local/sourcerer/SET_SELECTED_DATA_VIEW',
+      payload: {
+        id: 'detections',
+        selectedDataViewId: mockSourcererState.defaultDataView.id,
+        selectedPatterns: [mockSourcererState.signalIndexName],
+      },
     });
   });
   it('index field search is not repeated when default and timeline have same dataViewId', async () => {
-    await act(async () => {
-      const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-        () => useInitSourcerer(),
-        {
-          wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-        }
-      );
-      await waitForNextUpdate();
-      rerender();
-      await waitFor(() => {
-        expect(mockSearch).toHaveBeenCalledTimes(1);
-      });
+    const { rerender } = renderHook(() => useInitSourcerer(), {
+      wrapper: StoreProvider,
+    });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender();
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledTimes(1);
     });
   });
   it('index field search called twice when default and timeline have different dataViewId', async () => {
@@ -451,18 +431,13 @@ describe('Sourcerer Hooks', () => {
         },
       },
     });
-    await act(async () => {
-      const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-        () => useInitSourcerer(),
-        {
-          wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-        }
-      );
-      await waitForNextUpdate();
-      rerender();
-      await waitFor(() => {
-        expect(mockSearch).toHaveBeenCalledTimes(2);
-      });
+    const { rerender } = renderHook(() => useInitSourcerer(), {
+      wrapper: StoreProvider,
+    });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender();
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledTimes(2);
     });
   });
   describe('initialization settings', () => {
@@ -476,21 +451,16 @@ describe('Sourcerer Hooks', () => {
       }));
     });
     it('does not needToBeInit if scope is default and selectedPatterns/missingPatterns have values', async () => {
-      await act(async () => {
-        const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-          () => useInitSourcerer(),
-          {
-            wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-          }
-        );
-        await waitForNextUpdate();
-        rerender();
-        await waitFor(() => {
-          expect(mockIndexFieldsSearch).toHaveBeenCalledWith({
-            dataViewId: mockSourcererState.defaultDataView.id,
-            needToBeInit: false,
-            scopeId: SourcererScopeName.default,
-          });
+      const { rerender } = renderHook(() => useInitSourcerer(), {
+        wrapper: StoreProvider,
+      });
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+      rerender();
+      await waitFor(() => {
+        expect(mockIndexFieldsSearch).toHaveBeenCalledWith({
+          dataViewId: mockSourcererState.defaultDataView.id,
+          needToBeInit: false,
+          scopeId: SourcererScopeName.default,
         });
       });
     });
@@ -510,21 +480,16 @@ describe('Sourcerer Hooks', () => {
           },
         },
       });
-      await act(async () => {
-        const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-          () => useInitSourcerer(),
-          {
-            wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-          }
-        );
-        await waitForNextUpdate();
-        rerender();
-        await waitFor(() => {
-          expect(mockIndexFieldsSearch).toHaveBeenCalledWith({
-            dataViewId: mockSourcererState.defaultDataView.id,
-            needToBeInit: true,
-            scopeId: SourcererScopeName.default,
-          });
+      const { rerender } = renderHook(() => useInitSourcerer(), {
+        wrapper: StoreProvider,
+      });
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+      rerender();
+      await waitFor(() => {
+        expect(mockIndexFieldsSearch).toHaveBeenCalledWith({
+          dataViewId: mockSourcererState.defaultDataView.id,
+          needToBeInit: true,
+          scopeId: SourcererScopeName.default,
         });
       });
     });
@@ -549,22 +514,17 @@ describe('Sourcerer Hooks', () => {
           },
         },
       });
-      await act(async () => {
-        const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-          () => useInitSourcerer(),
-          {
-            wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-          }
-        );
-        await waitForNextUpdate();
-        rerender();
-        await waitFor(() => {
-          expect(mockIndexFieldsSearch).toHaveBeenNthCalledWith(2, {
-            dataViewId: 'something-weird',
-            needToBeInit: true,
-            scopeId: SourcererScopeName.timeline,
-            skipScopeUpdate: false,
-          });
+      const { rerender } = renderHook(() => useInitSourcerer(), {
+        wrapper: StoreProvider,
+      });
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+      rerender();
+      await waitFor(() => {
+        expect(mockIndexFieldsSearch).toHaveBeenNthCalledWith(2, {
+          dataViewId: 'something-weird',
+          needToBeInit: true,
+          scopeId: SourcererScopeName.timeline,
+          skipScopeUpdate: false,
         });
       });
     });
@@ -589,22 +549,17 @@ describe('Sourcerer Hooks', () => {
           },
         },
       });
-      await act(async () => {
-        const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-          () => useInitSourcerer(),
-          {
-            wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-          }
-        );
-        await waitForNextUpdate();
-        rerender();
-        await waitFor(() => {
-          expect(mockIndexFieldsSearch).toHaveBeenNthCalledWith(2, {
-            dataViewId: 'something-weird',
-            needToBeInit: true,
-            scopeId: SourcererScopeName.timeline,
-            skipScopeUpdate: true,
-          });
+      const { rerender } = renderHook(() => useInitSourcerer(), {
+        wrapper: StoreProvider,
+      });
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+      rerender();
+      await waitFor(() => {
+        expect(mockIndexFieldsSearch).toHaveBeenNthCalledWith(2, {
+          dataViewId: 'something-weird',
+          needToBeInit: true,
+          scopeId: SourcererScopeName.timeline,
+          skipScopeUpdate: true,
         });
       });
     });
@@ -633,21 +588,16 @@ describe('Sourcerer Hooks', () => {
           },
         },
       });
-      await act(async () => {
-        const { rerender, waitForNextUpdate } = renderHook<React.PropsWithChildren<{}>, void>(
-          () => useInitSourcerer(),
-          {
-            wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-          }
-        );
-        await waitForNextUpdate();
-        rerender();
-        await waitFor(() => {
-          expect(mockIndexFieldsSearch).toHaveBeenNthCalledWith(2, {
-            dataViewId: 'something-weird',
-            needToBeInit: false,
-            scopeId: SourcererScopeName.timeline,
-          });
+      const { rerender } = renderHook(() => useInitSourcerer(), {
+        wrapper: StoreProvider,
+      });
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+      rerender();
+      await waitFor(() => {
+        expect(mockIndexFieldsSearch).toHaveBeenNthCalledWith(2, {
+          dataViewId: 'something-weird',
+          needToBeInit: false,
+          scopeId: SourcererScopeName.timeline,
         });
       });
     });
@@ -655,38 +605,39 @@ describe('Sourcerer Hooks', () => {
 
   describe('useSourcererDataView', () => {
     it('Should put any excludes in the index pattern at the end of the pattern list, and sort both the includes and excludes', async () => {
-      await act(async () => {
-        store = createMockStore({
-          ...mockGlobalState,
-          sourcerer: {
-            ...mockGlobalState.sourcerer,
-            sourcererScopes: {
-              ...mockGlobalState.sourcerer.sourcererScopes,
-              [SourcererScopeName.default]: {
-                ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
-                selectedPatterns: [
-                  '-packetbeat-*',
-                  'endgame-*',
-                  'auditbeat-*',
-                  'filebeat-*',
-                  'winlogbeat-*',
-                  '-filebeat-*',
-                  'packetbeat-*',
-                  'traces-apm*',
-                  'apm-*-transaction*',
-                ],
-              },
+      store = createMockStore({
+        ...mockGlobalState,
+        sourcerer: {
+          ...mockGlobalState.sourcerer,
+          sourcererScopes: {
+            ...mockGlobalState.sourcerer.sourcererScopes,
+            [SourcererScopeName.default]: {
+              ...mockGlobalState.sourcerer.sourcererScopes[SourcererScopeName.default],
+              selectedPatterns: [
+                '-packetbeat-*',
+                'endgame-*',
+                'auditbeat-*',
+                'filebeat-*',
+                'winlogbeat-*',
+                '-filebeat-*',
+                'packetbeat-*',
+                'traces-apm*',
+                'apm-*-transaction*',
+              ],
             },
           },
-        });
-        const { result, rerender, waitForNextUpdate } = renderHook<
-          React.PropsWithChildren<{}>,
-          SelectedDataView
-        >(() => useSourcererDataView(), {
-          wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-        });
-        await waitForNextUpdate();
-        rerender();
+        },
+      });
+
+      const { result, rerender } = renderHook<SelectedDataView, SourcererScopeName>(
+        useSourcererDataView,
+        {
+          wrapper: StoreProvider,
+        }
+      );
+      await waitFor(() => new Promise((resolve) => resolve(null)));
+      rerender();
+      await waitFor(() => {
         expect(result.current.selectedPatterns).toEqual([
           'apm-*-transaction*',
           'auditbeat-*',
@@ -703,12 +654,9 @@ describe('Sourcerer Hooks', () => {
     });
 
     it('should update the title and name of the data view according to the selected patterns', async () => {
-      const { result, rerender } = renderHook<React.PropsWithChildren<{}>, SelectedDataView>(
-        () => useSourcererDataView(),
-        {
-          wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
-        }
-      );
+      const { result, rerender } = renderHook(() => useSourcererDataView(), {
+        wrapper: StoreProvider,
+      });
 
       expect(result.current.sourcererDataView?.title).toBe(
         'apm-*-transaction*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,traces-apm*,winlogbeat-*,-*elastic-cloud-logs-*'
@@ -725,7 +673,7 @@ describe('Sourcerer Hooks', () => {
         );
       });
 
-      await rerender();
+      rerender();
 
       expect(result.current.sourcererDataView?.title).toBe(testPatterns.join(','));
       expect(result.current.sourcererDataView?.name).toBe(testPatterns.join(','));

--- a/x-pack/plugins/security_solution/public/sourcerer/containers/use_signal_helpers.test.tsx
+++ b/x-pack/plugins/security_solution/public/sourcerer/containers/use_signal_helpers.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { createMockStore, mockGlobalState, TestProviders } from '../../common/mock';
-import { act, renderHook } from '@testing-library/react-hooks';
+import { waitFor, renderHook } from '@testing-library/react';
 import { useSignalHelpers } from './use_signal_helpers';
 import type { State } from '../../common/store';
 import { createSourcererDataView } from './create_sourcerer_data_view';
@@ -41,14 +41,12 @@ describe('useSignalHelpers', () => {
   );
 
   test('Default state, does not need init and does not need poll', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useSignalHelpers(), {
-        wrapper: wrapperContainer,
-      });
-      await waitForNextUpdate();
-      expect(result.current.signalIndexNeedsInit).toEqual(false);
-      expect(result.current.pollForSignalIndex).toEqual(undefined);
+    const { result } = renderHook(() => useSignalHelpers(), {
+      wrapper: wrapperContainer,
     });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    expect(result.current.signalIndexNeedsInit).toEqual(false);
+    expect(result.current.pollForSignalIndex).toEqual(undefined);
   });
   test('Needs init and does not need poll when signal index is not yet in default data view', async () => {
     const state: State = {
@@ -70,16 +68,14 @@ describe('useSignalHelpers', () => {
       },
     };
     const store = createMockStore(state);
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useSignalHelpers(), {
-        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
-          <TestProviders store={store}>{children}</TestProviders>
-        ),
-      });
-      await waitForNextUpdate();
-      expect(result.current.signalIndexNeedsInit).toEqual(true);
-      expect(result.current.pollForSignalIndex).toEqual(undefined);
+    const { result } = renderHook(() => useSignalHelpers(), {
+      wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+        <TestProviders store={store}>{children}</TestProviders>
+      ),
     });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    expect(result.current.signalIndexNeedsInit).toEqual(true);
+    expect(result.current.pollForSignalIndex).toEqual(undefined);
   });
   test('Init happened and signal index does not have data yet, poll function becomes available', async () => {
     const state: State = {
@@ -101,16 +97,14 @@ describe('useSignalHelpers', () => {
       },
     };
     const store = createMockStore(state);
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useSignalHelpers(), {
-        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
-          <TestProviders store={store}>{children}</TestProviders>
-        ),
-      });
-      await waitForNextUpdate();
-      expect(result.current.signalIndexNeedsInit).toEqual(false);
-      expect(result.current.pollForSignalIndex).not.toEqual(undefined);
+    const { result } = renderHook(() => useSignalHelpers(), {
+      wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+        <TestProviders store={store}>{children}</TestProviders>
+      ),
     });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    expect(result.current.signalIndexNeedsInit).toEqual(false);
+    expect(result.current.pollForSignalIndex).not.toEqual(undefined);
   });
 
   test('Init happened and signal index does not have data yet, poll function becomes available but createSourcererDataView throws an abort error', async () => {
@@ -134,17 +128,15 @@ describe('useSignalHelpers', () => {
       },
     };
     const store = createMockStore(state);
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useSignalHelpers(), {
-        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
-          <TestProviders store={store}>{children}</TestProviders>
-        ),
-      });
-      await waitForNextUpdate();
-      expect(result.current.signalIndexNeedsInit).toEqual(false);
-      expect(result.current.pollForSignalIndex).not.toEqual(undefined);
-      expect(mockAddError).not.toHaveBeenCalled();
+    const { result } = renderHook(() => useSignalHelpers(), {
+      wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+        <TestProviders store={store}>{children}</TestProviders>
+      ),
     });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    expect(result.current.signalIndexNeedsInit).toEqual(false);
+    expect(result.current.pollForSignalIndex).not.toEqual(undefined);
+    expect(mockAddError).not.toHaveBeenCalled();
   });
 
   test('Init happened and signal index does not have data yet, poll function becomes available but createSourcererDataView throws a non-abort error', async () => {
@@ -170,17 +162,15 @@ describe('useSignalHelpers', () => {
       },
     };
     const store = createMockStore(state);
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useSignalHelpers(), {
-        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
-          <TestProviders store={store}>{children}</TestProviders>
-        ),
-      });
-      await waitForNextUpdate();
-      expect(result.current.signalIndexNeedsInit).toEqual(false);
-      expect(result.current.pollForSignalIndex).not.toEqual(undefined);
-      result.current.pollForSignalIndex?.();
-      expect(mockAddError).toHaveBeenCalled();
+    const { result } = renderHook(() => useSignalHelpers(), {
+      wrapper: ({ children }: React.PropsWithChildren<{}>) => (
+        <TestProviders store={store}>{children}</TestProviders>
+      ),
     });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    expect(result.current.signalIndexNeedsInit).toEqual(false);
+    expect(result.current.pollForSignalIndex).not.toEqual(undefined);
+    result.current.pollForSignalIndex?.();
+    expect(mockAddError).toHaveBeenCalled();
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/create_field_button/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/create_field_button/index.test.tsx
@@ -5,19 +5,18 @@
  * 2.0.
  */
 
-import { render } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
 import React from 'react';
-import type { UseCreateFieldButton, UseCreateFieldButtonProps } from '.';
+import type { UseCreateFieldButtonProps } from '.';
 import { useCreateFieldButton } from '.';
 
 import { TestProviders } from '../../../../common/mock';
-import { renderHook } from '@testing-library/react-hooks';
 
 const mockOpenFieldEditor = jest.fn();
 const mockOnHide = jest.fn();
 
 const renderUseCreateFieldButton = (props: Partial<UseCreateFieldButtonProps> = {}) =>
-  renderHook<React.PropsWithChildren<UseCreateFieldButtonProps>, ReturnType<UseCreateFieldButton>>(
+  renderHook(
     () =>
       useCreateFieldButton({
         isAllowed: true,

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/field_table_columns/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/field_table_columns/index.test.tsx
@@ -6,12 +6,11 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
-import type { UseFieldTableColumnsProps, UseFieldTableColumns } from '.';
+import { render, renderHook } from '@testing-library/react';
+import type { UseFieldTableColumnsProps } from '.';
 import { useFieldTableColumns } from '.';
 
 import { TestProviders } from '../../../../common/mock';
-import { renderHook } from '@testing-library/react-hooks';
 import { EuiInMemoryTable } from '@elastic/eui';
 import type { BrowserFieldItem } from '@kbn/triggers-actions-ui-plugin/public/types';
 
@@ -21,7 +20,7 @@ const mockOpenDeleteFieldModal = jest.fn();
 
 // helper function to render the hook
 const renderUseFieldTableColumns = (props: Partial<UseFieldTableColumnsProps> = {}) =>
-  renderHook<React.PropsWithChildren<UseFieldTableColumnsProps>, ReturnType<UseFieldTableColumns>>(
+  renderHook(
     () =>
       useFieldTableColumns({
         hasFieldEditPermission: true,

--- a/x-pack/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/fields_browser/index.test.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import type { RenderHookResult } from '@testing-library/react';
+import { render, act, waitFor, renderHook } from '@testing-library/react';
 import type { Store } from 'redux';
 import type { UseFieldBrowserOptionsProps, UseFieldBrowserOptions, FieldEditorActionsRef } from '.';
 import { useFieldBrowserOptions } from '.';
@@ -16,8 +17,6 @@ import { indexPatternFieldEditorPluginMock } from '@kbn/data-view-field-editor-p
 import { TestProviders } from '../../../common/mock';
 import { useKibana } from '../../../common/lib/kibana';
 import type { DataView, DataViewField } from '@kbn/data-plugin/common';
-import type { RenderHookResult } from '@testing-library/react-hooks';
-import { renderHook } from '@testing-library/react-hooks';
 import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { defaultColumnHeaderType } from '../timeline/body/column_headers/default_headers';
 import { DEFAULT_COLUMN_MIN_WIDTH } from '../timeline/body/constants';
@@ -42,12 +41,13 @@ const mockOnHide = jest.fn();
 const runAllPromises = () => new Promise(setImmediate);
 
 // helper function to render the hook
-const renderUseFieldBrowserOptions = (
-  props: Partial<UseFieldBrowserOptionsProps & { store?: Store }> = {}
-) =>
+const renderUseFieldBrowserOptions = ({
+  store,
+  ...props
+}: Partial<UseFieldBrowserOptionsProps & { store?: Store }> = {}) =>
   renderHook<
-    React.PropsWithChildren<UseFieldBrowserOptionsProps & { store?: Store }>,
-    ReturnType<UseFieldBrowserOptions>
+    ReturnType<UseFieldBrowserOptions>,
+    React.PropsWithChildren<UseFieldBrowserOptionsProps & { store?: Store }>
   >(
     () =>
       useFieldBrowserOptions({
@@ -57,7 +57,7 @@ const renderUseFieldBrowserOptions = (
         ...props,
       }),
     {
-      wrapper: ({ children, store }) => {
+      wrapper: ({ children }) => {
         if (store) {
           return <TestProviders store={store}>{children}</TestProviders>;
         }
@@ -71,12 +71,12 @@ const renderUpdatedUseFieldBrowserOptions = async (
   props: Partial<UseFieldBrowserOptionsProps> = {}
 ) => {
   let renderHookResult: RenderHookResult<
-    UseFieldBrowserOptionsProps,
-    ReturnType<UseFieldBrowserOptions>
+    ReturnType<UseFieldBrowserOptions>,
+    UseFieldBrowserOptionsProps
   > | null = null;
   await act(async () => {
     renderHookResult = renderUseFieldBrowserOptions(props);
-    await renderHookResult.waitForNextUpdate();
+    await waitFor(() => new Promise((resolve) => resolve(null)));
   });
   return renderHookResult!;
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/helpers.test.ts
@@ -6,8 +6,7 @@
  */
 
 import { cloneDeep, getOr, omit } from 'lodash/fp';
-import { renderHook } from '@testing-library/react-hooks';
-import { waitFor } from '@testing-library/react';
+import { waitFor, renderHook } from '@testing-library/react';
 
 import { mockTimelineResults, mockGetOneTimelineResult } from '../../../common/mock';
 import { timelineDefaults } from '../../store/defaults';

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/index.test.tsx
@@ -6,9 +6,8 @@
  */
 
 import React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
 import { mount } from 'enzyme';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor, renderHook } from '@testing-library/react';
 import { useHistory, useParams } from 'react-router-dom';
 
 import '../../../common/mock/formatted_relative';
@@ -30,7 +29,6 @@ import { NotePreviews } from './note_previews';
 import { OPEN_TIMELINE_CLASS_NAME } from './helpers';
 import { StatefulOpenTimeline } from '.';
 import { TimelineTabsStyle } from './types';
-import type { UseTimelineTypesArgs, UseTimelineTypesResult } from './use_timeline_types';
 import { useTimelineTypes } from './use_timeline_types';
 import { deleteTimelinesByIds } from '../../containers/api';
 import { useUserPrivileges } from '../../../common/components/user_privileges';
@@ -165,12 +163,12 @@ describe('StatefulOpenTimeline', () => {
 
   describe("Template timelines' tab", () => {
     test("should land on correct timelines' tab with url timelines/default", () => {
-      const { result } = renderHook<
-        React.PropsWithChildren<UseTimelineTypesArgs>,
-        UseTimelineTypesResult
-      >(() => useTimelineTypes({ defaultTimelineCount: 0, templateTimelineCount: 0 }), {
-        wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
-      });
+      const { result } = renderHook(
+        () => useTimelineTypes({ defaultTimelineCount: 0, templateTimelineCount: 0 }),
+        {
+          wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+        }
+      );
 
       expect(result.current.timelineType).toBe(TimelineTypeEnum.default);
     });
@@ -181,12 +179,12 @@ describe('StatefulOpenTimeline', () => {
         pageName: SecurityPageName.timelines,
       });
 
-      const { result } = renderHook<
-        React.PropsWithChildren<UseTimelineTypesArgs>,
-        UseTimelineTypesResult
-      >(() => useTimelineTypes({ defaultTimelineCount: 0, templateTimelineCount: 0 }), {
-        wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
-      });
+      const { result } = renderHook(
+        () => useTimelineTypes({ defaultTimelineCount: 0, templateTimelineCount: 0 }),
+        {
+          wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+        }
+      );
 
       expect(result.current.timelineType).toBe(TimelineTypeEnum.template);
     });
@@ -223,12 +221,12 @@ describe('StatefulOpenTimeline', () => {
         pageName: SecurityPageName.case,
       });
 
-      const { result } = renderHook<
-        React.PropsWithChildren<UseTimelineTypesArgs>,
-        UseTimelineTypesResult
-      >(() => useTimelineTypes({ defaultTimelineCount: 0, templateTimelineCount: 0 }), {
-        wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
-      });
+      const { result } = renderHook(
+        () => useTimelineTypes({ defaultTimelineCount: 0, templateTimelineCount: 0 }),
+        {
+          wrapper: ({ children }) => <TestProviders> {children}</TestProviders>,
+        }
+      );
 
       expect(result.current.timelineType).toBe(TimelineTypeEnum.default);
     });

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/note_previews/hooks/use_delete_note.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/note_previews/hooks/use_delete_note.test.ts
@@ -4,7 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { renderHook, act } from '@testing-library/react-hooks';
+
+import { renderHook, act } from '@testing-library/react';
 import { useKibana } from '../../../../../common/lib/kibana';
 import { useAppToasts } from '../../../../../common/hooks/use_app_toasts';
 import { appActions } from '../../../../../common/store/app';

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/use_update_timeline.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/use_update_timeline.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, waitFor, renderHook } from '@testing-library/react';
 import { mockTimelineModel, TestProviders } from '../../../common/mock';
 import { setTimelineRangeDatePicker as dispatchSetTimelineRangeDatePicker } from '../../../common/store/inputs/actions';
 import {
@@ -79,7 +79,10 @@ describe('dispatchUpdateTimeline', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    clock = sinon.useFakeTimers(unix);
+    clock = sinon.useFakeTimers({
+      now: unix,
+      toFake: ['Date'],
+    });
   });
 
   afterEach(function () {
@@ -87,128 +90,134 @@ describe('dispatchUpdateTimeline', () => {
   });
 
   it('it invokes date range picker dispatch', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useUpdateTimeline(), {
-        wrapper: TestProviders,
-      });
-      await waitForNextUpdate();
-      result.current(defaultArgs);
+    const { result } = renderHook(() => useUpdateTimeline(), {
+      wrapper: TestProviders,
+    });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
 
-      expect(dispatchSetTimelineRangeDatePicker).toHaveBeenCalledWith({
-        from: '2020-03-26T14:35:56.356Z',
-        to: '2020-03-26T14:41:56.356Z',
-      });
+    act(() => {
+      result.current(defaultArgs);
+    });
+
+    expect(dispatchSetTimelineRangeDatePicker).toHaveBeenCalledWith({
+      from: '2020-03-26T14:35:56.356Z',
+      to: '2020-03-26T14:41:56.356Z',
     });
   });
 
   it('it invokes add timeline dispatch', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useUpdateTimeline(), {
-        wrapper: TestProviders,
-      });
-      await waitForNextUpdate();
-      result.current(defaultArgs);
+    const { result } = renderHook(() => useUpdateTimeline(), {
+      wrapper: TestProviders,
+    });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
 
-      expect(dispatchAddTimeline).toHaveBeenCalledWith({
-        id: TimelineId.active,
-        savedTimeline: true,
-        timeline: {
-          ...mockTimelineModel,
-          version: null,
-          updated: undefined,
-          changed: true,
-        },
-      });
+    act(() => {
+      result.current(defaultArgs);
+    });
+
+    expect(dispatchAddTimeline).toHaveBeenCalledWith({
+      id: TimelineId.active,
+      savedTimeline: true,
+      timeline: {
+        ...mockTimelineModel,
+        version: null,
+        updated: undefined,
+        changed: true,
+      },
     });
   });
 
   it('it does not invoke kql filter query dispatches if timeline.kqlQuery.filterQuery is null', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useUpdateTimeline(), {
-        wrapper: TestProviders,
-      });
-      await waitForNextUpdate();
-      result.current(defaultArgs);
-
-      expect(dispatchApplyKqlFilterQuery).not.toHaveBeenCalled();
+    const { result } = renderHook(() => useUpdateTimeline(), {
+      wrapper: TestProviders,
     });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+
+    act(() => {
+      result.current(defaultArgs);
+    });
+
+    expect(dispatchApplyKqlFilterQuery).not.toHaveBeenCalled();
   });
 
   it('it does not invoke notes dispatch if duplicate is true', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useUpdateTimeline(), {
-        wrapper: TestProviders,
-      });
-      await waitForNextUpdate();
-      result.current(defaultArgs);
-
-      expect(dispatchAddNotes).not.toHaveBeenCalled();
+    const { result } = renderHook(() => useUpdateTimeline(), {
+      wrapper: TestProviders,
     });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    act(() => {
+      result.current(defaultArgs);
+    });
+
+    expect(dispatchAddNotes).not.toHaveBeenCalled();
   });
 
   it('it does not invoke kql filter query dispatches if timeline.kqlQuery.kuery is null', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useUpdateTimeline(), {
-        wrapper: TestProviders,
-      });
-      await waitForNextUpdate();
-      const mockTimeline = {
-        ...mockTimelineModel,
-        kqlQuery: {
-          filterQuery: {
-            kuery: null,
-            serializedQuery: 'some-serialized-query',
-          },
+    const { result } = renderHook(() => useUpdateTimeline(), {
+      wrapper: TestProviders,
+    });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    const mockTimeline = {
+      ...mockTimelineModel,
+      kqlQuery: {
+        filterQuery: {
+          kuery: null,
+          serializedQuery: 'some-serialized-query',
         },
-      };
+      },
+    };
+
+    act(() => {
       result.current({
         ...defaultArgs,
         timeline: mockTimeline,
       });
-
-      expect(dispatchApplyKqlFilterQuery).not.toHaveBeenCalled();
     });
+
+    expect(dispatchApplyKqlFilterQuery).not.toHaveBeenCalled();
   });
 
   it('it invokes kql filter query dispatches if timeline.kqlQuery.filterQuery.kuery is not null', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useUpdateTimeline(), {
-        wrapper: TestProviders,
-      });
-      await waitForNextUpdate();
-      const mockTimeline = {
-        ...mockTimelineModel,
-        kqlQuery: {
-          filterQuery: {
-            kuery: { expression: 'expression', kind: 'kuery' as KueryFilterQueryKind },
-            serializedQuery: 'some-serialized-query',
-          },
+    const { result } = renderHook(() => useUpdateTimeline(), {
+      wrapper: TestProviders,
+    });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    const mockTimeline = {
+      ...mockTimelineModel,
+      kqlQuery: {
+        filterQuery: {
+          kuery: { expression: 'expression', kind: 'kuery' as KueryFilterQueryKind },
+          serializedQuery: 'some-serialized-query',
         },
-      };
+      },
+    };
+
+    act(() => {
       result.current({
         ...defaultArgs,
         timeline: mockTimeline,
       });
+    });
 
-      expect(dispatchApplyKqlFilterQuery).toHaveBeenCalledWith({
-        id: TimelineId.active,
-        filterQuery: {
-          kuery: {
-            kind: 'kuery',
-            expression: 'expression',
-          },
-          serializedQuery: 'some-serialized-query',
+    expect(dispatchApplyKqlFilterQuery).toHaveBeenCalledWith({
+      id: TimelineId.active,
+      filterQuery: {
+        kuery: {
+          kind: 'kuery',
+          expression: 'expression',
         },
-      });
+        serializedQuery: 'some-serialized-query',
+      },
     });
   });
 
   it('it invokes dispatchAddNotes if duplicate is false', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useUpdateTimeline(), {
-        wrapper: TestProviders,
-      });
-      await waitForNextUpdate();
+    const { result } = renderHook(() => useUpdateTimeline(), {
+      wrapper: TestProviders,
+    });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+
+    act(() => {
       result.current({
         ...defaultArgs,
         duplicate: false,
@@ -223,53 +232,55 @@ describe('dispatchUpdateTimeline', () => {
           },
         ],
       });
+    });
 
-      expect(dispatchAddGlobalTimelineNote).not.toHaveBeenCalled();
-      expect(dispatchUpdateNote).not.toHaveBeenCalled();
-      expect(dispatchAddNotes).toHaveBeenCalledWith({
-        notes: [
-          {
-            created: new Date('2020-03-26T14:35:56.356Z'),
-            eventId: null,
-            id: 'note-id',
-            lastEdit: new Date('2020-03-26T14:35:56.356Z'),
-            note: 'I am a note',
-            user: 'unknown',
-            saveObjectId: 'note-id',
-            timelineId: 'abc',
-            version: 'testVersion',
-          },
-        ],
-      });
+    expect(dispatchAddGlobalTimelineNote).not.toHaveBeenCalled();
+    expect(dispatchUpdateNote).not.toHaveBeenCalled();
+    expect(dispatchAddNotes).toHaveBeenCalledWith({
+      notes: [
+        {
+          created: new Date('2020-03-26T14:35:56.356Z'),
+          eventId: null,
+          id: 'note-id',
+          lastEdit: new Date('2020-03-26T14:35:56.356Z'),
+          note: 'I am a note',
+          user: 'unknown',
+          saveObjectId: 'note-id',
+          timelineId: 'abc',
+          version: 'testVersion',
+        },
+      ],
     });
   });
 
   it('it invokes dispatch to create a timeline note if duplicate is true and ruleNote exists', async () => {
+    const { result } = renderHook(() => useUpdateTimeline(), {
+      wrapper: TestProviders,
+    });
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+
     await act(async () => {
-      const { result, waitForNextUpdate } = renderHook(() => useUpdateTimeline(), {
-        wrapper: TestProviders,
-      });
-      await waitForNextUpdate();
       result.current({
         ...defaultArgs,
         ruleNote: '# this would be some markdown',
       });
-      const expectedNote: Note = {
-        created: new Date(anchor),
-        id: 'uuidv4()',
-        lastEdit: null,
-        note: '# this would be some markdown',
-        saveObjectId: null,
-        user: 'elastic',
-        version: null,
-      };
+    });
 
-      expect(dispatchAddNotes).not.toHaveBeenCalled();
-      expect(dispatchUpdateNote).toHaveBeenCalledWith({ note: expectedNote });
-      expect(dispatchAddGlobalTimelineNote).toHaveBeenLastCalledWith({
-        id: TimelineId.active,
-        noteId: 'uuidv4()',
-      });
+    const expectedNote: Note = {
+      created: new Date(anchor),
+      id: 'uuidv4()',
+      lastEdit: null,
+      note: '# this would be some markdown',
+      saveObjectId: null,
+      user: 'elastic',
+      version: null,
+    };
+
+    expect(dispatchAddNotes).not.toHaveBeenCalled();
+    expect(dispatchUpdateNote).toHaveBeenCalledWith({ note: expectedNote });
+    expect(dispatchAddGlobalTimelineNote).toHaveBeenLastCalledWith({
+      id: TimelineId.active,
+      noteId: 'uuidv4()',
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/use_notes_in_flyout.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/properties/use_notes_in_flyout.test.tsx
@@ -7,11 +7,10 @@
 
 import React from 'react';
 import { TimelineId, TimelineTabs } from '../../../../../common/types';
-import { renderHook, act } from '@testing-library/react-hooks/dom';
+import { act, waitFor, renderHook } from '@testing-library/react';
 import { createMockStore, mockGlobalState, TestProviders } from '../../../../common/mock';
 import type { UseNotesInFlyoutArgs } from './use_notes_in_flyout';
 import { useNotesInFlyout } from './use_notes_in_flyout';
-import { waitFor } from '@testing-library/react';
 import { useDispatch } from 'react-redux';
 
 jest.mock('react-redux', () => ({
@@ -202,8 +201,8 @@ describe('useNotesInFlyout', () => {
     expect(result.current.isNotesFlyoutVisible).toBe(false);
   });
 
-  it('should close the flyout when activeTab is changed', () => {
-    const { result, rerender, waitForNextUpdate } = renderTestHook();
+  it('should close the flyout when activeTab is changed', async () => {
+    const { result, rerender } = renderTestHook();
 
     act(() => {
       result.current.setNotesEventId('event-1');
@@ -226,8 +225,6 @@ describe('useNotesInFlyout', () => {
       rerender({ activeTab: TimelineTabs.eql });
     });
 
-    waitForNextUpdate();
-
-    expect(result.current.isNotesFlyoutVisible).toBe(false);
+    await waitFor(() => expect(result.current.isNotesFlyoutVisible).toBe(false));
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/esql/customizations/use_histogram_customizations.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/esql/customizations/use_histogram_customizations.test.ts
@@ -11,7 +11,7 @@ import type {
   ClickTriggerEvent,
   MultiClickTriggerEvent,
 } from '@kbn/charts-plugin/public';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import type {
   DiscoverStateContainer,
   UnifiedHistogramCustomization,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/esql/use_get_stateful_query_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/esql/use_get_stateful_query_bar.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { TestProviders } from '../../../../../common/mock';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useGetStatefulQueryBar } from './use_get_stateful_query_bar';
 
 describe('useGetStatefulQueryBar', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/session/use_session_view.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/session/use_session_view.test.tsx
@@ -8,8 +8,7 @@
 import type { PropsWithChildren } from 'react';
 import React, { memo } from 'react';
 
-import { render } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { render, renderHook } from '@testing-library/react';
 import { TimelineId, TimelineTabs } from '../../../../../../common/types/timeline';
 import { mockTimelineModel, TestProviders } from '../../../../../common/mock';
 import { useKibana } from '../../../../../common/lib/kibana';

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_columns.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_columns.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { TestProviders } from '../../../../../common/mock';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useTimelineColumns } from './use_timeline_columns';
 import { defaultUdtHeaders } from '../../body/column_headers/default_headers';
 import type { ColumnHeaderOptions } from '../../../../../../common/types/timeline/columns';

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/shared/use_timeline_control_columns.test.tsx
@@ -6,7 +6,7 @@
  */
 import type { EuiDataGridControlColumn } from '@elastic/eui';
 import { TestProviders } from '../../../../../common/mock';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useLicense } from '../../../../../common/hooks/use_license';
 import { useTimelineControlColumn } from './use_timeline_control_columns';
 import type { ColumnHeaderOptions } from '../../../../../../common/types/timeline/columns';

--- a/x-pack/plugins/security_solution/public/timelines/containers/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/index.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { DataLoadingState } from '@kbn/unified-data-table';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, waitFor, renderHook } from '@testing-library/react';
 import type { TimelineArgs, UseTimelineEventsProps } from '.';
 import { initSortDefault, useTimelineEvents } from '.';
 import { SecurityPageName } from '../../../common/constants';
@@ -15,7 +15,6 @@ import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experime
 import { mockTimelineData } from '../../common/mock';
 import { useRouteSpy } from '../../common/utils/route/use_route_spy';
 import { useFetchNotes } from '../../notes/hooks/use_fetch_notes';
-import { waitFor } from '@testing-library/dom';
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
@@ -142,136 +141,105 @@ describe('useTimelineEvents', () => {
   };
 
   test('init', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate } = renderHook<
-        UseTimelineEventsProps,
-        [DataLoadingState, TimelineArgs]
-      >((args) => useTimelineEvents(args), {
-        initialProps: { ...props },
-      });
+    const { result } = renderHook((args) => useTimelineEvents(args), {
+      initialProps: props,
+    });
 
-      // useEffect on params request
-      await waitForNextUpdate();
+    expect(result.current).toEqual([
+      DataLoadingState.loading,
+      {
+        events: [],
+        id: TimelineId.active,
+        inspect: expect.objectContaining({ dsl: [], response: [] }),
+        loadPage: expect.any(Function),
+        pageInfo: expect.objectContaining({
+          activePage: 0,
+          querySize: 0,
+        }),
+        refetch: expect.any(Function),
+        totalCount: -1,
+        refreshedAt: 0,
+      },
+    ]);
+  });
+
+  test('happy path query', async () => {
+    const { result, rerender } = renderHook<
+      [DataLoadingState, TimelineArgs],
+      UseTimelineEventsProps
+    >((args) => useTimelineEvents(args), {
+      initialProps: { ...props, startDate: '', endDate: '' },
+    });
+
+    // useEffect on params request
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender({ ...props, startDate, endDate });
+    // useEffect on params request
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledTimes(2);
       expect(result.current).toEqual([
         DataLoadingState.loaded,
         {
-          events: [],
+          events: mockEvents,
           id: TimelineId.active,
           inspect: result.current[1].inspect,
           loadPage: result.current[1].loadPage,
           pageInfo: result.current[1].pageInfo,
           refetch: result.current[1].refetch,
-          totalCount: -1,
-          refreshedAt: 0,
+          totalCount: 32,
+          refreshedAt: result.current[1].refreshedAt,
         },
       ]);
-    });
-  });
-
-  test('happy path query', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate, rerender } = renderHook<
-        UseTimelineEventsProps,
-        [DataLoadingState, TimelineArgs]
-      >((args) => useTimelineEvents(args), {
-        initialProps: { ...props, startDate: '', endDate: '' },
-      });
-
-      // useEffect on params request
-      await waitForNextUpdate();
-      rerender({ ...props, startDate, endDate });
-      // useEffect on params request
-      await waitForNextUpdate();
-
-      await waitFor(() => {
-        expect(mockSearch).toHaveBeenCalledTimes(2);
-        expect(result.current).toEqual([
-          DataLoadingState.loaded,
-          {
-            events: mockEvents,
-            id: TimelineId.active,
-            inspect: result.current[1].inspect,
-            loadPage: result.current[1].loadPage,
-            pageInfo: result.current[1].pageInfo,
-            refetch: result.current[1].refetch,
-            totalCount: 32,
-            refreshedAt: result.current[1].refreshedAt,
-          },
-        ]);
-      });
     });
   });
 
   test('Mock cache for active timeline when switching page', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate, rerender } = renderHook<
-        UseTimelineEventsProps,
-        [DataLoadingState, TimelineArgs]
-      >((args) => useTimelineEvents(args), {
-        initialProps: { ...props, startDate: '', endDate: '' },
-      });
+    const { result, rerender } = renderHook<
+      [DataLoadingState, TimelineArgs],
+      UseTimelineEventsProps
+    >((args) => useTimelineEvents(args), {
+      initialProps: { ...props, startDate: '', endDate: '' },
+    });
 
-      // useEffect on params request
-      await waitForNextUpdate();
-      rerender({ ...props, startDate, endDate });
-      // useEffect on params request
-      await waitForNextUpdate();
+    // useEffect on params request
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender({ ...props, startDate, endDate });
 
-      mockUseRouteSpy.mockReturnValue([
+    mockUseRouteSpy.mockReturnValue([
+      {
+        pageName: SecurityPageName.timelines,
+        detailName: undefined,
+        tabName: undefined,
+        search: '',
+        pathName: '/timelines',
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledTimes(2);
+      expect(result.current).toEqual([
+        DataLoadingState.loaded,
         {
-          pageName: SecurityPageName.timelines,
-          detailName: undefined,
-          tabName: undefined,
-          search: '',
-          pathName: '/timelines',
+          events: mockEvents,
+          id: TimelineId.active,
+          inspect: result.current[1].inspect,
+          loadPage: result.current[1].loadPage,
+          pageInfo: result.current[1].pageInfo,
+          refetch: result.current[1].refetch,
+          totalCount: 32,
+          refreshedAt: result.current[1].refreshedAt,
         },
       ]);
-
-      await waitFor(() => {
-        expect(mockSearch).toHaveBeenCalledTimes(2);
-
-        expect(result.current).toEqual([
-          DataLoadingState.loaded,
-          {
-            events: mockEvents,
-            id: TimelineId.active,
-            inspect: result.current[1].inspect,
-            loadPage: result.current[1].loadPage,
-            pageInfo: result.current[1].pageInfo,
-            refetch: result.current[1].refetch,
-            totalCount: 32,
-            refreshedAt: result.current[1].refreshedAt,
-          },
-        ]);
-      });
     });
   });
 
   test('Correlation pagination is calling search strategy when switching page', async () => {
-    await act(async () => {
-      const { result, waitForNextUpdate, rerender } = renderHook<
-        UseTimelineEventsProps,
-        [DataLoadingState, TimelineArgs]
-      >((args) => useTimelineEvents(args), {
-        initialProps: {
-          ...props,
-          language: 'eql',
-          eqlOptions: {
-            eventCategoryField: 'category',
-            tiebreakerField: '',
-            timestampField: '@timestamp',
-            query: 'find it EQL',
-            size: 100,
-          },
-        },
-      });
-
-      // useEffect on params request
-      await waitForNextUpdate();
-      rerender({
+    const { result, rerender } = renderHook<
+      [DataLoadingState, TimelineArgs],
+      UseTimelineEventsProps
+    >((args) => useTimelineEvents(args), {
+      initialProps: {
         ...props,
-        startDate,
-        endDate,
         language: 'eql',
         eqlOptions: {
           eventCategoryField: 'category',
@@ -280,119 +248,121 @@ describe('useTimelineEvents', () => {
           query: 'find it EQL',
           size: 100,
         },
-      });
-      // useEffect on params request
-      await waitForNextUpdate();
-      mockSearch.mockReset();
-      result.current[1].loadPage(4);
-      await waitForNextUpdate();
-      expect(mockSearch).toHaveBeenCalledTimes(1);
+      },
     });
+
+    // useEffect on params request
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender({
+      ...props,
+      startDate,
+      endDate,
+      language: 'eql',
+      eqlOptions: {
+        eventCategoryField: 'category',
+        tiebreakerField: '',
+        timestampField: '@timestamp',
+        query: 'find it EQL',
+        size: 100,
+      },
+    });
+    // useEffect on params request
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    mockSearch.mockReset();
+    act(() => {
+      result.current[1].loadPage(4);
+    });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
   });
 
   test('should query again when a new field is added', async () => {
-    await act(async () => {
-      const { waitForNextUpdate, rerender } = renderHook<
-        UseTimelineEventsProps,
-        [DataLoadingState, TimelineArgs]
-      >((args) => useTimelineEvents(args), {
-        initialProps: { ...props, startDate: '', endDate: '' },
-      });
-
-      // useEffect on params request
-      await waitForNextUpdate();
-      rerender({ ...props, startDate, endDate });
-      // useEffect on params request
-      await waitForNextUpdate();
-
-      expect(mockSearch).toHaveBeenCalledTimes(2);
-      mockSearch.mockClear();
-
-      rerender({
-        ...props,
-        startDate,
-        endDate,
-        fields: ['@timestamp', 'event.kind', 'event.category'],
-      });
-
-      await waitFor(() => {
-        expect(mockSearch).toHaveBeenCalledTimes(1);
-      });
+    const { rerender } = renderHook((args) => useTimelineEvents(args), {
+      initialProps: { ...props, startDate: '', endDate: '' },
     });
+
+    // useEffect on params request
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender({ ...props, startDate, endDate });
+    // useEffect on params request
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+
+    expect(mockSearch).toHaveBeenCalledTimes(2);
+    mockSearch.mockClear();
+
+    rerender({
+      ...props,
+      startDate,
+      endDate,
+      fields: ['@timestamp', 'event.kind', 'event.category'],
+    });
+
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
   });
 
   test('should not query again when a field is removed', async () => {
-    await act(async () => {
-      const { waitForNextUpdate, rerender } = renderHook<
-        UseTimelineEventsProps,
-        [DataLoadingState, TimelineArgs]
-      >((args) => useTimelineEvents(args), {
-        initialProps: { ...props, startDate: '', endDate: '' },
-      });
-
-      // useEffect on params request
-      await waitForNextUpdate();
-      rerender({ ...props, startDate, endDate });
-      // useEffect on params request
-      await waitForNextUpdate();
-
-      expect(mockSearch).toHaveBeenCalledTimes(2);
-      mockSearch.mockClear();
-
-      rerender({ ...props, startDate, endDate, fields: ['@timestamp'] });
-
-      expect(mockSearch).toHaveBeenCalledTimes(0);
+    const { rerender } = renderHook((args) => useTimelineEvents(args), {
+      initialProps: { ...props, startDate: '', endDate: '' },
     });
+
+    // useEffect on params request
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender({ ...props, startDate, endDate });
+    // useEffect on params request
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+
+    expect(mockSearch).toHaveBeenCalledTimes(2);
+    mockSearch.mockClear();
+
+    rerender({ ...props, startDate, endDate, fields: ['@timestamp'] });
+
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(0));
   });
 
   test('should not query again when a removed field is added back', async () => {
-    await act(async () => {
-      const { waitForNextUpdate, rerender } = renderHook<
-        UseTimelineEventsProps,
-        [DataLoadingState, TimelineArgs]
-      >((args) => useTimelineEvents(args), {
-        initialProps: { ...props, startDate: '', endDate: '' },
-      });
-
-      // useEffect on params request
-      await waitForNextUpdate();
-      rerender({ ...props, startDate, endDate });
-      // useEffect on params request
-      await waitForNextUpdate();
-
-      expect(mockSearch).toHaveBeenCalledTimes(2);
-      mockSearch.mockClear();
-
-      // remove `event.kind` from default fields
-      rerender({ ...props, startDate, endDate, fields: ['@timestamp'] });
-
-      expect(mockSearch).toHaveBeenCalledTimes(0);
-
-      // request default Fields
-      rerender({ ...props, startDate, endDate });
-
-      expect(mockSearch).toHaveBeenCalledTimes(0);
+    const { rerender } = renderHook((args) => useTimelineEvents(args), {
+      initialProps: { ...props, startDate: '', endDate: '' },
     });
+
+    // useEffect on params request
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+    rerender({ ...props, startDate, endDate });
+    // useEffect on params request
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+
+    expect(mockSearch).toHaveBeenCalledTimes(2);
+    mockSearch.mockClear();
+
+    // remove `event.kind` from default fields
+    rerender({ ...props, startDate, endDate, fields: ['@timestamp'] });
+
+    await waitFor(() => new Promise((resolve) => resolve(null)));
+
+    expect(mockSearch).toHaveBeenCalledTimes(0);
+
+    // request default Fields
+    rerender({ ...props, startDate, endDate });
+
+    // since there is no new update in useEffect, it should throw an timeout error
+    // await expect(waitFor(() => null)).rejects.toThrowError();
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(0));
   });
 
   test('should return the combined list of events for all the pages when multiple pages are queried', async () => {
-    await act(async () => {
-      const { result } = renderHook((args) => useTimelineEvents(args), {
-        initialProps: { ...props },
-      });
-      await waitFor(() => {
-        expect(result.current[1].events).toHaveLength(10);
-      });
+    const { result } = renderHook((args) => useTimelineEvents(args), {
+      initialProps: { ...props },
+    });
+    await waitFor(() => {
+      expect(result.current[1].events).toHaveLength(10);
+    });
 
-      result.current[1].loadPage(1);
+    result.current[1].loadPage(1);
 
-      await waitFor(() => {
-        expect(result.current[0]).toEqual(DataLoadingState.loadingMore);
-      });
+    await waitFor(() => {
+      expect(result.current[0]).toEqual(DataLoadingState.loadingMore);
+    });
 
-      await waitFor(() => {
-        expect(result.current[1].events).toHaveLength(20);
-      });
+    await waitFor(() => {
+      expect(result.current[1].events).toHaveLength(20);
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/containers/use_timeline_data_filters.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/use_timeline_data_filters.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { mockGlobalState, TestProviders, createMockStore } from '../../common/mock';
 import { useTimelineDataFilters } from './use_timeline_data_filters';
 import React from 'react';

--- a/x-pack/plugins/security_solution/public/timelines/hooks/use_create_timeline.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/hooks/use_create_timeline.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useCreateTimeline } from './use_create_timeline';
 import type { TimeRange } from '../../common/store/inputs/model';
 import { RowRendererCount, TimelineTypeEnum } from '../../../common/api/timeline';

--- a/x-pack/plugins/threat_intelligence/public/hooks/use_integrations.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/hooks/use_integrations.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { waitFor, renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { INSTALLATION_STATUS, THREAT_INTELLIGENCE_CATEGORY } from '../utils/filter_integrations';
 
@@ -25,9 +25,7 @@ const renderUseQuery = (result: { items: any[] }) =>
 describe('useIntegrations', () => {
   it('should have undefined data during loading state', async () => {
     const mockIntegrations = { items: [] };
-    const { result, waitFor } = renderUseQuery(mockIntegrations);
-
-    await waitFor(() => result.current.isLoading);
+    const { result } = renderUseQuery(mockIntegrations);
 
     expect(result.current.isLoading).toBeTruthy();
     expect(result.current.data).toBeUndefined();
@@ -43,9 +41,9 @@ describe('useIntegrations', () => {
         },
       ],
     };
-    const { result, waitFor } = renderUseQuery(mockIntegrations);
+    const { result } = renderUseQuery(mockIntegrations);
 
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.isLoading).toBeFalsy();
     expect(result.current.data).toEqual(mockIntegrations);

--- a/x-pack/plugins/threat_intelligence/public/modules/block_list/hooks/use_policies.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/block_list/hooks/use_policies.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { waitFor, renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 
 const createWrapper = () => {
@@ -24,9 +24,7 @@ const renderUseQuery = (result: { items: any[] }) =>
 describe('usePolicies', () => {
   it('should have undefined data during loading state', async () => {
     const mockPolicies = { items: [] };
-    const { result, waitFor } = renderUseQuery(mockPolicies);
-
-    await waitFor(() => result.current.isLoading);
+    const { result } = renderUseQuery(mockPolicies);
 
     expect(result.current.isLoading).toBeTruthy();
     expect(result.current.data).toBeUndefined();
@@ -41,9 +39,9 @@ describe('usePolicies', () => {
         },
       ],
     };
-    const { result, waitFor } = renderUseQuery(mockPolicies);
+    const { result } = renderUseQuery(mockPolicies);
 
-    await waitFor(() => result.current.isSuccess);
+    await waitFor(() => expect(result.current.isSuccess).toBeTruthy());
 
     expect(result.current.isLoading).toBeFalsy();
     expect(result.current.data).toEqual(mockPolicies);

--- a/x-pack/plugins/threat_intelligence/public/modules/cases/hooks/use_case_permission.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/cases/hooks/use_case_permission.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { FC, ReactNode } from 'react';
-import { Renderer, renderHook, RenderHookResult } from '@testing-library/react-hooks';
+import { renderHook, RenderHookResult } from '@testing-library/react';
 import { casesPluginMock } from '@kbn/cases-plugin/public/mocks';
 import { KibanaContext } from '../../../hooks/use_kibana';
 import { useCaseDisabled } from './use_case_permission';
@@ -27,7 +27,7 @@ const getProviderComponent =
     );
 
 describe('useCasePermission', () => {
-  let hookResult: RenderHookResult<{}, boolean, Renderer<unknown>>;
+  let hookResult: RenderHookResult<boolean, unknown>;
 
   it('should return false if user has correct permissions and indicator has a name', () => {
     const mockedServices = {

--- a/x-pack/plugins/threat_intelligence/public/modules/cases/hooks/use_indicator_by_id.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/cases/hooks/use_indicator_by_id.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
-import { useIndicatorById, UseIndicatorByIdValue } from './use_indicator_by_id';
+import { waitFor, renderHook } from '@testing-library/react';
+import { useIndicatorById } from './use_indicator_by_id';
 import { TestProvidersComponent } from '../../../mocks/test_providers';
 import { createFetchIndicatorById } from '../services/fetch_indicator_by_id';
 import { Indicator } from '../../../../common/types/indicator';
@@ -16,13 +16,10 @@ jest.mock('../services/fetch_indicator_by_id');
 const indicatorByIdQueryResult = { _id: 'testId' } as unknown as Indicator;
 
 const renderUseIndicatorById = (initialProps = { indicatorId: 'testId' }) =>
-  renderHook<{ indicatorId: string }, UseIndicatorByIdValue>(
-    (props) => useIndicatorById(props.indicatorId),
-    {
-      initialProps,
-      wrapper: TestProvidersComponent,
-    }
-  );
+  renderHook((props) => useIndicatorById(props.indicatorId), {
+    initialProps,
+    wrapper: TestProvidersComponent,
+  });
 
 describe('useIndicatorById()', () => {
   type MockedCreateFetchIndicators = jest.MockedFunction<typeof createFetchIndicatorById>;
@@ -49,8 +46,7 @@ describe('useIndicatorById()', () => {
       expect(indicatorsQuery).toHaveBeenCalledTimes(1);
 
       // isLoading should turn to false eventually
-      await hookResult.waitFor(() => !hookResult.result.current.isLoading);
-      expect(hookResult.result.current.isLoading).toEqual(false);
+      await waitFor(() => expect(hookResult.result.current.isLoading).toBe(false));
     });
   });
 });

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_aggregated_indicators.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_aggregated_indicators.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, waitFor, renderHook } from '@testing-library/react';
 import { useAggregatedIndicators, UseAggregatedIndicatorsParam } from './use_aggregated_indicators';
 import { mockedTimefilterService, TestProvidersComponent } from '../../../mocks/test_providers';
 import { createFetchAggregatedIndicators } from '../services/fetch_aggregated_indicators';
@@ -47,7 +47,7 @@ describe('useAggregatedIndicators()', () => {
   it('should create and call the aggregatedIndicatorsQuery correctly', async () => {
     aggregatedIndicatorsQuery.mockResolvedValue([]);
 
-    const { result, rerender, waitFor } = renderUseAggregatedIndicators();
+    const { result, rerender } = renderUseAggregatedIndicators();
 
     // indicators service and the query should be called just once
     expect(
@@ -81,7 +81,7 @@ describe('useAggregatedIndicators()', () => {
       expect.any(AbortSignal)
     );
 
-    await waitFor(() => !result.current.isLoading);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current).toMatchInlineSnapshot(`
       Object {

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_column_settings.test.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_column_settings.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { mockedServices, TestProvidersComponent } from '../../../mocks/test_providers';
-import { act, renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import { useColumnSettings } from './use_column_settings';
 
 const renderUseColumnSettings = () =>

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.test.tsx
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { act, renderHook } from '@testing-library/react-hooks';
-import { useIndicators, UseIndicatorsParams, UseIndicatorsValue } from './use_indicators';
+import { act, waitFor, renderHook } from '@testing-library/react';
+import { useIndicators, UseIndicatorsParams } from './use_indicators';
 import { TestProvidersComponent } from '../../../mocks/test_providers';
 import { createFetchIndicators } from '../services/fetch_indicators';
 import { mockTimeRange } from '../../../mocks/mock_indicators_filters_context';
@@ -23,7 +23,7 @@ const useIndicatorsParams: UseIndicatorsParams = {
 const indicatorsQueryResult = { indicators: [], total: 0 };
 
 const renderUseIndicators = (initialProps = useIndicatorsParams) =>
-  renderHook<UseIndicatorsParams, UseIndicatorsValue>((props) => useIndicators(props), {
+  renderHook(useIndicators, {
     initialProps,
     wrapper: TestProvidersComponent,
   });
@@ -53,7 +53,7 @@ describe('useIndicators()', () => {
       expect(indicatorsQuery).toHaveBeenCalledTimes(1);
 
       // isLoading should turn to false eventually
-      await hookResult.waitFor(() => !hookResult.result.current.isLoading);
+      await waitFor(() => expect(hookResult.result.current.isLoading).toBe(false));
       expect(hookResult.result.current.isLoading).toEqual(false);
     });
   });
@@ -77,7 +77,7 @@ describe('useIndicators()', () => {
       // Change page size
       await act(async () => hookResult.result.current.onChangeItemsPerPage(50));
 
-      expect(indicatorsQuery).toHaveBeenCalledTimes(3);
+      await waitFor(() => expect(indicatorsQuery).toHaveBeenCalledTimes(3));
       expect(indicatorsQuery).toHaveBeenLastCalledWith(
         expect.objectContaining({
           pagination: expect.objectContaining({ pageIndex: 0, pageSize: 50 }),
@@ -101,7 +101,7 @@ describe('useIndicators()', () => {
         expect.any(AbortSignal)
       );
 
-      await hookResult.waitFor(() => !hookResult.result.current.isLoading);
+      await waitFor(() => expect(hookResult.result.current.isLoading).toBe(false));
 
       expect(hookResult.result.current).toMatchInlineSnapshot(`
         Object {

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_toolbar_options.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_toolbar_options.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { TestProvidersComponent } from '../../../mocks/test_providers';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useToolbarOptions } from './use_toolbar_options';
 
 describe('useToolbarOptions()', () => {

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_total_count.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/hooks/use_total_count.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { mockedSearchService, TestProvidersComponent } from '../../../mocks/test_providers';
-import { act, renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import { BehaviorSubject } from 'rxjs';
 import { useIndicatorsTotalCount } from './use_total_count';
 

--- a/x-pack/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filter_in_out.test.ts
+++ b/x-pack/plugins/threat_intelligence/public/modules/query_bar/hooks/use_filter_in_out.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Renderer, renderHook, RenderHookResult } from '@testing-library/react-hooks';
+import { renderHook, RenderHookResult } from '@testing-library/react';
 import {
   generateMockIndicator,
   generateMockUrlIndicator,
@@ -19,7 +19,7 @@ import { updateFiltersArray } from '../utils/filter';
 jest.mock('../utils/filter', () => ({ updateFiltersArray: jest.fn() }));
 
 describe('useFilterInOut()', () => {
-  let hookResult: RenderHookResult<{}, UseFilterInValue, Renderer<unknown>>;
+  let hookResult: RenderHookResult<UseFilterInValue, unknown>;
 
   it('should return empty object if Indicator is incorrect', () => {
     const indicator: Indicator = generateMockIndicator();

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_add_to_timeline.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_add_to_timeline.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { EMPTY_VALUE } from '../../../constants/common';
-import { Renderer, renderHook, RenderHookResult } from '@testing-library/react-hooks';
+import { renderHook, RenderHookResult } from '@testing-library/react';
 import {
   generateMockIndicator,
   generateMockUrlIndicator,
@@ -16,7 +16,7 @@ import { TestProvidersComponent } from '../../../mocks/test_providers';
 import { useAddToTimeline, UseAddToTimelineValue } from './use_add_to_timeline';
 
 describe('useInvestigateInTimeline()', () => {
-  let hookResult: RenderHookResult<{}, UseAddToTimelineValue, Renderer<unknown>>;
+  let hookResult: RenderHookResult<UseAddToTimelineValue, unknown>;
 
   xit('should return empty object if Indicator is incorrect', () => {
     const indicator: Indicator = generateMockIndicator();

--- a/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_investigate_in_timeline.test.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/timeline/hooks/use_investigate_in_timeline.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Renderer, renderHook, RenderHookResult } from '@testing-library/react-hooks';
+import { renderHook, RenderHookResult } from '@testing-library/react';
 import {
   useInvestigateInTimeline,
   UseInvestigateInTimelineValue,
@@ -18,7 +18,7 @@ import {
 import { TestProvidersComponent } from '../../../mocks/test_providers';
 
 describe('useInvestigateInTimeline()', () => {
-  let hookResult: RenderHookResult<{}, UseInvestigateInTimelineValue, Renderer<unknown>>;
+  let hookResult: RenderHookResult<UseInvestigateInTimelineValue, unknown>;
 
   it('should return empty object if Indicator is incorrect', () => {
     const indicator: Indicator = generateMockIndicator();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[React18] Migrate test suites to account for testing library upgrades security-threat-hunting-investigations (#201145)](https://github.com/elastic/kibana/pull/201145)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-11-22T10:54:41Z","message":"[React18] Migrate test suites to account for testing library upgrades security-threat-hunting-investigations (#201145)\n\nThis PR migrates test suites that use `renderHook` from the library\r\n`@testing-library/react-hooks` to adopt the equivalent and replacement\r\nof `renderHook` from the export that is now available from\r\n`@testing-library/react`. This work is required for the planned\r\nmigration to react18.\r\n\r\n##  Context\r\n\r\nIn this PR, usages of `waitForNextUpdate` that previously could have\r\nbeen destructured from `renderHook` are now been replaced with `waitFor`\r\nexported from `@testing-library/react`, furthermore `waitFor`\r\nthat would also have been destructured from the same renderHook result\r\nis now been replaced with `waitFor` from the export of\r\n`@testing-library/react`.\r\n\r\n***Why is `waitFor` a sufficient enough replacement for\r\n`waitForNextUpdate`, and better for testing values subject to async\r\ncomputations?***\r\n\r\nWaitFor will retry the provided callback if an error is returned, till\r\nthe configured timeout elapses. By default the retry interval is `50ms`\r\nwith a timeout value of `1000ms` that\r\neffectively translates to at least 20 retries for assertions placed\r\nwithin waitFor. See\r\nhttps://testing-library.com/docs/dom-testing-library/api-async/#waitfor\r\nfor more information.\r\nThis however means that for person's writing tests, said person has to\r\nbe explicit about expectations that describe the internal state of the\r\nhook being tested.\r\nThis implies checking for instance when a react query hook is being\r\nrendered, there's an assertion that said hook isn't loading anymore.\r\n\r\nIn this PR you'd notice that this pattern has been adopted, with most\r\nexisting assertions following an invocation of `waitForNextUpdate` being\r\nplaced within a `waitFor`\r\ninvocation. In some cases the replacement is simply a `waitFor(() => new\r\nPromise((resolve) => resolve(null)))` (many thanks to @kapral18, for\r\npoint out exactly why this works),\r\nwhere this suffices the assertions that follow aren't placed within a\r\nwaitFor so this PR doesn't get larger than it needs to be.\r\n\r\nIt's also worth pointing out this PR might also contain changes to test\r\nand application code to improve said existing test.\r\n\r\n### What to do next?\r\n1. Review the changes in this PR.\r\n2. If you think the changes are correct, approve the PR.\r\n\r\n## Any questions?\r\nIf you have any questions or need help with this PR, please leave\r\ncomments in this PR.","sha":"06de5f3f51961df174ae109a200a8ae1e4acfaff","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","Team:Threat Hunting:Investigations","backport:prev-minor","React@18"],"number":201145,"url":"https://github.com/elastic/kibana/pull/201145","mergeCommit":{"message":"[React18] Migrate test suites to account for testing library upgrades security-threat-hunting-investigations (#201145)\n\nThis PR migrates test suites that use `renderHook` from the library\r\n`@testing-library/react-hooks` to adopt the equivalent and replacement\r\nof `renderHook` from the export that is now available from\r\n`@testing-library/react`. This work is required for the planned\r\nmigration to react18.\r\n\r\n##  Context\r\n\r\nIn this PR, usages of `waitForNextUpdate` that previously could have\r\nbeen destructured from `renderHook` are now been replaced with `waitFor`\r\nexported from `@testing-library/react`, furthermore `waitFor`\r\nthat would also have been destructured from the same renderHook result\r\nis now been replaced with `waitFor` from the export of\r\n`@testing-library/react`.\r\n\r\n***Why is `waitFor` a sufficient enough replacement for\r\n`waitForNextUpdate`, and better for testing values subject to async\r\ncomputations?***\r\n\r\nWaitFor will retry the provided callback if an error is returned, till\r\nthe configured timeout elapses. By default the retry interval is `50ms`\r\nwith a timeout value of `1000ms` that\r\neffectively translates to at least 20 retries for assertions placed\r\nwithin waitFor. See\r\nhttps://testing-library.com/docs/dom-testing-library/api-async/#waitfor\r\nfor more information.\r\nThis however means that for person's writing tests, said person has to\r\nbe explicit about expectations that describe the internal state of the\r\nhook being tested.\r\nThis implies checking for instance when a react query hook is being\r\nrendered, there's an assertion that said hook isn't loading anymore.\r\n\r\nIn this PR you'd notice that this pattern has been adopted, with most\r\nexisting assertions following an invocation of `waitForNextUpdate` being\r\nplaced within a `waitFor`\r\ninvocation. In some cases the replacement is simply a `waitFor(() => new\r\nPromise((resolve) => resolve(null)))` (many thanks to @kapral18, for\r\npoint out exactly why this works),\r\nwhere this suffices the assertions that follow aren't placed within a\r\nwaitFor so this PR doesn't get larger than it needs to be.\r\n\r\nIt's also worth pointing out this PR might also contain changes to test\r\nand application code to improve said existing test.\r\n\r\n### What to do next?\r\n1. Review the changes in this PR.\r\n2. If you think the changes are correct, approve the PR.\r\n\r\n## Any questions?\r\nIf you have any questions or need help with this PR, please leave\r\ncomments in this PR.","sha":"06de5f3f51961df174ae109a200a8ae1e4acfaff"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/201145","number":201145,"mergeCommit":{"message":"[React18] Migrate test suites to account for testing library upgrades security-threat-hunting-investigations (#201145)\n\nThis PR migrates test suites that use `renderHook` from the library\r\n`@testing-library/react-hooks` to adopt the equivalent and replacement\r\nof `renderHook` from the export that is now available from\r\n`@testing-library/react`. This work is required for the planned\r\nmigration to react18.\r\n\r\n##  Context\r\n\r\nIn this PR, usages of `waitForNextUpdate` that previously could have\r\nbeen destructured from `renderHook` are now been replaced with `waitFor`\r\nexported from `@testing-library/react`, furthermore `waitFor`\r\nthat would also have been destructured from the same renderHook result\r\nis now been replaced with `waitFor` from the export of\r\n`@testing-library/react`.\r\n\r\n***Why is `waitFor` a sufficient enough replacement for\r\n`waitForNextUpdate`, and better for testing values subject to async\r\ncomputations?***\r\n\r\nWaitFor will retry the provided callback if an error is returned, till\r\nthe configured timeout elapses. By default the retry interval is `50ms`\r\nwith a timeout value of `1000ms` that\r\neffectively translates to at least 20 retries for assertions placed\r\nwithin waitFor. See\r\nhttps://testing-library.com/docs/dom-testing-library/api-async/#waitfor\r\nfor more information.\r\nThis however means that for person's writing tests, said person has to\r\nbe explicit about expectations that describe the internal state of the\r\nhook being tested.\r\nThis implies checking for instance when a react query hook is being\r\nrendered, there's an assertion that said hook isn't loading anymore.\r\n\r\nIn this PR you'd notice that this pattern has been adopted, with most\r\nexisting assertions following an invocation of `waitForNextUpdate` being\r\nplaced within a `waitFor`\r\ninvocation. In some cases the replacement is simply a `waitFor(() => new\r\nPromise((resolve) => resolve(null)))` (many thanks to @kapral18, for\r\npoint out exactly why this works),\r\nwhere this suffices the assertions that follow aren't placed within a\r\nwaitFor so this PR doesn't get larger than it needs to be.\r\n\r\nIt's also worth pointing out this PR might also contain changes to test\r\nand application code to improve said existing test.\r\n\r\n### What to do next?\r\n1. Review the changes in this PR.\r\n2. If you think the changes are correct, approve the PR.\r\n\r\n## Any questions?\r\nIf you have any questions or need help with this PR, please leave\r\ncomments in this PR.","sha":"06de5f3f51961df174ae109a200a8ae1e4acfaff"}}]}] BACKPORT-->