### PR TITLE
[8.17] [Cloud Security] Remove preconfigured Agentless policy solution and feature flag (#197338)

### DIFF
--- a/x-pack/plugins/fleet/common/constants/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/constants/agent_policy.ts
@@ -38,7 +38,5 @@ export const LICENSE_FOR_SCHEDULE_UPGRADE = 'platinum';
 
 export const DEFAULT_MAX_AGENT_POLICIES_WITH_INACTIVITY_TIMEOUT = 750;
 
-export const AGENTLESS_POLICY_ID = 'agentless'; // the policy id defined here: https://github.com/elastic/project-controller/blob/main/internal/project/security/security_kibana_config.go#L86
-
 export const AGENT_LOG_LEVELS = ['error', 'warning', 'info', 'debug'] as const;
 export const DEFAULT_LOG_LEVEL = 'info' as const;

--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -21,7 +21,6 @@ const _allowedExperimentalValues = {
   kafkaOutput: true,
   outputSecretsStorage: true,
   remoteESOutput: true,
-  agentless: false,
   enableStrictKQLValidation: true,
   subfeaturePrivileges: false,
   advancedPolicySettings: true,

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -269,5 +269,4 @@ export interface FleetServerPolicy {
 
 export interface AgentlessApiResponse {
   id: string;
-  region_id: string;
 }

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.test.tsx
@@ -360,11 +360,8 @@ describe('PackagePolicyInputPanel', () => {
     beforeEach(() => {
       useAgentlessMock.mockReturnValue({
         isAgentlessEnabled: true,
-        isAgentlessPackagePolicy: jest.fn(),
         isAgentlessAgentPolicy: jest.fn(),
         isAgentlessIntegration: jest.fn(),
-        isAgentlessApiEnabled: true,
-        isDefaultAgentlessPolicyEnabled: false,
       });
     });
 
@@ -395,11 +392,8 @@ describe('PackagePolicyInputPanel', () => {
     beforeEach(() => {
       useAgentlessMock.mockReturnValue({
         isAgentlessEnabled: false,
-        isAgentlessPackagePolicy: jest.fn(),
         isAgentlessAgentPolicy: jest.fn(),
         isAgentlessIntegration: jest.fn(),
-        isAgentlessApiEnabled: true,
-        isDefaultAgentlessPolicyEnabled: false,
       });
     });
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -178,8 +178,7 @@ export function useOnSubmit({
   const [hasAgentPolicyError, setHasAgentPolicyError] = useState<boolean>(false);
   const hasErrors = validationResults ? validationHasErrors(validationResults) : false;
 
-  const { isAgentlessIntegration, isAgentlessAgentPolicy, isAgentlessPackagePolicy } =
-    useAgentless();
+  const { isAgentlessIntegration, isAgentlessAgentPolicy } = useAgentless();
 
   // Update agent policy method
   const updateAgentPolicies = useCallback(
@@ -316,9 +315,7 @@ export function useOnSubmit({
         (agentCount !== 0 ||
           (agentPolicies.length === 0 && selectedPolicyTab !== SelectedPolicyTab.NEW)) &&
         !(
-          isAgentlessIntegration(packageInfo) ||
-          isAgentlessPackagePolicy(packagePolicy) ||
-          isAgentlessAgentPolicy(overrideCreatedAgentPolicy)
+          isAgentlessIntegration(packageInfo) || isAgentlessAgentPolicy(overrideCreatedAgentPolicy)
         ) &&
         formState !== 'CONFIRM'
       ) {
@@ -365,9 +362,7 @@ export function useOnSubmit({
         : packagePolicy.policy_ids;
 
       const shouldForceInstallOnAgentless =
-        isAgentlessAgentPolicy(createdPolicy) ||
-        isAgentlessIntegration(packageInfo) ||
-        isAgentlessPackagePolicy(packagePolicy);
+        isAgentlessAgentPolicy(createdPolicy) || isAgentlessIntegration(packageInfo);
 
       const forceInstall = force || shouldForceInstallOnAgentless;
 
@@ -390,8 +385,7 @@ export function useOnSubmit({
       const hasGoogleCloudShell = data?.item ? getCloudShellUrlFromPackagePolicy(data.item) : false;
 
       // Check if agentless is configured in ESS and Serverless until Agentless API migrates to Serverless
-      const isAgentlessConfigured =
-        isAgentlessAgentPolicy(createdPolicy) || (data && isAgentlessPackagePolicy(data.item));
+      const isAgentlessConfigured = isAgentlessAgentPolicy(createdPolicy);
 
       // Removing this code will disabled the Save and Continue button. We need code below update form state and trigger correct modal depending on agent count
       if (hasFleetAddAgentsPrivileges && !isAgentlessConfigured) {
@@ -479,7 +473,6 @@ export function useOnSubmit({
       selectedPolicyTab,
       packagePolicy,
       isAgentlessAgentPolicy,
-      isAgentlessPackagePolicy,
       hasFleetAddAgentsPrivileges,
       withSysMonitoring,
       newAgentPolicy,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
@@ -13,8 +13,7 @@ import { createPackagePolicyMock } from '../../../../../../../../common/mocks';
 
 import type { RegistryPolicyTemplate, PackageInfo } from '../../../../../../../../common/types';
 import { SetupTechnology } from '../../../../../../../../common/types';
-import { ExperimentalFeaturesService } from '../../../../../services';
-import { sendGetOneAgentPolicy, useStartServices, useConfig } from '../../../../../hooks';
+import { useStartServices, useConfig } from '../../../../../hooks';
 import { SelectedPolicyTab } from '../../components';
 import { generateNewAgentPolicyWithDefaults } from '../../../../../../../../common/services/generate_new_agent_policy';
 
@@ -32,12 +31,7 @@ jest.mock('../../../../../../../../common/services/generate_new_agent_policy');
 type MockFn = jest.MockedFunction<any>;
 
 describe('useAgentless', () => {
-  const mockedExperimentalFeaturesService = jest.mocked(ExperimentalFeaturesService);
-
   beforeEach(() => {
-    mockedExperimentalFeaturesService.get.mockReturnValue({
-      agentless: false,
-    } as any);
     (useConfig as MockFn).mockReturnValue({
       agentless: undefined,
     } as any);
@@ -50,33 +44,25 @@ describe('useAgentless', () => {
     jest.clearAllMocks();
   });
 
-  it('should not return isAgentless when agentless is not enabled', () => {
+  it('should return isAgentlessEnabled as falsy when agentless is not enabled', () => {
     const { result } = renderHook(() => useAgentless());
 
     expect(result.current.isAgentlessEnabled).toBeFalsy();
-    expect(result.current.isAgentlessApiEnabled).toBeFalsy();
-    expect(result.current.isDefaultAgentlessPolicyEnabled).toBeFalsy();
   });
 
-  it('should return isAgentlessEnabled as falsy if agentless.enabled is true and experimental feature agentless is truthy without cloud or serverless', () => {
+  it('should return isAgentlessEnabled as falsy if agentless.enabled true without cloud or serverless', () => {
     (useConfig as MockFn).mockReturnValue({
       agentless: {
         enabled: true,
       },
     } as any);
 
-    mockedExperimentalFeaturesService.get.mockReturnValue({
-      agentless: false,
-    } as any);
-
     const { result } = renderHook(() => useAgentless());
 
     expect(result.current.isAgentlessEnabled).toBeFalsy();
-    expect(result.current.isAgentlessApiEnabled).toBeFalsy();
-    expect(result.current.isDefaultAgentlessPolicyEnabled).toBeFalsy();
   });
 
-  it('should return isAgentlessEnabled and isAgentlessApiEnabled as truthy with isCloudEnabled', () => {
+  it('should return isAgentlessEnabled as truthy with isCloudEnabled', () => {
     (useConfig as MockFn).mockReturnValue({
       agentless: {
         enabled: true,
@@ -93,14 +79,9 @@ describe('useAgentless', () => {
     const { result } = renderHook(() => useAgentless());
 
     expect(result.current.isAgentlessEnabled).toBeTruthy();
-    expect(result.current.isAgentlessApiEnabled).toBeTruthy();
-    expect(result.current.isDefaultAgentlessPolicyEnabled).toBeFalsy();
   });
-  it('should return isAgentlessEnabled and isDefaultAgentlessPolicyEnabled as truthy with isServerlessEnabled and experimental feature agentless is truthy', () => {
-    mockedExperimentalFeaturesService.get.mockReturnValue({
-      agentless: true,
-    } as any);
 
+  it('should return isAgentlessEnabled truthy with isServerlessEnabled', () => {
     (useStartServices as MockFn).mockReturnValue({
       cloud: {
         isServerlessEnabled: true,
@@ -108,18 +89,18 @@ describe('useAgentless', () => {
       },
     });
 
+    (useConfig as MockFn).mockReturnValue({
+      agentless: {
+        enabled: true,
+      },
+    } as any);
+
     const { result } = renderHook(() => useAgentless());
 
     expect(result.current.isAgentlessEnabled).toBeTruthy();
-    expect(result.current.isAgentlessApiEnabled).toBeFalsy();
-    expect(result.current.isDefaultAgentlessPolicyEnabled).toBeTruthy();
   });
 
-  it('should return isAgentlessEnabled as falsy and isDefaultAgentlessPolicyEnabled as falsy with isServerlessEnabled and experimental feature agentless is falsy', () => {
-    mockedExperimentalFeaturesService.get.mockReturnValue({
-      agentless: false,
-    } as any);
-
+  it('should return isAgentlessEnabled as falsy with isServerlessEnabled and without agentless config', () => {
     (useStartServices as MockFn).mockReturnValue({
       cloud: {
         isServerlessEnabled: true,
@@ -130,8 +111,6 @@ describe('useAgentless', () => {
     const { result } = renderHook(() => useAgentless());
 
     expect(result.current.isAgentlessEnabled).toBeFalsy();
-    expect(result.current.isAgentlessApiEnabled).toBeFalsy();
-    expect(result.current.isDefaultAgentlessPolicyEnabled).toBeFalsy();
   });
 });
 
@@ -180,20 +159,10 @@ describe('useSetupTechnology', () => {
 
   const packagePolicyMock = createPackagePolicyMock();
 
-  const mockedExperimentalFeaturesService = jest.mocked(ExperimentalFeaturesService);
-
   beforeEach(() => {
-    mockedExperimentalFeaturesService.get.mockReturnValue({
-      agentless: true,
-    } as any);
     (useConfig as MockFn).mockReturnValue({
       agentless: undefined,
     } as any);
-    (sendGetOneAgentPolicy as MockFn).mockResolvedValue({
-      data: {
-        item: { id: 'agentless-policy-id' },
-      },
-    });
     (useStartServices as MockFn).mockReturnValue({
       cloud: {
         isServerlessEnabled: true,
@@ -209,10 +178,6 @@ describe('useSetupTechnology', () => {
   });
 
   it('should initialize with default values when agentless is disabled', () => {
-    mockedExperimentalFeaturesService.get.mockReturnValue({
-      agentless: false,
-    } as any);
-
     const { result } = renderHook(() =>
       useSetupTechnology({
         setNewAgentPolicy,
@@ -223,24 +188,7 @@ describe('useSetupTechnology', () => {
       })
     );
 
-    expect(sendGetOneAgentPolicy).not.toHaveBeenCalled();
     expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
-  });
-
-  it('should fetch agentless policy if agentless feature is enabled and isServerless is true', async () => {
-    renderHook(() =>
-      useSetupTechnology({
-        setNewAgentPolicy,
-        newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicies: updateAgentPoliciesMock,
-        setSelectedPolicyTab: setSelectedPolicyTabMock,
-        packagePolicy: packagePolicyMock,
-      })
-    );
-
-    await waitFor(() => {
-      expect(sendGetOneAgentPolicy).toHaveBeenCalled();
-    });
   });
 
   it('should set agentless setup technology if agent policy supports agentless in edit page', async () => {
@@ -272,7 +220,7 @@ describe('useSetupTechnology', () => {
     expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENTLESS);
   });
 
-  it('should create agentless policy if agentless feature is enabled and isCloud is true and agentless.api.url', async () => {
+  it('should create agentless policy if isCloud  and agentless.enabled', async () => {
     (useConfig as MockFn).mockReturnValue({
       agentless: {
         enabled: true,
@@ -371,7 +319,7 @@ describe('useSetupTechnology', () => {
     });
   });
 
-  it('should not create agentless policy if agentless feature is enabled and isCloud is true and agentless.api.url is not defined', async () => {
+  it('should not create agentless policy isCloud is true and agentless.api.url is not defined', async () => {
     (useConfig as MockFn).mockReturnValue({} as any);
     (useStartServices as MockFn).mockReturnValue({
       cloud: {
@@ -398,55 +346,21 @@ describe('useSetupTechnology', () => {
     await waitFor(() => expect(setNewAgentPolicy).toHaveBeenCalledTimes(0));
   });
 
-  it('should not fetch agentless policy if agentless is enabled but serverless is disabled', async () => {
+  it('should update new agent policy and selected policy tab when setup technology is agent-based', async () => {
+    (useConfig as MockFn).mockReturnValue({
+      agentless: {
+        enabled: true,
+        api: {
+          url: 'https://agentless.api.url',
+        },
+      },
+    } as any);
     (useStartServices as MockFn).mockReturnValue({
       cloud: {
-        isServerlessEnabled: false,
+        isCloudEnabled: true,
       },
     });
 
-    const { result } = renderHook(() =>
-      useSetupTechnology({
-        setNewAgentPolicy,
-        newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicies: updateAgentPoliciesMock,
-        setSelectedPolicyTab: setSelectedPolicyTabMock,
-        packagePolicy: packagePolicyMock,
-      })
-    );
-
-    expect(sendGetOneAgentPolicy).not.toHaveBeenCalled();
-    expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
-  });
-
-  it('should update agent policy and selected policy tab when setup technology is agentless', async () => {
-    const { result } = renderHook(() =>
-      useSetupTechnology({
-        setNewAgentPolicy,
-        newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicies: updateAgentPoliciesMock,
-        setSelectedPolicyTab: setSelectedPolicyTabMock,
-        packagePolicy: packagePolicyMock,
-      })
-    );
-
-    act(() => {
-      result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
-    });
-
-    await waitFor(() => {
-      expect(updateAgentPoliciesMock).toHaveBeenCalledWith([
-        {
-          inactivity_timeout: 3600,
-          name: 'Agentless policy for endpoint-1',
-          supports_agentless: true,
-        },
-      ]);
-      expect(setSelectedPolicyTabMock).toHaveBeenCalledWith(SelectedPolicyTab.EXISTING);
-    });
-  });
-
-  it('should update new agent policy and selected policy tab when setup technology is agent-based', async () => {
     const { result } = renderHook(() =>
       useSetupTechnology({
         setNewAgentPolicy,
@@ -477,30 +391,6 @@ describe('useSetupTechnology', () => {
     });
   });
 
-  it('should not update agent policy and selected policy tab when agentless is disabled', async () => {
-    mockedExperimentalFeaturesService.get.mockReturnValue({
-      agentless: false,
-    } as any);
-
-    const { result } = renderHook(() =>
-      useSetupTechnology({
-        setNewAgentPolicy,
-        newAgentPolicy: newAgentPolicyMock,
-        updateAgentPolicies: updateAgentPoliciesMock,
-        setSelectedPolicyTab: setSelectedPolicyTabMock,
-        packagePolicy: packagePolicyMock,
-      })
-    );
-
-    expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
-
-    act(() => {
-      result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
-    });
-
-    expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
-  });
-
   it('should not update agent policy and selected policy tab when setup technology matches the current one ', async () => {
     const { result } = renderHook(() =>
       useSetupTechnology({
@@ -527,6 +417,19 @@ describe('useSetupTechnology', () => {
   });
 
   it('should revert the agent policy name to the original value when switching from agentless back to agent-based', async () => {
+    (useConfig as MockFn).mockReturnValue({
+      agentless: {
+        enabled: true,
+        api: {
+          url: 'https://agentless.api.url',
+        },
+      },
+    } as any);
+    (useStartServices as MockFn).mockReturnValue({
+      cloud: {
+        isServerlessEnabled: true,
+      },
+    });
     const { result } = renderHook(() =>
       useSetupTechnology({
         setNewAgentPolicy,
@@ -543,7 +446,9 @@ describe('useSetupTechnology', () => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
     });
 
-    expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENTLESS);
+    await waitFor(() =>
+      expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENTLESS)
+    );
 
     await waitFor(() => {
       expect(setNewAgentPolicy).toHaveBeenCalledWith({
@@ -557,8 +462,10 @@ describe('useSetupTechnology', () => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENT_BASED);
     });
 
-    expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
-    expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
+    await waitFor(() => {
+      expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
+      expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
+    });
   });
 
   it('should have global_data_tags with the integration team when creating agentless policy with global_data_tags', async () => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
@@ -8,7 +8,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useConfig } from '../../../../../hooks';
-import { ExperimentalFeaturesService } from '../../../../../services';
 import { generateNewAgentPolicyWithDefaults } from '../../../../../../../../common/services/generate_new_agent_policy';
 import type {
   AgentPolicy,
@@ -17,10 +16,9 @@ import type {
   PackageInfo,
 } from '../../../../../types';
 import { SetupTechnology } from '../../../../../types';
-import { sendGetOneAgentPolicy, useStartServices } from '../../../../../hooks';
+import { useStartServices } from '../../../../../hooks';
 import { SelectedPolicyTab } from '../../components';
 import {
-  AGENTLESS_POLICY_ID,
   AGENTLESS_GLOBAL_TAG_NAME_ORGANIZATION,
   AGENTLESS_GLOBAL_TAG_NAME_DIVISION,
   AGENTLESS_GLOBAL_TAG_NAME_TEAM,
@@ -32,23 +30,15 @@ import {
 
 export const useAgentless = () => {
   const config = useConfig();
-  const { agentless: agentlessExperimentalFeatureEnabled } = ExperimentalFeaturesService.get();
   const { cloud } = useStartServices();
   const isServerless = !!cloud?.isServerlessEnabled;
   const isCloud = !!cloud?.isCloudEnabled;
 
-  const isAgentlessApiEnabled = (isCloud || isServerless) && config.agentless?.enabled;
-  const isDefaultAgentlessPolicyEnabled =
-    !isAgentlessApiEnabled && isServerless && agentlessExperimentalFeatureEnabled;
-
-  const isAgentlessEnabled = isAgentlessApiEnabled || isDefaultAgentlessPolicyEnabled;
+  const isAgentlessEnabled = (isCloud || isServerless) && config.agentless?.enabled === true;
 
   const isAgentlessAgentPolicy = (agentPolicy: AgentPolicy | undefined) => {
     if (!agentPolicy) return false;
-    return (
-      isAgentlessEnabled &&
-      (agentPolicy?.id === AGENTLESS_POLICY_ID || !!agentPolicy?.supports_agentless)
-    );
+    return isAgentlessEnabled && !!agentPolicy?.supports_agentless;
   };
 
   // When an integration has at least a policy template enabled for agentless
@@ -59,17 +49,10 @@ export const useAgentless = () => {
     return false;
   };
 
-  // TODO: remove this check when CSPM implements the above flag and rely only on `isAgentlessIntegration`
-  const isAgentlessPackagePolicy = (packagePolicy: NewPackagePolicy) => {
-    return isAgentlessEnabled && packagePolicy.policy_ids.includes(AGENTLESS_POLICY_ID);
-  };
   return {
-    isAgentlessApiEnabled,
-    isDefaultAgentlessPolicyEnabled,
     isAgentlessEnabled,
     isAgentlessAgentPolicy,
     isAgentlessIntegration,
-    isAgentlessPackagePolicy,
   };
 };
 
@@ -92,8 +75,7 @@ export function useSetupTechnology({
   isEditPage?: boolean;
   agentPolicies?: AgentPolicy[];
 }) {
-  const { isAgentlessEnabled, isAgentlessApiEnabled, isDefaultAgentlessPolicyEnabled } =
-    useAgentless();
+  const { isAgentlessEnabled } = useAgentless();
 
   // this is a placeholder for the new agent-BASED policy that will be used when the user switches from agentless to agent-based and back
   const newAgentBasedPolicy = useRef<NewAgentPolicy>(newAgentPolicy);
@@ -114,7 +96,7 @@ export function useSetupTechnology({
       setSelectedSetupTechnology(SetupTechnology.AGENTLESS);
       return;
     }
-    if (isAgentlessApiEnabled && selectedSetupTechnology === SetupTechnology.AGENTLESS) {
+    if (isAgentlessEnabled && selectedSetupTechnology === SetupTechnology.AGENTLESS) {
       const nextNewAgentlessPolicy = {
         ...newAgentlessPolicy,
         name: getAgentlessAgentPolicyNameFromPackagePolicyName(packagePolicy.name),
@@ -126,7 +108,7 @@ export function useSetupTechnology({
       }
     }
   }, [
-    isAgentlessApiEnabled,
+    isAgentlessEnabled,
     isEditPage,
     newAgentlessPolicy,
     packagePolicy.name,
@@ -137,23 +119,6 @@ export function useSetupTechnology({
     setSelectedSetupTechnology,
   ]);
 
-  // tech debt: remove this useEffect when Serverless uses the Agentless API
-  // https://github.com/elastic/security-team/issues/9781
-  useEffect(() => {
-    const fetchAgentlessPolicy = async () => {
-      const { data, error } = await sendGetOneAgentPolicy(AGENTLESS_POLICY_ID);
-      const isAgentlessAvailable = !error && data && data.item;
-
-      if (isAgentlessAvailable) {
-        setNewAgentlessPolicy(data.item);
-      }
-    };
-
-    if (isDefaultAgentlessPolicyEnabled) {
-      fetchAgentlessPolicy();
-    }
-  }, [isDefaultAgentlessPolicyEnabled]);
-
   const handleSetupTechnologyChange = useCallback(
     (setupTechnology: SetupTechnology, policyTemplateName?: string) => {
       if (!isAgentlessEnabled || setupTechnology === selectedSetupTechnology) {
@@ -161,7 +126,7 @@ export function useSetupTechnology({
       }
 
       if (setupTechnology === SetupTechnology.AGENTLESS) {
-        if (isAgentlessApiEnabled) {
+        if (isAgentlessEnabled) {
           const agentlessPolicy = {
             ...newAgentlessPolicy,
             ...getAdditionalAgentlessPolicyInfo(policyTemplateName, packageInfo),
@@ -171,13 +136,6 @@ export function useSetupTechnology({
           setNewAgentlessPolicy(agentlessPolicy);
           setSelectedPolicyTab(SelectedPolicyTab.NEW);
           updateAgentPolicies([agentlessPolicy] as AgentPolicy[]);
-        }
-        // tech debt: remove this when Serverless uses the Agentless API
-        // https://github.com/elastic/security-team/issues/9781
-        if (isDefaultAgentlessPolicyEnabled) {
-          setNewAgentPolicy(newAgentlessPolicy as AgentPolicy);
-          updateAgentPolicies([newAgentlessPolicy] as AgentPolicy[]);
-          setSelectedPolicyTab(SelectedPolicyTab.EXISTING);
         }
       } else if (setupTechnology === SetupTechnology.AGENT_BASED) {
         setNewAgentPolicy({
@@ -192,8 +150,6 @@ export function useSetupTechnology({
     [
       isAgentlessEnabled,
       selectedSetupTechnology,
-      isAgentlessApiEnabled,
-      isDefaultAgentlessPolicyEnabled,
       setNewAgentPolicy,
       newAgentlessPolicy,
       setSelectedPolicyTab,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.test.tsx
@@ -13,17 +13,12 @@ import type { MockedFleetStartServices, TestRenderer } from '../../../../../../m
 import { createFleetTestRendererMock } from '../../../../../../mock';
 import { FLEET_ROUTING_PATHS, pagePathGetters, PLUGIN_ID } from '../../../../constants';
 import type { CreatePackagePolicyRouteState } from '../../../../types';
-
-import { ExperimentalFeaturesService } from '../../../../../../services';
-
 import {
   sendCreatePackagePolicy,
   sendCreateAgentPolicy,
   sendGetAgentStatus,
-  sendGetOneAgentPolicy,
   useIntraAppState,
   useStartServices,
-  useGetAgentPolicies,
   useGetPackageInfoByKeyQuery,
   useConfig,
 } from '../../../../hooks';
@@ -137,10 +132,6 @@ jest.mock('react-router-dom', () => ({
     },
   }),
 }));
-
-import { AGENTLESS_POLICY_ID } from '../../../../../../../common/constants';
-
-import { useAllNonManagedAgentPolicies } from '../components/steps/components/use_policies';
 
 import { CreatePackagePolicySinglePage } from '.';
 import { SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ } from './components/setup_technology_selector';
@@ -694,108 +685,6 @@ describe('When on the package policy create page', () => {
       });
     });
 
-    describe('With agentless policy and Serverless available', () => {
-      beforeEach(async () => {
-        (useStartServices as jest.MockedFunction<any>).mockReturnValue({
-          ...useStartServices(),
-          cloud: {
-            ...useStartServices().cloud,
-            isServerlessEnabled: true,
-          },
-        });
-        jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({ agentless: true } as any);
-        (useGetPackageInfoByKeyQuery as jest.Mock).mockReturnValue(
-          getMockPackageInfo({ requiresRoot: false, dataStreamRequiresRoot: false })
-        );
-
-        (sendGetOneAgentPolicy as jest.MockedFunction<any>).mockResolvedValue({
-          data: { item: { id: AGENTLESS_POLICY_ID, name: 'Agentless CSPM', namespace: 'default' } },
-        });
-        (useGetAgentPolicies as jest.MockedFunction<any>).mockReturnValue({
-          data: {
-            items: [{ id: AGENTLESS_POLICY_ID, name: 'Agentless CSPM', namespace: 'default' }],
-          },
-          error: undefined,
-          isLoading: false,
-          resendRequest: jest.fn(),
-        });
-        (useAllNonManagedAgentPolicies as jest.MockedFunction<any>).mockReturnValue([
-          { id: AGENTLESS_POLICY_ID, name: 'Agentless CSPM', namespace: 'default' },
-        ]);
-
-        await act(async () => {
-          render();
-        });
-      });
-
-      test('should not force create package policy when not in serverless', async () => {
-        jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({ agentless: false } as any);
-        (useStartServices as jest.MockedFunction<any>).mockReturnValue({
-          ...useStartServices(),
-          cloud: {
-            ...useStartServices().cloud,
-            isServerlessEnabled: false,
-          },
-        });
-        await act(async () => {
-          fireEvent.click(renderResult.getByText('Existing hosts')!);
-        });
-
-        await act(async () => {
-          fireEvent.click(renderResult.getByText(/Save and continue/).closest('button')!);
-        });
-
-        expect(sendCreateAgentPolicy as jest.MockedFunction<any>).not.toHaveBeenCalled();
-        expect(sendCreatePackagePolicy as jest.MockedFunction<any>).toHaveBeenCalledWith({
-          ...newPackagePolicy,
-          force: false,
-          policy_ids: [AGENTLESS_POLICY_ID],
-        });
-
-        await waitFor(() => {
-          expect(renderResult.getByText('Nginx integration added')).toBeInTheDocument();
-        });
-      });
-
-      test('should force create package policy', async () => {
-        await act(async () => {
-          fireEvent.click(renderResult.getByText('Existing hosts')!);
-        });
-
-        await act(async () => {
-          fireEvent.click(renderResult.getByText(/Save and continue/).closest('button')!);
-        });
-
-        expect(sendCreateAgentPolicy as jest.MockedFunction<any>).not.toHaveBeenCalled();
-        expect(sendCreatePackagePolicy as jest.MockedFunction<any>).toHaveBeenCalledWith({
-          ...newPackagePolicy,
-          force: true,
-          policy_ids: [AGENTLESS_POLICY_ID],
-        });
-
-        await waitFor(() => {
-          expect(renderResult.getByText('Nginx integration added')).toBeInTheDocument();
-        });
-      });
-
-      test('should not show confirmation modal', async () => {
-        (sendGetAgentStatus as jest.MockedFunction<any>).mockResolvedValueOnce({
-          data: { results: { total: 1 } },
-        });
-
-        await act(async () => {
-          fireEvent.click(renderResult.getByText('Existing hosts')!);
-        });
-
-        await act(async () => {
-          fireEvent.click(renderResult.getByText(/Save and continue/).closest('button')!);
-        });
-
-        expect(sendCreateAgentPolicy as jest.MockedFunction<any>).not.toHaveBeenCalled();
-        expect(sendCreatePackagePolicy as jest.MockedFunction<any>).toHaveBeenCalled();
-      });
-    });
-
     describe('With agentless Cloud available', () => {
       beforeEach(async () => {
         (useConfig as jest.MockedFunction<any>).mockReturnValue({
@@ -821,10 +710,6 @@ describe('When on the package policy create page', () => {
           },
         });
 
-        (sendCreatePackagePolicy as jest.MockedFunction<any>).mockResolvedValue({
-          data: { item: { id: 'policy-1', inputs: [], policy_ids: ['agentless-policy-1'] } },
-        });
-        jest.spyOn(ExperimentalFeaturesService, 'get').mockReturnValue({ agentless: true } as any);
         (useGetPackageInfoByKeyQuery as jest.Mock).mockReturnValue(
           getMockPackageInfo({
             requiresRoot: false,
@@ -842,9 +727,6 @@ describe('When on the package policy create page', () => {
           fireEvent.click(renderResult.getByText(/Save and continue/).closest('button')!);
         });
 
-        // tech debt: this should be converted to use MSW to mock the API calls
-        // https://github.com/elastic/security-team/issues/9816
-        expect(sendGetOneAgentPolicy).not.toHaveBeenCalled();
         expect(sendCreateAgentPolicy).toHaveBeenCalledWith(
           expect.objectContaining({
             monitoring_enabled: ['logs', 'metrics', 'traces'],

--- a/x-pack/plugins/fleet/server/routes/package_policy/utils/index.ts
+++ b/x-pack/plugins/fleet/server/routes/package_policy/utils/index.ts
@@ -11,7 +11,7 @@ import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-ser
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 
-import { isAgentlessApiEnabled } from '../../../services/utils/agentless';
+import { isAgentlessEnabled } from '../../../services/utils/agentless';
 
 import { getAgentlessAgentPolicyNameFromPackagePolicyName } from '../../../../common/services/agentless_policy_helper';
 
@@ -65,7 +65,7 @@ export async function renameAgentlessAgentPolicy(
   packagePolicy: PackagePolicy,
   name: string
 ) {
-  if (!isAgentlessApiEnabled()) {
+  if (!isAgentlessEnabled()) {
     return;
   }
   // If agentless is enabled for cloud, we need to rename the agent policy

--- a/x-pack/plugins/fleet/server/services/agents/agentless_agent.ts
+++ b/x-pack/plugins/fleet/server/services/agents/agentless_agent.ts
@@ -35,7 +35,7 @@ import { appContextService } from '../app_context';
 import { listEnrollmentApiKeys } from '../api_keys';
 import { listFleetServerHosts } from '../fleet_server_host';
 import type { AgentlessConfig } from '../utils/agentless';
-import { prependAgentlessApiBasePathToEndpoint, isAgentlessApiEnabled } from '../utils/agentless';
+import { prependAgentlessApiBasePathToEndpoint, isAgentlessEnabled } from '../utils/agentless';
 
 class AgentlessAgentService {
   public async createAgentlessAgent(
@@ -59,7 +59,7 @@ class AgentlessAgentService {
       throw new AgentlessAgentConfigError('missing Agentless API configuration in Kibana');
     }
 
-    if (!isAgentlessApiEnabled()) {
+    if (!isAgentlessEnabled()) {
       logger.error(
         '[Agentless API] Agentless agents are only supported in cloud deployment and serverless projects'
       );
@@ -179,7 +179,7 @@ class AgentlessAgentService {
       `[Agentless API] Start deleting agentless agent for agent policy ${requestConfigDebugStatus}`
     );
 
-    if (!isAgentlessApiEnabled) {
+    if (!isAgentlessEnabled) {
       logger.error(
         '[Agentless API] Agentless API is not supported. Deleting agentless agent is not supported in non-cloud or non-serverless environments'
       );
@@ -431,45 +431,38 @@ class AgentlessAgentService {
       400: {
         create: {
           log: '[Agentless API] Creating the agentless agent failed with a status 400, bad request for agentless policy.',
-          message:
-            'the Agentless API could not create the agentless agent. Please delete the agentless policy and try again or contact your administrator.',
+          message: `the Agentless API could not create the agentless agent. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
         delete: {
           log: '[Agentless API] Deleting the agentless deployment failed with a status 400, bad request for agentless policy',
-          message:
-            'the Agentless API could not create the agentless agent. Please delete the agentless policy try again or contact your administrator.',
+          message: `the Agentless API could not create the agentless agent. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
       },
       401: {
         create: {
           log: '[Agentless API] Creating the agentless agent failed with a status 401 unauthorized for agentless policy.',
-          message:
-            'the Agentless API could not create the agentless agent because an unauthorized request was sent. Please delete the agentless policy and try again or contact your administrator.',
+          message: `the Agentless API could not create the agentless agent because an unauthorized request was sent. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
         delete: {
           log: '[Agentless API] Deleting the agentless deployment failed with a status 401 unauthorized for agentless policy.  Check the Kibana Agentless API tls configuration',
-          message:
-            'the Agentless API could not delete the agentless deployment because an unauthorized request was sent. Please try again or contact your administrator.',
+          message: `the Agentless API could not delete the agentless deployment because an unauthorized request was sent. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
       },
       403: {
         create: {
           log: '[Agentless API] Creating the agentless agent failed with a status 403 forbidden for agentless policy. Check the Kibana Agentless API configuration and endpoints.',
-          message:
-            'the Agentless API could not create the agentless agent because a forbidden request was sent. Please delete the agentless policy and try again or contact your administrator.',
+          message: `the Agentless API could not create the agentless agent because a forbidden request was sent. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
         delete: {
           log: '[Agentless API] Deleting the agentless deployment failed with a status 403 forbidden for agentless policy. Check the Kibana Agentless API configuration and endpoints.',
-          message:
-            'the Agentless API could not delete the agentless deployment because a forbidden request was sent. Please try again or contact your administrator.',
+          message: `the Agentless API could not delete the agentless deployment because a forbidden request was sent. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
       },
       404: {
         // this is likely to happen when creating agentless agents, but covering it in case
         create: {
           log: '[Agentless API] Creating the agentless agent failed with a status 404 not found.',
-          message:
-            'the Agentless API could not create the agentless agent because it returned a 404 error not found.',
+          message: `the Agentless API could not create the agentless agent because it returned a 404 error not found. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
         delete: {
           log: '[Agentless API] Deleting the agentless deployment failed with a status 404 not found',
@@ -479,12 +472,11 @@ class AgentlessAgentService {
       408: {
         create: {
           log: '[Agentless API] Creating the agentless agent failed with a status 408, the request timed out',
-          message:
-            'the Agentless API request timed out waiting for the agentless agent status to respond, please wait a few minutes for the agent to enroll with fleet. If agent fails to enroll with Fleet please delete the agentless policy try again or contact your administrator.',
+          message: `the Agentless API request timed out waiting for the agentless agent status to respond, please wait a few minutes for the agent to enroll with fleet. If agent fails to enroll with Fleet please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
         delete: {
           log: '[Agentless API] Deleting the agentless deployment failed with a status 408, the request timed out',
-          message: `the Agentless API could not delete the agentless deployment ${agentlessPolicyId} because the request timed out, please wait a few minutes for the agentless agent deployment to be removed. If it continues to persist please try again or contact your administrator.`,
+          message: `the Agentless API could not delete the agentless deployment because the request timed out, please wait a few minutes for the agentless agent deployment to be removed. If it continues to persist please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
       },
       429: {
@@ -503,36 +495,31 @@ class AgentlessAgentService {
       500: {
         create: {
           log: '[Agentless API] Creating the agentless agent failed with a status 500 internal service error.',
-          message:
-            'the Agentless API could not create the agentless agent because it returned a 500 internal error. Please delete the agentless policy and try again later or contact your administrator.',
+          message: `the Agentless API could not create the agentless agent because it returned a 500 internal error. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
         delete: {
           log: '[Agentless API] Deleting the agentless deployment failed with a status 500 internal service error.',
-          message:
-            'the Agentless API could not delete the agentless deployment because it returned a 500 internal error. Please try again later or contact your administrator.',
+          message: `the Agentless API could not delete the agentless deployment because it returned a 500 internal error. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
       },
       unhandled_response: {
         create: {
           log: '[Agentless API] Creating agentless agent failed because the Agentless API responded with an unhandled status code that falls out of the range of 2xx:',
-          message:
-            'the Agentless API could not create the agentless agent due to an unexpected error. Please delete the agentless policy and try again later or contact your administrator.',
+          message: `the Agentless API could not create the agentless agent due to an unexpected error. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
         delete: {
           log: '[Agentless API] Deleting agentless deployment failed because the Agentless API responded with an unhandled status code that falls out of the range of 2xx:',
-          message: `the Agentless API could not delete the agentless deployment ${agentlessPolicyId}. Please try again later or contact your administrator.`,
+          message: `the Agentless API could not delete the agentless deployment. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
       },
       request_error: {
         create: {
           log: '[Agentless API] Creating agentless agent failed with a request error:',
-          message:
-            'the Agentless API could not create the agentless agent due to a request error. Please delete the agentless policy and try again later or contact your administrator.',
+          message: `the Agentless API could not create the agentless agent due to a request error. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
         delete: {
           log: '[Agentless API] Deleting agentless deployment failed with a request error:',
-          message:
-            'the Agentless API could not delete the agentless deployment due to a request error. Please try again later or contact your administrator.',
+          message: `the Agentless API could not delete the agentless deployment due to a request error. Please delete the agentless policy ${agentlessPolicyId} and try again or contact your administrator.`,
         },
       },
     };

--- a/x-pack/plugins/fleet/server/services/preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.test.ts
@@ -306,10 +306,8 @@ jest.mock('./app_context', () => ({
     }),
     getExternalCallbacks: jest.fn(),
     getCloud: jest.fn(),
-    getExperimentalFeatures: jest.fn().mockReturnValue({
-      agentless: false,
-    }),
     getConfig: jest.fn(),
+    getExperimentalFeatures: jest.fn().mockReturnValue({}),
     getInternalUserSOClientForSpaceId: jest.fn(),
   },
 }));
@@ -1074,10 +1072,6 @@ describe('policy preconfiguration', () => {
         mockDefaultDownloadService,
         DEFAULT_SPACE_ID
       );
-
-      jest.mocked(appContextService.getExperimentalFeatures).mockReturnValue({
-        agentless: true,
-      } as any);
 
       expect(appContextService.getInternalUserSOClientForSpaceId).toBeCalledTimes(1);
       expect(appContextService.getInternalUserSOClientForSpaceId).toBeCalledWith(TEST_NAMESPACE);

--- a/x-pack/plugins/fleet/server/services/utils/agentless.test.ts
+++ b/x-pack/plugins/fleet/server/services/utils/agentless.test.ts
@@ -9,12 +9,7 @@ import { securityMock } from '@kbn/security-plugin/server/mocks';
 
 import { appContextService } from '../app_context';
 
-import {
-  isAgentlessApiEnabled,
-  isAgentlessEnabled,
-  isDefaultAgentlessPolicyEnabled,
-  prependAgentlessApiBasePathToEndpoint,
-} from './agentless';
+import { isAgentlessEnabled, prependAgentlessApiBasePathToEndpoint } from './agentless';
 
 jest.mock('../app_context');
 
@@ -23,7 +18,7 @@ mockedAppContextService.getSecuritySetup.mockImplementation(() => ({
   ...securityMock.createSetup(),
 }));
 
-describe('isAgentlessApiEnabled', () => {
+describe('isAgentlessEnabled', () => {
   afterEach(() => {
     jest.clearAllMocks();
     mockedAppContextService.getConfig.mockReset();
@@ -36,7 +31,7 @@ describe('isAgentlessApiEnabled', () => {
     } as any);
     jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isCloudEnabled: false } as any);
 
-    expect(isAgentlessApiEnabled()).toBe(false);
+    expect(isAgentlessEnabled()).toBe(false);
   });
 
   it('should return false if cloud is enabled but agentless is not', () => {
@@ -47,7 +42,7 @@ describe('isAgentlessApiEnabled', () => {
     } as any);
     jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isCloudEnabled: true } as any);
 
-    expect(isAgentlessApiEnabled()).toBe(false);
+    expect(isAgentlessEnabled()).toBe(false);
   });
 
   it('should return true if cloud is enabled and agentless is enabled', () => {
@@ -58,109 +53,10 @@ describe('isAgentlessApiEnabled', () => {
     } as any);
     jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isCloudEnabled: true } as any);
 
-    expect(isAgentlessApiEnabled()).toBe(true);
-  });
-});
-
-describe('isDefaultAgentlessPolicyEnabled', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-    mockedAppContextService.getConfig.mockReset();
-  });
-
-  it('should return false if serverless is not enabled', () => {
-    jest
-      .spyOn(appContextService, 'getExperimentalFeatures')
-      .mockReturnValue({ agentless: false } as any);
-    jest
-      .spyOn(appContextService, 'getCloud')
-      .mockReturnValue({ isServerlessEnabled: false } as any);
-
-    expect(isDefaultAgentlessPolicyEnabled()).toBe(false);
-  });
-
-  it('should return false if serverless is enabled but agentless is not', () => {
-    jest
-      .spyOn(appContextService, 'getExperimentalFeatures')
-      .mockReturnValue({ agentless: false } as any);
-    jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isServerlessEnabled: true } as any);
-
-    expect(isDefaultAgentlessPolicyEnabled()).toBe(false);
-  });
-
-  it('should return true if serverless is enabled and agentless is enabled', () => {
-    jest
-      .spyOn(appContextService, 'getExperimentalFeatures')
-      .mockReturnValue({ agentless: true } as any);
-    jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isServerlessEnabled: true } as any);
-
-    expect(isDefaultAgentlessPolicyEnabled()).toBe(true);
-  });
-});
-
-describe('isAgentlessEnabled', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-    mockedAppContextService.getConfig.mockReset();
-  });
-
-  it('should return false if cloud and serverless are not enabled', () => {
-    jest
-      .spyOn(appContextService, 'getExperimentalFeatures')
-      .mockReturnValue({ agentless: false } as any);
-    jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isCloudEnabled: false } as any);
-    jest
-      .spyOn(appContextService, 'getCloud')
-      .mockReturnValue({ isServerlessEnabled: false } as any);
-
-    expect(isAgentlessEnabled()).toBe(false);
-  });
-
-  it('should return false if cloud is enabled but agentless is not', () => {
-    jest
-      .spyOn(appContextService, 'getExperimentalFeatures')
-      .mockReturnValue({ agentless: false } as any);
-    jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isCloudEnabled: true } as any);
-    jest
-      .spyOn(appContextService, 'getCloud')
-      .mockReturnValue({ isServerlessEnabled: false } as any);
-
-    expect(isAgentlessEnabled()).toBe(false);
-  });
-
-  it('should return false if serverless is enabled but agentless is not', () => {
-    jest
-      .spyOn(appContextService, 'getExperimentalFeatures')
-      .mockReturnValue({ agentless: false } as any);
-    jest
-      .spyOn(appContextService, 'getCloud')
-      .mockReturnValue({ isCloudEnabled: false, isServerlessEnabled: true } as any);
-
-    expect(isAgentlessEnabled()).toBe(false);
-  });
-
-  it('should return true if cloud is enabled and agentless is enabled', () => {
-    jest
-      .spyOn(appContextService, 'getConfig')
-      .mockReturnValue({ agentless: { enabled: true } } as any);
-    jest
-      .spyOn(appContextService, 'getCloud')
-      .mockReturnValue({ isCloudEnabled: true, isServerlessEnabled: false } as any);
-
-    expect(isAgentlessEnabled()).toBe(true);
-  });
-
-  it('should return true if serverless is enabled and agentless is enabled', () => {
-    jest
-      .spyOn(appContextService, 'getExperimentalFeatures')
-      .mockReturnValue({ agentless: true } as any);
-    jest
-      .spyOn(appContextService, 'getCloud')
-      .mockReturnValue({ isCloudEnabled: false, isServerlessEnabled: true } as any);
-
     expect(isAgentlessEnabled()).toBe(true);
   });
 });
+
 describe('prependAgentlessApiBasePathToEndpoint', () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/x-pack/plugins/fleet/server/services/utils/agentless.ts
+++ b/x-pack/plugins/fleet/server/services/utils/agentless.ts
@@ -9,19 +9,10 @@ import { appContextService } from '..';
 import type { FleetConfigType } from '../../config';
 export { isOnlyAgentlessIntegration } from '../../../common/services/agentless_policy_helper';
 
-export const isAgentlessApiEnabled = () => {
+export const isAgentlessEnabled = () => {
   const cloudSetup = appContextService.getCloud();
   const isHosted = cloudSetup?.isCloudEnabled || cloudSetup?.isServerlessEnabled;
   return Boolean(isHosted && appContextService.getConfig()?.agentless?.enabled);
-};
-export const isDefaultAgentlessPolicyEnabled = () => {
-  const cloudSetup = appContextService.getCloud && appContextService.getCloud();
-  return Boolean(
-    cloudSetup?.isServerlessEnabled && appContextService.getExperimentalFeatures().agentless
-  );
-};
-export const isAgentlessEnabled = () => {
-  return isAgentlessApiEnabled() || isDefaultAgentlessPolicyEnabled();
 };
 
 const AGENTLESS_ESS_API_BASE_PATH = '/api/v1/ess';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Cloud Security] Remove preconfigured Agentless policy solution and feature flag (#197338)](https://github.com/elastic/kibana/pull/197338)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"seanrathier","email":"sean.rathier@gmail.com"},"sourceCommit":{"committedDate":"2024-11-25T19:00:42Z","message":"[Cloud Security] Remove preconfigured Agentless policy solution and feature flag (#197338)","sha":"655cb7933371ce07b717eb40c3691fbc5ca08933","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:Fleet","v9.0.0","Team:Cloud Security","backport:prev-minor","ci:project-deploy-security"],"number":197338,"url":"https://github.com/elastic/kibana/pull/197338","mergeCommit":{"message":"[Cloud Security] Remove preconfigured Agentless policy solution and feature flag (#197338)","sha":"655cb7933371ce07b717eb40c3691fbc5ca08933"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/197338","number":197338,"mergeCommit":{"message":"[Cloud Security] Remove preconfigured Agentless policy solution and feature flag (#197338)","sha":"655cb7933371ce07b717eb40c3691fbc5ca08933"}}]}] BACKPORT-->