### PR TITLE
[Search] Web crawler name consistency

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
@@ -53,7 +53,7 @@ export const connectorsBreadcrumbs = [
 
 export const crawlersBreadcrumbs = [
   i18n.translate('xpack.enterpriseSearch.content.crawlers.breadcrumb', {
-    defaultMessage: 'Web crawlers',
+    defaultMessage: 'Web Crawlers',
   }),
 ];
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
@@ -93,7 +93,7 @@ export const Connectors: React.FC<ConnectorsProps> = ({ isCrawler }) => {
                 defaultMessage: 'Elasticsearch connectors',
               })
             : i18n.translate('xpack.enterpriseSearch.crawlers.title', {
-                defaultMessage: 'Elasticsearch web crawlers',
+                defaultMessage: 'Elastic Web Crawler',
               }),
           rightSideGroupProps: {
             gutterSize: 's',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawler_empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawler_empty_state.tsx
@@ -49,6 +49,7 @@ export const CrawlerEmptyState: React.FC = () => {
               fill
               iconType={GithubIcon}
               href={'https://github.com/elastic/crawler'}
+              target="_blank"
             >
               {i18n.translate(
                 'xpack.enterpriseSearch.crawlerEmptyState.openSourceCrawlerButtonLabel',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -289,7 +289,7 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
                 {i18n.translate(
                   'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.learnMoreCrawler.linkText',
                   {
-                    defaultMessage: 'Learn more about the Elastic web crawler',
+                    defaultMessage: 'Learn more about the Elastic Web Crawler',
                   }
                 )}
               </EuiLink>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/classic_nav_helpers.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/classic_nav_helpers.test.ts
@@ -37,7 +37,7 @@ describe('generateSideNavItems', () => {
     },
     'enterpriseSearchContent:webCrawlers': {
       id: 'enterpriseSearchContent:webCrawlers',
-      title: 'Web crawlers',
+      title: 'Web Crawlers',
       url: '/app/enterprise_search/content/crawlers',
     },
   } as unknown as Record<string, ChromeNavLink | undefined>;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -62,7 +62,7 @@ const baseNavItems = [
         href: '/app/enterprise_search/content/crawlers',
         id: 'crawlers',
         items: undefined,
-        name: 'Web crawlers',
+        name: 'Web Crawlers',
       },
     ],
     name: 'Content',
@@ -184,7 +184,7 @@ const mockNavLinks = [
   },
   {
     id: 'enterpriseSearchContent:webCrawlers',
-    title: 'Web crawlers',
+    title: 'Web Crawlers',
     url: '/app/enterprise_search/content/crawlers',
   },
   {

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -131,7 +131,7 @@ const contentLinks: AppDeepLink[] = [
     id: 'webCrawlers',
     path: `/${CRAWLERS_PATH}`,
     title: i18n.translate('xpack.enterpriseSearch.navigation.contentWebcrawlersLinkLabel', {
-      defaultMessage: 'Web crawlers',
+      defaultMessage: 'Web Crawlers',
     }),
   },
 ];

--- a/x-pack/plugins/search_solution/search_navigation/public/classic_navigation.test.ts
+++ b/x-pack/plugins/search_solution/search_navigation/public/classic_navigation.test.ts
@@ -30,7 +30,7 @@ describe('classicNavigationFactory', function () {
     },
     {
       id: 'enterpriseSearchContent:webCrawlers',
-      title: 'Web crawlers',
+      title: 'Web Crawlers',
       url: '/app/enterprise_search/content/crawlers',
     },
   ];

--- a/x-pack/plugins/serverless_search/common/i18n_string.ts
+++ b/x-pack/plugins/serverless_search/common/i18n_string.ts
@@ -68,7 +68,7 @@ export const CONNECTOR_LABEL: string = i18n.translate('xpack.serverlessSearch.co
 export const WEB_CRAWLERS_LABEL: string = i18n.translate(
   'xpack.serverlessSearch.webCrawlersLabel',
   {
-    defaultMessage: 'Web crawlers',
+    defaultMessage: 'Web Crawlers',
   }
 );
 

--- a/x-pack/plugins/serverless_search/public/application/components/web_crawlers/empty_web_crawlers_prompt.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/web_crawlers/empty_web_crawlers_prompt.tsx
@@ -230,6 +230,7 @@ export const EmptyWebCrawlersPrompt: React.FC = () => {
                   fill
                   iconType={githubIcon}
                   href={'https://github.com/elastic/crawler'}
+                  target="_blank"
                 >
                   {i18n.translate('xpack.serverlessSearch.webCrawlersEmpty.selfManagedButton', {
                     defaultMessage: 'Self-managed web crawler',

--- a/x-pack/plugins/serverless_search/public/application/components/web_crawlers_elastic_managed.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/web_crawlers_elastic_managed.tsx
@@ -27,7 +27,7 @@ export const WebCrawlersElasticManaged = () => {
     <EuiPageTemplate offset={0} grow restrictWidth data-test-subj="svlSearchConnectorsPage">
       <EuiPageTemplate.Header
         pageTitle={i18n.translate('xpack.serverlessSearch.webcrawlers.title', {
-          defaultMessage: 'Web crawlers',
+          defaultMessage: 'Web Crawlers',
         })}
         data-test-subj="serverlessSearchConnectorsTitle"
         restrictWidth

--- a/x-pack/plugins/serverless_search/public/application/components/web_crawlers_overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/web_crawlers_overview.tsx
@@ -27,7 +27,7 @@ export const WebCrawlersOverview = () => {
     <EuiPageTemplate offset={0} grow restrictWidth data-test-subj="svlSearchConnectorsPage">
       <EuiPageTemplate.Header
         pageTitle={i18n.translate('xpack.serverlessSearch.webcrawlers.title', {
-          defaultMessage: 'Web crawlers',
+          defaultMessage: 'Web Crawlers',
         })}
         data-test-subj="serverlessSearchConnectorsTitle"
         restrictWidth

--- a/x-pack/test/functional_search/tests/classic_navigation.ts
+++ b/x-pack/test/functional_search/tests/classic_navigation.ts
@@ -42,7 +42,7 @@ export default function searchSolutionNavigation({
         { id: 'Content', label: 'Content' },
         { id: 'Indices', label: 'Indices' },
         { id: 'Connectors', label: 'Connectors' },
-        { id: 'Crawlers', label: 'Web crawlers' },
+        { id: 'Crawlers', label: 'Web Crawlers' },
         { id: 'Build', label: 'Build' },
         { id: 'Playground', label: 'Playground' },
         { id: 'SearchApplications', label: 'Search Applications' },
@@ -76,7 +76,7 @@ export default function searchSolutionNavigation({
       await searchClassicNavigation.clickNavItem('Crawlers');
       await searchClassicNavigation.expectNavItemActive('Crawlers');
       await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Content');
-      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Web crawlers');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Web Crawlers');
 
       // Check Build
       // > Playground

--- a/x-pack/test/functional_search/tests/solution_navigation.ts
+++ b/x-pack/test/functional_search/tests/solution_navigation.ts
@@ -54,7 +54,7 @@ export default function searchSolutionNavigation({
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dashboards' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Indices' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Connectors' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Web crawlers' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Web Crawlers' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Search applications' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Behavioral Analytics' });
@@ -147,7 +147,7 @@ export default function searchSolutionNavigation({
         deepLinkId: 'enterpriseSearchContent:webCrawlers',
       });
       await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Content' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Web crawlers' });
+      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Web Crawlers' });
       await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
         deepLinkId: 'enterpriseSearchContent:webCrawlers',
       });

--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -241,7 +241,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Data' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Index Management' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Connectors' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Web crawlers' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Web Crawlers' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Build' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dev Tools' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });


### PR DESCRIPTION
## Summary

This PR fixes the areas where we display the Web Crawler naming bearing in mind these agreements :
- We should be capitalizing when referring to the product name: Elastic Web Crawler / Web Crawler /Elastic Open Web Crawler
- We can use lower case when referring to the feature or concept of web crawler( crawler in short): "Use the web crawler to ..."

ESS:
![CleanShot 2024-12-03 at 15 19 19@2x](https://github.com/user-attachments/assets/d5cba886-09b3-4c34-b6e5-565cb67b9e08)

ES3:
![CleanShot 2024-12-03 at 15 19 56@2x](https://github.com/user-attachments/assets/2a6b6a8a-697c-4001-96d8-c826b6769836)


Notes: Also fixing buttons that take users to the Open Web Crawler repo to open the links in a new tab and don't lose the product focus.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->