### PR TITLE
[Search][a11y] Fix table row screen reader error

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/body_row.tsx
@@ -66,7 +66,14 @@ export const BodyRow = <Item extends object>({
         <EuiFlexGroup direction="column">
           {errors.map((errorMessage, errorMessageIndex) => (
             <EuiFlexItem key={errorMessageIndex}>
-              <EuiCallOut iconType="warning" size="s" color="danger" title={errorMessage} />
+              <EuiCallOut
+                role="alert"
+                aria-live="polite"
+                iconType="warning"
+                size="s"
+                color="danger"
+                title={errorMessage}
+              />
             </EuiFlexItem>
           ))}
         </EuiFlexGroup>


### PR DESCRIPTION
##  Closes https://github.com/elastic/kibana/issues/199113

Allows errors in the table row to be read by screen readers.

https://github.com/user-attachments/assets/f1413adf-5e41-4449-9973-999da8b63ac4



<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.x"]} ONMERGE-->