### PR TITLE
[Security Solution] Optimize hot code path for browser fields even fu…

### DIFF
--- a/x-pack/plugins/security_solution/public/common/containers/source/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/containers/source/index.tsx
@@ -15,7 +15,7 @@ import type { DataViewSpec } from '@kbn/data-views-plugin/public';
 
 import { useKibana } from '../../lib/kibana';
 import * as i18n from './translations';
-import { getDataViewStateFromIndexFields } from './use_data_view';
+import { getDataViewStateFromIndexFieldsAsync } from './use_data_view';
 import { useAppToasts } from '../../hooks/use_app_toasts';
 import type { ENDPOINT_FIELDS_SEARCH_STRATEGY } from '../../../../common/endpoint/constants';
 
@@ -112,7 +112,7 @@ export const useFetchIndex = (
           abortCtrl.current = new AbortController();
           const dv = await data.dataViews.create({ title: iNames.join(','), allowNoIndex: true });
           const dataView = dv.toSpec();
-          const { browserFields } = getDataViewStateFromIndexFields(
+          const { browserFields } = await getDataViewStateFromIndexFieldsAsync(
             iNames.join(','),
             dataView.fields
           );

--- a/x-pack/plugins/security_solution/public/sourcerer/containers/get_sourcerer_data_view.ts
+++ b/x-pack/plugins/security_solution/public/sourcerer/containers/get_sourcerer_data_view.ts
@@ -8,7 +8,7 @@
 import type { DataViewsServicePublic } from '@kbn/data-views-plugin/public/types';
 import { ensurePatternFormat } from '../../../common/utils/sourcerer';
 import type { SourcererDataView } from '../store/model';
-import { getDataViewStateFromIndexFields } from '../../common/containers/source/use_data_view';
+import { getDataViewStateFromIndexFieldsAsync } from '../../common/containers/source/use_data_view';
 
 export const getSourcererDataView = async (
   dataViewId: string,
@@ -27,7 +27,8 @@ export const getSourcererDataView = async (
     fields: dataViewData.fields,
     patternList,
     dataView: dataViewData,
-    browserFields: getDataViewStateFromIndexFields(dataViewData.id ?? '', dataViewData.fields)
-      .browserFields,
+    browserFields: (
+      await getDataViewStateFromIndexFieldsAsync(dataViewData.id ?? '', dataViewData.fields)
+    ).browserFields,
   };
 };


### PR DESCRIPTION
# Summary

Splits browser fields processing into smaller chunks so that the browser does not hang with larger field sets.

It should keep the app responsive on lower end devices with 15k+ fields scenario while maintaining the previous cache solution.

https://github.com/elastic/kibana/issues/178373

