### PR TITLE
[Security Solution] Fix PATCH rule API test failure in Serverless

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
@@ -34,7 +34,6 @@ export default ({ getService }: FtrProviderContext) => {
     describe('patch rules', () => {
       beforeEach(async () => {
         await deleteAllRules(supertest, log);
-        await deleteAllPrebuiltRuleAssets(es, log);
       });
 
       it('should patch a single rule property of name using a rule_id', async () => {
@@ -233,8 +232,8 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      // Unskip: https://github.com/elastic/kibana/issues/195921
       it('@skipInServerlessMKI throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+        await deleteAllPrebuiltRuleAssets(es, log);
         // Install base prebuilt detection rule
         await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
           createRuleAssetSavedObject({ rule_id: 'rule-1', author: ['elastic'] }),


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/202812**

## Summary
This PR fixes a problem in the MKI Serverless periodic pipeline that was introduced in #201825. The issue happened because the test tried to delete prebuilt rule assets stored in .kibana_security_solution, but you can’t access this index in Serverless MKI.

The fix makes sure this call only runs in non-Serverless MKI environments.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->