### PR TITLE
[8.x] [Security Solution][Endpoint] Fix Cypress test to work with refactored Roles page (#202770)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/common/constants.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/common/constants.ts
@@ -18,4 +18,5 @@ export const KIBANA_KNOWN_DEFAULT_ACCOUNTS = {
   elastic: 'elastic',
   elastic_serverless: 'elastic_serverless',
   system_indices_superuser: 'system_indices_superuser',
+  admin: 'admin',
 } as const;

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/rbac/endpoint_role_rbac.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/rbac/endpoint_role_rbac.cy.ts
@@ -5,12 +5,17 @@
  * 2.0.
  */
 
+import {
+  expandEndpointSecurityFeaturePrivileges,
+  expandSecuritySolutionCategoryKibanaPrivileges,
+  navigateToRolePage,
+  openKibanaFeaturePrivilegesFlyout,
+  setKibanaPrivilegeSpace,
+} from '../../screens/stack_management/role_page';
 import { closeAllToasts } from '../../tasks/toasts';
 import { login, ROLE } from '../../tasks/login';
-import { loadPage } from '../../tasks/common';
 
-// Failing: See https://github.com/elastic/kibana/issues/200967
-describe.skip('When defining a kibana role for Endpoint security access', { tags: '@ess' }, () => {
+describe('When defining a kibana role for Endpoint security access', { tags: '@ess' }, () => {
   const getAllSubFeatureRows = (): Cypress.Chainable<JQuery<HTMLElement>> => {
     return cy
       .get('#featurePrivilegeControls_siem')
@@ -20,11 +25,13 @@ describe.skip('When defining a kibana role for Endpoint security access', { tags
 
   beforeEach(() => {
     login(ROLE.system_indices_superuser);
-    loadPage('/app/management/security/roles/edit');
+    navigateToRolePage();
     closeAllToasts();
-    cy.getByTestSubj('addSpacePrivilegeButton').click();
-    cy.getByTestSubj('featureCategoryButton_securitySolution').closest('button').click();
-    cy.get('.featurePrivilegeName:contains("Security")').closest('button').click();
+
+    openKibanaFeaturePrivilegesFlyout();
+    setKibanaPrivilegeSpace('default');
+    expandSecuritySolutionCategoryKibanaPrivileges();
+    expandEndpointSecurityFeaturePrivileges();
   });
 
   it('should display RBAC entries with expected controls', () => {

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/rbac/endpoint_role_rbac_with_space_awareness.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/rbac/endpoint_role_rbac_with_space_awareness.cy.ts
@@ -23,11 +23,10 @@ import {
   setSecuritySolutionEndpointGroupPrivilege,
 } from '../../screens/stack_management/role_page';
 
-// Failing: See https://github.com/elastic/kibana/issues/200962
-describe.skip(
+describe(
   'When defining a kibana role for Endpoint security access with space awareness enabled',
   {
-    // TODO:PR Remove `'@skipInServerlessMKI` once PR merges to `main`
+    // TODO:PR Remove `'@skipInServerlessMKI` once PR merges to `main` and feature flag is enabled in prod.
     tags: ['@ess', '@serverless', '@serverlessMKI', '@skipInServerlessMKI'],
     env: {
       ftrConfig: {
@@ -44,11 +43,13 @@ describe.skip(
     },
   },
   () => {
-    let spaceId: string = '';
+    // In Serverless MKI we use `admin` for the login user... other deployments use system indices superuser
+    const loginUser = Cypress.env('CLOUD_SERVERLESS') ? ROLE.admin : ROLE.system_indices_superuser;
     const roleName = `test_${Math.random().toString().substring(2, 6)}`;
+    let spaceId: string = '';
 
     before(() => {
-      login(ROLE.system_indices_superuser);
+      login(loginUser);
       createSpace(`foo_${Math.random().toString().substring(2, 6)}`).then((response) => {
         spaceId = response.body.id;
       });
@@ -62,16 +63,16 @@ describe.skip(
     });
 
     beforeEach(() => {
-      login(ROLE.system_indices_superuser);
+      login(loginUser);
       navigateToRolePage();
       setRoleName(roleName);
       openKibanaFeaturePrivilegesFlyout();
+      setKibanaPrivilegeSpace(spaceId);
       expandSecuritySolutionCategoryKibanaPrivileges();
       expandEndpointSecurityFeaturePrivileges();
     });
 
     it('should allow configuration per-space', () => {
-      setKibanaPrivilegeSpace(spaceId);
       setSecuritySolutionEndpointGroupPrivilege('all');
       clickEndpointSubFeaturePrivilegesCustomization();
       setEndpointSubFeaturePrivilege('endpoint_list', 'all');

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/alerts_response_console.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/alerts_response_console.cy.ts
@@ -85,6 +85,15 @@ describe(
       }
     });
 
+    afterEach(function () {
+      if (Cypress.env('IS_CI') && this.currentTest?.isFailed() && createdHost) {
+        cy.task('captureHostVmAgentDiagnostics', {
+          hostname: createdHost.hostname,
+          fileNamePrefix: this.currentTest?.fullTitle(),
+        });
+      }
+    });
+
     it('should open responder from alert details flyout', () => {
       waitForEndpointListPageToBeLoaded(createdHost.hostname);
       toggleRuleOffAndOn(ruleName);

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/execute.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/execute.cy.ts
@@ -63,6 +63,15 @@ describe('Response console', { tags: ['@ess', '@serverless'] }, () => {
       }
     });
 
+    afterEach(function () {
+      if (Cypress.env('IS_CI') && this.currentTest?.isFailed() && createdHost) {
+        cy.task('captureHostVmAgentDiagnostics', {
+          hostname: createdHost.hostname,
+          fileNamePrefix: this.currentTest?.fullTitle(),
+        });
+      }
+    });
+
     it('"execute --command" - should execute a command', () => {
       waitForEndpointListPageToBeLoaded(createdHost.hostname);
       openResponseConsoleFromEndpointList();

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/isolate.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/isolate.cy.ts
@@ -61,6 +61,15 @@ describe('Response console', { tags: ['@ess', '@serverless'] }, () => {
     }
   });
 
+  afterEach(function () {
+    if (Cypress.env('IS_CI') && this.currentTest?.isFailed() && createdHost) {
+      cy.task('captureHostVmAgentDiagnostics', {
+        hostname: createdHost.hostname,
+        fileNamePrefix: this.currentTest?.fullTitle(),
+      });
+    }
+  });
+
   describe('Host Isolation:', () => {
     beforeEach(() => {
       login();

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/process_operations.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/process_operations.cy.ts
@@ -66,6 +66,15 @@ describe('Response console', { tags: ['@ess', '@serverless', '@skipInServerlessM
       }
     });
 
+    afterEach(function () {
+      if (Cypress.env('IS_CI') && this.currentTest?.isFailed() && createdHost) {
+        cy.task('captureHostVmAgentDiagnostics', {
+          hostname: createdHost.hostname,
+          fileNamePrefix: this.currentTest?.fullTitle(),
+        });
+      }
+    });
+
     it('"processes" - should obtain a list of processes', () => {
       waitForEndpointListPageToBeLoaded(createdHost.hostname);
       openResponseConsoleFromEndpointList();

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/release.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/release.cy.ts
@@ -62,6 +62,15 @@ describe('Response console', { tags: ['@ess', '@serverless'] }, () => {
     }
   });
 
+  afterEach(function () {
+    if (Cypress.env('IS_CI') && this.currentTest?.isFailed() && createdHost) {
+      cy.task('captureHostVmAgentDiagnostics', {
+        hostname: createdHost.hostname,
+        fileNamePrefix: this.currentTest?.fullTitle(),
+      });
+    }
+  });
+
   describe('Host Isolation:', () => {
     beforeEach(() => {
       login();

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/scan.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/scan.cy.ts
@@ -81,6 +81,15 @@ describe(
         }
       });
 
+      afterEach(function () {
+        if (Cypress.env('IS_CI') && this.currentTest?.isFailed() && createdHost) {
+          cy.task('captureHostVmAgentDiagnostics', {
+            hostname: createdHost.hostname,
+            fileNamePrefix: this.currentTest?.fullTitle(),
+          });
+        }
+      });
+
       [
         ['file', filePath],
         ['folder', homeFilePath],

--- a/x-pack/plugins/security_solution/public/management/cypress/screens/stack_management/role_page.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/screens/stack_management/role_page.ts
@@ -85,6 +85,13 @@ export const setKibanaPrivilegeSpace = (spaceId: string) => {
   cy.getByTestSubj('comboBoxOptionsList spaceSelectorComboBox-optionsList')
     .find(`button#spaceOption_${spaceId}`)
     .click();
+
+  // Wait for the selection to be added to the list of selected spaces
+  cy.getByTestSubj('spaceSelectorComboBox').find(`#spaceOption_${spaceId}`);
+
+  // This `click()` just ensures that the combox in the UI is "closed" after the
+  // selection and mouse focus is moved away from that field.
+  getKibanaFeaturePrivilegesFlyout().click();
 };
 
 /**

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/login.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/login.ts
@@ -9,13 +9,12 @@ import type { LoginState } from '@kbn/security-plugin/common/login_state';
 import type { Role } from '@kbn/security-plugin/common';
 import { ENDPOINT_SECURITY_ROLE_NAMES } from '../../../../scripts/endpoint/common/roles_users';
 import type { SecurityTestUser } from '../common/constants';
+import { KIBANA_KNOWN_DEFAULT_ACCOUNTS } from '../common/constants';
 import { COMMON_API_HEADERS, request } from './common';
 
 export const ROLE = Object.freeze<Record<SecurityTestUser, SecurityTestUser>>({
   ...ENDPOINT_SECURITY_ROLE_NAMES,
-  elastic: 'elastic',
-  elastic_serverless: 'elastic_serverless',
-  system_indices_superuser: 'system_indices_superuser',
+  ...KIBANA_KNOWN_DEFAULT_ACCOUNTS,
 });
 
 interface CyLoginTask {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][Endpoint] Fix Cypress test to work with refactored Roles page (#202770)](https://github.com/elastic/kibana/pull/202770)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-12-05T15:56:53Z","message":"[Security Solution][Endpoint] Fix Cypress test to work with refactored Roles page (#202770)\n\n## Summary\r\n\r\n- Fixes cypress tests for space awareness RBAC checks to work with the\r\nrecent changes to the core Role page\r\n    - Fixes #200962\r\n    - Fixes #200967\r\n- Enables test file for runs on Serverless MKI environments","sha":"5262902a86a6b2b549e61b81037ce77933e2d484","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Defend Workflows","backport:prev-minor","v8.18.0"],"number":202770,"url":"https://github.com/elastic/kibana/pull/202770","mergeCommit":{"message":"[Security Solution][Endpoint] Fix Cypress test to work with refactored Roles page (#202770)\n\n## Summary\r\n\r\n- Fixes cypress tests for space awareness RBAC checks to work with the\r\nrecent changes to the core Role page\r\n    - Fixes #200962\r\n    - Fixes #200967\r\n- Enables test file for runs on Serverless MKI environments","sha":"5262902a86a6b2b549e61b81037ce77933e2d484"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/202770","number":202770,"mergeCommit":{"message":"[Security Solution][Endpoint] Fix Cypress test to work with refactored Roles page (#202770)\n\n## Summary\r\n\r\n- Fixes cypress tests for space awareness RBAC checks to work with the\r\nrecent changes to the core Role page\r\n    - Fixes #200962\r\n    - Fixes #200967\r\n- Enables test file for runs on Serverless MKI environments","sha":"5262902a86a6b2b549e61b81037ce77933e2d484"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->