### PR TITLE
Fix the text color for a navigation callout

### DIFF
--- a/packages/shared-ux/chrome/navigation/src/ui/components/feedback_btn.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/components/feedback_btn.tsx
@@ -50,7 +50,7 @@ export const FeedbackBtn: FC<Props> = ({ solutionId }) => {
       onDismiss={onDismiss}
       data-test-subj="sideNavfeedbackCallout"
     >
-      <EuiText size="s" color="dimgrey">
+      <EuiText size="s">
         {i18n.translate('sharedUXPackages.chrome.sideNavigation.feedbackCallout.title', {
           defaultMessage: `How's the navigation working for you? Missing anything?`,
         })}


### PR DESCRIPTION
## Summary

We currently have a problem with the text inside the callout for new navigation which asks for the feedback.
The PR makes color default so that it correlates with the regular text color of EUI.
[Slack conversation](https://elastic.slack.com/archives/C7QC1JV6F/p1733133123930929).

![image](https://github.com/user-attachments/assets/1f6f5e96-1f87-496b-9cc4-3b33beb0efd3)