### PR TITLE
[Lens] Unskip "Dashboard to TSVB to Lens" serverless test

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/visualizations/group3/open_in_lens/tsvb/dashboard.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/visualizations/group3/open_in_lens/tsvb/dashboard.ts
@@ -24,8 +24,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const visTitle = 'My TSVB to Lens viz 2';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/190737
-  describe.skip('Dashboard to TSVB to Lens', function describeIndexTests() {
+  describe('Dashboard to TSVB to Lens', function describeIndexTests() {
     const fixture =
       'x-pack/test_serverless/functional/fixtures/kbn_archiver/lens/open_in_lens/tsvb/dashboard.json';
 


### PR DESCRIPTION
## Summary
Fixes: #190737, #190802, #190990, #179307

This test started failing after @nreese Reset PR was merged here: https://github.com/elastic/kibana/pull/201687 and the Lens embeddable refactor PR introducing a regression which affected the test.
Later on the PR was reverted with https://github.com/elastic/kibana/pull/201902 .


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->