### PR TITLE
[kbn-test] extract ES logs only for svl

### DIFF
--- a/packages/kbn-scout/src/servers/run_elasticsearch.ts
+++ b/packages/kbn-scout/src/servers/run_elasticsearch.ts
@@ -12,8 +12,8 @@ import { resolve } from 'path';
 import type { ToolingLog } from '@kbn/tooling-log';
 import { REPO_ROOT } from '@kbn/repo-info';
 import type { ArtifactLicense, ServerlessProjectType } from '@kbn/es';
-import { isServerlessProjectType, extractAndArchiveLogs } from '@kbn/es/src/utils';
-import { createTestEsCluster, esTestConfig } from '@kbn/test';
+import { isServerlessProjectType } from '@kbn/es/src/utils';
+import { createTestEsCluster, esTestConfig, cleanupElasticsearch } from '@kbn/test';
 import { Config } from '../config';
 
 interface RunElasticsearchOptions {
@@ -82,8 +82,7 @@ export async function runElasticsearch(
     config,
   });
   return async () => {
-    await node.cleanup();
-    await extractAndArchiveLogs({ outputFolder: logsDir, log });
+    await cleanupElasticsearch(node, config.serverless, logsDir, log);
   };
 }
 

--- a/packages/kbn-test/index.ts
+++ b/packages/kbn-test/index.ts
@@ -22,6 +22,7 @@ export {
   remapPluginPaths,
   getKibanaCliArg,
   getKibanaCliLoggers,
+  cleanupElasticsearch,
 } from './src/functional_tests/lib';
 
 export { initLogsDir } from './src/functional_tests/lib';

--- a/packages/kbn-test/src/functional_tests/lib/index.ts
+++ b/packages/kbn-test/src/functional_tests/lib/index.ts
@@ -8,7 +8,7 @@
  */
 
 export { runKibanaServer } from './run_kibana_server';
-export { runElasticsearch } from './run_elasticsearch';
+export { runElasticsearch, cleanupElasticsearch } from './run_elasticsearch';
 export * from './run_ftr';
 export {
   parseRawFlags,


### PR DESCRIPTION
## Summary

PR fixes the issue reported by @dolaru when running stateful FTR environment without docker setup locally:

```
 info [es] killing node
 info [es] stopping node scout
 info [es] no debug files found, assuming es did not write any
 info [es] cleanup complete
ERROR UNHANDLED ERROR
ERROR Error: Command failed with exit code 1: docker ps -a --format {{.Names}}
      error during connect: Get "http://docker.example.com/v1.47/containers/json?all=1": command [ssh -o ConnectTimeout=30 -T -l dolaru -- debian-12-vm docker system dial-stdio] has exited with exit status 255, make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=ssh: Could not resolve hostname dolaru-m2-mbp-debian.local: nodename nor servname provided, or not known
          at makeError (/Users/dolaru/workspace/kibana/node_modules/execa/lib/error.js:60:11)
          at handlePromise (/Users/dolaru/workspace/kibana/node_modules/execa/index.js:118:26)
          at processTicksAndRejections (node:internal/process/task_queues:95:5)
          at extractAndArchiveLogs (extract_and_archive_logs.ts:34:41)
          at run_elasticsearch.ts:86:5
```

Since we don't need it for stateful ES instance, I added condition. kbn-scout had the same issue, so I exported `cleanupElasticsearch` from `kbn-test` to avoid code duplication

<!--ONMERGE {"backportTargets":["8.17"]} ONMERGE-->