### PR TITLE
[Search][Connectors] Disable setup options after creating configuration

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/start_step.tsx
@@ -67,6 +67,7 @@ export const StartStep: React.FC<StartStepProps> = ({
     generatedConfigData,
     isGenerateLoading,
     isCreateLoading,
+    isFormDirty,
   } = useValues(NewConnectorLogic);
   const { setRawName, createConnector, generateConnectorName, setFormDirty } =
     useActions(NewConnectorLogic);
@@ -211,7 +212,9 @@ export const StartStep: React.FC<StartStepProps> = ({
                     { defaultMessage: 'Elastic managed' }
                   )}
                   checked={selfManagePreference === 'native'}
-                  disabled={selectedConnector?.isNative === false || isRunningLocally}
+                  disabled={
+                    selectedConnector?.isNative === false || isRunningLocally || isFormDirty
+                  }
                   onChange={() => onSelfManagePreferenceChange('native')}
                   name="setUp"
                 />
@@ -232,6 +235,7 @@ export const StartStep: React.FC<StartStepProps> = ({
                     { defaultMessage: 'Self-managed' }
                   )}
                   checked={selfManagePreference === 'selfManaged'}
+                  disabled={isFormDirty}
                   onChange={() => onSelfManagePreferenceChange('selfManaged')}
                   name="setUp"
                 />


### PR DESCRIPTION
## Summary

This PR disables the _Elastic managed_ and _Self-managed_ setup options after clicking the _Generate configuration_ button in order to avoid the error described in this ticket https://github.com/elastic/search-team/issues/8665 when changing deployment method after generating the config.

![CleanShot 2024-12-09 at 10 32 08@2x](https://github.com/user-attachments/assets/dafea7ac-5d50-44a0-a59d-03ee29043dec)




<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->