### PR TITLE
[8.16] [Security Solution] Adds callback `onUpdatePageIndex` to get current `pageIndex` in Unified Data table (#201240)

### DIFF
--- a/packages/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -1355,4 +1355,64 @@ describe('UnifiedDataTable', () => {
       EXTENDED_JEST_TIMEOUT
     );
   });
+
+  describe('pagination', () => {
+    const onChangePageMock = jest.fn();
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    test('should effect pageIndex change', async () => {
+      const component = await getComponent({
+        ...getProps(),
+        onUpdatePageIndex: onChangePageMock,
+        rowsPerPageState: 1,
+        rowsPerPageOptions: [1, 5],
+      });
+
+      expect(findTestSubject(component, 'pagination-button-1').exists()).toBeTruthy();
+      onChangePageMock.mockClear();
+      findTestSubject(component, 'pagination-button-1').simulate('click');
+      expect(onChangePageMock).toHaveBeenNthCalledWith(1, 1);
+    });
+
+    test('should effect pageIndex change when itemsPerPage has been changed', async () => {
+      /*
+       * Use Case:
+       *
+       * Let's say we have 4 pages and we are on page 1 with 1 item per page.
+       * Now if we change items per page to 4, it should automatically change the pageIndex to 0.
+       *
+       * */
+      const component = await getComponent({
+        ...getProps(),
+        onUpdatePageIndex: onChangePageMock,
+        rowsPerPageState: 1,
+        rowsPerPageOptions: [1, 4],
+      });
+
+      expect(findTestSubject(component, 'pagination-button-4').exists()).toBeTruthy();
+      onChangePageMock.mockClear();
+      // go to last page
+      findTestSubject(component, 'pagination-button-4').simulate('click');
+      expect(onChangePageMock).toHaveBeenNthCalledWith(1, 4);
+      onChangePageMock.mockClear();
+
+      // Change items per Page so that pageIndex autoamtically changes.
+      expect(findTestSubject(component, 'tablePaginationPopoverButton').text()).toBe(
+        'Rows per page: 1'
+      );
+      findTestSubject(component, 'tablePaginationPopoverButton').simulate('click');
+      component.setProps({
+        rowsPerPageState: 5,
+      });
+
+      await waitFor(() => {
+        expect(findTestSubject(component, 'tablePaginationPopoverButton').text()).toBe(
+          'Rows per page: 5'
+        );
+      });
+
+      expect(onChangePageMock).toHaveBeenNthCalledWith(1, 0);
+    });
+  });
 });

--- a/x-pack/plugins/security_solution/common/types/timeline/store.ts
+++ b/x-pack/plugins/security_solution/common/types/timeline/store.ts
@@ -73,7 +73,7 @@ export type OnColumnRemoved = (columnId: ColumnId) => void;
 export type OnColumnResized = ({ columnId, delta }: { columnId: ColumnId; delta: number }) => void;
 
 /** Invoked when a user clicks to load more item */
