### PR TITLE
[8.x] [Security Solution] Fix PATCH rule API test failure in Serverless (#202885)

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_patch/basic_license_essentials_tier/patch_rules.ts
@@ -34,7 +34,6 @@ export default ({ getService }: FtrProviderContext) => {
     describe('patch rules', () => {
       beforeEach(async () => {
         await deleteAllRules(supertest, log);
-        await deleteAllPrebuiltRuleAssets(es, log);
       });
 
       it('should patch a single rule property of name using a rule_id', async () => {
@@ -233,7 +232,8 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      it('throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+      it('@skipInServerlessMKI throws an error if rule has external rule source and non-customizable fields are changed', async () => {
+        await deleteAllPrebuiltRuleAssets(es, log);
         // Install base prebuilt detection rule
         await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
           createRuleAssetSavedObject({ rule_id: 'rule-1', author: ['elastic'] }),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution] Fix PATCH rule API test failure in Serverless (#202885)](https://github.com/elastic/kibana/pull/202885)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nikita Indik","email":"nikita.indik@elastic.co"},"sourceCommit":{"committedDate":"2024-12-04T13:53:41Z","message":"[Security Solution] Fix PATCH rule API test failure in Serverless (#202885)\n\n**Resolves: https://github.com/elastic/kibana/issues/202812**\r\n\r\n## Summary\r\nThis PR fixes a problem in the MKI Serverless periodic pipeline that was\r\nintroduced in #201825. The issue happened because the test tried to\r\ndelete prebuilt rule assets stored in .kibana_security_solution, but you\r\ncan’t access this index in Serverless MKI.\r\n\r\nThe fix makes sure this call only runs in non-Serverless MKI\r\nenvironments.","sha":"0e10dbfc8190c77ed684284a4b2dc53eada437ea","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","backport:version","v8.17.0","v8.18.0","v8.16.2"],"number":202885,"url":"https://github.com/elastic/kibana/pull/202885","mergeCommit":{"message":"[Security Solution] Fix PATCH rule API test failure in Serverless (#202885)\n\n**Resolves: https://github.com/elastic/kibana/issues/202812**\r\n\r\n## Summary\r\nThis PR fixes a problem in the MKI Serverless periodic pipeline that was\r\nintroduced in #201825. The issue happened because the test tried to\r\ndelete prebuilt rule assets stored in .kibana_security_solution, but you\r\ncan’t access this index in Serverless MKI.\r\n\r\nThe fix makes sure this call only runs in non-Serverless MKI\r\nenvironments.","sha":"0e10dbfc8190c77ed684284a4b2dc53eada437ea"}},"sourceBranch":"main","suggestedTargetBranches":["8.17","8.x","8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/202885","number":202885,"mergeCommit":{"message":"[Security Solution] Fix PATCH rule API test failure in Serverless (#202885)\n\n**Resolves: https://github.com/elastic/kibana/issues/202812**\r\n\r\n## Summary\r\nThis PR fixes a problem in the MKI Serverless periodic pipeline that was\r\nintroduced in #201825. The issue happened because the test tried to\r\ndelete prebuilt rule assets stored in .kibana_security_solution, but you\r\ncan’t access this index in Serverless MKI.\r\n\r\nThe fix makes sure this call only runs in non-Serverless MKI\r\nenvironments.","sha":"0e10dbfc8190c77ed684284a4b2dc53eada437ea"}},{"branch":"8.17","label":"v8.17.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.16","label":"v8.16.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->