### PR TITLE
Remove saved objects client wrapper and update types for internal repository

### DIFF
--- a/src/plugins/telemetry/server/fetcher.ts
+++ b/src/plugins/telemetry/server/fetcher.ts
@@ -29,9 +29,8 @@ import type { TelemetryCollectionManagerPluginStart } from '@kbn/telemetry-colle
 import {
   type PluginInitializerContext,
   type Logger,
-  type SavedObjectsClientContract,
-  SavedObjectsClient,
   type CoreStart,
+  type ISavedObjectsRepository,
 } from '@kbn/core/server';
 import { getTelemetryChannelEndpoint } from '../common/telemetry_config';
 import {
@@ -77,7 +76,7 @@ export class FetcherTask {
   private readonly subscriptions = new Subscription();
   private readonly isOnline$ = new BehaviorSubject<boolean>(false); // Let's initially assume we are not online
   private readonly lastReported$ = new BehaviorSubject<number>(0);
-  private internalRepository?: SavedObjectsClientContract;
+  private internalRepository?: ISavedObjectsRepository;
   private telemetryCollectionManager?: TelemetryCollectionManagerPluginStart;
 
   constructor(initializerContext: PluginInitializerContext<TelemetryConfigType>) {
@@ -87,9 +86,7 @@ export class FetcherTask {
   }
 
   public start({ savedObjects }: CoreStart, { telemetryCollectionManager }: FetcherTaskDepsStart) {
-    this.internalRepository = new SavedObjectsClient(
-      savedObjects.createInternalRepository([TELEMETRY_SAVED_OBJECT_TYPE])
-    );
+    this.internalRepository = savedObjects.createInternalRepository([TELEMETRY_SAVED_OBJECT_TYPE]);
     this.telemetryCollectionManager = telemetryCollectionManager;
 
     this.subscriptions.add(this.validateConnectivity());


### PR DESCRIPTION
## Summary

Resolves: https://github.com/elastic/kibana/issues/147864

Remove saved objects client wrapper and update types for internal repository


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->