### PR TITLE
[Docs] Update certain references to cloud and ESS due to serverless GA

### DIFF
--- a/docs/maps/asset-tracking-tutorial.asciidoc
+++ b/docs/maps/asset-tracking-tutorial.asciidoc
@@ -24,7 +24,7 @@ image::maps/images/asset-tracking-tutorial/construction_zones.png[]
 [float]
 === Prerequisites
 
-- If you don’t already have {kib}, set it up with https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs[our free trial]. Download the deployment credentials.
+- If you don’t already have {kib}, sign up for https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs[a free Elastic Cloud trial] and create a hosted deployment. When creating it, download the deployment credentials.
 - Obtain an API key for https://developer.trimet.org/[TriMet web services] at https://developer.trimet.org/appid/registration/.
 - {fleet-guide}/fleet-overview.html[Fleet] is enabled on your cluster, and one or more {fleet-guide}/elastic-agent-installation.html[{agent}s] is enrolled.
 

--- a/docs/setup/install.asciidoc
+++ b/docs/setup/install.asciidoc
@@ -2,9 +2,9 @@
 == Install {kib}
 
 [float]
-=== Hosted {kib}
+=== {kib} on Elastic Cloud
 
-If you are running our hosted Elasticsearch Service on Elastic Cloud, you access Kibana with a single click. (You can {ess-trial}[sign up for a free trial] and start exploring data in minutes.)
+If you are using Elastic Cloud, you access Kibana with a single click. (You can {ess-trial}[sign up for a free trial] and start exploring data in minutes.)
 
 [float]
 === Install {kib} yourself

--- a/docs/user/alerting/troubleshooting/testing-connectors.asciidoc
+++ b/docs/user/alerting/troubleshooting/testing-connectors.asciidoc
@@ -18,7 +18,7 @@ image::user/alerting/images/teams-connector-test.png[Five clauses define the con
 ==== experimental[] Troubleshooting connectors with the `kbn-action` tool
 
 You can run an email action via https://github.com/pmuellr/kbn-action[kbn-action].
-In this example, it is a Cloud deployment of the {stack}:
+In this example, it is a Cloud hosted deployment of the {stack}:
 
 [source, txt]
 --------------------------------------------------

--- a/docs/user/reporting/index.asciidoc
+++ b/docs/user/reporting/index.asciidoc
@@ -72,7 +72,7 @@ NOTE: You can use the *Copy POST URL* option instead to generate the report from
 
 You can then download it from that message, or go to the *Stack Management > Reporting* page to view and access all of your reports.
 
-NOTE: In "stateful" deployments, reports are stored in {es} and managed by the `kibana-reporting` {ilm}
+NOTE: In self-managed and Cloud hosted deployments, reports are stored in {es} and managed by the `kibana-reporting` {ilm}
 ({ilm-init}) policy. By default, the policy stores reports forever. To learn more about {ilm-init} policies, refer
 to the {es} {ref}/index-lifecycle-management.html[{ilm-init} documentation].
 
@@ -108,7 +108,7 @@ Create and share JSON files for workpads.
 * *Embed code* &mdash; Embed fully interactive dashboards as an iframe on web pages.
 
 [[reporting-on-cloud-resource-requirements]]
-NOTE: For Elastic Cloud deployments, {kib} instances require a minimum of 2GB RAM to generate PDF or PNG reports. To
+NOTE: For Elastic Cloud hosted deployments, {kib} instances require a minimum of 2GB RAM to generate PDF or PNG reports. To
 change {kib} sizing, {ess-console}[edit the deployment].
 
 


### PR DESCRIPTION
This PR updates a few references to hosted deployments on Elastic Cloud to avoid ambiguity with serverless in anticipation of serverless GA.

Some more similar updates will be made on other repos to align.

Rel: https://github.com/elastic/platform-docs-team/issues/485

<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->