### PR TITLE
[8.17] [ResponseOps][Rules] Hide the "Role visibility" dropdown in the new rule form in serverless (#200727)

### DIFF
--- a/packages/kbn-alerts-ui-shared/src/rule_form/rule_definition/rule_definition.test.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/rule_definition/rule_definition.test.tsx
@@ -236,6 +236,34 @@ describe('Rule Definition', () => {
     expect(screen.queryByTestId('ruleConsumerSelection')).not.toBeInTheDocument();
   });
 
+  test('Hides consumer selection if there are irrelevant consumers and only 1 consumer to select', () => {
+    useRuleFormState.mockReturnValue({
+      plugins,
+      formData: {
+        id: 'test-id',
+        params: {},
+        schedule: {
+          interval: '1m',
+        },
+        alertDelay: {
+          active: 5,
+        },
+        notifyWhen: null,
+        consumer: 'stackAlerts',
+        ruleTypeId: '.es-query',
+      },
+      selectedRuleType: ruleType,
+      selectedRuleTypeModel: ruleModel,
+      availableRuleTypes: [ruleType],
+      canShowConsumerSelect: true,
+      validConsumers: ['logs', 'observability'],
+    });
+
+    render(<RuleDefinition />);
+
+    expect(screen.queryByTestId('ruleConsumerSelection')).not.toBeInTheDocument();
+  });
+
   test('Hides consumer selection if valid consumers contain observability', () => {
     useRuleFormState.mockReturnValue({
       plugins,

--- a/packages/kbn-alerts-ui-shared/src/rule_form/rule_definition/rule_definition.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/rule_definition/rule_definition.tsx
@@ -27,27 +27,27 @@ import {
 } from '@elastic/eui';
 import { RuleSpecificFlappingProperties } from '@kbn/alerting-types';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
-import { AlertConsumers } from '@kbn/rule-data-utils';
+import { ALERTING_FEATURE_ID, MULTI_CONSUMER_RULE_TYPE_IDS } from '../constants';
+import { useRuleFormDispatch, useRuleFormState } from '../hooks';
 import {
   DOC_LINK_TITLE,
   LOADING_RULE_TYPE_PARAMS_TITLE,
   SCHEDULE_TITLE,
   SCHEDULE_DESCRIPTION_TEXT,
   SCHEDULE_TOOLTIP_TEXT,
-  ALERT_DELAY_TITLE,
   SCOPE_TITLE,
   SCOPE_DESCRIPTION_TEXT,
   ADVANCED_OPTIONS_TITLE,
   ALERT_DELAY_DESCRIPTION_TEXT,
   ALERT_DELAY_HELP_TEXT,
+  ALERT_DELAY_TITLE,
+  FEATURE_NAME_MAP,
   ALERT_FLAPPING_DETECTION_TITLE,
   ALERT_FLAPPING_DETECTION_DESCRIPTION,
 } from '../translations';
 import { RuleAlertDelay } from './rule_alert_delay';
 import { RuleConsumerSelection } from './rule_consumer_selection';
 import { RuleSchedule } from './rule_schedule';
-import { useRuleFormState, useRuleFormDispatch } from '../hooks';
-import { ALERTING_FEATURE_ID, MULTI_CONSUMER_RULE_TYPE_IDS } from '../constants';
 import { getAuthorizedConsumers } from '../utils';
 import { RuleSettingsFlappingTitleTooltip } from '../../rule_settings/rule_settings_flapping_title_tooltip';
 import { RuleSettingsFlappingForm } from '../../rule_settings/rule_settings_flapping_form';
@@ -114,15 +114,18 @@ export const RuleDefinition = () => {
     if (!canShowConsumerSelection) {
       return false;
     }
-    if (!authorizedConsumers.length) {
+
+    /*
+     * This will filter out values like 'alerts' and 'observability' that will not be displayed
+     * in the drop down. It will allow us to hide the consumer select when there is only one
+     * selectable value.
+     */
+    const authorizedValidConsumers = authorizedConsumers.filter((c) => c in FEATURE_NAME_MAP);
+
+    if (authorizedValidConsumers.length <= 1) {
       return false;
     }
-    if (
-      authorizedConsumers.length <= 1 ||
-      authorizedConsumers.includes(AlertConsumers.OBSERVABILITY)
-    ) {
-      return false;
-    }
+
     return !!(ruleTypeId && MULTI_CONSUMER_RULE_TYPE_IDS.includes(ruleTypeId));
   }, [ruleTypeId, authorizedConsumers, canShowConsumerSelection]);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[ResponseOps][Rules] Hide the "Role visibility" dropdown in the new rule form in serverless (#200727)](https://github.com/elastic/kibana/pull/200727)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Antonio","email":"antonio.coelho@elastic.co"},"sourceCommit":{"committedDate":"2024-12-05T11:20:37Z","message":"[ResponseOps][Rules] Hide the \"Role visibility\" dropdown in the new rule form in serverless (#200727)\n\nFixes #199642\r\n\r\n## Summary\r\n\r\n~~This PR hides the role visibility dropdown in the new rule form when\r\nin serverless.~~\r\n\r\nThis PR hides the role visibility dropdown in the new rule form **when\r\nonly one consumer is available**.\r\n\r\n## How to test\r\n\r\n1. Run Kibana security serverless and confirm the rules in stack\r\nmanagement do not have the role visibility dropdown.\r\n2. Please also make sure that the drop-down still shows when\r\nneeded(outside of serverless).","sha":"7498ab00618baf5d5d30d32b989d4ba93da2803e","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Alerting","release_note:skip","Team:ResponseOps","v9.0.0","backport:prev-minor","v8.17.0","v8.18.0","v8.16.2"],"number":200727,"url":"https://github.com/elastic/kibana/pull/200727","mergeCommit":{"message":"[ResponseOps][Rules] Hide the \"Role visibility\" dropdown in the new rule form in serverless (#200727)\n\nFixes #199642\r\n\r\n## Summary\r\n\r\n~~This PR hides the role visibility dropdown in the new rule form when\r\nin serverless.~~\r\n\r\nThis PR hides the role visibility dropdown in the new rule form **when\r\nonly one consumer is available**.\r\n\r\n## How to test\r\n\r\n1. Run Kibana security serverless and confirm the rules in stack\r\nmanagement do not have the role visibility dropdown.\r\n2. Please also make sure that the drop-down still shows when\r\nneeded(outside of serverless).","sha":"7498ab00618baf5d5d30d32b989d4ba93da2803e"}},"sourceBranch":"main","suggestedTargetBranches":["8.17","8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/200727","number":200727,"mergeCommit":{"message":"[ResponseOps][Rules] Hide the \"Role visibility\" dropdown in the new rule form in serverless (#200727)\n\nFixes #199642\r\n\r\n## Summary\r\n\r\n~~This PR hides the role visibility dropdown in the new rule form when\r\nin serverless.~~\r\n\r\nThis PR hides the role visibility dropdown in the new rule form **when\r\nonly one consumer is available**.\r\n\r\n## How to test\r\n\r\n1. Run Kibana security serverless and confirm the rules in stack\r\nmanagement do not have the role visibility dropdown.\r\n2. Please also make sure that the drop-down still shows when\r\nneeded(outside of serverless).","sha":"7498ab00618baf5d5d30d32b989d4ba93da2803e"}},{"branch":"8.17","label":"v8.17.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/203077","number":203077,"state":"MERGED","mergeCommit":{"sha":"43f0dfaa131a1d7eed12b59ba0b9afc1a87633e9","message":"[8.x] [ResponseOps][Rules] Hide the &quot;Role visibility&quot; dropdown in the new rule form in serverless (#200727) (#203077)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[ResponseOps][Rules] Hide the &quot;Role visibility&quot; dropdown in\nthe new rule form in serverless\n(#200727)](https://github.com/elastic/kibana/pull/200727)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT\n[{\"author\":{\"name\":\"Antonio\",\"email\":\"antonio.coelho@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-12-05T11:20:37Z\",\"message\":\"[ResponseOps][Rules]\nHide the \\\"Role visibility\\\" dropdown in the new rule form in serverless\n(#200727)\\n\\nFixes #199642\\r\\n\\r\\n## Summary\\r\\n\\r\\n~~This PR hides the\nrole visibility dropdown in the new rule form when\\r\\nin\nserverless.~~\\r\\n\\r\\nThis PR hides the role visibility dropdown in the\nnew rule form **when\\r\\nonly one consumer is available**.\\r\\n\\r\\n## How\nto test\\r\\n\\r\\n1. Run Kibana security serverless and confirm the rules\nin stack\\r\\nmanagement do not have the role visibility dropdown.\\r\\n2.\nPlease also make sure that the drop-down still shows\nwhen\\r\\nneeded(outside of\nserverless).\",\"sha\":\"7498ab00618baf5d5d30d32b989d4ba93da2803e\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"Feature:Alerting\",\"release_note:skip\",\"Team:ResponseOps\",\"v9.0.0\",\"backport:prev-minor\",\"v8.17.0\",\"v8.18.0\",\"v8.16.2\"],\"title\":\"[ResponseOps][Rules]\nHide the \\\"Role visibility\\\" dropdown in the new rule form in\nserverless\",\"number\":200727,\"url\":\"https://github.com/elastic/kibana/pull/200727\",\"mergeCommit\":{\"message\":\"[ResponseOps][Rules]\nHide the \\\"Role visibility\\\" dropdown in the new rule form in serverless\n(#200727)\\n\\nFixes #199642\\r\\n\\r\\n## Summary\\r\\n\\r\\n~~This PR hides the\nrole visibility dropdown in the new rule form when\\r\\nin\nserverless.~~\\r\\n\\r\\nThis PR hides the role visibility dropdown in the\nnew rule form **when\\r\\nonly one consumer is available**.\\r\\n\\r\\n## How\nto test\\r\\n\\r\\n1. Run Kibana security serverless and confirm the rules\nin stack\\r\\nmanagement do not have the role visibility dropdown.\\r\\n2.\nPlease also make sure that the drop-down still shows\nwhen\\r\\nneeded(outside of\nserverless).\",\"sha\":\"7498ab00618baf5d5d30d32b989d4ba93da2803e\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.17\",\"8.x\",\"8.16\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/200727\",\"number\":200727,\"mergeCommit\":{\"message\":\"[ResponseOps][Rules]\nHide the \\\"Role visibility\\\" dropdown in the new rule form in serverless\n(#200727)\\n\\nFixes #199642\\r\\n\\r\\n## Summary\\r\\n\\r\\n~~This PR hides the\nrole visibility dropdown in the new rule form when\\r\\nin\nserverless.~~\\r\\n\\r\\nThis PR hides the role visibility dropdown in the\nnew rule form **when\\r\\nonly one consumer is available**.\\r\\n\\r\\n## How\nto test\\r\\n\\r\\n1. Run Kibana security serverless and confirm the rules\nin stack\\r\\nmanagement do not have the role visibility dropdown.\\r\\n2.\nPlease also make sure that the drop-down still shows\nwhen\\r\\nneeded(outside of\nserverless).\",\"sha\":\"7498ab00618baf5d5d30d32b989d4ba93da2803e\"}},{\"branch\":\"8.17\",\"label\":\"v8.17.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.x\",\"label\":\"v8.18.0\",\"branchLabelMappingKey\":\"^v8.18.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.16\",\"label\":\"v8.16.2\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Antonio <antonio.coelho@elastic.co>"}},{"branch":"8.16","label":"v8.16.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->