### PR TITLE
Updates the links to Logs Explorer and Discover in the Data Set details page

### DIFF
--- a/x-pack/plugins/observability_solution/dataset_quality/public/components/dataset_quality_details/overview/document_trends/degraded_docs/index.tsx
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/components/dataset_quality_details/overview/document_trends/degraded_docs/index.tsx
@@ -79,6 +79,7 @@ export default function DegradedDocs({ lastReloadTime }: { lastReloadTime: numbe
     dataStreamStat: datasetDetails,
     timeRangeConfig: timeRange,
     query: { language: 'kuery', query: `${_IGNORED}: *` },
+    breakdownField: breakdownDataViewField?.name,
     sendTelemetry,
   });
 

--- a/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_degraded_docs_chart.ts
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/hooks/use_degraded_docs_chart.ts
@@ -16,29 +16,12 @@ import { useCreateDataView } from './use_create_dataview';
 import { useKibanaContextForPlugin } from '../utils';
 import { useDatasetQualityDetailsState } from './use_dataset_quality_details_state';
 import { getLensAttributes } from '../components/dataset_quality_details/overview/document_trends/degraded_docs/lens_attributes';
-import { useRedirectLink } from './use_redirect_link';
 import { useDatasetDetailsTelemetry } from './use_dataset_details_telemetry';
-import { useDatasetDetailsRedirectLinkTelemetry } from './use_redirect_link_telemetry';
-
-const exploreDataInLogsExplorerText = i18n.translate(
-  'xpack.datasetQuality.details.chartExploreDataInLogsExplorerText',
-  {
-    defaultMessage: 'Explore data in Logs Explorer',
-  }
-);
-
-const exploreDataInDiscoverText = i18n.translate(
-  'xpack.datasetQuality.details.chartExploreDataInDiscoverText',
-  {
-    defaultMessage: 'Explore data in Discover',
-  }
-);
 
 const openInLensText = i18n.translate('xpack.datasetQuality.details.chartOpenInLensText', {
   defaultMessage: 'Open in Lens',
 });
 
-const ACTION_EXPLORE_IN_LOGS_EXPLORER = 'ACTION_EXPLORE_IN_LOGS_EXPLORER';
 const ACTION_OPEN_IN_LENS = 'ACTION_OPEN_IN_LENS';
 
 export const useDegradedDocsChart = () => {
@@ -154,45 +137,7 @@ export const useDegradedDocsChart = () => {
     };
   }, [openInLensCallback]);
 
-  const { sendTelemetry } = useDatasetDetailsRedirectLinkTelemetry({
-    query: { language: 'kuery', query: '_ignored:*' },
-    navigationSource: navigationSources.Chart,
-  });
-
-  const redirectLinkProps = useRedirectLink({
-    dataStreamStat: datasetDetails,
-    query: { language: 'kuery', query: '_ignored:*' },
-    timeRangeConfig: timeRange,
-    breakdownField: breakdownDataViewField?.name,
-    sendTelemetry,
-  });
-
-  const getOpenInLogsExplorerAction = useMemo(() => {
-    return {
-      id: ACTION_EXPLORE_IN_LOGS_EXPLORER,
-      type: 'link',
-      getDisplayName(): string {
-        return redirectLinkProps?.isLogsExplorerAvailable
-          ? exploreDataInLogsExplorerText
-          : exploreDataInDiscoverText;
-      },
-      getHref: async () => {
-        return redirectLinkProps.linkProps.href;
-      },
-      getIconType(): string | undefined {
-        return 'visTable';
-      },
-      async isCompatible(): Promise<boolean> {
-        return true;
-      },
-      async execute(): Promise<void> {
-        return redirectLinkProps.navigate();
-      },
-      order: 18,
-    };
-  }, [redirectLinkProps]);
-
-  const extraActions: Action[] = [getOpenInLensAction, getOpenInLogsExplorerAction];
+  const extraActions: Action[] = [getOpenInLensAction];
 
   const breakdown = useMemo(() => {
     return {


### PR DESCRIPTION
Updates the links to Logs Explorer and Discover in the Data Set details page:
- Removes the link from the degraded docs chart action popup
- Update the link which is next to the field selector in the degraded docs chart to include the breakdown field when navigating to Logs Explorer or Discover

### Before
https://github.com/user-attachments/assets/3586c22e-64e5-40c3-9b5e-f729c19a6816

### After
https://github.com/user-attachments/assets/fe53b5a2-b986-4343-8773-75e97c0fbc43

Closes https://github.com/elastic/kibana/issues/198856

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->