### PR TITLE
[Fix] Add a `version`  to the `formatRequest` test

### DIFF
--- a/packages/kbn-server-route-repository-utils/src/format_request.test.ts
+++ b/packages/kbn-server-route-repository-utils/src/format_request.test.ts
@@ -10,20 +10,21 @@
 import { formatRequest } from './format_request';
 
 describe('formatRequest', () => {
+  const version = 1;
   it('should return the correct path if the optional or required param is provided', () => {
     const pathParams = { param: 'testParam' };
-    const resultOptionalEnd = formatRequest('GET /api/endpoint/{param?}', pathParams);
+    const resultOptionalEnd = formatRequest(`GET /api/endpoint/{param?} ${version}`, pathParams);
     expect(resultOptionalEnd.pathname).toBe('/api/endpoint/testParam');
-    const resultRequiredEnd = formatRequest('GET /api/endpoint/{param}', pathParams);
+    const resultRequiredEnd = formatRequest(`GET /api/endpoint/{param} ${version}`, pathParams);
     expect(resultRequiredEnd.pathname).toBe('/api/endpoint/testParam');
   });
   it('should return the correct path if the only an optional param is provided', () => {
-    const resultOptEnd = formatRequest('GET /api/endpoint/{id?}', { id: 123 });
+    const resultOptEnd = formatRequest(`GET /api/endpoint/{id?} ${version}`, { id: 123 });
     expect(resultOptEnd.pathname).toBe('/api/endpoint/123');
   });
   it('should return the correct path if the optional param is not provided', () => {
     const pathParams = {};
-    const resultEnd = formatRequest('GET /api/endpoint/{pathParamReq?}', pathParams);
+    const resultEnd = formatRequest(`GET /api/endpoint/{pathParamReq?} ${version}`, pathParams);
     expect(resultEnd.pathname).toBe('/api/endpoint');
   });
 });


### PR DESCRIPTION
## Summary

This PR adds  a `version`  to the `formatRequest` test (found an [issue](https://buildkiteartifacts.com/e0f3970e-3a75-4621-919f-e6c773e2bb12/0fda5127-f57f-42fb-8e5a-146b3d535916/0193729a-f02c-4a3e-92be-d62ec0f91762/019372b6-1e4e-493f-b711-679457e765b2/target/test_failures/019372b6-1e4e-493f-b711-679457e765b2_b8be2ab240c3af76aa62e1fcad3ec562.html?response-content-type=text%2Fhtml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7LTUSWSE7V%2F20241129%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241129T124819Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEMv%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIQCBtHsxCwyPkjuXFut7cE0I%2FQ1SpDfwz%2BUL6ULSc0AbhwIge%2BVhDpL22YYe4fkrNwRadeobqd9oEHMVP6k5tJRJRCoq8QMIdBAAGgwwMzIzNzk3MDUzMDMiDLYAxitOg6M5AO4yOSrOA%2BXsP7JEfPo3AlXET%2FjR9qJi4AJxQZBGvP3HkWOKs8zEJoYXudxq06XmYw9T2Pk4Qovoy2Oghz7UjCzfb9AWJWr5wzAESxWQgfWnAmFTsR2CP81TVtGdHtrX%2FQd1ucHWCA58JFbNe4uG0IWWj4TrrqPUeKeKspvoYknZiFOMN9xIP6r4fMshpNDmz6zOzMWKzgTZGRlVq0%2Biy5sgpl8e039KNiJNde4jrFfx4CcxGEuzDZihApsV%2FKIG3%2B62mEohtK94OQvbR7%2FPPso2FTkA1ndUQHD2jc4woHaJx7cA0aV8Gw2%2FdGgnW2%2FvAX2F0LcBL%2FlPRTw%2BL0T7EDhcz0ldK8FzwCK3aeLBfVvlQaEdoWLBgMf%2FrHYZN4AtrUfCbi91RfpRW7%2B84lF9OqHEc%2Fi8%2FKaRm%2FZA6jyeODfk9gyTwLoCMY%2F1gC1sBgCM7pTS7U5EwK4%2BzPeTusZoLEkcd2zbwN6umOA54CfxeavUkH2uuxsr8ioLVpaCroHe%2FDlhqd%2BGb8CFBherH4pB3GQ0F8JuTbl4RQqY57AH7ahPvMH1Zl0NihqmAJvUNOFss5NUfqN4LNG2xZlqG9mUKpUFaHeUxptYiXf1H79Vyc7TjJ2sVzCCvKa6BjqlAbPc8CIZ5QdsweyEBVEesbmITDsjgiG%2FMlwqzmNf57BPecF%2FkhXgwgR3B%2BK8cg9h3apLMlUtVrTsLq3vPf7nlY8fEwPvLHTGVQoSYwL4AHGPHcZnpSrdI5HDkK0%2BuwTZMKjp1jQ5xbbami6ih2N2mnmFuz1a04SQHLogLBgyw%2BGUZwp%2Fa7jg9RHiSeSWiuCeo8iPVGbkGAe0vA2rr8BHO2tO4H1LPA%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=e18c6abd4208db972d3cdf975d8390de30502170e1ded9db52b5b1342a106d0e) in the backport PRs: https://github.com/elastic/kibana/pull/202153 and https://github.com/elastic/kibana/pull/202154 )

