### PR TITLE
[Fleet] Rollover datastreams on subobjects mapper exception

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -1084,6 +1084,10 @@ const updateExistingDataStream = async ({
 
     // if update fails, rollover data stream and bail out
   } catch (err) {
+    subobjectsFieldChanged =
+      subobjectsFieldChanged ||
+      (err.body?.error?.type === 'mapper_exception' &&
+        err.body?.error?.reason?.includes('subobjects'));
     if (
       (isResponseError(err) &&
         err.statusCode === 400 &&


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/193044

The previously added `subobjectsFieldChanged` check was not picking up the subobjects change in this case (okta integration), maybe because it is in dynamic template mappings. Added an additional condition to pick up on the `mapper_exception` with subobjects mentioned in the reason.

To verify:
- install okta-2.11.0 integration
- upgrade to okta-2.12.0
- expect upgrade successful, the data stream should be rolled over
```
POST kbn:/api/fleet/epm/packages/okta/2.11.0
{
  "force": true
}

POST logs-okta.system-default/_doc
 {
    "message": "abc",
    "@timestamp": "2024-05-30T07:50:00.000Z"
 }

POST kbn:/api/fleet/epm/packages/okta/2.12.0
{
  "force": true
}

GET logs-okta.system-default/_mapping
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->