### PR TITLE
[8.x] [Logs] Deprecate configuration settings (#201625)

### DIFF
--- a/x-pack/plugins/observability_solution/infra/server/config.ts
+++ b/x-pack/plugins/observability_solution/infra/server/config.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { i18n } from '@kbn/i18n';
+
+import { offeringBasedSchema, schema } from '@kbn/config-schema';
+import { PluginConfigDescriptor } from '@kbn/core-plugins-server';
+import { ConfigDeprecation } from '@kbn/config';
+import { InfraConfig } from './types';
+import { publicConfigKeys } from '../common/plugin_config_types';
+
+export type { InfraConfig };
+
+export const config: PluginConfigDescriptor<InfraConfig> = {
+  schema: schema.object({
+    enabled: schema.boolean({ defaultValue: true }),
+    alerting: schema.object({
+      inventory_threshold: schema.object({
+        group_by_page_size: schema.number({ defaultValue: 5_000 }),
+      }),
+      metric_threshold: schema.object({
+        group_by_page_size: schema.number({ defaultValue: 10_000 }),
+      }),
+    }),
+    inventory: schema.object({
+      compositeSize: schema.number({ defaultValue: 2000 }),
+    }),
+    sources: schema.maybe(
+      schema.object({
+        default: schema.maybe(
+          schema.object({
+            fields: schema.maybe(
+              schema.object({
+                message: schema.maybe(schema.arrayOf(schema.string())),
+              })
+            ),
+          })
+        ),
+      })
+    ),
+    featureFlags: schema.object({
+      customThresholdAlertsEnabled: offeringBasedSchema({
+        traditional: schema.boolean({ defaultValue: false }),
+        serverless: schema.boolean({ defaultValue: false }),
+      }),
+      logsUIEnabled: offeringBasedSchema({
+        traditional: schema.boolean({ defaultValue: true }),
+        serverless: schema.boolean({ defaultValue: false }),
+      }),
+      metricsExplorerEnabled: offeringBasedSchema({
+        traditional: schema.boolean({ defaultValue: true }),
+        serverless: schema.boolean({ defaultValue: false }),
+      }),
+      osqueryEnabled: schema.boolean({ defaultValue: true }),
+      inventoryThresholdAlertRuleEnabled: offeringBasedSchema({
+        traditional: schema.boolean({ defaultValue: true }),
+        serverless: schema.boolean({ defaultValue: true }),
+      }),
+      metricThresholdAlertRuleEnabled: offeringBasedSchema({
+        traditional: schema.boolean({ defaultValue: true }),
+        serverless: schema.boolean({ defaultValue: false }),
+      }),
+      logThresholdAlertRuleEnabled: offeringBasedSchema({
+        traditional: schema.boolean({ defaultValue: true }),
+        serverless: schema.boolean({ defaultValue: false }),
+      }),
+      alertsAndRulesDropdownEnabled: offeringBasedSchema({
+        traditional: schema.boolean({ defaultValue: true }),
+        serverless: schema.boolean({ defaultValue: true }),
+      }),
+      /**
+       * Depends on optional "profilingDataAccess" and "profiling"
+       * plugins. Enable both with `xpack.profiling.enabled: true` before
+       * enabling this feature flag.
+       */
+      profilingEnabled: schema.boolean({ defaultValue: false }),
+      ruleFormV2Enabled: schema.boolean({ defaultValue: false }),
+    }),
+  }),
+  deprecations: () => [sourceFieldsMessageDeprecation],
+  exposeToBrowser: publicConfigKeys,
+};
+
+const sourceFieldsMessageDeprecation: ConfigDeprecation = (settings, fromPath, addDeprecation) => {
+  const sourceFieldsMessageSetting = settings?.xpack?.infra?.sources?.default?.fields?.message;
+
+  if (sourceFieldsMessageSetting) {
+    addDeprecation({
+      configPath: `${fromPath}.sources.default.fields.message`,
+      title: i18n.translate('xpack.infra.deprecations.sourcesDefaultFieldsMessage.title', {
+        defaultMessage: 'The "xpack.infra.sources.default.fields.message" setting is deprecated.',
+        ignoreTag: true,
+      }),
+      message: i18n.translate('xpack.infra.deprecations.sourcesDefaultFieldsMessage.message', {
+        defaultMessage:
+          'Features using this configurations are set to be removed in v9 and this is no longer used.',
+      }),
+      level: 'warning',
+      documentationUrl: `https://www.elastic.co/guide/en/kibana/current/logs-ui-settings-kb.html#general-logs-ui-settings-kb`,
+      correctiveActions: {
+        manualSteps: [
+          i18n.translate('xpack.infra.deprecations.sourcesDefaultFieldsMessage.manualSteps1', {
+            defaultMessage: 'Remove "xpack.infra.sources.default.fields.message" from kibana.yml.',
+            ignoreTag: true,
+          }),
+        ],
+      },
+    });
+  }
+};

--- a/x-pack/plugins/observability_solution/infra/server/index.ts
+++ b/x-pack/plugins/observability_solution/infra/server/index.ts
@@ -6,11 +6,9 @@
  */
 
 import { PluginInitializerContext } from '@kbn/core/server';
-import { config, InfraConfig } from './plugin';
 
+export { config, type InfraConfig } from './config';
 export type { InfraPluginSetup, InfraPluginStart, InfraRequestHandlerContext } from './types';
-export type { InfraConfig };
-export { config };
 
 export async function plugin(context: PluginInitializerContext) {
   const { InfraServerPlugin } = await import('./plugin');

--- a/x-pack/plugins/observability_solution/infra/server/lib/adapters/framework/kibana_framework_adapter.ts
+++ b/x-pack/plugins/observability_solution/infra/server/lib/adapters/framework/kibana_framework_adapter.ts
@@ -13,8 +13,7 @@ import { UI_SETTINGS } from '@kbn/data-plugin/server';
 import { TimeseriesVisData } from '@kbn/vis-type-timeseries-plugin/server';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import { TSVBMetricModel } from '@kbn/metrics-data-access-plugin/common';
-import { InfraConfig } from '../../../plugin';
-import type { InfraPluginRequestHandlerContext } from '../../../types';
+import type { InfraConfig, InfraPluginRequestHandlerContext } from '../../../types';
 import {
   CallWithRequestParams,
   InfraDatabaseGetIndicesAliasResponse,

--- a/x-pack/plugins/observability_solution/infra/server/plugin.ts
+++ b/x-pack/plugins/observability_solution/infra/server/plugin.ts
@@ -6,13 +6,7 @@
  */
 
 import { Server } from '@hapi/hapi';
-import { schema, offeringBasedSchema } from '@kbn/config-schema';
-import {
-  CoreStart,
-  Plugin,
-  PluginConfigDescriptor,
-  PluginInitializerContext,
-} from '@kbn/core/server';
+import { CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
 import { handleEsError } from '@kbn/es-ui-shared-plugin/server';
 import { i18n } from '@kbn/i18n';
 import { Logger } from '@kbn/logging';
@@ -26,7 +20,6 @@ import {
 import { type AlertsLocatorParams, alertsLocatorID } from '@kbn/observability-plugin/common';
 import { mapValues } from 'lodash';
 import { LOGS_FEATURE_ID, METRICS_FEATURE_ID } from '../common/constants';
-import { publicConfigKeys } from '../common/plugin_config_types';
 import { LOGS_FEATURE, METRICS_FEATURE } from './features';
 import { registerRoutes } from './infra_server';
 import { InfraServerPluginSetupDeps, InfraServerPluginStartDeps } from './lib/adapters/framework';
@@ -60,77 +53,6 @@ import {
 import { UsageCollector } from './usage/usage_collector';
 import { mapSourceToLogView } from './utils/map_source_to_log_view';
 import { uiSettings } from '../common/ui_settings';
-
-export const config: PluginConfigDescriptor<InfraConfig> = {
-  schema: schema.object({
-    enabled: schema.boolean({ defaultValue: true }),
-    alerting: schema.object({
-      inventory_threshold: schema.object({
-        group_by_page_size: schema.number({ defaultValue: 5_000 }),
-      }),
-      metric_threshold: schema.object({
-        group_by_page_size: schema.number({ defaultValue: 10_000 }),
-      }),
-    }),
-    inventory: schema.object({
-      compositeSize: schema.number({ defaultValue: 2000 }),
-    }),
-    sources: schema.maybe(
-      schema.object({
-        default: schema.maybe(
-          schema.object({
-            fields: schema.maybe(
-              schema.object({
-                message: schema.maybe(schema.arrayOf(schema.string())),
-              })
-            ),
-          })
-        ),
-      })
-    ),
-    featureFlags: schema.object({
-      customThresholdAlertsEnabled: offeringBasedSchema({
-        traditional: schema.boolean({ defaultValue: false }),
-        serverless: schema.boolean({ defaultValue: false }),
-      }),
-      logsUIEnabled: offeringBasedSchema({
-        traditional: schema.boolean({ defaultValue: true }),
-        serverless: schema.boolean({ defaultValue: false }),
-      }),
-      metricsExplorerEnabled: offeringBasedSchema({
-        traditional: schema.boolean({ defaultValue: true }),
-        serverless: schema.boolean({ defaultValue: false }),
-      }),
-      osqueryEnabled: schema.boolean({ defaultValue: true }),
-      inventoryThresholdAlertRuleEnabled: offeringBasedSchema({
-        traditional: schema.boolean({ defaultValue: true }),
-        serverless: schema.boolean({ defaultValue: true }),
-      }),
-      metricThresholdAlertRuleEnabled: offeringBasedSchema({
-        traditional: schema.boolean({ defaultValue: true }),
-        serverless: schema.boolean({ defaultValue: false }),
-      }),
-      logThresholdAlertRuleEnabled: offeringBasedSchema({
-        traditional: schema.boolean({ defaultValue: true }),
-        serverless: schema.boolean({ defaultValue: false }),
-      }),
-      alertsAndRulesDropdownEnabled: offeringBasedSchema({
-        traditional: schema.boolean({ defaultValue: true }),
-        serverless: schema.boolean({ defaultValue: true }),
-      }),
-      /**
-       * Depends on optional "profilingDataAccess" and "profiling"
-       * plugins. Enable both with `xpack.profiling.enabled: true` before
-       * enabling this feature flag.
-       */
-      profilingEnabled: schema.boolean({ defaultValue: false }),
-      ruleFormV2Enabled: schema.boolean({ defaultValue: false }),
-    }),
-  }),
-  exposeToBrowser: publicConfigKeys,
-};
-
-export type { InfraConfig };
 
 export interface KbnServer extends Server {
   usage: any;

--- a/x-pack/plugins/observability_solution/infra/tsconfig.json
+++ b/x-pack/plugins/observability_solution/infra/tsconfig.json
@@ -116,7 +116,10 @@
     "@kbn/entityManager-plugin",
     "@kbn/entities-schema",
     "@kbn/zod",
-    "@kbn/observability-utils-server"
+    "@kbn/observability-utils-server",
+    "@kbn/core-plugins-server",
+    "@kbn/config",
+    "@kbn/observability-utils-common"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/plugins/observability_solution/infra/tsconfig.json
+++ b/x-pack/plugins/observability_solution/infra/tsconfig.json
@@ -119,7 +119,6 @@
     "@kbn/observability-utils-server",
     "@kbn/core-plugins-server",
     "@kbn/config",
-    "@kbn/observability-utils-common"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/plugins/observability_solution/logs_shared/server/config.ts
+++ b/x-pack/plugins/observability_solution/logs_shared/server/config.ts
@@ -26,4 +26,5 @@ export const configSchema = schema.object({
 
 export const config: PluginConfigDescriptor<LogsSharedConfig> = {
   schema: configSchema,
+  deprecations: ({ unused }) => [unused('savedObjects.logView.enabled', { level: 'warning' })],
 };

--- a/x-pack/plugins/observability_solution/logs_shared/server/lib/logs_shared_types.ts
+++ b/x-pack/plugins/observability_solution/logs_shared/server/lib/logs_shared_types.ts
@@ -23,4 +23,5 @@ export interface LogsSharedBackendLibs extends LogsSharedDomainLibs {
   getStartServices: LogsSharedPluginStartServicesAccessor;
   getUsageCollector: () => UsageCollector;
   logger: Logger;
+  isServerless: boolean;
 }

--- a/x-pack/plugins/observability_solution/logs_shared/server/plugin.ts
+++ b/x-pack/plugins/observability_solution/logs_shared/server/plugin.ts
@@ -42,7 +42,7 @@ export class LogsSharedPlugin
   private logViews: LogViewsService;
   private usageCollector: UsageCollector;
 
-  constructor(context: PluginInitializerContext<LogsSharedConfig>) {
+  constructor(private readonly context: PluginInitializerContext<LogsSharedConfig>) {
     this.config = context.config.get();
     this.logger = context.logger.get();
     this.usageCollector = {};
@@ -51,11 +51,13 @@ export class LogsSharedPlugin
   }
 
   public setup(core: LogsSharedPluginCoreSetup, plugins: LogsSharedServerPluginSetupDeps) {
+    const isServerless = this.context.env.packageInfo.buildFlavor === 'serverless';
+
     const framework = new KibanaFramework(core, plugins);
 
     const logViews = this.logViews.setup();
 
-    if (this.config.savedObjects.logView.enabled) {
+    if (!isServerless) {
       // Conditionally register log view saved objects
       core.savedObjects.registerType(logViewSavedObjectType);
     } else {
@@ -78,6 +80,7 @@ export class LogsSharedPlugin
       getStartServices: () => core.getStartServices(),
       getUsageCollector: () => this.usageCollector,
       logger: this.logger,
+      isServerless,
     };
 
     // Register server side APIs

--- a/x-pack/plugins/observability_solution/logs_shared/server/routes/log_views/get_log_view.ts
+++ b/x-pack/plugins/observability_solution/logs_shared/server/routes/log_views/get_log_view.ts
@@ -14,6 +14,7 @@ export const initGetLogViewRoute = ({
   config,
   framework,
   getStartServices,
+  isServerless,
 }: LogsSharedBackendLibs) => {
   framework
     .registerVersionedRoute({
@@ -41,7 +42,7 @@ export const initGetLogViewRoute = ({
            * - if the log view saved object is correctly registered, perform a lookup for retrieving it
            * - else, skip the saved object lookup and immediately get the internal log view if exists.
            */
-          const logView = config.savedObjects.logView.enabled
+          const logView = !isServerless
             ? await logViewsClient.getLogView(logViewId)
             : await logViewsClient.getInternalLogView(logViewId);
 

--- a/x-pack/plugins/observability_solution/logs_shared/server/routes/log_views/index.ts
+++ b/x-pack/plugins/observability_solution/logs_shared/server/routes/log_views/index.ts
@@ -12,7 +12,7 @@ export const initLogViewRoutes = (libs: LogsSharedBackendLibs) => {
   initGetLogViewRoute(libs);
 
   // Register the log view update endpoint only when the Saved object is correctly registered
-  if (libs.config.savedObjects.logView.enabled) {
+  if (!libs.isServerless) {
     initPutLogViewRoute(libs);
   }
 };

--- a/x-pack/plugins/observability_solution/observability_logs_explorer/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/observability_logs_explorer/public/plugin.ts
@@ -36,13 +36,10 @@ import type {
 export class ObservabilityLogsExplorerPlugin
   implements Plugin<ObservabilityLogsExplorerPluginSetup, ObservabilityLogsExplorerPluginStart>
 {
-  private config: ObservabilityLogsExplorerConfig;
   private locators?: ObservabilityLogsExplorerLocators;
   private appStateUpdater = new BehaviorSubject<AppUpdater>(() => ({}));
 
-  constructor(context: PluginInitializerContext<ObservabilityLogsExplorerConfig>) {
-    this.config = context.config.get();
-  }
+  constructor(context: PluginInitializerContext<ObservabilityLogsExplorerConfig>) {}
 
   public setup(
     core: CoreSetup<ObservabilityLogsExplorerStartDeps, ObservabilityLogsExplorerPluginStart>,
@@ -56,9 +53,7 @@ export class ObservabilityLogsExplorerPlugin
       title: logsExplorerAppTitle,
       category: DEFAULT_APP_CATEGORIES.observability,
       euiIconType: 'logoLogging',
-      visibleIn: this.config.navigation.showAppLink
-        ? ['globalSearch', 'sideNav']
-        : ['globalSearch'],
+      visibleIn: ['globalSearch'],
       keywords: ['logs', 'log', 'explorer', 'logs explorer'],
       updater$: this.appStateUpdater,
       mount: async (appMountParams: ObservabilityLogsExplorerAppMountParameters) => {

--- a/x-pack/plugins/observability_solution/observability_logs_explorer/server/config.ts
+++ b/x-pack/plugins/observability_solution/observability_logs_explorer/server/config.ts
@@ -25,7 +25,7 @@ export const configSchema = schema.object({
 
 export const config: PluginConfigDescriptor<ObservabilityLogsExplorerConfig> = {
   schema: configSchema,
-  deprecations: ({ renameFromRoot }) => [
+  deprecations: ({ renameFromRoot, unused }) => [
     renameFromRoot(
       'xpack.discoverLogExplorer.featureFlags.deepLinkVisible',
       'xpack.observabilityLogsExplorer.navigation.showAppLink',
@@ -41,6 +41,7 @@ export const config: PluginConfigDescriptor<ObservabilityLogsExplorerConfig> = {
       'xpack.observabilityLogsExplorer.enabled',
       { level: 'warning' }
     ),
+    unused('navigation.showAppLink', { level: 'warning' }),
   ],
   exposeToBrowser: {
     navigation: {

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/shared/header_action_menu.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/shared/header_action_menu.tsx
@@ -22,15 +22,14 @@ interface Props {
 
 export function ObservabilityOnboardingHeaderActionMenu({ setHeaderActionMenu, theme$ }: Props) {
   const {
-    services: { config },
+    services: { context },
   } = useKibana<ObservabilityOnboardingAppServices>();
   const location = useLocation();
   const normalizedPathname = location.pathname.replace(/\/$/, '');
 
   const isRootPage = normalizedPathname === '';
-  const isServerless = config.serverless.enabled;
 
-  if (!isServerless && !isRootPage) {
+  if (!context.isServerless && !isRootPage) {
     return (
       <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
         <EuiButton

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/plugin.ts
@@ -79,53 +79,45 @@ export class ObservabilityOnboardingPlugin
   public setup(core: CoreSetup, plugins: ObservabilityOnboardingPluginSetupDeps) {
     const stackVersion = this.ctx.env.packageInfo.version;
     const config = this.ctx.config.get<ObservabilityOnboardingConfig>();
-    const {
-      ui: { enabled: isObservabilityOnboardingUiEnabled },
-    } = config;
     const isServerlessBuild = this.ctx.env.packageInfo.buildFlavor === 'serverless';
     const isDevEnvironment = this.ctx.env.mode.dev;
     const pluginSetupDeps = plugins;
 
-    // set xpack.observability_onboarding.ui.enabled: true
-    // and go to /app/observabilityOnboarding
-    if (isObservabilityOnboardingUiEnabled) {
-      core.application.register({
-        id: PLUGIN_ID,
-        title: 'Observability Onboarding',
-        order: 8500,
-        euiIconType: 'logoObservability',
-        category: DEFAULT_APP_CATEGORIES.observability,
-        keywords: [],
-        async mount(appMountParameters: AppMountParameters) {
-          // Load application bundle and Get start service
-          const [{ renderApp }, [coreStart, corePlugins]] = await Promise.all([
-            import('./application/app'),
-            core.getStartServices(),
-          ]);
+    core.application.register({
+      id: PLUGIN_ID,
+      title: 'Observability Onboarding',
+      order: 8500,
+      euiIconType: 'logoObservability',
+      category: DEFAULT_APP_CATEGORIES.observability,
+      keywords: [],
+      async mount(appMountParameters: AppMountParameters) {
+        // Load application bundle and Get start service
+        const [{ renderApp }, [coreStart, corePlugins]] = await Promise.all([
+          import('./application/app'),
+          core.getStartServices(),
+        ]);
 
-          const { createCallApi } = await import('./services/rest/create_call_api');
+        const { createCallApi } = await import('./services/rest/create_call_api');
 
-          createCallApi(core);
+        createCallApi(core);
 
-          return renderApp({
-            core: coreStart,
-            deps: pluginSetupDeps,
-            appMountParameters,
-            corePlugins: corePlugins as ObservabilityOnboardingPluginStartDeps,
-            config,
-            context: {
-              isDev: isDevEnvironment,
-              isCloud: Boolean(pluginSetupDeps.cloud?.isCloudEnabled),
-              isServerless:
-                Boolean(pluginSetupDeps.cloud?.isServerlessEnabled) || isServerlessBuild,
-              stackVersion,
-              cloudServiceProvider: pluginSetupDeps.cloud?.csp,
-            },
-          });
-        },
-        visibleIn: [],
-      });
-    }
+        return renderApp({
+          core: coreStart,
+          deps: pluginSetupDeps,
+          appMountParameters,
+          corePlugins: corePlugins as ObservabilityOnboardingPluginStartDeps,
+          config,
+          context: {
+            isDev: isDevEnvironment,
+            isCloud: Boolean(pluginSetupDeps.cloud?.isCloudEnabled),
+            isServerless: Boolean(pluginSetupDeps.cloud?.isServerlessEnabled) || isServerlessBuild,
+            stackVersion,
+            cloudServiceProvider: pluginSetupDeps.cloud?.csp,
+          },
+        });
+      },
+      visibleIn: [],
+    });
 
     this.locators = {
       onboarding: plugins.share.url.locators.create(new ObservabilityOnboardingLocatorDefinition()),

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/config.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/config.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { TypeOf, offeringBasedSchema, schema } from '@kbn/config-schema';
+import { PluginConfigDescriptor } from '@kbn/core-plugins-server';
+
+const configSchema = schema.object({
+  ui: schema.object({
+    enabled: schema.boolean({ defaultValue: true }),
+  }),
+  serverless: schema.object({
+    enabled: offeringBasedSchema({
+      serverless: schema.literal(true),
+      options: { defaultValue: schema.contextRef('serverless') },
+    }),
+  }),
+});
+
+export type ObservabilityOnboardingConfig = TypeOf<typeof configSchema>;
+
+// plugin config
+export const config: PluginConfigDescriptor<ObservabilityOnboardingConfig> = {
+  exposeToBrowser: {
+    ui: true,
+    serverless: true,
+  },
+  schema: configSchema,
+  deprecations: ({ unused }) => [
+    unused('ui.enabled', { level: 'warning' }),
+    unused('serverless.enabled', { level: 'warning' }),
+  ],
+};

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/index.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/index.ts
@@ -5,31 +5,9 @@
  * 2.0.
  */
 
-import { offeringBasedSchema, schema, TypeOf } from '@kbn/config-schema';
-import { PluginConfigDescriptor, PluginInitializerContext } from '@kbn/core/server';
+import { PluginInitializerContext } from '@kbn/core/server';
 
-const configSchema = schema.object({
-  ui: schema.object({
-    enabled: schema.boolean({ defaultValue: true }),
-  }),
-  serverless: schema.object({
-    enabled: offeringBasedSchema({
-      serverless: schema.literal(true),
-      options: { defaultValue: schema.contextRef('serverless') },
-    }),
-  }),
-});
-
-export type ObservabilityOnboardingConfig = TypeOf<typeof configSchema>;
-
-// plugin config
-export const config: PluginConfigDescriptor<ObservabilityOnboardingConfig> = {
-  exposeToBrowser: {
-    ui: true,
-    serverless: true,
-  },
-  schema: configSchema,
-};
+export { config, type ObservabilityOnboardingConfig } from './config';
 
 export async function plugin(initializerContext: PluginInitializerContext) {
   const { ObservabilityOnboardingPlugin } = await import('./plugin');

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/plugin.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/plugin.ts
@@ -23,9 +23,9 @@ import {
   ObservabilityOnboardingPluginStart,
   ObservabilityOnboardingPluginStartDependencies,
 } from './types';
-import { ObservabilityOnboardingConfig } from '.';
 import { observabilityOnboardingFlow } from './saved_objects/observability_onboarding_status';
 import { EsLegacyConfigService } from './services/es_legacy_config_service';
+import { ObservabilityOnboardingConfig } from './config';
 
 export class ObservabilityOnboardingPlugin
   implements

--- a/x-pack/plugins/observability_solution/observability_onboarding/server/routes/types.ts
+++ b/x-pack/plugins/observability_solution/observability_onboarding/server/routes/types.ts
@@ -13,13 +13,13 @@ import {
 } from '@kbn/core/server';
 import * as t from 'io-ts';
 import { ObservabilityOnboardingServerRouteRepository } from '.';
-import { ObservabilityOnboardingConfig } from '..';
 import { EsLegacyConfigService } from '../services/es_legacy_config_service';
 import {
   ObservabilityOnboardingPluginSetupDependencies,
   ObservabilityOnboardingPluginStartDependencies,
   ObservabilityOnboardingRequestHandlerContext,
 } from '../types';
+import { ObservabilityOnboardingConfig } from '../config';
 
 export type { ObservabilityOnboardingServerRouteRepository };
 

--- a/x-pack/plugins/observability_solution/observability_onboarding/tsconfig.json
+++ b/x-pack/plugins/observability_solution/observability_onboarding/tsconfig.json
@@ -43,7 +43,8 @@
     "@kbn/deeplinks-analytics",
     "@kbn/custom-integrations-plugin",
     "@kbn/server-route-repository-utils",
-    "@kbn/core-application-browser"
+    "@kbn/core-application-browser",
+    "@kbn/core-plugins-server"
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Logs] Deprecate configuration settings (#201625)](https://github.com/elastic/kibana/pull/201625)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Marco Antonio Ghiani","email":"marcoantonio.ghiani01@gmail.com"},"sourceCommit":{"committedDate":"2024-12-05T09:23:54Z","message":"[Logs] Deprecate configuration settings (#201625)\n\n## 📓 Summary\r\n\r\nCloses #200898 \r\n\r\nThese changes deprecate some unused configurations and update the\r\nimplementation where required in preparation for the Kibana v9 upgrade.\r\n\r\n<img width=\"3004\" alt=\"Screenshot 2024-11-25 at 12 54 14\"\r\nsrc=\"https://github.com/user-attachments/assets/cfa56d25-a270-4ec5-a97a-e72e7a7478a4\">\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2994b0001cbae6bc1528bc1ad77c435597e0d5a2","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:deprecation","v9.0.0","backport:prev-minor","ci:project-deploy-observability","Team:obs-ux-logs"],"number":201625,"url":"https://github.com/elastic/kibana/pull/201625","mergeCommit":{"message":"[Logs] Deprecate configuration settings (#201625)\n\n## 📓 Summary\r\n\r\nCloses #200898 \r\n\r\nThese changes deprecate some unused configurations and update the\r\nimplementation where required in preparation for the Kibana v9 upgrade.\r\n\r\n<img width=\"3004\" alt=\"Screenshot 2024-11-25 at 12 54 14\"\r\nsrc=\"https://github.com/user-attachments/assets/cfa56d25-a270-4ec5-a97a-e72e7a7478a4\">\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2994b0001cbae6bc1528bc1ad77c435597e0d5a2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/201625","number":201625,"mergeCommit":{"message":"[Logs] Deprecate configuration settings (#201625)\n\n## 📓 Summary\r\n\r\nCloses #200898 \r\n\r\nThese changes deprecate some unused configurations and update the\r\nimplementation where required in preparation for the Kibana v9 upgrade.\r\n\r\n<img width=\"3004\" alt=\"Screenshot 2024-11-25 at 12 54 14\"\r\nsrc=\"https://github.com/user-attachments/assets/cfa56d25-a270-4ec5-a97a-e72e7a7478a4\">\r\n\r\n---------\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2994b0001cbae6bc1528bc1ad77c435597e0d5a2"}}]}] BACKPORT-->