### PR TITLE
[8.x] [Automatic Import] Add serverless availability cypress test (#202872)

### DIFF
--- a/.buildkite/pipelines/pull_request/security_solution/automatic_import.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/automatic_import.yml
@@ -1,0 +1,20 @@
+steps:
+  - command: .buildkite/scripts/steps/functional/security_serverless_automatic_import.sh
+    label: 'Serverless Automatic Import - Security Solution Cypress Tests'
+    agents:
+      machineType: n2-standard-4
+      preemptible: true
+    depends_on:
+      - build
+      - quick_checks
+      - checks
+      - linting
+      - linting_with_types
+      - check_types
+      - check_oas_snapshot
+    timeout_in_minutes: 60
+    parallelism: 1
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 1

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -267,6 +267,9 @@ const getPipeline = (filename: string, removeSteps = true) => {
         getPipeline('.buildkite/pipelines/pull_request/security_solution/ai_assistant.yml')
       );
       pipeline.push(
+        getPipeline('.buildkite/pipelines/pull_request/security_solution/automatic_import.yml')
+      );
+      pipeline.push(
         getPipeline('.buildkite/pipelines/pull_request/security_solution/detection_engine.yml')
       );
       pipeline.push(

--- a/.buildkite/scripts/steps/functional/security_serverless_automatic_import.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_automatic_import.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source .buildkite/scripts/steps/functional/common.sh
+
+export JOB=kibana-security-solution-chrome
+export KIBANA_INSTALL_DIR=${KIBANA_BUILD_LOCATION}
+
+echo "--- Automatic Import Cypress Tests on Serverless"
+
+cd x-pack/test/security_solution_cypress
+
+set +e
+BK_ANALYTICS_API_KEY=$(vault_get security-solution-ci sec-sol-cypress-bk-api-key)
+
+BK_ANALYTICS_API_KEY=$BK_ANALYTICS_API_KEY yarn cypress:automatic_import:run:serverless; status=$?; yarn junit:merge || :; exit $status

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1582,6 +1582,8 @@ x-pack/test/api_integration/apis/management/index_management/inference_endpoints
 /x-pack/plugins/security_solution/public/assistant @elastic/security-generative-ai
 /x-pack/plugins/security_solution/public/attack_discovery @elastic/security-generative-ai
 /x-pack/test/security_solution_cypress/cypress/e2e/ai_assistant @elastic/security-generative-ai
+/x-pack/plugins/security_solution_ess/public/upselling/pages/attack_discovery @elastic/security-generative-ai
+/x-pack/test/security_solution_cypress/cypress/e2e/automatic_import @elastic/security-scalability
 
 # Security Solution cross teams ownership
 /x-pack/test/security_solution_cypress/cypress/fixtures @elastic/security-detections-response @elastic/security-threat-hunting

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1582,7 +1582,6 @@ x-pack/test/api_integration/apis/management/index_management/inference_endpoints
 /x-pack/plugins/security_solution/public/assistant @elastic/security-generative-ai
 /x-pack/plugins/security_solution/public/attack_discovery @elastic/security-generative-ai
 /x-pack/test/security_solution_cypress/cypress/e2e/ai_assistant @elastic/security-generative-ai
-/x-pack/plugins/security_solution_ess/public/upselling/pages/attack_discovery @elastic/security-generative-ai
 /x-pack/test/security_solution_cypress/cypress/e2e/automatic_import @elastic/security-scalability
 
 # Security Solution cross teams ownership

--- a/x-pack/test/security_solution_cypress/cypress/e2e/automatic_import/feature_essentials.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/automatic_import/feature_essentials.cy.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ASSISTANT_BUTTON, CREATE_INTEGRATION_LANDING_PAGE } from '../../screens/automatic_import';
+import { login } from '../../tasks/login';
+
+describe(
+  'App Features for Security Essentials',
+  {
+    tags: ['@serverless'],
+    env: {
+      ftrConfig: {
+        productTypes: [
+          { product_line: 'security', product_tier: 'essentials' },
+          { product_line: 'endpoint', product_tier: 'essentials' },
+        ],
+      },
+    },
+  },
+  () => {
+    beforeEach(() => {
+      login();
+    });
+
+    it('should not have Automatic Import available', () => {
+      cy.visit(CREATE_INTEGRATION_LANDING_PAGE);
+      cy.get(ASSISTANT_BUTTON).should('not.exist');
+    });
+  }
+);

--- a/x-pack/test/security_solution_cypress/cypress/screens/automatic_import.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/automatic_import.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const CREATE_INTEGRATION_LANDING_PAGE = '/app/integrations/create';
+export const ASSISTANT_BUTTON = 'assistantButton';

--- a/x-pack/test/security_solution_cypress/package.json
+++ b/x-pack/test/security_solution_cypress/package.json
@@ -33,6 +33,7 @@
     "cypress:detection_engine:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/detection_response/detection_engine/!(exceptions)/**/*.cy.ts'",
     "cypress:detection_engine:exceptions:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/detection_response/detection_engine/exceptions/**/*.cy.ts'",
     "cypress:ai_assistant:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/ai_assistant/**/*.cy.ts'",
+    "cypress:automatic_import:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/automatic_import/**/*.cy.ts'",
     "cypress:investigations:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/investigations/**/*.cy.ts'",
     "cypress:explore:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/explore/**/*.cy.ts'",
     "cypress:changed-specs-only:serverless": "yarn cypress:serverless --changed-specs-only --env burn=5",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Automatic Import] Add serverless availability cypress test (#202872)](https://github.com/elastic/kibana/pull/202872)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Bharat Pasupula","email":"123897612+bhapas@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-12-05T20:25:07Z","message":"[Automatic Import] Add serverless availability cypress test (#202872)","sha":"5145d76fb1159b7a574eafaacbcf57e51cf00273","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","release_note:skip","v9.0.0","backport:prev-minor","Team:Security-Scalability","Feature:AutomaticImport"],"number":202872,"url":"https://github.com/elastic/kibana/pull/202872","mergeCommit":{"message":"[Automatic Import] Add serverless availability cypress test (#202872)","sha":"5145d76fb1159b7a574eafaacbcf57e51cf00273"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/202872","number":202872,"mergeCommit":{"message":"[Automatic Import] Add serverless availability cypress test (#202872)","sha":"5145d76fb1159b7a574eafaacbcf57e51cf00273"}}]}] BACKPORT-->