### PR TITLE
[KibanaRootContextProvider] destructure the params to KibanaEuiProvider

### DIFF
--- a/packages/react/kibana_context/render/render_provider.tsx
+++ b/packages/react/kibana_context/render/render_provider.tsx
@@ -25,9 +25,13 @@ export type KibanaRenderContextProviderProps = Omit<KibanaRootContextProviderPro
 export const KibanaRenderContextProvider: FC<
   PropsWithChildren<KibanaRenderContextProviderProps>
 > = ({ children, ...props }) => {
+  const { analytics, i18n, theme, userProfile, colorMode, modify } = props;
   return (
-    <KibanaRootContextProvider globalStyles={false} {...props}>
-      <KibanaErrorBoundaryProvider analytics={props.analytics}>
+    <KibanaRootContextProvider
+      globalStyles={false}
+      {...{ i18n, theme, userProfile, modify, colorMode }}
+    >
+      <KibanaErrorBoundaryProvider analytics={analytics}>
         <KibanaErrorBoundary>{children}</KibanaErrorBoundary>
       </KibanaErrorBoundaryProvider>
     </KibanaRootContextProvider>

--- a/packages/react/kibana_context/root/root_provider.test.tsx
+++ b/packages/react/kibana_context/root/root_provider.test.tsx
@@ -15,8 +15,6 @@ import { useEuiTheme } from '@elastic/eui';
 import type { UseEuiTheme } from '@elastic/eui';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
 import type { KibanaTheme } from '@kbn/react-kibana-context-common';
-import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
-import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
 import { i18nServiceMock } from '@kbn/core-i18n-browser-mocks';
 import { I18nStart } from '@kbn/core-i18n-browser';
 import type { UserProfileService } from '@kbn/core-user-profile-browser';
@@ -26,12 +24,10 @@ import { KibanaRootContextProvider } from './root_provider';
 describe('KibanaRootContextProvider', () => {
   let euiTheme: UseEuiTheme | undefined;
   let i18nMock: I18nStart;
-  let analytics: AnalyticsServiceStart;
   let userProfile: UserProfileService;
 
   beforeEach(() => {
     euiTheme = undefined;
-    analytics = analyticsServiceMock.createAnalyticsServiceStart();
     i18nMock = i18nServiceMock.createStartContract();
     userProfile = userProfileServiceMock.createStart();
   });
@@ -66,7 +62,6 @@ describe('KibanaRootContextProvider', () => {
 
     const wrapper = mountWithIntl(
       <KibanaRootContextProvider
-        analytics={analytics}
         i18n={i18nMock}
         userProfile={userProfile}
         theme={{ theme$: of(coreTheme) }}
@@ -85,7 +80,6 @@ describe('KibanaRootContextProvider', () => {
 
     const wrapper = mountWithIntl(
       <KibanaRootContextProvider
-        analytics={analytics}
         i18n={i18nMock}
         userProfile={userProfile}
         theme={{ theme$: coreTheme$ }}

--- a/packages/react/kibana_context/root/root_provider.tsx
+++ b/packages/react/kibana_context/root/root_provider.tsx
@@ -54,8 +54,9 @@ export const KibanaRootContextProvider: FC<PropsWithChildren<KibanaRootContextPr
     );
     return <i18n.Context>{children}</i18n.Context>;
   } else {
+    const { theme, userProfile, globalStyles, colorMode, modify } = props;
     return (
-      <KibanaEuiProvider {...props}>
+      <KibanaEuiProvider {...{ theme, userProfile, globalStyles, colorMode, modify }}>
         <i18n.Context>{children}</i18n.Context>
       </KibanaEuiProvider>
     );

--- a/packages/react/kibana_context/root/tsconfig.json
+++ b/packages/react/kibana_context/root/tsconfig.json
@@ -22,7 +22,6 @@
     "@kbn/core-i18n-browser",
     "@kbn/core-base-common",
     "@kbn/core-analytics-browser",
-    "@kbn/core-analytics-browser-mocks",
     "@kbn/core-user-profile-browser",
     "@kbn/core-user-profile-browser-mocks",
   ]


### PR DESCRIPTION
## Summary

Addresses: https://github.com/elastic/kibana/pull/202606#discussion_r1871947907

This discards the
> unused portions of core, before adding them to the context value, but still allow people to pass the entire construct if we were to need something else

cc @clintandrewhall 

----

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

**none**

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

**none**





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->