### PR TITLE
[deps] Remove faker from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -401,26 +401,6 @@
       "minimumReleaseAge": "7 days"
     },
     {
-      "groupName": "@elastic/kibana-visualizations test dependencies",
-      "matchDepNames": [
-        "@types/faker",
-        "faker"
-      ],
-      "reviewers": [
-        "team:visualizations"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "Team:Visualizations",
-        "release_note:skip",
-        "backport:prev-minor"
-      ],
-      "enabled": true,
-      "minimumReleaseAge": "7 days"
-    },
-    {
       "groupName": "@elastic/charts",
       "matchDepNames": [
         "@elastic/charts"


### PR DESCRIPTION
## Summary

With the [replacement](https://github.com/elastic/kibana/pull/201105) of `faker` with `@faker-js` there is no more need of this renovate configuration.

