### PR TITLE
[Dataset Quality][Observability Onboarding] Update axios headers

### DIFF
--- a/x-pack/plugins/observability_solution/dataset_quality/server/test_helpers/create_dataset_quality_users/helpers/call_kibana.ts
+++ b/x-pack/plugins/observability_solution/dataset_quality/server/test_helpers/create_dataset_quality_users/helpers/call_kibana.ts
@@ -24,14 +24,18 @@ export async function callKibana<T>({
     ...options,
     baseURL: baseUrl,
     auth: { username, password },
-    headers: { 'kbn-xsrf': 'true', ...options.headers },
+    headers: { 'kbn-xsrf': 'true', 'x-elastic-internal-origin': 'kibana', ...options.headers },
   });
   return data;
 }
 
 const getBaseUrl = once(async (kibanaHostname: string) => {
   try {
-    await axios.request({ url: kibanaHostname, maxRedirects: 0 });
+    await axios.request({
+      url: kibanaHostname,
+      maxRedirects: 0,
+      headers: { 'x-elastic-internal-origin': 'kibana' },
+    });
   } catch (e) {
     if (isAxiosError(e)) {
       const location = e.response?.headers?.location ?? '';

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/test_helpers/create_observability_onboarding_users/helpers/call_kibana.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/test_helpers/create_observability_onboarding_users/helpers/call_kibana.ts
@@ -24,14 +24,18 @@ export async function callKibana<T>({
     ...options,
     baseURL: baseUrl,
     auth: { username, password },
-    headers: { 'kbn-xsrf': 'true', ...options.headers },
+    headers: { 'kbn-xsrf': 'true', 'x-elastic-internal-origin': 'kibana', ...options.headers },
   });
   return data;
 }
 
 const getBaseUrl = once(async (kibanaHostname: string) => {
   try {
-    await axios.request({ url: kibanaHostname, maxRedirects: 0 });
+    await axios.request({
+      url: kibanaHostname,
+      maxRedirects: 0,
+      headers: { 'x-elastic-internal-origin': 'kibana' },
+    });
   } catch (e) {
     if (isAxiosError(e)) {
       const location = e.response?.headers?.location ?? '';


### PR DESCRIPTION
## 📓 Summary

To ensure Kibana features/tests don't break after the update to v9.0.0, we need to provide the `'x-elastic-internal-origin': 'kibana'` header is set on API providers that are not the internal core HTTP service.

These changes fix a couple of utilities using the axios library for testing purpose.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->