### PR TITLE
Replace `style` with `css` in CSP plugin

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/chart_panel.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/chart_panel.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { ReactNode, FC, PropsWithChildren } from 'react';
+import type { Interpolation, Theme } from '@emotion/react';
 import {
   EuiPanel,
   EuiText,
@@ -24,6 +25,7 @@ interface ChartPanelProps {
   isError?: boolean;
   rightSideItems?: ReactNode[];
   styles?: React.CSSProperties;
+  css?: Interpolation<Theme>;
   children: React.ReactNode;
 }
 
@@ -57,6 +59,7 @@ export const ChartPanel: FC<PropsWithChildren<ChartPanelProps>> = ({
   children,
   rightSideItems,
   styles,
+  css,
 }) => {
   const { euiTheme } = useEuiTheme();
   const renderChart = () => {
@@ -66,23 +69,29 @@ export const ChartPanel: FC<PropsWithChildren<ChartPanelProps>> = ({
   };
 
   return (
-    <EuiPanel hasBorder={hasBorder} hasShadow={false} style={styles} data-test-subj="chart-panel">
-      <EuiFlexGroup direction="column" gutterSize="m" style={{ height: '100%' }}>
+    <EuiPanel
+      hasBorder={hasBorder}
+      hasShadow={false}
+      style={styles}
+      css={css}
+      data-test-subj="chart-panel"
+    >
+      <EuiFlexGroup direction="column" gutterSize="m" css={{ height: '100%' }}>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup justifyContent={'spaceBetween'}>
-            <EuiFlexItem grow={false} style={{ justifyContent: 'center' }}>
+            <EuiFlexItem grow={false} css={{ justifyContent: 'center' }}>
               {title && (
                 <EuiTitle size="s">
-                  <h3 style={{ lineHeight: 'initial', paddingLeft: euiTheme.size.s }}>{title}</h3>
+                  <h3 css={{ lineHeight: 'initial', paddingLeft: euiTheme.size.s }}>{title}</h3>
                 </EuiTitle>
               )}
             </EuiFlexItem>
-            <EuiFlexItem grow={false} style={{ flexDirection: 'row', gap: euiTheme.size.s }}>
+            <EuiFlexItem grow={false} css={{ flexDirection: 'row', gap: euiTheme.size.s }}>
               {rightSideItems}
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
-        <EuiFlexItem style={{ height: '100%' }}>{renderChart()}</EuiFlexItem>
+        <EuiFlexItem css={{ height: '100%' }}>{renderChart()}</EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>
   );

--- a/x-pack/plugins/cloud_security_posture/public/components/csp_inline_description_list.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/csp_inline_description_list.tsx
@@ -60,7 +60,7 @@ export const CspInlineDescriptionList = ({
       data-test-subj={testId}
       type="inline"
       titleProps={{
-        style: {
+        css: {
           background: 'initial',
           color: euiTheme.colors.subduedText,
           fontSize,
@@ -69,7 +69,7 @@ export const CspInlineDescriptionList = ({
         },
       }}
       descriptionProps={{
-        style: {
+        css: {
           color: euiTheme.colors.subduedText,
           marginRight: euiTheme.size.xs,
           fontSize,

--- a/x-pack/plugins/cloud_security_posture/public/components/empty_states_illustration_container.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/empty_states_illustration_container.tsx
@@ -18,4 +18,4 @@ const SVG_WIDTH = 376;
  */
 export const EmptyStatesIllustrationContainer: React.FC<{ children: React.ReactNode }> = ({
   children,
-}) => <div style={{ height: SVG_HEIGHT, width: SVG_WIDTH }}>{children}</div>;
+}) => <div css={{ height: SVG_HEIGHT, width: SVG_WIDTH }}>{children}</div>;

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/csp_boxed_radio_group.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/csp_boxed_radio_group.tsx
@@ -57,7 +57,7 @@ export const RadioGroup = ({
             key={option.id}
             content={option.tooltip}
             anchorProps={{
-              style: {
+              css: {
                 flex: '1 1 0',
               },
             }}
@@ -75,7 +75,7 @@ export const RadioGroup = ({
               iconType={option.icon}
               iconSide="right"
               contentProps={{
-                style: {
+                css: {
                   justifyContent: 'flex-start',
                 },
               }}

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/csp_boxed_radio_group.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/csp_boxed_radio_group.tsx
@@ -65,9 +65,8 @@ export const RadioGroup = ({
             <EuiButton
               disabled={option.disabled || disabled}
               style={{
-                border: `1px solid ${
-                  isChecked ? euiTheme.colors.primary : euiTheme.colors.lightShade
-                }`,
+                borderColor: isChecked ? euiTheme.colors.primary : euiTheme.colors.lightShade,
+                height: size === 's' ? euiTheme.size.xxl : euiTheme.size.xxxl,
               }}
               // Use empty string to fallback to no color
               // @ts-ignore
@@ -81,8 +80,8 @@ export const RadioGroup = ({
                 },
               }}
               css={css`
+                border: 1px solid;
                 width: 100%;
-                height: ${size === 's' ? euiTheme.size.xxl : euiTheme.size.xxxl};
                 svg,
                 img {
                   margin-left: auto;

--- a/x-pack/plugins/cloud_security_posture/public/components/no_findings_states/no_findings_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_findings_states/no_findings_states.tsx
@@ -190,7 +190,7 @@ const EmptySecurityFindingsPrompt = () => {
     <EuiFlexGroup>
       <EuiFlexItem>
         <EuiEmptyPrompt
-          style={{ padding: euiTheme.size.l }}
+          css={{ padding: euiTheme.size.l }}
           data-test-subj={PACKAGE_NOT_INSTALLED_TEST_SUBJECT}
           icon={
             <EmptyStatesIllustrationContainer>
@@ -266,7 +266,7 @@ const EmptySecurityFindingsPrompt = () => {
       {is3PSupportedPage && (
         <EuiFlexItem>
           <EuiEmptyPrompt
-            style={{ padding: euiTheme.size.l }}
+            css={{ padding: euiTheme.size.l }}
             data-test-subj={THIRD_PARTY_INTEGRATIONS_NO_MISCONFIGURATIONS_FINDINGS_PROMPT}
             icon={
               <EmptyStatesIllustrationContainer>

--- a/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
@@ -83,7 +83,7 @@ const CnvmIntegrationNotInstalledEmptyPrompt = ({
     <EuiFlexGroup>
       <EuiFlexItem>
         <EuiEmptyPrompt
-          style={{ padding: euiTheme.size.l }}
+          css={{ padding: euiTheme.size.l }}
           data-test-subj={NO_VULNERABILITIES_STATUS_TEST_SUBJ.NOT_INSTALLED}
           icon={
             <EmptyStatesIllustrationContainer>
@@ -146,7 +146,7 @@ const CnvmIntegrationNotInstalledEmptyPrompt = ({
       {is3PSupportedPage && (
         <EuiFlexItem>
           <EuiEmptyPrompt
-            style={{ padding: euiTheme.size.l }}
+            css={{ padding: euiTheme.size.l }}
             data-test-subj={THIRD_PARTY_INTEGRATIONS_NO_VULNERABILITIES_FINDINGS_PROMPT}
             icon={
               <EmptyStatesIllustrationContainer>

--- a/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks.tsx
@@ -104,7 +104,7 @@ const TotalIntegrationsCount = ({
   pageCount,
   totalCount,
 }: Record<'pageCount' | 'totalCount', number>) => (
-  <EuiText size="xs" style={{ marginLeft: 8 }}>
+  <EuiText size="xs" css={{ marginLeft: 8 }}>
     <EuiTextColor color="subdued">
       <FormattedMessage
         id="xpack.csp.benchmarks.totalIntegrationsCountMessage"
@@ -125,7 +125,7 @@ const BenchmarkSearchField = ({
 
   return (
     <EuiFlexGroup>
-      <EuiFlexItem grow={true} style={{ alignItems: 'flex-end' }}>
+      <EuiFlexItem grow={true} css={{ alignItems: 'flex-end' }}>
         <EuiFieldSearch
           fullWidth
           onSearch={setLocalValue}

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/compliance_score_chart.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_charts/compliance_score_chart.tsx
@@ -65,7 +65,7 @@ const CounterButtonLink = ({
     <>
       <EuiText
         size="s"
-        style={{
+        css={{
           fontWeight: euiTheme.font.weight.bold,
           marginBottom: euiTheme.size.xs,
         }}
@@ -87,12 +87,14 @@ const CounterButtonLink = ({
         <EuiText
           color={color}
           css={css`
+            font-weight: ${euiTheme.font.weight.medium};
+            font-size: 18px;
+
             &:hover {
               border-bottom: 2px solid ${color};
               padding-bottom: 4px;
             }
           `}
-          style={{ fontWeight: euiTheme.font.weight.medium, fontSize: '18px' }}
           size="s"
         >
           <CompactFormattedNumber number={count} abbreviateAbove={999} />
@@ -146,7 +148,7 @@ const PercentageLabels = ({
   const borderLeftStyles = { borderLeft: euiTheme.border.thin, paddingLeft: euiTheme.size.m };
   return (
     <EuiFlexGroup gutterSize="l" justifyContent="spaceBetween">
-      <EuiFlexItem grow={false} style={borderLeftStyles}>
+      <EuiFlexItem grow={false} css={borderLeftStyles}>
         <CounterButtonLink
           text="Passed Findings"
           count={stats.totalPassed}
@@ -155,7 +157,7 @@ const PercentageLabels = ({
           onClick={() => onEvalCounterClick(RULE_PASSED)}
         />
       </EuiFlexItem>
-      <EuiFlexItem grow={false} style={borderLeftStyles}>
+      <EuiFlexItem grow={false} css={borderLeftStyles}>
         <CounterButtonLink
           text="Failed Findings"
           count={stats.totalFailed}
@@ -268,7 +270,7 @@ const CounterLink = ({
         onClick={onClick}
         css={{ display: 'flex' }}
       >
-        <EuiText color={color} style={{ fontWeight: euiTheme.font.weight.medium }} size="s">
+        <EuiText color={color} css={{ fontWeight: euiTheme.font.weight.medium }} size="s">
           <CompactFormattedNumber number={count} abbreviateAbove={999} />
           &nbsp;
         </EuiText>
@@ -290,7 +292,7 @@ export const ComplianceScoreChart = ({
     <EuiFlexGroup
       direction="column"
       justifyContent="spaceBetween"
-      style={{ height: '100%' }}
+      css={{ height: '100%' }}
       gutterSize="none"
     >
       <EuiFlexItem grow={2}>
@@ -303,7 +305,7 @@ export const ComplianceScoreChart = ({
               justifyContent="flexEnd"
               gutterSize="none"
               alignItems="flexStart"
-              style={{ paddingRight: euiTheme.size.xl }}
+              css={{ paddingRight: euiTheme.size.xl }}
             >
               {compact ? (
                 <CompactPercentageLabels

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/compliance_dashboard.tsx
@@ -145,7 +145,7 @@ const IntegrationPostureDashboard = ({
     return (
       // height is calculated for the screen height minus the kibana header, page title, and tabs
       <div
-        style={{
+        css={{
           height: `calc(100vh - ${KIBANA_HEADERS_HEIGHT}px)`,
           display: 'flex',
           justifyContent: 'center',

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmark_details_box.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmark_details_box.tsx
@@ -182,7 +182,7 @@ export const BenchmarkDetailsBox = ({ benchmark }: { benchmark: BenchmarkData })
           <EuiText size="xs">{benchmarkInfo.assetType}</EuiText>
         </EuiLink>
       </EuiFlexItem>
-      <EuiFlexItem grow={false} style={{ justifyContent: 'flex-end' }}>
+      <EuiFlexItem grow={false} css={{ justifyContent: 'flex-end' }}>
         <EuiFlexGroup gutterSize="m" alignItems="center">
           <CISBenchmarkIcon type={benchmarkId} name={`${benchmarkName}`} />
           <EuiToolTip content={cisTooltip}>

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmarks_section.tsx
@@ -196,7 +196,7 @@ export const BenchmarksSection = ({
           </EuiFlexItem>
           <EuiFlexItem grow={dashboardColumnsGrow.third}>
             <div
-              style={{
+              css={{
                 paddingRight: euiTheme.size.base,
               }}
             >

--- a/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
@@ -189,7 +189,7 @@ export const SummarySection = ({
       </EuiFlexItem>
       <EuiFlexItem grow={dashboardColumnsGrow.third}>
         <ChartPanel
-          styles={{
+          css={{
             padding: `${euiTheme.size.m} ${euiTheme.size.m} ${euiTheme.size.s} ${euiTheme.size.m}`,
           }}
           title={i18n.translate(

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/findings_flyout.tsx
@@ -212,14 +212,14 @@ export const MissingFieldsCallout = ({
 
   return (
     <EuiCallOut
-      style={{
+      css={{
         borderRadius: 4,
         overflow: 'hidden',
       }}
       size="s"
       iconType="iInCircle"
       title={
-        <span style={{ color: euiTheme.colors.text }}>
+        <span css={{ color: euiTheme.colors.text }}>
           <FormattedMessage
             id="xpack.csp.findings.findingsFlyout.calloutTitle"
             defaultMessage="Some fields not provided by {vendor}"
@@ -252,7 +252,7 @@ export const FindingsRuleFlyout = ({
           <EuiFlexItem grow={false}>
             <CspEvaluationBadge type={finding.result?.evaluation} />
           </EuiFlexItem>
-          <EuiFlexItem grow style={{ minWidth: 0 }}>
+          <EuiFlexItem grow css={{ minWidth: 0 }}>
             <EuiTitle size="m" className="eui-textTruncate">
               <EuiTextColor color="primary" title={finding.rule?.name}>
                 {finding.rule?.name}
@@ -287,7 +287,7 @@ export const FindingsRuleFlyout = ({
       </EuiFlyoutHeader>
       <EuiFlyoutBody key={tab.id}>
         {!isNativeCspFinding(finding) && ['overview', 'rule'].includes(tab.id) && (
-          <div style={{ marginBottom: euiThemeVars.euiSize }}>
+          <div css={{ marginBottom: euiThemeVars.euiSize }}>
             <MissingFieldsCallout finding={finding} />
           </div>
         )}

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/json_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/json_tab.tsx
@@ -11,7 +11,7 @@ import { XJsonLang } from '@kbn/monaco';
 import type { CspFinding } from '@kbn/cloud-security-posture-common';
 
 export const JsonTab = ({ data }: { data: CspFinding }) => (
-  <div style={{ position: 'absolute', inset: 0 }}>
+  <div css={{ position: 'absolute', inset: 0 }}>
     <CodeEditor
       isCopyable
       allowFullScreen

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/table_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/table_tab.tsx
@@ -66,7 +66,7 @@ const columns: EuiInMemoryTableProps<FlattenedItem>['columns'] = [
   {
     field: 'value',
     name: i18n.translate('xpack.csp.flyout.tableTab.fieldValueLabel', { defaultMessage: 'Value' }),
-    render: (value, record) => <div style={{ width: '100%' }}>{getDescriptionDisplay(value)}</div>,
+    render: (value, record) => <div css={{ width: '100%' }}>{getDescriptionDisplay(value)}</div>,
   },
 ];
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -33,7 +33,7 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
           <EuiFlexGroup direction="column" gutterSize="none">
             <EuiFlexItem css={{ width: 'fit-content' }}>
               <Link to={generatePath(cloudPosturePages.benchmarks.path)}>
-                <EuiButtonEmpty iconType="arrowLeft" contentProps={{ style: { padding: 0 } }}>
+                <EuiButtonEmpty iconType="arrowLeft" contentProps={{ css: { padding: 0 } }}>
                   <FormattedMessage
                     id="xpack.csp.rules.rulesPageHeader.benchmarkRulesButtonLabel"
                     defaultMessage="Benchmarks"

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/index.tsx
@@ -31,7 +31,7 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
         bottomBorder
         pageTitle={
           <EuiFlexGroup direction="column" gutterSize="none">
-            <EuiFlexItem style={{ width: 'fit-content' }}>
+            <EuiFlexItem css={{ width: 'fit-content' }}>
               <Link to={generatePath(cloudPosturePages.benchmarks.path)}>
                 <EuiButtonEmpty iconType="arrowLeft" contentProps={{ style: { padding: 0 } }}>
                   <FormattedMessage
@@ -43,7 +43,7 @@ export const Rules = ({ match: { params } }: RouteComponentProps<PageUrlParams>)
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiFlexGroup gutterSize="s">
-                <EuiFlexItem grow={false} style={{ marginBottom: 6 }}>
+                <EuiFlexItem grow={false} css={{ marginBottom: 6 }}>
                   <CISBenchmarkIcon type={params.benchmarkId} size={'l'} />
                 </EuiFlexItem>
                 <EuiFlexItem>

--- a/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/rules/rules_table_header.tsx
@@ -212,7 +212,7 @@ const SearchField = ({
 
   return (
     <div>
-      <EuiFlexItem grow={true} style={{ alignItems: 'flex-end' }}>
+      <EuiFlexItem grow={true} css={{ alignItems: 'flex-end' }}>
         <EuiFieldSearch
           isLoading={isSearching}
           placeholder={i18n.translate('xpack.csp.rules.rulesTable.searchPlaceholder', {
@@ -220,7 +220,7 @@ const SearchField = ({
           })}
           value={localValue}
           onChange={(e) => setLocalValue(e.target.value)}
-          style={{ minWidth: 150 }}
+          css={{ minWidth: 150 }}
           fullWidth
         />
       </EuiFlexItem>
@@ -309,7 +309,7 @@ const CurrentPageOfTotal = ({
       <EuiSpacer size="s" />
       <EuiFlexGroup gutterSize="s" alignItems={'center'}>
         <EuiFlexItem grow={false}>
-          <EuiText size="xs" textAlign="left" color="subdued" style={{ marginLeft: '8px' }}>
+          <EuiText size="xs" textAlign="left" color="subdued" css={{ marginLeft: '8px' }}>
             <FormattedMessage
               id="xpack.csp.rules.rulesTable.showingPageOfTotalLabel"
               defaultMessage="Showing {pageSize} of {total, plural, one {# rule} other {# rules}} {pipe} Selected {selectedRulesAmount, plural, one {# rule} other {# rules}}"
@@ -358,8 +358,8 @@ const CurrentPageOfTotal = ({
             anchorPosition="downLeft"
             panelPaddingSize="s"
           >
-            <EuiPopoverTitle style={{ minWidth: 240 }}>
-              <EuiText size="s" textAlign="left" color="subdued" style={{ marginLeft: '8px' }}>
+            <EuiPopoverTitle css={{ minWidth: 240 }}>
+              <EuiText size="s" textAlign="left" color="subdued" css={{ marginLeft: '8px' }}>
                 <b>
                   <FormattedMessage
                     id="xpack.csp.rules.rulesTable.bulkActionsOptionTitle"

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_finding_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_finding_flyout.tsx
@@ -235,7 +235,7 @@ export const VulnerabilityFindingFlyout = ({
           contentAriaLabel={LOADING_ARIA_LABEL}
         >
           {!isNativeCspFinding(vulnerabilityRecord) && selectedTabId === overviewTabId && (
-            <div style={{ marginBottom: euiThemeVars.euiSize }}>
+            <div css={{ marginBottom: euiThemeVars.euiSize }}>
               <MissingFieldsCallout finding={vulnerabilityRecord} />
             </div>
           )}

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_json_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_json_tab.tsx
@@ -15,7 +15,7 @@ interface VulnerabilityJsonTabProps {
 }
 export const VulnerabilityJsonTab = ({ vulnerabilityRecord }: VulnerabilityJsonTabProps) => {
   return (
-    <div style={{ position: 'absolute', inset: 0 }} data-test-subj={JSON_TAB_VULNERABILITY_FLYOUT}>
+    <div css={{ position: 'absolute', inset: 0 }} data-test-subj={JSON_TAB_VULNERABILITY_FLYOUT}>
       <CodeEditor
         enableFindAction
         isCopyable

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_table_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities_finding_flyout/vulnerability_table_tab.tsx
@@ -70,7 +70,7 @@ const columns: EuiInMemoryTableProps<FlattenedItem>['columns'] = [
     name: i18n.translate('xpack.csp.vulnerabilities.flyoutTabs.fieldValueLabel', {
       defaultMessage: 'Value',
     }),
-    render: (value: unknown) => <div style={{ width: '100%' }}>{getDescriptionDisplay(value)}</div>,
+    render: (value: unknown) => <div css={{ width: '100%' }}>{getDescriptionDisplay(value)}</div>,
   },
 ];
 

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerability_dashboard/vulnerability_table_panel_section.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerability_dashboard/vulnerability_table_panel_section.tsx
@@ -121,7 +121,7 @@ export const VulnerabilityTablePanelSection = () => {
         field: 'vulnerabilityCount',
         name: (
           <span>
-            <EuiIcon type={'sortDown'} style={{ marginRight: euiTheme.size.xs }} />
+            <EuiIcon type={'sortDown'} css={{ marginRight: euiTheme.size.xs }} />
             {i18n.translate(
               'xpack.csp.cnvmDashboardTable.section.topVulnerableResources.column.vulnerabilities',
               {
@@ -202,7 +202,7 @@ export const VulnerabilityTablePanelSection = () => {
           field: 'vulnerabilityCount',
           name: (
             <span>
-              <EuiIcon type={'sortDown'} style={{ marginRight: euiTheme.size.xs }} />
+              <EuiIcon type={'sortDown'} css={{ marginRight: euiTheme.size.xs }} />
               {i18n.translate(
                 'xpack.csp.cnvmDashboardTable.section.topVulnerableResources.column.vulnerabilityCount',
                 {
@@ -330,7 +330,7 @@ export const VulnerabilityTablePanelSection = () => {
         field: 'vulnerabilityCount',
         name: (
           <span>
-            <EuiIcon type={'sortDown'} style={{ marginRight: euiTheme.size.xs }} />
+            <EuiIcon type={'sortDown'} css={{ marginRight: euiTheme.size.xs }} />
             {i18n.translate(
               'xpack.csp.cnvmDashboardTable.section.topVulnerability.column.vulnerabilities',
               {

--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerability_dashboard/vulnerability_trend_graph.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerability_dashboard/vulnerability_trend_graph.tsx
@@ -72,7 +72,7 @@ const AccountDropDown = ({
   options: Array<{ value: string; label: string }>;
 }) => (
   <EuiComboBox
-    style={{ width: 320 }}
+    css={{ width: 320 }}
     compressed
     prepend={i18n.translate(
       'xpack.csp.vulnerabilityDashboard.trendGraphChart.accountsDropDown.prepend.accountsTitle',
@@ -210,7 +210,7 @@ export const VulnerabilityTrendGraph = () => {
         <ViewAllButton key="vulnerability-trend-graph-view-all-button" />,
       ]}
     >
-      <div style={chartStyle}>
+      <div css={chartStyle}>
         <Chart>
           <Settings
             baseTheme={charts.theme.useChartsBaseTheme()}

--- a/x-pack/plugins/cloud_security_posture/public/plugin.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/plugin.tsx
@@ -74,7 +74,7 @@ export class CspPlugin
     const App = (props: CspRouterProps) => (
       <KibanaContextProvider services={{ ...core, ...plugins, storage }}>
         <RedirectAppLinks coreStart={core}>
-          <div style={{ width: '100%', height: '100%' }}>
+          <div css={{ width: '100%', height: '100%' }}>
             <SetupContext.Provider value={{ isCloudEnabled: this.isCloudEnabled }}>
               <CspRouter {...props} />
             </SetupContext.Provider>


### PR DESCRIPTION
## Summary

Part of the resolution of this issue: 
- https://github.com/elastic/kibana/issues/149246

Removes the `style` prop in React components and elements to avoid using inline styles. Instead, it uses now the `emotion.css` prop to dynamically attach all styles to the native `class` attribute.

### Motivation

Using inline styles at scale causes a performance penalty at rendering time. It's way more efficient to attach styles to a single or several classnames instead.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)