### PR TITLE
enable skipped `inputs_with_standalone_docker_agent` test

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
+++ b/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
@@ -25,8 +25,7 @@ export default function (providerContext: FtrProviderContext) {
   const config = getService('config');
   const log = getService('log');
 
-  // Failing: See https://github.com/elastic/kibana/issues/193625
-  describe.skip('inputs_with_standalone_docker_agent', () => {
+  describe('inputs_with_standalone_docker_agent', () => {
     skipIfNoDockerRegistry(providerContext);
     let apiKey: string;
     let agent: AgentProcess;

--- a/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
+++ b/x-pack/test/fleet_api_integration/apis/integrations/inputs_with_standalone_docker_agent.ts
@@ -76,17 +76,22 @@ ${inputsYaml}
       const MAX_ITERATIONS = 20;
       let foundMetrics = false;
       for (let i = 0; i < MAX_ITERATIONS; i++) {
-        const searchRes = await es.search({
-          index: 'metrics-system.cpu-default',
-          q: `agent.name:${agent.name}`,
-          ignore_unavailable: true,
-        });
+        try {
+          const searchRes = await es.search({
+            index: 'metrics-system.cpu-default',
+            q: `agent.name:${agent.name}`,
+            ignore_unavailable: true,
+          });
 
-        // @ts-expect-error TotalHit
-        if (searchRes.hits.total.value > 0) {
-          foundMetrics = true;
-          break;
+          // @ts-expect-error TotalHit
+          if (searchRes.hits.total.value > 0) {
+            foundMetrics = true;
+            break;
+          }
+        } catch (err) {
+          log.error(err);
         }
+
         // await agent.log(); uncomment if you need to debug agent logs
         await new Promise((resolve) => setTimeout(resolve, 5 * 1000));
       }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/193625

Catch es errors in the test, to let it retry.
Flaky test runner passed 125 times.


### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->