### PR TITLE
[8.x] Sync devcontainer with main

### DIFF
--- a/.devcontainer/.env.template
+++ b/.devcontainer/.env.template
@@ -1,4 +1,5 @@
 # /bin/bash or /bin/zsh (oh-my-zsh is installed by default as well)
 SHELL=/bin/bash
-# Switch to 1 to enable FIPS environment, any other value to disable
+# Switch to 1 to enable FIPS environment, any other value to disable,
+# then close and reopen a new terminal to setup the environment
 FIPS=0

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,11 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
 
+ARG KBN_DIR
+
 ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 ENV HOME=/home/vscode
 ENV NVM_DIR=${HOME}/nvm
 ENV NVM_VERSION=v0.39.1
-ENV KBN_DIR=/workspaces/kibana
 ENV OPENSSL_PATH=${HOME}/openssl
 # Only specific versions are FIPS certified.
 ENV OPENSSL_VERSION='3.0.8'
@@ -49,6 +50,10 @@ WORKDIR ${KBN_DIR}
 
 # Node and NVM setup
 COPY .node-version /tmp/
+
+# Mac will have permissions issues if Node and NVM are installed as root
+USER vscode
+
 RUN mkdir -p $NVM_DIR && \
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash && \
   . "$NVM_DIR/nvm.sh" && \
@@ -61,9 +66,11 @@ RUN mkdir -p $NVM_DIR && \
   echo "source $NVM_DIR/nvm.sh" >> ${HOME}/.zshrc  && \
   chown -R 1000:1000 "${HOME}/.npm"
 
+USER root
+
 # Reload the env everytime a new shell is opened incase the .env file changed.
-RUN echo "source $KBN_DIR/.devcontainer/scripts/env.sh" >> ${HOME}/.bashrc && \
-  echo "source $KBN_DIR/.devcontainer/scripts/env.sh" >> ${HOME}/.zshrc
+RUN echo "source ${KBN_DIR}/.devcontainer/scripts/env.sh" >> ${HOME}/.bashrc && \
+  echo "source ${KBN_DIR}/.devcontainer/scripts/env.sh" >> ${HOME}/.zshrc
 
 # This is for documentation. Ports are exposed via devcontainer.json
 EXPOSE 9200 5601 9229 9230 9231

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,10 @@
   "name": "Kibana",
   "build": {
     "dockerfile": "Dockerfile",
-    "context": ".."
+    "context": "..",
+    "args": {
+      "KBN_DIR": "${containerWorkspaceFolder}"
+    }
   },
   "customizations": {
     "vscode": {
@@ -23,8 +26,11 @@
     9230,
     9231
   ],
-  "postStartCommand": "/workspaces/kibana/.devcontainer/scripts/post_start.sh",
+  "postStartCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/post_start.sh",
   "remoteUser": "vscode",
+  "containerEnv": {
+    "KBN_DIR": "${containerWorkspaceFolder}"
+  },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",


### PR DESCRIPTION
## Summary

When switching branches in the devcontainer, if the configuration is different from the previous branch or missing entirely, the container can easily get in a bad state or trigger rebuilds. We want the devcontainer to be seamless between branches.
