### PR TITLE
[Dashboard] Adjust panel titles

### DIFF
--- a/src/plugins/presentation_panel/public/panel_component/_presentation_panel.scss
+++ b/src/plugins/presentation_panel/public/panel_component/_presentation_panel.scss
@@ -54,7 +54,7 @@
 }
 
 .embPanel__title {
-  @include euiTitle('xxxs');
+  @include euiTitle('xxs');
   overflow: hidden;
   line-height: 1.5;
   flex-grow: 1;
@@ -80,7 +80,7 @@
 
   .embPanel__titleText {
     @include euiTextTruncate;
-    font-weight: $euiFontWeightBold;
+    font-weight: $euiFontWeightSemiBold;
   }
 
   .embPanel__placeholderTitleText {


### PR DESCRIPTION
## Summary

As presented in DnD, this PR adjusts the title of panels in Dashboards. It increases the font size from 12 to 14px and reduces the font-weight from bold to semibold.

<img width="1625" alt="Actual implementation" src="https://github.com/user-attachments/assets/c5e58346-cf10-4413-b628-1fa78af43652">

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
~- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
~- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
~- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


