### PR TITLE
[dashboard] fix Viewing dashboards with unsaved changes can display empty panels for new by-reference embeddable panels

### DIFF
--- a/packages/presentation/presentation_containers/interfaces/presentation_container.ts
+++ b/packages/presentation/presentation_containers/interfaces/presentation_container.ts
@@ -11,7 +11,10 @@ import { apiHasParentApi, apiHasUniqueId, PublishingSubject } from '@kbn/present
 import { BehaviorSubject, combineLatest, isObservable, map, Observable, of, switchMap } from 'rxjs';
 import { apiCanAddNewPanel, CanAddNewPanel } from './can_add_new_panel';
 
-export interface PanelPackage<SerializedState extends object = object, RuntimeState extends object = object> {
+export interface PanelPackage<
+  SerializedState extends object = object,
+  RuntimeState extends object = object
+> {
   panelType: string;
   serializedState?: SerializedState;
   runtimeState?: RuntimeState;

--- a/packages/presentation/presentation_containers/interfaces/presentation_container.ts
+++ b/packages/presentation/presentation_containers/interfaces/presentation_container.ts
@@ -11,9 +11,10 @@ import { apiHasParentApi, apiHasUniqueId, PublishingSubject } from '@kbn/present
 import { BehaviorSubject, combineLatest, isObservable, map, Observable, of, switchMap } from 'rxjs';
 import { apiCanAddNewPanel, CanAddNewPanel } from './can_add_new_panel';
 
-export interface PanelPackage<SerializedState extends object = object> {
+export interface PanelPackage<SerializedState extends object = object, RuntimeState extends object = object> {
   panelType: string;
-  initialState?: SerializedState;
+  serializedState?: SerializedState;
+  runtimeState?: RuntimeState;
 }
 
 export interface PresentationContainer extends CanAddNewPanel {

--- a/src/plugins/controls/public/control_group/get_control_group_factory.tsx
+++ b/src/plugins/controls/public/control_group/get_control_group_factory.tsx
@@ -179,7 +179,7 @@ export const getControlGroupEmbeddableFactory = () => {
             onSave: ({ type: controlType, state: initialState }) => {
               controlsManager.api.addNewPanel({
                 panelType: controlType,
-                initialState: settings?.controlStateTransform
+                runtimeState: settings?.controlStateTransform
                   ? settings.controlStateTransform(initialState, controlType)
                   : initialState,
               });

--- a/src/plugins/controls/public/control_group/init_controls_manager.test.ts
+++ b/src/plugins/controls/public/control_group/init_controls_manager.test.ts
@@ -28,7 +28,7 @@ describe('PresentationContainer api', () => {
     const controlsManager = initControlsManager(intialControlsState, lastSavedControlsState$);
     const addNewPanelPromise = controlsManager.api.addNewPanel({
       panelType: 'testControl',
-      initialState: {},
+      runtimeState: {},
     });
     controlsManager.setControlApi('delta', {} as unknown as DefaultControlApi);
     await addNewPanelPromise;
@@ -53,7 +53,7 @@ describe('PresentationContainer api', () => {
     const controlsManager = initControlsManager(intialControlsState, lastSavedControlsState$);
     const replacePanelPromise = controlsManager.api.replacePanel('bravo', {
       panelType: 'testControl',
-      initialState: {},
+      runtimeState: {},
     });
     controlsManager.setControlApi('delta', {} as unknown as DefaultControlApi);
     await replacePanelPromise;
@@ -294,7 +294,7 @@ describe('getNewControlState', () => {
     const controlsManager = initControlsManager({}, new BehaviorSubject<ControlPanelsState>({}));
     controlsManager.api.addNewPanel({
       panelType: 'testControl',
-      initialState: {
+      runtimeState: {
         grow: false,
         width: 'small',
         dataViewId: 'myOtherDataViewId',

--- a/src/plugins/controls/public/control_group/init_controls_manager.ts
+++ b/src/plugins/controls/public/control_group/init_controls_manager.ts
@@ -99,17 +99,17 @@ export function initControlsManager(
   }
 
   async function addNewPanel(
-    { panelType, initialState }: PanelPackage<DefaultControlState>,
+    { panelType, runtimeState }: PanelPackage<object, DefaultControlState>,
     index: number
   ) {
-    if ((initialState as DefaultDataControlState)?.dataViewId) {
-      lastUsedDataViewId$.next((initialState as DefaultDataControlState).dataViewId);
+    if ((runtimeState as DefaultDataControlState)?.dataViewId) {
+      lastUsedDataViewId$.next((runtimeState as DefaultDataControlState).dataViewId);
     }
-    if (initialState?.width) {
-      lastUsedWidth$.next(initialState.width);
+    if (runtimeState?.width) {
+      lastUsedWidth$.next(runtimeState.width);
     }
-    if (typeof initialState?.grow === 'boolean') {
-      lastUsedGrow$.next(initialState.grow);
+    if (typeof runtimeState?.grow === 'boolean') {
+      lastUsedGrow$.next(runtimeState.grow);
     }
 
     const id = generateId();
@@ -119,7 +119,7 @@ export function initControlsManager(
       type: panelType,
     });
     controlsInOrder$.next(nextControlsInOrder);
-    currentControlsState[id] = initialState ?? {};
+    currentControlsState[id] = runtimeState ?? {};
     return await untilControlLoaded(id);
   }
 

--- a/src/plugins/controls/public/controls/data_controls/initialize_data_control.ts
+++ b/src/plugins/controls/public/controls/data_controls/initialize_data_control.ts
@@ -165,7 +165,7 @@ export const initializeDataControl = <EditorState extends object = {}>(
           );
         } else {
           // replace the control with a new one of the updated type
-          controlGroupApi.replacePanel(controlId, { panelType: newType, initialState: newState });
+          controlGroupApi.replacePanel(controlId, { panelType: newType, runtimeState: newState });
         }
       },
       initialState: {

--- a/src/plugins/dashboard/public/dashboard_actions/add_to_library_action.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/add_to_library_action.tsx
@@ -127,7 +127,7 @@ export class AddToLibraryAction implements Action<EmbeddableApiContext> {
       if (byRefState) {
         await embeddable.parentApi.replacePanel(embeddable.uuid, {
           panelType: embeddable.type,
-          initialState: byRefState,
+          serializedState: byRefState,
         });
       }
       coreServices.notifications.toasts.addSuccess({

--- a/src/plugins/dashboard/public/dashboard_actions/unlink_from_library_action.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/unlink_from_library_action.tsx
@@ -94,7 +94,7 @@ export class UnlinkFromLibraryAction implements Action<EmbeddableApiContext> {
       if (apiHasLibraryTransforms(embeddable)) {
         await embeddable.parentApi.replacePanel(embeddable.uuid, {
           panelType: embeddable.type,
-          initialState: { ...embeddable.getByValueState(), title },
+          runtimeState: { ...embeddable.getByValueState(), title },
         });
       } else if (apiHasInPlaceLibraryTransforms(embeddable)) {
         embeddable.unlinkFromLibrary();

--- a/src/plugins/dashboard/public/dashboard_app/hooks/use_observability_ai_assistant_context.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/hooks/use_observability_ai_assistant_context.tsx
@@ -358,7 +358,7 @@ export function useObservabilityAIAssistantContext({
                 return dashboardApi
                   .addNewPanel({
                     panelType: 'lens',
-                    initialState: embeddableInput,
+                    runtimeState: embeddableInput,
                   })
                   .then(() => {
                     return {

--- a/src/plugins/dashboard/public/dashboard_app/top_nav/controls_toolbar_button/add_time_slider_control_button.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/controls_toolbar_button/add_time_slider_control_button.tsx
@@ -52,7 +52,7 @@ export const AddTimeSliderControlButton = ({ closePopover, controlGroupApi, ...r
       onClick={async () => {
         controlGroupApi?.addNewPanel({
           panelType: TIME_SLIDER_CONTROL,
-          initialState: {
+          runtimeState: {
             grow: true,
             width: 'large',
             id: uuidv4(),

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.ts
@@ -380,7 +380,7 @@ export const initializeDashboard = async ({
           if (!incomingEmbeddable.size) {
             return await container.addNewPanel<{ uuid: string }>({
               panelType: incomingEmbeddable.type,
-              initialState: incomingEmbeddable.input,
+              runtimeState: incomingEmbeddable.input,
             });
           }
 

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -617,12 +617,17 @@ export class DashboardContainer
         panelPackage.panelType
       );
 
-      const customPlacementSettings = getCustomPlacementSettingFunc
-        ? await getCustomPlacementSettingFunc(
+      let customPlacementSettings = {};
+      if (getCustomPlacementSettingFunc) {
+        try {
+          customPlacementSettings = await getCustomPlacementSettingFunc(
             panelPackage.serializedState,
             panelPackage.runtimeState
-          )
-        : {};
+          );
+        } catch (error) {
+          // fall back to defaults when getCustomPlacementSettingFunc throws
+        }
+      }
 
       const placementSettings = {
         width: DEFAULT_PANEL_WIDTH,

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -346,6 +346,9 @@ export class DashboardContainer
 
     this.useMargins$ = new BehaviorSubject(this.getState().explicitInput.useMargins);
     this.panels$ = new BehaviorSubject(this.getState().explicitInput.panels);
+    this.panels$.subscribe((panels) => {
+      console.log('panels emit', panels);
+    })
     this.publishingSubscription.add(
       this.onStateChange(() => {
         const state = this.getState();
@@ -597,6 +600,7 @@ export class DashboardContainer
     panelPackage: PanelPackage,
     displaySuccessMessage?: boolean
   ) {
+    debugger
     const onSuccess = (id?: string, title?: string) => {
       if (!displaySuccessMessage) return;
       coreServices.notifications.toasts.addSuccess({
@@ -643,6 +647,7 @@ export class DashboardContainer
         },
         explicitInput: {
           id: newId,
+          ...(panelPackage?.initialState ?? {})
         },
       };
       if (panelPackage.initialState) {

--- a/src/plugins/dashboard/public/dashboard_container/panel_placement/panel_placement_registry.ts
+++ b/src/plugins/dashboard/public/dashboard_container/panel_placement/panel_placement_registry.ts
@@ -12,9 +12,12 @@ import { panelPlacementStrings } from '../_dashboard_container_strings';
 
 const registry = new Map<string, GetPanelPlacementSettings>();
 
-export const registerDashboardPanelPlacementSetting = (
+export const registerDashboardPanelPlacementSetting = <
+  SerializedState extends object = object,
+  RuntimeState extends object = object
+>(
   embeddableType: string,
-  getPanelPlacementSettings: GetPanelPlacementSettings
+  getPanelPlacementSettings: GetPanelPlacementSettings<SerializedState, RuntimeState>
 ) => {
   if (registry.has(embeddableType)) {
     throw new Error(panelPlacementStrings.getPanelPlacementSettingsExistsError(embeddableType));

--- a/src/plugins/dashboard/public/dashboard_container/panel_placement/panel_placement_registry.ts
+++ b/src/plugins/dashboard/public/dashboard_container/panel_placement/panel_placement_registry.ts
@@ -10,11 +10,11 @@
 import { GetPanelPlacementSettings } from './types';
 import { panelPlacementStrings } from '../_dashboard_container_strings';
 
-const registry = new Map<string, GetPanelPlacementSettings<object>>();
+const registry = new Map<string, GetPanelPlacementSettings>();
 
-export const registerDashboardPanelPlacementSetting = <SerializedState extends object = object>(
+export const registerDashboardPanelPlacementSetting = (
   embeddableType: string,
-  getPanelPlacementSettings: GetPanelPlacementSettings<SerializedState>
+  getPanelPlacementSettings: GetPanelPlacementSettings
 ) => {
   if (registry.has(embeddableType)) {
     throw new Error(panelPlacementStrings.getPanelPlacementSettingsExistsError(embeddableType));

--- a/src/plugins/dashboard/public/dashboard_container/panel_placement/types.ts
+++ b/src/plugins/dashboard/public/dashboard_container/panel_placement/types.ts
@@ -40,6 +40,10 @@ export interface IProvidesLegacyPanelPlacementSettings<
   ) => Partial<PanelPlacementSettings>;
 }
 
-export type GetPanelPlacementSettings<SerializedState extends object = object> = (
-  serializedState?: SerializedState
+export type GetPanelPlacementSettings<
+  SerializedState extends object = object,
+  RuntimeState extends object = object
+> = (
+  serializedState?: SerializedState,
+  runtimeState?: RuntimeState
 ) => MaybePromise<PanelPlacementSettings>;

--- a/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
@@ -117,8 +117,6 @@ export function startDiffingDashboardState(
       ),
     ]).subscribe(([dashboardChanges, unsavedPanelState, controlGroupChanges]) => {
       // calculate unsaved changes
-      console.log('dashboardChanges', dashboardChanges);
-      console.log('unsavedPanelState', unsavedPanelState);
       const hasUnsavedChanges =
         Object.keys(omit(dashboardChanges, keysNotConsideredUnsavedChanges)).length > 0 ||
         unsavedPanelState !== undefined ||

--- a/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
+++ b/src/plugins/dashboard/public/dashboard_container/state/diffing/dashboard_diffing_integration.ts
@@ -117,6 +117,8 @@ export function startDiffingDashboardState(
       ),
     ]).subscribe(([dashboardChanges, unsavedPanelState, controlGroupChanges]) => {
       // calculate unsaved changes
+      console.log('dashboardChanges', dashboardChanges);
+      console.log('unsavedPanelState', unsavedPanelState);
       const hasUnsavedChanges =
         Object.keys(omit(dashboardChanges, keysNotConsideredUnsavedChanges)).length > 0 ||
         unsavedPanelState !== undefined ||

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -134,9 +134,12 @@ export interface DashboardStart {
   locator?: DashboardAppLocator;
   dashboardFeatureFlagConfig: DashboardFeatureFlagConfig;
   findDashboardsService: () => Promise<FindDashboardsService>;
-  registerDashboardPanelPlacementSetting: <SerializedState extends object = object>(
+  registerDashboardPanelPlacementSetting: <
+    SerializedState extends object = object,
+    RuntimeState extends object = object
+  >(
     embeddableType: string,
-    getPanelPlacementSettings: GetPanelPlacementSettings<SerializedState>
+    getPanelPlacementSettings: GetPanelPlacementSettings<SerializedState, RuntimeState>
   ) => void;
 }
 

--- a/src/plugins/embeddable/public/lib/containers/container.ts
+++ b/src/plugins/embeddable/public/lib/containers/container.ts
@@ -548,6 +548,7 @@ export abstract class Container<
   }
 
   private async onPanelAdded(panel: PanelState) {
+    debugger
     // do nothing if this panel's type is in the new Embeddable registry.
     if (reactEmbeddableRegistryHasKey(panel.type)) {
       this.updateOutput({

--- a/src/plugins/embeddable/public/lib/containers/container.ts
+++ b/src/plugins/embeddable/public/lib/containers/container.ts
@@ -136,7 +136,7 @@ export abstract class Container<
   ): Promise<ApiType | undefined> {
     const newEmbeddable = await this.addNewEmbeddable(
       panelPackage.panelType,
-      panelPackage.initialState as Partial<EmbeddableInput>
+      panelPackage.serializedState as Partial<EmbeddableInput>
     );
     return newEmbeddable as ApiType;
   }
@@ -548,7 +548,6 @@ export abstract class Container<
   }
 
   private async onPanelAdded(panel: PanelState) {
-    debugger
     // do nothing if this panel's type is in the new Embeddable registry.
     if (reactEmbeddableRegistryHasKey(panel.type)) {
       this.updateOutput({

--- a/src/plugins/embeddable/public/lib/containers/container.ts
+++ b/src/plugins/embeddable/public/lib/containers/container.ts
@@ -141,10 +141,10 @@ export abstract class Container<
     return newEmbeddable as ApiType;
   }
 
-  public async replacePanel(idToRemove: string, { panelType, initialState }: PanelPackage) {
+  public async replacePanel(idToRemove: string, { panelType, serializedState }: PanelPackage) {
     return await this.replaceEmbeddable(
       idToRemove,
-      initialState as Partial<EmbeddableInput>,
+      serializedState as Partial<EmbeddableInput>,
       panelType,
       true
     );

--- a/src/plugins/embeddable/public/lib/embeddables/compatibility/link_legacy_embeddable.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/compatibility/link_legacy_embeddable.ts
@@ -62,6 +62,6 @@ export const linkLegacyEmbeddable = async (embeddable: CommonLegacyEmbeddable) =
   }
   await root.replacePanel(panelToReplace.explicitInput.id, {
     panelType: embeddable.type,
-    initialState: { ...newInput },
+    serializedState: { ...newInput },
   });
 };

--- a/src/plugins/embeddable/public/lib/embeddables/compatibility/unlink_legacy_embeddable.ts
+++ b/src/plugins/embeddable/public/lib/embeddables/compatibility/unlink_legacy_embeddable.ts
@@ -45,6 +45,6 @@ export const unlinkLegacyEmbeddable = async (embeddable: CommonLegacyEmbeddable)
   }
   await root.replacePanel(panelToReplace.explicitInput.id, {
     panelType: embeddable.type,
-    initialState: { ...newInput, title: embeddable.getTitle() },
+    serializedState: { ...newInput, title: embeddable.getTitle() },
   });
 };

--- a/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
+++ b/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
@@ -91,15 +91,18 @@ export const ReactEmbeddableRenderer = <
         const buildEmbeddable = async () => {
           const factory = await getReactEmbeddableFactory<SerializedState, RuntimeState, Api>(type);
           const serializedState = parentApi.getSerializedStateForChild(uuid);
+          if (type !== 'control_group') console.log('serializedState', serializedState);
           const lastSavedRuntimeState = serializedState
             ? await factory.deserializeState(serializedState)
             : ({} as RuntimeState);
+          if (type !== 'control_group') console.log('lastSavedRuntimeState', lastSavedRuntimeState);
 
           // If the parent provides runtime state for the child (usually as a state backup or cache),
           // we merge it with the last saved runtime state.
           const partialRuntimeState = apiHasRuntimeChildState<RuntimeState>(parentApi)
             ? parentApi.getRuntimeStateForChild(uuid) ?? ({} as Partial<RuntimeState>)
             : ({} as Partial<RuntimeState>);
+          if (type !== 'control_group') console.log('partialRuntimeState', partialRuntimeState);
 
           const initialRuntimeState = { ...lastSavedRuntimeState, ...partialRuntimeState };
 

--- a/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
+++ b/src/plugins/embeddable/public/react_embeddable_system/react_embeddable_renderer.tsx
@@ -91,18 +91,15 @@ export const ReactEmbeddableRenderer = <
         const buildEmbeddable = async () => {
           const factory = await getReactEmbeddableFactory<SerializedState, RuntimeState, Api>(type);
           const serializedState = parentApi.getSerializedStateForChild(uuid);
-          if (type !== 'control_group') console.log('serializedState', serializedState);
           const lastSavedRuntimeState = serializedState
             ? await factory.deserializeState(serializedState)
             : ({} as RuntimeState);
-          if (type !== 'control_group') console.log('lastSavedRuntimeState', lastSavedRuntimeState);
 
           // If the parent provides runtime state for the child (usually as a state backup or cache),
           // we merge it with the last saved runtime state.
           const partialRuntimeState = apiHasRuntimeChildState<RuntimeState>(parentApi)
             ? parentApi.getRuntimeStateForChild(uuid) ?? ({} as Partial<RuntimeState>)
             : ({} as Partial<RuntimeState>);
-          if (type !== 'control_group') console.log('partialRuntimeState', partialRuntimeState);
 
           const initialRuntimeState = { ...lastSavedRuntimeState, ...partialRuntimeState };
 

--- a/src/plugins/links/public/get_links_panel_placement.ts
+++ b/src/plugins/links/public/get_links_panel_placement.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { DASHBOARD_GRID_COLUMN_COUNT, PanelPlacementStrategy } from "@kbn/dashboard-plugin/public";
+import { LinksRuntimeState, LinksSerializedState } from "./types";
+import { deserializeLinksSavedObject } from "./lib/deserialize_from_library";
+import { linksClient } from "./content_management";
+
+export async function getLinksPanelPlacement(serializedState?: LinksSerializedState, runtimeState?: LinksRuntimeState) {
+  if (serializedState && 'savedObjectId' in serializedState && serializedState.savedObjectId) {
+    const linksSavedObject = await linksClient.get(serializedState.savedObjectId);
+    return getPanelPlacementFromRuntimeState(await deserializeLinksSavedObject(linksSavedObject.item));
+  }
+
+  return runtimeState
+    ? getPanelPlacementFromRuntimeState(runtimeState)
+    : {};
+}
+
+function getPanelPlacementFromRuntimeState(runtimeState: LinksRuntimeState) {
+  const isHorizontal = runtimeState.layout === 'horizontal';
+  const width = isHorizontal ? DASHBOARD_GRID_COLUMN_COUNT : 8;
+  const height = isHorizontal ? 4 : (runtimeState.links?.length ?? 1 * 3) + 4;
+  return { width, height, strategy: PanelPlacementStrategy.placeAtTop };
+}

--- a/src/plugins/links/public/get_links_panel_placement.ts
+++ b/src/plugins/links/public/get_links_panel_placement.ts
@@ -7,20 +7,23 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { DASHBOARD_GRID_COLUMN_COUNT, PanelPlacementStrategy } from "@kbn/dashboard-plugin/public";
-import { LinksRuntimeState, LinksSerializedState } from "./types";
-import { deserializeLinksSavedObject } from "./lib/deserialize_from_library";
-import { linksClient } from "./content_management";
+import { DASHBOARD_GRID_COLUMN_COUNT, PanelPlacementStrategy } from '@kbn/dashboard-plugin/public';
+import { LinksRuntimeState, LinksSerializedState } from './types';
+import { deserializeLinksSavedObject } from './lib/deserialize_from_library';
+import { linksClient } from './content_management';
 
-export async function getLinksPanelPlacement(serializedState?: LinksSerializedState, runtimeState?: LinksRuntimeState) {
+export async function getLinksPanelPlacement(
+  serializedState?: LinksSerializedState,
+  runtimeState?: LinksRuntimeState
+) {
   if (serializedState && 'savedObjectId' in serializedState && serializedState.savedObjectId) {
     const linksSavedObject = await linksClient.get(serializedState.savedObjectId);
-    return getPanelPlacementFromRuntimeState(await deserializeLinksSavedObject(linksSavedObject.item));
+    return getPanelPlacementFromRuntimeState(
+      await deserializeLinksSavedObject(linksSavedObject.item)
+    );
   }
 
-  return runtimeState
-    ? getPanelPlacementFromRuntimeState(runtimeState)
-    : {};
+  return runtimeState ? getPanelPlacementFromRuntimeState(runtimeState) : {};
 }
 
 function getPanelPlacementFromRuntimeState(runtimeState: LinksRuntimeState) {

--- a/src/plugins/links/public/plugin.ts
+++ b/src/plugins/links/public/plugin.ts
@@ -12,9 +12,7 @@ import {
   ContentManagementPublicStart,
 } from '@kbn/content-management-plugin/public';
 import { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
-import {
-  DashboardStart,
-} from '@kbn/dashboard-plugin/public';
+import { DashboardStart } from '@kbn/dashboard-plugin/public';
 import { EmbeddableSetup, EmbeddableStart } from '@kbn/embeddable-plugin/public';
 import { PresentationUtilPluginStart } from '@kbn/presentation-util-plugin/public';
 import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
@@ -63,7 +61,7 @@ export class LinksPlugin
           container.addNewPanel<LinksRuntimeState>({
             panelType: CONTENT_ID,
             serializedState: {
-              savedObjectId: savedObject.id
+              savedObjectId: savedObject.id,
             },
           });
         },
@@ -99,7 +97,11 @@ export class LinksPlugin
                 title,
                 editor: {
                   onEdit: async (savedObjectId: string) => {
-                    const [{ openEditorFlyout } , { deserializeLinksSavedObject }, linksSavedObject] = await Promise.all([
+                    const [
+                      { openEditorFlyout },
+                      { deserializeLinksSavedObject },
+                      linksSavedObject,
+                    ] = await Promise.all([
                       import('./editor/open_editor_flyout'),
                       import('./lib/deserialize_from_library'),
                       getLinksClient().get(savedObjectId),
@@ -127,7 +129,10 @@ export class LinksPlugin
     untilPluginStartServicesReady().then(() => {
       registerCreateLinksPanelAction();
 
-      plugins.dashboard.registerDashboardPanelPlacementSetting<LinksSerializedState, LinksRuntimeState>(
+      plugins.dashboard.registerDashboardPanelPlacementSetting<
+        LinksSerializedState,
+        LinksRuntimeState
+      >(
         CONTENT_ID,
         async (serializedState?: LinksSerializedState, runtimeState?: LinksRuntimeState) => {
           const { getLinksPanelPlacement } = await import('./get_links_panel_placement');

--- a/src/plugins/links/public/plugin.ts
+++ b/src/plugins/links/public/plugin.ts
@@ -66,7 +66,9 @@ export class LinksPlugin
           const initialState = await deserializeLinksSavedObject(savedObject);
           container.addNewPanel<LinksRuntimeState>({
             panelType: CONTENT_ID,
-            initialState,
+            initialState: {
+              savedObjectId: savedObject.id
+            },
           });
         },
         embeddableType: CONTENT_ID,

--- a/src/plugins/links/public/plugin.ts
+++ b/src/plugins/links/public/plugin.ts
@@ -14,8 +14,6 @@ import {
 import { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import {
   DashboardStart,
-  DASHBOARD_GRID_COLUMN_COUNT,
-  PanelPlacementStrategy,
 } from '@kbn/dashboard-plugin/public';
 import { EmbeddableSetup, EmbeddableStart } from '@kbn/embeddable-plugin/public';
 import { PresentationUtilPluginStart } from '@kbn/presentation-util-plugin/public';
@@ -23,14 +21,13 @@ import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import { VisualizationsSetup } from '@kbn/visualizations-plugin/public';
 
 import { UiActionsPublicStart } from '@kbn/ui-actions-plugin/public/plugin';
-import { LinksRuntimeState } from './types';
+import { LinksRuntimeState, LinksSerializedState } from './types';
 import { APP_ICON, APP_NAME, CONTENT_ID, LATEST_VERSION } from '../common';
 import { LinksCrudTypes } from '../common/content_management';
 import { LinksStrings } from './components/links_strings';
 import { getLinksClient } from './content_management/links_content_management_client';
 import { setKibanaServices, untilPluginStartServicesReady } from './services/kibana_services';
 import { registerCreateLinksPanelAction } from './actions/create_links_panel_action';
-import { deserializeLinksSavedObject } from './lib/deserialize_from_library';
 export interface LinksSetupDependencies {
   embeddable: EmbeddableSetup;
   visualizations: VisualizationsSetup;
@@ -63,10 +60,9 @@ export class LinksPlugin
 
       plugins.embeddable.registerReactEmbeddableSavedObject({
         onAdd: async (container, savedObject) => {
-          const initialState = await deserializeLinksSavedObject(savedObject);
           container.addNewPanel<LinksRuntimeState>({
             panelType: CONTENT_ID,
-            initialState: {
+            serializedState: {
               savedObjectId: savedObject.id
             },
           });
@@ -103,8 +99,11 @@ export class LinksPlugin
                 title,
                 editor: {
                   onEdit: async (savedObjectId: string) => {
-                    const { openEditorFlyout } = await import('./editor/open_editor_flyout');
-                    const linksSavedObject = await getLinksClient().get(savedObjectId);
+                    const [{ openEditorFlyout } , { deserializeLinksSavedObject }, linksSavedObject] = await Promise.all([
+                      import('./editor/open_editor_flyout'),
+                      import('./lib/deserialize_from_library'),
+                      getLinksClient().get(savedObjectId),
+                    ]);
                     const initialState = await deserializeLinksSavedObject(linksSavedObject.item);
                     await openEditorFlyout({ initialState });
                   },
@@ -128,14 +127,11 @@ export class LinksPlugin
     untilPluginStartServicesReady().then(() => {
       registerCreateLinksPanelAction();
 
-      plugins.dashboard.registerDashboardPanelPlacementSetting(
+      plugins.dashboard.registerDashboardPanelPlacementSetting<LinksSerializedState, LinksRuntimeState>(
         CONTENT_ID,
-        async (runtimeState?: LinksRuntimeState) => {
-          if (!runtimeState) return {};
-          const isHorizontal = runtimeState.layout === 'horizontal';
-          const width = isHorizontal ? DASHBOARD_GRID_COLUMN_COUNT : 8;
-          const height = isHorizontal ? 4 : (runtimeState.links?.length ?? 1 * 3) + 4;
-          return { width, height, strategy: PanelPlacementStrategy.placeAtTop };
+        async (serializedState?: LinksSerializedState, runtimeState?: LinksRuntimeState) => {
+          const { getLinksPanelPlacement } = await import('./get_links_panel_placement');
+          return getLinksPanelPlacement(serializedState, runtimeState);
         }
       );
     });

--- a/src/plugins/visualizations/public/plugin.ts
+++ b/src/plugins/visualizations/public/plugin.ts
@@ -415,7 +415,7 @@ export class VisualizationsPlugin
       onAdd: (container, savedObject) => {
         container.addNewPanel<VisualizeSerializedState>({
           panelType: VISUALIZE_EMBEDDABLE_TYPE,
-          initialState: { savedObjectId: savedObject.id },
+          serializedState: { savedObjectId: savedObject.id },
         });
       },
       embeddableType: VISUALIZE_EMBEDDABLE_TYPE,

--- a/x-pack/plugins/lens/public/plugin.ts
+++ b/x-pack/plugins/lens/public/plugin.ts
@@ -148,7 +148,6 @@ import {
 import type { EditLensConfigurationProps } from './app_plugin/shared/edit_on_the_fly/get_edit_lens_configuration';
 import { convertToLensActionFactory } from './trigger_actions/convert_to_lens_action';
 import { LensRenderer } from './react_embeddable/renderer/lens_custom_renderer_component';
-import { deserializeState } from './react_embeddable/helper';
 
 export type { SaveProps } from './app_plugin';
 
@@ -397,18 +396,9 @@ export class LensPlugin {
       // Let Dashboard know about the Lens panel type
       embeddable.registerReactEmbeddableSavedObject<LensSavedObjectAttributes>({
         onAdd: async (container, savedObject) => {
-          const { attributeService } = await getStartServicesForEmbeddable();
-          // deserialize the saved object from visualize library
-          // this make sure to fit into the new embeddable model, where the following build()
-          // function expects a fully loaded runtime state
-          const state = await deserializeState(
-            attributeService,
-            { savedObjectId: savedObject.id },
-            savedObject.references
-          );
           container.addNewPanel({
             panelType: LENS_EMBEDDABLE_TYPE,
-            initialState: state,
+            serializedState: { savedObjectId: savedObject.id },
           });
         },
         embeddableType: LENS_EMBEDDABLE_TYPE,

--- a/x-pack/plugins/lens/public/trigger_actions/open_lens_config/create_action_helpers.ts
+++ b/x-pack/plugins/lens/public/trigger_actions/open_lens_config/create_action_helpers.ts
@@ -125,7 +125,7 @@ export async function executeCreateAction({
 
   const embeddable = await api.addNewPanel<object, LensApi>({
     panelType: 'lens',
-    initialState: {
+    runtimeState: {
       attributes: attrs,
       id: generateId(),
       isNewPanel: true,

--- a/x-pack/plugins/maps/public/react_embeddable/setup_map_embeddable.ts
+++ b/x-pack/plugins/maps/public/react_embeddable/setup_map_embeddable.ts
@@ -26,7 +26,7 @@ export function setupMapEmbeddable(embeddableSetup: EmbeddableSetup) {
     onAdd: (container, savedObject) => {
       container.addNewPanel({
         panelType: MAP_SAVED_OBJECT_TYPE,
-        initialState: { savedObjectId: savedObject.id },
+        serializedState: { savedObjectId: savedObject.id },
       });
     },
     embeddableType: MAP_SAVED_OBJECT_TYPE,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/198853