### PR TITLE
[Synthetics] Fix overview trends for read-only user !!

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/server/routes/overview_trends/overview_trends.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/routes/overview_trends/overview_trends.ts
@@ -53,6 +53,7 @@ export async function fetchTrends(
 
 export const createOverviewTrendsRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'POST',
+  writeAccess: false,
   path: SYNTHETICS_API_URLS.OVERVIEW_TRENDS,
   validate: {
     body: schema.arrayOf(


### PR DESCRIPTION
## Summary

Fix overview trends for read-only user , we wrongly assume that this `POST` route needs write permission.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->