### PR TITLE
[UA] Ensure that old indices are detected for reindexing

### DIFF
--- a/x-pack/plugins/upgrade_assistant/server/lib/__fixtures__/fake_deprecations.json
+++ b/x-pack/plugins/upgrade_assistant/server/lib/__fixtures__/fake_deprecations.json
@@ -147,6 +147,15 @@
         "details": "[[type: tweet, field: liked]]",
         "resolve_during_rolling_upgrade": false
       }
+    ],
+    "myindex": [
+      {
+        "level": "critical",
+        "message": "Old index with a compatibility version < 8.0",
+        "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
+        "details": "This index has version: 7.17.25",
+        "resolve_during_rolling_upgrade": false
+      }
     ]
   },
   "data_streams": {

--- a/x-pack/plugins/upgrade_assistant/server/lib/es_deprecations_status/__snapshots__/index.test.ts.snap
+++ b/x-pack/plugins/upgrade_assistant/server/lib/es_deprecations_status/__snapshots__/index.test.ts.snap
@@ -159,6 +159,19 @@ Object {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_mappings_changes.html#_coercion_of_boolean_fields",
     },
     Object {
+      "correctiveAction": Object {
+        "blockerForReindexing": undefined,
+        "type": "reindex",
+      },
+      "details": "This index has version: 7.17.25",
+      "index": "myindex",
+      "isCritical": true,
+      "message": "Old index with a compatibility version < 8.0",
+      "resolveDuringUpgrade": false,
+      "type": "index_settings",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
+    },
+    Object {
       "correctiveAction": undefined,
       "details": "This data stream has backing indices that were created before Elasticsearch 8.0.0",
       "index": "my-v7-data-stream",
@@ -169,6 +182,6 @@ Object {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
     },
   ],
-  "totalCriticalDeprecations": 5,
+  "totalCriticalDeprecations": 6,
 }
 `;

--- a/x-pack/plugins/upgrade_assistant/server/lib/es_deprecations_status/get_corrective_actions.ts
+++ b/x-pack/plugins/upgrade_assistant/server/lib/es_deprecations_status/get_corrective_actions.ts
@@ -20,6 +20,12 @@ type EsMetadata = Actions & {
   [key: string]: string;
 };
 
+// TODO(jloleysens): Replace these regexes once this issue is addressed https://github.com/elastic/elasticsearch/issues/118062
+const ES_INDEX_MESSAGES_REQIURING_REINDEX = [
+  /Index created before/,
+  /index with a compatibility version \</,
+];
+
 export const getCorrectiveAction = (
   message: string,
   metadata: EsMetadata,
@@ -31,7 +37,9 @@ export const getCorrectiveAction = (
   const clusterSettingDeprecation = metadata?.actions?.find(
     (action) => action.action_type === 'remove_settings' && typeof indexName === 'undefined'
   );
-  const requiresReindexAction = /Index created before/.test(message);
+  const requiresReindexAction = ES_INDEX_MESSAGES_REQIURING_REINDEX.some((regexp) =>
+    regexp.test(message)
+  );
   const requiresIndexSettingsAction = Boolean(indexSettingDeprecation);
   const requiresClusterSettingsAction = Boolean(clusterSettingDeprecation);
   const requiresMlAction = /[Mm]odel snapshot/.test(message);


### PR DESCRIPTION
## Summary

We need to handle the following response shape from `GET _migration/deprecations`

```jsonc
    "myindex": [
      {
        "level": "critical",
        "message": "Old index with a compatibility version < 8.0", // specifically this message
        "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
        "details": "This index has version: 7.17.25",
        "resolve_during_rolling_upgrade": false
      }
    ]
```

<img width="1142" alt="Screenshot 2024-12-05 at 12 44 59" src="https://github.com/user-attachments/assets/723e19ab-dd9d-4b6a-bcda-26a5c8bffa0b">


## To reviewers

These changes were developed/tested on `8.x` and must be backported.

Related
* https://github.com/elastic/kibana/issues/202669
* https://github.com/elastic/elasticsearch/issues/118062

<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->