### PR TITLE
[8.x] feat: [Dashboards] Hide clear control button in floating actions when no filters are selected (#200177)

### DIFF
--- a/src/plugins/controls/public/actions/clear_control_action.test.tsx
+++ b/src/plugins/controls/public/actions/clear_control_action.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { BehaviorSubject } from 'rxjs';
+import { getMockedControlGroupApi } from '../controls/mocks/control_mocks';
+import { ClearControlAction } from './clear_control_action';
+
+import type { ViewMode } from '@kbn/presentation-publishing';
+
+const dashboardApi = {
+  viewMode: new BehaviorSubject<ViewMode>('view'),
+};
+const controlGroupApi = getMockedControlGroupApi(dashboardApi, {
+  removePanel: jest.fn(),
+  replacePanel: jest.fn(),
+  addNewPanel: jest.fn(),
+  children$: new BehaviorSubject({}),
+});
+
+const clearControlAction = new ClearControlAction();
+const hasSelections$ = new BehaviorSubject<boolean | undefined>(undefined);
+
+const controlApi = {
+  type: 'test',
+  uuid: '1',
+  parentApi: controlGroupApi,
+  hasSelections$,
+  clearSelections: jest.fn(),
+};
+beforeEach(() => {
+  hasSelections$.next(false);
+});
+
+describe('ClearControlAction', () => {
+  test('should throw an error when called with an embeddable not in a parent', async () => {
+    const noParentApi = { ...controlApi, parentApi: undefined };
+
+    await expect(async () => {
+      await clearControlAction.execute({ embeddable: noParentApi });
+    }).rejects.toThrow(Error);
+  });
+
+  test('should call onChange when isCompatible changes', () => {
+    const onChange = jest.fn();
+
+    hasSelections$.next(true);
+    clearControlAction.subscribeToCompatibilityChanges({ embeddable: controlApi }, onChange);
+
+    expect(onChange).toHaveBeenCalledWith(true, clearControlAction);
+  });
+
+  describe('Clear control button compatibility', () => {
+    test('should be incompatible if there is no selection', async () => {
+      const nothingIsSelected = { ...controlApi, hasSelections$: false };
+
+      expect(await clearControlAction.isCompatible({ embeddable: nothingIsSelected })).toBe(false);
+    });
+
+    test('should be compatible if there is a selection', async () => {
+      const hasSelections = { ...controlApi, hasSelections$: true };
+
+      expect(await clearControlAction.isCompatible({ embeddable: hasSelections })).toBe(true);
+    });
+  });
+});

--- a/src/plugins/controls/public/controls/data_controls/range_slider/get_range_slider_control_factory.tsx
+++ b/src/plugins/controls/public/controls/data_controls/range_slider/get_range_slider_control_factory.tsx
@@ -101,6 +101,7 @@ export const getRangesliderControlFactory = (): DataControlFactory<
           clearSelections: () => {
             selections.setValue(undefined);
           },
+          hasSelections$: selections.hasRangeSelection$,
         },
         {
           ...dataControl.comparators,

--- a/src/plugins/controls/public/controls/data_controls/range_slider/range_control_selections.ts
+++ b/src/plugins/controls/public/controls/data_controls/range_slider/range_control_selections.ts
@@ -16,9 +16,12 @@ export function initializeRangeControlSelections(
   onSelectionChange: () => void
 ) {
   const value$ = new BehaviorSubject<RangeValue | undefined>(initialState.value);
+  const hasRangeSelection$ = new BehaviorSubject<boolean>(Boolean(value$.getValue()));
+
   function setValue(next: RangeValue | undefined) {
     if (value$.value !== next) {
       value$.next(next);
+      hasRangeSelection$.next(Boolean(next));
       onSelectionChange();
     }
   }
@@ -29,6 +32,7 @@ export function initializeRangeControlSelections(
     } as StateComparators<Pick<RangesliderControlState, 'value'>>,
     hasInitialSelections: initialState.value !== undefined,
     value$: value$ as PublishingSubject<RangeValue | undefined>,
+    hasRangeSelection$: hasRangeSelection$ as PublishingSubject<boolean | undefined>,
     setValue,
   };
 }

