### PR TITLE
[Index management] Fix a11y focus order in index mappings page 

### DIFF
--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/document_fields.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/document_fields.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { deNormalize } from '../../lib';
 import { useDispatch, useMappingsState } from '../../mappings_state_context';
@@ -27,6 +27,7 @@ interface Props {
   onCancelAddingNewFields?: () => void;
   isAddingFields?: boolean;
   semanticTextInfo?: SemanticTextInfo;
+  editFieldButtonRef: React.RefObject<HTMLButtonElement>;
 }
 export const DocumentFields = React.memo(
   ({
@@ -35,6 +36,7 @@ export const DocumentFields = React.memo(
     onCancelAddingNewFields,
     isAddingFields,
     semanticTextInfo,
+    editFieldButtonRef,
   }: Props) => {
     const { fields, documentFields } = useMappingsState();
     const dispatch = useDispatch();
@@ -64,14 +66,14 @@ export const DocumentFields = React.memo(
     const exitEdit = useCallback(() => {
       dispatch({ type: 'documentField.changeStatus', value: 'idle' });
     }, [dispatch]);
-
+    // const editFieldButtonRef = useRef<HTMLButtonElement>(null);
     useEffect(() => {
       if (isEditing) {
         // Open the flyout with the <EditField /> content
         addContentToGlobalFlyout<EditFieldContainerProps>({
           id: 'mappingsEditField',
           Component: EditFieldContainer,
-          props: { exitEdit },
+          props: { exitEdit, editFieldButtonRef },
           flyoutProps: { ...defaultFlyoutProps, onClose: exitEdit },
           cleanUpFunc: exitEdit,
         });

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/document_fields.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/document_fields.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { deNormalize } from '../../lib';
 import { useDispatch, useMappingsState } from '../../mappings_state_context';
@@ -27,7 +27,7 @@ interface Props {
   onCancelAddingNewFields?: () => void;
   isAddingFields?: boolean;
   semanticTextInfo?: SemanticTextInfo;
-  editFieldButtonRef: React.RefObject<HTMLButtonElement>;
+  pendingFieldsRef?: React.RefObject<HTMLDivElement>;
 }
 export const DocumentFields = React.memo(
   ({
@@ -36,7 +36,7 @@ export const DocumentFields = React.memo(
     onCancelAddingNewFields,
     isAddingFields,
     semanticTextInfo,
-    editFieldButtonRef,
+    pendingFieldsRef,
   }: Props) => {
     const { fields, documentFields } = useMappingsState();
     const dispatch = useDispatch();
@@ -60,20 +60,21 @@ export const DocumentFields = React.memo(
           onCancelAddingNewFields={onCancelAddingNewFields}
           isAddingFields={isAddingFields}
           semanticTextInfo={semanticTextInfo}
+          pendingFieldsRef={pendingFieldsRef}
         />
       );
 
     const exitEdit = useCallback(() => {
       dispatch({ type: 'documentField.changeStatus', value: 'idle' });
     }, [dispatch]);
-    // const editFieldButtonRef = useRef<HTMLButtonElement>(null);
+
     useEffect(() => {
       if (isEditing) {
         // Open the flyout with the <EditField /> content
         addContentToGlobalFlyout<EditFieldContainerProps>({
           id: 'mappingsEditField',
           Component: EditFieldContainer,
-          props: { exitEdit, editFieldButtonRef },
+          props: { exitEdit },
           flyoutProps: { ...defaultFlyoutProps, onClose: exitEdit },
           cleanUpFunc: exitEdit,
         });
@@ -83,8 +84,9 @@ export const DocumentFields = React.memo(
     useEffect(() => {
       if (!isEditing) {
         removeContentFromGlobalFlyout('mappingsEditField');
+        if (pendingFieldsRef?.current) pendingFieldsRef.current.focus();
       }
-    }, [isEditing, removeContentFromGlobalFlyout]);
+    }, [isEditing, removeContentFromGlobalFlyout, pendingFieldsRef]);
 
     useEffect(() => {
       return () => {

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/type_parameter.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/type_parameter.tsx
@@ -24,6 +24,7 @@ interface Props {
   isMultiField?: boolean | null;
   showDocLink?: boolean;
   isSemanticTextEnabled?: boolean;
+  fieldTypeInputRef: React.MutableRefObject<HTMLInputElement | null>;
 }
 
 export const TypeParameter = ({
@@ -31,6 +32,7 @@ export const TypeParameter = ({
   isRootLevelField,
   showDocLink = false,
   isSemanticTextEnabled = true,
+  fieldTypeInputRef,
 }: Props) => {
   const fieldTypeOptions = useMemo(() => {
     let options = isMultiField
@@ -97,6 +99,9 @@ export const TypeParameter = ({
               onChange={typeField.setValue}
               isClearable={false}
               data-test-subj="fieldType"
+              inputRef={(input) => {
+                if (fieldTypeInputRef) fieldTypeInputRef.current = input;
+              }}
             />
           </EuiFormRow>
         );

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/type_parameter.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/type_parameter.tsx
@@ -24,7 +24,7 @@ interface Props {
   isMultiField?: boolean | null;
   showDocLink?: boolean;
   isSemanticTextEnabled?: boolean;
-  fieldTypeInputRef: React.MutableRefObject<HTMLInputElement | null>;
+  fieldTypeInputRef?: React.MutableRefObject<HTMLInputElement | null>;
 }
 
 export const TypeParameter = ({

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/create_field.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/create_field.tsx
@@ -113,9 +113,11 @@ export const CreateField = React.memo(function CreateFieldComponent({
   });
 
   const isSemanticText = form.getFormData().type === 'semantic_text';
+
   useEffect(() => {
     if (createFieldFormRef?.current) createFieldFormRef?.current.focus();
   }, [createFieldFormRef]);
+
   const submitForm = async (
     e?: React.FormEvent,
     exitAfter: boolean = false,

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/create_field.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/create_field.tsx
@@ -17,7 +17,7 @@ import { i18n } from '@kbn/i18n';
 import { TrainedModelStat } from '@kbn/ml-plugin/common/types/trained_models';
 import { MlPluginStart } from '@kbn/ml-plugin/public';
 import classNames from 'classnames';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { EUI_SIZE, TYPE_DEFINITION } from '../../../../constants';
 import { fieldSerializer } from '../../../../lib';
 import { isSemanticTextField } from '../../../../lib/utils';
@@ -62,6 +62,7 @@ interface Props {
   onCancelAddingNewFields?: () => void;
   isAddingFields?: boolean;
   semanticTextInfo?: SemanticTextInfo;
+  createFieldFormRef: React.RefObject<HTMLDivElement>;
 }
 
 export const CreateField = React.memo(function CreateFieldComponent({
@@ -74,9 +75,11 @@ export const CreateField = React.memo(function CreateFieldComponent({
   onCancelAddingNewFields,
   isAddingFields,
   semanticTextInfo,
+  createFieldFormRef,
 }: Props) {
   const { isSemanticTextEnabled, ml, setErrorsInTrainedModelDeployment } = semanticTextInfo ?? {};
   const dispatch = useDispatch();
+  const fieldTypeInputRef = useRef<HTMLInputElement>(null);
 
   const { form } = useForm<Field>({
     serializer: fieldSerializer,
@@ -110,7 +113,9 @@ export const CreateField = React.memo(function CreateFieldComponent({
   });
 
   const isSemanticText = form.getFormData().type === 'semantic_text';
-
+  useEffect(() => {
+    if (createFieldFormRef?.current) createFieldFormRef?.current.focus();
+  }, [createFieldFormRef]);
   const submitForm = async (
     e?: React.FormEvent,
     exitAfter: boolean = false,
@@ -133,6 +138,10 @@ export const CreateField = React.memo(function CreateFieldComponent({
         cancel();
       }
       form.reset();
+    }
+
+    if (fieldTypeInputRef.current) {
+      fieldTypeInputRef.current.focus();
     }
   };
 
@@ -157,6 +166,7 @@ export const CreateField = React.memo(function CreateFieldComponent({
           isMultiField={isMultiField}
           showDocLink
           isSemanticTextEnabled={isSemanticTextEnabled}
+          fieldTypeInputRef={fieldTypeInputRef}
         />
       </EuiFlexItem>
 
@@ -266,6 +276,8 @@ export const CreateField = React.memo(function CreateFieldComponent({
                   : paddingLeft
               }px`,
             }}
+            ref={createFieldFormRef}
+            tabIndex={0}
           >
             <div className="mappingsEditor__createFieldContent">
               {renderFormFields()}

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/create_field.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/create_field.tsx
@@ -62,7 +62,7 @@ interface Props {
   onCancelAddingNewFields?: () => void;
   isAddingFields?: boolean;
   semanticTextInfo?: SemanticTextInfo;
-  createFieldFormRef: React.RefObject<HTMLDivElement>;
+  createFieldFormRef?: React.RefObject<HTMLDivElement>;
 }
 
 export const CreateField = React.memo(function CreateFieldComponent({

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useRef } from 'react';
+import React from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiFlyoutHeader,

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field.tsx
@@ -59,16 +59,11 @@ const FormWrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) => 
 
 export const EditField = React.memo(
   ({ form, field, allFields, exitEdit, updateField, kibanaVersion }: Props) => {
-    const fieldTypeInputRef = useRef<HTMLInputElement>(null);
-
     const submitForm = async () => {
       const { isValid, data } = await form.submit();
 
       if (isValid) {
         updateField({ ...field, source: data });
-      }
-      if (fieldTypeInputRef.current) {
-        fieldTypeInputRef.current.focus();
       }
     };
 
@@ -154,7 +149,6 @@ export const EditField = React.memo(
             defaultValue={field.source}
             isRootLevelField={field.parentId === undefined}
             isMultiField={isMultiField}
-            fieldTypeInputRef={fieldTypeInputRef}
           />
 
           <FormDataProvider pathsToWatch={['type', 'subType']}>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiFlyoutHeader,
@@ -59,11 +59,16 @@ const FormWrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) => 
 
 export const EditField = React.memo(
   ({ form, field, allFields, exitEdit, updateField, kibanaVersion }: Props) => {
+    const fieldTypeInputRef = useRef<HTMLInputElement>(null);
+
     const submitForm = async () => {
       const { isValid, data } = await form.submit();
 
       if (isValid) {
         updateField({ ...field, source: data });
+      }
+      if (fieldTypeInputRef.current) {
+        fieldTypeInputRef.current.focus();
       }
     };
 
@@ -149,6 +154,7 @@ export const EditField = React.memo(
             defaultValue={field.source}
             isRootLevelField={field.parentId === undefined}
             isMultiField={isMultiField}
+            fieldTypeInputRef={fieldTypeInputRef}
           />
 
           <FormDataProvider pathsToWatch={['type', 'subType']}>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_container.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_container.tsx
@@ -25,9 +25,10 @@ export const defaultFlyoutProps = {
 
 export interface Props {
   exitEdit: () => void;
+  editFieldButtonRef: React.RefObject<HTMLButtonElement>;
 }
 
-export const EditFieldContainer = React.memo(({ exitEdit }: Props) => {
+export const EditFieldContainer = React.memo(({ exitEdit, editFieldButtonRef }: Props) => {
   const { fields, documentFields } = useMappingsState();
   const dispatch = useDispatch();
   const { updateField, modal } = useUpdateField();
@@ -78,6 +79,7 @@ export const EditFieldContainer = React.memo(({ exitEdit }: Props) => {
         exitEdit={exitEdit}
         updateField={updateField}
         kibanaVersion={kibanaVersion.get()}
+        // editFieldButtonRef={editFieldButtonRef}
       />
       {renderModal()}
     </>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_container.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_container.tsx
@@ -25,10 +25,9 @@ export const defaultFlyoutProps = {
 
 export interface Props {
   exitEdit: () => void;
-  editFieldButtonRef: React.RefObject<HTMLButtonElement>;
 }
 
-export const EditFieldContainer = React.memo(({ exitEdit, editFieldButtonRef }: Props) => {
+export const EditFieldContainer = React.memo(({ exitEdit }: Props) => {
   const { fields, documentFields } = useMappingsState();
   const dispatch = useDispatch();
   const { updateField, modal } = useUpdateField();
@@ -79,7 +78,6 @@ export const EditFieldContainer = React.memo(({ exitEdit, editFieldButtonRef }: 
         exitEdit={exitEdit}
         updateField={updateField}
         kibanaVersion={kibanaVersion.get()}
-        // editFieldButtonRef={editFieldButtonRef}
       />
       {renderModal()}
     </>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_header_form.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_header_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
 import { FormDataProvider } from '../../../../shared_imports';
@@ -19,6 +19,7 @@ interface Props {
   defaultValue: Field;
   isRootLevelField: boolean;
   isMultiField: boolean;
+  fieldTypeInputRef: React.MutableRefObject<HTMLInputElement | null>;
 }
 
 const getTypeDefinition = (type: MainType, subType: SubType): DataTypeDefinition | undefined => {
@@ -41,7 +42,7 @@ const getTypeDefinition = (type: MainType, subType: SubType): DataTypeDefinition
 };
 
 export const EditFieldHeaderForm = React.memo(
-  ({ defaultValue, isRootLevelField, isMultiField }: Props) => {
+  ({ defaultValue, isRootLevelField, isMultiField, fieldTypeInputRef }: Props) => {
     return (
       <>
         <EuiFlexGroup gutterSize="s">
@@ -52,7 +53,11 @@ export const EditFieldHeaderForm = React.memo(
 
           {/* Field type */}
           <EuiFlexItem>
-            <TypeParameter isRootLevelField={isRootLevelField} isMultiField={isMultiField} />
+            <TypeParameter
+              isRootLevelField={isRootLevelField}
+              isMultiField={isMultiField}
+              fieldTypeInputRef={fieldTypeInputRef}
+            />
           </EuiFlexItem>
 
           {/* Field subType (if any) */}

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_header_form.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_header_form.tsx
@@ -19,7 +19,6 @@ interface Props {
   defaultValue: Field;
   isRootLevelField: boolean;
   isMultiField: boolean;
-  fieldTypeInputRef: React.MutableRefObject<HTMLInputElement | null>;
 }
 
 const getTypeDefinition = (type: MainType, subType: SubType): DataTypeDefinition | undefined => {
@@ -42,7 +41,7 @@ const getTypeDefinition = (type: MainType, subType: SubType): DataTypeDefinition
 };
 
 export const EditFieldHeaderForm = React.memo(
-  ({ defaultValue, isRootLevelField, isMultiField, fieldTypeInputRef }: Props) => {
+  ({ defaultValue, isRootLevelField, isMultiField }: Props) => {
     return (
       <>
         <EuiFlexGroup gutterSize="s">
@@ -53,11 +52,7 @@ export const EditFieldHeaderForm = React.memo(
 
           {/* Field type */}
           <EuiFlexItem>
-            <TypeParameter
-              isRootLevelField={isRootLevelField}
-              isMultiField={isMultiField}
-              fieldTypeInputRef={fieldTypeInputRef}
-            />
+            <TypeParameter isRootLevelField={isRootLevelField} isMultiField={isMultiField} />
           </EuiFlexItem>
 
           {/* Field subType (if any) */}

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_header_form.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/edit_field/edit_field_header_form.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useRef } from 'react';
+import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
 import { FormDataProvider } from '../../../../shared_imports';

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list.tsx
@@ -16,6 +16,7 @@ interface Props {
   state: State;
   setPreviousState?: (state: State) => void;
   isAddingFields?: boolean;
+  pendingFieldsRef?: React.RefObject<HTMLDivElement>;
 }
 
 export const FieldsList = React.memo(function FieldsListComponent({
@@ -24,6 +25,7 @@ export const FieldsList = React.memo(function FieldsListComponent({
   state,
   setPreviousState,
   isAddingFields,
+  pendingFieldsRef,
 }: Props) {
   if (fields === undefined) {
     return null;
@@ -39,6 +41,7 @@ export const FieldsList = React.memo(function FieldsListComponent({
           state={state}
           setPreviousState={setPreviousState}
           isAddingFields={isAddingFields}
+          pendingFieldsRef={pendingFieldsRef}
         />
       ))}
     </ul>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useRef } from 'react';
 import classNames from 'classnames';
 import {
   EuiFlexGroup,
@@ -64,6 +64,7 @@ interface Props {
   treeDepth: number;
   state: State;
   isAddingFields?: boolean;
+  createFieldFormRef: React.RefObject<HTMLDivElement>;
 }
 
 function FieldListItemComponent(
@@ -85,6 +86,7 @@ function FieldListItemComponent(
     state,
     isAddingFields,
     setPreviousState,
+    createFieldFormRef,
   }: Props,
   ref: React.Ref<HTMLLIElement>
 ) {
@@ -130,6 +132,7 @@ function FieldListItemComponent(
         paddingLeft={indentCreateField}
         maxNestedDepth={maxNestedDepth}
         isAddingFields={isAddingFields}
+        createFieldFormRef={createFieldFormRef}
       />
     );
   };
@@ -141,7 +144,6 @@ function FieldListItemComponent(
 
     const { addMultiFieldButtonLabel, addPropertyButtonLabel, editButtonLabel, deleteButtonLabel } =
       i18nTexts;
-
     return (
       <EuiFlexGroup gutterSize="s" className="mappingsEditor__fieldsListItem__actions">
         {canHaveMultiFields && (
@@ -177,6 +179,7 @@ function FieldListItemComponent(
               onClick={editField}
               data-test-subj="editFieldButton"
               aria-label={editButtonLabel}
+              buttonRef={editFieldButtonRef}
             />
           </EuiToolTip>
         </EuiFlexItem>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
@@ -64,7 +64,7 @@ interface Props {
   treeDepth: number;
   state: State;
   isAddingFields?: boolean;
-  createFieldFormRef: React.RefObject<HTMLDivElement>;
+  createFieldFormRef?: React.RefObject<HTMLDivElement>;
   pendingFieldsRef?: React.RefObject<HTMLDivElement>;
 }
 
@@ -87,7 +87,6 @@ function FieldListItemComponent(
     state,
     isAddingFields,
     setPreviousState,
-    createFieldFormRef,
     pendingFieldsRef,
   }: Props,
   ref: React.Ref<HTMLLIElement>
@@ -134,7 +133,6 @@ function FieldListItemComponent(
         paddingLeft={indentCreateField}
         maxNestedDepth={maxNestedDepth}
         isAddingFields={isAddingFields}
-        createFieldFormRef={createFieldFormRef}
       />
     );
   };

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { forwardRef, useRef } from 'react';
+import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 import {
   EuiFlexGroup,
@@ -65,6 +65,7 @@ interface Props {
   state: State;
   isAddingFields?: boolean;
   createFieldFormRef: React.RefObject<HTMLDivElement>;
+  pendingFieldsRef?: React.RefObject<HTMLDivElement>;
 }
 
 function FieldListItemComponent(
@@ -87,6 +88,7 @@ function FieldListItemComponent(
     isAddingFields,
     setPreviousState,
     createFieldFormRef,
+    pendingFieldsRef,
   }: Props,
   ref: React.Ref<HTMLLIElement>
 ) {
@@ -179,7 +181,6 @@ function FieldListItemComponent(
               onClick={editField}
               data-test-subj="editFieldButton"
               aria-label={editButtonLabel}
-              buttonRef={editFieldButtonRef}
             />
           </EuiToolTip>
         </EuiFlexItem>
@@ -324,6 +325,7 @@ function FieldListItemComponent(
           state={state}
           isAddingFields={isAddingFields}
           setPreviousState={setPreviousState}
+          pendingFieldsRef={pendingFieldsRef}
         />
       )}
 

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item_container.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item_container.tsx
@@ -31,7 +31,6 @@ export const FieldsListItemContainer = ({
   pendingFieldsRef,
 }: Props) => {
   const dispatch = useDispatch();
-  const createFieldFormRef = useRef<HTMLDivElement>(null);
   const listElement = useRef<HTMLLIElement | null>(null);
   const {
     documentFields: { status, fieldToAddFieldTo, fieldToEdit },
@@ -113,7 +112,6 @@ export const FieldsListItemContainer = ({
       toggleExpand={toggleExpand}
       state={state}
       isAddingFields={isAddingFields}
-      createFieldFormRef={createFieldFormRef}
       pendingFieldsRef={pendingFieldsRef}
     />
   );

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item_container.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item_container.tsx
@@ -29,6 +29,7 @@ export const FieldsListItemContainer = ({
   isAddingFields,
 }: Props) => {
   const dispatch = useDispatch();
+  const createFieldFormRef = useRef<HTMLDivElement>(null);
   const listElement = useRef<HTMLLIElement | null>(null);
   const {
     documentFields: { status, fieldToAddFieldTo, fieldToEdit },
@@ -58,6 +59,10 @@ export const FieldsListItemContainer = ({
       type: 'documentField.createField',
       value: fieldId,
     });
+    // console.log('Field_list_item_container createFieldFormRef.current', createFieldFormRef.current);
+    // if (createFieldFormRef.current) {
+    //   createFieldFormRef.current.focus();
+    // }
   }, [fieldId, dispatch]);
 
   const editField = useCallback(() => {
@@ -110,6 +115,7 @@ export const FieldsListItemContainer = ({
       toggleExpand={toggleExpand}
       state={state}
       isAddingFields={isAddingFields}
+      createFieldFormRef={createFieldFormRef}
     />
   );
 };

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item_container.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item_container.tsx
@@ -18,6 +18,7 @@ interface Props {
   state: State;
   setPreviousState?: (state: State) => void;
   isAddingFields?: boolean;
+  pendingFieldsRef?: React.RefObject<HTMLDivElement>;
 }
 
 export const FieldsListItemContainer = ({
@@ -27,6 +28,7 @@ export const FieldsListItemContainer = ({
   state,
   setPreviousState,
   isAddingFields,
+  pendingFieldsRef,
 }: Props) => {
   const dispatch = useDispatch();
   const createFieldFormRef = useRef<HTMLDivElement>(null);
@@ -59,10 +61,6 @@ export const FieldsListItemContainer = ({
       type: 'documentField.createField',
       value: fieldId,
     });
-    // console.log('Field_list_item_container createFieldFormRef.current', createFieldFormRef.current);
-    // if (createFieldFormRef.current) {
-    //   createFieldFormRef.current.focus();
-    // }
   }, [fieldId, dispatch]);
 
   const editField = useCallback(() => {
@@ -116,6 +114,7 @@ export const FieldsListItemContainer = ({
       state={state}
       isAddingFields={isAddingFields}
       createFieldFormRef={createFieldFormRef}
+      pendingFieldsRef={pendingFieldsRef}
     />
   );
 };

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields_tree_editor.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields_tree_editor.tsx
@@ -16,12 +16,14 @@ interface Props {
   onCancelAddingNewFields?: () => void;
   isAddingFields?: boolean;
   semanticTextInfo?: SemanticTextInfo;
+  pendingFieldsRef?: React.RefObject<HTMLDivElement>;
 }
 
 export const DocumentFieldsTreeEditor = ({
   onCancelAddingNewFields,
   isAddingFields,
   semanticTextInfo,
+  pendingFieldsRef,
 }: Props) => {
   const dispatch = useDispatch();
   const {
@@ -81,7 +83,12 @@ export const DocumentFieldsTreeEditor = ({
 
   return (
     <>
-      <FieldsList fields={fields} state={useMappingsState()} isAddingFields={isAddingFields} />
+      <FieldsList
+        fields={fields}
+        state={useMappingsState()}
+        isAddingFields={isAddingFields}
+        pendingFieldsRef={pendingFieldsRef}
+      />
       {renderCreateField()}
       {renderAddFieldButton()}
     </>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields_tree_editor.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields_tree_editor.tsx
@@ -7,7 +7,7 @@
 
 import { EuiButtonEmpty, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 
 import { useDispatch, useMappingsState } from '../../mappings_state_context';
 import { CreateField, FieldsList, SemanticTextInfo } from './fields';
@@ -28,13 +28,16 @@ export const DocumentFieldsTreeEditor = ({
     fields: { byId, rootLevelFields },
     documentFields: { status, fieldToAddFieldTo },
   } = useMappingsState();
-
+  const createFieldFormRef = useRef<HTMLDivElement>(null);
   const getField = useCallback((fieldId: string) => byId[fieldId], [byId]);
   const fields = useMemo(() => rootLevelFields.map(getField), [rootLevelFields, getField]);
 
   const addField = useCallback(() => {
     dispatch({ type: 'documentField.createField' });
-  }, [dispatch]);
+    if (createFieldFormRef.current) {
+      createFieldFormRef.current.focus();
+    }
+  }, [dispatch, createFieldFormRef.current]);
 
   const renderCreateField = () => {
     // The "fieldToAddFieldTo" is undefined when adding to the top level "properties" object.
@@ -52,6 +55,7 @@ export const DocumentFieldsTreeEditor = ({
         onCancelAddingNewFields={onCancelAddingNewFields}
         isAddingFields={isAddingFields}
         semanticTextInfo={semanticTextInfo}
+        createFieldFormRef={createFieldFormRef}
       />
     );
   };

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields_tree_editor.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields_tree_editor.tsx
@@ -36,10 +36,7 @@ export const DocumentFieldsTreeEditor = ({
 
   const addField = useCallback(() => {
     dispatch({ type: 'documentField.createField' });
-    if (createFieldFormRef.current) {
-      createFieldFormRef.current.focus();
-    }
-  }, [dispatch, createFieldFormRef.current]);
+  }, [dispatch]);
 
   const renderCreateField = () => {
     // The "fieldToAddFieldTo" is undefined when adding to the top level "properties" object.

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -85,7 +85,8 @@ export const DetailsPageMappingsContent: FunctionComponent<{
     overlays,
     history,
   } = useAppContext();
-  const editFieldButtonRef = useRef<HTMLButtonElement>(null);
+  const pendingFieldsRef = useRef<HTMLDivElement>(null);
+
   const [isPlatinumLicense, setIsPlatinumLicense] = useState<boolean>(false);
   useEffect(() => {
     const subscription = licensing?.license$.subscribe((license: ILicense) => {
@@ -559,7 +560,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
           </EuiFlexItem>
           {errorSavingMappings}
           {isAddingFields && (
-            <EuiFlexItem grow={false}>
+            <EuiFlexItem grow={false} ref={pendingFieldsRef} tabIndex={0}>
               <EuiPanel hasBorder paddingSize="s">
                 <EuiAccordion
                   id={pendingFieldListId}
@@ -597,13 +598,13 @@ export const DetailsPageMappingsContent: FunctionComponent<{
                         onCancelAddingNewFields={onCancelAddingNewFields}
                         isAddingFields={isAddingFields}
                         semanticTextInfo={semanticTextInfo}
-                        editFieldButtonRef={editFieldButtonRef}
+                        pendingFieldsRef={pendingFieldsRef}
                       />
                     ) : (
                       <DocumentFields
                         isAddingFields={isAddingFields}
                         semanticTextInfo={semanticTextInfo}
-                        editFieldButtonRef={editFieldButtonRef}
+                        pendingFieldsRef={pendingFieldsRef}
                       />
                     )}
                   </EuiPanel>

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -27,7 +27,7 @@ import {
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ILicense } from '@kbn/licensing-plugin/public';
 import { useUnsavedChangesPrompt } from '@kbn/unsaved-changes-prompt';
 import {
@@ -85,7 +85,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
     overlays,
     history,
   } = useAppContext();
-
+  const editFieldButtonRef = useRef<HTMLButtonElement>(null);
   const [isPlatinumLicense, setIsPlatinumLicense] = useState<boolean>(false);
   useEffect(() => {
     const subscription = licensing?.license$.subscribe((license: ILicense) => {
@@ -597,11 +597,13 @@ export const DetailsPageMappingsContent: FunctionComponent<{
                         onCancelAddingNewFields={onCancelAddingNewFields}
                         isAddingFields={isAddingFields}
                         semanticTextInfo={semanticTextInfo}
+                        editFieldButtonRef={editFieldButtonRef}
                       />
                     ) : (
                       <DocumentFields
                         isAddingFields={isAddingFields}
                         semanticTextInfo={semanticTextInfo}
+                        editFieldButtonRef={editFieldButtonRef}
                       />
                     )}
                   </EuiPanel>


### PR DESCRIPTION
## Summary

Fix a11y focus order in index mappings page. When new field is in pending state and  after closing edit pending field Flyout.

https://github.com/user-attachments/assets/dbdf59e5-0ebd-47e0-9b5e-19ab1556e771

### Test instructions 
#### Adding a field
1. Add new field in index mappings page by navigating via tab 
2. Notice that type fields combo box is focused
3. Add field and click to Add field button again with in pending fields form
4. Notice focus is on new create field form

#### Edit field in pending state
1. Add new fields via tab key
2. click on edit field 
3. Try closing, updating and cancelling in the edit field flyout form
4. Notice after edit field flyout is closed, focus is on the pending fields form


 






<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.x"]} ONMERGE-->