### PR TITLE
Update .NET documentation

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/common/tutorial/instructions/apm_agent_instructions.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/tutorial/instructions/apm_agent_instructions.ts
@@ -384,21 +384,22 @@ export const createDotNetAgentInstructions = (apmServerUrl = '', secretToken = '
     }),
     textPre: i18n.translate('xpack.apm.tutorial.dotNetClient.configureApplication.textPre', {
       defaultMessage:
-        'In case of ASP.NET Core with the `Elastic.Apm.NetCoreAll` package, call the `UseAllElasticApm` \
-      method in the `Configure` method within the `Startup.cs` file.',
+        'In case of ASP.NET Core with the `Elastic.Apm.NetCoreAll` package, call the `AddAllElasticApm` \
+      extension method on the `IServiceCollection` available via the `WebApplicationBuilder` \
+      within the `Program.cs` file.',
     }),
-    commands: `public class Startup
-{curlyOpen}
-  public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-  {curlyOpen}
-    app.UseAllElasticApm(Configuration);
-    //…rest of the method
-  {curlyClose}
-  //…rest of the class
-{curlyClose}`.split('\n'),
+    commands: `var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAllElasticApm();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+
+app.Run();`.split('\n'),
     textPost: i18n.translate('xpack.apm.tutorial.dotNetClient.configureApplication.textPost', {
       defaultMessage:
-        'Passing an `IConfiguration` instance is optional and by doing so, the agent will read config settings through this \
+        'The agent will implicitly read config settings from the applications \
       `IConfiguration` instance (e.g. from the `appsettings.json` file).',
     }),
   },
@@ -409,8 +410,7 @@ export const createDotNetAgentInstructions = (apmServerUrl = '', secretToken = '
     customComponentName: 'TutorialConfigAgent',
     textPost: i18n.translate('xpack.apm.tutorial.dotNetClient.configureAgent.textPost', {
       defaultMessage:
-        'In case you don’t pass an `IConfiguration` instance to the agent (e.g. in case of non ASP.NET Core applications) \
-      you can also configure the agent through environment variables. \n \
+        'You can also configure the agent through environment variables. \n \
       See [the documentation]({documentationLink}) for advanced usage, including the [Profiler Auto instrumentation]({profilerLink}) quick start.',
       values: {
         documentationLink:

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/instructions/dotnet_agent.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/instructions/dotnet_agent.tsx
@@ -25,15 +25,15 @@ export const createDotNetAgentInstructions = (commonOptions: AgentInstructions):
     agentStatus,
     agentStatusLoading,
   } = commonOptions;
-  const codeBlock = `public class Startup
-{
-  public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-  {
-    app.UseAllElasticApm(Configuration);
-    //…rest of the method
-  }
-  //…rest of the class
-}`;
+  const codeBlock = `var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAllElasticApm();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+
+app.Run();`;
   return [
     {
       title: i18n.translate('xpack.apm.onboarding.dotNet.download.title', {
@@ -72,8 +72,8 @@ export const createDotNetAgentInstructions = (commonOptions: AgentInstructions):
           <EuiMarkdownFormat>
             {i18n.translate('xpack.apm.onboarding.dotNet.configureApplication.textPre', {
               defaultMessage:
-                'In case of ASP.NET Core with the `Elastic.Apm.NetCoreAll` package, call the `UseAllElasticApm` \
-      method in the `Configure` method within the `Startup.cs` file.',
+                'In case of ASP.NET Core with the `Elastic.Apm.NetCoreAll` package, call the `AddAllElasticApm` \
+      extension method on the `IServiceCollection` within the `Program.cs` file.',
             })}
           </EuiMarkdownFormat>
           <EuiSpacer />
@@ -84,7 +84,7 @@ export const createDotNetAgentInstructions = (commonOptions: AgentInstructions):
           <EuiMarkdownFormat>
             {i18n.translate('xpack.apm.onboarding.dotNet.configureApplication.textPost', {
               defaultMessage:
-                'Passing an `IConfiguration` instance is optional and by doing so, the agent will read config settings through this \
+                'The agent will implicitly read config settings through the application’s \
       `IConfiguration` instance (e.g. from the `appsettings.json` file).',
             })}
           </EuiMarkdownFormat>
@@ -119,8 +119,7 @@ export const createDotNetAgentInstructions = (commonOptions: AgentInstructions):
           <EuiMarkdownFormat>
             {i18n.translate('xpack.apm.onboarding.dotNet.configureAgent.textPost', {
               defaultMessage:
-                'In case you don’t pass an `IConfiguration` instance to the agent (e.g. in case of non ASP.NET Core applications) \
-      you can also configure the agent through environment variables. \n \
+                'You can also configure the agent through environment variables. \n \
       See [the documentation]({documentationLink}) for advanced usage, including the [Profiler Auto instrumentation]({profilerLink}) quick start.',
               values: {
                 documentationLink: `${baseUrl}guide/en/apm/agent/dotnet/current/configuration.html`,


### PR DESCRIPTION
## Summary

This PR updates our quick starts for .NET to use the latest preferred methods. I have been unable to get this running locally. If it's possible for an approver to check it renders correctly, that would be ideal. Otherwise, I can look at getting a VM set up so I can try to build Kibana and run it in that environment.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

None