### PR TITLE
[8.x] [eem] metadata as keyword (#202611)

### DIFF
--- a/x-pack/plugins/entity_manager/server/lib/v2/queries/index.test.ts
+++ b/x-pack/plugins/entity_manager/server/lib/v2/queries/index.test.ts
@@ -29,9 +29,10 @@ describe('getEntityInstancesQuery', () => {
 
       expect(query).toEqual(
         'FROM logs-*, metrics-* | ' +
-          'WHERE service.name IS NOT NULL | ' +
+          'WHERE service.name::keyword IS NOT NULL | ' +
           'WHERE custom_timestamp_field >= "2024-11-20T19:00:00.000Z" AND custom_timestamp_field <= "2024-11-20T20:00:00.000Z" | ' +
-          'STATS host.name = VALUES(host.name), entity.last_seen_timestamp = MAX(custom_timestamp_field), service.id = MAX(service.id) BY service.name | ' +
+          'STATS host.name = VALUES(host.name::keyword), entity.last_seen_timestamp = MAX(custom_timestamp_field), service.id = MAX(service.id::keyword) BY service.name::keyword | ' +
+          'RENAME `service.name::keyword` AS service.name | ' +
           'EVAL entity.type = "service", entity.id = service.name, entity.display_name = COALESCE(service.id, entity.id) | ' +
           'SORT entity.id DESC | ' +
           'LIMIT 5'

--- a/x-pack/plugins/entity_manager/server/lib/v2/queries/utils.ts
+++ b/x-pack/plugins/entity_manager/server/lib/v2/queries/utils.ts
@@ -65,3 +65,7 @@ export function mergeEntitiesList(
 
   return Object.values(instances);
 }
+
+export function asKeyword(field: string) {
+  return `${field}::keyword`;
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[eem] metadata as keyword (#202611)](https://github.com/elastic/kibana/pull/202611)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Lacabane","email":"kevin.lacabane@elastic.co"},"sourceCommit":{"committedDate":"2024-12-05T11:57:12Z","message":"[eem] metadata as keyword (#202611)\n\nCast identity fields and metadata fields as keyword to prevent ambiguous\r\nmappings error\r\n\r\n### Testing\r\n\r\n- setup data\r\n```\r\nPUT service-name-as-keyword\r\n{\r\n    \"mappings\": {\r\n        \"dynamic\": false,\r\n        \"properties\": {\r\n            \"service.name\": {\r\n                \"type\": \"keyword\"\r\n            }\r\n        }\r\n    }\r\n}\r\n\r\nPOST service-name-as-keyword/_doc\r\n{\r\n  \"service.name\": \"as-keyword\"\r\n}\r\n\r\nPUT service-name-as-text\r\n{\r\n    \"mappings\": {\r\n        \"dynamic\": false,\r\n        \"properties\": {\r\n            \"service.name\": {\r\n                \"type\": \"text\"\r\n            }\r\n        }\r\n    }\r\n}\r\n\r\n\r\nPOST service-name-as-text/_doc\r\n{\r\n  \"service.name\": \"as-text\"\r\n}\r\n```\r\n\r\n- data loads successfully in `/app/entity_manager`\r\n![Screenshot 2024-12-03 at 11 50\r\n10](https://github.com/user-attachments/assets/12d6cbd8-c075-475f-b140-9158e93158ff)\r\n\r\n_new query_\r\n```\r\nPOST _query\r\n{\r\n    \"query\": \"\"\"FROM service-name-as* | WHERE service.name::keyword IS NOT NULL | STATS  BY service.name::keyword | RENAME `service.name::keyword` AS service.name | EVAL entity.type = \"service\", entity.id = service.name, entity.display_name = entity.id | SORT entity.id ASC | LIMIT 10\"\"\"\r\n}\r\n```\r\n\r\n- previous query fails with ambiguous mappings error\r\n```\r\nPOST _query\r\n{\r\n    \"query\": \"\"\"FROM service-name-as* | WHERE service.name IS NOT NULL | STATS  BY service.name | EVAL entity.type = \"service\", entity.id = service.name, entity.display_name = entity.id | SORT entity.id ASC | LIMIT 10\"\"\"\r\n}\r\n```","sha":"58f51fdac79937cd3706c9f202e460b7a568fc12","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","backport:prev-minor","Team:obs-entities"],"number":202611,"url":"https://github.com/elastic/kibana/pull/202611","mergeCommit":{"message":"[eem] metadata as keyword (#202611)\n\nCast identity fields and metadata fields as keyword to prevent ambiguous\r\nmappings error\r\n\r\n### Testing\r\n\r\n- setup data\r\n```\r\nPUT service-name-as-keyword\r\n{\r\n    \"mappings\": {\r\n        \"dynamic\": false,\r\n        \"properties\": {\r\n            \"service.name\": {\r\n                \"type\": \"keyword\"\r\n            }\r\n        }\r\n    }\r\n}\r\n\r\nPOST service-name-as-keyword/_doc\r\n{\r\n  \"service.name\": \"as-keyword\"\r\n}\r\n\r\nPUT service-name-as-text\r\n{\r\n    \"mappings\": {\r\n        \"dynamic\": false,\r\n        \"properties\": {\r\n            \"service.name\": {\r\n                \"type\": \"text\"\r\n            }\r\n        }\r\n    }\r\n}\r\n\r\n\r\nPOST service-name-as-text/_doc\r\n{\r\n  \"service.name\": \"as-text\"\r\n}\r\n```\r\n\r\n- data loads successfully in `/app/entity_manager`\r\n![Screenshot 2024-12-03 at 11 50\r\n10](https://github.com/user-attachments/assets/12d6cbd8-c075-475f-b140-9158e93158ff)\r\n\r\n_new query_\r\n```\r\nPOST _query\r\n{\r\n    \"query\": \"\"\"FROM service-name-as* | WHERE service.name::keyword IS NOT NULL | STATS  BY service.name::keyword | RENAME `service.name::keyword` AS service.name | EVAL entity.type = \"service\", entity.id = service.name, entity.display_name = entity.id | SORT entity.id ASC | LIMIT 10\"\"\"\r\n}\r\n```\r\n\r\n- previous query fails with ambiguous mappings error\r\n```\r\nPOST _query\r\n{\r\n    \"query\": \"\"\"FROM service-name-as* | WHERE service.name IS NOT NULL | STATS  BY service.name | EVAL entity.type = \"service\", entity.id = service.name, entity.display_name = entity.id | SORT entity.id ASC | LIMIT 10\"\"\"\r\n}\r\n```","sha":"58f51fdac79937cd3706c9f202e460b7a568fc12"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/202611","number":202611,"mergeCommit":{"message":"[eem] metadata as keyword (#202611)\n\nCast identity fields and metadata fields as keyword to prevent ambiguous\r\nmappings error\r\n\r\n### Testing\r\n\r\n- setup data\r\n```\r\nPUT service-name-as-keyword\r\n{\r\n    \"mappings\": {\r\n        \"dynamic\": false,\r\n        \"properties\": {\r\n            \"service.name\": {\r\n                \"type\": \"keyword\"\r\n            }\r\n        }\r\n    }\r\n}\r\n\r\nPOST service-name-as-keyword/_doc\r\n{\r\n  \"service.name\": \"as-keyword\"\r\n}\r\n\r\nPUT service-name-as-text\r\n{\r\n    \"mappings\": {\r\n        \"dynamic\": false,\r\n        \"properties\": {\r\n            \"service.name\": {\r\n                \"type\": \"text\"\r\n            }\r\n        }\r\n    }\r\n}\r\n\r\n\r\nPOST service-name-as-text/_doc\r\n{\r\n  \"service.name\": \"as-text\"\r\n}\r\n```\r\n\r\n- data loads successfully in `/app/entity_manager`\r\n![Screenshot 2024-12-03 at 11 50\r\n10](https://github.com/user-attachments/assets/12d6cbd8-c075-475f-b140-9158e93158ff)\r\n\r\n_new query_\r\n```\r\nPOST _query\r\n{\r\n    \"query\": \"\"\"FROM service-name-as* | WHERE service.name::keyword IS NOT NULL | STATS  BY service.name::keyword | RENAME `service.name::keyword` AS service.name | EVAL entity.type = \"service\", entity.id = service.name, entity.display_name = entity.id | SORT entity.id ASC | LIMIT 10\"\"\"\r\n}\r\n```\r\n\r\n- previous query fails with ambiguous mappings error\r\n```\r\nPOST _query\r\n{\r\n    \"query\": \"\"\"FROM service-name-as* | WHERE service.name IS NOT NULL | STATS  BY service.name | EVAL entity.type = \"service\", entity.id = service.name, entity.display_name = entity.id | SORT entity.id ASC | LIMIT 10\"\"\"\r\n}\r\n```","sha":"58f51fdac79937cd3706c9f202e460b7a568fc12"}}]}] BACKPORT-->