### PR TITLE
[8.x] [ObsUX][Synthtrace] Fallback to latest GA package version if latest prerelease fetch fails (#195889)

### DIFF
--- a/packages/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_kibana_client.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_kibana_client.ts
@@ -34,24 +34,40 @@ export class ApmSynthtraceKibanaClient {
 
   async fetchLatestApmPackageVersion() {
     this.logger.debug(`Fetching latest APM package version`);
-    const url = `${this.getFleetApmPackagePath()}?prerelease=true`;
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: kibanaHeaders(),
-      agent: getFetchAgent(url),
-    });
 
-    const responseJson = await response.json();
+    const fetchPackageVersion = async ({ prerelease }: { prerelease: boolean }) => {
+      const url = `${this.getFleetApmPackagePath()}?prerelease=${prerelease}`;
+      this.logger.debug(`Fetching from URL: ${url}`);
 
-    if (response.status !== 200) {
-      throw new Error(
-        `Failed to fetch latest APM package version, received HTTP ${response.status} and message: ${responseJson.message}`
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: kibanaHeaders(),
+        agent: getFetchAgent(url),
+      });
+
+      const responseJson = await response.json();
+
+      if (response.status !== 200) {
+        throw new Error(
+          `Failed to fetch APM package version, received HTTP ${response.status} and message: ${responseJson.message}`
+        );
+      }
+
+      return responseJson.item.latestVersion as string;
+    };
+
+    try {
+      return await fetchPackageVersion({ prerelease: true });
+    } catch (error) {
+      this.logger.debug(
+        'Fetching latestes prerelease version failed, retrying with latest GA version'
       );
+      const retryResult = await fetchPackageVersion({ prerelease: false }).catch((retryError) => {
+        throw retryError;
+      });
+
+      return retryResult;
     }
-
-    const { latestVersion } = responseJson.item;
-
-    return latestVersion as string;
   }
 
   async installApmPackage(packageVersion?: string) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ObsUX][Synthtrace] Fallback to latest GA package version if latest prerelease fetch fails (#195889)](https://github.com/elastic/kibana/pull/195889)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Miriam","email":"31922082+MiriamAparicio@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-10-14T14:06:33Z","message":"[ObsUX][Synthtrace] Fallback to latest GA package version if latest prerelease fetch fails (#195889)\n\nCloses https://github.com/elastic/kibana/issues/195436","sha":"ce2cf6bb3c7fb36ed7a3d5bf23960994f0b17b50","branchLabelMapping":{"^v9.0.0$":"main","^v8.16.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","ci:project-deploy-observability","Team:obs-ux-infra_services","v8.16.0"],"number":195889,"url":"https://github.com/elastic/kibana/pull/195889","mergeCommit":{"message":"[ObsUX][Synthtrace] Fallback to latest GA package version if latest prerelease fetch fails (#195889)\n\nCloses https://github.com/elastic/kibana/issues/195436","sha":"ce2cf6bb3c7fb36ed7a3d5bf23960994f0b17b50"}},"sourceBranch":"main","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/195889","number":195889,"mergeCommit":{"message":"[ObsUX][Synthtrace] Fallback to latest GA package version if latest prerelease fetch fails (#195889)\n\nCloses https://github.com/elastic/kibana/issues/195436","sha":"ce2cf6bb3c7fb36ed7a3d5bf23960994f0b17b50"}},{"branch":"8.x","label":"v8.16.0","labelRegex":"^v8.16.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->