### PR TITLE
[Security Solution] Remove feature flag `entityAlertPreviewDisabled`

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -110,11 +110,6 @@ export const allowedExperimentalValues = Object.freeze({
   securitySolutionNotesDisabled: false,
 
   /**
-   * Disables entity and alert previews
-   */
-  entityAlertPreviewDisabled: false,
-
-  /**
    * Enables the Assistant Model Evaluation advanced setting and API endpoint, introduced in `8.11.0`.
    */
   assistantModelEvaluation: false,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs.test.tsx
@@ -49,12 +49,6 @@ const riskScore = {
   },
 };
 
-const mockUseIsExperimentalFeatureEnabled = jest.fn().mockReturnValue(false);
-
-jest.mock('../../../../../common/hooks/use_experimental_features', () => ({
-  useIsExperimentalFeatureEnabled: () => mockUseIsExperimentalFeatureEnabled(),
-}));
-
 const riskScoreWithAssetCriticalityContribution = (contribution: number) => {
   const score = JSON.parse(JSON.stringify(riskScore));
   score.user.risk.category_2_score = contribution;
@@ -129,8 +123,7 @@ describe('RiskInputsTab', () => {
     expect(queryByTestId('risk-input-contexts-title')).toBeInTheDocument();
   });
 
-  it('it renders alert preview button when feature flag is enable', () => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  it('it renders alert preview button', () => {
     mockUseRiskScore.mockReturnValue({
       loading: false,
       error: false,
@@ -149,28 +142,6 @@ describe('RiskInputsTab', () => {
     );
 
     expect(getByTestId(EXPAND_ALERT_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('it does not render alert preview button when feature flag is disable', () => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
-    mockUseRiskScore.mockReturnValue({
-      loading: false,
-      error: false,
-      data: [riskScore],
-    });
-    mockUseRiskContributingAlerts.mockReturnValue({
-      loading: false,
-      error: false,
-      data: [alertInputDataMock],
-    });
-
-    const { queryByTestId } = render(
-      <TestProviders>
-        <RiskInputsTab entityType={RiskScoreEntity.user} entityName="elastic" scopeId={'scopeId'} />
-      </TestProviders>
-    );
-
-    expect(queryByTestId(EXPAND_ALERT_TEST_ID)).not.toBeInTheDocument();
   });
 
   it('Displays 0.00 for the asset criticality contribution if the contribution value is less than -0.01', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
@@ -14,7 +14,6 @@ import { ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 
 import { get } from 'lodash/fp';
 import { AlertPreviewButton } from '../../../../../flyout/shared/components/alert_preview_button';
-import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { useGlobalTime } from '../../../../../common/containers/use_global_time';
 import { useQueryInspector } from '../../../../../common/components/page/manage_query';
 import { formatRiskScore } from '../../../../common';
@@ -98,26 +97,20 @@ export const RiskInputsTab = ({ entityType, entityName, scopeId }: RiskInputsTab
     }),
     []
   );
-  const isPreviewEnabled = !useIsExperimentalFeatureEnabled('entityAlertPreviewDisabled');
 
   const inputColumns: Array<EuiBasicTableColumn<InputAlert>> = useMemo(
     () => [
-      ...(isPreviewEnabled
-        ? [
-            {
-              render: (data: InputAlert) => (
-                <AlertPreviewButton
-                  id={data._id}
-                  indexName={data.input.index}
-                  scopeId={scopeId}
-                  data-test-subj={EXPAND_ALERT_TEST_ID}
-                />
-              ),
-              width: '5%',
-            },
-          ]
-        : []),
-
+      {
+        render: (data: InputAlert) => (
+          <AlertPreviewButton
+            id={data._id}
+            indexName={data.input.index}
+            scopeId={scopeId}
+            data-test-subj={EXPAND_ALERT_TEST_ID}
+          />
+        ),
+        width: '5%',
+      },
       {
         name: (
           <FormattedMessage
@@ -172,7 +165,7 @@ export const RiskInputsTab = ({ entityType, entityName, scopeId }: RiskInputsTab
         render: formatContribution,
       },
     ],
-    [isPreviewEnabled, scopeId]
+    [scopeId]
   );
 
   if (riskScoreError) {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details_alerts_table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details_alerts_table.test.tsx
@@ -11,7 +11,6 @@ import { TestProviders } from '../../../../common/mock';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { CorrelationsDetailsAlertsTable } from './correlations_details_alerts_table';
 import { usePaginatedAlerts } from '../hooks/use_paginated_alerts';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { mockFlyoutApi } from '../../shared/mocks/mock_flyout_context';
 import { mockContextValue } from '../../shared/mocks/mock_context';
 import { DocumentDetailsPreviewPanelKey } from '../../shared/constants/panel_keys';
@@ -20,8 +19,6 @@ import { DocumentDetailsContext } from '../../shared/context';
 import { RulePreviewPanelKey, RULE_PREVIEW_BANNER } from '../../../rule_details/right';
 
 jest.mock('../hooks/use_paginated_alerts');
-jest.mock('../../../../common/hooks/use_experimental_features');
-const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
 
 jest.mock('@kbn/expandable-flyout');
 
@@ -47,7 +44,6 @@ const renderCorrelationsTable = (panelContext: DocumentDetailsContext) =>
 describe('CorrelationsDetailsAlertsTable', () => {
   beforeEach(() => {
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
     jest.mocked(usePaginatedAlerts).mockReturnValue({
       setPagination: jest.fn(),
       setSorting: jest.fn(),
@@ -88,16 +84,16 @@ describe('CorrelationsDetailsAlertsTable', () => {
   });
 
   it('renders EuiBasicTable with correct props', () => {
-    const { getByTestId, queryByTestId, queryAllByRole } =
+    const { getByTestId, getAllByTestId, queryAllByRole } =
       renderCorrelationsTable(mockContextValue);
 
     expect(getByTestId(`${TEST_ID}InvestigateInTimeline`)).toBeInTheDocument();
     expect(getByTestId(`${TEST_ID}Table`)).toBeInTheDocument();
-    expect(queryByTestId(`${TEST_ID}AlertPreviewButton`)).not.toBeInTheDocument();
+    expect(getAllByTestId(`${TEST_ID}AlertPreviewButton`)).toHaveLength(2);
 
     expect(jest.mocked(usePaginatedAlerts)).toHaveBeenCalled();
 
-    expect(queryAllByRole('columnheader').length).toBe(4);
+    expect(queryAllByRole('columnheader').length).toBe(5);
     expect(queryAllByRole('row').length).toBe(3); // 1 header row and 2 data rows
     expect(queryAllByRole('row')[1].textContent).toContain('Jan 1, 2022 @ 00:00:00.000');
     expect(queryAllByRole('row')[1].textContent).toContain('Reason1');
@@ -105,8 +101,7 @@ describe('CorrelationsDetailsAlertsTable', () => {
     expect(queryAllByRole('row')[1].textContent).toContain('Severity1');
   });
 
-  it('renders open preview button when feature flag is on', () => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  it('renders open preview button', () => {
     const { getByTestId, getAllByTestId } = renderCorrelationsTable({
       ...mockContextValue,
       isPreviewMode: true,
@@ -128,8 +123,7 @@ describe('CorrelationsDetailsAlertsTable', () => {
     });
   });
 
-  it('opens rule preview when feature flag is on and isPreview is false', () => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  it('opens rule preview when isPreview is false', () => {
     const { getAllByTestId } = renderCorrelationsTable(mockContextValue);
 
     expect(getAllByTestId(`${TEST_ID}RulePreview`).length).toBe(2);
@@ -145,8 +139,7 @@ describe('CorrelationsDetailsAlertsTable', () => {
     });
   });
 
-  it('does not render preview link when feature flag is on and isPreview is true', () => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  it('does not render preview link when isPreview is true', () => {
     const { queryByTestId } = renderCorrelationsTable({ ...mockContextValue, isPreview: true });
     expect(queryByTestId(`${TEST_ID}RulePreview`)).not.toBeInTheDocument();
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details_alerts_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/correlations_details_alerts_table.tsx
@@ -14,7 +14,6 @@ import { isRight } from 'fp-ts/lib/Either';
 import { ALERT_REASON, ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { CellTooltipWrapper } from '../../shared/components/cell_tooltip_wrapper';
 import type { DataProvider } from '../../../../../common/types';
 import { SeverityBadge } from '../../../../common/components/severity_badge';
@@ -82,8 +81,6 @@ export const CorrelationsDetailsAlertsTable: FC<CorrelationsDetailsAlertsTablePr
     sorting,
     error,
   } = usePaginatedAlerts(alertIds || []);
-  const isPreviewEnabled = !useIsExperimentalFeatureEnabled('entityAlertPreviewDisabled');
-
   const { isPreview } = useDocumentDetailsContext();
 
   const onTableChange = useCallback(
@@ -129,21 +126,17 @@ export const CorrelationsDetailsAlertsTable: FC<CorrelationsDetailsAlertsTablePr
 
   const columns = useMemo(
     () => [
-      ...(isPreviewEnabled
-        ? [
-            {
-              render: (row: Record<string, unknown>) => (
-                <AlertPreviewButton
-                  id={row.id as string}
-                  indexName={row.index as string}
-                  data-test-subj={`${dataTestSubj}AlertPreviewButton`}
-                  scopeId={scopeId}
-                />
-              ),
-              width: '5%',
-            },
-          ]
-        : []),
+      {
+        render: (row: Record<string, unknown>) => (
+          <AlertPreviewButton
+            id={row.id as string}
+            indexName={row.index as string}
+            data-test-subj={`${dataTestSubj}AlertPreviewButton`}
+            scopeId={scopeId}
+          />
+        ),
+        width: '5%',
+      },
       {
         field: '@timestamp',
         name: (
@@ -176,20 +169,16 @@ export const CorrelationsDetailsAlertsTable: FC<CorrelationsDetailsAlertsTablePr
           const ruleId = row['kibana.alert.rule.uuid'] as string;
           return (
             <CellTooltipWrapper tooltip={ruleName}>
-              {isPreviewEnabled ? (
-                <PreviewLink
-                  field={ALERT_RULE_NAME}
-                  value={ruleName}
-                  scopeId={scopeId}
-                  ruleId={ruleId}
-                  isPreview={isPreview}
-                  data-test-subj={`${dataTestSubj}RulePreview`}
-                >
-                  <span>{ruleName}</span>
-                </PreviewLink>
-              ) : (
+              <PreviewLink
+                field={ALERT_RULE_NAME}
+                value={ruleName}
+                scopeId={scopeId}
+                ruleId={ruleId}
+                isPreview={isPreview}
+                data-test-subj={`${dataTestSubj}RulePreview`}
+              >
                 <span>{ruleName}</span>
-              )}
+              </PreviewLink>
             </CellTooltipWrapper>
           );
         },
@@ -229,7 +218,7 @@ export const CorrelationsDetailsAlertsTable: FC<CorrelationsDetailsAlertsTablePr
         },
       },
     ],
-    [isPreviewEnabled, scopeId, dataTestSubj, isPreview]
+    [scopeId, dataTestSubj, isPreview]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.test.tsx
@@ -17,7 +17,6 @@ import { useMlCapabilities } from '../../../../common/components/ml/hooks/use_ml
 import { mockAnomalies } from '../../../../common/components/ml/mock';
 import { useHostDetails } from '../../../../explore/hosts/containers/hosts/details';
 import { useHostRelatedUsers } from '../../../../common/containers/related_entities/related_users';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { RiskSeverity } from '../../../../../common/search_strategy';
 import {
   HOST_DETAILS_TEST_ID,
@@ -45,9 +44,6 @@ import { useAlertsByStatus } from '../../../../overview/components/detection_res
 jest.mock('@kbn/expandable-flyout');
 jest.mock('@kbn/cloud-security-posture/src/hooks/use_misconfiguration_preview');
 jest.mock('@kbn/cloud-security-posture/src/hooks/use_vulnerabilities_preview');
-
-jest.mock('../../../../common/hooks/use_experimental_features');
-const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -180,20 +176,18 @@ describe('<HostDetails />', () => {
     mockUseHostDetails.mockReturnValue(mockHostDetailsResponse);
     mockUseRiskScore.mockReturnValue(mockRiskScoreResponse);
     mockUseHostsRelatedUsers.mockReturnValue(mockRelatedUsersResponse);
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
     (useMisconfigurationPreview as jest.Mock).mockReturnValue({});
     (useVulnerabilitiesPreview as jest.Mock).mockReturnValue({});
     (useAlertsByStatus as jest.Mock).mockReturnValue({ isLoading: false, items: {} });
   });
 
   it('should render host details correctly', () => {
-    const { getByTestId, queryByTestId } = renderHostDetails(mockContextValue);
+    const { getByTestId } = renderHostDetails(mockContextValue);
     expect(getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(HOST_DETAILS_TEST_ID))).toBeInTheDocument();
-    expect(queryByTestId(HOST_DETAILS_LINK_TEST_ID)).not.toBeInTheDocument();
+    expect(getByTestId(HOST_DETAILS_LINK_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should render host name as clicable link when preview is not disabled', () => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  it('should render host name as clicable link', () => {
     const { getByTestId } = renderHostDetails(mockContextValue);
     expect(getByTestId(HOST_DETAILS_LINK_TEST_ID)).toBeInTheDocument();
 
@@ -242,7 +236,7 @@ describe('<HostDetails />', () => {
 
   describe('Related users', () => {
     it('should render the related user table with correct dates and indices', () => {
-      const { getByTestId, queryByTestId } = renderHostDetails(mockContextValue);
+      const { getByTestId } = renderHostDetails(mockContextValue);
       expect(mockUseHostsRelatedUsers).toBeCalledWith({
         from: timestamp,
         hostName: 'test host',
@@ -250,7 +244,7 @@ describe('<HostDetails />', () => {
         skip: false,
       });
       expect(getByTestId(HOST_DETAILS_RELATED_USERS_TABLE_TEST_ID)).toBeInTheDocument();
-      expect(queryByTestId(HOST_DETAILS_RELATED_USERS_LINK_TEST_ID)).not.toBeInTheDocument();
+      expect(getByTestId(HOST_DETAILS_RELATED_USERS_LINK_TEST_ID)).toBeInTheDocument();
     });
 
     it('should render user risk score column when license and capabilities are valid', () => {
@@ -296,8 +290,7 @@ describe('<HostDetails />', () => {
       );
     });
 
-    it('should render user name as clicable link when preview is not disabled', () => {
-      mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+    it('should render user name as clicable link', () => {
       const { getAllByTestId } = renderHostDetails(mockContextValue);
       expect(getAllByTestId(HOST_DETAILS_RELATED_USERS_LINK_TEST_ID).length).toBe(1);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.tsx
@@ -25,14 +25,12 @@ import type { EuiBasicTableColumn } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import type { RelatedUser } from '../../../../../common/search_strategy/security_solution/related_entities/related_users';
 import type { RiskSeverity } from '../../../../../common/search_strategy';
 import { HostOverview } from '../../../../overview/components/host_overview';
 import { AnomalyTableProvider } from '../../../../common/components/ml/anomaly/anomaly_table_provider';
 import { InspectButton, InspectButtonContainer } from '../../../../common/components/inspect';
-import { NetworkDetailsLink } from '../../../../common/components/links';
 import { RiskScoreEntity } from '../../../../../common/search_strategy';
 import { RiskScoreLevel } from '../../../../entity_analytics/components/severity/common';
 import { DefaultFieldRenderer } from '../../../../timelines/components/field_renderers/default_renderer';
@@ -110,7 +108,6 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, s
   const isEntityAnalyticsAuthorized = isPlatinumOrTrialLicense && hasEntityAnalyticsCapability;
 
   const { openPreviewPanel } = useExpandableFlyoutApi();
-  const isPreviewEnabled = !useIsExperimentalFeatureEnabled('entityAlertPreviewDisabled');
 
   const narrowDateRange = useCallback<NarrowDateRange>(
     (score, interval) => {
@@ -176,16 +173,12 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, s
         render: (user: string) => (
           <EuiText grow={false} size="xs">
             <CellActions field={USER_NAME_FIELD_NAME} value={user}>
-              {isPreviewEnabled ? (
-                <PreviewLink
-                  field={USER_NAME_FIELD_NAME}
-                  value={user}
-                  scopeId={scopeId}
-                  data-test-subj={HOST_DETAILS_RELATED_USERS_LINK_TEST_ID}
-                />
-              ) : (
-                <>{user}</>
-              )}
+              <PreviewLink
+                field={USER_NAME_FIELD_NAME}
+                value={user}
+                scopeId={scopeId}
+                data-test-subj={HOST_DETAILS_RELATED_USERS_LINK_TEST_ID}
+              />
             </CellActions>
           </EuiText>
         ),
@@ -208,15 +201,13 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, s
               render={(ip) =>
                 ip == null ? (
                   getEmptyTagValue()
-                ) : isPreviewEnabled ? (
+                ) : (
                   <PreviewLink
                     field={HOST_IP_FIELD_NAME}
                     value={ip}
                     scopeId={scopeId}
                     data-test-subj={HOST_DETAILS_RELATED_USERS_IP_LINK_TEST_ID}
                   />
-                ) : (
-                  <NetworkDetailsLink ip={ip} />
                 )
               }
               scopeId={scopeId}
@@ -242,7 +233,7 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, s
           ]
         : []),
     ],
-    [isEntityAnalyticsAuthorized, scopeId, isPreviewEnabled]
+    [isEntityAnalyticsAuthorized, scopeId]
   );
 
   const relatedUsersCount = useMemo(
@@ -273,19 +264,14 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, s
   };
 
   const hostLink = useMemo(
-    () =>
-      isPreviewEnabled
-        ? {
-            callback: openHostPreview,
-            tooltip: i18n.translate(
-              'xpack.securitySolution.flyout.left.insights.entities.host.hostPreviewTitle',
-              {
-                defaultMessage: 'Preview host',
-              }
-            ),
-          }
-        : undefined,
-    [isPreviewEnabled, openHostPreview]
+    () => ({
+      callback: openHostPreview,
+      tooltip: i18n.translate(
+        'xpack.securitySolution.flyout.left.insights.entities.host.hostPreviewTitle',
+        { defaultMessage: 'Preview host' }
+      ),
+    }),
+    [openHostPreview]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.test.tsx
@@ -24,7 +24,6 @@ import {
 import { usePrevalence } from '../../shared/hooks/use_prevalence';
 import { TestProviders } from '../../../../common/mock';
 import { licenseService } from '../../../../common/hooks/use_license';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { mockFlyoutApi } from '../../shared/mocks/mock_flyout_context';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { HostPreviewPanelKey } from '../../../entity_details/host_right';
@@ -45,9 +44,6 @@ jest.mock('../../../../common/lib/kibana', () => {
     }),
   };
 });
-
-jest.mock('../../../../common/hooks/use_experimental_features');
-const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
 
 jest.mock('../../shared/hooks/use_prevalence');
 
@@ -138,7 +134,6 @@ describe('PrevalenceDetails', () => {
     jest.clearAllMocks();
     licenseServiceMock.isPlatinumPlus.mockReturnValue(true);
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
   });
 
   it('should render the table with all data if license is platinum', () => {
@@ -162,13 +157,10 @@ describe('PrevalenceDetails', () => {
     ).toBeGreaterThan(1);
     expect(queryByTestId(PREVALENCE_DETAILS_UPSELL_TEST_ID)).not.toBeInTheDocument();
     expect(queryByText(NO_DATA_MESSAGE)).not.toBeInTheDocument();
-    expect(
-      queryByTestId(PREVALENCE_DETAILS_TABLE_PREVIEW_LINK_CELL_TEST_ID)
-    ).not.toBeInTheDocument();
+    expect(getAllByTestId(PREVALENCE_DETAILS_TABLE_PREVIEW_LINK_CELL_TEST_ID)).toHaveLength(2);
   });
 
-  it('should render host and user name as clickable link if preview is enabled', () => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  it('should render host and user name as clickable link', () => {
     (usePrevalence as jest.Mock).mockReturnValue(mockPrevelanceReturnValue);
 
     const { getAllByTestId } = renderPrevalenceDetails();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/prevalence_details.tsx
@@ -22,7 +22,6 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { FormattedCount } from '../../../../common/components/formatted_number';
 import { useLicense } from '../../../../common/hooks/use_license';
 import { InvestigateInTimelineButton } from '../../../../common/components/event_details/investigate_in_timeline_button';
@@ -82,10 +81,6 @@ interface PrevalenceDetailsRow extends PrevalenceData {
    */
   isPlatinumPlus: boolean;
   /**
-   * If enabled, clicking host or user should open an entity preview
-   */
-  isPreviewEnabled: boolean;
-  /**
    * Scope id to pass to the preview link
    */
   scopeId: string;
@@ -115,7 +110,7 @@ const columns: Array<EuiBasicTableColumn<PrevalenceDetailsRow>> = [
     render: (data: PrevalenceDetailsRow) => (
       <EuiFlexGroup direction="column" gutterSize="none">
         {data.values.map((value) => {
-          if (data.isPreviewEnabled && hasPreview(data.field)) {
+          if (hasPreview(data.field)) {
             return (
               <EuiFlexItem key={value}>
                 <CellActions field={data.field} value={value}>
@@ -331,7 +326,6 @@ export const PrevalenceDetails: React.FC = () => {
     useDocumentDetailsContext();
 
   const isPlatinumPlus = useLicense().isPlatinumPlus();
-  const isPreviewEnabled = !useIsExperimentalFeatureEnabled('entityAlertPreviewDisabled');
 
   // these two are used by the usePrevalence hook to fetch the data
   const [start, setStart] = useState(DEFAULT_FROM);
@@ -382,10 +376,9 @@ export const PrevalenceDetails: React.FC = () => {
         from: absoluteStart,
         to: absoluteEnd,
         isPlatinumPlus,
-        isPreviewEnabled,
         scopeId,
       })),
-    [data, absoluteStart, absoluteEnd, isPlatinumPlus, isPreviewEnabled, scopeId]
+    [data, absoluteStart, absoluteEnd, isPlatinumPlus, scopeId]
   );
 
   const upsell = (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.test.tsx
@@ -16,7 +16,6 @@ import { useMlCapabilities } from '../../../../common/components/ml/hooks/use_ml
 import { mockAnomalies } from '../../../../common/components/ml/mock';
 import { useObservedUserDetails } from '../../../../explore/users/containers/users/observed_details';
 import { useUserRelatedHosts } from '../../../../common/containers/related_entities/related_hosts';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { RiskSeverity } from '../../../../../common/search_strategy';
 import {
   USER_DETAILS_TEST_ID,
@@ -42,9 +41,6 @@ import { useAlertsByStatus } from '../../../../overview/components/detection_res
 
 jest.mock('@kbn/expandable-flyout');
 jest.mock('@kbn/cloud-security-posture/src/hooks/use_misconfiguration_preview');
-
-jest.mock('../../../../common/hooks/use_experimental_features');
-const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -174,19 +170,17 @@ describe('<UserDetails />', () => {
     mockUseObservedUserDetails.mockReturnValue(mockUserDetailsResponse);
     mockUseRiskScore.mockReturnValue(mockRiskScoreResponse);
     mockUseUsersRelatedHosts.mockReturnValue(mockRelatedHostsResponse);
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
     (useMisconfigurationPreview as jest.Mock).mockReturnValue({});
     (useAlertsByStatus as jest.Mock).mockReturnValue({ isLoading: false, items: {} });
   });
 
   it('should render user details correctly', () => {
-    const { getByTestId, queryByTestId } = renderUserDetails(mockContextValue);
+    const { getByTestId } = renderUserDetails(mockContextValue);
     expect(getByTestId(EXPANDABLE_PANEL_CONTENT_TEST_ID(USER_DETAILS_TEST_ID))).toBeInTheDocument();
-    expect(queryByTestId(USER_DETAILS_LINK_TEST_ID)).not.toBeInTheDocument();
+    expect(getByTestId(USER_DETAILS_LINK_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should render user name as clicable link when feature flag is true', () => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  it('should render user name as clicable link', () => {
     const { getByTestId } = renderUserDetails(mockContextValue);
     expect(getByTestId(USER_DETAILS_LINK_TEST_ID)).toBeInTheDocument();
 
@@ -233,7 +227,7 @@ describe('<UserDetails />', () => {
 
   describe('Related hosts', () => {
     it('should render the related host table with correct dates and indices', () => {
-      const { getByTestId, queryByTestId } = renderUserDetails(mockContextValue);
+      const { getByTestId } = renderUserDetails(mockContextValue);
       expect(mockUseUsersRelatedHosts).toBeCalledWith({
         from: timestamp,
         userName: 'test user',
@@ -241,7 +235,7 @@ describe('<UserDetails />', () => {
         skip: false,
       });
       expect(getByTestId(USER_DETAILS_RELATED_HOSTS_TABLE_TEST_ID)).toBeInTheDocument();
-      expect(queryByTestId(USER_DETAILS_RELATED_HOSTS_LINK_TEST_ID)).not.toBeInTheDocument();
+      expect(getByTestId(USER_DETAILS_RELATED_HOSTS_LINK_TEST_ID)).toBeInTheDocument();
     });
 
     it('should render host risk score column when license is valid', () => {
@@ -274,8 +268,7 @@ describe('<UserDetails />', () => {
       );
     });
 
-    it('should render host name and ip as clicable link when preview is enabled', () => {
-      mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+    it('should render host name and ip as clicable link', () => {
       const { getAllByTestId } = renderUserDetails(mockContextValue);
       expect(getAllByTestId(USER_DETAILS_RELATED_HOSTS_LINK_TEST_ID).length).toBe(1);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.tsx
@@ -25,14 +25,12 @@ import type { EuiBasicTableColumn } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import type { RelatedHost } from '../../../../../common/search_strategy/security_solution/related_entities/related_hosts';
 import type { RiskSeverity } from '../../../../../common/search_strategy';
 import { UserOverview } from '../../../../overview/components/user_overview';
 import { AnomalyTableProvider } from '../../../../common/components/ml/anomaly/anomaly_table_provider';
 import { InspectButton, InspectButtonContainer } from '../../../../common/components/inspect';
-import { NetworkDetailsLink } from '../../../../common/components/links';
 import { RiskScoreEntity } from '../../../../../common/search_strategy';
 import { RiskScoreLevel } from '../../../../entity_analytics/components/severity/common';
 import { DefaultFieldRenderer } from '../../../../timelines/components/field_renderers/default_renderer';
@@ -109,7 +107,6 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, s
   const isEntityAnalyticsAuthorized = isPlatinumOrTrialLicense && hasEntityAnalyticsCapability;
 
   const { openPreviewPanel } = useExpandableFlyoutApi();
-  const isPreviewEnabled = !useIsExperimentalFeatureEnabled('entityAlertPreviewDisabled');
 
   const narrowDateRange = useCallback<NarrowDateRange>(
     (score, interval) => {
@@ -175,16 +172,12 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, s
         render: (host: string) => (
           <EuiText grow={false} size="xs">
             <CellActions field={HOST_NAME_FIELD_NAME} value={host}>
-              {isPreviewEnabled ? (
-                <PreviewLink
-                  field={HOST_NAME_FIELD_NAME}
-                  value={host}
-                  scopeId={scopeId}
-                  data-test-subj={USER_DETAILS_RELATED_HOSTS_LINK_TEST_ID}
-                />
-              ) : (
-                <>{host}</>
-              )}
+              <PreviewLink
+                field={HOST_NAME_FIELD_NAME}
+                value={host}
+                scopeId={scopeId}
+                data-test-subj={USER_DETAILS_RELATED_HOSTS_LINK_TEST_ID}
+              />
             </CellActions>
           </EuiText>
         ),
@@ -207,15 +200,13 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, s
               render={(ip) =>
                 ip == null ? (
                   getEmptyTagValue()
-                ) : isPreviewEnabled ? (
+                ) : (
                   <PreviewLink
                     field={HOST_IP_FIELD_NAME}
                     value={ip}
                     scopeId={scopeId}
                     data-test-subj={USER_DETAILS_RELATED_HOSTS_IP_LINK_TEST_ID}
                   />
-                ) : (
-                  <NetworkDetailsLink ip={ip} />
                 )
               }
               scopeId={scopeId}
@@ -241,7 +232,7 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, s
           ]
         : []),
     ],
-    [isEntityAnalyticsAuthorized, scopeId, isPreviewEnabled]
+    [isEntityAnalyticsAuthorized, scopeId]
   );
 
   const relatedHostsCount = useMemo(
@@ -272,19 +263,14 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, s
   };
 
   const userLink = useMemo(
-    () =>
-      isPreviewEnabled
-        ? {
-            callback: openUserPreview,
-            tooltip: i18n.translate(
-              'xpack.securitySolution.flyout.left.insights.entities.user.userPreviewTitle',
-              {
-                defaultMessage: 'Preview user',
-              }
-            ),
-          }
-        : undefined,
-    [isPreviewEnabled, openUserPreview]
+    () => ({
+      callback: openUserPreview,
+      tooltip: i18n.translate(
+        'xpack.securitySolution.flyout.left.insights.entities.user.userPreviewTitle',
+        { defaultMessage: 'Preview user' }
+      ),
+    }),
+    [openUserPreview]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields_cell.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields_cell.test.tsx
@@ -14,11 +14,7 @@ import {
 } from './test_ids';
 import { HighlightedFieldsCell } from './highlighted_fields_cell';
 import { DocumentDetailsContext } from '../../shared/context';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
-import { LeftPanelInsightsTab } from '../../left';
 import { TestProviders } from '../../../../common/mock';
-import { ENTITIES_TAB_ID } from '../../left/components/entities_details';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useGetAgentStatus } from '../../../../management/hooks/agents/use_get_agent_status';
 import { mockFlyoutApi } from '../../shared/mocks/mock_flyout_context';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
@@ -47,9 +43,6 @@ jest.mock('../../../../common/lib/kibana', () => {
 
 const useGetAgentStatusMock = useGetAgentStatus as jest.Mock;
 
-jest.mock('../../../../common/hooks/use_experimental_features');
-const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
-
 const panelContextValue = {
   eventId: 'event id',
   indexName: 'indexName',
@@ -68,7 +61,6 @@ const renderHighlightedFieldsCell = (values: string[], field: string) =>
 describe('<HighlightedFieldsCell />', () => {
   beforeAll(() => {
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
   });
 
   it('should render a basic cell', () => {
@@ -83,23 +75,7 @@ describe('<HighlightedFieldsCell />', () => {
     expect(getByTestId(HIGHLIGHTED_FIELDS_BASIC_CELL_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should open left panel when clicking on the link within a a link cell when preview is disabled', () => {
-    const { getByTestId } = renderHighlightedFieldsCell(['value'], 'user.name');
-
-    getByTestId(HIGHLIGHTED_FIELDS_LINKED_CELL_TEST_ID).click();
-    expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
-      id: DocumentDetailsLeftPanelKey,
-      path: { tab: LeftPanelInsightsTab, subTab: ENTITIES_TAB_ID },
-      params: {
-        id: panelContextValue.eventId,
-        indexName: panelContextValue.indexName,
-        scopeId: panelContextValue.scopeId,
-      },
-    });
-  });
-
-  it('should open host preview when click on host when preview is not disabled', () => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  it('should open host preview when click on host', () => {
     const { getByTestId } = renderHighlightedFieldsCell(['test host'], 'host.name');
     expect(getByTestId(HIGHLIGHTED_FIELDS_LINKED_CELL_TEST_ID)).toBeInTheDocument();
 
@@ -114,8 +90,7 @@ describe('<HighlightedFieldsCell />', () => {
     });
   });
 
-  it('should open user preview when click on user when preview is not disabled', () => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  it('should open user preview when click on user', () => {
     const { getByTestId } = renderHighlightedFieldsCell(['test user'], 'user.name');
     expect(getByTestId(HIGHLIGHTED_FIELDS_LINKED_CELL_TEST_ID)).toBeInTheDocument();
 
@@ -130,8 +105,7 @@ describe('<HighlightedFieldsCell />', () => {
     });
   });
 
-  it('should open ip preview when click on ip when preview is not disabled', () => {
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  it('should open ip preview when click on ip', () => {
     const { getByTestId } = renderHighlightedFieldsCell(['100:XXX:XXX'], 'source.ip');
     expect(getByTestId(HIGHLIGHTED_FIELDS_LINKED_CELL_TEST_ID)).toBeInTheDocument();
 
@@ -204,6 +178,7 @@ describe('<HighlightedFieldsCell />', () => {
 
     expect(getByTestId(HIGHLIGHTED_FIELDS_AGENT_STATUS_CELL_TEST_ID)).toBeInTheDocument();
   });
+
   it('should not render if values is null', () => {
     const { container } = render(
       <TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields_cell.tsx
@@ -5,19 +5,14 @@
  * 2.0.
  */
 
-import type { VFC } from 'react';
-import React, { useCallback, useMemo } from 'react';
-import { EuiFlexItem, EuiLink } from '@elastic/eui';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import type { FC } from 'react';
+import React, { useMemo } from 'react';
+import { EuiFlexItem } from '@elastic/eui';
 import { getAgentTypeForAgentIdField } from '../../../../common/lib/endpoint/utils/get_agent_type_for_agent_id_field';
 import type { ResponseActionAgentType } from '../../../../../common/endpoint/service/response_actions/constants';
 import { AgentStatus } from '../../../../common/components/endpoint/agents/agent_status';
 import { useDocumentDetailsContext } from '../../shared/context';
 import { AGENT_STATUS_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
-import { LeftPanelInsightsTab } from '../../left';
-import { ENTITIES_TAB_ID } from '../../left/components/entities_details';
 import {
   HIGHLIGHTED_FIELDS_AGENT_STATUS_CELL_TEST_ID,
   HIGHLIGHTED_FIELDS_BASIC_CELL_TEST_ID,
@@ -44,26 +39,12 @@ export interface HighlightedFieldsCellProps {
 /**
  * Renders a component in the highlighted fields table cell based on the field name
  */
-export const HighlightedFieldsCell: VFC<HighlightedFieldsCellProps> = ({
+export const HighlightedFieldsCell: FC<HighlightedFieldsCellProps> = ({
   values,
   field,
   originalField = '',
 }) => {
-  const { scopeId, eventId, indexName } = useDocumentDetailsContext();
-  const { openLeftPanel } = useExpandableFlyoutApi();
-  const isPreviewEnabled = !useIsExperimentalFeatureEnabled('entityAlertPreviewDisabled');
-
-  const goToInsightsEntities = useCallback(() => {
-    openLeftPanel({
-      id: DocumentDetailsLeftPanelKey,
-      path: { tab: LeftPanelInsightsTab, subTab: ENTITIES_TAB_ID },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
-  }, [eventId, indexName, openLeftPanel, scopeId]);
+  const { scopeId } = useDocumentDetailsContext();
 
   const agentType: ResponseActionAgentType = useMemo(() => {
     return getAgentTypeForAgentIdField(originalField);
@@ -79,20 +60,13 @@ export const HighlightedFieldsCell: VFC<HighlightedFieldsCellProps> = ({
               key={`${i}-${value}`}
               data-test-subj={`${value}-${HIGHLIGHTED_FIELDS_CELL_TEST_ID}`}
             >
-              {isPreviewEnabled && hasPreview(field) ? (
+              {hasPreview(field) ? (
                 <PreviewLink
                   field={field}
                   value={value}
                   scopeId={scopeId}
                   data-test-subj={HIGHLIGHTED_FIELDS_LINKED_CELL_TEST_ID}
                 />
-              ) : hasPreview(field) ? (
-                <EuiLink
-                  onClick={goToInsightsEntities}
-                  data-test-subj={HIGHLIGHTED_FIELDS_LINKED_CELL_TEST_ID}
-                >
-                  {value}
-                </EuiLink>
               ) : field === AGENT_STATUS_FIELD_NAME ? (
                 <AgentStatus
                   agentId={String(value ?? '')}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.test.tsx
@@ -26,11 +26,7 @@ import { DocumentDetailsContext } from '../../shared/context';
 import { mockContextValue } from '../../shared/mocks/mock_context';
 import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_formatted_for_field_browser';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
 import { HostPreviewPanelKey } from '../../../entity_details/host_right';
-import { LeftPanelInsightsTab } from '../../left';
-import { ENTITIES_TAB_ID } from '../../left/components/entities_details';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import { mockFlyoutApi } from '../../shared/mocks/mock_flyout_context';
 import { createTelemetryServiceMock } from '../../../../common/lib/telemetry/telemetry_service.mock';
@@ -86,9 +82,6 @@ jest.mock('../../../../common/lib/kibana', () => {
   };
 });
 
-jest.mock('../../../../common/hooks/use_experimental_features');
-const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
-
 const mockUseGlobalTime = jest.fn().mockReturnValue({ from, to });
 jest.mock('../../../../common/containers/use_global_time', () => {
   return {
@@ -124,7 +117,6 @@ const renderHostEntityContent = () =>
 describe('<HostEntityContent />', () => {
   beforeAll(() => {
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
     (useMisconfigurationPreview as jest.Mock).mockReturnValue({});
     (useVulnerabilitiesPreview as jest.Mock).mockReturnValue({});
     (useAlertsByStatus as jest.Mock).mockReturnValue({ isLoading: false, items: {} });
@@ -204,28 +196,9 @@ describe('<HostEntityContent />', () => {
       expect(getByTestId(ENTITIES_HOST_OVERVIEW_LAST_SEEN_TEST_ID)).toHaveTextContent('—');
     });
 
-    it('should navigate to left panel entities tab when clicking on title when feature flag is off', () => {
+    it('should open host preview when clicking on title', () => {
       mockUseHostDetails.mockReturnValue([false, { hostDetails: hostData }]);
       mockUseRiskScore.mockReturnValue({ data: riskLevel, isAuthorized: true });
-
-      const { getByTestId } = renderHostEntityContent();
-
-      getByTestId(ENTITIES_HOST_OVERVIEW_LINK_TEST_ID).click();
-      expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
-        id: DocumentDetailsLeftPanelKey,
-        path: { tab: LeftPanelInsightsTab, subTab: ENTITIES_TAB_ID },
-        params: {
-          id: panelContextValue.eventId,
-          indexName: panelContextValue.indexName,
-          scopeId: panelContextValue.scopeId,
-        },
-      });
-    });
-
-    it('should open host preview when clicking on title when feature flag is on', () => {
-      mockUseHostDetails.mockReturnValue([false, { hostDetails: hostData }]);
-      mockUseRiskScore.mockReturnValue({ data: riskLevel, isAuthorized: true });
-      mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
 
       const { getByTestId } = renderHostEntityContent();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
@@ -5,11 +5,10 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiLink,
   EuiText,
   EuiIcon,
   useEuiTheme,
@@ -19,8 +18,6 @@ import {
 import { css } from '@emotion/css';
 import { getOr } from 'lodash/fp';
 import { i18n } from '@kbn/i18n';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { HOST_NAME_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import { useDocumentDetailsContext } from '../../shared/context';
@@ -44,7 +41,6 @@ import {
   LAST_SEEN,
   HOST_RISK_LEVEL,
 } from '../../../../overview/components/host_overview/translations';
-import { ENTITIES_TAB_ID } from '../../left/components/entities_details';
 import {
   ENTITIES_HOST_OVERVIEW_TEST_ID,
   ENTITIES_HOST_OVERVIEW_OS_FAMILY_TEST_ID,
@@ -56,8 +52,6 @@ import {
   ENTITIES_HOST_OVERVIEW_MISCONFIGURATIONS_TEST_ID,
   ENTITIES_HOST_OVERVIEW_VULNERABILITIES_TEST_ID,
 } from './test_ids';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
-import { LeftPanelInsightsTab } from '../../left';
 import { RiskScoreDocTooltip } from '../../../../overview/components/common';
 import { PreviewLink } from '../../../shared/components/preview_link';
 import { MisconfigurationsInsight } from '../../shared/components/misconfiguration_insight';
@@ -85,21 +79,7 @@ export const HOST_PREVIEW_BANNER = {
  * Host preview content for the entities preview in right flyout. It contains ip addresses and risk level
  */
 export const HostEntityOverview: React.FC<HostEntityOverviewProps> = ({ hostName }) => {
-  const { eventId, indexName, scopeId } = useDocumentDetailsContext();
-  const { openLeftPanel } = useExpandableFlyoutApi();
-  const isPreviewEnabled = !useIsExperimentalFeatureEnabled('entityAlertPreviewDisabled');
-
-  const goToEntitiesTab = useCallback(() => {
-    openLeftPanel({
-      id: DocumentDetailsLeftPanelKey,
-      path: { tab: LeftPanelInsightsTab, subTab: ENTITIES_TAB_ID },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
-  }, [eventId, openLeftPanel, indexName, scopeId]);
+  const { scopeId } = useDocumentDetailsContext();
   const { from, to } = useGlobalTime();
   const { selectedPatterns } = useSourcererDataView();
 
@@ -212,34 +192,21 @@ export const HostEntityOverview: React.FC<HostEntityOverviewProps> = ({ hostName
             <EuiIcon type={HOST_ICON} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            {isPreviewEnabled ? (
-              <PreviewLink
-                field={HOST_NAME_FIELD_NAME}
-                value={hostName}
-                scopeId={scopeId}
-                data-test-subj={ENTITIES_HOST_OVERVIEW_LINK_TEST_ID}
-              >
-                <EuiText
-                  css={css`
-                    font-size: ${xsFontSize};
-                    font-weight: ${euiTheme.font.weight.bold};
-                  `}
-                >
-                  {hostName}
-                </EuiText>
-              </PreviewLink>
-            ) : (
-              <EuiLink
-                data-test-subj={ENTITIES_HOST_OVERVIEW_LINK_TEST_ID}
+            <PreviewLink
+              field={HOST_NAME_FIELD_NAME}
+              value={hostName}
+              scopeId={scopeId}
+              data-test-subj={ENTITIES_HOST_OVERVIEW_LINK_TEST_ID}
+            >
+              <EuiText
                 css={css`
                   font-size: ${xsFontSize};
                   font-weight: ${euiTheme.font.weight.bold};
                 `}
-                onClick={goToEntitiesTab}
               >
                 {hostName}
-              </EuiLink>
-            )}
+              </EuiText>
+            </PreviewLink>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/table_field_value_cell.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/table_field_value_cell.test.tsx
@@ -9,7 +9,6 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import type { FieldSpec } from '@kbn/data-plugin/common';
 import { DocumentDetailsContext } from '../../shared/context';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { EventFieldsData } from '../../../../common/components/event_details/types';
 import { TableFieldValueCell } from './table_field_value_cell';
@@ -34,9 +33,6 @@ jest.mock('../../../../common/lib/kibana', () => {
     }),
   };
 });
-
-jest.mock('../../../../common/hooks/use_experimental_features');
-const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
 
 const panelContextValue = {
   eventId: 'event id',
@@ -66,7 +62,6 @@ describe('TableFieldValueCell', () => {
   beforeAll(() => {
     jest.clearAllMocks();
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
   });
 
   describe('common behavior', () => {
@@ -213,7 +208,7 @@ describe('TableFieldValueCell', () => {
       });
     });
 
-    it('should open preview when preview is not disabled', () => {
+    it('should open preview', () => {
       screen.getByTestId(`${FLYOUT_TABLE_PREVIEW_LINK_FIELD_TEST_ID}-0`).click();
 
       expect(mockFlyoutApi.openPreviewPanel).toHaveBeenCalledWith({

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/table_field_value_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/table_field_value_cell.tsx
@@ -8,7 +8,6 @@
 import React, { memo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import type { FieldSpec } from '@kbn/data-plugin/common';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { getFieldFormat } from '../utils/get_field_format';
 import type { EventFieldsData } from '../../../../common/components/event_details/types';
 import { OverflowField } from '../../../../common/components/tables/helpers';
@@ -66,7 +65,6 @@ export const TableFieldValueCell = memo(
     values,
     isPreview,
   }: FieldValueCellProps) => {
-    const isPreviewEnabled = !useIsExperimentalFeatureEnabled('entityAlertPreviewDisabled');
     if (values == null) {
       return null;
     }
@@ -92,7 +90,7 @@ export const TableFieldValueCell = memo(
             <EuiFlexItem grow={false} key={`${i}-${value}`}>
               {data.field === MESSAGE_FIELD_NAME ? (
                 <OverflowField value={value} />
-              ) : isPreviewEnabled && hasPreview(data.field) ? (
+              ) : hasPreview(data.field) ? (
                 <PreviewLink
                   field={data.field}
                   value={value}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.test.tsx
@@ -23,12 +23,8 @@ import { useObservedUserDetails } from '../../../../explore/users/containers/use
 import { mockContextValue } from '../../shared/mocks/mock_context';
 import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_formatted_for_field_browser';
 import { DocumentDetailsContext } from '../../shared/context';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
-import { LeftPanelInsightsTab } from '../../left';
-import { ENTITIES_TAB_ID } from '../../left/components/entities_details';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { mockFlyoutApi } from '../../shared/mocks/mock_flyout_context';
 import { UserPreviewPanelKey } from '../../../entity_details/user_right';
 import { useAlertsByStatus } from '../../../../overview/components/detection_response/alerts_by_status/use_alerts_by_status';
@@ -71,9 +67,6 @@ const mockAlertData = {
   },
 };
 
-jest.mock('../../../../common/hooks/use_experimental_features');
-const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
-
 const mockUseGlobalTime = jest.fn().mockReturnValue({ from, to });
 jest.mock('../../../../common/containers/use_global_time', () => {
   return {
@@ -109,7 +102,6 @@ const renderUserEntityOverview = () =>
 describe('<UserEntityOverview />', () => {
   beforeAll(() => {
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
-    mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
     (useMisconfigurationPreview as jest.Mock).mockReturnValue({});
     (useAlertsByStatus as jest.Mock).mockReturnValue({ isLoading: false, items: {} });
   });
@@ -190,34 +182,9 @@ describe('<UserEntityOverview />', () => {
       expect(queryByTestId(ENTITIES_USER_OVERVIEW_DOMAIN_TEST_ID)).not.toBeInTheDocument();
     });
 
-    it('should navigate to left panel entities tab when clicking on title when feature flag is off', () => {
+    it('should open user preview', () => {
       mockUseUserDetails.mockReturnValue([false, { userDetails: userData }]);
       mockUseRiskScore.mockReturnValue({ data: riskLevel, isAuthorized: true });
-
-      const { getByTestId } = render(
-        <TestProviders>
-          <DocumentDetailsContext.Provider value={panelContextValue}>
-            <UserEntityOverview userName={userName} />
-          </DocumentDetailsContext.Provider>
-        </TestProviders>
-      );
-
-      getByTestId(ENTITIES_USER_OVERVIEW_LINK_TEST_ID).click();
-      expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
-        id: DocumentDetailsLeftPanelKey,
-        path: { tab: LeftPanelInsightsTab, subTab: ENTITIES_TAB_ID },
-        params: {
-          id: panelContextValue.eventId,
-          indexName: panelContextValue.indexName,
-          scopeId: panelContextValue.scopeId,
-        },
-      });
-    });
-
-    it('should open user preview if feature flag is true', () => {
-      mockUseUserDetails.mockReturnValue([false, { userDetails: userData }]);
-      mockUseRiskScore.mockReturnValue({ data: riskLevel, isAuthorized: true });
-      mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
 
       const { getByTestId } = render(
         <TestProviders>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
@@ -5,13 +5,12 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
   EuiText,
-  EuiLink,
   useEuiTheme,
   useEuiFontSize,
   EuiSkeletonText,
@@ -19,11 +18,6 @@ import {
 import { css } from '@emotion/css';
 import { getOr } from 'lodash/fp';
 import { i18n } from '@kbn/i18n';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
-import { LeftPanelInsightsTab } from '../../left';
-import { ENTITIES_TAB_ID } from '../../left/components/entities_details';
 import { useDocumentDetailsContext } from '../../shared/context';
 import type { DescriptionList } from '../../../../../common/utility_types';
 import { USER_NAME_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
@@ -83,22 +77,7 @@ export const USER_PREVIEW_BANNER = {
  * User preview content for the entities preview in right flyout. It contains ip addresses and risk level
  */
 export const UserEntityOverview: React.FC<UserEntityOverviewProps> = ({ userName }) => {
-  const { eventId, indexName, scopeId } = useDocumentDetailsContext();
-  const { openLeftPanel } = useExpandableFlyoutApi();
-
-  const isPreviewEnabled = !useIsExperimentalFeatureEnabled('entityAlertPreviewDisabled');
-
-  const goToEntitiesTab = useCallback(() => {
-    openLeftPanel({
-      id: DocumentDetailsLeftPanelKey,
-      path: { tab: LeftPanelInsightsTab, subTab: ENTITIES_TAB_ID },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
-  }, [eventId, openLeftPanel, indexName, scopeId]);
+  const { scopeId } = useDocumentDetailsContext();
   const { from, to } = useGlobalTime();
   const { selectedPatterns } = useSourcererDataView();
 
@@ -210,34 +189,21 @@ export const UserEntityOverview: React.FC<UserEntityOverviewProps> = ({ userName
             <EuiIcon type={USER_ICON} />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            {isPreviewEnabled ? (
-              <PreviewLink
-                field={USER_NAME_FIELD_NAME}
-                value={userName}
-                scopeId={scopeId}
-                data-test-subj={ENTITIES_USER_OVERVIEW_LINK_TEST_ID}
-              >
-                <EuiText
-                  css={css`
-                    font-size: ${xsFontSize};
-                    font-weight: ${euiTheme.font.weight.bold};
-                  `}
-                >
-                  {userName}
-                </EuiText>
-              </PreviewLink>
-            ) : (
-              <EuiLink
-                data-test-subj={ENTITIES_USER_OVERVIEW_LINK_TEST_ID}
+            <PreviewLink
+              field={USER_NAME_FIELD_NAME}
+              value={userName}
+              scopeId={scopeId}
+              data-test-subj={ENTITIES_USER_OVERVIEW_LINK_TEST_ID}
+            >
+              <EuiText
                 css={css`
                   font-size: ${xsFontSize};
                   font-weight: ${euiTheme.font.weight.bold};
                 `}
-                onClick={goToEntitiesTab}
               >
                 {userName}
-              </EuiLink>
-            )}
+              </EuiText>
+            </PreviewLink>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>


### PR DESCRIPTION
## Summary

This PR removes the feature flag `entityAlertPreviewDisabled` and cleaned up related unit tests.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->