### PR TITLE
[Infra] Fix Actions on Charts

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/components/lens/lens_chart.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/lens/lens_chart.tsx
@@ -25,6 +25,12 @@ import { ChartLoadError } from './chart_load_error';
 import { HOST_MISSING_FIELDS } from '../../common/visualizations/constants';
 
 const MIN_HEIGHT = 300;
+const DEFAULT_DISABLED_ACTIONS = [
+  'ACTION_CUSTOMIZE_PANEL',
+  'ACTION_EXPORT_CSV',
+  'embeddable_addToExistingCase',
+  'create-ml-ad-job-action',
+];
 
 export type LensChartProps = BaseChartProps &
   Pick<EuiPanelProps, 'borderRadius'> & {
@@ -33,6 +39,8 @@ export type LensChartProps = BaseChartProps &
     description?: string;
   } & {
     lensAttributes: UseLensAttributesParams;
+    withDefaultActions?: boolean;
+    disabledActions?: string[];
   };
 
 export const LensChart = React.memo(
@@ -52,6 +60,8 @@ export const LensChart = React.memo(
     height = MIN_HEIGHT,
     loading = false,
     lensAttributes,
+    withDefaultActions = true,
+    disabledActions = DEFAULT_DISABLED_ACTIONS,
   }: LensChartProps) => {
     const { formula, attributes, getExtraActions, error } = useLensAttributes(lensAttributes);
 
@@ -122,6 +132,8 @@ export const LensChart = React.memo(
         dateRange={dateRange}
         disableTriggers={disableTriggers}
         extraActions={extraActions}
+        withDefaultActions={withDefaultActions}
+        disabledActions={disabledActions}
         filters={filters}
         hidePanelTitles={hidePanelTitles}
         loading={isLoading}

--- a/x-pack/plugins/observability_solution/infra/public/components/lens/lens_wrapper.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/components/lens/lens_wrapper.tsx
@@ -93,7 +93,6 @@ export const LensWrapper = ({
     <div
       css={css`
         position: relative;
-        overflow: hidden;
         height: 100%;
         .echMetric {
           border-radius: ${euiTheme.border.radius.medium};


### PR DESCRIPTION
## Summary

Closes #201535 

This PR fixes the actions not displayed on Infra charts while hovering with the mouse, while also modifying the actions that should be displayed.

Right now, the following actions are displayed:
- Explore in Discover
- Inspect
- Open in Lens (as a custom action, clicking the 3 dots)

### How to test
1. Start Kibana and fill it with data, `node scripts/synthtrace infra_hosts_with_apm_hosts` can be used if you don't have data.
2. Navigate to Host list, check if hovering a chart displays the actions
3. Navigate to Host details, check if hovering a chart displays the actions


### Screenshots
Before|After
-|-
![image](https://github.com/user-attachments/assets/489b00e0-9702-4ac2-a55e-cc1e1e733783)|![image](https://github.com/user-attachments/assets/fa37a6ba-9074-403f-ad10-1b6b58e3f64a)




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->