### PR TITLE
[Entity Analytics][Entity Store] Clear error on second entity engine init API call

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/saved_object/engine_descriptor.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/saved_object/engine_descriptor.ts
@@ -49,6 +49,7 @@ export class EngineDescriptorClient {
       const old = engineDescriptor.saved_objects[0].attributes;
       const update = {
         ...old,
+        error: undefined, // if the engine is being re-initialized, clear any previous error
         status: ENGINE_STATUS.INSTALLING,
         filter,
         fieldHistoryLength,


### PR DESCRIPTION
## Summary

If the first call to init an entity engine fails, we add the `error` property to the engine status, if we then call the API a second time this error was not being wiped. This PR resets the error on the second call. 

### Test steps

- Do not visit the UI of a kibana so that the security default data view does not exist
- Call the init API for an entity engine e,g host
- Call the engine status API, notice the status has an error
- Visait the security solution UI and wait for the data view to be created
- Re-call the init API and notice the error has gone

<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->