### PR TITLE
[ML] Trained Models: Show deployment stats for unallocated deployments 

### DIFF
--- a/x-pack/plugins/ml/common/types/trained_models.ts
+++ b/x-pack/plugins/ml/common/types/trained_models.ts
@@ -193,6 +193,7 @@ export interface AllocatedModel {
    */
   model_id?: string;
   state: string;
+  reason?: string;
   model_size_bytes: number;
   required_native_memory_bytes: number;
   node: {

--- a/x-pack/plugins/ml/public/application/memory_usage/nodes_overview/allocated_models.tsx
+++ b/x-pack/plugins/ml/public/application/memory_usage/nodes_overview/allocated_models.tsx
@@ -57,15 +57,17 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
     {
       width: '8%',
       name: i18n.translate('xpack.ml.trainedModels.nodesList.modelsList.modelRoutingStateHeader', {
-        defaultMessage: 'Routing state',
+        defaultMessage: 'State',
       }),
       'data-test-subj': 'mlAllocatedModelsTableRoutingState',
       render: (v: AllocatedModel) => {
         const { routing_state: routingState, reason } = v.node.routing_state;
 
+        const isFailed = routingState === 'failed';
+
         return (
           <EuiToolTip content={reason ? reason : ''}>
-            <EuiBadge color={reason ? 'danger' : 'hollow'}>{routingState}</EuiBadge>
+            <EuiBadge color={isFailed ? 'danger' : 'hollow'}>{routingState}</EuiBadge>
           </EuiToolTip>
         );
       },

--- a/x-pack/plugins/ml/public/application/memory_usage/nodes_overview/allocated_models.tsx
+++ b/x-pack/plugins/ml/public/application/memory_usage/nodes_overview/allocated_models.tsx
@@ -254,7 +254,7 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
       }),
       'data-test-subj': 'mlAllocatedModelsTableStartedTime',
       render: (v: AllocatedModel) => {
-        return dateFormatter(v.node.start_time);
+        return v.node.start_time ? dateFormatter(v.node.start_time) : '-';
       },
     },
     {

--- a/x-pack/plugins/ml/public/application/model_management/expanded_row.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/expanded_row.tsx
@@ -169,13 +169,40 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
     license_level,
   ]);
 
-  const deploymentStatItems: AllocatedModel[] = useMemo<AllocatedModel[]>(() => {
+  const deploymentStatItems = useMemo<AllocatedModel[]>(() => {
     const deploymentStats = stats.deployment_stats;
     const modelSizeStats = stats.model_size_stats;
 
     if (!deploymentStats || !modelSizeStats) return [];
 
-    const items: AllocatedModel[] = deploymentStats.flatMap((perDeploymentStat) => {
+    return deploymentStats.flatMap((perDeploymentStat) => {
+      // A deployment can be in a starting state and not allocated to any node yet.
+      if (perDeploymentStat.nodes.length < 1) {
+        return [
+          {
+            key: `${perDeploymentStat.deployment_id}_no_node`,
+            ...perDeploymentStat,
+            ...modelSizeStats,
+            node: {
+              name: '-',
+              average_inference_time_ms: 0,
+              inference_count: 0,
+              routing_state: {
+                routing_state: perDeploymentStat.state,
+                reason: perDeploymentStat.reason,
+              },
+              last_access: 0,
+              number_of_pending_requests: 0,
+              start_time: 0,
+              throughput_last_minute: 0,
+              number_of_allocations: 0,
+              threads_per_allocation: 0,
+              error_count: 0,
+            },
+          },
+        ];
+      }
+
       return perDeploymentStat.nodes.map((n) => {
         const nodeName = Object.values(n.node)[0].name;
         return {
@@ -201,8 +228,6 @@ export const ExpandedRow: FC<ExpandedRowProps> = ({ item }) => {
         };
       });
     });
-
-    return items;
   }, [stats]);
 
   const hideColumns = useMemo(() => {


### PR DESCRIPTION
## Summary

Fixes #201930 

Show deployment on the Deployent stats table even if it hasn't been allocated to any node yet. 


<img width="875" alt="image" src="https://github.com/user-attachments/assets/858041fd-16d4-44f3-8d13-1ad45550452e">









<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->