### PR TITLE
[Files] Don't use dot index name in server integration tests

### DIFF
--- a/src/plugins/files/server/file_client/integration_tests/es_file_client.test.ts
+++ b/src/plugins/files/server/file_client/integration_tests/es_file_client.test.ts
@@ -19,8 +19,8 @@ describe('ES-index-backed file client', () => {
   let esClient: TestEnvironmentUtils['esClient'];
   let fileClient: FileClient;
   let testHarness: TestEnvironmentUtils;
-  const blobStorageIndex = '.kibana-test-blob';
-  const metadataIndex = '.kibana-test-metadata';
+  const blobStorageIndex = 'kibana-files-test-blob';
+  const metadataIndex = 'kibana-files-test-metadata';
 
   const deleteFile = async ({
     id,

--- a/src/plugins/files/server/test_utils/setup_integration_environment.ts
+++ b/src/plugins/files/server/test_utils/setup_integration_environment.ts
@@ -21,7 +21,7 @@ export type TestEnvironmentUtils = Awaited<ReturnType<typeof setupIntegrationEnv
 
 export async function setupIntegrationEnvironment() {
   const fileKind: string = 'test-file-kind';
-  const testIndex = '.kibana-test-files';
+  const testIndex = 'kibana-test-files';
 
   /**
    * Functionality to create files easily


### PR DESCRIPTION
In this PR I've renamed the index names that we use in our integration tests to not use names that start with a dot "." to avoid usage of deprecated ES API.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->