-export type OnChangePage = (nextPage: number) => void;
+export type OnFetchMoreRecords = (nextPage: number) => void;
 
 /** Invoked when a user checks/un-checks a row */
 export type OnRowSelected = ({

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.test.tsx
@@ -12,7 +12,7 @@ import { UnifiedTimeline } from '../unified_components';
 import { defaultUdtHeaders } from '../unified_components/default_headers';
 import type { UnifiedTimelineBodyProps } from './unified_timeline_body';
 import { UnifiedTimelineBody } from './unified_timeline_body';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { defaultHeaders, mockTimelineData, TestProviders } from '../../../../common/mock';
 
 jest.mock('../unified_components', () => {
@@ -32,17 +32,14 @@ const defaultProps: UnifiedTimelineBodyProps = {
   isTextBasedQuery: false,
   itemsPerPage: 25,
   itemsPerPageOptions: [10, 25, 50],
-  onChangePage: jest.fn(),
+  onFetchMoreRecords: jest.fn(),
   refetch: jest.fn(),
   rowRenderers: [],
   sort: [],
   timelineId: 'timeline-1',
   totalCount: 0,
   updatedAt: 0,
-  pageInfo: {
-    activePage: 0,
-    querySize: 0,
-  },
+  onUpdatePageIndex: jest.fn(),
 };
 
 const renderTestComponents = (props?: UnifiedTimelineBodyProps) => {
@@ -56,39 +53,6 @@ const MockUnifiedTimelineComponent = jest.fn(() => <div />);
 describe('UnifiedTimelineBody', () => {
   beforeEach(() => {
     (UnifiedTimeline as unknown as jest.Mock).mockImplementation(MockUnifiedTimelineComponent);
-  });
-  it('should pass correct page rows', () => {
-    const { rerender } = renderTestComponents();
-
-    expect(screen.getByTestId('unifiedTimelineBody')).toBeVisible();
-    expect(MockUnifiedTimelineComponent).toHaveBeenCalledTimes(2);
-
-    expect(MockUnifiedTimelineComponent).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        events: mockEventsData.flat(),
-      }),
-      {}
-    );
-
-    const newEventsData = structuredClone([mockEventsData[0]]);
-
-    const newProps = {
-      ...defaultProps,
-      pageInfo: {
-        activePage: 1,
-        querySize: 0,
-      },
-      events: newEventsData,
-    };
-
-    MockUnifiedTimelineComponent.mockClear();
-    rerender(<UnifiedTimelineBody {...newProps} />);
-    expect(MockUnifiedTimelineComponent).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        events: [...mockEventsData, ...newEventsData].flat(),
-      }),
-      {}
-    );
   });
 
   it('should pass default columns when empty column list is supplied', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.tsx
@@ -6,23 +6,20 @@
  */
 
 import type { ComponentProps, ReactElement } from 'react';
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { RootDragDropProvider } from '@kbn/dom-drag-drop';
 import { StyledTableFlexGroup, StyledUnifiedTableFlexItem } from '../unified_components/styles';
 import { UnifiedTimeline } from '../unified_components';
-import { defaultUdtHeaders } from '../unified_components/default_headers';
-import type { PaginationInputPaginated, TimelineItem } from '../../../../../common/search_strategy';
+import { defaultUdtHeaders } from './column_headers/default_headers';
 
 export interface UnifiedTimelineBodyProps extends ComponentProps<typeof UnifiedTimeline> {
   header: ReactElement;
-  pageInfo: Pick<PaginationInputPaginated, 'activePage' | 'querySize'>;
 }
 
 export const UnifiedTimelineBody = (props: UnifiedTimelineBodyProps) => {
   const {
     header,
     isSortEnabled,
-    pageInfo,
     columns,
     rowRenderers,
     timelineId,
@@ -33,27 +30,13 @@ export const UnifiedTimelineBody = (props: UnifiedTimelineBodyProps) => {
     refetch,
     dataLoadingState,
     totalCount,
-    onChangePage,
+    onFetchMoreRecords,
     activeTab,
     updatedAt,
     trailingControlColumns,
     leadingControlColumns,
+    onUpdatePageIndex,
   } = props;
-
-  const [pageRows, setPageRows] = useState<TimelineItem[][]>([]);
-
-  const rows = useMemo(() => pageRows.flat(), [pageRows]);
-
-  useEffect(() => {
-    setPageRows((currentPageRows) => {
-      if (pageInfo.activePage !== 0 && currentPageRows[pageInfo.activePage]?.length) {
-        return currentPageRows;
-      }
-      const newPageRows = pageInfo.activePage === 0 ? [] : [...currentPageRows];
-      newPageRows[pageInfo.activePage] = events;
-      return newPageRows;
-    });
-  }, [events, pageInfo.activePage]);
 
   const columnsHeader = useMemo(() => columns ?? defaultUdtHeaders, [columns]);
 
@@ -73,16 +56,17 @@ export const UnifiedTimelineBody = (props: UnifiedTimelineBodyProps) => {
             itemsPerPage={itemsPerPage}
             itemsPerPageOptions={itemsPerPageOptions}
             sort={sort}
-            events={rows}
+            events={events}
             refetch={refetch}
             dataLoadingState={dataLoadingState}
             totalCount={totalCount}
-            onChangePage={onChangePage}
+            onFetchMoreRecords={onFetchMoreRecords}
             activeTab={activeTab}
             updatedAt={updatedAt}
             isTextBasedQuery={false}
             trailingControlColumns={trailingControlColumns}
             leadingControlColumns={leadingControlColumns}
+            onUpdatePageIndex={onUpdatePageIndex}
           />
         </RootDragDropProvider>
       </StyledUnifiedTableFlexItem>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.tsx
@@ -10,7 +10,7 @@ import React, { useMemo } from 'react';
 import { RootDragDropProvider } from '@kbn/dom-drag-drop';
 import { StyledTableFlexGroup, StyledUnifiedTableFlexItem } from '../unified_components/styles';
 import { UnifiedTimeline } from '../unified_components';
-import { defaultUdtHeaders } from './column_headers/default_headers';
+import { defaultHeaders } from './column_headers/default_headers';
 
 export interface UnifiedTimelineBodyProps extends ComponentProps<typeof UnifiedTimeline> {
   header: ReactElement;
@@ -38,7 +38,7 @@ export const UnifiedTimelineBody = (props: UnifiedTimelineBodyProps) => {
     onUpdatePageIndex,
   } = props;
 
-  const columnsHeader = useMemo(() => columns ?? defaultUdtHeaders, [columns]);
+  const columnsHeader = useMemo(() => columns ?? defaultHeaders, [columns]);
 
   return (
     <StyledTableFlexGroup direction="column" gutterSize="s">

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/events.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/events.ts
@@ -13,7 +13,7 @@ export type {
   OnColumnsSorted,
   OnColumnRemoved,
   OnColumnResized,
-  OnChangePage,
+  OnFetchMoreRecords as OnChangePage,
   OnPinEvent,
   OnRowSelected,
   OnSelectAll,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
@@ -5,18 +5,16 @@
  * 2.0.
  */
 
-import React from 'react';
+import type { ComponentProps } from 'react';
+import React, { useEffect } from 'react';
 import useResizeObserver from 'use-resize-observer/polyfilled';
-import type { Dispatch } from 'redux';
 
-import { defaultRowRenderers } from '../../body/renderers';
-import { DefaultCellRenderer } from '../../cell_rendering/default_cell_renderer';
-import { defaultHeaders, mockTimelineData } from '../../../../../common/mock';
+import { createMockStore, mockGlobalState, mockTimelineData } from '../../../../../common/mock';
 import { TestProviders } from '../../../../../common/mock/test_providers';
 
 import type { Props as EqlTabContentComponentProps } from '.';
-import { EqlTabContentComponent } from '.';
-import { TimelineId, TimelineTabs } from '../../../../../../common/types/timeline';
+import EqlTabContentComponent from '.';
+import { TimelineId } from '../../../../../../common/types/timeline';
 import { useTimelineEvents } from '../../../../containers';
 import { useTimelineEventsDetails } from '../../../../containers/details';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
@@ -24,7 +22,15 @@ import { mockSourcererScope } from '../../../../../sourcerer/containers/mocks';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import type { ExperimentalFeatures } from '../../../../../../common';
 import { allowedExperimentalValues } from '../../../../../../common';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as notesApi from '../../../../../notes/api/api';
+import { timelineActions } from '../../../../store';
+import { DefaultCellRenderer } from '../../cell_rendering/default_cell_renderer';
+import { defaultRowRenderers } from '../../body/renderers';
+import { useDispatch } from 'react-redux';
+import { TimelineTabs } from '@kbn/securitysolution-data-table';
+
+const SPECIAL_TEST_TIMEOUT = 30000;
 
 jest.mock('../../../../containers', () => ({
   useTimelineEvents: jest.fn(),
@@ -53,10 +59,43 @@ mockUseResizeObserver.mockImplementation(() => ({}));
 
 jest.mock('../../../../../common/lib/kibana');
 
+let useTimelineEventsMock = jest.fn();
+
+const loadPageMock = jest.fn();
+
+const mockState = {
+  ...structuredClone(mockGlobalState),
+};
+mockState.timeline.timelineById[TimelineId.test].activeTab = TimelineTabs.eql;
+
+const TestComponent = (props: Partial<ComponentProps<typeof EqlTabContentComponent>>) => {
+  const testComponentDefaultProps: ComponentProps<typeof EqlTabContentComponent> = {
+    timelineId: TimelineId.test,
+    renderCellValue: DefaultCellRenderer,
+    rowRenderers: defaultRowRenderers,
+  };
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    // Unified field list can be a culprit for long load times, so we wait for the timeline to be interacted with to load
+    dispatch(timelineActions.showTimeline({ id: TimelineId.test, show: true }));
+
+    // populating timeline so that it is not blank
+    dispatch(
+      timelineActions.updateEqlOptions({
+        id: TimelineId.test,
+        field: 'query',
+        value: 'any where true',
+      })
+    );
+  }, [dispatch]);
+
+  return <EqlTabContentComponent {...testComponentDefaultProps} {...props} />;
+};
+
 describe('EQL Tab', () => {
-  let props = {} as EqlTabContentComponentProps;
-  const startDate = '2018-03-23T18:49:23.132Z';
-  const endDate = '2018-03-24T03:33:52.253Z';
+  const props = {} as EqlTabContentComponentProps;
 
   beforeAll(() => {
     // https://github.com/atlassian/react-beautiful-dnd/blob/4721a518356f72f1dac45b5fd4ee9d466aa2996b/docs/guides/setup-problem-detection-and-error-recovery.md#disable-logging
@@ -68,7 +107,7 @@ describe('EQL Tab', () => {
   });
 
   beforeEach(() => {
-    (useTimelineEvents as jest.Mock).mockReturnValue([
+    useTimelineEventsMock = jest.fn(() => [
       false,
       {
         events: mockTimelineData.slice(0, 1),
@@ -78,6 +117,7 @@ describe('EQL Tab', () => {
         },
       },
     ]);
+    (useTimelineEvents as jest.Mock).mockImplementation(useTimelineEventsMock);
     (useTimelineEventsDetails as jest.Mock).mockReturnValue([false, {}]);
 
     (useSourcererDataView as jest.Mock).mockReturnValue(mockSourcererScope);
@@ -88,30 +128,23 @@ describe('EQL Tab', () => {
       }
     );
 
-    props = {
-      dispatch: {} as Dispatch,
-      activeTab: TimelineTabs.eql,
-      columns: defaultHeaders,
-      end: endDate,
-      eqlOptions: {},
-      isLive: false,
-      itemsPerPage: 5,
-      itemsPerPageOptions: [5, 10, 20],
-      renderCellValue: DefaultCellRenderer,
-      rowRenderers: defaultRowRenderers,
-      start: startDate,
-      timelineId: TimelineId.test,
-      timerangeKind: 'absolute',
-      pinnedEventIds: {},
-      eventIdToNoteIds: {},
-    };
+    HTMLElement.prototype.getBoundingClientRect = jest.fn(() => {
+      return {
+        width: 1000,
+        height: 1000,
+        x: 0,
+        y: 0,
+      } as DOMRect;
+    });
   });
 
   describe('rendering', () => {
+    const fetchNotesMock = jest.spyOn(notesApi, 'fetchNotesByDocumentIds');
     test('should render the timeline table', async () => {
+      fetchNotesMock.mockImplementation(jest.fn());
       render(
-        <TestProviders>
-          <EqlTabContentComponent {...props} />
+        <TestProviders store={createMockStore(mockState)}>
+          <TestComponent />
         </TestProviders>
       );
 
@@ -120,8 +153,8 @@ describe('EQL Tab', () => {
 
     test('it renders the timeline column headers', async () => {
       render(
-        <TestProviders>
-          <EqlTabContentComponent {...props} />
+        <TestProviders store={createMockStore(mockState)}>
+          <TestComponent />
         </TestProviders>
       );
 
@@ -141,12 +174,175 @@ describe('EQL Tab', () => {
       ]);
 
       render(
-        <TestProviders>
-          <EqlTabContentComponent {...props} />
+        <TestProviders store={createMockStore(mockState)}>
+          <TestComponent />
         </TestProviders>
       );
 
       expect(await screen.findByText('No results found')).toBeVisible();
+    });
+
+    describe('pagination', () => {
+      beforeEach(() => {
+        // pagination tests need more than 1 record so here
+        // we return 5 records instead of just 1.
+        useTimelineEventsMock = jest.fn(() => [
+          false,
+          {
+            events: structuredClone(mockTimelineData.slice(0, 5)),
+            pageInfo: {
+              activePage: 0,
+              totalPages: 5,
+            },
+            refreshedAt: Date.now(),
+            /*
+             * `totalCount` could be any number w.r.t this test
+             * and actually means total hits on elastic search
+             * and not the fecthed number of records.
+             *
+             * This helps in testing `sampleSize` and `loadMore`
+             */
+            totalCount: 50,
+            loadPage: loadPageMock,
+          },
+        ]);
+
+        (useTimelineEvents as jest.Mock).mockImplementation(useTimelineEventsMock);
+      });
+
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it(
+        'should load notes for current page only',
+        async () => {
+          const mockStateWithNoteInTimeline = {
+            ...mockGlobalState,
+            timeline: {
+              ...mockGlobalState.timeline,
+              timelineById: {
+                [TimelineId.test]: {
+                  ...mockGlobalState.timeline.timelineById[TimelineId.test],
+                  /* 1 record for each page */
+                  activeTab: TimelineTabs.eql,
+                  itemsPerPage: 1,
+                  itemsPerPageOptions: [1, 2, 3, 4, 5],
+                  savedObjectId: 'timeline-1', // match timelineId in mocked notes data
+                  pinnedEventIds: { '1': true },
+                },
+              },
+            },
+          };
+
+          render(
+            <TestProviders
+              store={createMockStore({
+                ...structuredClone(mockStateWithNoteInTimeline),
+              })}
+            >
+              <TestComponent {...props} />
+            </TestProviders>
+          );
+
+          expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+          expect(screen.getByTestId('pagination-button-previous')).toBeVisible();
+
+          expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'true');
+          expect(fetchNotesMock).toHaveBeenCalledWith(['1']);
+
+          // Page : 2
+
+          fetchNotesMock.mockClear();
+          expect(screen.getByTestId('pagination-button-1')).toBeVisible();
+
+          fireEvent.click(screen.getByTestId('pagination-button-1'));
+
+          await waitFor(() => {
+            expect(screen.getByTestId('pagination-button-1')).toHaveAttribute(
+              'aria-current',
+              'true'
+            );
+
+            expect(fetchNotesMock).toHaveBeenNthCalledWith(1, [mockTimelineData[1]._id]);
+          });
+
+          // Page : 3
+
+          fetchNotesMock.mockClear();
+          expect(screen.getByTestId('pagination-button-2')).toBeVisible();
+          fireEvent.click(screen.getByTestId('pagination-button-2'));
+
+          await waitFor(() => {
+            expect(screen.getByTestId('pagination-button-2')).toHaveAttribute(
+              'aria-current',
+              'true'
+            );
+
+            expect(fetchNotesMock).toHaveBeenNthCalledWith(1, [mockTimelineData[2]._id]);
+          });
+        },
+        SPECIAL_TEST_TIMEOUT
+      );
+
+      it(
+        'should load notes for correct page size',
+        async () => {
+          const mockStateWithNoteInTimeline = {
+            ...mockGlobalState,
+            timeline: {
+              ...mockGlobalState.timeline,
+              timelineById: {
+                [TimelineId.test]: {
+                  ...mockGlobalState.timeline.timelineById[TimelineId.test],
+                  /* 1 record for each page */
+                  itemsPerPage: 1,
+                  pageIndex: 0,
+                  itemsPerPageOptions: [1, 2, 3, 4, 5],
+                  savedObjectId: 'timeline-1', // match timelineId in mocked notes data
+                  pinnedEventIds: { '1': true },
+                },
+              },
+            },
+          };
+
+          render(
+            <TestProviders
+              store={createMockStore({
+                ...structuredClone(mockStateWithNoteInTimeline),
+              })}
+            >
+              <TestComponent {...props} />
+            </TestProviders>
+          );
+
+          expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+          expect(screen.getByTestId('pagination-button-previous')).toBeVisible();
+
+          expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'true');
+          expect(screen.getByTestId('tablePaginationPopoverButton')).toHaveTextContent(
+            'Rows per page: 1'
+          );
+          fireEvent.click(screen.getByTestId('tablePaginationPopoverButton'));
+
+          await waitFor(() => {
+            expect(screen.getByTestId('tablePagination-2-rows')).toBeVisible();
+          });
+
+          fetchNotesMock.mockClear();
+          fireEvent.click(screen.getByTestId('tablePagination-2-rows'));
+
+          await waitFor(() => {
+            expect(fetchNotesMock).toHaveBeenNthCalledWith(1, [
+              mockTimelineData[0]._id,
+              mockTimelineData[1]._id,
+            ]);
+          });
+        },
+        SPECIAL_TEST_TIMEOUT
+      );
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -7,7 +7,7 @@
 
 import { EuiFlexGroup } from '@elastic/eui';
 import { isEmpty } from 'lodash/fp';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ConnectedProps } from 'react-redux';
 import { connect, useDispatch } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
@@ -17,6 +17,7 @@ import type { EuiDataGridControlColumn } from '@elastic/eui';
 import { DataLoadingState } from '@kbn/unified-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import { useFetchNotes } from '../../../../../notes/hooks/use_fetch_notes';
 import { InputsModelId } from '../../../../../common/store/inputs/constants';
 import { useKibana } from '../../../../../common/lib/kibana';
 import {
@@ -64,6 +65,13 @@ export const EqlTabContentComponent: React.FC<Props> = ({
   pinnedEventIds,
   eventIdToNoteIds,
 }) => {
+  /*
+   * Needs to be maintained for each table in each tab independently
+   * and consequently it cannot be the part of common redux state
+   * of the timeline.
+   *
+   */
+  const [pageIndex, setPageIndex] = useState(0);
   const { telemetry } = useKibana().services;
   const dispatch = useDispatch();
   const { query: eqlQuery = '', ...restEqlOption } = eqlOptions;
@@ -97,24 +105,42 @@ export const EqlTabContentComponent: React.FC<Props> = ({
     [end, isBlankTimeline, loadingSourcerer, start]
   );
 
-  const [
-    dataLoadingState,
-    { events, inspect, totalCount, pageInfo, loadPage, refreshedAt, refetch },
-  ] = useTimelineEvents({
-    dataViewId,
-    endDate: end,
-    eqlOptions: restEqlOption,
-    fields: timelineQueryFieldsFromColumns,
-    filterQuery: eqlQuery ?? '',
-    id: timelineId,
-    indexNames: selectedPatterns,
-    language: 'eql',
-    limit: sampleSize,
-    runtimeMappings: sourcererDataView?.runtimeFieldMap as RunTimeMappings,
-    skip: !canQueryTimeline(),
-    startDate: start,
-    timerangeKind,
-  });
+  const [dataLoadingState, { events, inspect, totalCount, loadPage, refreshedAt, refetch }] =
+    useTimelineEvents({
+      dataViewId,
+      endDate: end,
+      eqlOptions: restEqlOption,
+      fields: timelineQueryFieldsFromColumns,
+      filterQuery: eqlQuery ?? '',
+      id: timelineId,
+      indexNames: selectedPatterns,
+      language: 'eql',
+      limit: sampleSize,
+      runtimeMappings: sourcererDataView.runtimeFieldMap as RunTimeMappings,
+      skip: !canQueryTimeline(),
+      startDate: start,
+      timerangeKind,
+    });
+
+  const { onLoad: loadNotesOnEventsLoad } = useFetchNotes();
+
+  useEffect(() => {
+    // This useEffect loads the notes only for the events on the current
+    // page.
+    const eventsOnCurrentPage = events.slice(
+      itemsPerPage * pageIndex,
+      itemsPerPage * (pageIndex + 1)
+    );
+
+    loadNotesOnEventsLoad(eventsOnCurrentPage);
+  }, [events, pageIndex, itemsPerPage, loadNotesOnEventsLoad]);
+
+  /**
+   *
+   * Triggers on Datagrid page change
+   *
+   */
+  const onUpdatePageIndex = useCallback((newPageIndex: number) => setPageIndex(newPageIndex), []);
 
   const { openFlyout } = useExpandableFlyoutApi();
   const securitySolutionNotesDisabled = useIsExperimentalFeatureEnabled(
@@ -272,12 +298,12 @@ export const EqlTabContentComponent: React.FC<Props> = ({
           refetch={refetch}
           dataLoadingState={dataLoadingState}
           totalCount={isBlankTimeline ? 0 : totalCount}
-          onChangePage={loadPage}
+          onFetchMoreRecords={loadPage}
           activeTab={activeTab}
           updatedAt={refreshedAt}
           isTextBasedQuery={false}
-          pageInfo={pageInfo}
           leadingControlColumns={leadingControlColumns as EuiDataGridControlColumn[]}
+          onUpdatePageIndex={onUpdatePageIndex}
         />
       </FullWidthFlexGroup>
     </>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.tsx
@@ -116,7 +116,7 @@ export const EqlTabContentComponent: React.FC<Props> = ({
       indexNames: selectedPatterns,
       language: 'eql',
       limit: sampleSize,
-      runtimeMappings: sourcererDataView.runtimeFieldMap as RunTimeMappings,
+      runtimeMappings: sourcererDataView?.runtimeFieldMap as RunTimeMappings,
       skip: !canQueryTimeline(),
       startDate: start,
       timerangeKind,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -6,13 +6,14 @@
  */
 
 import { isEmpty } from 'lodash/fp';
-import React, { useMemo, useCallback, memo } from 'react';
+import React, { useMemo, useCallback, memo, useState, useEffect } from 'react';
 import type { ConnectedProps } from 'react-redux';
 import { connect } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
 import type { EuiDataGridControlColumn } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import { useFetchNotes } from '../../../../../notes/hooks/use_fetch_notes';
 import {
   DocumentDetailsLeftPanelKey,
   DocumentDetailsRightPanelKey,
@@ -67,6 +68,14 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
   sort,
   eventIdToNoteIds,
 }) => {
+  /*
+   * Needs to be maintained for each table in each tab independently
+   * and consequently it cannot be the part of common redux state
+   * of the timeline.
+   *
+   */
+  const [pageIndex, setPageIndex] = useState(0);
+
   const { telemetry } = useKibana().services;
   const { dataViewId, sourcererDataView, selectedPatterns } = useSourcererDataView(
     SourcererScopeName.timeline
@@ -129,7 +138,7 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
   );
   const { augmentedColumnHeaders } = useTimelineColumns(columns);
 
-  const [queryLoadingState, { events, totalCount, pageInfo, loadPage, refreshedAt, refetch }] =
+  const [queryLoadingState, { events, totalCount, loadPage, refreshedAt, refetch }] =
     useTimelineEvents({
       endDate: '',
       id: `pinned-${timelineId}`,
@@ -144,6 +153,26 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
       sort: timelineQuerySortField,
       timerangeKind: undefined,
     });
+
+  const { onLoad: loadNotesOnEventsLoad } = useFetchNotes();
+
+  useEffect(() => {
+    // This useEffect loads the notes only for the events on the current
+    // page.
+    const eventsOnCurrentPage = events.slice(
+      itemsPerPage * pageIndex,
+      itemsPerPage * (pageIndex + 1)
+    );
+
+    loadNotesOnEventsLoad(eventsOnCurrentPage);
+  }, [events, pageIndex, itemsPerPage, loadNotesOnEventsLoad]);
+
+  /**
+   *
+   * Triggers on Datagrid page change
+   *
+   */
+  const onUpdatePageIndex = useCallback((newPageIndex: number) => setPageIndex(newPageIndex), []);
 
   const { openFlyout } = useExpandableFlyoutApi();
   const securitySolutionNotesDisabled = useIsExperimentalFeatureEnabled(
@@ -256,13 +285,13 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
         refetch={refetch}
         dataLoadingState={queryLoadingState}
         totalCount={totalCount}
-        onChangePage={loadPage}
+        onFetchMoreRecords={loadPage}
         activeTab={TimelineTabs.pinned}
         updatedAt={refreshedAt}
         isTextBasedQuery={false}
-        pageInfo={pageInfo}
         leadingControlColumns={leadingControlColumns as EuiDataGridControlColumn[]}
         trailingControlColumns={rowDetailColumn}
+        onUpdatePageIndex={onUpdatePageIndex}
       />
     </>
   );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
@@ -39,6 +39,7 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { createExpandableFlyoutApiMock } from '../../../../../common/mock/expandable_flyout';
 import { OPEN_FLYOUT_BUTTON_TEST_ID } from '../../../../../notes/components/test_ids';
 import { userEvent } from '@testing-library/user-event';
+import * as notesApi from '../../../../../notes/api/api';
 
 jest.mock('../../../../../common/components/user_privileges');
 
@@ -156,7 +157,9 @@ const { storage: storageMock } = createSecuritySolutionStorageMock();
 let useTimelineEventsMock = jest.fn();
 
 describe('query tab with unified timeline', () => {
+  const fetchNotesMock = jest.spyOn(notesApi, 'fetchNotesByDocumentIds');
   beforeAll(() => {
+    fetchNotesMock.mockImplementation(jest.fn());
     jest.mocked(useExpandableFlyoutApi).mockImplementation(() => ({
       ...createExpandableFlyoutApiMock(),
       openFlyout: mockOpenFlyout,
@@ -178,6 +181,7 @@ describe('query tab with unified timeline', () => {
   afterEach(() => {
     jest.clearAllMocks();
     storageMock.clear();
+    fetchNotesMock.mockClear();
     cleanup();
     localStorage.clear();
   });
@@ -423,6 +427,130 @@ describe('query tab with unified timeline', () => {
         });
         fireEvent.click(screen.getByTestId('dscGridSampleSizeFetchMoreLink'));
         expect(loadPageMock).toHaveBeenNthCalledWith(1, 1);
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
+
+    it(
+      'should load notes for current page only',
+      async () => {
+        const mockStateWithNoteInTimeline = {
+          ...mockGlobalState,
+          timeline: {
+            ...mockGlobalState.timeline,
+            timelineById: {
+              [TimelineId.test]: {
+                ...mockGlobalState.timeline.timelineById[TimelineId.test],
+                /* 1 record for each page */
+                itemsPerPage: 1,
+                pageIndex: 0,
+                itemsPerPageOptions: [1, 2, 3, 4, 5],
+                savedObjectId: 'timeline-1', // match timelineId in mocked notes data
+                pinnedEventIds: { '1': true },
+              },
+            },
+          },
+        };
+
+        render(
+          <TestProviders
+            store={createMockStore({
+              ...structuredClone(mockStateWithNoteInTimeline),
+            })}
+          >
+            <TestComponent />
+          </TestProviders>
+        );
+
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        expect(screen.getByTestId('pagination-button-previous')).toBeVisible();
+
+        expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'true');
+        expect(fetchNotesMock).toHaveBeenCalledWith(['1']);
+
+        // Page : 2
+
+        fetchNotesMock.mockClear();
+        expect(screen.getByTestId('pagination-button-1')).toBeVisible();
+
+        fireEvent.click(screen.getByTestId('pagination-button-1'));
+
+        await waitFor(() => {
+          expect(screen.getByTestId('pagination-button-1')).toHaveAttribute('aria-current', 'true');
+
+          expect(fetchNotesMock).toHaveBeenNthCalledWith(1, [mockTimelineData[1]._id]);
+        });
+
+        // Page : 3
+
+        fetchNotesMock.mockClear();
+        expect(screen.getByTestId('pagination-button-2')).toBeVisible();
+        fireEvent.click(screen.getByTestId('pagination-button-2'));
+
+        await waitFor(() => {
+          expect(screen.getByTestId('pagination-button-2')).toHaveAttribute('aria-current', 'true');
+
+          expect(fetchNotesMock).toHaveBeenNthCalledWith(1, [mockTimelineData[2]._id]);
+        });
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
+
+    it(
+      'should load notes for correct page size',
+      async () => {
+        const mockStateWithNoteInTimeline = {
+          ...mockGlobalState,
+          timeline: {
+            ...mockGlobalState.timeline,
+            timelineById: {
+              [TimelineId.test]: {
+                ...mockGlobalState.timeline.timelineById[TimelineId.test],
+                /* 1 record for each page */
+                itemsPerPage: 1,
+                pageIndex: 0,
+                itemsPerPageOptions: [1, 2, 3, 4, 5],
+                savedObjectId: 'timeline-1', // match timelineId in mocked notes data
+                pinnedEventIds: { '1': true },
+              },
+            },
+          },
+        };
+
+        render(
+          <TestProviders
+            store={createMockStore({
+              ...structuredClone(mockStateWithNoteInTimeline),
+            })}
+          >
+            <TestComponent />
+          </TestProviders>
+        );
+
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+
+        expect(screen.getByTestId('pagination-button-previous')).toBeVisible();
+
+        expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'true');
+        expect(screen.getByTestId('tablePaginationPopoverButton')).toHaveTextContent(
+          'Rows per page: 1'
+        );
+        fireEvent.click(screen.getByTestId('tablePaginationPopoverButton'));
+
+        await waitFor(() => {
+          expect(screen.getByTestId('tablePagination-2-rows')).toBeVisible();
+        });
+
+        fetchNotesMock.mockClear();
+        fireEvent.click(screen.getByTestId('tablePagination-2-rows'));
+
+        await waitFor(() => {
+          expect(fetchNotesMock).toHaveBeenNthCalledWith(1, [
+            mockTimelineData[0]._id,
+            mockTimelineData[1]._id,
+          ]);
+        });
       },
       SPECIAL_TEST_TIMEOUT
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { isEmpty } from 'lodash/fp';
-import React, { useMemo, useEffect, useCallback } from 'react';
+import React, { useMemo, useEffect, useCallback, useState } from 'react';
 import type { ConnectedProps } from 'react-redux';
 import { connect, useDispatch } from 'react-redux';
 import deepEqual from 'fast-deep-equal';
@@ -15,6 +15,7 @@ import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { DataLoadingState } from '@kbn/unified-data-table';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import { useFetchNotes } from '../../../../../notes/hooks/use_fetch_notes';
 import {
   DocumentDetailsLeftPanelKey,
   DocumentDetailsRightPanelKey,
@@ -92,6 +93,13 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     selectedPatterns,
     sourcererDataView,
   } = useSourcererDataView(SourcererScopeName.timeline);
+  /*
+   * `pageIndex` needs to be maintained for each table in each tab independently
+   * and consequently it cannot be the part of common redux state
+   * of the timeline.
+   *
+   */
+  const [pageIndex, setPageIndex] = useState(0);
 
   const { uiSettings, telemetry, timelineDataService } = useKibana().services;
   const {
@@ -167,7 +175,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
 
   const [
     dataLoadingState,
-    { events, inspect, totalCount, pageInfo, loadPage, refreshedAt, refetch },
+    { events, inspect, totalCount, loadPage: loadNextEventBatch, refreshedAt, refetch },
   ] = useTimelineEvents({
     dataViewId,
     endDate: end,
@@ -183,6 +191,26 @@ export const QueryTabContentComponent: React.FC<Props> = ({
     startDate: start,
     timerangeKind,
   });
+
+  const { onLoad: loadNotesOnEventsLoad } = useFetchNotes();
+
+  useEffect(() => {
+    // This useEffect loads the notes only for the events on the current
+    // page.
+    const eventsOnCurrentPage = events.slice(
+      itemsPerPage * pageIndex,
+      itemsPerPage * (pageIndex + 1)
+    );
+
+    loadNotesOnEventsLoad(eventsOnCurrentPage);
+  }, [events, pageIndex, itemsPerPage, loadNotesOnEventsLoad]);
+
+  /**
+   *
+   * Triggers on Datagrid page change
+   *
+   */
+  const onUpdatePageIndex = useCallback((newPageIndex: number) => setPageIndex(newPageIndex), []);
 
   const { openFlyout } = useExpandableFlyoutApi();
   const securitySolutionNotesDisabled = useIsExperimentalFeatureEnabled(
@@ -364,11 +392,11 @@ export const QueryTabContentComponent: React.FC<Props> = ({
         dataLoadingState={dataLoadingState}
         totalCount={isBlankTimeline ? 0 : totalCount}
         leadingControlColumns={leadingControlColumns as EuiDataGridControlColumn[]}
-        onChangePage={loadPage}
+        onFetchMoreRecords={loadNextEventBatch}
         activeTab={activeTab}
         updatedAt={refreshedAt}
         isTextBasedQuery={false}
-        pageInfo={pageInfo}
+        onUpdatePageIndex={onUpdatePageIndex}
       />
     </>
   );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
@@ -72,7 +72,7 @@ const TestComponent = (props: TestComponentProps) => {
         refetch={refetchMock}
         dataLoadingState={DataLoadingState.loaded}
         totalCount={mockTimelineData.length}
-        onChangePage={onChangePageMock}
+        onFetchMoreRecords={onChangePageMock}
         updatedAt={Date.now()}
         onSetColumns={jest.fn()}
         onFilter={jest.fn()}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -30,7 +30,7 @@ import type { TimelineItem } from '../../../../../../common/search_strategy';
 import { useKibana } from '../../../../../common/lib/kibana';
 import type {
   ColumnHeaderOptions,
-  OnChangePage,
+  OnFetchMoreRecords,
   RowRenderer,
   TimelineTabs,
 } from '../../../../../../common/types/timeline';
@@ -63,7 +63,7 @@ type CommonDataTableProps = {
   refetch: inputsModel.Refetch;
   onFieldEdited: () => void;
   totalCount: number;
-  onChangePage: OnChangePage;
+  onFetchMoreRecords: OnFetchMoreRecords;
   activeTab: TimelineTabs;
   dataLoadingState: DataLoadingState;
   updatedAt: number;
@@ -78,6 +78,7 @@ type CommonDataTableProps = {
   | 'renderCustomGridBody'
   | 'trailingControlColumns'
   | 'isSortEnabled'
+  | 'onUpdatePageIndex'
 >;
 
 interface DataTableProps extends CommonDataTableProps {
@@ -101,13 +102,14 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
     refetch,
     dataLoadingState,
     totalCount,
-    onChangePage,
+    onFetchMoreRecords,
     updatedAt,
     isTextBasedQuery = false,
     onSetColumns,
     onSort,
     onFilter,
     leadingControlColumns,
+    onUpdatePageIndex,
   }) {
     const dispatch = useDispatch();
 
@@ -234,9 +236,9 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
     );
 
     const handleFetchMoreRecords = useCallback(() => {
-      onChangePage(fetchedPage + 1);
+      onFetchMoreRecords(fetchedPage + 1);
       setFechedPage(fetchedPage + 1);
-    }, [fetchedPage, onChangePage]);
+    }, [fetchedPage, onFetchMoreRecords]);
 
     const additionalControls = useMemo(
       () => <ToolbarAdditionalControls timelineId={timelineId} updatedAt={updatedAt} />,
@@ -423,6 +425,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
             renderCustomGridBody={finalRenderCustomBodyCallback}
             trailingControlColumns={finalTrailControlColumns}
             externalControlColumns={leadingControlColumns}
+            onUpdatePageIndex={onUpdatePageIndex}
           />
         </StyledTimelineUnifiedDataTable>
       </StatefulEventContext.Provider>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
@@ -111,10 +111,11 @@ const TestComponent = (
     events: localMockedTimelineData,
     refetch: jest.fn(),
     totalCount: localMockedTimelineData.length,
-    onChangePage: jest.fn(),
+    onFetchMoreRecords: jest.fn(),
     dataLoadingState: DataLoadingState.loaded,
     updatedAt: Date.now(),
     isTextBasedQuery: false,
+    onUpdatePageIndex: jest.fn(),
   };
 
   const dispatch = useDispatch();

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/index.tsx
@@ -12,7 +12,7 @@ import { useDispatch } from 'react-redux';
 import { generateFilters } from '@kbn/data-plugin/public';
 import type { DataView, DataViewField } from '@kbn/data-plugin/common';
 import type { SortOrder } from '@kbn/saved-search-plugin/public';
-import type { DataLoadingState } from '@kbn/unified-data-table';
+import type { DataLoadingState, UnifiedDataTableProps } from '@kbn/unified-data-table';
 import { useColumns } from '@kbn/unified-data-table';
 import { popularizeField } from '@kbn/unified-data-table/src/utils/popularize_field';
 import type { DropType } from '@kbn/dom-drag-drop';
@@ -34,7 +34,7 @@ import { useKibana } from '../../../../common/lib/kibana';
 import { defaultHeaders } from '../body/column_headers/default_headers';
 import type {
   ColumnHeaderOptions,
-  OnChangePage,
+  OnFetchMoreRecords,
   RowRenderer,
   SortColumnTimeline,
   TimelineTabs,
@@ -107,7 +107,7 @@ interface Props {
   events: TimelineItem[];
   refetch: inputsModel.Refetch;
   totalCount: number;
-  onChangePage: OnChangePage;
+  onFetchMoreRecords: OnFetchMoreRecords;
   activeTab: TimelineTabs;
   dataLoadingState: DataLoadingState;
   updatedAt: number;
@@ -115,6 +115,7 @@ interface Props {
   dataView: DataView;
   trailingControlColumns?: EuiDataGridProps['trailingControlColumns'];
   leadingControlColumns?: EuiDataGridProps['leadingControlColumns'];
+  onUpdatePageIndex?: UnifiedDataTableProps['onUpdatePageIndex'];
 }
 
 const UnifiedTimelineComponent: React.FC<Props> = ({
@@ -130,12 +131,13 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
   refetch,
   dataLoadingState,
   totalCount,
-  onChangePage,
+  onFetchMoreRecords,
   updatedAt,
   isTextBasedQuery,
   dataView,
   trailingControlColumns,
   leadingControlColumns,
+  onUpdatePageIndex,
 }) => {
   const dispatch = useDispatch();
   const unifiedFieldListContainerRef = useRef<UnifiedFieldListSidebarContainerApi>(null);
@@ -436,13 +438,14 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
                       onFieldEdited={onFieldEdited}
                       dataLoadingState={dataLoadingState}
                       totalCount={totalCount}
-                      onChangePage={onChangePage}
+                      onFetchMoreRecords={onFetchMoreRecords}
                       activeTab={activeTab}
                       updatedAt={updatedAt}
                       isTextBasedQuery={isTextBasedQuery}
                       onFilter={onAddFilter as DocViewFilterFn}
                       trailingControlColumns={trailingControlColumns}
                       leadingControlColumns={leadingControlColumns}
+                      onUpdatePageIndex={onUpdatePageIndex}
                     />
                   </EventDetailsWidthProvider>
                 </DropOverlayWrapper>

--- a/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/index.tsx
@@ -7,7 +7,7 @@
 
 import deepEqual from 'fast-deep-equal';
 import { isEmpty, noop } from 'lodash/fp';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { Subscription } from 'rxjs';
 
@@ -46,12 +46,21 @@ import type {
 } from '../../../common/search_strategy/timeline/events/eql';
 import { useTrackHttpRequest } from '../../common/lib/apm/use_track_http_request';
 import { APP_UI_ID } from '../../../common/constants';
-import { useFetchNotes } from '../../notes/hooks/use_fetch_notes';
 
 export interface TimelineArgs {
   events: TimelineItem[];
   id: string;
   inspect: InspectResponse;
+
+  /**
+   * `loadPage` loads the next page/batch of records.
+   * This is different from the data grid pages. Data grid pagination is only
+   * client side and changing data grid pages does not impact this function.
+   *
+   * When user manually requests next batch of records, then a next batch is fetched
+   * irrespective of where user is in Data grid pagination.
+   *
+   */
   loadPage: LoadPage;
   pageInfo: Pick<PaginationInputPaginated, 'activePage' | 'querySize'>;
   refetch: inputsModel.Refetch;
@@ -174,6 +183,15 @@ export const useTimelineEventsHandler = ({
     }
   }, [dispatch, id]);
 
+  /**
+   * `wrappedLoadPage` loads the next page/batch of records.
+   * This is different from the data grid pages. Data grid pagination is only
+   * client side and changing data grid pages does not impact this function.
+   *
+   * When user manually requests next batch of records, then a next batch is fetched
+   * irrespective of where user is in Data grid pagination.
+   *
+   */
   const wrappedLoadPage = useCallback(
     (newActivePage: number) => {
       clearSignalsState();
@@ -185,6 +203,12 @@ export const useTimelineEventsHandler = ({
     },
     [clearSignalsState, id]
   );
+
+  useEffect(() => {
+    return () => {
+      searchSubscription$.current?.unsubscribe();
+    };
+  }, []);
 
   const refetchGrid = useCallback(() => {
     if (refetch.current != null) {
@@ -240,10 +264,12 @@ export const useTimelineEventsHandler = ({
             next: (response) => {
               if (!isRunningResponse(response)) {
                 endTracking('success');
+
                 setLoading(DataLoadingState.loaded);
                 setTimelineResponse((prevResponse) => {
                   const newTimelineResponse = {
                     ...prevResponse,
+                    /**/
                     events: getTimelineEvents(response.edges),
                     inspect: getInspectResponse(response, prevResponse.inspect),
                     pageInfo: response.pageInfo,
@@ -269,6 +295,7 @@ export const useTimelineEventsHandler = ({
             },
             error: (msg) => {
               endTracking(abortCtrl.current.signal.aborted ? 'aborted' : 'error');
+
               setLoading(DataLoadingState.loaded);
               data.search.showError(msg);
               searchSubscription$.current.unsubscribe();
@@ -483,8 +510,8 @@ export const useTimelineEvents = ({
   sort = initSortDefault,
   skip = false,
   timerangeKind,
-  fetchNotes = true,
 }: UseTimelineEventsProps): [DataLoadingState, TimelineArgs] => {
+  const [eventsPerPage, setEventsPerPage] = useState<TimelineItem[][]>([[]]);
   const [dataLoadingState, timelineResponse, timelineSearchHandler] = useTimelineEventsHandler({
     dataViewId,
     endDate,
@@ -501,19 +528,35 @@ export const useTimelineEvents = ({
     skip,
     timerangeKind,
   });
-  const { onLoad } = useFetchNotes();
 
-  const onTimelineSearchComplete: OnNextResponseHandler = useCallback(
-    (response) => {
-      if (fetchNotes) onLoad(response.events);
-    },
-    [fetchNotes, onLoad]
-  );
+  useEffect(() => {
+    /*
+     * `timelineSearchHandler` only returns the events for the current page.
+     * This effect is responsible for storing the events for each page so that
+     * the combined list of events can be supplied to DataGrid.
+     *
+     * */
+    setEventsPerPage((prev) => {
+      const result = [...prev];
+      result[timelineResponse.pageInfo.activePage] = timelineResponse.events;
+      return result;
+    });
+  }, [timelineResponse.events, timelineResponse.pageInfo.activePage]);
 
   useEffect(() => {
     if (!timelineSearchHandler) return;
-    timelineSearchHandler(onTimelineSearchComplete);
-  }, [timelineSearchHandler, onTimelineSearchComplete]);
+    timelineSearchHandler();
+  }, [timelineSearchHandler]);
 
-  return [dataLoadingState, timelineResponse];
+  const combinedEvents = useMemo(() => eventsPerPage.flat(), [eventsPerPage]);
+
+  const combinedResponse = useMemo(
+    () => ({
+      ...timelineResponse,
+      events: combinedEvents,
+    }),
+    [timelineResponse, combinedEvents]
+  );
+
+  return [dataLoadingState, combinedResponse];
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Security Solution] Adds callback `onUpdatePageIndex` to get current `pageIndex` in Unified Data table (#201240)](https://github.com/elastic/kibana/pull/201240)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2024-11-29T15:14:27Z","message":"[Security Solution] Adds callback `onUpdatePageIndex` to get current `pageIndex` in Unified Data table (#201240)\n\n## Summary\n\nHandles resolution for\n- Notes fetching data for all Timeline Records which leads to\nperformance issues.\n- https://github.com/elastic/kibana/issues/201330 \n\n## Issue - Notes fetching data for all Timeline Records \n\nCurrently, there was no way for consumer of `UnifiedDataGrid` to get the\ncurrent `pageIndex`. Security Solution needs to get the current\n`pageIndex` so the items on the current page can be calculated.\n\n@elastic/kibana-data-discovery , please let us know if you have any\nopinion here.\n\nThis results in notes being fetched for all Timeline Records which means\nminimum of 500 records and if user has queries 5000 records ( for\nexample ), a request will be made to query notes for all those 5000\nnotes which leads to performance issue and sometimes error as shown\nbelow:\n\n\n![image](https://github.com/user-attachments/assets/6fcfe05d-340c-4dcb-a273-5af53ed12945)\n\n\n## 👨‍💻 Changes\n\nThis adds attribute `pageIndex` to timeline state. \n\n```javascript\n{\n    \"pageIndex\": number\n}\n```\n`pageIndex` helps with getting the events for that particular page.\n\n## 🟡 Caveat\n\n- Currently this `pageIndex` is shared between Query and EQL tabs which\ncan lead to wonky behavior at time.\n- Additionally, as of now table maintains its own page index and\nconsumer component cannot effect the `pageIndex` of the UnifiedDataGrid.","sha":"de9d5465df5900936991d79306cb2cbbe63f4623","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:fix","v9.0.0","Team:Threat Hunting:Investigations","v8.16.2"],"number":201240,"url":"https://github.com/elastic/kibana/pull/201240","mergeCommit":{"message":"[Security Solution] Adds callback `onUpdatePageIndex` to get current `pageIndex` in Unified Data table (#201240)\n\n## Summary\n\nHandles resolution for\n- Notes fetching data for all Timeline Records which leads to\nperformance issues.\n- https://github.com/elastic/kibana/issues/201330 \n\n## Issue - Notes fetching data for all Timeline Records \n\nCurrently, there was no way for consumer of `UnifiedDataGrid` to get the\ncurrent `pageIndex`. Security Solution needs to get the current\n`pageIndex` so the items on the current page can be calculated.\n\n@elastic/kibana-data-discovery , please let us know if you have any\nopinion here.\n\nThis results in notes being fetched for all Timeline Records which means\nminimum of 500 records and if user has queries 5000 records ( for\nexample ), a request will be made to query notes for all those 5000\nnotes which leads to performance issue and sometimes error as shown\nbelow:\n\n\n![image](https://github.com/user-attachments/assets/6fcfe05d-340c-4dcb-a273-5af53ed12945)\n\n\n## 👨‍💻 Changes\n\nThis adds attribute `pageIndex` to timeline state. \n\n```javascript\n{\n    \"pageIndex\": number\n}\n```\n`pageIndex` helps with getting the events for that particular page.\n\n## 🟡 Caveat\n\n- Currently this `pageIndex` is shared between Query and EQL tabs which\ncan lead to wonky behavior at time.\n- Additionally, as of now table maintains its own page index and\nconsumer component cannot effect the `pageIndex` of the UnifiedDataGrid.","sha":"de9d5465df5900936991d79306cb2cbbe63f4623"}},"sourceBranch":"main","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/201240","number":201240,"mergeCommit":{"message":"[Security Solution] Adds callback `onUpdatePageIndex` to get current `pageIndex` in Unified Data table (#201240)\n\n## Summary\n\nHandles resolution for\n- Notes fetching data for all Timeline Records which leads to\nperformance issues.\n- https://github.com/elastic/kibana/issues/201330 \n\n## Issue - Notes fetching data for all Timeline Records \n\nCurrently, there was no way for consumer of `UnifiedDataGrid` to get the\ncurrent `pageIndex`. Security Solution needs to get the current\n`pageIndex` so the items on the current page can be calculated.\n\n@elastic/kibana-data-discovery , please let us know if you have any\nopinion here.\n\nThis results in notes being fetched for all Timeline Records which means\nminimum of 500 records and if user has queries 5000 records ( for\nexample ), a request will be made to query notes for all those 5000\nnotes which leads to performance issue and sometimes error as shown\nbelow:\n\n\n![image](https://github.com/user-attachments/assets/6fcfe05d-340c-4dcb-a273-5af53ed12945)\n\n\n## 👨‍💻 Changes\n\nThis adds attribute `pageIndex` to timeline state. \n\n```javascript\n{\n    \"pageIndex\": number\n}\n```\n`pageIndex` helps with getting the events for that particular page.\n\n## 🟡 Caveat\n\n- Currently this `pageIndex` is shared between Query and EQL tabs which\ncan lead to wonky behavior at time.\n- Additionally, as of now table maintains its own page index and\nconsumer component cannot effect the `pageIndex` of the UnifiedDataGrid.","sha":"de9d5465df5900936991d79306cb2cbbe63f4623"}},{"branch":"8.16","label":"v8.16.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->