### PR TITLE
Remove deprecated usage of `environment`

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/apm/public/plugin.ts
@@ -198,7 +198,6 @@ export class ApmPlugin implements Plugin<ApmPluginSetup, ApmPluginStart> {
     const { featureFlags } = config;
 
     if (pluginSetupDeps.home) {
-      pluginSetupDeps.home.environment.update({ apmUi: true });
       pluginSetupDeps.home.featureCatalogue.register(featureCatalogueEntry);
     }
 


### PR DESCRIPTION
Closes #200720

## Summary

This PR removes deprecated usage of `environment` property. The code isn't used anymore, therefore can be removed safely. 

https://github.com/elastic/kibana/blob/d0d33aab38009fe19cb18bacd3bf1943b5a8043f/src/plugins/home/public/plugin.ts#L202-L208



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->