### PR TITLE
Correct cloud_defend name in security package exclusion list

### DIFF
--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -94,7 +94,7 @@ xpack.fleet.internal.registry.excludePackages: [
     'dga',
 
     # Unsupported in serverless
-    'cloud-defend',
+    'cloud_defend',
   ]
 # fleet_server package installed to publish agent metrics
 xpack.fleet.packages:


### PR DESCRIPTION
## Summary

Fix the `cloud_defend` package name in the security app exclusion list. `cloud_defend` is the actual package that should be excluded.  Cloud Defend is not supported in serverless, so the package should not be shown to users.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~~
- [ ] ~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
- [ ] ~~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~~
- [ ] ~~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] ~~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~
- [ ] ~~The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~~



