### PR TITLE
[Session management] update cleanup query to allow partial search results for PIT query

### DIFF
--- a/x-pack/plugins/security/server/session_management/session_index.test.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.test.ts
@@ -446,6 +446,7 @@ describe('Session index', () => {
         {
           index: aliasName,
           keep_alive: '5m',
+          allow_partial_search_results: true,
         },
         { ignore: [404], meta: true }
       );
@@ -454,6 +455,7 @@ describe('Session index', () => {
         {
           index: aliasName,
           keep_alive: '5m',
+          allow_partial_search_results: true,
         },
         { meta: true }
       );

--- a/x-pack/plugins/security/server/session_management/session_index.test.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.test.ts
@@ -475,7 +475,6 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.search).toHaveBeenCalledTimes(1);
       expect(mockElasticsearchClient.search).toHaveBeenCalledWith({
         _source_includes: 'usernameHash,provider',
-        allow_partial_search_results: true,
         sort: '_shard_doc',
         track_total_hits: false,
         search_after: undefined,
@@ -558,7 +557,6 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.search).toHaveBeenCalledTimes(1);
       expect(mockElasticsearchClient.search).toHaveBeenCalledWith({
         _source_includes: 'usernameHash,provider',
-        allow_partial_search_results: true,
         sort: '_shard_doc',
         track_total_hits: false,
         search_after: undefined,
@@ -653,7 +651,6 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.search).toHaveBeenCalledTimes(1);
       expect(mockElasticsearchClient.search).toHaveBeenCalledWith({
         _source_includes: 'usernameHash,provider',
-        allow_partial_search_results: true,
         sort: '_shard_doc',
         track_total_hits: false,
         search_after: undefined,
@@ -742,7 +739,6 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.search).toHaveBeenCalledTimes(1);
       expect(mockElasticsearchClient.search).toHaveBeenCalledWith({
         _source_includes: 'usernameHash,provider',
-        allow_partial_search_results: true,
         sort: '_shard_doc',
         track_total_hits: false,
         search_after: undefined,
@@ -856,7 +852,6 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.search).toHaveBeenCalledTimes(1);
       expect(mockElasticsearchClient.search).toHaveBeenCalledWith({
         _source_includes: 'usernameHash,provider',
-        allow_partial_search_results: true,
         sort: '_shard_doc',
         track_total_hits: false,
         search_after: undefined,

--- a/x-pack/plugins/security/server/session_management/session_index.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.ts
@@ -830,6 +830,9 @@ export class SessionIndex {
         {
           index: this.aliasName,
           keep_alive: SESSION_INDEX_CLEANUP_KEEP_ALIVE,
+          // @ts-expect-error client support this option, but it is not documented and typed yet, but we need this fix in 8.16.2.
+          // once support added we should remove this expected type error
+          // https://github.com/elastic/elasticsearch-specification/issues/3144
           allow_partial_search_results: true,
         },
         { ignore: [404], meta: true }
@@ -842,6 +845,9 @@ export class SessionIndex {
           {
             index: this.aliasName,
             keep_alive: SESSION_INDEX_CLEANUP_KEEP_ALIVE,
+            // @ts-expect-error client support this option, but it is not documented and typed yet, but we need this fix in 8.16.2.
+            // once support added we should remove this expected type error
+            // https://github.com/elastic/elasticsearch-specification/issues/3144
             allow_partial_search_results: true,
           },
           { meta: true }

--- a/x-pack/plugins/security/server/session_management/session_index.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.ts
@@ -865,7 +865,6 @@ export class SessionIndex {
           size: SESSION_INDEX_CLEANUP_BATCH_SIZE,
           sort: '_shard_doc',
           track_total_hits: false, // for performance
-          allow_partial_search_results: true,
         });
         const { hits } = searchResponse.hits;
         if (hits.length > 0) {

--- a/x-pack/plugins/security/server/session_management/session_index.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.ts
@@ -830,7 +830,7 @@ export class SessionIndex {
         {
           index: this.aliasName,
           keep_alive: SESSION_INDEX_CLEANUP_KEEP_ALIVE,
-          // @ts-expect-error client support this option, but it is not documented and typed yet, but we need this fix in 8.16.2.
+          // @ts-expect-error client support this option, but it is not documented and typed yet.
           // once support added we should remove this expected type error
           // https://github.com/elastic/elasticsearch-specification/issues/3144
           allow_partial_search_results: true,
@@ -845,7 +845,7 @@ export class SessionIndex {
           {
             index: this.aliasName,
             keep_alive: SESSION_INDEX_CLEANUP_KEEP_ALIVE,
-            // @ts-expect-error client support this option, but it is not documented and typed yet, but we need this fix in 8.16.2.
+            // @ts-expect-error client support this option, but it is not documented and typed yet.
             // once support added we should remove this expected type error
             // https://github.com/elastic/elasticsearch-specification/issues/3144
             allow_partial_search_results: true,

--- a/x-pack/plugins/security/server/session_management/session_index.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.ts
@@ -830,6 +830,7 @@ export class SessionIndex {
         {
           index: this.aliasName,
           keep_alive: SESSION_INDEX_CLEANUP_KEEP_ALIVE,
+          allow_partial_search_results: true,
         },
         { ignore: [404], meta: true }
       );
@@ -841,6 +842,7 @@ export class SessionIndex {
           {
             index: this.aliasName,
             keep_alive: SESSION_INDEX_CLEANUP_KEEP_ALIVE,
+            allow_partial_search_results: true,
           },
           { meta: true }
         ));


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/203440

### Summary
Update session cleanup task by adding the partial search results flag to the PIT query as well and not just the search query. 

#### Notes 
In the previous “fix”, the partial search results flag was incorrectly added to the search query that depended on the PIT query. However, the correct way is to set the flag when we `openPointInTimeQuery` which is then used in the subsequent `search` query 

### Release notes
Fixes error with opening point in time query for session deletion by now accounting for partial results.


Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_node:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
