### PR TITLE
[product documentation] Fix index names

### DIFF
--- a/x-pack/packages/ai-infra/product-doc-common/src/indices.ts
+++ b/x-pack/packages/ai-infra/product-doc-common/src/indices.ts
@@ -7,9 +7,9 @@
 
 import type { ProductName } from './product';
 
-export const productDocIndexPrefix = '.kibana-ai-product-doc';
-export const productDocIndexPattern = `${productDocIndexPrefix}-*`;
+export const productDocIndexPrefix = '.kibana_ai_product_doc';
+export const productDocIndexPattern = `${productDocIndexPrefix}_*`;
 
 export const getProductDocIndexName = (productName: ProductName): string => {
-  return `${productDocIndexPrefix}-${productName.toLowerCase()}`;
+  return `${productDocIndexPrefix}_${productName.toLowerCase()}`;
 };


### PR DESCRIPTION
## Summary

Follow-up of https://github.com/elastic/kibana/pull/194379.

Turns out, the prefix for kibana system indices is `.kibana_*`, so our indices were not considered as kibana system indices and causing warnings when created, such as 

```
Elasticsearch deprecation: 299 Elasticsearch-6db572c986d7e114b8b46f1d6f4169bed06717c5 "index name [.kibana-ai-product-doc-kibana] starts with a dot '.', in the next major version, index names starting with a dot are reserved for hidden indices and system indices"
Origin:kibana
```

This PR addresses it, by changing the product doc index names to follow our system index pattern.

<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->