### PR TITLE
[Stack Connectors][SentinelOne] Fix SentinelOne API response schema to allow `null` for `rangerVersion`

### DIFF
--- a/x-pack/plugins/stack_connectors/common/sentinelone/schema.ts
+++ b/x-pack/plugins/stack_connectors/common/sentinelone/schema.ts
@@ -117,7 +117,7 @@ export const SentinelOneGetAgentsResponseSchema = schema.object(
             { unknowns: 'allow' }
           ),
           isDecommissioned: schema.boolean(),
-          rangerVersion: schema.string(),
+          rangerVersion: schema.nullable(schema.string()),
           userActionsNeeded: schema.arrayOf(
             schema.object(
               {


### PR DESCRIPTION
## Summary

- Adjusts the SentinelOne API response schema for `getAgent()` sub-action so that `rangerVersion` can also be `null`




