### PR TITLE
[UA] `kibana-core` ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -991,7 +991,7 @@ x-pack/plugins/timelines @elastic/security-threat-hunting-investigations
 x-pack/plugins/transform @elastic/ml-ui
 x-pack/plugins/translations @elastic/kibana-localization
 x-pack/plugins/triggers_actions_ui @elastic/response-ops
-x-pack/plugins/upgrade_assistant @elastic/kibana-core
+x-pack/plugins/upgrade_assistant @elastic/kibana-management
 x-pack/plugins/watcher @elastic/kibana-management
 x-pack/solutions/observability/plugins/observability_solution/entities_data_access @elastic/obs-entities
 x-pack/solutions/observability/plugins/observability_solution/entity_manager_app @elastic/obs-entities

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -991,7 +991,7 @@ x-pack/plugins/timelines @elastic/security-threat-hunting-investigations
 x-pack/plugins/transform @elastic/ml-ui
 x-pack/plugins/translations @elastic/kibana-localization
 x-pack/plugins/triggers_actions_ui @elastic/response-ops
-x-pack/plugins/upgrade_assistant @elastic/kibana-management
+x-pack/plugins/upgrade_assistant @elastic/kibana-core
 x-pack/plugins/watcher @elastic/kibana-management
 x-pack/solutions/observability/plugins/observability_solution/entities_data_access @elastic/obs-entities
 x-pack/solutions/observability/plugins/observability_solution/entity_manager_app @elastic/obs-entities
@@ -2005,7 +2005,7 @@ x-pack/test/api_integration/apis/management/index_management/inference_endpoints
 # Management Experience - Deployment Management
 /test/functional/fixtures/kbn_archiver/management.json @elastic/kibana-management @elastic/kibana-data-discovery # Assigned per 2 uses: test/functional/apps/management/_import_objects.ts && test/functional/apps/management/data_views/_scripted_fields_filter.ts
 /x-pack/test/functional/fixtures/kbn_archiver/home/feature_controls/security/security.json @elastic/kibana-management
-/x-pack/test/functional/es_archives/upgrade_assistant @elastic/kibana-management
+/x-pack/test/functional/es_archives/upgrade_assistant @elastic/kibana-core
 /x-pack/test/functional/services/ace_editor.js @elastic/kibana-management
 /x-pack/test/functional/page_objects/remote_clusters_page.ts @elastic/kibana-management
 /x-pack/test/stack_functional_integration/apps/ccs @elastic/kibana-management
@@ -2031,7 +2031,7 @@ x-pack/test/api_integration/apis/management/index_management/inference_endpoints
 /x-pack/test/functional/apps/license_management @elastic/kibana-management
 /x-pack/test/functional/apps/management @elastic/kibana-management
 /x-pack/test/functional/apps/remote_clusters @elastic/kibana-management
-/x-pack/test/functional/apps/upgrade_assistant @elastic/kibana-management
+/x-pack/test/functional/apps/upgrade_assistant @elastic/kibana-core
 /x-pack/test/functional/apps/dev_tools @elastic/kibana-management
 /test/plugin_functional/test_suites/management @elastic/kibana-management
 /x-pack/test/upgrade_assistant_integration @elastic/kibana-management
@@ -2055,7 +2055,7 @@ x-pack/test/api_integration/apis/management/index_management/inference_endpoints
 /x-pack/test/api_integration/services/ingest_pipelines @elastic/kibana-management
 /x-pack/test/functional/apps/watcher @elastic/kibana-management
 /x-pack/test/api_integration/apis/watcher @elastic/kibana-management
-/x-pack/test/api_integration/apis/upgrade_assistant @elastic/kibana-management
+/x-pack/test/api_integration/apis/upgrade_assistant @elastic/kibana-core
 /x-pack/test/api_integration/apis/searchprofiler @elastic/kibana-management
 /x-pack/test/api_integration/apis/console @elastic/kibana-management
 /x-pack/test_serverless/**/test_suites/common/index_management/ @elastic/kibana-management
@@ -2088,7 +2088,7 @@ x-pack/test/api_integration/apis/management/index_management/inference_endpoints
 /x-pack/test/accessibility/apps/group3/license_management.ts @elastic/kibana-management
 /x-pack/test/accessibility/apps/group3/remote_clusters.ts @elastic/kibana-management
 /x-pack/test/accessibility/apps/group3/rollup_jobs.ts @elastic/kibana-management
-/x-pack/test/accessibility/apps/group3/upgrade_assistant.ts @elastic/kibana-management
+/x-pack/test/accessibility/apps/group3/upgrade_assistant.ts @elastic/kibana-core
 /x-pack/test/accessibility/apps/group3/watcher.ts @elastic/kibana-management
 
 #CC# /x-pack/plugins/cross_cluster_replication/ @elastic/kibana-management


### PR DESCRIPTION
## Summary

As Core will be driving a lot of the development for UA for 8->9 this PR makes `kibana-core` the temporary code owners for UA until we've completed the 9.0 release.

<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->