### PR TITLE
Fix flaky test #181955

### DIFF
--- a/test/functional/apps/dashboard/group1/embeddable_data_grid.ts
+++ b/test/functional/apps/dashboard/group1/embeddable_data_grid.ts
@@ -25,8 +25,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const retry = getService('retry');
   const dataGrid = getService('dataGrid');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/181955
-  describe.skip('dashboard embeddable data grid', () => {
+  describe('dashboard embeddable data grid', () => {
     before(async () => {
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/dashboard/current/data');
@@ -62,16 +61,24 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('are added when a cell filter is clicked', async function () {
-      await find.clickByCssSelector(`[role="gridcell"]:nth-child(4)`);
-      // needs a short delay between becoming visible & being clickable
-      await common.sleep(250);
-      await find.clickByCssSelector(`[data-test-subj="filterOutButton"]`);
+      const gridCell = '[role="gridcell"]:nth-child(4)';
+      const filterOutButton = '[data-test-subj="filterOutButton"]';
+      const filterForButton = '[data-test-subj="filterForButton"]';
+      await retry.try(async () => {
+        await find.clickByCssSelector(gridCell);
+        await find.clickByCssSelector(filterOutButton);
+        await header.waitUntilLoadingHasFinished();
+        const filterCount = await filterBar.getFilterCount();
+        expect(filterCount).to.equal(1);
+      });
       await header.waitUntilLoadingHasFinished();
-      await find.clickByCssSelector(`[role="gridcell"]:nth-child(4)`);
-      await common.sleep(250);
-      await find.clickByCssSelector(`[data-test-subj="filterForButton"]`);
-      const filterCount = await filterBar.getFilterCount();
-      expect(filterCount).to.equal(2);
+      await retry.try(async () => {
+        await find.clickByCssSelector(gridCell);
+        await find.clickByCssSelector(filterForButton);
+        await header.waitUntilLoadingHasFinished();
+        const filterCount = await filterBar.getFilterCount();
+        expect(filterCount).to.equal(2);
+      });
     });
   });
 }

--- a/test/functional/apps/dashboard/group1/embeddable_data_grid.ts
+++ b/test/functional/apps/dashboard/group1/embeddable_data_grid.ts
@@ -16,12 +16,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const find = getService('find');
-  const { common, dashboard, header, timePicker } = getPageObjects([
-    'common',
-    'dashboard',
-    'header',
-    'timePicker',
-  ]);
+  const { dashboard, header, timePicker } = getPageObjects(['dashboard', 'header', 'timePicker']);
   const retry = getService('retry');
   const dataGrid = getService('dataGrid');
 


### PR DESCRIPTION
## Summary

Resolves #181955.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->