### PR TITLE
[APM]  Update alert rule producer terms in getServicesAlerts query

### DIFF
--- a/x-pack/plugins/observability_solution/apm/common/alerting/config/apm_alerting_feature_ids.ts
+++ b/x-pack/plugins/observability_solution/apm/common/alerting/config/apm_alerting_feature_ids.ts
@@ -11,7 +11,7 @@ import {
   type ValidFeatureId,
 } from '@kbn/rule-data-utils';
 
-export const apmAlertingConsumers: ValidFeatureId[] = [
+export const APM_ALERTING_CONSUMERS: ValidFeatureId[] = [
   AlertConsumers.LOGS,
   AlertConsumers.APM,
   AlertConsumers.SLO,
@@ -20,4 +20,4 @@ export const apmAlertingConsumers: ValidFeatureId[] = [
   AlertConsumers.ALERTS,
 ];
 
-export const apmAlertingRuleTypeIds: string[] = [...OBSERVABILITY_RULE_TYPE_IDS];
+export const APM_ALERTING_RULE_TYPE_IDS: string[] = [...OBSERVABILITY_RULE_TYPE_IDS];

--- a/x-pack/plugins/observability_solution/apm/public/components/app/alerts_overview/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/alerts_overview/index.tsx
@@ -14,8 +14,8 @@ import { BoolQuery } from '@kbn/es-query';
 import { AlertConsumers } from '@kbn/rule-data-utils';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import {
-  apmAlertingConsumers,
-  apmAlertingRuleTypeIds,
+  APM_ALERTING_CONSUMERS,
+  APM_ALERTING_RULE_TYPE_IDS,
 } from '../../../../common/alerting/config/apm_alerting_feature_ids';
 import { ApmPluginStartDeps } from '../../../plugin';
 import { useAnyOfApmParams } from '../../../hooks/use_apm_params';
@@ -111,8 +111,8 @@ export function AlertsOverview() {
               alertsTableConfigurationRegistry={alertsTableConfigurationRegistry}
               id={'service-overview-alerts'}
               configurationId={AlertConsumers.OBSERVABILITY}
-              ruleTypeIds={apmAlertingRuleTypeIds}
-              consumers={apmAlertingConsumers}
+              ruleTypeIds={APM_ALERTING_RULE_TYPE_IDS}
+              consumers={APM_ALERTING_CONSUMERS}
               query={esQuery}
               showAlertStatusWithFlapping
               cellContext={{ observabilityRuleTypeRegistry }}

--- a/x-pack/plugins/observability_solution/apm/server/lib/helpers/get_apm_alerts_client.ts
+++ b/x-pack/plugins/observability_solution/apm/server/lib/helpers/get_apm_alerts_client.ts
@@ -12,7 +12,7 @@ import { DataTier } from '@kbn/observability-shared-plugin/common';
 import { searchExcludedDataTiers } from '@kbn/observability-plugin/common/ui_settings_keys';
 import { estypes } from '@elastic/elasticsearch';
 import { getDataTierFilterCombined } from '@kbn/apm-data-access-plugin/server/utils';
-import { apmAlertingRuleTypeIds } from '../../../common/alerting/config/apm_alerting_feature_ids';
+import { APM_ALERTING_RULE_TYPE_IDS } from '../../../common/alerting/config/apm_alerting_feature_ids';
 import type { MinimalAPMRouteHandlerResources } from '../../routes/apm_routes/register_apm_server_routes';
 
 export type ApmAlertsClient = Awaited<ReturnType<typeof getApmAlertsClient>>;
@@ -32,7 +32,9 @@ export async function getApmAlertsClient({
 
   const ruleRegistryPluginStart = await plugins.ruleRegistry.start();
   const alertsClient = await ruleRegistryPluginStart.getRacClientWithRequest(request);
-  const apmAlertsIndices = await alertsClient.getAuthorizedAlertsIndices(apmAlertingRuleTypeIds);
+  const apmAlertsIndices = await alertsClient.getAuthorizedAlertsIndices(
+    APM_ALERTING_RULE_TYPE_IDS
+  );
 
   if (!apmAlertsIndices || isEmpty(apmAlertsIndices)) {
     throw Error('No alert indices exist for "apm"');

--- a/x-pack/plugins/observability_solution/apm/server/routes/services/get_services/get_service_alerts.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/services/get_services/get_service_alerts.ts
@@ -86,7 +86,6 @@ export async function getServicesAlerts({
     },
   };
 
-  console.log('APM - PARAMS', JSON.stringify(params));
 
   const result = await apmAlertsClient.search(params);
 

--- a/x-pack/plugins/observability_solution/apm/server/routes/services/get_services/get_service_alerts.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/services/get_services/get_service_alerts.ts
@@ -86,7 +86,6 @@ export async function getServicesAlerts({
     },
   };
 
-
   const result = await apmAlertsClient.search(params);
 
   const filterAggBuckets = result.aggregations?.services.buckets ?? [];

--- a/x-pack/plugins/observability_solution/apm/server/routes/services/get_services/get_service_alerts.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/services/get_services/get_service_alerts.ts
@@ -18,7 +18,7 @@ import {
   ALERT_STATUS_ACTIVE,
   ALERT_UUID,
 } from '@kbn/rule-data-utils';
-import { observabilityFeatureId } from '@kbn/observability-shared-plugin/common';
+import { apmAlertingConsumers } from '../../../../common/alerting/config/apm_alerting_feature_ids';
 import { SERVICE_NAME } from '../../../../common/es_fields/apm';
 import { ServiceGroup } from '../../../../common/service_groups';
 import { ApmAlertsClient } from '../../../lib/helpers/get_apm_alerts_client';
@@ -58,7 +58,7 @@ export async function getServicesAlerts({
     query: {
       bool: {
         filter: [
-          ...termsQuery(ALERT_RULE_PRODUCER, 'apm', observabilityFeatureId),
+          ...termsQuery(ALERT_RULE_PRODUCER, ...apmAlertingConsumers),
           ...termQuery(ALERT_STATUS, ALERT_STATUS_ACTIVE),
           ...rangeQuery(start, end),
           ...kqlQuery(kuery),
@@ -85,6 +85,8 @@ export async function getServicesAlerts({
       },
     },
   };
+
+  console.log('APM - PARAMS', JSON.stringify(params));
 
   const result = await apmAlertsClient.search(params);
 

--- a/x-pack/plugins/observability_solution/apm/server/routes/services/get_services/get_service_alerts.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/services/get_services/get_service_alerts.ts
@@ -18,7 +18,7 @@ import {
   ALERT_STATUS_ACTIVE,
   ALERT_UUID,
 } from '@kbn/rule-data-utils';
-import { apmAlertingConsumers } from '../../../../common/alerting/config/apm_alerting_feature_ids';
+import { APM_ALERTING_CONSUMERS } from '../../../../common/alerting/config/apm_alerting_feature_ids';
 import { SERVICE_NAME } from '../../../../common/es_fields/apm';
 import { ServiceGroup } from '../../../../common/service_groups';
 import { ApmAlertsClient } from '../../../lib/helpers/get_apm_alerts_client';
@@ -58,7 +58,7 @@ export async function getServicesAlerts({
     query: {
       bool: {
         filter: [
-          ...termsQuery(ALERT_RULE_PRODUCER, ...apmAlertingConsumers),
+          ...termsQuery(ALERT_RULE_PRODUCER, ...APM_ALERTING_CONSUMERS),
           ...termQuery(ALERT_STATUS, ALERT_STATUS_ACTIVE),
           ...rangeQuery(start, end),
           ...kqlQuery(kuery),


### PR DESCRIPTION
## Summary

This PR continues the work from https://github.com/elastic/kibana/issues/201565. 
We missed updating the alert rules in the `getServicesAlerts` function, so this fixes that.

There's an ongoing [issue](https://github.com/elastic/kibana/issues/202415) to test the alert counts across solutions and ensure it works as expected in all scenarios.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->