### PR TITLE
[Fleet] fix schema validation to allow undefined/null

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -6547,9 +6547,6 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "enabled"
-                            ],
                             "type": "object"
                           },
                           "monitoring_output_id": {
@@ -7316,9 +7313,6 @@
                         "type": "number"
                       }
                     },
-                    "required": [
-                      "enabled"
-                    ],
                     "type": "object"
                   },
                   "monitoring_output_id": {
@@ -7577,9 +7571,6 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "enabled"
-                          ],
                           "type": "object"
                         },
                         "monitoring_output_id": {
@@ -8376,9 +8367,6 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "enabled"
-                            ],
                             "type": "object"
                           },
                           "monitoring_output_id": {
@@ -9436,9 +9424,6 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "enabled"
-                          ],
                           "type": "object"
                         },
                         "monitoring_output_id": {
@@ -10204,9 +10189,6 @@
                         "type": "number"
                       }
                     },
-                    "required": [
-                      "enabled"
-                    ],
                     "type": "object"
                   },
                   "monitoring_output_id": {
@@ -10465,9 +10447,6 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "enabled"
-                          ],
                           "type": "object"
                         },
                         "monitoring_output_id": {
@@ -11265,9 +11244,6 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "enabled"
-                          ],
                           "type": "object"
                         },
                         "monitoring_output_id": {
@@ -13278,6 +13254,7 @@
                           },
                           "upgrade_details": {
                             "additionalProperties": false,
+                            "nullable": true,
                             "properties": {
                               "action_id": {
                                 "type": "string"
@@ -15470,6 +15447,7 @@
                         },
                         "upgrade_details": {
                           "additionalProperties": false,
+                          "nullable": true,
                           "properties": {
                             "action_id": {
                               "type": "string"
@@ -15958,6 +15936,7 @@
                         },
                         "upgrade_details": {
                           "additionalProperties": false,
+                          "nullable": true,
                           "properties": {
                             "action_id": {
                               "type": "string"

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -6547,9 +6547,6 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "enabled"
-                            ],
                             "type": "object"
                           },
                           "monitoring_output_id": {
@@ -7316,9 +7313,6 @@
                         "type": "number"
                       }
                     },
-                    "required": [
-                      "enabled"
-                    ],
                     "type": "object"
                   },
                   "monitoring_output_id": {
@@ -7577,9 +7571,6 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "enabled"
-                          ],
                           "type": "object"
                         },
                         "monitoring_output_id": {
@@ -8376,9 +8367,6 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "enabled"
-                            ],
                             "type": "object"
                           },
                           "monitoring_output_id": {
@@ -9436,9 +9424,6 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "enabled"
-                          ],
                           "type": "object"
                         },
                         "monitoring_output_id": {
@@ -10204,9 +10189,6 @@
                         "type": "number"
                       }
                     },
