### PR TITLE
[ES|QL] Removes the warnings from the console

### DIFF
--- a/packages/kbn-esql-editor/src/editor_footer/index.tsx
+++ b/packages/kbn-esql-editor/src/editor_footer/index.tsx
@@ -297,7 +297,13 @@ export const EditorFooter = memo(function EditorFooter({
                     />
                   )}
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon iconType="documentation" onClick={toggleLanguageComponent} />
+                    <EuiButtonIcon
+                      iconType="documentation"
+                      onClick={toggleLanguageComponent}
+                      aria-label={i18n.translate('esqlEditor.query.documentationAriaLabel', {
+                        defaultMessage: 'Open documentation',
+                      })}
+                    />
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiFlexItem>


### PR DESCRIPTION
## Summary

Removes the warning from the console caused by the EuiButtonIcon not having an aria-label

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->