### PR TITLE
[Profiling] Switch to 19Hz sampling frequency

### DIFF
--- a/x-pack/plugins/observability_solution/profiling/public/hooks/use_calculate_impact_estimates.test.ts
+++ b/x-pack/plugins/observability_solution/profiling/public/hooks/use_calculate_impact_estimates.test.ts
@@ -40,9 +40,9 @@ describe('useCalculateImpactEstimate', () => {
   it('calculates impact when countExclusive is lower than countInclusive', () => {
     const calculateImpactEstimates = useCalculateImpactEstimate();
     const { selfCPU, totalCPU, totalSamples } = calculateImpactEstimates({
-      countExclusive: 500,
-      countInclusive: 1000,
-      totalSamples: 10000,
+      countExclusive: 475,
+      countInclusive: 950,
+      totalSamples: 9500,
       totalSeconds: 15 * 60, // 15m
     });
 
@@ -68,9 +68,9 @@ describe('useCalculateImpactEstimate', () => {
   it('calculates impact', () => {
     const calculateImpactEstimates = useCalculateImpactEstimate();
     const { selfCPU, totalCPU, totalSamples } = calculateImpactEstimates({
-      countExclusive: 1000,
-      countInclusive: 1000,
-      totalSamples: 10000,
+      countExclusive: 950,
+      countInclusive: 950,
+      totalSamples: 9500,
       totalSeconds: 15 * 60, // 15m
     });
 

--- a/x-pack/plugins/observability_solution/profiling/public/hooks/use_calculate_impact_estimates.ts
+++ b/x-pack/plugins/observability_solution/profiling/public/hooks/use_calculate_impact_estimates.ts
@@ -28,7 +28,7 @@ export function useCalculateImpactEstimate() {
     totalSeconds: number;
   }) {
     const annualizedScaleUp = ANNUAL_SECONDS / totalSeconds;
-    const totalCoreSeconds = totalSamples / 20;
+    const totalCoreSeconds = totalSamples / 19;
     const percentage = samples / totalSamples;
     const coreSeconds = totalCoreSeconds * percentage;
     const annualizedCoreSeconds = coreSeconds * annualizedScaleUp;


### PR DESCRIPTION
## Summary

With 9.0.0, profiling switches to 19Hz default sampling frequency.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



