### PR TITLE
[ci/trigger-version-dependent-jobs] Revert skip_intermediate_builds

### DIFF
--- a/.buildkite/pipeline-resource-definitions/trigger-version-dependent-jobs.yml
+++ b/.buildkite/pipeline-resource-definitions/trigger-version-dependent-jobs.yml
@@ -31,6 +31,7 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/scripts/pipelines/trigger_version_dependent_jobs/pipeline.sh
+      skip_intermediate_builds: false
       provider_settings:
         prefix_pull_request_fork_branch_names: false
         skip_pull_request_builds_for_existing_commits: true


### PR DESCRIPTION
Partially reverts a change I introduced in https://github.com/elastic/kibana/commit/c050bb4175aeaad97b8b4d1a76abdb7b0f22e003.

This pipeline has scheduled runs at the same time that have been skipped when they should not be.
https://buildkite.com/elastic/kibana-trigger-version-dependent-jobs/builds?state=skipped

I checked all the other pipelines in the original change, this is the only case with overlapping schedules on the same branch.