### PR TITLE
[Dashboard][Collapsable Panels] Add auto-scroll for dragging + resizing events

### DIFF
--- a/packages/kbn-grid-layout/grid/use_grid_layout_events.ts
+++ b/packages/kbn-grid-layout/grid/use_grid_layout_events.ts
@@ -38,14 +38,17 @@ export const useGridLayoutEvents = ({
   useEffect(() => {
     const { runtimeSettings$, interactionEvent$, gridLayout$ } = gridLayoutStateManager;
 
+    const stopAutoScrollIfNecessary = () => {
+      if (scrollInterval.current) {
+        clearInterval(scrollInterval.current);
+        scrollInterval.current = null;
+      }
+    };
+
     const calculateUserEvent = (e: Event) => {
       if (!interactionEvent$.value) {
-        if (scrollInterval.current) {
-          // if there is a scroll happening without an interaction event, cancel it
-          clearInterval(scrollInterval.current);
-          scrollInterval.current = null;
-        }
-        // no interaction event is happening, so nothing about the layout needs to be updated
+        // if no interaction event, stop auto scroll (if necessary) and return early
+        stopAutoScrollIfNecessary();
         return;
       }
       e.preventDefault();
@@ -152,10 +155,8 @@ export const useGridLayoutEvents = ({
           // only start scrolling if it's not already happening
           scrollInterval.current = scrollOnInterval(startScrollingUp ? 'up' : 'down');
         }
-      } else if (scrollInterval.current) {
-        // if the event happens outside of the targetted area, stop the auto-scroll
-        clearInterval(scrollInterval.current);
-        scrollInterval.current = null;
+      } else {
+        stopAutoScrollIfNecessary();
       }
 
       // resolve the new grid layout

--- a/packages/kbn-grid-layout/grid/use_grid_layout_events.ts
+++ b/packages/kbn-grid-layout/grid/use_grid_layout_events.ts
@@ -39,7 +39,15 @@ export const useGridLayoutEvents = ({
     const { runtimeSettings$, interactionEvent$, gridLayout$ } = gridLayoutStateManager;
 
     const calculateUserEvent = (e: Event) => {
-      if (!interactionEvent$.value) return;
+      if (!interactionEvent$.value) {
+        if (scrollInterval.current) {
+          // if there is a scroll happening without an interaction event, cancel it
+          clearInterval(scrollInterval.current);
+          scrollInterval.current = null;
+        }
+        // no interaction event is happening, so nothing about the layout needs to be updated
+        return;
+      }
       e.preventDefault();
       e.stopPropagation();
 

--- a/packages/kbn-grid-layout/grid/use_grid_layout_events.ts
+++ b/packages/kbn-grid-layout/grid/use_grid_layout_events.ts
@@ -15,10 +15,7 @@ import { isGridDataEqual } from './utils/equality_checks';
 
 const scrollOnInterval = (direction: 'up' | 'down') => {
   const interval = setInterval(() => {
-    window.scroll({
-      top: window.scrollY + (direction === 'down' ? 50 : -50),
-      behavior: 'smooth',
-    });
+    window.scrollBy({ top: direction === 'down' ? 50 : -50, behavior: 'smooth' });
   }, 100);
   return interval;
 };

--- a/packages/kbn-grid-layout/grid/use_grid_layout_events.ts
+++ b/packages/kbn-grid-layout/grid/use_grid_layout_events.ts
@@ -14,8 +14,16 @@ import { GridPanelData, GridLayoutStateManager } from './types';
 import { isGridDataEqual } from './utils/equality_checks';
 
 const scrollOnInterval = (direction: 'up' | 'down') => {
+  let count = 0;
   const interval = setInterval(() => {
-    window.scrollBy({ top: direction === 'down' ? 50 : -50, behavior: 'smooth' });
+    // calculate the speed based on how long the interval has been going to create an ease effect
+    // via the parabola formula `y = a(x - h)^2 + k`
+    // - the starting speed is k = 50
+    // - the maximum speed is 250
+    // - the rate at which the speed increases is controlled by a = 0.75
+    const speed = Math.min(0.75 * count ** 2 + 50, 250);
+    window.scrollBy({ top: direction === 'down' ? speed : -speed, behavior: 'smooth' });
+    count++;
   }, 100);
   return interval;
 };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/201626

## Summary

This PR makes it so that the grid layout will auto-scroll with the following behaviour:

- Auto-scroll up when....
     - the panel is dragged to the top 5% of the window **or above** (including outside of the window)
- Auto-scroll down when....
     - the panel is dragged to the bottom 5% of the window **or below** (including outside of the window)
     - the panel is being dragged and the resize handle is dragged to the bottom 5% of the window **or below** (including outside of the window)



https://github.com/user-attachments/assets/6880fd14-e492-4cd9-81c6-3dfb30b80960



### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

There are no risks to this PR, since all work is contained in the `examples` plugin.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->