### PR TITLE
Remove mention of (secure) settings qualifier from docs

### DIFF
--- a/docs/setup/secure-settings.asciidoc
+++ b/docs/setup/secure-settings.asciidoc
@@ -8,8 +8,8 @@ keystore, and the `kibana-keystore` tool to manage the settings in the keystore.
 [NOTE]
 ====
 * Run all commands as the user who runs {kib}.
-* Only the settings with the `(Secure)` qualifier should be stored in the keystore.
-   Unsupported, extraneous or invalid JSON-string settings cause {kib} to fail to start up.
+* Any valid {kib} setting be stored in the keystore securely.
+   Unsupported, extraneous or invalid settings will cause {kib} to fail to start up.
 ====
 
 [float]

--- a/docs/setup/secure-settings.asciidoc
+++ b/docs/setup/secure-settings.asciidoc
@@ -8,7 +8,7 @@ keystore, and the `kibana-keystore` tool to manage the settings in the keystore.
 [NOTE]
 ====
 * Run all commands as the user who runs {kib}.
-* Any valid {kib} setting be stored in the keystore securely.
+* Any valid {kib} setting can be stored in the keystore securely.
    Unsupported, extraneous or invalid settings will cause {kib} to fail to start up.
 ====
 


### PR DESCRIPTION
## Summary

Removes mentioning `(Secure)` settings from the keystore docs because Kibana does not have any settings which use this qualifier.



<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.x"]} ONMERGE-->