### PR TITLE
[Security Assistant] Fix abort stream OpenAI issue

### DIFF
--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/helpers.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/helpers.ts
@@ -160,7 +160,16 @@ export const streamGraph = async ({
               finalMessage += msg.content;
             }
           } else if (event.event === 'on_llm_end' && !didEnd) {
-            handleStreamEnd(event.data.output?.generations[0][0]?.text ?? finalMessage);
+            const generation = event.data.output?.generations[0][0];
+            if (
+              // no finish_reason means the stream was aborted
+              !generation?.generationInfo?.finish_reason ||
+              generation?.generationInfo?.finish_reason === 'stop'
+            ) {
+              handleStreamEnd(
+                generation?.text && generation?.text.length ? generation?.text : finalMessage
+              );
+            }
           }
         }
       }

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.ts
@@ -173,9 +173,10 @@ export const callAssistantGraph: AgentExecutor<true | false> = async ({
     // we need to pass it like this or streaming does not work for bedrock
     createLlmInstance,
     logger,
-    signal: abortSignal,
     tools,
     replacements,
+    // some chat models (bedrock) require a signal to be passed on agent invoke rather than the signal passed to the chat model
+    ...(llmType === 'bedrock' ? { signal: abortSignal } : {}),
   });
   const inputs: GraphInputs = {
     responseLanguage,


### PR DESCRIPTION
## Summary

I made a mistake in the [Abort signal fix PR](https://github.com/elastic/kibana/pull/203041/). I thought I [could get rid of the `finish_reason` condition](https://github.com/elastic/kibana/pull/203041/files#r1870452190), but we need it as [some finish reasons](https://github.com/openai/openai-node/blob/fbd968576357e635e541a3475a67fb741f603292/src/resources/chat/completions.ts#L102) should not end the stream. 

I brought back that `finish_reason === 'stop'` condition and added to the condition to `handleStreamEnd` when there is not a `finish_reason` as this indicates abort.

I also found that my addition of `signal` to agent `.invoke` in order to satisfy Bedrock broke abort signal handling for OpenAI. Therefore, I added a condition to only include `signal` to agent `.invoke` when the connector is Bedrock.

## To test

1. Using OpenAI connector, ask the assistant a question you know will trigger a tool (how many open alerts do i have?). Ensure a response is streamed back
2. Using OpenAI connector, ask the assistant a question you know will give a very long response (Write a poem about elastic security). When the response begins to stream back, hit "Stop generating". Switch conversations and return back to the original conversation. Ensure the cut-off response is persisted

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->