### PR TITLE
[eem] _search accepts kql filters

### DIFF
--- a/x-pack/plugins/entity_manager/server/lib/v2/entity_client.ts
+++ b/x-pack/plugins/entity_manager/server/lib/v2/entity_client.ts
@@ -98,7 +98,7 @@ export class EntityClient {
           );
         }
 
-        const query = getEntityInstancesQuery({
+        const { query, filter } = getEntityInstancesQuery({
           source: {
             ...source,
             metadata_fields: availableMetadataFields,
@@ -109,10 +109,13 @@ export class EntityClient {
           sort,
           limit,
         });
-        this.options.logger.debug(`Entity query: ${query}`);
+        this.options.logger.debug(
+          `Entity query:\n${query}\nfilter:${JSON.stringify(filter, null, 2)}`
+        );
 
         const rawEntities = await runESQLQuery<EntityV2>('resolve entities', {
           query,
+          filter,
           esClient: this.options.clusterClient.asCurrentUser,
           logger: this.options.logger,
         });

--- a/x-pack/plugins/entity_manager/server/lib/v2/entity_client.ts
+++ b/x-pack/plugins/entity_manager/server/lib/v2/entity_client.ts
@@ -110,7 +110,7 @@ export class EntityClient {
           limit,
         });
         this.options.logger.debug(
-          `Entity query:\n${query}\nfilter:${JSON.stringify(filter, null, 2)}`
+          `Entity query: ${query}\nfilter: ${JSON.stringify(filter, null, 2)}`
         );
 
         const rawEntities = await runESQLQuery<EntityV2>('resolve entities', {

--- a/x-pack/plugins/entity_manager/server/lib/v2/entity_client.ts
+++ b/x-pack/plugins/entity_manager/server/lib/v2/entity_client.ts
@@ -110,7 +110,7 @@ export class EntityClient {
           limit,
         });
         this.options.logger.debug(
-          `Entity query: ${query}\nfilter: ${JSON.stringify(filter, null, 2)}`
+          () => `Entity query: ${query}\nfilter: ${JSON.stringify(filter, null, 2)}`
         );
 
         const rawEntities = await runESQLQuery<EntityV2>('resolve entities', {

--- a/x-pack/plugins/entity_manager/server/lib/v2/run_esql_query.ts
+++ b/x-pack/plugins/entity_manager/server/lib/v2/run_esql_query.ts
@@ -25,7 +25,7 @@ export async function runESQLQuery<T>(
     esClient: ElasticsearchClient;
     logger: Logger;
     query: string;
-    filter: QueryDslQueryContainer;
+    filter?: QueryDslQueryContainer;
   }
 ): Promise<T[]> {
   logger.trace(

--- a/x-pack/plugins/observability_solution/entity_manager_app/public/pages/overview/index.tsx
+++ b/x-pack/plugins/observability_solution/entity_manager_app/public/pages/overview/index.tsx
@@ -70,7 +70,7 @@ function EntitySourceForm({
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiFormRow label="Filters (comma-separated ESQL filters)">
+        <EuiFormRow label="Filters (comma-separated KQL filters)">
           <EuiFieldText
             data-test-subj="entityManagerFormFilters"
             name="filters"


### PR DESCRIPTION
## Summary

`searchEntities` now accepts kql filters instead of esql and translates that to dsl filters at the query level





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->