### PR TITLE
[APM] Fix deprecated usage of license plugin

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/application/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/application/index.tsx
@@ -59,6 +59,7 @@ export const renderApp = ({
     observabilityAIAssistant: pluginsStart.observabilityAIAssistant,
     share: pluginsSetup.share,
     kibanaEnvironment,
+    licensing: pluginsStart.licensing,
   };
 
   // render APM feedback link in global help menu

--- a/x-pack/plugins/observability_solution/apm/public/context/apm_plugin/apm_plugin_context.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/context/apm_plugin/apm_plugin_context.tsx
@@ -19,6 +19,7 @@ import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { ObservabilityAIAssistantPublicStart } from '@kbn/observability-ai-assistant-plugin/public';
 import { SharePluginSetup } from '@kbn/share-plugin/public';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { ApmPluginSetupDeps } from '../../plugin';
 import type { ConfigSchema } from '../..';
 import type { KibanaEnvContext } from '../kibana_environment_context/kibana_environment_context';
@@ -40,6 +41,7 @@ export interface ApmPluginContextValue {
   share: SharePluginSetup;
   kibanaEnvironment: KibanaEnvContext;
   lens: LensPublicStart;
+  licensing: LicensingPluginStart;
 }
 
 export const ApmPluginContext = createContext({} as ApmPluginContextValue);

--- a/x-pack/plugins/observability_solution/apm/public/context/license/license_context.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/context/license/license_context.tsx
@@ -14,8 +14,7 @@ import { InvalidLicenseNotification } from './invalid_license_notification';
 export const LicenseContext = React.createContext<ILicense | undefined>(undefined);
 
 export function LicenseProvider({ children }: { children: React.ReactChild }) {
-  const { plugins } = useApmPluginContext();
-  const { licensing } = plugins;
+  const { licensing } = useApmPluginContext();
   const license = useObservable(licensing.license$);
   // if license is not loaded yet, consider it valid
   const hasInvalidLicense = license?.isActive === false;

--- a/x-pack/plugins/observability_solution/apm/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/apm/public/plugin.ts
@@ -34,7 +34,7 @@ import { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
 import type { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { LensPublicStart } from '@kbn/lens-plugin/public';
 import { LicenseManagementUIPluginSetup } from '@kbn/license-management-plugin/public';
-import type { LicensingPluginSetup } from '@kbn/licensing-plugin/public';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { MapsStartApi } from '@kbn/maps-plugin/public';
 import type { MlPluginSetup, MlPluginStart } from '@kbn/ml-plugin/public';
 import type {
@@ -96,7 +96,6 @@ export interface ApmPluginSetupDeps {
   unifiedSearch: UnifiedSearchPublicPluginStart;
   features: FeaturesPluginSetup;
   home?: HomePublicPluginSetup;
-  licensing: LicensingPluginSetup;
   licenseManagement?: LicenseManagementUIPluginSetup;
   ml?: MlPluginSetup;
   observability: ObservabilityPublicSetup;
@@ -122,7 +121,7 @@ export interface ApmPluginStartDeps {
   embeddable: EmbeddableStart;
   home: void;
   inspector: InspectorPluginStart;
-  licensing: void;
+  licensing: LicensingPluginStart;
   maps?: MapsStartApi;
   ml?: MlPluginStart;
   triggersActionsUi: TriggersAndActionsUIPublicPluginStart;


### PR DESCRIPTION
Closes #200709

## Summary

This PR replaces deprecated usage of licensing plugin (remove plugin from setup in favor of start up).





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->