### PR TITLE
[8.17] [Spaces UI] Role Editor Flyout Should Match in Roles Mgmt (#198182)

### DIFF
--- a/x-pack/packages/security/ui_components/kibana.jsonc
+++ b/x-pack/packages/security/ui_components/kibana.jsonc
@@ -1,5 +1,5 @@
 {
-    "type": "shared-common",
+    "type": "shared-browser",
     "id": "@kbn/security-ui-components",
     "owner": "@elastic/kibana-security"
 }

--- a/x-pack/packages/security/ui_components/src/kibana_privilege_table/feature_table.test.tsx
+++ b/x-pack/packages/security/ui_components/src/kibana_privilege_table/feature_table.test.tsx
@@ -54,6 +54,7 @@ const setup = (config: TestConfig) => {
         kibanaPrivileges={kibanaPrivileges}
         onChange={onChange}
         onChangeAll={onChangeAll}
+        showAdditionalPermissionsMessage={true}
         canCustomizeSubFeaturePrivileges={config.canCustomizeSubFeaturePrivileges}
         privilegeIndex={config.privilegeIndex}
         allSpacesSelected={true}

--- a/x-pack/packages/security/ui_components/src/kibana_privilege_table/feature_table.tsx
+++ b/x-pack/packages/security/ui_components/src/kibana_privilege_table/feature_table.tsx
@@ -45,13 +45,10 @@ interface Props {
   privilegeIndex: number;
   onChange: (featureId: string, privileges: string[]) => void;
   onChangeAll: (privileges: string[]) => void;
+  showAdditionalPermissionsMessage: boolean;
   canCustomizeSubFeaturePrivileges: boolean;
   allSpacesSelected: boolean;
   disabled?: boolean;
-  /**
-   * default is true, to remain backwards compatible
-   */
-  showTitle?: boolean;
 }
 
 interface State {
@@ -62,7 +59,6 @@ export class FeatureTable extends Component<Props, State> {
   public static defaultProps = {
     privilegeIndex: -1,
     showLocks: true,
-    showTitle: true,
   };
 
   private featureCategories: Map<string, SecuredFeature[]> = new Map();
@@ -189,20 +185,7 @@ export class FeatureTable extends Component<Props, State> {
     return (
       <div>
         <EuiFlexGroup alignItems={'flexEnd'}>
-          <EuiFlexItem>
-            {this.props.showTitle && (
-              <EuiText size="xs">
-                <b>
-                  {i18n.translate(
-                    'xpack.security.management.editRole.featureTable.featureVisibilityTitle',
-                    {
-                      defaultMessage: 'Customize feature privileges',
-                    }
-                  )}
-                </b>
-              </EuiText>
-            )}
-          </EuiFlexItem>
+          <EuiFlexItem />
           {!this.props.disabled && (
             <EuiFlexItem grow={false}>
               <ChangeAllPrivilegesControl
@@ -397,7 +380,7 @@ export class FeatureTable extends Component<Props, State> {
   };
 
   private getCategoryHelpText = (category: AppCategory) => {
-    if (category.id === 'management') {
+    if (category.id === 'management' && this.props.showAdditionalPermissionsMessage) {
       return i18n.translate(
         'xpack.security.management.editRole.featureTable.managementCategoryHelpText',
         {

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/simple_privilege_section/simple_privilege_section.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/simple_privilege_section/simple_privilege_section.tsx
@@ -226,6 +226,7 @@ export class SimplePrivilegeSection extends Component<Props, State> {
                   privilegeIndex={this.props.role.kibana.findIndex((k) =>
                     isGlobalPrivilegeDefinition(k)
                   )}
+                  showAdditionalPermissionsMessage={true}
                   canCustomizeSubFeaturePrivileges={this.props.canCustomizeSubFeaturePrivileges}
                   allSpacesSelected
                   disabled={!this.props.editable}

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_form.test.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_form.test.tsx
@@ -19,7 +19,6 @@ import type { Space } from '@kbn/spaces-plugin/public';
 import { findTestSubject, mountWithIntl } from '@kbn/test-jest-helpers';
 
 import { PrivilegeSpaceForm } from './privilege_space_form';
-import { SpaceSelector } from './space_selector';
 import type { Role } from '../../../../../../../common';
 
 const createRole = (kibana: Role['kibana'] = []): Role => {
@@ -57,7 +56,7 @@ const renderComponent = (props: React.ComponentProps<typeof PrivilegeSpaceForm>)
 };
 
 describe('PrivilegeSpaceForm', () => {
-  it('renders an empty form when the role contains no Kibana privileges', () => {
+  it('renders no form when no role is selected', () => {
     const role = createRole();
     const kibanaPrivileges = createKibanaPrivileges(kibanaFeatures);
 
@@ -71,40 +70,9 @@ describe('PrivilegeSpaceForm', () => {
       onCancel: jest.fn(),
     });
 
-    expect(
-      wrapper.find(EuiButtonGroup).filter('[name="basePrivilegeButtonGroup"]').props().idSelected
-    ).toEqual(`basePrivilege_custom`);
-    expect(wrapper.find(FeatureTable).props().disabled).toEqual(true);
-    expect(getDisplayedFeaturePrivileges(wrapper)).toMatchInlineSnapshot(`
-      Object {
-        "excluded_from_base": Object {
-          "primaryFeaturePrivilege": "none",
-          "subFeaturePrivileges": Array [],
-        },
-        "no_sub_features": Object {
-          "primaryFeaturePrivilege": "none",
-          "subFeaturePrivileges": Array [],
-        },
-        "with_excluded_sub_features": Object {
-          "primaryFeaturePrivilege": "none",
-          "subFeaturePrivileges": Array [],
-        },
-        "with_require_all_spaces_for_feature_and_sub_features": Object {
-          "primaryFeaturePrivilege": "none",
-          "subFeaturePrivileges": Array [],
-        },
-        "with_require_all_spaces_sub_features": Object {
-          "primaryFeaturePrivilege": "none",
-          "subFeaturePrivileges": Array [],
-        },
-        "with_sub_features": Object {
-          "primaryFeaturePrivilege": "none",
-          "subFeaturePrivileges": Array [],
-        },
-      }
-    `);
-
-    expect(findTestSubject(wrapper, 'spaceFormGlobalPermissionsSupersedeWarning')).toHaveLength(0);
+    expect(wrapper.find(EuiButtonGroup).filter('[name="basePrivilegeButtonGroup"]')).toHaveLength(
+      0
+    );
   });
 
   it('renders when a base privilege is selected', () => {
@@ -230,43 +198,6 @@ describe('PrivilegeSpaceForm', () => {
     `);
 
     expect(findTestSubject(wrapper, 'spaceFormGlobalPermissionsSupersedeWarning')).toHaveLength(0);
-  });
-
-  it('renders a warning when configuring a global privilege after space privileges are already defined', () => {
-    const role = createRole([
-      {
-        base: [],
-        feature: {
-          with_sub_features: ['read'],
-        },
-        spaces: ['foo'],
-      },
-      {
-        base: [],
-        feature: {
-          with_sub_features: ['all'],
-        },
-        spaces: ['*'],
-      },
-    ]);
-
-    const kibanaPrivileges = createKibanaPrivileges(kibanaFeatures);
-
-    const wrapper = renderComponent({
-      role,
-      spaces: displaySpaces,
-      kibanaPrivileges,
-      privilegeIndex: -1,
-      canCustomizeSubFeaturePrivileges: true,
-      onChange: jest.fn(),
-      onCancel: jest.fn(),
-    });
-
-    wrapper.find(SpaceSelector).props().onChange(['*']);
-
-    wrapper.update();
-
-    expect(findTestSubject(wrapper, 'globalPrivilegeWarning')).toHaveLength(1);
   });
 
   it('renders a warning when space privileges are less permissive than configured global privileges', () => {

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_form.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/privilege_space_form.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { EuiButtonColor } from '@elastic/eui';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -21,7 +20,6 @@ import {
   EuiForm,
   EuiFormRow,
   EuiSpacer,
-  EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import { remove } from 'lodash';
@@ -105,20 +103,19 @@ export class PrivilegeSpaceForm extends Component<Props, State> {
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
             <h2>
-              <FormattedMessage
-                id="xpack.security.management.editRole.spacePrivilegeForm.modalTitle"
-                defaultMessage="Assign role to space"
-              />
+              {this.state.mode === 'create' ? (
+                <FormattedMessage
+                  id="xpack.security.management.editRole.spacePrivilegeForm.modalTitleCreate"
+                  defaultMessage="Assign role to spaces"
+                />
+              ) : (
+                <FormattedMessage
+                  id="xpack.security.management.editRole.spacePrivilegeForm.modalTitleUpdate"
+                  defaultMessage="Edit role privileges for spaces"
+                />
+              )}
             </h2>
           </EuiTitle>
-          <EuiText size="s">
-            <p>
-              <FormattedMessage
-                id="xpack.security.management.editRole.spacePrivilegeForm.modalHeadline"
-                defaultMessage="This role will be granted access to the following spaces"
-              />
-            </p>
-          </EuiText>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>
           <EuiErrorBoundary>{this.getForm()}</EuiErrorBoundary>
@@ -180,14 +177,13 @@ export class PrivilegeSpaceForm extends Component<Props, State> {
           label={i18n.translate(
             'xpack.security.management.editRole.spacePrivilegeForm.spaceSelectorFormLabel',
             {
-              defaultMessage: 'Spaces',
+              defaultMessage: 'Select spaces',
             }
           )}
           helpText={i18n.translate(
             'xpack.security.management.editRole.spacePrivilegeForm.spaceSelectorFormHelpText',
             {
-              defaultMessage:
-                'Select one or more Kibana spaces to which you wish to assign privileges.',
+              defaultMessage: 'Users assigned to this role will gain access to selected spaces.',
             }
           )}
         >
@@ -198,99 +194,85 @@ export class PrivilegeSpaceForm extends Component<Props, State> {
           />
         </EuiFormRow>
 
-        {this.getPrivilegeCallout()}
+        {Boolean(this.state.selectedSpaceIds.length) && (
+          <>
+            <EuiFormRow fullWidth>
+              <EuiCallOut
+                color="primary"
+                iconType="iInCircle"
+                size="s"
+                title={i18n.translate(
+                  'xpack.security.management.editRole.spacePrivilegeForm.privilegeCombinationMsg.title',
+                  {
+                    defaultMessage: `The user's resulting access depends on a combination of their role's global space privileges and specific privileges applied to this space.`,
+                  }
+                )}
+              />
+            </EuiFormRow>
 
-        <EuiFormRow
-          fullWidth
-          label={i18n.translate(
-            'xpack.security.management.editRole.spacePrivilegeForm.privilegeSelectorFormLabel',
-            {
-              defaultMessage: 'Privileges for all features',
-            }
-          )}
-          helpText={i18n.translate(
-            'xpack.security.management.editRole.spacePrivilegeForm.privilegeSelectorFormHelpText',
-            {
-              defaultMessage:
-                'Assign the privilege level you wish to grant to all present and future features across this space.',
-            }
-          )}
-        >
-          <EuiButtonGroup
-            name={`basePrivilegeButtonGroup`}
-            data-test-subj={`basePrivilegeButtonGroup`}
-            isFullWidth={true}
-            color={'primary'}
-            options={[
-              {
-                id: 'basePrivilege_all',
-                label: 'All',
-                ['data-test-subj']: 'basePrivilege_all',
-              },
-              {
-                id: 'basePrivilege_read',
-                label: 'Read',
-                ['data-test-subj']: 'basePrivilege_read',
-              },
-              {
-                id: 'basePrivilege_custom',
-                label: 'Customize',
-                ['data-test-subj']: 'basePrivilege_custom',
-              },
-            ]}
-            idSelected={this.getDisplayedBasePrivilege()}
-            isDisabled={!hasSelectedSpaces}
-            onChange={this.onSpaceBasePrivilegeChange}
-            legend={i18n.translate(
-              'xpack.security.management.editRole.spacePrivilegeForm.basePrivilegeControlLegend',
-              {
-                defaultMessage: 'Privileges for all features',
-              }
-            )}
-          />
-        </EuiFormRow>
+            <EuiFormRow
+              fullWidth
+              label={i18n.translate(
+                'xpack.security.management.editRole.spacePrivilegeForm.privilegeSelectorFormLabel',
+                {
+                  defaultMessage: 'Define privileges',
+                }
+              )}
+              helpText={i18n.translate(
+                'xpack.security.management.editRole.spacePrivilegeForm.privilegeSelectorFormHelpText',
+                {
+                  defaultMessage:
+                    'Assign the privilege level you wish to grant to all present and future features across this space.',
+                }
+              )}
+            >
+              <EuiButtonGroup
+                name={`basePrivilegeButtonGroup`}
+                data-test-subj={`basePrivilegeButtonGroup`}
+                isFullWidth={true}
+                color={'primary'}
+                options={[
+                  {
+                    id: 'basePrivilege_all',
+                    label: 'All',
+                    ['data-test-subj']: 'basePrivilege_all',
+                  },
+                  {
+                    id: 'basePrivilege_read',
+                    label: 'Read',
+                    ['data-test-subj']: 'basePrivilege_read',
+                  },
+                  {
+                    id: 'basePrivilege_custom',
+                    label: 'Customize',
+                    ['data-test-subj']: 'basePrivilege_custom',
+                  },
+                ]}
+                idSelected={this.getDisplayedBasePrivilege()}
+                isDisabled={!hasSelectedSpaces}
+                onChange={this.onSpaceBasePrivilegeChange}
+                legend={i18n.translate(
+                  'xpack.security.management.editRole.spacePrivilegeForm.basePrivilegeControlLegend',
+                  {
+                    defaultMessage: 'Privileges for all features',
+                  }
+                )}
+              />
+            </EuiFormRow>
 
-        <EuiSpacer />
-
-        <EuiTitle size="xxs">
-          <h3>{this.getFeatureListLabel(this.state.selectedBasePrivilege.length > 0)}</h3>
-        </EuiTitle>
-
-        <EuiSpacer size="xs" />
-
-        <EuiText size="s">
-          <p>{this.getFeatureListDescription(this.state.selectedBasePrivilege.length > 0)}</p>
-        </EuiText>
-
-        <EuiSpacer size="l" />
-
-        <KibanaPrivilegeTable
-          role={this.state.role}
-          privilegeCalculator={this.state.privilegeCalculator}
-          onChange={this.onFeaturePrivilegesChange}
-          onChangeAll={this.onChangeAllFeaturePrivileges}
-          kibanaPrivileges={this.props.kibanaPrivileges}
-          privilegeIndex={this.state.privilegeIndex}
-          canCustomizeSubFeaturePrivileges={this.props.canCustomizeSubFeaturePrivileges}
-          disabled={this.state.selectedBasePrivilege.length > 0 || !hasSelectedSpaces}
-          allSpacesSelected={this.state.selectedSpaceIds.includes(ALL_SPACES_ID)}
-        />
-
-        {this.requiresGlobalPrivilegeWarning() && (
-          <Fragment>
-            <EuiSpacer size="l" />
-            <EuiCallOut
-              color="warning"
-              iconType="warning"
-              data-test-subj="globalPrivilegeWarning"
-              title={
-                <FormattedMessage
-                  id="xpack.security.management.editRole.spacePrivilegeForm.globalPrivilegeWarning"
-                  defaultMessage="Creating a global privilege might impact your other space privileges."
-                />
-              }
+            <KibanaPrivilegeTable
+              role={this.state.role}
+              privilegeCalculator={this.state.privilegeCalculator}
+              onChange={this.onFeaturePrivilegesChange}
+              onChangeAll={this.onChangeAllFeaturePrivileges}
+              kibanaPrivileges={this.props.kibanaPrivileges}
+              privilegeIndex={this.state.privilegeIndex}
+              showAdditionalPermissionsMessage={true}
+              canCustomizeSubFeaturePrivileges={this.props.canCustomizeSubFeaturePrivileges}
+              disabled={this.state.selectedBasePrivilege.length > 0 || !hasSelectedSpaces}
+              allSpacesSelected={this.state.selectedSpaceIds.includes(ALL_SPACES_ID)}
             />
-          </Fragment>
+          </>
         )}
       </EuiForm>
     );
@@ -298,50 +280,26 @@ export class PrivilegeSpaceForm extends Component<Props, State> {
 
   private getSaveButton = () => {
     const { mode } = this.state;
-    const isGlobal = this.isDefiningGlobalPrivilege();
     let buttonText;
     switch (mode) {
       case 'create':
-        if (isGlobal) {
-          buttonText = (
-            <FormattedMessage
-              id="xpack.security.management.editRolespacePrivilegeForm.createGlobalPrivilegeButton"
-              defaultMessage="Create global privilege"
-            />
-          );
-        } else {
-          buttonText = (
-            <FormattedMessage
-              id="xpack.security.management.editRolespacePrivilegeForm.createPrivilegeButton"
-              defaultMessage="Add Kibana privilege"
-            />
-          );
-        }
+        buttonText = (
+          <FormattedMessage
+            id="xpack.security.management.editRolespacePrivilegeForm.createPrivilegeButton"
+            defaultMessage="Assign role"
+          />
+        );
         break;
       case 'update':
-        if (isGlobal) {
-          buttonText = (
-            <FormattedMessage
-              id="xpack.security.management.editRolespacePrivilegeForm.updateGlobalPrivilegeButton"
-              defaultMessage="Update global privilege"
-            />
-          );
-        } else {
-          buttonText = (
-            <FormattedMessage
-              id="xpack.security.management.editRolespacePrivilegeForm.updatePrivilegeButton"
-              defaultMessage="Update space privilege"
-            />
-          );
-        }
+        buttonText = (
+          <FormattedMessage
+            id="xpack.security.management.editRolespacePrivilegeForm.updatePrivilegeButton"
+            defaultMessage="Update role privileges"
+          />
+        );
         break;
       default:
         throw new Error(`Unsupported mode: ${mode}`);
-    }
-
-    let buttonColor: EuiButtonColor = 'primary';
-    if (this.requiresGlobalPrivilegeWarning()) {
-      buttonColor = 'warning';
     }
 
     return (
@@ -349,71 +307,12 @@ export class PrivilegeSpaceForm extends Component<Props, State> {
         onClick={this.onSaveClick}
         fill
         disabled={!this.canSave()}
-        color={buttonColor}
+        color="primary"
         data-test-subj={'createSpacePrivilegeButton'}
       >
         {buttonText}
       </EuiButton>
     );
-  };
-
-  private getFeatureListLabel = (disabled: boolean) => {
-    if (disabled) {
-      return i18n.translate(
-        'xpack.security.management.editRole.spacePrivilegeForm.summaryOfFeaturePrivileges',
-        {
-          defaultMessage: 'Summary of feature privileges',
-        }
-      );
-    } else {
-      return i18n.translate(
-        'xpack.security.management.editRole.spacePrivilegeForm.customizeFeaturePrivileges',
-        {
-          defaultMessage: 'Customize by feature',
-        }
-      );
-    }
-  };
-
-  private getFeatureListDescription = (disabled: boolean) => {
-    if (disabled) {
-      return i18n.translate(
-        'xpack.security.management.editRole.spacePrivilegeForm.featurePrivilegeSummaryDescription',
-        {
-          defaultMessage:
-            'Some features might be hidden by the space or affected by a global space privilege.',
-        }
-      );
-    } else {
-      return i18n.translate(
-        'xpack.security.management.editRole.spacePrivilegeForm.customizeFeaturePrivilegeDescription',
-        {
-          defaultMessage:
-            'Increase privilege levels on a per feature basis. Some features might be hidden by the space or affected by a global space privilege.',
-        }
-      );
-    }
-  };
-
-  private getPrivilegeCallout = () => {
-    if (this.isDefiningGlobalPrivilege()) {
-      return (
-        <EuiFormRow fullWidth>
-          <EuiCallOut
-            color="primary"
-            iconType="iInCircle"
-            title={i18n.translate(
-              'xpack.security.management.editRole.spacePrivilegeForm.globalPrivilegeNotice',
-              {
-                defaultMessage: 'These privileges will apply to all current and future spaces.',
-              }
-            )}
-          />
-        </EuiFormRow>
-      );
-    }
-
-    return null;
   };
 
   private closeFlyout = () => {
@@ -594,13 +493,4 @@ export class PrivilegeSpaceForm extends Component<Props, State> {
   };
 
   private isDefiningGlobalPrivilege = () => this.state.selectedSpaceIds.includes('*');
-
-  private requiresGlobalPrivilegeWarning = () => {
-    const hasOtherSpacePrivilegesDefined = this.props.role.kibana.length > 0;
-    return (
-      this.state.mode === 'create' &&
-      this.isDefiningGlobalPrivilege() &&
-      hasOtherSpacePrivilegesDefined
-    );
-  };
 }

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/space_selector.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/kibana/space_aware_privilege_section/space_selector.tsx
@@ -57,6 +57,9 @@ export class SpaceSelector extends Component<Props, {}> {
         aria-label={i18n.translate('xpack.security.management.editRole.spaceSelectorLabel', {
           defaultMessage: 'Spaces',
         })}
+        placeholder={i18n.translate('xpack.security.management.editRole.spaceSelectorPlaceholder', {
+          defaultMessage: 'Add spaces...',
+        })}
         fullWidth
         options={this.getOptions()}
         renderOption={renderOption}

--- a/x-pack/plugins/spaces/public/management/components/solution_view/solution_view.tsx
+++ b/x-pack/plugins/spaces/public/management/components/solution_view/solution_view.tsx
@@ -8,7 +8,6 @@
 import type { EuiSuperSelectOption, EuiThemeComputed } from '@elastic/eui';
 import {
   EuiBetaBadge,
-  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
@@ -180,21 +179,6 @@ export const SolutionView: FunctionComponent<Props> = ({
               isInvalid={validator.validateSolutionView(space, isEditing).isInvalid}
             />
           </EuiFormRow>
-
-          {showClassicDefaultViewCallout && (
-            <>
-              <EuiSpacer size="m" />
-              <EuiCallOut
-                color="primary"
-                size="s"
-                iconType="iInCircle"
-                title={i18n.translate(
-                  'xpack.spaces.management.manageSpacePage.solutionViewSelect.classicDefaultViewCallout',
-                  { defaultMessage: 'By default your current view is Classic' }
-                )}
-              />
-            </>
-          )}
         </EuiFlexItem>
       </EuiFlexGroup>
     </SectionPanel>

--- a/x-pack/plugins/spaces/public/management/edit_space/edit_space_roles_tab.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/edit_space_roles_tab.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { EuiConfirmModal, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import type { FC } from 'react';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import type { KibanaFeature } from '@kbn/features-plugin/common';
 import { i18n } from '@kbn/i18n';
@@ -39,6 +39,8 @@ export const EditSpaceAssignedRolesTab: FC<Props> = ({ space, features, isReadOn
     notifications,
     invokeClient,
   } = services;
+
+  const [removeRoleConfirm, setRemoveRoleConfirm] = useState<Role | null>(null);
 
   // Roles are already loaded in app state, refresh them when user navigates to this tab
   useEffect(() => {
@@ -175,7 +177,7 @@ export const EditSpaceAssignedRolesTab: FC<Props> = ({ space, features, isReadOn
   );
 
   return (
-    <React.Fragment>
+    <>
       <EuiFlexGroup direction="column">
         <EuiFlexItem>
           <EuiText>
@@ -194,8 +196,8 @@ export const EditSpaceAssignedRolesTab: FC<Props> = ({ space, features, isReadOn
             onClickBulkRemove={async (selectedRoles) => {
               await removeRole(selectedRoles);
             }}
-            onClickRowRemoveAction={async (rowRecord) => {
-              await removeRole([rowRecord]);
+            onClickRemoveRoleConfirm={async (rowRecord) => {
+              setRemoveRoleConfirm(rowRecord);
             }}
             onClickAssignNewRole={async () => {
               showRolesPrivilegeEditor();
@@ -203,6 +205,36 @@ export const EditSpaceAssignedRolesTab: FC<Props> = ({ space, features, isReadOn
           />
         </EuiFlexItem>
       </EuiFlexGroup>
-    </React.Fragment>
+      {removeRoleConfirm && (
+        <EuiConfirmModal
+          aria-labelledby="remove-role-confirm-modal"
+          titleProps={{ id: 'remove-role-confirm-modal' }}
+          title={i18n.translate('xpack.spaces.management.spaceDetails.roles.removeRoleModalTitle', {
+            defaultMessage: 'Remove role "{roleName}" from the space?',
+            values: { roleName: removeRoleConfirm.name },
+          })}
+          cancelButtonText={i18n.translate(
+            'xpack.spaces.management.spaceDetails.roles.removeRoleModalCancel',
+            { defaultMessage: 'Cancel' }
+          )}
+          confirmButtonText={i18n.translate(
+            'xpack.spaces.management.spaceDetails.roles.removeRoleModalConfirm',
+            { defaultMessage: 'Confirm' }
+          )}
+          onCancel={() => setRemoveRoleConfirm(null)}
+          onConfirm={() => {
+            removeRole([removeRoleConfirm]);
+            setRemoveRoleConfirm(null);
+          }}
+        >
+          <p>
+            <FormattedMessage
+              id="xpack.spaces.management.spaceDetails.roles.removeRoleModalBody"
+              defaultMessage="You can't undo this operation."
+            />
+          </p>
+        </EuiConfirmModal>
+      )}
+    </>
   );
 };

--- a/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assign_role_privilege_form.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assign_role_privilege_form.tsx
@@ -20,7 +20,6 @@ import {
   EuiFormRow,
   EuiLink,
   EuiLoadingSpinner,
-  EuiSpacer,
   EuiText,
   EuiTitle,
   useGeneratedHtmlId,
@@ -31,7 +30,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { KibanaFeature, KibanaFeatureConfig } from '@kbn/features-plugin/common';
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
 import type {
   RawKibanaPrivileges,
   Role,
@@ -157,7 +155,7 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
 
   const [roleSpacePrivilege, setRoleSpacePrivilege] = useState<KibanaRolePrivilege>(
     !selectedRoles.length || !selectedRolesCombinedPrivileges.length
-      ? FEATURE_PRIVILEGES_ALL
+      ? FEATURE_PRIVILEGES_CUSTOM
       : selectedRolesCombinedPrivileges[0]
   );
 
@@ -378,17 +376,19 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
                 { defaultMessage: 'Select roles' }
               )}
               labelAppend={
-                <EuiLink
-                  id={manageRoleLinkId}
-                  href={getUrlForApp('management', { deepLinkId: 'roles' })}
-                  external={false}
-                  target="_blank"
-                >
-                  {i18n.translate(
-                    'xpack.spaces.management.spaceDetails.roles.selectRolesFormRowLabelAnchor',
-                    { defaultMessage: 'Manage roles' }
-                  )}
-                </EuiLink>
+                <EuiText size="xs">
+                  <EuiLink
+                    id={manageRoleLinkId}
+                    href={getUrlForApp('management', { deepLinkId: 'roles' })}
+                    external={false}
+                    target="_blank"
+                  >
+                    {i18n.translate(
+                      'xpack.spaces.management.spaceDetails.roles.selectRolesFormRowLabelAnchor',
+                      { defaultMessage: 'Manage roles' }
+                    )}
+                  </EuiLink>
+                </EuiText>
               }
               helpText={i18n.translate(
                 'xpack.spaces.management.spaceDetails.roles.selectRolesHelp',
@@ -409,7 +409,7 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
                 )}
                 placeholder={i18n.translate(
                   'xpack.spaces.management.spaceDetails.roles.selectRolesPlaceholder',
-                  { defaultMessage: 'Add a role...' }
+                  { defaultMessage: 'Add roles...' }
                 )}
                 isLoading={fetchingDataDeps}
                 options={createRolesComboBoxOptions(spaceUnallocatedRoles)}
@@ -452,9 +452,9 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
                     iconType="iInCircle"
                     data-test-subj="privilege-info-callout"
                     title={i18n.translate(
-                      'xpack.spaces.management.spaceDetails.roles.assign.privilegeConflictMsg.title',
+                      'xpack.spaces.management.spaceDetails.roles.assign.privilegeCombinationMsg.title',
                       {
-                        defaultMessage: 'Privileges will apply only to this space.',
+                        defaultMessage: `The user's resulting access depends on a combination of their role's global space privileges and specific privileges applied to this space.`,
                       }
                     )}
                   />
@@ -464,7 +464,14 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
                 label={i18n.translate(
                   'xpack.spaces.management.spaceDetails.roles.assign.privilegesLabelText',
                   {
-                    defaultMessage: 'Define role privileges',
+                    defaultMessage: 'Define privileges',
+                  }
+                )}
+                helpText={i18n.translate(
+                  'xpack.spaces.management.spaceDetails.roles.assign.privilegesHelpText',
+                  {
+                    defaultMessage:
+                      'Assign the privilege level you wish to grant to all present and future features across this space.',
                   }
                 )}
               >
@@ -518,7 +525,6 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
                       <EuiLoadingSpinner size="l" />
                     ) : (
                       <KibanaPrivilegeTable
-                        showTitle={false}
                         disabled={roleSpacePrivilege !== FEATURE_PRIVILEGES_CUSTOM}
                         role={roleCustomizationAnchor.value!}
                         privilegeIndex={roleCustomizationAnchor.privilegeIndex}
@@ -597,6 +603,7 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
                         canCustomizeSubFeaturePrivileges={
                           license?.getFeatures().allowSubFeaturePrivileges ?? false
                         }
+                        showAdditionalPermissionsMessage={false}
                       />
                     )}
                   </React.Fragment>
@@ -643,10 +650,10 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
       >
         {isEditOperation.current
           ? i18n.translate('xpack.spaces.management.spaceDetails.roles.updateRoleButton', {
-              defaultMessage: 'Update',
+              defaultMessage: 'Update role privileges',
             })
           : i18n.translate('xpack.spaces.management.spaceDetails.roles.assignRoleButton', {
-              defaultMessage: 'Assign',
+              defaultMessage: 'Assign roles',
             })}
       </EuiButton>
     );
@@ -659,7 +666,7 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
           <h2>
             {isEditOperation.current
               ? i18n.translate('xpack.spaces.management.spaceDetails.roles.assignRoleButton', {
-                  defaultMessage: 'Edit role privileges',
+                  defaultMessage: 'Edit role privileges for space',
                 })
               : i18n.translate(
                   'xpack.spaces.management.spaceDetails.roles.assign.privileges.custom',
@@ -669,15 +676,6 @@ export const PrivilegesRolesForm: FC<PrivilegesRolesFormProps> = (props) => {
                 )}
           </h2>
         </EuiTitle>
-        <EuiSpacer size="s" />
-        <EuiText size="s">
-          <p>
-            <FormattedMessage
-              id="xpack.spaces.management.spaceDetails.privilegeForm.heading"
-              defaultMessage="Define the privileges a given role should have in this space."
-            />
-          </p>
-        </EuiText>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>{getForm()}</EuiFlyoutBody>
       <EuiFlyoutFooter>

--- a/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assigned_roles_table.test.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assigned_roles_table.test.tsx
@@ -18,7 +18,7 @@ const defaultProps: Pick<
   | 'onClickAssignNewRole'
   | 'onClickBulkRemove'
   | 'onClickRowEditAction'
-  | 'onClickRowRemoveAction'
+  | 'onClickRemoveRoleConfirm'
   | 'currentSpace'
 > = {
   currentSpace: {
@@ -29,7 +29,7 @@ const defaultProps: Pick<
   onClickBulkRemove: jest.fn(),
   onClickRowEditAction: jest.fn(),
   onClickAssignNewRole: jest.fn(),
-  onClickRowRemoveAction: jest.fn(),
+  onClickRemoveRoleConfirm: jest.fn(),
 };
 
 const renderTestComponent = (

--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.test.tsx
@@ -153,12 +153,21 @@ describe('SpacesGridPage', () => {
     wrapper.update();
 
     expect(wrapper.find('EuiInMemoryTable').prop('items')).toBe(spacesWithSolution);
-    expect(wrapper.find('EuiInMemoryTable').prop('columns')).toContainEqual({
-      field: 'solution',
-      name: 'Solution view',
-      sortable: true,
-      render: expect.any(Function),
-    });
+    expect(wrapper.find('EuiInMemoryTable').prop('columns')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: '', field: 'initials' }),
+        expect.objectContaining({ name: 'Space', field: 'name' }),
+        expect.objectContaining({ name: 'Description', field: 'description' }),
+        expect.objectContaining({ name: 'Solution view', field: 'solution' }),
+        expect.objectContaining({
+          actions: expect.arrayContaining([
+            expect.objectContaining({ name: 'Edit', icon: 'pencil' }),
+            expect.objectContaining({ name: 'Switch', icon: 'merge' }),
+            expect.objectContaining({ name: 'Delete', icon: 'trash' }),
+          ]),
+        }),
+      ])
+    );
   });
 
   it('renders a "current" badge for the current space', async () => {
@@ -409,5 +418,43 @@ describe('SpacesGridPage', () => {
     expect(notifications.toasts.addError).toHaveBeenCalledWith(error, {
       title: 'Error loading spaces',
     });
+  });
+
+  it(`does not render the 'Features visible' column when serverless`, async () => {
+    const httpStart = httpServiceMock.createStartContract();
+    httpStart.get.mockResolvedValue([]);
+
+    const error = new Error('something awful happened');
+
+    const notifications = notificationServiceMock.createStartContract();
+
+    const wrapper = shallowWithIntl(
+      <SpacesGridPage
+        spacesManager={spacesManager}
+        getFeatures={() => Promise.reject(error)}
+        notifications={notifications}
+        getUrlForApp={getUrlForApp}
+        history={history}
+        capabilities={{
+          navLinks: {},
+          management: {},
+          catalogue: {},
+          spaces: { manage: true },
+        }}
+        allowSolutionVisibility
+        {...spacesGridCommonProps}
+      />
+    );
+
+    // allow spacesManager to load spaces and lazy-load SpaceAvatar
+    await act(async () => {});
+    wrapper.update();
+
+    expect(wrapper.find('EuiInMemoryTable').prop('columns')).not.toContainEqual(
+      expect.objectContaining({
+        field: 'disabledFeatures',
+        name: 'Features visible',
+      })
+    );
   });
 });

--- a/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
+++ b/x-pack/plugins/spaces/public/management/spaces_grid/spaces_grid_page.tsx
@@ -18,8 +18,6 @@ import {
   EuiPageHeader,
   EuiPageSection,
   EuiSpacer,
-  EuiText,
-  useIsWithinBreakpoints,
 } from '@elastic/eui';
 import React, { Component, lazy, Suspense } from 'react';
 
@@ -36,17 +34,12 @@ import { reactRouterNavigate } from '@kbn/kibana-react-plugin/public';
 
 import { addSpaceIdToPath, type Space } from '../../../common';
 import { isReservedSpace } from '../../../common';
-import {
-  DEFAULT_SPACE_ID,
-  ENTER_SPACE_PATH,
-  SOLUTION_VIEW_CLASSIC,
-} from '../../../common/constants';
+import { DEFAULT_SPACE_ID, ENTER_SPACE_PATH } from '../../../common/constants';
 import { getSpacesFeatureDescription } from '../../constants';
 import { getSpaceAvatarComponent } from '../../space_avatar';
 import { SpaceSolutionBadge } from '../../space_solution_badge';
 import type { SpacesManager } from '../../spaces_manager';
 import { ConfirmDeleteModal, UnauthorizedPrompt } from '../components';
-import { getEnabledFeatures } from '../lib/feature_utils';
 
 // No need to wrap LazySpaceAvatar in an error boundary, because it is one of the first chunks loaded when opening Kibana.
 const LazySpaceAvatar = lazy(() =>
@@ -254,8 +247,7 @@ export class SpacesGridPage extends Component<Props, State> {
   };
 
   public getColumnConfig() {
-    const { activeSpace, features } = this.state;
-    const { solution: activeSolution } = activeSpace ?? {};
+    const { activeSpace } = this.state;
 
     const config: Array<EuiBasicTableColumn<Space>> = [
       {
@@ -283,15 +275,8 @@ export class SpacesGridPage extends Component<Props, State> {
         render: (value: string, rowRecord: Space) => {
           const SpaceName = () => {
             const isCurrent = this.state.activeSpace?.id === rowRecord.id;
-            const isWide = useIsWithinBreakpoints(['xl']);
-            const gridColumns = isCurrent && isWide ? 2 : 1;
             return (
-              <EuiFlexGrid
-                responsive={false}
-                columns={gridColumns}
-                alignItems="center"
-                gutterSize="s"
-              >
+              <EuiFlexGrid responsive={false} columns={2} alignItems="center" gutterSize="s">
                 <EuiFlexItem>
                   <EuiLink
                     {...reactRouterNavigate(this.props.history, this.getEditSpacePath(rowRecord))}
@@ -322,7 +307,7 @@ export class SpacesGridPage extends Component<Props, State> {
           return <SpaceName />;
         },
         'data-test-subj': 'spacesListTableRowNameCell',
-        width: '15%',
+        width: '20%',
       },
       {
         field: 'description',
@@ -331,53 +316,9 @@ export class SpacesGridPage extends Component<Props, State> {
         }),
         sortable: true,
         truncateText: true,
-        width: '45%',
+        width: '40%',
       },
     ];
-
-    const shouldShowFeaturesColumn = !activeSolution || activeSolution === SOLUTION_VIEW_CLASSIC;
-    if (shouldShowFeaturesColumn) {
-      config.push({
-        field: 'disabledFeatures',
-        name: i18n.translate('xpack.spaces.management.spacesGridPage.featuresColumnName', {
-          defaultMessage: 'Features visible',
-        }),
-        sortable: (space: Space) => {
-          return getEnabledFeatures(features, space).length;
-        },
-        render: (_disabledFeatures: string[], rowRecord: Space) => {
-          const enabledFeatureCount = getEnabledFeatures(features, rowRecord).length;
-          if (enabledFeatureCount === features.length) {
-            return (
-              <FormattedMessage
-                id="xpack.spaces.management.spacesGridPage.allFeaturesEnabled"
-                defaultMessage="All features"
-              />
-            );
-          }
-          if (enabledFeatureCount === 0) {
-            return (
-              <EuiText color={'danger'} size="s">
-                <FormattedMessage
-                  id="xpack.spaces.management.spacesGridPage.noFeaturesEnabled"
-                  defaultMessage="No features visible"
-                />
-              </EuiText>
-            );
-          }
-          return (
-            <FormattedMessage
-              id="xpack.spaces.management.spacesGridPage.someFeaturesEnabled"
-              defaultMessage="{enabledFeatureCount} / {totalFeatureCount}"
-              values={{
-                enabledFeatureCount,
-                totalFeatureCount: features.length,
-              }}
-            />
-          );
-        },
-      });
-    }
 
     config.push({
       field: 'id',
@@ -403,6 +344,7 @@ export class SpacesGridPage extends Component<Props, State> {
         render: (solution: Space['solution'], record: Space) => (
           <SpaceSolutionBadge solution={solution} data-test-subj={`${record.id}-solution`} />
         ),
+        width: '10%',
       });
     }
 

--- a/x-pack/test/accessibility/apps/group1/roles.ts
+++ b/x-pack/test/accessibility/apps/group1/roles.ts
@@ -14,6 +14,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const a11y = getService('a11y');
   const esArchiver = getService('esArchiver');
   const testSubjects = getService('testSubjects');
+  const find = getService('find');
   const retry = getService('retry');
   const kibanaServer = getService('kibanaServer');
 
@@ -82,6 +83,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('a11y test for customize feature privilege', async () => {
+      await testSubjects.click('spaceSelectorComboBox');
+      const globalSpaceOption = await find.byCssSelector(`#spaceOption_\\*`);
+      await globalSpaceOption.click();
       await testSubjects.click('featureCategory_kibana');
       await a11y.testAppSnapshot();
       await testSubjects.click('cancelSpacePrivilegeButton');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Spaces UI] Role Editor Flyout Should Match in Roles Mgmt (#198182)](https://github.com/elastic/kibana/pull/198182)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tim Sullivan","email":"tsullivan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-11-20T14:39:41Z","message":"[Spaces UI] Role Editor Flyout Should Match in Roles Mgmt (#198182)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana-team/issues/1242\r\n\r\n**Fixes for alignment of the Role editor flyout**\r\n1. Remove the warning callout regarding global privileges that impact\r\nother privileges\r\n1. Unify the info callouts regarding combination of privileges\r\n1. set \"Customize\" as the default selected option when assigning new\r\nprivileges\r\n1. update placeholders for selector box when assigning privileges\r\n1. Hide privileges controls if no spaces are selected\r\n1. Update button group label text to \"Define privileges\" and align\r\nhelper texts below\r\n1. Align headers for assign/edit states\r\n1. Remove descriptions under headers\r\n1. Update size of info callout above button group to small\r\n1. Reduce text size for the \"Manage roles\" link\r\n1. Remove the \"Additional Stack Management permissions can be found\r\noutside of this menu...\" test for the Spaces Management context.\r\n\r\n**Polish fixes**\r\n1. Remove features visible column\r\n1. ~~Remove identifier column from spaces grid~~\r\n1. Fix vertical alignment of non-current space name in table\r\n1. Ordered the listing of assigned roles during and after search\r\n1. Removing a role from the space shows a confirmation modal\r\n1. Update columns widths in the spaces grid\r\n1. Remove the \"By default your current view is Classic\" callout\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [x] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [x] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [x] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)","sha":"226924eafebff8852a67723a49e8f4fdbb6ed869","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","ci:cloud-deploy","backport:version","v8.17.0"],"number":198182,"url":"https://github.com/elastic/kibana/pull/198182","mergeCommit":{"message":"[Spaces UI] Role Editor Flyout Should Match in Roles Mgmt (#198182)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana-team/issues/1242\r\n\r\n**Fixes for alignment of the Role editor flyout**\r\n1. Remove the warning callout regarding global privileges that impact\r\nother privileges\r\n1. Unify the info callouts regarding combination of privileges\r\n1. set \"Customize\" as the default selected option when assigning new\r\nprivileges\r\n1. update placeholders for selector box when assigning privileges\r\n1. Hide privileges controls if no spaces are selected\r\n1. Update button group label text to \"Define privileges\" and align\r\nhelper texts below\r\n1. Align headers for assign/edit states\r\n1. Remove descriptions under headers\r\n1. Update size of info callout above button group to small\r\n1. Reduce text size for the \"Manage roles\" link\r\n1. Remove the \"Additional Stack Management permissions can be found\r\noutside of this menu...\" test for the Spaces Management context.\r\n\r\n**Polish fixes**\r\n1. Remove features visible column\r\n1. ~~Remove identifier column from spaces grid~~\r\n1. Fix vertical alignment of non-current space name in table\r\n1. Ordered the listing of assigned roles during and after search\r\n1. Removing a role from the space shows a confirmation modal\r\n1. Update columns widths in the spaces grid\r\n1. Remove the \"By default your current view is Classic\" callout\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [x] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [x] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [x] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)","sha":"226924eafebff8852a67723a49e8f4fdbb6ed869"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/198182","number":198182,"mergeCommit":{"message":"[Spaces UI] Role Editor Flyout Should Match in Roles Mgmt (#198182)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana-team/issues/1242\r\n\r\n**Fixes for alignment of the Role editor flyout**\r\n1. Remove the warning callout regarding global privileges that impact\r\nother privileges\r\n1. Unify the info callouts regarding combination of privileges\r\n1. set \"Customize\" as the default selected option when assigning new\r\nprivileges\r\n1. update placeholders for selector box when assigning privileges\r\n1. Hide privileges controls if no spaces are selected\r\n1. Update button group label text to \"Define privileges\" and align\r\nhelper texts below\r\n1. Align headers for assign/edit states\r\n1. Remove descriptions under headers\r\n1. Update size of info callout above button group to small\r\n1. Reduce text size for the \"Manage roles\" link\r\n1. Remove the \"Additional Stack Management permissions can be found\r\noutside of this menu...\" test for the Spaces Management context.\r\n\r\n**Polish fixes**\r\n1. Remove features visible column\r\n1. ~~Remove identifier column from spaces grid~~\r\n1. Fix vertical alignment of non-current space name in table\r\n1. Ordered the listing of assigned roles during and after search\r\n1. Removing a role from the space shows a confirmation modal\r\n1. Update columns widths in the spaces grid\r\n1. Remove the \"By default your current view is Classic\" callout\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [x] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [x] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [x] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)","sha":"226924eafebff8852a67723a49e8f4fdbb6ed869"}},{"branch":"8.x","label":"v8.17.0","labelRegex":"^v8.17.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->