### PR TITLE
test: refactor tests to use async waitFor and improve asynchronous ha…

### DIFF
--- a/packages/kbn-cell-actions/src/hooks/use_data_grid_column_cell_actions.test.tsx
+++ b/packages/kbn-cell-actions/src/hooks/use_data_grid_column_cell_actions.test.tsx
@@ -88,18 +88,22 @@ describe('useDataGridColumnsCellActions', () => {
       initialProps: useDataGridColumnsCellActionsProps,
     });
 
-    await waitFor(() => new Promise((resolve) => resolve(null)));
+    await waitFor(() => {
+      expect(result.current).toHaveLength(columns.length);
+    });
 
     renderCellAction(result.current[0][0], { rowIndex: 0 });
     renderCellAction(result.current[0][1], { rowIndex: 1 });
     renderCellAction(result.current[1][0], { rowIndex: 0 });
     renderCellAction(result.current[1][1], { rowIndex: 1 });
 
-    expect(mockGetCellValue).toHaveBeenCalledTimes(4);
-    expect(mockGetCellValue).toHaveBeenCalledWith(field1.name, 0);
-    expect(mockGetCellValue).toHaveBeenCalledWith(field1.name, 1);
-    expect(mockGetCellValue).toHaveBeenCalledWith(field2.name, 0);
-    expect(mockGetCellValue).toHaveBeenCalledWith(field2.name, 1);
+    await waitFor(() => {
+      expect(mockGetCellValue).toHaveBeenCalledTimes(4);
+      expect(mockGetCellValue).toHaveBeenCalledWith(field1.name, 0);
+      expect(mockGetCellValue).toHaveBeenCalledWith(field1.name, 1);
+      expect(mockGetCellValue).toHaveBeenCalledWith(field2.name, 0);
+      expect(mockGetCellValue).toHaveBeenCalledWith(field2.name, 1);
+    });
   });
 
   it('should render the cell actions', async () => {
@@ -107,28 +111,34 @@ describe('useDataGridColumnsCellActions', () => {
       initialProps: useDataGridColumnsCellActionsProps,
     });
 
-    await waitFor(() => new Promise((resolve) => resolve(null)));
+    await waitFor(() => {
+      expect(result.current).toHaveLength(columns.length);
+    });
 
     const cellAction1 = renderCellAction(result.current[0][0]);
 
-    expect(cellAction1.getByTestId(`dataGridColumnCellAction-${action1.id}`)).toBeInTheDocument();
-    expect(cellAction1.getByText(action1.getDisplayName())).toBeInTheDocument();
+    await waitFor(() => {
+      expect(cellAction1.getByTestId(`dataGridColumnCellAction-${action1.id}`)).toBeInTheDocument();
+      expect(cellAction1.getByText(action1.getDisplayName())).toBeInTheDocument();
+    });
 
     const cellAction2 = renderCellAction(result.current[0][1]);
 
-    expect(cellAction2.getByTestId(`dataGridColumnCellAction-${action2.id}`)).toBeInTheDocument();
-    expect(cellAction2.getByText(action2.getDisplayName())).toBeInTheDocument();
+    await waitFor(() => {
+      expect(cellAction2.getByTestId(`dataGridColumnCellAction-${action2.id}`)).toBeInTheDocument();
+      expect(cellAction2.getByText(action2.getDisplayName())).toBeInTheDocument();
+    });
   });
 
   it('should execute the action on click', async () => {
     const { result } = renderHook(useDataGridColumnsCellActions, {
       initialProps: useDataGridColumnsCellActionsProps,
     });
-    await waitFor(() => new Promise((resolve) => resolve(null)));
 
-    const cellAction = renderCellAction(result.current[0][0]);
-
-    cellAction.getByTestId(`dataGridColumnCellAction-${action1.id}`).click();
+    await waitFor(() => {
+      const cellAction = renderCellAction(result.current[0][0]);
+      cellAction.getByTestId(`dataGridColumnCellAction-${action1.id}`).click();
+    });
 
     await waitFor(() => {
       expect(action1.execute).toHaveBeenCalled();
@@ -139,7 +149,10 @@ describe('useDataGridColumnsCellActions', () => {
     const { result } = renderHook(useDataGridColumnsCellActions, {
       initialProps: useDataGridColumnsCellActionsProps,
     });
-    await waitFor(() => new Promise((resolve) => resolve(null)));
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(columns.length);
+    });
 
     const cellAction1 = renderCellAction(result.current[0][0], { rowIndex: 1 });
 
@@ -196,15 +209,16 @@ describe('useDataGridColumnsCellActions', () => {
     const { result } = renderHook(useDataGridColumnsCellActions, {
       initialProps: useDataGridColumnsCellActionsProps,
     });
-    await waitFor(() => new Promise((resolve) => resolve(null)));
-
-    const cellAction = renderCellAction(result.current[0][0], { rowIndex: 25 });
-
-    cellAction.getByTestId(`dataGridColumnCellAction-${action1.id}`).click();
-
-    expect(mockGetCellValue).toHaveBeenCalledWith(field1.name, 25);
 
     await waitFor(() => {
+      expect(result.current).toHaveLength(columns.length);
+    });
+
+    const cellAction = renderCellAction(result.current[0][0], { rowIndex: 25 });
+    cellAction.getByTestId(`dataGridColumnCellAction-${action1.id}`).click();
+
+    await waitFor(() => {
+      expect(mockGetCellValue).toHaveBeenCalledWith(field1.name, 25);
       expect(action1.execute).toHaveBeenCalledWith(
         expect.objectContaining({
           data: [
@@ -227,10 +241,12 @@ describe('useDataGridColumnsCellActions', () => {
     const { result } = renderHook(useDataGridColumnsCellActions, {
       initialProps: useDataGridColumnsCellActionsProps,
     });
-    await waitFor(() => new Promise((resolve) => resolve(null)));
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(columns.length);
+    });
 
     const cellAction = renderCellAction(result.current[0][0], { rowIndex: 25 });
-
     cellAction.getByTestId(`dataGridColumnCellAction-${action1.id}`).click();
 
     await waitFor(() => {
@@ -246,10 +262,10 @@ describe('useDataGridColumnsCellActions', () => {
       },
     });
 
-    await waitFor(() => new Promise((resolve) => resolve(null)));
-
-    expect(result.current).toBeInstanceOf(Array);
-    expect(result.current.length).toBe(0);
+    await waitFor(() => {
+      expect(result.current).toBeInstanceOf(Array);
+      expect(result.current.length).toBe(0);
+    });
   });
 
   it('should return empty array of actions when list of fields is undefined', async () => {
@@ -260,9 +276,9 @@ describe('useDataGridColumnsCellActions', () => {
       },
     });
 
-    await waitFor(() => new Promise((resolve) => resolve(null)));
-
-    expect(result.current).toBeInstanceOf(Array);
-    expect(result.current.length).toBe(0);
+    await waitFor(() => {
+      expect(result.current).toBeInstanceOf(Array);
+      expect(result.current.length).toBe(0);
+    });
   });
 });

--- a/packages/kbn-cell-actions/src/hooks/use_load_actions.test.tsx
+++ b/packages/kbn-cell-actions/src/hooks/use_load_actions.test.tsx
@@ -26,9 +26,11 @@ class ErrorCatcher extends React.Component<React.PropsWithChildren> {
   }
 
   render() {
-    return this.state.error
-      ? React.createElement('div', { 'data-test-subj': 'leaf-error' }, this.state.error.toString())
-      : this.props.children;
+    return this.state.error ? (
+      <div data-test-subj="leaf-error">{this.state.error.toString()}</div>
+    ) : (
+      this.props.children
+    );
   }
 }
 

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/hooks/use_ilm_explain/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/hooks/use_ilm_explain/index.test.tsx
@@ -98,12 +98,18 @@ describe('useIlmExplain', () => {
     test('it returns the expected ilmExplain map', async () => {
       const { result } = setup();
       await waitFor(() => {
+        expect(result.current.loading).toBe(false);
         expect(result.current.ilmExplain).toEqual(mockIlmExplain);
       });
     });
 
     test('it returns loading: false, because the data has loaded', async () => {
       const { result } = setup();
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(true);
+      });
+
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
@@ -112,6 +118,7 @@ describe('useIlmExplain', () => {
     test('it returns a null error, because no errors occurred', async () => {
       const { result } = setup();
       await waitFor(() => {
+        expect(result.current.loading).toBe(false);
         expect(result.current.error).toBeNull();
       });
     });
@@ -128,12 +135,18 @@ describe('useIlmExplain', () => {
     test('it returns the expected ilmExplain map', async () => {
       const { result } = setup();
       await waitFor(() => {
+        expect(result.current.loading).toBe(false);
         expect(result.current.ilmExplain).toEqual(null);
       });
     });
 
     test('it returns loading: false, because the request is aborted', async () => {
       const { result } = setup();
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(true);
+      });
+
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
@@ -151,13 +164,20 @@ describe('useIlmExplain', () => {
 
     test('it returns a null ilmExplain, because an error occurred', async () => {
       const { result } = setup();
+
       await waitFor(() => {
+        expect(result.current.loading).toBe(false);
         expect(result.current.ilmExplain).toBeNull();
       });
     });
 
     test('it returns loading: false, because data loading reached a terminal state', async () => {
       const { result } = setup();
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(true);
+      });
+
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
@@ -166,6 +186,7 @@ describe('useIlmExplain', () => {
     test('it returns the expected error', async () => {
       const { result } = setup();
       await waitFor(() => {
+        expect(result.current.loading).toBe(false);
         expect(result.current.error).toEqual(ERROR_LOADING_ILM_EXPLAIN(errorMessage));
       });
     });

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/hooks/use_ilm_explain/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/hooks/use_ilm_explain/index.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { DataQualityProvider } from '../../../../../data_quality_context';
 import { mockIlmExplain } from '../../../../../mock/ilm_explain/mock_ilm_explain';
 import { ERROR_LOADING_ILM_EXPLAIN } from '../../../../../translations';
-import { useIlmExplain, UseIlmExplain } from '.';
+import { useIlmExplain } from '.';
 import { notificationServiceMock } from '@kbn/core-notifications-browser-mocks';
 import { Theme } from '@elastic/charts';
 
@@ -23,8 +23,10 @@ const mockTelemetryEvents = {
   reportDataQualityCheckAllCompleted: mockReportDataQualityCheckAllClicked,
 };
 const { toasts } = notificationServiceMock.createSetupContract();
-const ContextWrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const isILMAvailable = true;
+const ContextWrapper: React.FC<React.PropsWithChildren<{ isILMAvailable?: boolean }>> = ({
+  children,
+  isILMAvailable = true,
+}) => {
   return (
     <DataQualityProvider
       httpFetch={mockHttpFetch}
@@ -86,125 +88,86 @@ describe('useIlmExplain', () => {
   });
 
   describe('successful response from the ilm api', () => {
-    let ilmExplainResult: UseIlmExplain | undefined;
-
-    beforeEach(async () => {
+    function setup() {
       mockHttpFetch.mockResolvedValue(mockIlmExplain);
-
-      const { result } = renderHook(() => useIlmExplain(pattern), {
+      return renderHook(() => useIlmExplain(pattern), {
         wrapper: ContextWrapper,
       });
-      await waitFor(() => new Promise((resolve) => resolve(null)));
-      ilmExplainResult = await result.current;
-    });
+    }
 
     test('it returns the expected ilmExplain map', async () => {
-      expect(ilmExplainResult?.ilmExplain).toEqual(mockIlmExplain);
+      const { result } = setup();
+      await waitFor(() => {
+        expect(result.current.ilmExplain).toEqual(mockIlmExplain);
+      });
     });
 
     test('it returns loading: false, because the data has loaded', async () => {
-      expect(ilmExplainResult?.loading).toBe(false);
+      const { result } = setup();
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
     });
 
     test('it returns a null error, because no errors occurred', async () => {
-      expect(ilmExplainResult?.error).toBeNull();
+      const { result } = setup();
+      await waitFor(() => {
+        expect(result.current.error).toBeNull();
+      });
     });
   });
 
   describe('skip ilm api when isILMAvailable is false', () => {
-    let ilmExplainResult: UseIlmExplain | undefined;
-
-    beforeEach(async () => {
-      const { result } = renderHook(() => useIlmExplain(pattern), {
-        wrapper: ({ children }: React.PropsWithChildren<{}>) => (
-          <DataQualityProvider
-            httpFetch={mockHttpFetch}
-            telemetryEvents={mockTelemetryEvents}
-            isILMAvailable={false}
-            toasts={toasts}
-            addSuccessToast={jest.fn()}
-            canUserCreateAndReadCases={jest.fn(() => true)}
-            endDate={null}
-            formatBytes={jest.fn()}
-            formatNumber={jest.fn()}
-            isAssistantEnabled={true}
-            lastChecked={'2023-03-28T22:27:28.159Z'}
-            openCreateCaseFlyout={jest.fn()}
-            patterns={['auditbeat-*']}
-            setLastChecked={jest.fn()}
-            startDate={null}
-            theme={{
-              background: {
-                color: '#000',
-              },
-            }}
-            baseTheme={
-              {
-                background: {
-                  color: '#000',
-                },
-              } as Theme
-            }
-            ilmPhases={['hot', 'warm', 'unmanaged']}
-            selectedIlmPhaseOptions={[
-              {
-                label: 'Hot',
-                value: 'hot',
-              },
-              {
-                label: 'Warm',
-                value: 'warm',
-              },
-              {
-                label: 'Unmanaged',
-                value: 'unmanaged',
-              },
-            ]}
-            setSelectedIlmPhaseOptions={jest.fn()}
-            defaultStartTime={'now-7d'}
-            defaultEndTime={'now'}
-          >
-            {children}
-          </DataQualityProvider>
-        ),
+    function setup() {
+      mockHttpFetch.mockResolvedValue(mockIlmExplain);
+      return renderHook(() => useIlmExplain(pattern), {
+        wrapper: (props) => <ContextWrapper {...props} isILMAvailable={false} />,
       });
-      await waitFor(() => new Promise((resolve) => resolve(null)));
-      ilmExplainResult = await result.current;
-    });
+    }
 
     test('it returns the expected ilmExplain map', async () => {
-      expect(ilmExplainResult?.ilmExplain).toEqual(null);
+      const { result } = setup();
+      await waitFor(() => {
+        expect(result.current.ilmExplain).toEqual(null);
+      });
     });
 
     test('it returns loading: false, because the request is aborted', async () => {
-      expect(ilmExplainResult?.loading).toBe(false);
+      const { result } = setup();
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
     });
   });
 
   describe('fetch rejects with an error', () => {
-    let ilmExplainResult: UseIlmExplain | undefined;
     const errorMessage = 'simulated error';
-
-    beforeEach(async () => {
+    function setup() {
       mockHttpFetch.mockRejectedValue(new Error(errorMessage));
-
-      const { result } = renderHook(() => useIlmExplain(pattern), {
+      return renderHook(() => useIlmExplain(pattern), {
         wrapper: ContextWrapper,
       });
-      await waitFor(() => new Promise((resolve) => resolve(null)));
-      ilmExplainResult = await result.current;
-    });
+    }
 
     test('it returns a null ilmExplain, because an error occurred', async () => {
-      expect(ilmExplainResult?.ilmExplain).toBeNull();
+      const { result } = setup();
+      await waitFor(() => {
+        expect(result.current.ilmExplain).toBeNull();
+      });
     });
 
     test('it returns loading: false, because data loading reached a terminal state', async () => {
-      expect(ilmExplainResult?.loading).toBe(false);
+      const { result } = setup();
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
     });
 
     test('it returns the expected error', async () => {
-      expect(ilmExplainResult?.error).toEqual(ERROR_LOADING_ILM_EXPLAIN(errorMessage));
+      const { result } = setup();
+      await waitFor(() => {
+        expect(result.current.error).toEqual(ERROR_LOADING_ILM_EXPLAIN(errorMessage));
+      });
     });
   });
 });

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/hooks/use_stats/index.test.tsx
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality_panel/data_quality_details/indices_details/pattern/hooks/use_stats/index.test.tsx
@@ -126,12 +126,18 @@ describe('useStats', () => {
     test('it returns the expected stats', async () => {
       const result = setup();
       await waitFor(() => {
+        expect(result.current.loading).toBe(false);
         expect(result.current.stats).toEqual(mockStatsAuditbeatIndex);
       });
     });
 
     test('it returns loading: false, because the data has loaded', async () => {
       const result = setup();
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(true);
+      });
+
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
@@ -140,6 +146,7 @@ describe('useStats', () => {
     test('it returns a null error, because no errors occurred', async () => {
       const result = setup();
       await waitFor(() => {
+        expect(result.current.loading).toBe(false);
         expect(result.current.error).toBeNull();
       });
     });
@@ -168,12 +175,18 @@ describe('useStats', () => {
     test('it returns null stats, because an error occurred', async () => {
       const result = setup();
       await waitFor(() => {
+        expect(result.current.loading).toBe(false);
         expect(result.current.stats).toBeNull();
       });
     });
 
     test('it returns loading: false, because data loading reached a terminal state', async () => {
       const result = setup();
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(true);
+      });
+
       await waitFor(() => {
         expect(result.current.loading).toBe(false);
       });
@@ -181,7 +194,9 @@ describe('useStats', () => {
 
     test('it returns the expected error', async () => {
       const result = setup();
+
       await waitFor(() => {
+        expect(result.current.loading).toBe(false);
         expect(result.current.error).toEqual(ERROR_LOADING_STATS(errorMessage));
       });
     });

--- a/x-pack/plugins/security_solution/public/common/components/guided_onboarding_tour/tour.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/guided_onboarding_tour/tour.test.tsx
@@ -7,9 +7,10 @@
 
 import { waitFor, act, renderHook } from '@testing-library/react';
 import { of } from 'rxjs';
+
 import { siemGuideId } from '../../../../common/guided_onboarding/siem_guide_config';
 import { TourContextProvider, useTourContext } from './tour';
-import { SecurityStepId, securityTourConfig } from './tour_config';
+import { type AlertsCasesTourSteps, SecurityStepId, securityTourConfig } from './tour_config';
 import { useKibana } from '../../lib/kibana';
 
 jest.mock('../../lib/kibana');
@@ -44,7 +45,7 @@ describe('useTourContext', () => {
   // @ts-ignore
   const tourIds = [SecurityStepId.alertsCases];
   describe.each(tourIds)('%s', (tourId: SecurityStepId) => {
-    it('if guidedOnboardingApi?.isGuideStepActive$ is false, isTourShown should be false', () => {
+    it('if guidedOnboardingApi?.isGuideStepActive$ is false, isTourShown should be false', async () => {
       (useKibana as jest.Mock).mockReturnValue({
         services: {
           guidedOnboarding: {
@@ -57,35 +58,41 @@ describe('useTourContext', () => {
       const { result } = renderHook(() => useTourContext(), {
         wrapper: TourContextProvider,
       });
-      expect(result.current.isTourShown(tourId)).toBe(false);
+      await waitFor(() => {
+        expect(result.current.isTourShown(tourId)).toBe(false);
+      });
     });
-    it('if guidedOnboardingApi?.isGuideStepActive$ is true, isTourShown should be true', () => {
+    it('if guidedOnboardingApi?.isGuideStepActive$ is true, isTourShown should be true', async () => {
       const { result } = renderHook(() => useTourContext(), {
         wrapper: TourContextProvider,
       });
-      expect(result.current.isTourShown(tourId)).toBe(true);
+      await waitFor(() => {
+        expect(result.current.isTourShown(tourId)).toBe(true);
+      });
     });
     it('endTourStep calls completeGuideStep with correct tourId', async () => {
       const { result } = renderHook(() => useTourContext(), {
         wrapper: TourContextProvider,
       });
-      await waitFor(() => new Promise((resolve) => resolve(null)));
       act(() => {
         result.current.endTourStep(tourId);
       });
-      expect(mockCompleteGuideStep).toHaveBeenCalledWith(siemGuideId, tourId);
+      await waitFor(() => {
+        expect(mockCompleteGuideStep).toHaveBeenCalledWith(siemGuideId, tourId);
+      });
     });
-    it('activeStep is initially 1', () => {
+    it('activeStep is initially 1', async () => {
       const { result } = renderHook(() => useTourContext(), {
         wrapper: TourContextProvider,
       });
-      expect(result.current.activeStep).toBe(1);
+      await waitFor(() => {
+        expect(result.current.activeStep).toBe(1);
+      });
     });
     it('incrementStep properly increments for each tourId, and if attempted to increment beyond length of tour config steps resets activeStep to 1', async () => {
       const { result } = renderHook(() => useTourContext(), {
         wrapper: TourContextProvider,
       });
-      await waitFor(() => new Promise((resolve) => resolve(null)));
       const stepCount = securityTourConfig[tourId].length;
       act(() => {
         for (let i = 0; i < stepCount - 1; i++) {
@@ -93,35 +100,40 @@ describe('useTourContext', () => {
         }
       });
       const lastStep = stepCount ? stepCount : 1;
-      expect(result.current.activeStep).toBe(lastStep);
+      await waitFor(() => {
+        expect(result.current.activeStep).toBe(lastStep);
+      });
       act(() => {
         result.current.incrementStep(tourId);
       });
-      expect(result.current.activeStep).toBe(1);
+      await waitFor(() => {
+        expect(result.current.activeStep).toBe(1);
+      });
     });
 
     it('setStep sets activeStep to step number argument', async () => {
       const { result } = renderHook(() => useTourContext(), {
         wrapper: TourContextProvider,
       });
-      await waitFor(() => new Promise((resolve) => resolve(null)));
       act(() => {
         result.current.setStep(tourId, 6);
       });
-      expect(result.current.activeStep).toBe(6);
+      await waitFor(() => {
+        expect(result.current.activeStep).toBe(6);
+      });
     });
 
     it('does not setStep sets activeStep to non-existing step number', async () => {
       const { result } = renderHook(() => useTourContext(), {
         wrapper: TourContextProvider,
       });
-      await waitFor(() => new Promise((resolve) => resolve(null)));
 
       act(() => {
-        // @ts-expect-error testing invalid step
-        result.current.setStep(tourId, 88);
+        result.current.setStep(tourId, 88 as AlertsCasesTourSteps);
       });
-      expect(result.current.activeStep).toBe(1);
+      await waitFor(() => {
+        expect(result.current.activeStep).toBe(1);
+      });
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/guided_onboarding_tour/tour.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/guided_onboarding_tour/tour.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { FC, PropsWithChildren } from 'react';
+import type { FC, ReactNode } from 'react';
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import useObservable from 'react-use/lib/useObservable';
@@ -39,7 +39,7 @@ const initialState: TourContextValue = {
 
 const TourContext = createContext<TourContextValue>(initialState);
 
-export const RealTourContextProvider: FC<Required<PropsWithChildren>> = ({ children }) => {
+export const RealTourContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const { guidedOnboarding } = useKibana().services;
   const [hidden, setHidden] = useState(false);
 
@@ -131,7 +131,7 @@ export const RealTourContextProvider: FC<Required<PropsWithChildren>> = ({ child
   return <TourContext.Provider value={context}>{children}</TourContext.Provider>;
 };
 
-export const TourContextProvider: FC<Required<PropsWithChildren>> = ({ children }) => {
+export const TourContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const { pathname } = useLocation();
 
   const ContextProvider = useMemo(

--- a/x-pack/plugins/security_solution/public/common/components/guided_onboarding_tour/tour.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/guided_onboarding_tour/tour.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { ReactChild } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import useObservable from 'react-use/lib/useObservable';
@@ -39,7 +39,7 @@ const initialState: TourContextValue = {
 
 const TourContext = createContext<TourContextValue>(initialState);
 
-export const RealTourContextProvider = ({ children }: { children: ReactChild }) => {
+export const RealTourContextProvider: FC<Required<PropsWithChildren>> = ({ children }) => {
   const { guidedOnboarding } = useKibana().services;
   const [hidden, setHidden] = useState(false);
 
@@ -131,7 +131,7 @@ export const RealTourContextProvider = ({ children }: { children: ReactChild }) 
   return <TourContext.Provider value={context}>{children}</TourContext.Provider>;
 };
 
-export const TourContextProvider = ({ children }: React.PropsWithChildren) => {
+export const TourContextProvider: FC<Required<PropsWithChildren>> = ({ children }) => {
   const { pathname } = useLocation();
 
   const ContextProvider = useMemo(
@@ -139,11 +139,7 @@ export const TourContextProvider = ({ children }: React.PropsWithChildren) => {
     [pathname]
   );
 
-  return (
-    <ContextProvider value={initialState}>
-      {React.createElement(React.Fragment, null, children)}
-    </ContextProvider>
-  );
+  return <ContextProvider value={initialState}>{children}</ContextProvider>;
 };
 
 export const useTourContext = (): TourContextValue => {

--- a/x-pack/plugins/security_solution/public/dashboards/containers/use_fetch_security_dashboards.test.ts
+++ b/x-pack/plugins/security_solution/public/dashboards/containers/use_fetch_security_dashboards.test.ts
@@ -26,14 +26,6 @@ const renderUseFetchSecurityDashboards = () =>
     wrapper: DashboardContextProvider,
   });
 
-const asyncRenderUseFetchSecurityDashboards = async () => {
-  const renderedHook = renderUseFetchSecurityDashboards();
-
-  await waitFor(() => new Promise((resolve) => resolve(null)));
-
-  return renderedHook;
-};
-
 describe('useFetchSecurityDashboards', () => {
   beforeAll(() => {
     useKibana().services.http = mockHttp as unknown as HttpStart;
@@ -49,32 +41,39 @@ describe('useFetchSecurityDashboards', () => {
   });
 
   it('should fetch Security Solution tags', async () => {
-    await asyncRenderUseFetchSecurityDashboards();
-    expect(getTagsByName).toHaveBeenCalledTimes(1);
+    renderUseFetchSecurityDashboards();
+
+    await waitFor(() => {
+      expect(getTagsByName).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('should fetch Security Solution dashboards', async () => {
-    await asyncRenderUseFetchSecurityDashboards();
+    renderUseFetchSecurityDashboards();
 
-    expect(getDashboardsByTagIds).toHaveBeenCalledTimes(1);
-    expect(getDashboardsByTagIds).toHaveBeenCalledWith(
-      {
-        http: mockHttp,
-        tagIds: [MOCK_TAG_ID],
-      },
-      expect.any(Object)
-    );
+    await waitFor(() => {
+      expect(getDashboardsByTagIds).toHaveBeenCalledTimes(1);
+      expect(getDashboardsByTagIds).toHaveBeenCalledWith(
+        {
+          http: mockHttp,
+          tagIds: [MOCK_TAG_ID],
+        },
+        expect.any(Object)
+      );
+    });
   });
 
   it('should fetch Security Solution dashboards with abort signal', async () => {
-    await asyncRenderUseFetchSecurityDashboards();
+    renderUseFetchSecurityDashboards();
 
-    expect(getDashboardsByTagIds).toHaveBeenCalledTimes(1);
-    expect((getDashboardsByTagIds as jest.Mock).mock.calls[0][1]).toEqual(mockAbortSignal);
+    await waitFor(() => {
+      expect(getDashboardsByTagIds).toHaveBeenCalledTimes(1);
+      expect((getDashboardsByTagIds as jest.Mock).mock.calls[0][1]).toEqual(mockAbortSignal);
+    });
   });
 
   it('should return Security Solution dashboards', async () => {
-    const { result } = await asyncRenderUseFetchSecurityDashboards();
+    const { result } = renderUseFetchSecurityDashboards();
 
     await waitFor(() => {
       expect(result.current.isLoading).toEqual(false);

--- a/x-pack/plugins/security_solution/public/dashboards/containers/use_fetch_security_tags.test.ts
+++ b/x-pack/plugins/security_solution/public/dashboards/containers/use_fetch_security_tags.test.ts
@@ -28,12 +28,6 @@ const mockAbortSignal = {} as unknown as AbortSignal;
 const mockCreateTag = jest.fn();
 const renderUseCreateSecurityDashboardLink = () => renderHook(() => useFetchSecurityTags(), {});
 
-const asyncRenderUseCreateSecurityDashboardLink = async () => {
-  const renderedHook = renderUseCreateSecurityDashboardLink();
-  await waitFor(() => null);
-  return renderedHook;
-};
-
 describe('useFetchSecurityTags', () => {
   beforeAll(() => {
     useKibana().services.http = { get: mockGet } as unknown as HttpStart;
@@ -52,25 +46,31 @@ describe('useFetchSecurityTags', () => {
 
   test('should fetch Security Solution tags', async () => {
     mockGet.mockResolvedValue([]);
-    await asyncRenderUseCreateSecurityDashboardLink();
 
-    expect(mockGet).toHaveBeenCalledWith(
-      INTERNAL_TAGS_URL,
-      expect.objectContaining({
-        query: { name: SECURITY_TAG_NAME },
-        signal: mockAbortSignal,
-      })
-    );
+    renderUseCreateSecurityDashboardLink();
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(
+        INTERNAL_TAGS_URL,
+        expect.objectContaining({
+          query: { name: SECURITY_TAG_NAME },
+          signal: mockAbortSignal,
+        })
+      );
+    });
   });
 
   test('should create a Security Solution tag if no Security Solution tags were found', async () => {
     mockGet.mockResolvedValue([]);
-    await asyncRenderUseCreateSecurityDashboardLink();
 
-    expect(mockCreateTag).toHaveBeenCalledWith({
-      name: SECURITY_TAG_NAME,
-      description: SECURITY_TAG_DESCRIPTION,
-      color: '#FFFFFF',
+    renderUseCreateSecurityDashboardLink();
+
+    await waitFor(() => {
+      expect(mockCreateTag).toHaveBeenCalledWith({
+        name: SECURITY_TAG_NAME,
+        description: SECURITY_TAG_DESCRIPTION,
+        color: '#FFFFFF',
+      });
     });
   });
 
@@ -82,9 +82,11 @@ describe('useFetchSecurityTags', () => {
       type: 'tag',
       ...tag.attributes,
     }));
-    const { result } = await asyncRenderUseCreateSecurityDashboardLink();
+    const { result } = renderUseCreateSecurityDashboardLink();
 
-    expect(mockCreateTag).not.toHaveBeenCalled();
-    expect(result.current.tags).toEqual(expect.objectContaining(expected));
+    await waitFor(() => {
+      expect(mockCreateTag).not.toHaveBeenCalled();
+      expect(result.current.tags).toEqual(expect.objectContaining(expected));
+    });
   });
 });

--- a/x-pack/plugins/security_solution/public/dashboards/hooks/use_create_security_dashboard_link.test.tsx
+++ b/x-pack/plugins/security_solution/public/dashboards/hooks/use_create_security_dashboard_link.test.tsx
@@ -34,14 +34,6 @@ const renderUseCreateSecurityDashboardLink = () =>
     ),
   });
 
-const asyncRenderUseCreateSecurityDashboard = async () => {
-  const renderedHook = renderUseCreateSecurityDashboardLink();
-
-  await waitFor(() => new Promise((resolve) => resolve(null)));
-
-  return renderedHook;
-};
-
 describe('useCreateSecurityDashboardLink', () => {
   beforeAll(() => {
     (useKibana as jest.Mock).mockReturnValue({
@@ -60,33 +52,46 @@ describe('useCreateSecurityDashboardLink', () => {
 
   describe('useSecurityDashboardsTableItems', () => {
     it('should fetch Security Solution tags when renders', async () => {
-      await asyncRenderUseCreateSecurityDashboard();
+      renderUseCreateSecurityDashboardLink();
 
-      expect(getTagsByName).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(getTagsByName).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('should return a memoized value when rerendered', async () => {
-      const { result, rerender } = await asyncRenderUseCreateSecurityDashboard();
+      const { result, rerender } = renderUseCreateSecurityDashboardLink();
 
       const result1 = result.current;
       act(() => rerender());
       const result2 = result.current;
-      expect(result1).toEqual(result2);
+
+      await waitFor(() => {
+        expect(result1).toEqual(result2);
+      });
     });
 
     it('should not re-request tag id when re-rendered', async () => {
-      const { rerender } = await asyncRenderUseCreateSecurityDashboard();
+      const { rerender } = renderUseCreateSecurityDashboardLink();
 
-      expect(getTagsByName).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(getTagsByName).toHaveBeenCalledTimes(1);
+      });
+
       act(() => rerender());
-      expect(getTagsByName).toHaveBeenCalledTimes(1);
+
+      await waitFor(() => {
+        expect(getTagsByName).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('should return isLoading while requesting', async () => {
       const { result } = renderUseCreateSecurityDashboardLink();
 
-      expect(result.current.isLoading).toEqual(true);
-      expect(result.current.url).toEqual('/app/security/dashboards/create');
+      await waitFor(() => {
+        expect(result.current.isLoading).toEqual(true);
+        expect(result.current.url).toEqual('/app/security/dashboards/create');
+      });
 
       await waitFor(() => {
         expect(result.current.isLoading).toEqual(false);

--- a/x-pack/plugins/security_solution/public/dashboards/hooks/use_dashboard_renderer.test.tsx
+++ b/x-pack/plugins/security_solution/public/dashboards/hooks/use_dashboard_renderer.test.tsx
@@ -15,11 +15,11 @@ jest.mock('../../common/lib/kibana');
 const mockDashboardContainer = {} as DashboardApi;
 
 describe('useDashboardRenderer', () => {
-  it('should set dashboard container correctly when dashboard is loaded', async () => {
+  it('should set dashboard container correctly when dashboard is loaded', () => {
     const { result } = renderHook(() => useDashboardRenderer());
 
-    await act(async () => {
-      await result.current.handleDashboardLoaded(mockDashboardContainer);
+    act(() => {
+      result.current.handleDashboardLoaded(mockDashboardContainer);
     });
 
     expect(result.current.dashboardContainer).toEqual(mockDashboardContainer);

--- a/x-pack/plugins/security_solution/public/dashboards/hooks/use_security_dashboards_table.test.tsx
+++ b/x-pack/plugins/security_solution/public/dashboards/hooks/use_security_dashboards_table.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { render, act, waitFor, renderHook } from '@testing-library/react';
+import { render, waitFor, renderHook } from '@testing-library/react';
 import type { DashboardStart } from '@kbn/dashboard-plugin/public';
 import { EuiBasicTable } from '@elastic/eui';
 import { useKibana } from '../../common/lib/kibana';
@@ -27,20 +27,20 @@ import type { HttpStart } from '@kbn/core/public';
 jest.mock('../../common/lib/kibana');
 jest.mock('../../common/containers/tags/api');
 jest.mock('../../common/containers/dashboards/api');
+
+const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
+
 const spyUseGetSecuritySolutionUrl = jest.spyOn(linkTo, 'useGetSecuritySolutionUrl');
 const spyTrack = jest.spyOn(telemetry, 'track');
 const {
   id: mockReturnDashboardId,
   attributes: { title: mockReturnDashboardTitle, description: mockReturnDashboardDescription },
 } = DEFAULT_DASHBOARDS_RESPONSE[0];
-const renderUseSecurityDashboardsTableItems = async () => {
-  const renderedHook = renderHook(useSecurityDashboardsTableItems, {
+
+const renderUseSecurityDashboardsTableItems = () => {
+  return renderHook(useSecurityDashboardsTableItems, {
     wrapper: DashboardContextProvider,
   });
-  // needed to let dashboard items to be updated from saved objects response
-  await waitFor(() => new Promise((resolve) => resolve(null)));
-
-  return renderedHook;
 };
 
 const renderUseDashboardsTableColumns = () =>
@@ -48,44 +48,58 @@ const renderUseDashboardsTableColumns = () =>
     wrapper: TestProviders,
   });
 
+const tagsColumn = {
+  field: 'id', // set existing field to prevent test error
+  name: 'Tags',
+  'data-test-subj': 'dashboardTableTagsCell',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('Security Dashboards Table hooks', () => {
-  const mockGetRedirectUrl = jest.fn(() => '/path');
-  useKibana().services.dashboard = {
-    locator: { getRedirectUrl: mockGetRedirectUrl },
-  } as unknown as DashboardStart;
-  useKibana().services.http = {} as unknown as HttpStart;
+  let mockTaggingGetTableColumnDefinition: jest.Mock;
 
-  const mockTaggingGetTableColumnDefinition = useKibana().services.savedObjectsTagging?.ui
-    .getTableColumnDefinition as jest.Mock;
-  const tagsColumn = {
-    field: 'id', // set existing field to prevent test error
-    name: 'Tags',
-    'data-test-subj': 'dashboardTableTagsCell',
-  };
-  mockTaggingGetTableColumnDefinition.mockReturnValue(tagsColumn);
+  beforeEach(() => {
+    useKibanaMock().services.dashboard = {
+      locator: { getRedirectUrl: jest.fn(() => '/path') },
+    } as unknown as DashboardStart;
+    useKibanaMock().services.http = {} as unknown as HttpStart;
 
-  afterEach(() => {
-    jest.clearAllMocks();
+    mockTaggingGetTableColumnDefinition = useKibanaMock().services.savedObjectsTagging?.ui
+      .getTableColumnDefinition as jest.Mock;
+
+    mockTaggingGetTableColumnDefinition.mockReturnValue(tagsColumn);
   });
 
   describe('useSecurityDashboardsTableItems', () => {
     it('should request when renders', async () => {
-      await renderUseSecurityDashboardsTableItems();
-      expect(getDashboardsByTagIds).toHaveBeenCalledTimes(1);
+      renderUseSecurityDashboardsTableItems();
+
+      await waitFor(() => {
+        expect(getDashboardsByTagIds).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('should not request again when rerendered', async () => {
-      const { rerender } = await renderUseSecurityDashboardsTableItems();
+      const { rerender } = renderUseSecurityDashboardsTableItems();
 
-      expect(getDashboardsByTagIds).toHaveBeenCalledTimes(1);
-      act(() => rerender());
-      expect(getDashboardsByTagIds).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(getDashboardsByTagIds).toHaveBeenCalledTimes(1);
+      });
+
+      rerender();
+
+      await waitFor(() => {
+        return expect(getDashboardsByTagIds).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('should return a memoized value when rerendered', async () => {
-      const { result, rerender } = await renderUseSecurityDashboardsTableItems();
+      const { result, rerender } = renderUseSecurityDashboardsTableItems();
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      waitFor(() => expect(result.current.isLoading).toBe(false));
 
       const result1 = result.current.items;
 
@@ -98,7 +112,7 @@ describe('Security Dashboards Table hooks', () => {
     });
 
     it('should return dashboard items', async () => {
-      const { result } = await renderUseSecurityDashboardsTableItems();
+      const { result } = renderUseSecurityDashboardsTableItems();
 
       const [dashboard1] = DEFAULT_DASHBOARDS_RESPONSE;
 
@@ -115,25 +129,29 @@ describe('Security Dashboards Table hooks', () => {
   });
 
   describe('useDashboardsTableColumns', () => {
-    it('should call getTableColumnDefinition to get tags column', () => {
+    it('should call getTableColumnDefinition to get tags column', async () => {
       renderUseDashboardsTableColumns();
-      expect(mockTaggingGetTableColumnDefinition).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockTaggingGetTableColumnDefinition).toHaveBeenCalled();
+      });
     });
 
-    it('should return dashboard columns', () => {
+    it('should return dashboard columns', async () => {
       const { result } = renderUseDashboardsTableColumns();
 
-      expect(result.current).toEqual([
-        expect.objectContaining({
-          field: 'title',
-          name: 'Title',
-        }),
-        expect.objectContaining({
-          field: 'description',
-          name: 'Description',
-        }),
-        expect.objectContaining(tagsColumn),
-      ]);
+      await waitFor(() => {
+        expect(result.current).toEqual([
+          expect.objectContaining({
+            field: 'title',
+            name: 'Title',
+          }),
+          expect.objectContaining({
+            field: 'description',
+            name: 'Description',
+          }),
+          expect.objectContaining(tagsColumn),
+        ]);
+      });
     });
 
     it('returns a memoized value', async () => {
@@ -145,13 +163,21 @@ describe('Security Dashboards Table hooks', () => {
 
       const result2 = result.current;
 
-      expect(result1).toBe(result2);
+      await waitFor(() => {
+        expect(result1).toBe(result2);
+      });
     });
   });
 
   it('should render a table with consistent items and columns', async () => {
-    const { result: itemsResult } = await renderUseSecurityDashboardsTableItems();
+    const { result: itemsResult } = renderUseSecurityDashboardsTableItems();
     const { result: columnsResult } = renderUseDashboardsTableColumns();
+
+    await waitFor(() => {
+      expect(itemsResult.current.isLoading).toBe(false);
+      expect(itemsResult.current.items).toHaveLength(1);
+      expect(columnsResult.current).toHaveLength(3);
+    });
 
     const result = render(
       <EuiBasicTable items={itemsResult.current.items} columns={columnsResult.current} />,
@@ -160,21 +186,27 @@ describe('Security Dashboards Table hooks', () => {
       }
     );
 
-    expect(result.getAllByText('Title').length).toBeGreaterThan(0);
-    expect(result.getAllByText('Description').length).toBeGreaterThan(0);
-    expect(result.getAllByText('Tags').length).toBeGreaterThan(0);
+    expect(await result.findAllByText('Title')).toHaveLength(1);
+    expect(await result.findAllByText('Description')).toHaveLength(1);
+    expect(await result.findAllByText('Tags')).toHaveLength(1);
 
-    expect(result.getByText(mockReturnDashboardTitle)).toBeInTheDocument();
-    expect(result.getByText(mockReturnDashboardDescription)).toBeInTheDocument();
+    expect(await result.findByText(mockReturnDashboardTitle)).toBeInTheDocument();
+    expect(await result.findByText(mockReturnDashboardDescription)).toBeInTheDocument();
 
-    expect(result.queryAllByTestId('dashboardTableTitleCell')).toHaveLength(1);
-    expect(result.queryAllByTestId('dashboardTableDescriptionCell')).toHaveLength(1);
-    expect(result.queryAllByTestId('dashboardTableTagsCell')).toHaveLength(1);
+    expect(await result.findAllByTestId('dashboardTableTitleCell')).toHaveLength(1);
+    expect(await result.findAllByTestId('dashboardTableDescriptionCell')).toHaveLength(1);
+    expect(await result.findAllByTestId('dashboardTableTagsCell')).toHaveLength(1);
   });
 
   it('should send telemetry when dashboard title clicked', async () => {
-    const { result: itemsResult } = await renderUseSecurityDashboardsTableItems();
+    const { result: itemsResult } = renderUseSecurityDashboardsTableItems();
     const { result: columnsResult } = renderUseDashboardsTableColumns();
+
+    await waitFor(() => {
+      expect(itemsResult.current.isLoading).toBe(false);
+      expect(itemsResult.current.items).toHaveLength(1);
+      expect(columnsResult.current).toHaveLength(3);
+    });
 
     const result = render(
       <EuiBasicTable items={itemsResult.current.items} columns={columnsResult.current} />,
@@ -184,22 +216,33 @@ describe('Security Dashboards Table hooks', () => {
     );
 
     result.getByText(mockReturnDashboardTitle).click();
-    expect(spyTrack).toHaveBeenCalledWith(METRIC_TYPE.CLICK, TELEMETRY_EVENT.DASHBOARD);
+
+    await waitFor(() => {
+      expect(spyTrack).toHaveBeenCalledWith(METRIC_TYPE.CLICK, TELEMETRY_EVENT.DASHBOARD);
+    });
   });
 
   it('should land on SecuritySolution dashboard view page when dashboard title clicked', async () => {
     const mockGetSecuritySolutionUrl = jest.fn();
     spyUseGetSecuritySolutionUrl.mockImplementation(() => mockGetSecuritySolutionUrl);
-    const { result: itemsResult } = await renderUseSecurityDashboardsTableItems();
+    const { result: itemsResult } = renderUseSecurityDashboardsTableItems();
     const { result: columnsResult } = renderUseDashboardsTableColumns();
+
+    await waitFor(() => {
+      expect(itemsResult.current.isLoading).toBe(false);
+      expect(itemsResult.current.items).toHaveLength(1);
+      expect(columnsResult.current).toHaveLength(3);
+    });
 
     render(<EuiBasicTable items={itemsResult.current.items} columns={columnsResult.current} />, {
       wrapper: TestProviders,
     });
 
-    expect(mockGetSecuritySolutionUrl).toHaveBeenCalledWith({
-      deepLinkId: SecurityPageName.dashboards,
-      path: mockReturnDashboardId,
+    await waitFor(() => {
+      expect(mockGetSecuritySolutionUrl).toHaveBeenCalledWith({
+        deepLinkId: SecurityPageName.dashboards,
+        path: mockReturnDashboardId,
+      });
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/overview/components/detection_response/cases_table/use_case_items.test.ts
+++ b/x-pack/plugins/security_solution/public/overview/components/detection_response/cases_table/use_case_items.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { act, waitFor, renderHook } from '@testing-library/react';
+import { waitFor, renderHook } from '@testing-library/react';
 
 import { mockCasesResult, parsedCasesItems } from './mock_data';
 import { useCaseItems } from './use_case_items';

--- a/x-pack/plugins/security_solution/public/overview/components/detection_response/cases_table/use_case_items.test.ts
+++ b/x-pack/plugins/security_solution/public/overview/components/detection_response/cases_table/use_case_items.test.ts
@@ -66,22 +66,22 @@ describe('useCaseItems', () => {
   it('should return default values', async () => {
     const { result } = renderUseCaseItems();
 
-    await waitFor(() => new Promise((resolve) => resolve(null)));
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        items: [],
+        isLoading: false,
+        updatedAt: dateNow,
+      });
 
-    expect(result.current).toEqual({
-      items: [],
-      isLoading: false,
-      updatedAt: dateNow,
-    });
-
-    expect(mockCasesApi).toBeCalledWith({
-      from: '2020-07-07T08:20:18.966Z',
-      to: '2020-07-08T08:20:18.966Z',
-      owner: 'securitySolution',
-      sortField: 'createdAt',
-      sortOrder: 'desc',
-      page: 1,
-      perPage: 4,
+      expect(mockCasesApi).toBeCalledWith({
+        from: '2020-07-07T08:20:18.966Z',
+        to: '2020-07-08T08:20:18.966Z',
+        owner: 'securitySolution',
+        sortField: 'createdAt',
+        sortOrder: 'desc',
+        page: 1,
+        perPage: 4,
+      });
     });
   });
 
@@ -108,13 +108,11 @@ describe('useCaseItems', () => {
   test('it should call deleteQuery when unmounting', async () => {
     const { unmount } = renderUseCaseItems();
 
-    await waitFor(() => new Promise((resolve) => resolve(null)));
+    unmount();
 
-    act(() => {
-      unmount();
+    await waitFor(() => {
+      expect(mockDeleteQuery).toHaveBeenCalled();
     });
-
-    expect(mockDeleteQuery).toHaveBeenCalled();
   });
 
   it('should return new updatedAt', async () => {

--- a/x-pack/plugins/security_solution/public/overview/components/detection_response/soc_trends/hooks/use_cases_mttr.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/detection_response/soc_trends/hooks/use_cases_mttr.test.tsx
@@ -59,15 +59,17 @@ describe('useCasesMttr', () => {
       wrapper: wrapperContainer,
     });
 
-    expect(result.current).toEqual({
-      stat: '-',
-      isLoading: true,
-      percentage: {
-        percent: null,
-        color: 'hollow',
-        note: i18n.NO_DATA('case'),
-      },
-      ...basicData,
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        stat: '-',
+        isLoading: true,
+        percentage: {
+          percent: null,
+          color: 'hollow',
+          note: i18n.NO_DATA('case'),
+        },
+        ...basicData,
+      });
     });
   });
 

--- a/x-pack/plugins/security_solution/public/overview/components/detection_response/soc_trends/hooks/use_critical_alerts.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/detection_response/soc_trends/hooks/use_critical_alerts.test.tsx
@@ -76,15 +76,17 @@ describe('useCriticalAlerts', () => {
       wrapper: wrapperContainer,
     });
 
-    expect(result.current).toEqual({
-      stat: '-',
-      isLoading: false,
-      percentage: {
-        percent: null,
-        color: 'hollow',
-        note: i18n.NO_DATA('alerts'),
-      },
-      ...basicData,
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        stat: '-',
+        isLoading: false,
+        percentage: {
+          percent: null,
+          color: 'hollow',
+          note: i18n.NO_DATA('alerts'),
+        },
+        ...basicData,
+      });
     });
   });
   it('finds positive percentage change', async () => {

--- a/x-pack/plugins/security_solution/public/overview/components/detection_response/soc_trends/hooks/use_soc_trends.test.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/detection_response/soc_trends/hooks/use_soc_trends.test.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+
 import { useSocTrends } from './use_soc_trends';
-import { renderHook } from '@testing-library/react';
 import { TestProviders } from '../../../../../common/mock';
 import { useGlobalTime } from '../../../../../common/containers/use_global_time';
 import * as i18n from '../translations';
@@ -48,37 +49,39 @@ describe('useSocTrends', () => {
         wrapper: wrapperContainer,
       }
     );
-    expect(result.current).toEqual({
-      stats: [
-        {
-          stat: '-',
-          isLoading: true,
-          percentage: {
-            percent: null,
-            color: 'hollow',
-            note: i18n.NO_DATA('case'),
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        stats: [
+          {
+            stat: '-',
+            isLoading: true,
+            percentage: {
+              percent: null,
+              color: 'hollow',
+              note: i18n.NO_DATA('case'),
+            },
+            testRef: 'casesMttr',
+            title: i18n.CASES_MTTR_STAT,
+            description: i18n.CASES_MTTR_DESCRIPTION,
+            updatedAt: dateNow,
           },
-          testRef: 'casesMttr',
-          title: i18n.CASES_MTTR_STAT,
-          description: i18n.CASES_MTTR_DESCRIPTION,
-          updatedAt: dateNow,
-        },
-        {
-          stat: '-',
-          isLoading: true,
-          percentage: {
-            percent: null,
-            color: 'hollow',
-            note: i18n.NO_DATA('alerts'),
+          {
+            stat: '-',
+            isLoading: true,
+            percentage: {
+              percent: null,
+              color: 'hollow',
+              note: i18n.NO_DATA('alerts'),
+            },
+            testRef: 'criticalAlerts',
+            title: i18n.CRITICAL_ALERTS_STAT,
+            description: i18n.CRITICAL_ALERTS_DESCRIPTION,
+            updatedAt: dateNow,
           },
-          testRef: 'criticalAlerts',
-          title: i18n.CRITICAL_ALERTS_STAT,
-          description: i18n.CRITICAL_ALERTS_DESCRIPTION,
-          updatedAt: dateNow,
-        },
-      ],
-      isUpdating: true,
-      latestUpdate: dateNow,
+        ],
+        isUpdating: true,
+        latestUpdate: dateNow,
+      });
     });
   });
 });


### PR DESCRIPTION
…ndling

Addresses https://github.com/elastic/kibana/pull/201142

- replace waitFor(() => new Promise(resolve => resolve(null))) calls with waitFor() expectation blocks
- wrap remaining expectation blocks with waitFor() to avoid act warnings
- Rename test files from `.test.ts` to `.test.tsx` where necessary.
- Refactor components to use `FC` and `PropsWithChildren` for better TypeScript support.
- Remove unnecessary `act` wrappers and streamline test setup functions.
