### PR TITLE
[SharedUX] Modify code editor theme definition and resolution implementation to account for color modes in EUI Theme

### DIFF
--- a/packages/kbn-monaco/index.ts
+++ b/packages/kbn-monaco/index.ts
@@ -45,8 +45,7 @@ export {
 export type { ParsedRequest } from './src/console';
 
 export {
-  CODE_EDITOR_LIGHT_THEME_ID,
-  CODE_EDITOR_DARK_THEME_ID,
-  CODE_EDITOR_LIGHT_THEME_TRANSPARENT_ID,
-  CODE_EDITOR_DARK_THEME_TRANSPARENT_ID,
+  defaultThemesResolvers,
+  CODE_EDITOR_DEFAULT_THEME_ID,
+  CODE_EDITOR_TRANSPARENT_THEME_ID,
 } from './src/code_editor';

--- a/packages/kbn-monaco/src/code_editor/constants.ts
+++ b/packages/kbn-monaco/src/code_editor/constants.ts
@@ -7,7 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export const CODE_EDITOR_LIGHT_THEME_ID = 'codeEditorLightTheme';
-export const CODE_EDITOR_DARK_THEME_ID = 'codeEditorDarkTheme';
-export const CODE_EDITOR_LIGHT_THEME_TRANSPARENT_ID = 'codeEditorLightTransparentTheme';
-export const CODE_EDITOR_DARK_THEME_TRANSPARENT_ID = 'codeEditorDarkTransparentTheme';
+export const CODE_EDITOR_DEFAULT_THEME_ID = 'codeEditorDefaultTheme';
+export const CODE_EDITOR_TRANSPARENT_THEME_ID = 'codeEditorTransparentTheme';

--- a/packages/kbn-monaco/src/code_editor/index.ts
+++ b/packages/kbn-monaco/src/code_editor/index.ts
@@ -6,17 +6,14 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
+import { CODE_EDITOR_DEFAULT_THEME_ID, CODE_EDITOR_TRANSPARENT_THEME_ID } from './constants';
 
-export {
-  CODE_EDITOR_LIGHT_THEME_ID,
-  CODE_EDITOR_DARK_THEME_ID,
-  CODE_EDITOR_LIGHT_THEME_TRANSPARENT_ID,
-  CODE_EDITOR_DARK_THEME_TRANSPARENT_ID,
-} from './constants';
+import { buildTheme, buildTransparentTheme } from './theme';
 
-export {
-  buildLightTheme,
-  buildDarkTheme,
-  buildLightTransparentTheme,
-  buildDarkTransparentTheme,
-} from './theme';
+// export these so that they are consumed by the actual code editor implementation
+export const defaultThemesResolvers = {
+  [CODE_EDITOR_DEFAULT_THEME_ID]: buildTheme,
+  [CODE_EDITOR_TRANSPARENT_THEME_ID]: buildTransparentTheme,
+};
+
+export { CODE_EDITOR_DEFAULT_THEME_ID, CODE_EDITOR_TRANSPARENT_THEME_ID };

--- a/packages/kbn-monaco/src/code_editor/theme.ts
+++ b/packages/kbn-monaco/src/code_editor/theme.ts
@@ -11,11 +11,9 @@ import type { UseEuiTheme } from '@elastic/eui';
 import { monaco } from '../..';
 
 export function createTheme(
-  { colorMode, euiTheme }: UseEuiTheme,
+  { euiTheme }: UseEuiTheme,
   backgroundColor?: string
 ): monaco.editor.IStandaloneThemeData {
-  const selectionBackgroundColor = colorMode === 'DARK' ? '#343551' : '#E3E4ED';
-
   return {
     base: 'vs',
     inherit: true,
@@ -87,11 +85,11 @@ export function createTheme(
     ],
     colors: {
       'editor.foreground': euiTheme.colors.darkestShade,
-      'editor.background': backgroundColor ?? euiTheme.colors.backgroundBaseSubdued,
+      'editor.background': backgroundColor ?? euiTheme.colors.backgroundBasePlain,
       'editorLineNumber.foreground': euiTheme.colors.darkShade,
       'editorLineNumber.activeForeground': euiTheme.colors.darkShade,
       'editorIndentGuide.background1': euiTheme.colors.lightShade,
-      'editor.selectionBackground': selectionBackgroundColor,
+      'editor.selectionBackground': euiTheme.colors.backgroundBaseInteractiveSelect,
       'editorWidget.border': euiTheme.colors.lightShade,
       'editorWidget.background': euiTheme.colors.lightestShade,
       'editorCursor.foreground': euiTheme.colors.darkestShade,

--- a/packages/kbn-monaco/src/code_editor/theme.ts
+++ b/packages/kbn-monaco/src/code_editor/theme.ts
@@ -7,106 +7,105 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { euiDarkVars as darkTheme, euiLightVars as lightTheme } from '@kbn/ui-theme';
+import type { UseEuiTheme } from '@elastic/eui';
 import { monaco } from '../..';
 
 export function createTheme(
-  euiTheme: typeof darkTheme | typeof lightTheme,
-  selectionBackgroundColor: string,
+  { colorMode, euiTheme }: UseEuiTheme,
   backgroundColor?: string
 ): monaco.editor.IStandaloneThemeData {
+  const selectionBackgroundColor = colorMode === 'DARK' ? '#343551' : '#E3E4ED';
+
   return {
     base: 'vs',
     inherit: true,
     rules: [
       {
         token: '',
-        foreground: euiTheme.euiColorDarkestShade,
-        background: euiTheme.euiFormBackgroundColor,
+        foreground: euiTheme.colors.darkestShade,
+        background: euiTheme.colors.backgroundBaseSubdued,
       },
-      { token: 'invalid', foreground: euiTheme.euiColorAccentText },
+      { token: 'invalid', foreground: euiTheme.colors.accent },
       { token: 'emphasis', fontStyle: 'italic' },
       { token: 'strong', fontStyle: 'bold' },
 
-      { token: 'variable', foreground: euiTheme.euiColorPrimaryText },
-      { token: 'variable.predefined', foreground: euiTheme.euiColorSuccessText },
-      { token: 'constant', foreground: euiTheme.euiColorAccentText },
-      { token: 'comment', foreground: euiTheme.euiTextSubduedColor },
-      { token: 'number', foreground: euiTheme.euiColorAccentText },
-      { token: 'number.hex', foreground: euiTheme.euiColorAccentText },
-      { token: 'regexp', foreground: euiTheme.euiColorDangerText },
-      { token: 'annotation', foreground: euiTheme.euiTextSubduedColor },
-      { token: 'type', foreground: euiTheme.euiColorSuccessText },
+      { token: 'variable', foreground: euiTheme.colors.textPrimary },
+      { token: 'variable.predefined', foreground: euiTheme.colors.textSuccess },
+      { token: 'constant', foreground: euiTheme.colors.accent },
+      { token: 'comment', foreground: euiTheme.colors.textSubdued },
+      { token: 'number', foreground: euiTheme.colors.accent },
+      { token: 'number.hex', foreground: euiTheme.colors.accent },
+      { token: 'regexp', foreground: euiTheme.colors.textDanger },
+      { token: 'annotation', foreground: euiTheme.colors.textSubdued },
+      { token: 'type', foreground: euiTheme.colors.textSuccess },
 
-      { token: 'delimiter', foreground: euiTheme.euiTextSubduedColor },
-      { token: 'delimiter.html', foreground: euiTheme.euiColorDarkShade },
-      { token: 'delimiter.xml', foreground: euiTheme.euiColorPrimaryText },
+      { token: 'delimiter', foreground: euiTheme.colors.textSubdued },
+      { token: 'delimiter.html', foreground: euiTheme.colors.darkShade },
+      { token: 'delimiter.xml', foreground: euiTheme.colors.textPrimary },
 
-      { token: 'tag', foreground: euiTheme.euiColorDangerText },
-      { token: 'tag.id.jade', foreground: euiTheme.euiColorPrimaryText },
-      { token: 'tag.class.jade', foreground: euiTheme.euiColorPrimaryText },
-      { token: 'meta.scss', foreground: euiTheme.euiColorAccentText },
-      { token: 'metatag', foreground: euiTheme.euiColorSuccessText },
-      { token: 'metatag.content.html', foreground: euiTheme.euiColorDangerText },
-      { token: 'metatag.html', foreground: euiTheme.euiTextSubduedColor },
-      { token: 'metatag.xml', foreground: euiTheme.euiTextSubduedColor },
+      { token: 'tag', foreground: euiTheme.colors.textDanger },
+      { token: 'tag.id.jade', foreground: euiTheme.colors.textPrimary },
+      { token: 'tag.class.jade', foreground: euiTheme.colors.textPrimary },
+      { token: 'meta.scss', foreground: euiTheme.colors.accent },
+      { token: 'metatag', foreground: euiTheme.colors.textSuccess },
+      { token: 'metatag.content.html', foreground: euiTheme.colors.textDanger },
+      { token: 'metatag.html', foreground: euiTheme.colors.textDanger },
+      { token: 'metatag.xml', foreground: euiTheme.colors.textSubdued },
       { token: 'metatag.php', fontStyle: 'bold' },
 
-      { token: 'key', foreground: euiTheme.euiColorWarningText },
-      { token: 'string.key.json', foreground: euiTheme.euiColorDangerText },
-      { token: 'string.value.json', foreground: euiTheme.euiColorPrimaryText },
+      { token: 'key', foreground: euiTheme.colors.textWarning },
+      { token: 'string.key.json', foreground: euiTheme.colors.textDanger },
+      { token: 'string.value.json', foreground: euiTheme.colors.textPrimary },
 
-      { token: 'attribute.name', foreground: euiTheme.euiColorDangerText },
-      { token: 'attribute.name.css', foreground: euiTheme.euiColorSuccessText },
-      { token: 'attribute.value', foreground: euiTheme.euiColorPrimaryText },
-      { token: 'attribute.value.number', foreground: euiTheme.euiColorWarningText },
-      { token: 'attribute.value.unit', foreground: euiTheme.euiColorWarningText },
-      { token: 'attribute.value.html', foreground: euiTheme.euiColorPrimaryText },
-      { token: 'attribute.value.xml', foreground: euiTheme.euiColorPrimaryText },
+      { token: 'attribute.name', foreground: euiTheme.colors.textDanger },
+      { token: 'attribute.name.css', foreground: euiTheme.colors.textSuccess },
+      { token: 'attribute.value', foreground: euiTheme.colors.textPrimary },
+      { token: 'attribute.value.number', foreground: euiTheme.colors.textWarning },
+      { token: 'attribute.value.unit', foreground: euiTheme.colors.textWarning },
+      { token: 'attribute.value.html', foreground: euiTheme.colors.textPrimary },
+      { token: 'attribute.value.xml', foreground: euiTheme.colors.textPrimary },
 
-      { token: 'string', foreground: euiTheme.euiColorDangerText },
-      { token: 'string.html', foreground: euiTheme.euiColorPrimaryText },
-      { token: 'string.sql', foreground: euiTheme.euiColorDangerText },
-      { token: 'string.yaml', foreground: euiTheme.euiColorPrimaryText },
+      { token: 'string', foreground: euiTheme.colors.textDanger },
+      { token: 'string.html', foreground: euiTheme.colors.textPrimary },
+      { token: 'string.sql', foreground: euiTheme.colors.textDanger },
+      { token: 'string.yaml', foreground: euiTheme.colors.textPrimary },
 
-      { token: 'keyword', foreground: euiTheme.euiColorPrimaryText },
-      { token: 'keyword.json', foreground: euiTheme.euiColorPrimaryText },
-      { token: 'keyword.flow', foreground: euiTheme.euiColorWarningText },
-      { token: 'keyword.flow.scss', foreground: euiTheme.euiColorPrimaryText },
+      { token: 'keyword', foreground: euiTheme.colors.textPrimary },
+      { token: 'keyword.json', foreground: euiTheme.colors.textPrimary },
+      { token: 'keyword.flow', foreground: euiTheme.colors.textWarning },
+      { token: 'keyword.flow.scss', foreground: euiTheme.colors.textPrimary },
       // Monaco editor supports strikethrough font style only starting from 0.32.0.
-      { token: 'keyword.deprecated', foreground: euiTheme.euiColorAccentText },
+      { token: 'keyword.deprecated', foreground: euiTheme.colors.accent },
 
-      { token: 'operator.scss', foreground: euiTheme.euiColorDarkShade },
-      { token: 'operator.sql', foreground: euiTheme.euiTextSubduedColor },
-      { token: 'operator.swift', foreground: euiTheme.euiTextSubduedColor },
-      { token: 'predefined.sql', foreground: euiTheme.euiTextSubduedColor },
+      { token: 'operator.scss', foreground: euiTheme.colors.darkShade },
+      { token: 'operator.sql', foreground: euiTheme.colors.textSubdued },
+      { token: 'operator.swift', foreground: euiTheme.colors.textSubdued },
+      { token: 'predefined.sql', foreground: euiTheme.colors.textSubdued },
 
-      { token: 'text', foreground: euiTheme.euiTitleColor },
-      { token: 'label', foreground: euiTheme.euiColorVis9 },
+      { token: 'text', foreground: euiTheme.colors.textAccent },
+      { token: 'label', foreground: euiTheme.colors.vis.euiColorVis9 },
     ],
     colors: {
-      'editor.foreground': euiTheme.euiColorDarkestShade,
-      'editor.background': backgroundColor ?? euiTheme.euiFormBackgroundColor,
-      'editorLineNumber.foreground': euiTheme.euiColorDarkShade,
-      'editorLineNumber.activeForeground': euiTheme.euiColorDarkShade,
-      'editorIndentGuide.background1': euiTheme.euiColorLightShade,
+      'editor.foreground': euiTheme.colors.darkestShade,
+      'editor.background': backgroundColor ?? euiTheme.colors.backgroundBaseSubdued,
+      'editorLineNumber.foreground': euiTheme.colors.darkShade,
+      'editorLineNumber.activeForeground': euiTheme.colors.darkShade,
+      'editorIndentGuide.background1': euiTheme.colors.lightShade,
       'editor.selectionBackground': selectionBackgroundColor,
-      'editorWidget.border': euiTheme.euiColorLightShade,
-      'editorWidget.background': euiTheme.euiColorLightestShade,
-      'editorCursor.foreground': euiTheme.euiColorDarkestShade,
-      'editorSuggestWidget.selectedForeground': euiTheme.euiColorDarkestShade,
-      'editorSuggestWidget.focusHighlightForeground': euiTheme.euiColorPrimary,
-      'editorSuggestWidget.selectedBackground': euiTheme.euiColorLightShade,
-      'list.hoverBackground': euiTheme.euiColorLightShade,
-      'list.highlightForeground': euiTheme.euiColorPrimary,
-      'editor.lineHighlightBorder': euiTheme.euiColorLightestShade,
-      'editorHoverWidget.foreground': euiTheme.euiColorDarkestShade,
-      'editorHoverWidget.background': euiTheme.euiFormBackgroundColor,
+      'editorWidget.border': euiTheme.colors.lightShade,
+      'editorWidget.background': euiTheme.colors.lightestShade,
+      'editorCursor.foreground': euiTheme.colors.darkestShade,
+      'editorSuggestWidget.selectedForeground': euiTheme.colors.darkestShade,
+      'editorSuggestWidget.focusHighlightForeground': euiTheme.colors.primary,
+      'editorSuggestWidget.selectedBackground': euiTheme.colors.lightShade,
+      'list.hoverBackground': euiTheme.colors.lightestShade,
+      'list.highlightForeground': euiTheme.colors.primary,
+      'editor.lineHighlightBorder': euiTheme.colors.lightestShade,
+      'editorHoverWidget.foreground': euiTheme.colors.darkestShade,
+      'editorHoverWidget.background': euiTheme.colors.backgroundBaseSubdued,
     },
   };
 }
 
-export const buildDarkTheme = () => createTheme(darkTheme, '#343551');
-export const buildLightTheme = () => createTheme(lightTheme, '#E3E4ED');
-export const buildDarkTransparentTheme = () => createTheme(darkTheme, '#343551', '#00000000');
-export const buildLightTransparentTheme = () => createTheme(lightTheme, '#E3E4ED', '#00000000');
+export const buildTheme = createTheme;
+export const buildTransparentTheme = (euiTheme: UseEuiTheme) => createTheme(euiTheme, '#00000000');

--- a/packages/kbn-monaco/src/code_editor/theme.ts
+++ b/packages/kbn-monaco/src/code_editor/theme.ts
@@ -9,6 +9,7 @@
 
 import type { UseEuiTheme } from '@elastic/eui';
 import { monaco } from '../..';
+/*import { rgb } from 'chroma-js';*/
 
 export function createTheme(
   { euiTheme }: UseEuiTheme,
@@ -20,31 +21,31 @@ export function createTheme(
     rules: [
       {
         token: '',
-        foreground: euiTheme.colors.darkestShade,
+        foreground: euiTheme.colors.textParagraph,
         background: euiTheme.colors.backgroundBaseSubdued,
       },
-      { token: 'invalid', foreground: euiTheme.colors.accent },
+      { token: 'invalid', foreground: euiTheme.colors.textAccent },
       { token: 'emphasis', fontStyle: 'italic' },
       { token: 'strong', fontStyle: 'bold' },
 
       { token: 'variable', foreground: euiTheme.colors.textPrimary },
       { token: 'variable.predefined', foreground: euiTheme.colors.textSuccess },
-      { token: 'constant', foreground: euiTheme.colors.accent },
+      { token: 'constant', foreground: euiTheme.colors.textAccent },
       { token: 'comment', foreground: euiTheme.colors.textSubdued },
-      { token: 'number', foreground: euiTheme.colors.accent },
-      { token: 'number.hex', foreground: euiTheme.colors.accent },
+      { token: 'number', foreground: euiTheme.colors.textAccent },
+      { token: 'number.hex', foreground: euiTheme.colors.textAccent },
       { token: 'regexp', foreground: euiTheme.colors.textDanger },
       { token: 'annotation', foreground: euiTheme.colors.textSubdued },
       { token: 'type', foreground: euiTheme.colors.textSuccess },
 
       { token: 'delimiter', foreground: euiTheme.colors.textSubdued },
-      { token: 'delimiter.html', foreground: euiTheme.colors.darkShade },
+      { token: 'delimiter.html', foreground: euiTheme.colors.textParagraph },
       { token: 'delimiter.xml', foreground: euiTheme.colors.textPrimary },
 
       { token: 'tag', foreground: euiTheme.colors.textDanger },
       { token: 'tag.id.jade', foreground: euiTheme.colors.textPrimary },
       { token: 'tag.class.jade', foreground: euiTheme.colors.textPrimary },
-      { token: 'meta.scss', foreground: euiTheme.colors.accent },
+      { token: 'meta.scss', foreground: euiTheme.colors.textAccent },
       { token: 'metatag', foreground: euiTheme.colors.textSuccess },
       { token: 'metatag.content.html', foreground: euiTheme.colors.textDanger },
       { token: 'metatag.html', foreground: euiTheme.colors.textDanger },
@@ -73,30 +74,30 @@ export function createTheme(
       { token: 'keyword.flow', foreground: euiTheme.colors.textWarning },
       { token: 'keyword.flow.scss', foreground: euiTheme.colors.textPrimary },
       // Monaco editor supports strikethrough font style only starting from 0.32.0.
-      { token: 'keyword.deprecated', foreground: euiTheme.colors.accent },
+      { token: 'keyword.deprecated', foreground: euiTheme.colors.textAccent },
 
-      { token: 'operator.scss', foreground: euiTheme.colors.darkShade },
+      { token: 'operator.scss', foreground: euiTheme.colors.textParagraph },
       { token: 'operator.sql', foreground: euiTheme.colors.textSubdued },
       { token: 'operator.swift', foreground: euiTheme.colors.textSubdued },
       { token: 'predefined.sql', foreground: euiTheme.colors.textSubdued },
 
-      { token: 'text', foreground: euiTheme.colors.textAccent },
+      { token: 'text', foreground: euiTheme.colors.textHeading },
       { token: 'label', foreground: euiTheme.colors.vis.euiColorVis9 },
     ],
     colors: {
-      'editor.foreground': euiTheme.colors.darkestShade,
+      'editor.foreground': euiTheme.colors.textParagraph,
       'editor.background': backgroundColor ?? euiTheme.colors.backgroundBasePlain,
-      'editorLineNumber.foreground': euiTheme.colors.darkShade,
-      'editorLineNumber.activeForeground': euiTheme.colors.darkShade,
+      'editorLineNumber.foreground': euiTheme.colors.textSubdued,
+      'editorLineNumber.activeForeground': euiTheme.colors.textSubdued,
       'editorIndentGuide.background1': euiTheme.colors.lightShade,
       'editor.selectionBackground': euiTheme.colors.backgroundBaseInteractiveSelect,
-      'editorWidget.border': euiTheme.colors.lightShade,
-      'editorWidget.background': euiTheme.colors.lightestShade,
+      'editorWidget.border': euiTheme.colors.borderBasePlain,
+      'editorWidget.background': euiTheme.colors.backgroundBaseSubdued,
       'editorCursor.foreground': euiTheme.colors.darkestShade,
       'editorSuggestWidget.selectedForeground': euiTheme.colors.darkestShade,
       'editorSuggestWidget.focusHighlightForeground': euiTheme.colors.primary,
       'editorSuggestWidget.selectedBackground': euiTheme.colors.lightShade,
-      'list.hoverBackground': euiTheme.colors.lightestShade,
+      'list.hoverBackground': euiTheme.colors.backgroundBaseSubdued,
       'list.highlightForeground': euiTheme.colors.primary,
       'editor.lineHighlightBorder': euiTheme.colors.lightestShade,
       'editorHoverWidget.foreground': euiTheme.colors.darkestShade,

--- a/packages/kbn-monaco/src/code_editor/theme.ts
+++ b/packages/kbn-monaco/src/code_editor/theme.ts
@@ -9,7 +9,6 @@
 
 import type { UseEuiTheme } from '@elastic/eui';
 import { monaco } from '../..';
-/*import { rgb } from 'chroma-js';*/
 
 export function createTheme(
   { euiTheme }: UseEuiTheme,

--- a/packages/kbn-monaco/src/console/constants.ts
+++ b/packages/kbn-monaco/src/console/constants.ts
@@ -8,6 +8,5 @@
  */
 
 export const CONSOLE_LANG_ID = 'console';
-export const CONSOLE_THEME_ID = 'consoleTheme';
 export const CONSOLE_OUTPUT_LANG_ID = 'consoleOutput';
 export const CONSOLE_POSTFIX = '.console';

--- a/packages/kbn-monaco/src/console/index.ts
+++ b/packages/kbn-monaco/src/console/index.ts
@@ -22,9 +22,11 @@ import {
 } from './lexer_rules';
 import { foldingRangeProvider } from './folding_range_provider';
 
-export { CONSOLE_LANG_ID, CONSOLE_OUTPUT_LANG_ID, CONSOLE_THEME_ID } from './constants';
-
-export { buildConsoleTheme } from './theme';
+export { CONSOLE_LANG_ID, CONSOLE_OUTPUT_LANG_ID } from './constants';
+/**
+ * export the theme id for the console language
+ */
+export { CONSOLE_THEME_ID } from './language';
 
 export const ConsoleLang: LangModuleType = {
   ID: CONSOLE_LANG_ID,

--- a/packages/kbn-monaco/src/console/language.ts
+++ b/packages/kbn-monaco/src/console/language.ts
@@ -12,12 +12,17 @@ import { ConsoleWorkerProxyService } from './console_worker_proxy';
 import { monaco } from '../monaco_imports';
 import { CONSOLE_LANG_ID } from './constants';
 import { ConsoleParsedRequestsProvider } from './console_parsed_requests_provider';
+import { buildConsoleTheme } from './theme';
 
 const workerProxyService = new ConsoleWorkerProxyService();
 
 export const getParsedRequestsProvider = (model: monaco.editor.ITextModel | null) => {
   return new ConsoleParsedRequestsProvider(workerProxyService, model);
 };
+
+// Theme id is the same as lang id, as we register only one theme resolver that's color mode aware
+export const CONSOLE_THEME_ID = CONSOLE_LANG_ID;
+monaco.editor.registerLanguageThemeDefinition(CONSOLE_THEME_ID, buildConsoleTheme);
 
 monaco.languages.onLanguage(CONSOLE_LANG_ID, async () => {
   workerProxyService.setup();

--- a/packages/kbn-monaco/src/console/language.ts
+++ b/packages/kbn-monaco/src/console/language.ts
@@ -22,7 +22,7 @@ export const getParsedRequestsProvider = (model: monaco.editor.ITextModel | null
 
 // Theme id is the same as lang id, as we register only one theme resolver that's color mode aware
 export const CONSOLE_THEME_ID = CONSOLE_LANG_ID;
-monaco.editor.registerLanguageThemeDefinition(CONSOLE_THEME_ID, buildConsoleTheme);
+monaco.editor.registerLanguageThemeResolver(CONSOLE_THEME_ID, buildConsoleTheme);
 
 monaco.languages.onLanguage(CONSOLE_LANG_ID, async () => {
   workerProxyService.setup();

--- a/packages/kbn-monaco/src/console/theme.ts
+++ b/packages/kbn-monaco/src/console/theme.ts
@@ -18,7 +18,7 @@ const getConsoleColorConfig = (themeVars: UseEuiTheme['euiTheme']) => {
     background: themeVars.colors.backgroundBaseSubdued,
     booleanTextColor: themeVars.colors.textPrimary,
     methodTextColor: themeVars.colors.textAccent,
-    urlTextColor: themeVars.colors.accentSecondary,
+    urlTextColor: themeVars.colors.textAccentSecondary,
     defaultStatusBackgroundColor: themeVars.colors.backgroundLightAccentSecondary,
     successStatusBackgroundColor: themeVars.colors.backgroundLightSuccess,
     primaryStatusBackgroundColor: themeVars.colors.backgroundLightPrimary,

--- a/packages/kbn-monaco/src/console/theme.ts
+++ b/packages/kbn-monaco/src/console/theme.ts
@@ -7,93 +7,127 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { makeHighContrastColor } from '@elastic/eui';
-import { euiThemeVars } from '@kbn/ui-theme';
-import { darkMode } from '@kbn/ui-theme';
-import { buildLightTheme, buildDarkTheme } from '../code_editor';
+import { makeHighContrastColor, type UseEuiTheme } from '@elastic/eui';
+import { defaultThemesResolvers, CODE_EDITOR_DEFAULT_THEME_ID } from '../code_editor';
 import { themeRuleGroupBuilderFactory } from '../common/theme';
-import { monaco } from '../monaco_imports';
 
 const buildRuleGroup = themeRuleGroupBuilderFactory();
 
-const background = euiThemeVars.euiFormBackgroundColor;
-const booleanTextColor = '#585CF6';
-const methodTextColor = '#DD0A73';
-const urlTextColor = '#00A69B';
-const defaultStatusBackgroundColor = darkMode ? '#191B20' : '#F7F8FA';
-const successStatusBackgroundColor = darkMode ? '#212B30' : '#E7F5F5';
-const primaryStatusBackgroundColor = darkMode ? '#1E232D' : '#EBF1F7';
-const warningStatusBackgroundColor = darkMode ? '#2C2B25' : '#FBF6E9';
-const dangerStatusBackgroundColor = darkMode ? '#2E2024' : '#F6E6E7';
-export const buildConsoleTheme = (): monaco.editor.IStandaloneThemeData => {
-  const euiTheme = darkMode ? buildDarkTheme() : buildLightTheme();
+const getConsoleColorConfig = (themeVars: UseEuiTheme['euiTheme'], isDarkMode: boolean) => {
   return {
-    ...euiTheme,
+    background: themeVars.colors.backgroundBaseSubdued,
+    booleanTextColor: '#585CF6',
+    methodTextColor: '#DD0A73',
+    urlTextColor: '#00A69B',
+    defaultStatusBackgroundColor: isDarkMode ? '#191B20' : '#F7F8FA',
+    successStatusBackgroundColor: isDarkMode ? '#212B30' : '#E7F5F5',
+    primaryStatusBackgroundColor: isDarkMode ? '#1E232D' : '#EBF1F7',
+    warningStatusBackgroundColor: isDarkMode ? '#2C2B25' : '#FBF6E9',
+    dangerStatusBackgroundColor: isDarkMode ? '#2E2024' : '#F6E6E7',
+  };
+};
+
+export const buildConsoleTheme = ({ colorMode, euiTheme, ...rest }: UseEuiTheme) => {
+  const isDarkMode = colorMode === 'DARK';
+  const consoleColors = getConsoleColorConfig(euiTheme, isDarkMode);
+
+  const themeBase = defaultThemesResolvers[CODE_EDITOR_DEFAULT_THEME_ID]({
+    colorMode,
+    euiTheme,
+    ...rest,
+  });
+
+  return {
+    ...themeBase,
     rules: [
-      ...euiTheme.rules,
+      ...themeBase.rules,
       ...buildRuleGroup(
         ['string-literal', 'multi-string', 'punctuation.end-triple-quote'],
-        makeHighContrastColor(euiThemeVars.euiColorDangerText)(background)
+        makeHighContrastColor(euiTheme.colors.textDanger)(consoleColors.background)
       ),
       ...buildRuleGroup(
         ['constant.language.boolean'],
-        makeHighContrastColor(booleanTextColor)(background)
+        makeHighContrastColor(consoleColors.booleanTextColor)(consoleColors.background)
       ),
       ...buildRuleGroup(
         ['constant.numeric'],
-        makeHighContrastColor(euiThemeVars.euiColorAccentText)(background)
+        makeHighContrastColor(euiTheme.colors.textAccent)(consoleColors.background)
       ),
       ...buildRuleGroup(
         ['comment.default'],
-        makeHighContrastColor(euiThemeVars.euiTextColor)(defaultStatusBackgroundColor)
+        makeHighContrastColor(euiTheme.colors.textPrimary)(
+          consoleColors.defaultStatusBackgroundColor
+        )
       ),
       ...buildRuleGroup(
         ['comment.success'],
-        makeHighContrastColor(euiThemeVars.euiColorSuccessText)(successStatusBackgroundColor)
+        makeHighContrastColor(euiTheme.colors.textSuccess)(
+          consoleColors.successStatusBackgroundColor
+        )
       ),
       ...buildRuleGroup(
         ['comment.primary'],
-        makeHighContrastColor(euiThemeVars.euiTextColor)(primaryStatusBackgroundColor)
+        makeHighContrastColor(euiTheme.colors.textPrimary)(
+          consoleColors.primaryStatusBackgroundColor
+        )
       ),
       ...buildRuleGroup(
         ['comment.warning'],
-        makeHighContrastColor(euiThemeVars.euiColorWarningText)(warningStatusBackgroundColor)
+        makeHighContrastColor(euiTheme.colors.textWarning)(
+          consoleColors.warningStatusBackgroundColor
+        )
       ),
       ...buildRuleGroup(
         ['comment.danger'],
-        makeHighContrastColor(euiThemeVars.euiColorDangerText)(dangerStatusBackgroundColor)
+        makeHighContrastColor(euiTheme.colors.textDanger)(consoleColors.dangerStatusBackgroundColor)
       ),
       ...buildRuleGroup(
         ['status.default'],
-        makeHighContrastColor(euiThemeVars.euiTextColor)(defaultStatusBackgroundColor),
+        makeHighContrastColor(euiTheme.colors.textPrimary)(
+          consoleColors.defaultStatusBackgroundColor
+        ),
         true
       ),
       ...buildRuleGroup(
         ['status.success'],
-        makeHighContrastColor(euiThemeVars.euiColorSuccessText)(successStatusBackgroundColor),
+        makeHighContrastColor(euiTheme.colors.textSuccess)(
+          consoleColors.successStatusBackgroundColor
+        ),
         true
       ),
       ...buildRuleGroup(
         ['status.primary'],
-        makeHighContrastColor(euiThemeVars.euiTextColor)(primaryStatusBackgroundColor),
+        makeHighContrastColor(euiTheme.colors.textPrimary)(
+          consoleColors.primaryStatusBackgroundColor
+        ),
         true
       ),
       ...buildRuleGroup(
         ['status.warning'],
-        makeHighContrastColor(euiThemeVars.euiColorWarningText)(warningStatusBackgroundColor),
+        makeHighContrastColor(euiTheme.colors.textWarning)(
+          consoleColors.warningStatusBackgroundColor
+        ),
         true
       ),
       ...buildRuleGroup(
         ['status.danger'],
-        makeHighContrastColor(euiThemeVars.euiColorDangerText)(dangerStatusBackgroundColor),
+        makeHighContrastColor(euiTheme.colors.textDanger)(
+          consoleColors.dangerStatusBackgroundColor
+        ),
         true
       ),
-      ...buildRuleGroup(['method'], makeHighContrastColor(methodTextColor)(background)),
-      ...buildRuleGroup(['url'], makeHighContrastColor(urlTextColor)(background)),
+      ...buildRuleGroup(
+        ['method'],
+        makeHighContrastColor(consoleColors.methodTextColor)(consoleColors.background)
+      ),
+      ...buildRuleGroup(
+        ['url'],
+        makeHighContrastColor(consoleColors.urlTextColor)(consoleColors.background)
+      ),
     ],
     colors: {
-      ...euiTheme.colors,
-      'editorLineNumber.foreground': euiThemeVars.euiTextColor,
+      ...themeBase.colors,
+      'editorLineNumber.foreground': euiTheme.colors.textPrimary,
     },
   };
 };

--- a/packages/kbn-monaco/src/console/theme.ts
+++ b/packages/kbn-monaco/src/console/theme.ts
@@ -13,23 +13,22 @@ import { themeRuleGroupBuilderFactory } from '../common/theme';
 
 const buildRuleGroup = themeRuleGroupBuilderFactory();
 
-const getConsoleColorConfig = (themeVars: UseEuiTheme['euiTheme'], isDarkMode: boolean) => {
+const getConsoleColorConfig = (themeVars: UseEuiTheme['euiTheme']) => {
   return {
     background: themeVars.colors.backgroundBaseSubdued,
-    booleanTextColor: '#585CF6',
-    methodTextColor: '#DD0A73',
-    urlTextColor: '#00A69B',
-    defaultStatusBackgroundColor: isDarkMode ? '#191B20' : '#F7F8FA',
-    successStatusBackgroundColor: isDarkMode ? '#212B30' : '#E7F5F5',
-    primaryStatusBackgroundColor: isDarkMode ? '#1E232D' : '#EBF1F7',
-    warningStatusBackgroundColor: isDarkMode ? '#2C2B25' : '#FBF6E9',
-    dangerStatusBackgroundColor: isDarkMode ? '#2E2024' : '#F6E6E7',
+    booleanTextColor: themeVars.colors.textPrimary,
+    methodTextColor: themeVars.colors.textAccent,
+    urlTextColor: themeVars.colors.accentSecondary,
+    defaultStatusBackgroundColor: themeVars.colors.backgroundLightAccentSecondary,
+    successStatusBackgroundColor: themeVars.colors.backgroundLightSuccess,
+    primaryStatusBackgroundColor: themeVars.colors.backgroundLightPrimary,
+    warningStatusBackgroundColor: themeVars.colors.backgroundLightWarning,
+    dangerStatusBackgroundColor: themeVars.colors.backgroundLightDanger,
   };
 };
 
 export const buildConsoleTheme = ({ colorMode, euiTheme, ...rest }: UseEuiTheme) => {
-  const isDarkMode = colorMode === 'DARK';
-  const consoleColors = getConsoleColorConfig(euiTheme, isDarkMode);
+  const consoleColors = getConsoleColorConfig(euiTheme);
 
   const themeBase = defaultThemesResolvers[CODE_EDITOR_DEFAULT_THEME_ID]({
     colorMode,

--- a/packages/kbn-monaco/src/esql/language.ts
+++ b/packages/kbn-monaco/src/esql/language.ts
@@ -16,6 +16,7 @@ import type { CustomLangModuleType } from '../types';
 import type { ESQLWorker } from './worker/esql_worker';
 
 import { WorkerProxyService } from '../common/worker_proxy';
+import { buildESQLTheme } from './lib/esql_theme';
 import { ESQLAstAdapter } from './lib/esql_ast_provider';
 import { wrapAsMonacoSuggestions } from './lib/converters/suggestions';
 import { wrapAsMonacoCodeActions } from './lib/converters/actions';
@@ -34,6 +35,7 @@ export const ESQLLang: CustomLangModuleType<ESQLCallbacks> = {
 
     monaco.languages.setTokensProvider(ESQL_LANG_ID, new ESQLTokensProvider());
   },
+  languageThemeResolver: buildESQLTheme,
   languageConfiguration: {
     brackets: [
       ['(', ')'],

--- a/packages/kbn-monaco/src/esql/lib/esql_theme.test.ts
+++ b/packages/kbn-monaco/src/esql/lib/esql_theme.test.ts
@@ -8,13 +8,20 @@
  */
 
 import { ESQLErrorListener, getLexer as _getLexer } from '@kbn/esql-ast';
+import type { UseEuiTheme } from '@elastic/eui';
 import { ESQL_TOKEN_POSTFIX } from './constants';
 import { buildESQLTheme } from './esql_theme';
 import { CharStreams } from 'antlr4';
 
+const mockTheme: UseEuiTheme = {
+  colorMode: 'DARK',
+  euiTheme: { colors: {} } as unknown as UseEuiTheme['euiTheme'],
+  modifications: {},
+};
+
 describe('ESQL Theme', () => {
   it('should not have multiple rules for a single token', () => {
-    const theme = buildESQLTheme({ darkMode: false });
+    const theme = buildESQLTheme(mockTheme);
 
     const seen = new Set<string>();
     const duplicates: string[] = [];
@@ -40,7 +47,7 @@ describe('ESQL Theme', () => {
     .map((name) => name!.toLowerCase());
 
   it('every rule should apply to a valid lexical name', () => {
-    const theme = buildESQLTheme({ darkMode: false });
+    const theme = buildESQLTheme(mockTheme);
 
     // These names aren't from the lexer... they are added on our side
     // see packages/kbn-monaco/src/esql/lib/esql_token_helpers.ts
@@ -62,7 +69,7 @@ describe('ESQL Theme', () => {
   });
 
   it('every valid lexical name should have a corresponding rule', () => {
-    const theme = buildESQLTheme({ darkMode: false });
+    const theme = buildESQLTheme(mockTheme);
     const tokenIDs = theme.rules.map((rule) => rule.token.replace(ESQL_TOKEN_POSTFIX, ''));
 
     const validExceptions = [

--- a/packages/kbn-monaco/src/esql/lib/esql_theme.ts
+++ b/packages/kbn-monaco/src/esql/lib/esql_theme.ts
@@ -36,7 +36,7 @@ export const buildESQLTheme = ({
           'unquoted_identifier',
           'pipe',
         ],
-        euiTheme.colors.textAccent
+        euiTheme.colors.textParagraph
       ),
 
       // source commands

--- a/packages/kbn-monaco/src/esql/lib/esql_theme.ts
+++ b/packages/kbn-monaco/src/esql/lib/esql_theme.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { euiDarkVars, euiLightVars } from '@kbn/ui-theme';
+import type { UseEuiTheme } from '@elastic/eui';
 import { themeRuleGroupBuilderFactory } from '../../common/theme';
 import { ESQL_TOKEN_POSTFIX } from './constants';
 import { monaco } from '../../monaco_imports';
@@ -15,14 +15,11 @@ import { monaco } from '../../monaco_imports';
 const buildRuleGroup = themeRuleGroupBuilderFactory(ESQL_TOKEN_POSTFIX);
 
 export const buildESQLTheme = ({
-  darkMode,
-}: {
-  darkMode: boolean;
-}): monaco.editor.IStandaloneThemeData => {
-  const euiThemeVars = darkMode ? euiDarkVars : euiLightVars;
-
+  euiTheme,
+  colorMode,
+}: UseEuiTheme): monaco.editor.IStandaloneThemeData => {
   return {
-    base: darkMode ? 'vs-dark' : 'vs',
+    base: colorMode === 'DARK' ? 'vs-dark' : 'vs',
     inherit: true,
     rules: [
       // base
@@ -39,13 +36,13 @@ export const buildESQLTheme = ({
           'unquoted_identifier',
           'pipe',
         ],
-        euiThemeVars.euiTextColor
+        euiTheme.colors.textAccent
       ),
 
       // source commands
       ...buildRuleGroup(
         ['from', 'row', 'show'],
-        euiThemeVars.euiColorPrimary,
+        euiTheme.colors.primary,
         true // isBold
       ),
 
@@ -88,12 +85,12 @@ export const buildESQLTheme = ({
           'desc',
           'nulls_order',
         ],
-        euiThemeVars.euiColorAccent,
+        euiTheme.colors.accent,
         true // isBold
       ),
 
       // functions
-      ...buildRuleGroup(['functions'], euiThemeVars.euiColorPrimary),
+      ...buildRuleGroup(['functions'], euiTheme.colors.primary),
 
       // operators
       ...buildRuleGroup(
@@ -116,7 +113,7 @@ export const buildESQLTheme = ({
           'percent', // '%'
           'cast_op', // '::'
         ],
-        euiThemeVars.euiColorPrimary
+        euiTheme.colors.primary
       ),
 
       // comments
@@ -156,7 +153,7 @@ export const buildESQLTheme = ({
           'closing_metrics_line_comment',
           'closing_metrics_multiline_comment',
         ],
-        euiThemeVars.euiTextSubduedColor
+        euiTheme.colors.textSubdued
       ),
 
       // values
@@ -169,23 +166,23 @@ export const buildESQLTheme = ({
           'param',
           'timespan_literal',
         ],
-        euiThemeVars.euiColorSuccessText
+        euiTheme.colors.textSuccess
       ),
     ],
     colors: {
-      'editor.foreground': euiThemeVars.euiTextColor,
-      'editor.background': euiThemeVars.euiColorEmptyShade,
-      'editor.lineHighlightBackground': euiThemeVars.euiColorLightestShade,
-      'editor.lineHighlightBorder': euiThemeVars.euiColorLightestShade,
-      'editor.selectionHighlightBackground': euiThemeVars.euiColorLightestShade,
-      'editor.selectionHighlightBorder': euiThemeVars.euiColorLightShade,
-      'editorSuggestWidget.background': euiThemeVars.euiColorEmptyShade,
-      'editorSuggestWidget.border': euiThemeVars.euiColorEmptyShade,
-      'editorSuggestWidget.focusHighlightForeground': euiThemeVars.euiColorEmptyShade,
-      'editorSuggestWidget.foreground': euiThemeVars.euiTextColor,
-      'editorSuggestWidget.highlightForeground': euiThemeVars.euiColorPrimary,
-      'editorSuggestWidget.selectedBackground': euiThemeVars.euiColorPrimary,
-      'editorSuggestWidget.selectedForeground': euiThemeVars.euiColorEmptyShade,
+      'editor.foreground': euiTheme.colors.textPrimary,
+      'editor.background': euiTheme.colors.backgroundBasePlain,
+      'editor.lineHighlightBackground': euiTheme.colors.lightestShade,
+      'editor.lineHighlightBorder': euiTheme.colors.lightestShade,
+      'editor.selectionHighlightBackground': euiTheme.colors.lightestShade,
+      'editor.selectionHighlightBorder': euiTheme.colors.lightShade,
+      'editorSuggestWidget.background': euiTheme.colors.emptyShade,
+      'editorSuggestWidget.border': euiTheme.colors.emptyShade,
+      'editorSuggestWidget.focusHighlightForeground': euiTheme.colors.emptyShade,
+      'editorSuggestWidget.foreground': euiTheme.colors.textAccent,
+      'editorSuggestWidget.highlightForeground': euiTheme.colors.primary,
+      'editorSuggestWidget.selectedBackground': euiTheme.colors.primary,
+      'editorSuggestWidget.selectedForeground': euiTheme.colors.emptyShade,
     },
   };
 };

--- a/packages/kbn-monaco/src/esql/lib/esql_theme.ts
+++ b/packages/kbn-monaco/src/esql/lib/esql_theme.ts
@@ -170,7 +170,7 @@ export const buildESQLTheme = ({
       ),
     ],
     colors: {
-      'editor.foreground': euiTheme.colors.textPrimary,
+      'editor.foreground': euiTheme.colors.textParagraph,
       'editor.background': euiTheme.colors.backgroundBasePlain,
       'editor.lineHighlightBackground': euiTheme.colors.lightestShade,
       'editor.lineHighlightBorder': euiTheme.colors.lightestShade,
@@ -179,7 +179,7 @@ export const buildESQLTheme = ({
       'editorSuggestWidget.background': euiTheme.colors.emptyShade,
       'editorSuggestWidget.border': euiTheme.colors.emptyShade,
       'editorSuggestWidget.focusHighlightForeground': euiTheme.colors.emptyShade,
-      'editorSuggestWidget.foreground': euiTheme.colors.textAccent,
+      'editorSuggestWidget.foreground': euiTheme.colors.textParagraph,
       'editorSuggestWidget.highlightForeground': euiTheme.colors.primary,
       'editorSuggestWidget.selectedBackground': euiTheme.colors.primary,
       'editorSuggestWidget.selectedForeground': euiTheme.colors.emptyShade,

--- a/packages/kbn-monaco/src/helpers.ts
+++ b/packages/kbn-monaco/src/helpers.ts
@@ -15,6 +15,10 @@ export function registerLanguage(language: LangModuleType | CustomLangModuleType
 
   monaco.languages.register({ id: ID });
 
+  if ('languageThemeResolver' in language) {
+    monaco.editor.registerLanguageThemeDefinition(ID, language.languageThemeResolver);
+  }
+
   monaco.languages.onLanguage(ID, async () => {
     if (lexerRules) {
       monaco.languages.setMonarchTokensProvider(ID, lexerRules);
@@ -34,6 +38,10 @@ export function registerLanguage(language: LangModuleType | CustomLangModuleType
   });
 }
 
+/**
+ *
+ * @deprecated avoid using this function, use `monaco.editor.registerLanguageThemeDefinition` instead
+ */
 export function registerTheme(id: string, themeData: monaco.editor.IStandaloneThemeData) {
   try {
     monaco.editor.defineTheme(id, themeData);

--- a/packages/kbn-monaco/src/helpers.ts
+++ b/packages/kbn-monaco/src/helpers.ts
@@ -16,7 +16,7 @@ export function registerLanguage(language: LangModuleType | CustomLangModuleType
   monaco.languages.register({ id: ID });
 
   if ('languageThemeResolver' in language) {
-    monaco.editor.registerLanguageThemeDefinition(ID, language.languageThemeResolver);
+    monaco.editor.registerLanguageThemeResolver(ID, language.languageThemeResolver);
   }
 
   monaco.languages.onLanguage(ID, async () => {

--- a/packages/kbn-monaco/src/monaco_imports.test.ts
+++ b/packages/kbn-monaco/src/monaco_imports.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { monaco } from './monaco_imports';
+
+describe('monaco augmentation', () => {
+  it('has the property registerLanguageThemeResolver defined', () => {
+    expect(monaco.editor).toHaveProperty('registerLanguageThemeResolver', expect.any(Function));
+  });
+
+  it('has the property getLanguageThemeResolver defined', () => {
+    expect(monaco.editor).toHaveProperty('getLanguageThemeResolver', expect.any(Function));
+  });
+
+  it('registers a theme resolver to a specific ID and returns the same registered theme resolver using the same ID', () => {
+    const themeResolver = jest.fn();
+    monaco.editor.registerLanguageThemeResolver('test', themeResolver);
+    expect(monaco.editor.getLanguageThemeResolver('test')).toBe(themeResolver);
+  });
+});

--- a/packages/kbn-monaco/src/monaco_imports.test.ts
+++ b/packages/kbn-monaco/src/monaco_imports.test.ts
@@ -10,17 +10,31 @@
 import { monaco } from './monaco_imports';
 
 describe('monaco augmentation', () => {
-  it('has the property registerLanguageThemeResolver defined', () => {
-    expect(monaco.editor).toHaveProperty('registerLanguageThemeResolver', expect.any(Function));
+  describe('getLanguageThemeResolver', () => {
+    it('has the property getLanguageThemeResolver defined', () => {
+      expect(monaco.editor).toHaveProperty('getLanguageThemeResolver', expect.any(Function));
+    });
   });
 
-  it('has the property getLanguageThemeResolver defined', () => {
-    expect(monaco.editor).toHaveProperty('getLanguageThemeResolver', expect.any(Function));
-  });
+  describe('registerLanguageThemeResolver', () => {
+    it('has the property registerLanguageThemeResolver defined', () => {
+      expect(monaco.editor).toHaveProperty('registerLanguageThemeResolver', expect.any(Function));
+    });
 
-  it('registers a theme resolver to a specific ID and returns the same registered theme resolver using the same ID', () => {
-    const themeResolver = jest.fn();
-    monaco.editor.registerLanguageThemeResolver('test', themeResolver);
-    expect(monaco.editor.getLanguageThemeResolver('test')).toBe(themeResolver);
+    it('registers a theme resolver to a specific ID and returns the same registered theme resolver using the same ID', () => {
+      const themeResolver = jest.fn();
+      monaco.editor.registerLanguageThemeResolver('test', themeResolver);
+      expect(monaco.editor.getLanguageThemeResolver('test')).toBe(themeResolver);
+    });
+
+    it('throws an error when attempting to register a different theme resolver if one exists for the specified theme ID', () => {
+      expect(() => monaco.editor.registerLanguageThemeResolver('test', jest.fn())).toThrow();
+    });
+
+    it('allows registering a different theme resolver for a theme ID with existing resolver definition by specifying the override flag', () => {
+      const alternateThemeResolver = jest.fn();
+      monaco.editor.registerLanguageThemeResolver('test', alternateThemeResolver, true);
+      expect(monaco.editor.getLanguageThemeResolver('test')).toBe(alternateThemeResolver);
+    });
   });
 });

--- a/packages/kbn-monaco/src/monaco_imports.ts
+++ b/packages/kbn-monaco/src/monaco_imports.ts
@@ -66,7 +66,8 @@ declare module 'monaco-editor/esm/vs/editor/editor.api' {
     // augment monaco editor types
     function registerLanguageThemeResolver(
       langId: string,
-      languageThemeResolver: CustomLangModuleType['languageThemeResolver']
+      languageThemeResolver: CustomLangModuleType['languageThemeResolver'],
+      forceOverride?: boolean
     ): void;
     function getLanguageThemeResolver(
       langId: string
@@ -82,8 +83,12 @@ Object.defineProperties(monaco.editor, {
   registerLanguageThemeResolver: {
     value: (
       langId: string,
-      languageThemeDefinition: CustomLangModuleType['languageThemeResolver']
+      languageThemeDefinition: CustomLangModuleType['languageThemeResolver'],
+      forceOverride?: boolean
     ) => {
+      if (!forceOverride && languageThemeResolverDefinitions.has(langId)) {
+        throw new Error(`Language theme resolver for ${langId} is already registered`);
+      }
       languageThemeResolverDefinitions.set(langId, languageThemeDefinition);
     },
     enumerable: true,

--- a/packages/kbn-monaco/src/monaco_imports.ts
+++ b/packages/kbn-monaco/src/monaco_imports.ts
@@ -53,4 +53,47 @@ export {
   language as yamlLanguage,
 } from 'monaco-editor/esm/vs/basic-languages/yaml/yaml';
 
+import type { CustomLangModuleType } from './types';
+
+const languageThemeDefinitions = new Map<string, CustomLangModuleType['languageThemeResolver']>();
+
+declare module 'monaco-editor/esm/vs/editor/editor.api' {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  export namespace editor {
+    // augment monaco editor types
+    function registerLanguageThemeDefinition(
+      langId: string,
+      languageThemeDefinition: CustomLangModuleType['languageThemeResolver']
+    ): void;
+    function getLanguageThemeDefinition(
+      langId: string
+    ): CustomLangModuleType['languageThemeResolver'];
+  }
+}
+
+// add custom methods to monaco editor
+Object.defineProperties(monaco.editor, {
+  /**
+   * @description Registers language theme definition for a language
+   */
+  registerLanguageThemeDefinition: {
+    value: (
+      langId: string,
+      languageThemeDefinition: CustomLangModuleType['languageThemeResolver']
+    ) => {
+      languageThemeDefinitions.set(langId, languageThemeDefinition);
+    },
+    enumerable: true,
+    configurable: false,
+  },
+  /**
+   * @description Returns language theme definition for a language
+   */
+  getLanguageThemeDefinition: {
+    value: (langId: string) => languageThemeDefinitions.get(langId),
+    enumerable: true,
+    configurable: false,
+  },
+});
+
 export { monaco };

--- a/packages/kbn-monaco/src/monaco_imports.ts
+++ b/packages/kbn-monaco/src/monaco_imports.ts
@@ -55,17 +55,20 @@ export {
 
 import type { CustomLangModuleType } from './types';
 
-const languageThemeDefinitions = new Map<string, CustomLangModuleType['languageThemeResolver']>();
+const languageThemeResolverDefinitions = new Map<
+  string,
+  CustomLangModuleType['languageThemeResolver']
+>();
 
 declare module 'monaco-editor/esm/vs/editor/editor.api' {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   export namespace editor {
     // augment monaco editor types
-    function registerLanguageThemeDefinition(
+    function registerLanguageThemeResolver(
       langId: string,
-      languageThemeDefinition: CustomLangModuleType['languageThemeResolver']
+      languageThemeResolver: CustomLangModuleType['languageThemeResolver']
     ): void;
-    function getLanguageThemeDefinition(
+    function getLanguageThemeResolver(
       langId: string
     ): CustomLangModuleType['languageThemeResolver'];
   }
@@ -76,12 +79,12 @@ Object.defineProperties(monaco.editor, {
   /**
    * @description Registers language theme definition for a language
    */
-  registerLanguageThemeDefinition: {
+  registerLanguageThemeResolver: {
     value: (
       langId: string,
       languageThemeDefinition: CustomLangModuleType['languageThemeResolver']
     ) => {
-      languageThemeDefinitions.set(langId, languageThemeDefinition);
+      languageThemeResolverDefinitions.set(langId, languageThemeDefinition);
     },
     enumerable: true,
     configurable: false,
@@ -89,8 +92,8 @@ Object.defineProperties(monaco.editor, {
   /**
    * @description Returns language theme definition for a language
    */
-  getLanguageThemeDefinition: {
-    value: (langId: string) => languageThemeDefinitions.get(langId),
+  getLanguageThemeResolver: {
+    value: (langId: string) => languageThemeResolverDefinitions.get(langId),
     enumerable: true,
     configurable: false,
   },

--- a/packages/kbn-monaco/src/register_globals.ts
+++ b/packages/kbn-monaco/src/register_globals.ts
@@ -11,20 +11,10 @@ import { XJsonLang } from './xjson';
 import { PainlessLang } from './painless';
 import { SQLLang } from './sql';
 import { monaco } from './monaco_imports';
-import { ESQL_DARK_THEME_ID, ESQL_LIGHT_THEME_ID, ESQLLang, buildESQLTheme } from './esql';
+import { ESQLLang } from './esql';
 import { YAML_LANG_ID } from './yaml';
-import { registerLanguage, registerTheme } from './helpers';
-import { ConsoleLang, ConsoleOutputLang, CONSOLE_THEME_ID, buildConsoleTheme } from './console';
-import {
-  CODE_EDITOR_LIGHT_THEME_ID,
-  CODE_EDITOR_DARK_THEME_ID,
-  CODE_EDITOR_LIGHT_THEME_TRANSPARENT_ID,
-  CODE_EDITOR_DARK_THEME_TRANSPARENT_ID,
-  buildLightTheme,
-  buildDarkTheme,
-  buildLightTransparentTheme,
-  buildDarkTransparentTheme,
-} from './code_editor';
+import { registerLanguage } from './helpers';
+import { ConsoleLang, ConsoleOutputLang } from './console';
 
 export const DEFAULT_WORKER_ID = 'default';
 const langSpecificWorkerIds = [
@@ -46,17 +36,6 @@ registerLanguage(SQLLang);
 registerLanguage(ESQLLang);
 registerLanguage(ConsoleLang);
 registerLanguage(ConsoleOutputLang);
-
-/**
- * Register custom themes
- */
-registerTheme(ESQL_LIGHT_THEME_ID, buildESQLTheme({ darkMode: false }));
-registerTheme(ESQL_DARK_THEME_ID, buildESQLTheme({ darkMode: true }));
-registerTheme(CONSOLE_THEME_ID, buildConsoleTheme());
-registerTheme(CODE_EDITOR_LIGHT_THEME_ID, buildLightTheme());
-registerTheme(CODE_EDITOR_DARK_THEME_ID, buildDarkTheme());
-registerTheme(CODE_EDITOR_LIGHT_THEME_TRANSPARENT_ID, buildLightTransparentTheme());
-registerTheme(CODE_EDITOR_DARK_THEME_TRANSPARENT_ID, buildDarkTransparentTheme());
 
 const monacoBundleDir = (window as any).__kbnPublicPath__?.['kbn-monaco'];
 

--- a/packages/kbn-monaco/src/types.ts
+++ b/packages/kbn-monaco/src/types.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Observable } from 'rxjs';
+import type { UseEuiTheme } from '@elastic/eui';
 import { monaco } from './monaco_imports';
 
 export interface LangModuleType {
@@ -41,6 +42,7 @@ export interface CustomLangModuleType<Deps = unknown>
   extends Omit<LangModuleType, 'getSuggestionProvider'>,
     LanguageProvidersModule<Deps> {
   onLanguage: () => void;
+  languageThemeResolver: (args: UseEuiTheme) => monaco.editor.IStandaloneThemeData;
 }
 
 export interface MonacoEditorError {

--- a/packages/kbn-monaco/tsconfig.json
+++ b/packages/kbn-monaco/tsconfig.json
@@ -24,7 +24,6 @@
   "kbn_references": [
     "@kbn/i18n",
     "@kbn/repo-info",
-    "@kbn/ui-theme",
     "@kbn/esql-ast",
     "@kbn/esql-validation-autocomplete",
   ],

--- a/packages/shared-ux/code_editor/impl/__snapshots__/code_editor.test.tsx.snap
+++ b/packages/shared-ux/code_editor/impl/__snapshots__/code_editor.test.tsx.snap
@@ -340,7 +340,7 @@ exports[`<CodeEditor /> is rendered 1`] = `
                 "wrappingIndent": "indent",
               }
             }
-            theme="codeEditorLightTheme"
+            theme="codeEditorDefaultTheme"
             value="
 [Sun Mar 7 20:54:27 2004] [notice] [client xx.xx.xx.xx] This is a notice!
 [Sun Mar 7 20:58:27 2004] [info] [client xx.xx.xx.xx] (104)Connection reset by peer: client stopped connection before send body completed
@@ -378,7 +378,7 @@ exports[`<CodeEditor /> is rendered 1`] = `
                     "wrappingIndent": "indent",
                   }
                 }
-                theme="codeEditorLightTheme"
+                theme="codeEditorDefaultTheme"
                 value="
 [Sun Mar 7 20:54:27 2004] [notice] [client xx.xx.xx.xx] This is a notice!
 [Sun Mar 7 20:58:27 2004] [info] [client xx.xx.xx.xx] (104)Connection reset by peer: client stopped connection before send body completed

--- a/packages/shared-ux/code_editor/impl/code_editor.tsx
+++ b/packages/shared-ux/code_editor/impl/code_editor.tsx
@@ -23,10 +23,8 @@ import {
 } from '@elastic/eui';
 import {
   monaco,
-  CODE_EDITOR_LIGHT_THEME_ID,
-  CODE_EDITOR_DARK_THEME_ID,
-  CODE_EDITOR_LIGHT_THEME_TRANSPARENT_ID,
-  CODE_EDITOR_DARK_THEME_TRANSPARENT_ID,
+  CODE_EDITOR_DEFAULT_THEME_ID,
+  CODE_EDITOR_TRANSPARENT_THEME_ID,
 } from '@kbn/monaco';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -117,11 +115,6 @@ export interface CodeEditorProps {
   editorWillUnmount?: () => void;
 
   /**
-   * Should the editor use the dark theme
-   */
-  useDarkTheme?: boolean;
-
-  /**
    * Should the editor use a transparent background
    */
   transparentBackground?: boolean;
@@ -177,7 +170,6 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   editorDidMount,
   editorWillMount,
   editorWillUnmount,
-  useDarkTheme: useDarkThemeProp,
   transparentBackground,
   suggestionProvider,
   signatureProvider,
@@ -198,8 +190,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   enableFindAction,
   dataTestSubj,
 }) => {
-  const { colorMode, euiTheme } = useEuiTheme();
-  const useDarkTheme = useDarkThemeProp ?? colorMode === 'DARK';
+  const { euiTheme } = useEuiTheme();
 
   // We need to be able to mock the MonacoEditor in our test in order to not test implementation
   // detail and not have to call methods on the <CodeEditor /> component instance.
@@ -495,13 +486,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
 
   const theme =
     options?.theme ??
-    (transparentBackground
-      ? useDarkTheme
-        ? CODE_EDITOR_DARK_THEME_TRANSPARENT_ID
-        : CODE_EDITOR_LIGHT_THEME_TRANSPARENT_ID
-      : useDarkTheme
-      ? CODE_EDITOR_DARK_THEME_ID
-      : CODE_EDITOR_LIGHT_THEME_ID);
+    (transparentBackground ? CODE_EDITOR_TRANSPARENT_THEME_ID : CODE_EDITOR_DEFAULT_THEME_ID);
 
   return (
     <div

--- a/packages/shared-ux/code_editor/impl/index.tsx
+++ b/packages/shared-ux/code_editor/impl/index.tsx
@@ -8,7 +8,6 @@
  */
 
 import React from 'react';
-import { euiLightVars as lightTheme, euiDarkVars as darkTheme } from '@kbn/ui-theme';
 import {
   EuiDelayRender,
   EuiSkeletonText,
@@ -58,17 +57,15 @@ export const CodeEditor: React.FunctionComponent<CodeEditorProps> = (props) => {
  * Renders a Monaco code editor in the same style as other EUI form fields.
  */
 export const CodeEditorField: React.FunctionComponent<CodeEditorProps> = (props) => {
-  const { width, height, options, fullWidth, useDarkTheme: useDarkThemeProp } = props;
-  const { colorMode } = useEuiTheme();
-  const useDarkTheme = useDarkThemeProp ?? colorMode === 'DARK';
-  const theme = useDarkTheme ? darkTheme : lightTheme;
+  const { width, height, options, fullWidth } = props;
+  const { euiTheme } = useEuiTheme();
 
   const style = {
     width,
     height,
     backgroundColor: options?.readOnly
-      ? theme.euiFormBackgroundReadOnlyColor
-      : theme.euiFormBackgroundColor,
+      ? euiTheme.colors.backgroundBaseDisabled
+      : euiTheme.colors.backgroundBaseSubdued,
   };
 
   return (

--- a/packages/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
+++ b/packages/shared-ux/code_editor/impl/react_monaco_editor/editor.tsx
@@ -182,11 +182,9 @@ export function MonacoEditor({
 
     // register theme configurations for supported languages
     monaco.languages.getLanguages().forEach(({ id: languageId }) => {
-      let languageThemeDefinition;
-      if (
-        Boolean((languageThemeDefinition = monaco.editor.getLanguageThemeDefinition(languageId)))
-      ) {
-        monaco.editor.defineTheme(languageId, languageThemeDefinition(euiTheme));
+      let languageThemeResolver;
+      if (Boolean((languageThemeResolver = monaco.editor.getLanguageThemeResolver(languageId)))) {
+        monaco.editor.defineTheme(languageId, languageThemeResolver(euiTheme));
       }
     });
   }, [euiTheme]);

--- a/packages/shared-ux/code_editor/impl/tsconfig.json
+++ b/packages/shared-ux/code_editor/impl/tsconfig.json
@@ -22,7 +22,6 @@
     "@kbn/monaco",
     "@kbn/i18n",
     "@kbn/i18n-react",
-    "@kbn/ui-theme",
     "@kbn/test-jest-helpers",
     "@kbn/shared-ux-storybook-mock",
     "@kbn/code-editor-mock",

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -92,7 +92,6 @@ export const ESQLEditor = memo(function ESQLEditor({
     fieldsMetadata,
     uiSettings,
   } = kibana.services;
-  const darkMode = core.theme?.getTheme().darkMode;
 
   const histogramBarTarget = uiSettings?.get('histogram:barTarget') ?? 50;
   const [code, setCode] = useState<string>(query.esql ?? '');

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -25,14 +25,7 @@ import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { AggregateQuery } from '@kbn/es-query';
 import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import {
-  ESQLLang,
-  ESQL_LANG_ID,
-  ESQL_DARK_THEME_ID,
-  ESQL_LIGHT_THEME_ID,
-  monaco,
-  type ESQLCallbacks,
-} from '@kbn/monaco';
+import { ESQLLang, ESQL_LANG_ID, monaco, type ESQLCallbacks } from '@kbn/monaco';
 import memoize from 'lodash/memoize';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -607,7 +600,7 @@ export const ESQLEditor = memo(function ESQLEditor({
       verticalScrollbarSize: 6,
     },
     scrollBeyondLastLine: false,
-    theme: darkMode ? ESQL_DARK_THEME_ID : ESQL_LIGHT_THEME_ID,
+    theme: ESQL_LANG_ID,
     wordWrap: 'on',
     wrappingIndent: 'none',
   };

--- a/src/platform/plugins/shared/console/public/application/containers/config/config.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/config/config.tsx
@@ -24,7 +24,7 @@ export function Config() {
 
   return (
     <EuiPanel
-      color="subdued"
+      color="plain"
       paddingSize="l"
       hasShadow={false}
       borderRadius="none"

--- a/src/platform/plugins/shared/console/public/application/containers/editor/editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/editor.tsx
@@ -17,8 +17,8 @@ import {
   EuiButtonEmpty,
   EuiResizableContainer,
   useIsWithinBreakpoints,
+  useEuiTheme,
 } from '@elastic/eui';
-import { euiThemeVars } from '@kbn/ui-theme';
 
 import { i18n } from '@kbn/i18n';
 import { TextObject } from '../../../../common/text_object';
@@ -54,6 +54,7 @@ export const Editor = memo(({ loading, inputEditorValue, setInputEditorValue }: 
   const {
     services: { storage, objectStorageClient },
   } = useServicesContext();
+  const { euiTheme } = useEuiTheme();
 
   const { currentTextObject } = useEditorReadContext();
 
@@ -228,7 +229,7 @@ export const Editor = memo(({ loading, inputEditorValue, setInputEditorValue }: 
                     grow={false}
                     paddingSize="s"
                     css={{
-                      backgroundColor: euiThemeVars.euiFormBackgroundColor,
+                      backgroundColor: euiTheme.colors.backgroundBasePlain,
                     }}
                     className="consoleEditorPanel"
                   >

--- a/src/platform/plugins/shared/console/public/application/containers/editor/editor.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/editor/editor.tsx
@@ -175,9 +175,7 @@ export const Editor = memo(({ loading, inputEditorValue, setInputEditorValue }: 
                   <EuiSplitPanel.Inner
                     grow={false}
                     paddingSize="s"
-                    css={{
-                      backgroundColor: euiThemeVars.euiFormBackgroundColor,
-                    }}
+                    color="subdued"
                     className="consoleEditorPanel"
                   >
                     <EuiButtonEmpty

--- a/src/platform/plugins/shared/console/tsconfig.json
+++ b/src/platform/plugins/shared/console/tsconfig.json
@@ -29,7 +29,6 @@
     "@kbn/core-notifications-browser",
     "@kbn/react-kibana-context-render",
     "@kbn/react-kibana-mount",
-    "@kbn/ui-theme",
     "@kbn/core-doc-links-browser",
     "@kbn/shared-ux-router",
   ],

--- a/x-pack/packages/security/api_key_management/src/components/api_key_flyout.tsx
+++ b/x-pack/packages/security/api_key_management/src/components/api_key_flyout.tsx
@@ -40,7 +40,7 @@ import { CodeEditorField } from '@kbn/code-editor';
 import type { AuthenticatedUser, CoreStart } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import { FormattedDate, FormattedMessage } from '@kbn/i18n-react';
-import { useDarkMode, useKibana } from '@kbn/kibana-react-plugin/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { KibanaServerError } from '@kbn/kibana-utils-plugin/public';
 import { FormField, FormRow } from '@kbn/security-form-components';
 import type {
@@ -185,7 +185,6 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
   isLoadingCurrentUser,
 }) => {
   const { euiTheme } = useEuiTheme();
-  const isDarkMode = useDarkMode();
   const {
     services: { http },
   } = useKibana();
@@ -743,7 +742,6 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                       fullWidth
                       languageId="xjson"
                       height={200}
-                      useDarkTheme={isDarkMode}
                     />
                   </FormRow>
                 </EuiPanel>
@@ -882,7 +880,6 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                           fullWidth
                           languageId="xjson"
                           height={200}
-                          useDarkTheme={isDarkMode}
                         />
                       </FormRow>
                     </>
@@ -967,7 +964,6 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                         fullWidth
                         languageId="xjson"
                         height={200}
-                        useDarkTheme={isDarkMode}
                       />
                     </FormRow>
                   </>

--- a/x-pack/platform/plugins/private/painless_lab/public/styles/_index.scss
+++ b/x-pack/platform/plugins/private/painless_lab/public/styles/_index.scss
@@ -12,7 +12,7 @@ $bottomBarHeight: $euiSize * 3;
 
 .painlessLabLeftPane {
   padding-top: $euiSizeM;
-  background-color: $euiFormBackgroundColor;
+  background-color: $euiColorEmptyShade;
 }
 
 .painlessLabRightPane {

--- a/x-pack/plugins/security/public/management/role_mappings/edit_role_mapping/rule_editor_panel/json_rule_editor.tsx
+++ b/x-pack/plugins/security/public/management/role_mappings/edit_role_mapping/rule_editor_panel/json_rule_editor.tsx
@@ -11,7 +11,7 @@ import React, { Fragment, useState } from 'react';
 import { CodeEditorField } from '@kbn/code-editor';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useDarkMode, useKibana } from '@kbn/kibana-react-plugin/public';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { XJsonLang } from '@kbn/monaco';
 
 import type { Rule } from '../../model';
@@ -26,7 +26,6 @@ interface Props {
 
 export const JSONRuleEditor = (props: Props) => {
   const docLinks = useKibana().services.docLinks!;
-  const isDarkMode = useDarkMode();
   const [rawRules, setRawRules] = useState(
     JSON.stringify(props.rules ? props.rules.toRaw() : {}, null, 2)
   );
@@ -102,7 +101,6 @@ export const JSONRuleEditor = (props: Props) => {
           onChange={onRulesChange}
           fullWidth={true}
           height="300px"
-          useDarkTheme={isDarkMode}
           options={{
             accessibilitySupport: 'off',
             lineNumbers: 'on',

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/index_privilege_form.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/index_privilege_form.tsx
@@ -436,7 +436,6 @@ export class IndexPrivilegeForm extends Component<Props, State> {
                   )}
                   value={indexPrivilege.query ?? ''}
                   onChange={this.onQueryChange}
-                  useDarkTheme={this.props.isDarkMode}
                   options={{
                     readOnly: this.props.isRoleReadOnly,
                     minimap: {


### PR DESCRIPTION
## Summary

<!-- ### DONT MERGE, THIS PR DEPENDS ON AN UPDATE TO EUI, THAT'S IN FLIGHT -->

Closes https://github.com/elastic/kibana/issues/202782

This PR reworks how custom themes used within the kibana code editor  for  the default visual look and ones specific to supported languages are defined to accomodate the upcoming visual refresh, the approach here leverages the `euiTheme` object value  returned from the `useEuiTheme` hook, now a single theme declaration is all that is required such that using either  the `colorMode `value  or the `euiTheme` from the provided `UseEUITheme` value it's possible to craft a theme that's in the context of kIbana, color mode aware and the editor would be able to resolve the appropriate colors depending on the user's color mode. 

This required some modification to monaco itself; now when defining languages if the  `CustomLanguageType` specification is being followed, a function that resolves to a standard monaco theme can be provided on the property `languageThemeResolver` which will be passed the `euiTheme` when registering this theme. It's worth mentioning that this can also be done manually by leveraging the custom method `registerLanguageThemeResolver` added  on the monaco editor object, like so 

```tsx
 monaco.editor.registerLanguageThemeResolver(LanguageID, languageThemeResolver);
``` 

However one should take note that when calling this method directly, the ID passed must correlate to a registered language ID, else the theme will not be available for use after Monaco is initialised, hence the theme name must equal an existing language ID if it's to be used for a specific language. 


## How to test

- Enable borealis, like so;
	- in your `kibana.dev.yml` file include the following config;
		```yml
		uiSettings.experimental.themeSwitcherEnabled: true
		```
	-  start kibana using the following command; `KBN_OPTIMIZER_THEMES="borealislight,borealisdark,v8light,v8dark" yarn start --run-examples`
- Tryout all downstream of the code editor to ascertain the code editor colors are as should be for both Amsterdam and Borealis; downstreams include; 
  - ES|QL editor, navigate to discover and click the "try ES|QL" button
  - Dev tools, on clicking the nav hamburger menu under the management menu group there's a menu item that links to all dev tools
  - Index Management use cases; navigate to stack management, under Index management select any existing index, then navigate to it's settings this should load up the code editor.
  - Saved Object use case; navigate to stack management, under saved objects attempt inspecting any saved object we'd be presented with the code editor  etc. 
  
<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


-->
