### PR TITLE
[Search][ES3] Fix polynomial regex

### DIFF
--- a/packages/kbn-search-connectors/utils/to_alphanumeric.ts
+++ b/packages/kbn-search-connectors/utils/to_alphanumeric.ts
@@ -11,5 +11,5 @@ export const toAlphanumeric = (input: string) =>
   input
     .trim()
     .replace(/[^a-zA-Z0-9]+/g, '-') // Replace all special/non-alphanumerical characters with dashes
-    .replace(/^[-]+|[-]+$/g, '') // Strip all leading and trailing dashes
+    .replace(/(^-+|(?<!-)-+$)/g, '') // Strip all leading and trailing dashes
     .toLowerCase();


### PR DESCRIPTION
## Summary

The expression here violates [polynomial regular expression used on uncontrolled data](https://codeql.github.com/codeql-query-help/javascript/js-polynomial-redos/)

This PR replaces the problem regex with one that is not ambiguous about when to start matching `-` sequences. This is done through using a negative look-behind.
