### PR TITLE
[8.16] [APM] Make `trace.id` an optional field (#201821)

### DIFF
--- a/x-pack/plugins/observability_solution/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
@@ -69,7 +69,6 @@ export async function getErrorSampleDetails({
   const requiredFields = asMutableArray([
     AGENT_NAME,
     PROCESSOR_EVENT,
-    TRACE_ID,
     TIMESTAMP_US,
     AT_TIMESTAMP,
     SERVICE_NAME,
@@ -78,6 +77,7 @@ export async function getErrorSampleDetails({
   ] as const);
 
   const optionalFields = asMutableArray([
+    TRACE_ID,
     TRANSACTION_ID,
     SPAN_ID,
     AGENT_VERSION,
@@ -131,7 +131,7 @@ export async function getErrorSampleDetails({
   const errorFromFields = unflattenKnownApmEventFields(hit.fields, requiredFields);
 
   const transactionId = errorFromFields.transaction?.id ?? errorFromFields.span?.id;
-  const traceId = errorFromFields.trace.id;
+  const traceId = errorFromFields.trace?.id;
 
   let transaction: Transaction | undefined;
   if (transactionId && traceId) {

--- a/x-pack/test/apm_api_integration/tests/errors/generate_data.ts
+++ b/x-pack/test/apm_api_integration/tests/errors/generate_data.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { apm, timerange } from '@kbn/apm-synthtrace-client';
+import { ApmFields, apm, timerange } from '@kbn/apm-synthtrace-client';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
 
 export const config = {
@@ -25,11 +25,13 @@ export async function generateData({
   serviceName,
   start,
   end,
+  overrides,
 }: {
   apmSynthtraceEsClient: ApmSynthtraceEsClient;
   serviceName: string;
   start: number;
   end: number;
+  overrides?: Partial<ApmFields>;
 }) {
   const serviceGoProdInstance = apm
     .service({ name: serviceName, environment: 'production', agentName: 'go' })
@@ -47,6 +49,7 @@ export async function generateData({
         .generator((timestamp) =>
           serviceGoProdInstance
             .transaction({ transactionName: transaction.name })
+            .overrides(overrides ? overrides : {})
             .timestamp(timestamp)
             .duration(1000)
             .success()
@@ -57,6 +60,7 @@ export async function generateData({
         .generator((timestamp) =>
           serviceGoProdInstance
             .transaction({ transactionName: transaction.name })
+            .overrides(overrides ? overrides : {})
             .errors(
               serviceGoProdInstance
                 .error({ message: `Error ${index}`, type: transaction.name })

--- a/x-pack/test/apm_api_integration/tests/errors/group_id_samples.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/errors/group_id_samples.spec.ts
@@ -138,6 +138,33 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
     });
 
+    describe('error sample without trace.id', () => {
+      before(async () => {
+        await generateData({
+          serviceName,
+          start,
+          end,
+          apmSynthtraceEsClient,
+          overrides: {
+            'trace.id': undefined,
+          },
+        });
+      });
+
+      after(() => apmSynthtraceEsClient.clean());
+
+      it('returns 200', async () => {
+        const errorsSamplesResponse = await callErrorGroupSamplesApi({
+          groupId: '0000000000000000000000000Error 1',
+        });
+
+        const errorId = errorsSamplesResponse.body.errorSampleIds[0];
+
+        const response = await callErrorSampleDetailsApi(errorId);
+        expect(response.status).to.be(200);
+      });
+    });
+
     describe('with sampled and unsampled transactions', () => {
       let errorGroupSamplesResponse: ErrorGroupSamples;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[APM] Make `trace.id` an optional field (#201821)](https://github.com/elastic/kibana/pull/201821)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-11-27T10:55:51Z","message":"[APM] Make `trace.id` an optional field (#201821)\n\nfixes [#201803](https://github.com/elastic/kibana/issues/201803)\r\n\r\n## Summary\r\n\r\nThis PR fixes the error sample details function, making the `trace.id`\r\nan optional field, to prevent the function from crashing in case this\r\nfield is not in the docs.\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"caea2066e4ca70e913b83a1ae13d3f2cd0d46804","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor","ci:project-deploy-observability","Team:obs-ux-infra_services","v8.16.0","backport:version","v8.17.0","v8.18.0"],"number":201821,"url":"https://github.com/elastic/kibana/pull/201821","mergeCommit":{"message":"[APM] Make `trace.id` an optional field (#201821)\n\nfixes [#201803](https://github.com/elastic/kibana/issues/201803)\r\n\r\n## Summary\r\n\r\nThis PR fixes the error sample details function, making the `trace.id`\r\nan optional field, to prevent the function from crashing in case this\r\nfield is not in the docs.\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"caea2066e4ca70e913b83a1ae13d3f2cd0d46804"}},"sourceBranch":"main","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/201821","number":201821,"mergeCommit":{"message":"[APM] Make `trace.id` an optional field (#201821)\n\nfixes [#201803](https://github.com/elastic/kibana/issues/201803)\r\n\r\n## Summary\r\n\r\nThis PR fixes the error sample details function, making the `trace.id`\r\nan optional field, to prevent the function from crashing in case this\r\nfield is not in the docs.\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"caea2066e4ca70e913b83a1ae13d3f2cd0d46804"}},{"branch":"8.16","label":"v8.16.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201939","number":201939,"state":"MERGED","mergeCommit":{"sha":"7b10d16a8e1557fa7af07a3ad40ac866b7c462df","message":"[8.17] [APM] Make &#x60;trace.id&#x60; an optional field (#201821) (#201939)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.17`:\n- [[APM] Make &#x60;trace.id&#x60; an optional field\n(#201821)](https://github.com/elastic/kibana/pull/201821)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Carlos\nCrespo\",\"email\":\"crespocarlos@users.noreply.github.com\"},\"sourceCommit\":{\"committedDate\":\"2024-11-27T10:55:51Z\",\"message\":\"[APM]\nMake `trace.id` an optional field (#201821)\\n\\nfixes\n[#201803](https://github.com/elastic/kibana/issues/201803)\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nThis PR fixes the error sample details function, making\nthe `trace.id`\\r\\nan optional field, to prevent the function from\ncrashing in case this\\r\\nfield is not in the\ndocs.\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by: Elastic Machine\n<elasticmachine@users.noreply.github.com>\",\"sha\":\"caea2066e4ca70e913b83a1ae13d3f2cd0d46804\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"backport:prev-minor\",\"ci:project-deploy-observability\",\"Team:obs-ux-infra_services\",\"v8.16.0\",\"backport:version\",\"v8.17.0\"],\"title\":\"[APM]\nMake `trace.id` an optional\nfield\",\"number\":201821,\"url\":\"https://github.com/elastic/kibana/pull/201821\",\"mergeCommit\":{\"message\":\"[APM]\nMake `trace.id` an optional field (#201821)\\n\\nfixes\n[#201803](https://github.com/elastic/kibana/issues/201803)\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nThis PR fixes the error sample details function, making\nthe `trace.id`\\r\\nan optional field, to prevent the function from\ncrashing in case this\\r\\nfield is not in the\ndocs.\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by: Elastic Machine\n<elasticmachine@users.noreply.github.com>\",\"sha\":\"caea2066e4ca70e913b83a1ae13d3f2cd0d46804\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.16\",\"8.17\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/201821\",\"number\":201821,\"mergeCommit\":{\"message\":\"[APM]\nMake `trace.id` an optional field (#201821)\\n\\nfixes\n[#201803](https://github.com/elastic/kibana/issues/201803)\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nThis PR fixes the error sample details function, making\nthe `trace.id`\\r\\nan optional field, to prevent the function from\ncrashing in case this\\r\\nfield is not in the\ndocs.\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by: Elastic Machine\n<elasticmachine@users.noreply.github.com>\",\"sha\":\"caea2066e4ca70e913b83a1ae13d3f2cd0d46804\"}},{\"branch\":\"8.16\",\"label\":\"v8.16.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.17\",\"label\":\"v8.17.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/201940","number":201940,"state":"MERGED","mergeCommit":{"sha":"4c3fcad3a7e94f2a340940acefe915414bbfabc4","message":"[8.x] [APM] Make &#x60;trace.id&#x60; an optional field (#201821) (#201940)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[APM] Make &#x60;trace.id&#x60; an optional field\n(#201821)](https://github.com/elastic/kibana/pull/201821)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Carlos\nCrespo\",\"email\":\"crespocarlos@users.noreply.github.com\"},\"sourceCommit\":{\"committedDate\":\"2024-11-27T10:55:51Z\",\"message\":\"[APM]\nMake `trace.id` an optional field (#201821)\\n\\nfixes\n[#201803](https://github.com/elastic/kibana/issues/201803)\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nThis PR fixes the error sample details function, making\nthe `trace.id`\\r\\nan optional field, to prevent the function from\ncrashing in case this\\r\\nfield is not in the\ndocs.\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by: Elastic Machine\n<elasticmachine@users.noreply.github.com>\",\"sha\":\"caea2066e4ca70e913b83a1ae13d3f2cd0d46804\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"backport:prev-minor\",\"ci:project-deploy-observability\",\"Team:obs-ux-infra_services\",\"v8.16.0\",\"backport:version\",\"v8.17.0\"],\"title\":\"[APM]\nMake `trace.id` an optional\nfield\",\"number\":201821,\"url\":\"https://github.com/elastic/kibana/pull/201821\",\"mergeCommit\":{\"message\":\"[APM]\nMake `trace.id` an optional field (#201821)\\n\\nfixes\n[#201803](https://github.com/elastic/kibana/issues/201803)\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nThis PR fixes the error sample details function, making\nthe `trace.id`\\r\\nan optional field, to prevent the function from\ncrashing in case this\\r\\nfield is not in the\ndocs.\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by: Elastic Machine\n<elasticmachine@users.noreply.github.com>\",\"sha\":\"caea2066e4ca70e913b83a1ae13d3f2cd0d46804\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.16\",\"8.17\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/201821\",\"number\":201821,\"mergeCommit\":{\"message\":\"[APM]\nMake `trace.id` an optional field (#201821)\\n\\nfixes\n[#201803](https://github.com/elastic/kibana/issues/201803)\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nThis PR fixes the error sample details function, making\nthe `trace.id`\\r\\nan optional field, to prevent the function from\ncrashing in case this\\r\\nfield is not in the\ndocs.\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by: Elastic Machine\n<elasticmachine@users.noreply.github.com>\",\"sha\":\"caea2066e4ca70e913b83a1ae13d3f2cd0d46804\"}},{\"branch\":\"8.16\",\"label\":\"v8.16.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.17\",\"label\":\"v8.17.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>"}}]}] BACKPORT-->