### PR TITLE
[Fleet] Use index.mapping.source.mode instead of _source.mode

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.test.ts
@@ -124,12 +124,13 @@ describe('EPM index template install', () => {
 
     const packageTemplate = componentTemplates['metrics-package.dataset@package'].template;
 
-    if (!('mappings' in packageTemplate)) {
+    if (!('settings' in packageTemplate)) {
       throw new Error('no mappings on package template');
     }
 
-    expect(packageTemplate.mappings).toHaveProperty('_source');
-    expect(packageTemplate.mappings._source).toEqual({ mode: 'synthetic' });
+    expect(packageTemplate.settings?.index?.mapping).toHaveProperty('source');
+    // @ts-expect-error esclient mapping out-of-date
+    expect(packageTemplate.settings?.index?.mapping?.source).toEqual({ mode: 'synthetic' });
   });
 
   it('tests prepareTemplate to set source mode to synthetics if index_mode:time_series', async () => {
@@ -154,12 +155,13 @@ describe('EPM index template install', () => {
 
     const packageTemplate = componentTemplates['metrics-package.dataset@package'].template;
 
-    if (!('mappings' in packageTemplate)) {
-      throw new Error('no mappings on package template');
+    if (!('settings' in packageTemplate)) {
+      throw new Error('no settings on package template');
     }
 
-    expect(packageTemplate.mappings).toHaveProperty('_source');
-    expect(packageTemplate.mappings._source).toEqual({ mode: 'synthetic' });
+    expect(packageTemplate.settings?.index?.mapping).toHaveProperty('source');
+    // @ts-expect-error esclient mapping out-of-date
+    expect(packageTemplate.settings?.index?.mapping?.source).toEqual({ mode: 'synthetic' });
   });
 
   it('tests prepareTemplate to not set source mode to synthetics if index_mode:time_series and user disabled synthetic', async () => {
@@ -193,11 +195,11 @@ describe('EPM index template install', () => {
 
     const packageTemplate = componentTemplates['metrics-package.dataset@package'].template;
 
-    if (!('mappings' in packageTemplate)) {
+    if (!('settings' in packageTemplate)) {
       throw new Error('no mappings on package template');
     }
 
-    expect(packageTemplate.mappings).not.toHaveProperty('_source');
+    expect(packageTemplate.settings?.index?.mapping).not.toHaveProperty('source');
   });
 
   it('tests prepareTemplate to not set source mode to synthetics if specified but user disabled it', async () => {
@@ -231,11 +233,11 @@ describe('EPM index template install', () => {
 
     const packageTemplate = componentTemplates['metrics-package.dataset@package'].template;
 
-    if (!('mappings' in packageTemplate)) {
-      throw new Error('no mappings on package template');
+    if (!('settings' in packageTemplate)) {
+      throw new Error('no settings on package template');
     }
 
-    expect(packageTemplate.mappings).not.toHaveProperty('_source');
+    expect(packageTemplate.settings?.index?.mapping).not.toHaveProperty('source');
   });
 
   it('tests prepareTemplate to set index_mode time series if index_mode:time_series', async () => {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.test.ts
@@ -196,7 +196,7 @@ describe('EPM index template install', () => {
     const packageTemplate = componentTemplates['metrics-package.dataset@package'].template;
 
     if (!('settings' in packageTemplate)) {
-      throw new Error('no mappings on package template');
+      throw new Error('no settings on package template');
     }
 
     expect(packageTemplate.settings?.index?.mapping).not.toHaveProperty('source');

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -409,6 +409,14 @@ export function buildComponentTemplates(params: {
                 templateSettings.index?.mapping?.total_fields?.limit
               ),
             },
+            ...(templateSettings.index?.mapping?.source || sourceModeSynthetic
+              ? {
+                  source: {
+                    ...templateSettings.index?.mapping?.source,
+                    ...(sourceModeSynthetic ? { mode: 'synthetic' } : {}),
+                  },
+                }
+              : {}),
           },
         },
       },
@@ -418,15 +426,7 @@ export function buildComponentTemplates(params: {
           ? { runtime: mappingsRuntimeFields }
           : {}),
         dynamic_templates: mappingsDynamicTemplates.length ? mappingsDynamicTemplates : undefined,
-        ...omit(indexTemplateMappings, 'properties', 'dynamic_templates', '_source', 'runtime'),
-        ...(indexTemplateMappings?._source || sourceModeSynthetic
-          ? {
-              _source: {
-                ...indexTemplateMappings?._source,
-                ...(sourceModeSynthetic ? { mode: 'synthetic' } : {}),
-              },
-            }
-          : {}),
+        ...omit(indexTemplateMappings, 'properties', 'dynamic_templates', 'runtime'),
       },
       ...(lifecycle ? { lifecycle } : {}),
     },

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -1031,8 +1031,8 @@ const updateExistingDataStream = async ({
   const existingDsConfig = Object.values(existingDs);
   const currentBackingIndexConfig = existingDsConfig.at(-1);
   const currentIndexMode = currentBackingIndexConfig?.settings?.index?.mode;
-  // @ts-expect-error Property 'mode' does not exist on type 'MappingSourceField'
-  const currentSourceType = currentBackingIndexConfig.mappings?._source?.mode;
+  // @ts-expect-error Property 'source.mode' does not exist on type 'IndicesMappingLimitSettings'
+  const currentSourceType = currentBackingIndexConfig?.settings?.index?.mapping?.source?.mode;
 
   let settings: IndicesIndexSettings;
   let mappings: MappingTypeMapping = {};
@@ -1137,7 +1137,7 @@ const updateExistingDataStream = async ({
   // Trigger a rollover if the index mode or source type has changed
   if (
     currentIndexMode !== settings?.index?.mode ||
-    currentSourceType !== mappings?._source?.mode ||
+    currentSourceType !== settings?.index?.source?.mode ||
     dynamicDimensionMappingsChanged
   ) {
     if (options?.skipDataStreamRollover === true) {


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/199698 


`_source.mode` in index mappings has been deprecated in favor of `index.mapping.source.mode`, that PR change our usage to not use the deprecated version when generating template.

## Test

You can verify package with tsdb create the correct component template, (`elastic_agent` metrics for example).
The change is covered by unit tests. 


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->