--- a/src/plugins/controls/public/controls/timeslider_control/get_timeslider_control_factory.tsx
+++ b/src/plugins/controls/public/controls/timeslider_control/get_timeslider_control_factory.tsx
@@ -13,6 +13,7 @@ import { BehaviorSubject, debounceTime, first, map } from 'rxjs';
 import { EuiInputPopover } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import {
+  PublishingSubject,
   ViewMode,
   apiHasParentApi,
   apiPublishesDataLoading,
@@ -57,6 +58,7 @@ export const getTimesliderControlFactory = (): ControlFactory<
       const timeslice$ = new BehaviorSubject<[number, number] | undefined>(undefined);
       const isAnchored$ = new BehaviorSubject<boolean | undefined>(initialState.isAnchored);
       const isPopoverOpen$ = new BehaviorSubject(false);
+      const hasTimeSliceSelection$ = new BehaviorSubject<boolean>(Boolean(timeslice$));
 
       const timeRangePercentage = initTimeRangePercentage(
         initialState,
@@ -102,6 +104,7 @@ export const getTimesliderControlFactory = (): ControlFactory<
       }
 
       function onChange(timeslice?: Timeslice) {
+        hasTimeSliceSelection$.next(Boolean(timeslice));
         setTimeslice(timeslice);
         const nextSelectedRange = timeslice
           ? timeslice[TO_INDEX] - timeslice[FROM_INDEX]
@@ -224,7 +227,9 @@ export const getTimesliderControlFactory = (): ControlFactory<
           },
           clearSelections: () => {
             setTimeslice(undefined);
+            hasTimeSliceSelection$.next(false);
           },
+          hasSelections$: hasTimeSliceSelection$ as PublishingSubject<boolean | undefined>,
           CustomPrependComponent: () => {
             const [autoApplySelections, viewMode] = useBatchedPublishingSubjects(
               controlGroupApi.autoApplySelections$,

--- a/src/plugins/controls/public/controls/types.ts
+++ b/src/plugins/controls/public/controls/types.ts
@@ -59,7 +59,7 @@ export type ControlApiRegistration<ControlApi extends DefaultControlApi = Defaul
 export type ControlApiInitialization<ControlApi extends DefaultControlApi = DefaultControlApi> =
   Omit<
     ControlApiRegistration<ControlApi>,
-    'serializeState' | 'getTypeDisplayName' | 'clearSelections'
+    'serializeState' | 'getTypeDisplayName' | keyof CanClearSelections
   >;
 
 export interface ControlFactory<

--- a/src/plugins/controls/public/types.ts
+++ b/src/plugins/controls/public/types.ts
@@ -11,13 +11,18 @@ import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { EmbeddableSetup } from '@kbn/embeddable-plugin/public';
 import { UiActionsStart } from '@kbn/ui-actions-plugin/public';
+import { PublishingSubject } from '@kbn/presentation-publishing';
 
 export interface CanClearSelections {
   clearSelections: () => void;
+  hasSelections$: PublishingSubject<boolean | undefined>;
 }
 
 export const isClearableControl = (control: unknown): control is CanClearSelections => {
-  return typeof (control as CanClearSelections).clearSelections === 'function';
+  return (
+    typeof (control as CanClearSelections).clearSelections === 'function' &&
+    Boolean((control as CanClearSelections).hasSelections$)
+  );
 };
 
 /**

--- a/src/plugins/presentation_util/public/components/floating_actions/floating_actions.tsx
+++ b/src/plugins/presentation_util/public/components/floating_actions/floating_actions.tsx
@@ -10,6 +10,7 @@
 import classNames from 'classnames';
 import React, { FC, ReactElement, useEffect, useState } from 'react';
 import { v4 } from 'uuid';
+import { Subscription } from 'rxjs';
 
 import {
   PANEL_HOVER_TRIGGER,
@@ -19,7 +20,7 @@ import {
 } from '@kbn/embeddable-plugin/public';
 import { apiHasUniqueId } from '@kbn/presentation-publishing';
 import { Action } from '@kbn/ui-actions-plugin/public';
-
+import { AnyApiAction } from '@kbn/presentation-panel-plugin/public/panel_actions/types';
 import { uiActionsService } from '../../services/kibana_services';
 import './floating_actions.scss';
 
@@ -33,6 +34,10 @@ export interface FloatingActionsProps {
   disabledActions?: EmbeddableInput['disabledActions'];
 }
 
+export type FloatingActionItem = AnyApiAction & {
+  MenuItem: React.FC<{ context: unknown }>;
+};
+
 export const FloatingActions: FC<FloatingActionsProps> = ({
   children,
   viewMode,
@@ -41,59 +46,88 @@ export const FloatingActions: FC<FloatingActionsProps> = ({
   className = '',
   disabledActions,
 }) => {
-  const [floatingActions, setFloatingActions] = useState<JSX.Element | undefined>(undefined);
+  const [floatingActions, setFloatingActions] = useState<FloatingActionItem[]>([]);
 
   useEffect(() => {
     if (!api) return;
 
-    const getActions = async () => {
-      let mounted = true;
-      const context = {
-        embeddable: api,
-        trigger: panelHoverTrigger,
-      };
+    let mounted = true;
+    const context = {
+      embeddable: api,
+      trigger: panelHoverTrigger,
+    };
+
+    const sortByOrder = (a: Action | FloatingActionItem, b: Action | FloatingActionItem) => {
+      return (a.order || 0) - (b.order || 0);
+    };
+
+    const getActions: () => Promise<FloatingActionItem[]> = async () => {
       const actions = (
         await uiActionsService.getTriggerCompatibleActions(PANEL_HOVER_TRIGGER, context)
       )
-        .filter((action): action is Action & { MenuItem: React.FC<{ context: unknown }> } => {
+        .filter((action) => {
           return action.MenuItem !== undefined && (disabledActions ?? []).indexOf(action.id) === -1;
         })
-        .sort((a, b) => (a.order || 0) - (b.order || 0));
-
-      if (!mounted) return;
-      if (actions.length > 0) {
-        setFloatingActions(
-          <>
-            {actions.map((action) =>
-              React.createElement(action.MenuItem, {
-                key: action.id,
-                context,
-              })
-            )}
-          </>
-        );
-      } else {
-        setFloatingActions(undefined);
-      }
-      return () => {
-        mounted = false;
-      };
+        .sort(sortByOrder);
+      return actions as FloatingActionItem[];
     };
 
-    getActions();
+    const subscriptions = new Subscription();
+
+    const handleActionCompatibilityChange = (isCompatible: boolean, action: Action) => {
+      if (!mounted) return;
+      setFloatingActions((currentActions) => {
+        const newActions: FloatingActionItem[] = currentActions
+          ?.filter((current) => current.id !== action.id)
+          .sort(sortByOrder) as FloatingActionItem[];
+        if (isCompatible) {
+          return [action as FloatingActionItem, ...newActions];
+        }
+        return newActions;
+      });
+    };
+
+    (async () => {
+      const actions = await getActions();
+      if (!mounted) return;
+      setFloatingActions(actions);
+
+      const frequentlyChangingActions = uiActionsService.getFrequentlyChangingActionsForTrigger(
+        PANEL_HOVER_TRIGGER,
+        context
+      );
+
+      for (const action of frequentlyChangingActions) {
+        subscriptions.add(
+          action.subscribeToCompatibilityChanges(context, handleActionCompatibilityChange)
+        );
+      }
+    })();
+
+    return () => {
+      mounted = false;
+      subscriptions.unsubscribe();
+    };
   }, [api, viewMode, disabledActions]);
 
   return (
     <div className="presentationUtil__floatingActionsWrapper">
       {children}
-      {isEnabled && floatingActions && (
+      {isEnabled && floatingActions.length > 0 && (
         <div
           data-test-subj={`presentationUtil__floatingActions__${
             apiHasUniqueId(api) ? api.uuid : v4()
           }`}
           className={classNames('presentationUtil__floatingActions', className)}
         >
-          {floatingActions}
+          <>
+            {floatingActions.map((action) =>
+              React.createElement(action.MenuItem, {
+                key: action.id,
+                context: { embeddable: api },
+              })
+            )}
+          </>
         </div>
       )}
     </div>

--- a/src/plugins/presentation_util/tsconfig.json
+++ b/src/plugins/presentation_util/tsconfig.json
@@ -37,6 +37,7 @@
     "@kbn/field-utils",
     "@kbn/presentation-publishing",
     "@kbn/core-ui-settings-browser",
+    "@kbn/presentation-panel-plugin",
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -81,6 +81,7 @@ import { FIELDS_BROWSER_BTN } from '../screens/rule_details';
 import { openFilterGroupContextMenu } from './common/filter_group';
 import { visitWithTimeRange } from './navigation';
 import { GET_DATA_GRID_HEADER_ACTION_BUTTON } from '../screens/common/data_grid';
+import { getDataTestSubjectSelector } from '../helpers/common';
 
 export const addExceptionFromFirstAlert = () => {
   expandFirstAlertActions();
@@ -195,9 +196,19 @@ export const closePageFilterPopover = (filterIndex: number) => {
   cy.get(OPTION_LIST_VALUES(filterIndex)).should('not.have.class', 'euiFilterButton-isSelected');
 };
 
+export const hasSelection = (filterIndex: number) => {
+  return cy.get(OPTION_LIST_VALUES(filterIndex)).then(($el) => {
+    return $el.find(getDataTestSubjectSelector('optionsListSelections')).length > 0;
+  });
+};
+
 export const clearAllSelections = (filterIndex: number) => {
-  cy.get(OPTION_LIST_VALUES(filterIndex)).realHover();
-  cy.get(OPTION_LIST_CLEAR_BTN).eq(filterIndex).click();
+  hasSelection(filterIndex).then(($el) => {
+    if ($el) {
+      cy.get(OPTION_LIST_VALUES(filterIndex)).realHover();
+      cy.get(OPTION_LIST_CLEAR_BTN).eq(filterIndex).click();
+    }
+  });
 };
 
 export const selectPageFilterValue = (filterIndex: number, ...values: string[]) => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [feat: [Dashboards] Hide clear control button in floating actions when no filters are selected (#200177)](https://github.com/elastic/kibana/pull/200177)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Paulina Shakirova","email":"paulina.shakirova@elastic.co"},"sourceCommit":{"committedDate":"2024-11-26T19:36:12Z","message":"feat: [Dashboards] Hide clear control button in floating actions when no filters are selected (#200177)\n\n## Summary\nThis PR resolves the issue [[Controls] Show clear option only when\nvalues have been\nselected](https://github.com/elastic/kibana/issues/192619).\n\nPreviously, the clear button would be visible at all times, regardless\nof whether any filters were applied.\n\n![Screenshot 2024-11-19 at 09 33\n21](https://github.com/user-attachments/assets/6122225b-8497-4bef-953e-efbfc70b4276)\n\nWith this PR, the clear control button will only be visible if there are\nany filters applied and will dynamically disappear when the user clears\ntheir filters.\n\n![Screenshot 2024-11-19 at 09 37\n35](https://github.com/user-attachments/assets/2f4c8d0e-85f6-47d9-affb-590a5812f16f)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"95ef95c9f23f8d0d4ed8db3f3b91786622ac2935","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","v9.0.0","backport:prev-minor","papercut","v8.17.0"],"number":200177,"url":"https://github.com/elastic/kibana/pull/200177","mergeCommit":{"message":"feat: [Dashboards] Hide clear control button in floating actions when no filters are selected (#200177)\n\n## Summary\nThis PR resolves the issue [[Controls] Show clear option only when\nvalues have been\nselected](https://github.com/elastic/kibana/issues/192619).\n\nPreviously, the clear button would be visible at all times, regardless\nof whether any filters were applied.\n\n![Screenshot 2024-11-19 at 09 33\n21](https://github.com/user-attachments/assets/6122225b-8497-4bef-953e-efbfc70b4276)\n\nWith this PR, the clear control button will only be visible if there are\nany filters applied and will dynamically disappear when the user clears\ntheir filters.\n\n![Screenshot 2024-11-19 at 09 37\n35](https://github.com/user-attachments/assets/2f4c8d0e-85f6-47d9-affb-590a5812f16f)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"95ef95c9f23f8d0d4ed8db3f3b91786622ac2935"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/200177","number":200177,"mergeCommit":{"message":"feat: [Dashboards] Hide clear control button in floating actions when no filters are selected (#200177)\n\n## Summary\nThis PR resolves the issue [[Controls] Show clear option only when\nvalues have been\nselected](https://github.com/elastic/kibana/issues/192619).\n\nPreviously, the clear button would be visible at all times, regardless\nof whether any filters were applied.\n\n![Screenshot 2024-11-19 at 09 33\n21](https://github.com/user-attachments/assets/6122225b-8497-4bef-953e-efbfc70b4276)\n\nWith this PR, the clear control button will only be visible if there are\nany filters applied and will dynamically disappear when the user clears\ntheir filters.\n\n![Screenshot 2024-11-19 at 09 37\n35](https://github.com/user-attachments/assets/2f4c8d0e-85f6-47d9-affb-590a5812f16f)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"95ef95c9f23f8d0d4ed8db3f3b91786622ac2935"}},{"branch":"8.17","label":"v8.17.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->