-                    "required": [
-                      "enabled"
-                    ],
                     "type": "object"
                   },
                   "monitoring_output_id": {
@@ -10465,9 +10447,6 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "enabled"
-                          ],
                           "type": "object"
                         },
                         "monitoring_output_id": {
@@ -11265,9 +11244,6 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "enabled"
-                          ],
                           "type": "object"
                         },
                         "monitoring_output_id": {
@@ -13278,6 +13254,7 @@
                           },
                           "upgrade_details": {
                             "additionalProperties": false,
+                            "nullable": true,
                             "properties": {
                               "action_id": {
                                 "type": "string"
@@ -15470,6 +15447,7 @@
                         },
                         "upgrade_details": {
                           "additionalProperties": false,
+                          "nullable": true,
                           "properties": {
                             "action_id": {
                               "type": "string"
@@ -15958,6 +15936,7 @@
                         },
                         "upgrade_details": {
                           "additionalProperties": false,
+                          "nullable": true,
                           "properties": {
                             "action_id": {
                               "type": "string"

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -9628,8 +9628,6 @@ paths:
                               maximum: 65353
                               minimum: 0
                               type: number
-                          required:
-                            - enabled
                         monitoring_output_id:
                           nullable: true
                           type: string
@@ -10160,8 +10158,6 @@ paths:
                       maximum: 65353
                       minimum: 0
                       type: number
-                  required:
-                    - enabled
                 monitoring_output_id:
                   nullable: true
                   type: string
@@ -10342,8 +10338,6 @@ paths:
                             maximum: 65353
                             minimum: 0
                             type: number
-                        required:
-                          - enabled
                       monitoring_output_id:
                         nullable: true
                         type: string
@@ -10896,8 +10890,6 @@ paths:
                               maximum: 65353
                               minimum: 0
                               type: number
-                          required:
-                            - enabled
                         monitoring_output_id:
                           nullable: true
                           type: string
@@ -11430,8 +11422,6 @@ paths:
                             maximum: 65353
                             minimum: 0
                             type: number
-                        required:
-                          - enabled
                       monitoring_output_id:
                         nullable: true
                         type: string
@@ -11961,8 +11951,6 @@ paths:
                       maximum: 65353
                       minimum: 0
                       type: number
-                  required:
-                    - enabled
                 monitoring_output_id:
                   nullable: true
                   type: string
@@ -12143,8 +12131,6 @@ paths:
                             maximum: 65353
                             minimum: 0
                             type: number
-                        required:
-                          - enabled
                       monitoring_output_id:
                         nullable: true
                         type: string
@@ -12697,8 +12683,6 @@ paths:
                             maximum: 65353
                             minimum: 0
                             type: number
-                        required:
-                          - enabled
                       monitoring_output_id:
                         nullable: true
                         type: string
@@ -14248,6 +14232,7 @@ paths:
                           type: array
                         upgrade_details:
                           additionalProperties: false
+                          nullable: true
                           type: object
                           properties:
                             action_id:
@@ -14715,6 +14700,7 @@ paths:
                         type: array
                       upgrade_details:
                         additionalProperties: false
+                        nullable: true
                         type: object
                         properties:
                           action_id:
@@ -15059,6 +15045,7 @@ paths:
                         type: array
                       upgrade_details:
                         additionalProperties: false
+                        nullable: true
                         type: object
                         properties:
                           action_id:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -12489,8 +12489,6 @@ paths:
                               maximum: 65353
                               minimum: 0
                               type: number
-                          required:
-                            - enabled
                         monitoring_output_id:
                           nullable: true
                           type: string
@@ -13020,8 +13018,6 @@ paths:
                       maximum: 65353
                       minimum: 0
                       type: number
-                  required:
-                    - enabled
                 monitoring_output_id:
                   nullable: true
                   type: string
@@ -13202,8 +13198,6 @@ paths:
                             maximum: 65353
                             minimum: 0
                             type: number
-                        required:
-                          - enabled
                       monitoring_output_id:
                         nullable: true
                         type: string
@@ -13755,8 +13749,6 @@ paths:
                               maximum: 65353
                               minimum: 0
                               type: number
-                          required:
-                            - enabled
                         monitoring_output_id:
                           nullable: true
                           type: string
@@ -14288,8 +14280,6 @@ paths:
                             maximum: 65353
                             minimum: 0
                             type: number
-                        required:
-                          - enabled
                       monitoring_output_id:
                         nullable: true
                         type: string
@@ -14818,8 +14808,6 @@ paths:
                       maximum: 65353
                       minimum: 0
                       type: number
-                  required:
-                    - enabled
                 monitoring_output_id:
                   nullable: true
                   type: string
@@ -15000,8 +14988,6 @@ paths:
                             maximum: 65353
                             minimum: 0
                             type: number
-                        required:
-                          - enabled
                       monitoring_output_id:
                         nullable: true
                         type: string
@@ -15553,8 +15539,6 @@ paths:
                             maximum: 65353
                             minimum: 0
                             type: number
-                        required:
-                          - enabled
                       monitoring_output_id:
                         nullable: true
                         type: string
@@ -17096,6 +17080,7 @@ paths:
                           type: array
                         upgrade_details:
                           additionalProperties: false
+                          nullable: true
                           type: object
                           properties:
                             action_id:
@@ -17560,6 +17545,7 @@ paths:
                         type: array
                       upgrade_details:
                         additionalProperties: false
+                        nullable: true
                         type: object
                         properties:
                           action_id:
@@ -17903,6 +17889,7 @@ paths:
                         type: array
                       upgrade_details:
                         additionalProperties: false
+                        nullable: true
                         type: object
                         properties:
                           action_id:

--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -46,7 +46,7 @@ export interface NewAgentPolicy {
   global_data_tags?: GlobalDataTag[];
   monitoring_pprof_enabled?: boolean;
   monitoring_http?: {
-    enabled: boolean;
+    enabled?: boolean;
     host?: string;
     port?: number;
     buffer?: {

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -135,7 +135,7 @@ export const AgentPolicyBaseSchema = {
   monitoring_pprof_enabled: schema.maybe(schema.boolean()),
   monitoring_http: schema.maybe(
     schema.object({
-      enabled: schema.boolean(),
+      enabled: schema.maybe(schema.boolean()),
       host: schema.maybe(schema.string({ defaultValue: 'localhost' })),
       port: schema.maybe(schema.number({ min: 0, max: 65353, defaultValue: 6791 })),
       buffer: schema.maybe(schema.object({ enabled: schema.boolean({ defaultValue: false }) })),

--- a/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/agent.ts
@@ -138,22 +138,25 @@ export const AgentResponseSchema = schema.object({
   upgraded_at: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
   upgrade_started_at: schema.maybe(schema.oneOf([schema.literal(null), schema.string()])),
   upgrade_details: schema.maybe(
-    schema.object({
-      target_version: schema.string(),
-      action_id: schema.string(),
-      state: AgentUpgradeStateTypeSchema,
-      metadata: schema.maybe(
-        schema.object({
-          scheduled_at: schema.maybe(schema.string()),
-          download_percent: schema.maybe(schema.number()),
-          download_rate: schema.maybe(schema.number()),
-          failed_state: schema.maybe(AgentUpgradeStateTypeSchema),
-          error_msg: schema.maybe(schema.string()),
-          retry_error_msg: schema.maybe(schema.string()),
-          retry_until: schema.maybe(schema.string()),
-        })
-      ),
-    })
+    schema.oneOf([
+      schema.literal(null),
+      schema.object({
+        target_version: schema.string(),
+        action_id: schema.string(),
+        state: AgentUpgradeStateTypeSchema,
+        metadata: schema.maybe(
+          schema.object({
+            scheduled_at: schema.maybe(schema.string()),
+            download_percent: schema.maybe(schema.number()),
+            download_rate: schema.maybe(schema.number()),
+            failed_state: schema.maybe(AgentUpgradeStateTypeSchema),
+            error_msg: schema.maybe(schema.string()),
+            retry_error_msg: schema.maybe(schema.string()),
+            retry_until: schema.maybe(schema.string()),
+          })
+        ),
+      }),
+    ])
   ),
   access_api_key_id: schema.maybe(schema.string()),
   default_api_key: schema.maybe(schema.string()),


### PR DESCRIPTION
## Summary

Fix a few issues encountered with schema validation.

One of them reported here: https://discuss.elastic.co/t/fleet-error-updating-policy-settings/371332

The other encountered locally when testing upgrades:
```
"Failed output validation: [request body.items.0.upgrade_details]: expected a plain object value, but found [null] instead."
```


<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.x"]} ONMERGE-->