### PR TITLE
[Obs AI Assistant] Remove `is_correction` attribute

### DIFF
--- a/x-pack/plugins/observability_solution/observability_ai_assistant/common/types.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/common/types.ts
@@ -85,7 +85,6 @@ export interface KnowledgeBaseEntry {
   title?: string;
   text: string;
   confidence: 'low' | 'medium' | 'high';
-  is_correction: boolean;
   type?: 'user_instruction' | 'contextual';
   public: boolean;
   labels?: Record<string, string>;

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/functions/summarize.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/functions/summarize.ts
@@ -20,7 +20,7 @@ export function registerSummarizationFunction({
     {
       name: SUMMARIZE_FUNCTION_NAME,
       description: `Use this function to store facts in the knowledge database if the user requests it.
-        You can score the learnings with a confidence metric, whether it is a correction on a previous learning.
+        You can score the learnings with a confidence metric.
         An embedding will be created that you can recall later with a semantic search.
         When you create this summarisation, make sure you craft it in a way that can be recalled with a semantic
         search later, and that it would have answered the user's original request.`,
@@ -39,10 +39,6 @@ export function registerSummarizationFunction({
             description:
               "A human-readable summary of what you have learned, described in such a way that you can recall it later with semantic search, and that it would have answered the user's original request.",
           },
-          is_correction: {
-            type: 'boolean',
-            description: 'Whether this is a correction for a previous learning.',
-          },
           confidence: {
             type: 'string',
             description: 'How confident you are about this being a correct and useful learning',
@@ -54,19 +50,10 @@ export function registerSummarizationFunction({
               'Whether this information is specific to the user, or generally applicable to any user of the product',
           },
         },
-        required: [
-          'title' as const,
-          'text' as const,
-          'is_correction' as const,
-          'confidence' as const,
-          'public' as const,
-        ],
+        required: ['title' as const, 'text' as const, 'confidence' as const, 'public' as const],
       },
     },
-    async (
-      { arguments: { title, text, is_correction: isCorrection, confidence, public: isPublic } },
-      signal
-    ) => {
+    async ({ arguments: { title, text, confidence, public: isPublic } }, signal) => {
       const id = v4();
       resources.logger.debug(`Creating new knowledge base entry with id: ${id}`);
 
@@ -79,7 +66,6 @@ export function registerSummarizationFunction({
             public: isPublic,
             role: KnowledgeBaseEntryRole.AssistantSummarization,
             confidence,
-            is_correction: isCorrection,
             labels: {},
           },
           // signal,

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/routes/functions/route.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/routes/functions/route.ts
@@ -127,7 +127,6 @@ const functionSummariseRoute = createObservabilityAIAssistantServerRoute({
       title: t.string,
       text: nonEmptyStringRt,
       confidence: t.union([t.literal('low'), t.literal('medium'), t.literal('high')]),
-      is_correction: toBooleanRt,
       public: toBooleanRt,
       labels: t.record(t.string, t.string),
     }),
@@ -142,21 +141,14 @@ const functionSummariseRoute = createObservabilityAIAssistantServerRoute({
       throw notImplemented();
     }
 
-    const {
-      title,
-      confidence,
-      is_correction: isCorrection,
-      text,
-      public: isPublic,
-      labels,
-    } = resources.params.body;
+    const { title, confidence, text, public: isPublic, labels } = resources.params.body;
 
     return client.addKnowledgeBaseEntry({
       entry: {
         title,
         confidence,
         id: v4(),
-        is_correction: isCorrection,
+
         text,
         public: isPublic,
         labels,

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/routes/knowledge_base/route.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/routes/knowledge_base/route.ts
@@ -191,7 +191,6 @@ const knowledgeBaseEntryRt = t.intersection([
   }),
   t.partial({
     confidence: t.union([t.literal('low'), t.literal('medium'), t.literal('high')]),
-    is_correction: toBooleanRt,
     public: toBooleanRt,
     labels: t.record(t.string, t.string),
     role: t.union([
@@ -221,7 +220,6 @@ const saveKnowledgeBaseEntry = createObservabilityAIAssistantServerRoute({
     return client.addKnowledgeBaseEntry({
       entry: {
         confidence: 'high',
-        is_correction: false,
         public: true,
         labels: {},
         role: KnowledgeBaseEntryRole.UserEntry,
@@ -281,7 +279,7 @@ const importKnowledgeBaseEntries = createObservabilityAIAssistantServerRoute({
         return client.addKnowledgeBaseEntry({
           entry: {
             confidence: 'high',
-            is_correction: false,
+
             public: true,
             labels: {},
             role: KnowledgeBaseEntryRole.UserEntry,

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/client/index.ts
@@ -745,10 +745,7 @@ export class ObservabilityAIAssistantClient {
   addUserInstruction = async ({
     entry,
   }: {
-    entry: Omit<
-      KnowledgeBaseEntry,
-      '@timestamp' | 'confidence' | 'is_correction' | 'type' | 'role'
-    >;
+    entry: Omit<KnowledgeBaseEntry, '@timestamp' | 'confidence' | 'type' | 'role'>;
   }): Promise<void> => {
     // for now we want to limit the number of user instructions to 1 per user
     // if a user instruction already exists for the user, we get the id and update it
@@ -770,7 +767,6 @@ export class ObservabilityAIAssistantClient {
       entry: {
         ...entry,
         confidence: 'high',
-        is_correction: false,
         type: KnowledgeBaseType.UserInstruction,
         labels: {},
         role: KnowledgeBaseEntryRole.UserEntry,

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/kb_component_template.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/kb_component_template.ts
@@ -71,9 +71,6 @@ export const kbComponentTemplate: ClusterComponentTemplate['component_template']
         type: 'rank_features',
       },
       confidence: keyword,
-      is_correction: {
-        type: 'boolean',
-      },
       public: {
         type: 'boolean',
       },

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/index.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/index.ts
@@ -43,7 +43,6 @@ export interface RecalledEntry {
   id: string;
   text: string;
   score: number | null;
-  is_correction?: boolean;
   labels?: Record<string, string>;
 }
 
@@ -88,7 +87,7 @@ export class KnowledgeBaseService {
     user?: { name: string };
   }): Promise<RecalledEntry[]> {
     const response = await this.dependencies.esClient.asInternalUser.search<
-      Pick<KnowledgeBaseEntry, 'text' | 'is_correction' | 'labels' | 'title'> & { doc_id?: string }
+      Pick<KnowledgeBaseEntry, 'text' | 'labels' | 'title'> & { doc_id?: string }
     >({
       index: [resourceNames.aliases.kb],
       query: {
@@ -114,13 +113,12 @@ export class KnowledgeBaseService {
       },
       size: 20,
       _source: {
-        includes: ['text', 'is_correction', 'labels', 'doc_id', 'title'],
+        includes: ['text', 'labels', 'doc_id', 'title'],
       },
     });
 
     return response.hits.hits.map((hit) => ({
       text: hit._source?.text!,
-      is_correction: hit._source?.is_correction,
       labels: hit._source?.labels,
       title: hit._source?.title ?? hit._source?.doc_id, // use `doc_id` as fallback title for backwards compatibility
       score: hit._score!,
@@ -293,7 +291,6 @@ export class KnowledgeBaseService {
             'title',
             'doc_id',
             'text',
-            'is_correction',
             'labels',
             'confidence',
             'public',

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/recall_from_search_connectors.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/recall_from_search_connectors.ts
@@ -105,7 +105,6 @@ async function recallFromSemanticTextConnectors({
   const results = response.hits.hits.map((hit) => ({
     text: JSON.stringify(hit._source),
     score: hit._score!,
-    is_correction: false,
     id: hit._id!,
   }));
 
@@ -192,7 +191,6 @@ async function recallFromLegacyConnectors({
   const results = response.hits.hits.map((hit) => ({
     text: JSON.stringify(hit._source),
     score: hit._score!,
-    is_correction: false,
     id: hit._id!,
   }));
 

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/hooks/use_import_knowledge_base_entries.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/hooks/use_import_knowledge_base_entries.ts
@@ -27,10 +27,9 @@ export function useImportKnowledgeBaseEntries() {
     ServerError,
     {
       entries: Array<
-        Omit<
-          KnowledgeBaseEntry,
-          '@timestamp' | 'confidence' | 'is_correction' | 'public' | 'labels'
-        > & { title: string }
+        Omit<KnowledgeBaseEntry, '@timestamp' | 'confidence' | 'public' | 'labels'> & {
+          title: string;
+        }
       >;
     }
   >(

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/routes/components/knowledge_base_edit_manual_entry_flyout.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/routes/components/knowledge_base_edit_manual_entry_flyout.tsx
@@ -63,7 +63,6 @@ export function KnowledgeBaseEditManualEntryFlyout({
         public: isPublic,
         role: KnowledgeBaseEntryRole.UserEntry,
         confidence: 'high',
-        is_correction: false,
         labels: {},
       },
     });

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/routes/components/knowledge_base_tab.test.tsx
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_management/public/routes/components/knowledge_base_tab.test.tsx
@@ -89,7 +89,6 @@ describe('KnowledgeBaseTab', () => {
           text: 'bar',
           role: 'user_entry',
           confidence: 'high',
-          is_correction: false,
           labels: expect.any(Object),
         },
       });

--- a/x-pack/test/observability_ai_assistant_api_integration/tests/complete/functions/summarize.spec.ts
+++ b/x-pack/test/observability_ai_assistant_api_integration/tests/complete/functions/summarize.spec.ts
@@ -63,7 +63,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           arguments: JSON.stringify({
             title: 'My Title',
             text: 'Hello world',
-            is_correction: false,
             confidence: 'high',
             public: false,
           }),

--- a/x-pack/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
@@ -40,7 +40,6 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
           title: 'Favourite color',
           text,
           confidence: 'high',
-          is_correction: false,
           public: false,
           labels: {},
         },

--- a/x-pack/test_serverless/api_integration/test_suites/observability/ai_assistant/tests/complete/functions/summarize.spec.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/ai_assistant/tests/complete/functions/summarize.spec.ts
@@ -61,7 +61,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           arguments: JSON.stringify({
             id: 'my-id',
             text: 'Hello world',
-            is_correction: false,
             confidence: 1,
             public: false,
           }),


### PR DESCRIPTION
This does not seem used anymore. I suggest removing it unless there are any loud objections (@dgieselaar ?)

Context: in order to prepare ourself for the unified knowledge base we should only have essential, useful KB attributes that we intend to support going forward.

