### PR TITLE
use waitFor in place of act

### DIFF
--- a/x-pack/plugins/fleet/public/components/agentless_enrollment_flyout/index.test.tsx
+++ b/x-pack/plugins/fleet/public/components/agentless_enrollment_flyout/index.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { act, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 
 import { sendGetAgents, useGetPackageInfoByKeyQuery } from '../../hooks';
 import { usePollingIncomingData } from '../agent_enrollment_flyout/use_get_agent_incoming_data';
@@ -64,7 +64,7 @@ describe('AgentlessEnrollmentFlyout', () => {
     const { getByText } = renderer.render(
       <AgentlessEnrollmentFlyout onClose={onClose} packagePolicy={packagePolicy} />
     );
-    await act(async () => {
+    await waitFor(async () => {
       expect(getByText('Confirm agentless enrollment')).toBeInTheDocument();
       expect(getByText('Step 1 is loading')).toBeInTheDocument();
       expect(


### PR DESCRIPTION
## Summary

Fixes incorrect usage of act for assertions. Informed from https://buildkite.com/elastic/kibana-pull-request/builds/254649#019369dd-02e4-4d1e-9c45-face1da80884

### Before

<img width="1239" alt="Screenshot 2024-11-27 at 10 46 23" src="https://github.com/user-attachments/assets/89fb0142-add8-401d-b270-d9bc8a3cbe23">

## After

<img width="1052" alt="Screenshot 2024-11-27 at 10 46 34" src="https://github.com/user-attachments/assets/61f4d278-676c-4761-a003-1e22714cf5b7">


<!-- 
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...

-->



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->