### PR TITLE
[Security Solutoin] [Detections] skip flaky eql sequence test

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql_alert_suppression.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql_alert_suppression.ts
@@ -2982,7 +2982,8 @@ export default ({ getService }: FtrProviderContext) => {
         expect(suppressionEnd).toBeGreaterThan(new Date(secondTimestamp).getDate());
       });
 
-      it('does not suppress alerts outside of duration', async () => {
+      // Skipped here: https://github.com/elastic/kibana/issues/202945
+      it.skip('does not suppress alerts outside of duration', async () => {
         const id = uuidv4();
         // this timestamp is 1 minute in the past
         const firstTimestamp = new Date(Date.now() - 5000).toISOString();
@@ -3170,7 +3171,8 @@ export default ({ getService }: FtrProviderContext) => {
         });
       });
 
-      it('does not suppress alerts outside of duration when query with 3 sequences', async () => {
+      // Skipped here: https://github.com/elastic/kibana/issues/202945
+      it.skip('does not suppress alerts outside of duration when query with 3 sequences', async () => {
         const id = uuidv4();
         const dateNow = Date.now();
         const timestampSequenceEvent1 = new Date(dateNow - 5000).toISOString();


### PR DESCRIPTION
## Summary

skips flakey test: https://github.com/elastic/kibana/issues/202945




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->