### PR TITLE
[CI autocommits] Add telemetry_check --fix

### DIFF
--- a/.buildkite/scripts/steps/checks/telemetry.sh
+++ b/.buildkite/scripts/steps/checks/telemetry.sh
@@ -5,4 +5,10 @@ set -euo pipefail
 source .buildkite/scripts/common/util.sh
 
 echo --- Check Telemetry Schema
-node scripts/telemetry_check
+
+if is_pr && ! is_auto_commit_disabled; then
+  node scripts/telemetry_check --fix
+  check_for_changed_files "node scripts/telemetry_check" true
+else
+  node scripts/telemetry_check
+fi


### PR DESCRIPTION
## Summary

It doesn't make sense to fail the entire CI and ask a developer to run it locally.

This should be automatically fixed.

NOTE: This script updates the telemetry schemas that trigger a review of the Kibana Core members to make them aware of changes in the Snapshot Telemetry document.




