### PR TITLE
skip fetches for entity store status and privileges if isEntityStoreD…

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/api/entity_store.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/api/entity_store.ts
@@ -19,10 +19,11 @@ import type {
 } from '../../../common/api/entity_analytics';
 import { API_VERSIONS } from '../../../common/entity_analytics/constants';
 import { useKibana } from '../../common/lib/kibana/kibana_react';
+import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 
 export const useEntityStoreRoutes = () => {
   const http = useKibana().services.http;
-
+  const isEntityStoreFeatureFlagDisabled = useIsExperimentalFeatureEnabled('entityStoreDisabled');
   return useMemo(() => {
     const enableEntityStore = async (
       options: InitEntityStoreRequestBody = { fieldHistoryLength: 10 }
@@ -35,6 +36,9 @@ export const useEntityStoreRoutes = () => {
     };
 
     const getEntityStoreStatus = async (withComponents = false) => {
+      if (isEntityStoreFeatureFlagDisabled) {
+        return null;
+      }
       return http.fetch<GetEntityStoreStatusResponse>('/api/entity_store/status', {
         method: 'GET',
         version: API_VERSIONS.public.v1,
@@ -81,5 +85,5 @@ export const useEntityStoreRoutes = () => {
       deleteEntityEngine,
       listEntityEngines,
     };
-  }, [http]);
+  }, [http, isEntityStoreFeatureFlagDisabled]);
 };

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_engine_privileges.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_engine_privileges.ts
@@ -8,6 +8,7 @@
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import type { SecurityAppError } from '@kbn/securitysolution-t-grid';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import type { EntityAnalyticsPrivileges } from '../../../../../common/api/entity_analytics';
 import { useEntityAnalyticsRoutes } from '../../../api/api';
 
@@ -17,6 +18,9 @@ export const useEntityEnginePrivileges = (): UseQueryResult<
   EntityAnalyticsPrivileges,
   SecurityAppError
 > => {
+  const isEntityStoreFeatureFlagDisabled = useIsExperimentalFeatureEnabled('entityStoreDisabled');
   const { fetchEntityStorePrivileges } = useEntityAnalyticsRoutes();
-  return useQuery(GET_ENTITY_ENGINE_PRIVILEGES, fetchEntityStorePrivileges);
+  return useQuery(GET_ENTITY_ENGINE_PRIVILEGES, fetchEntityStorePrivileges, {
+    enabled: !isEntityStoreFeatureFlagDisabled,
+  });
 };

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/entity_store.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/entity_store.ts
@@ -6,18 +6,18 @@
  */
 
 import expect from 'expect';
+// import { useIsExperimentalFeatureEnabled } from '@kbn/security-solution-plugin/public/common/hooks/use_experimental_features';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 import { EntityStoreUtils } from '../../utils';
 import { dataViewRouteHelpersFactory } from '../../utils/data_view';
-import { useIsExperimentalFeatureEnabled } from '@kbn/security-solution-plugin/public/common/hooks/use_experimental_features';
 export default ({ getService }: FtrProviderContext) => {
   const api = getService('securitySolutionApi');
   const supertest = getService('supertest');
 
   const utils = EntityStoreUtils(getService);
 
-  jest.mock('../hooks/useIsExperimentalFeatureEnabled');
-  const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
+  // jest.mock('../hooks/useIsExperimentalFeatureEnabled');
+  // const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
 
   describe('@ess @skipInServerlessMKI Entity Store APIs', () => {
     const dataView = dataViewRouteHelpersFactory(supertest);
@@ -282,50 +282,52 @@ export default ({ getService }: FtrProviderContext) => {
         });
 
         it('should return null when isEntityStoreFeatureFlagDisabled is true', async () => {
-          mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
-          const result = await api.getEntityStoreStatus({query: {}});
-          expect(result).toBeNull();
-      });
-    });
-
-    describe('apply_dataview_indices', () => {
-      before(async () => {
-        await utils.initEntityEngineForEntityTypesAndWait(['host']);
+          /* mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+          const result = await api.getEntityStoreStatus({ query: {} });
+          expect(result).toBeNull();*/
+          // TODO: implement the above test
+        });
       });
 
-      after(async () => {
-        await utils.cleanEngines();
-      });
+      describe('apply_dataview_indices', () => {
+        before(async () => {
+          await utils.initEntityEngineForEntityTypesAndWait(['host']);
+        });
 
-      afterEach(async () => {
-        await dataView.delete('security-solution');
-        await dataView.create('security-solution');
-      });
+        after(async () => {
+          await utils.cleanEngines();
+        });
 
-      it("should not update the index patten when it didn't change", async () => {
-        const response = await api.applyEntityEngineDataviewIndices();
+        afterEach(async () => {
+          await dataView.delete('security-solution');
+          await dataView.create('security-solution');
+        });
 
-        expect(response.body).toEqual({ success: true, result: [{ type: 'host', changes: {} }] });
-      });
+        it("should not update the index patten when it didn't change", async () => {
+          const response = await api.applyEntityEngineDataviewIndices();
 
-      it('should update the index pattern when the data view changes', async () => {
-        await dataView.updateIndexPattern('security-solution', 'test-*');
-        const response = await api.applyEntityEngineDataviewIndices();
+          expect(response.body).toEqual({ success: true, result: [{ type: 'host', changes: {} }] });
+        });
 
-        expect(response.body).toEqual({
-          success: true,
-          result: [
-            {
-              type: 'host',
-              changes: {
-                indexPatterns: [
-                  'test-*',
-                  '.asset-criticality.asset-criticality-default',
-                  'risk-score.risk-score-latest-default',
-                ],
+        it('should update the index pattern when the data view changes', async () => {
+          await dataView.updateIndexPattern('security-solution', 'test-*');
+          const response = await api.applyEntityEngineDataviewIndices();
+
+          expect(response.body).toEqual({
+            success: true,
+            result: [
+              {
+                type: 'host',
+                changes: {
+                  indexPatterns: [
+                    'test-*',
+                    '.asset-criticality.asset-criticality-default',
+                    'risk-score.risk-score-latest-default',
+                  ],
+                },
               },
-            },
-          ],
+            ],
+          });
         });
       });
     });

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/entity_store.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/entity_store/trial_license_complete_tier/entity_store.ts
@@ -9,11 +9,16 @@ import expect from 'expect';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 import { EntityStoreUtils } from '../../utils';
 import { dataViewRouteHelpersFactory } from '../../utils/data_view';
+import { useIsExperimentalFeatureEnabled } from '@kbn/security-solution-plugin/public/common/hooks/use_experimental_features';
 export default ({ getService }: FtrProviderContext) => {
   const api = getService('securitySolutionApi');
   const supertest = getService('supertest');
 
   const utils = EntityStoreUtils(getService);
+
+  jest.mock('../hooks/useIsExperimentalFeatureEnabled');
+  const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
+
   describe('@ess @skipInServerlessMKI Entity Store APIs', () => {
     const dataView = dataViewRouteHelpersFactory(supertest);
 
@@ -275,6 +280,11 @@ export default ({ getService }: FtrProviderContext) => {
             expect.objectContaining({ resource: 'component_template' }),
           ]);
         });
+
+        it('should return null when isEntityStoreFeatureFlagDisabled is true', async () => {
+          mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+          const result = await api.getEntityStoreStatus({query: {}});
+          expect(result).toBeNull();
       });
     });
 


### PR DESCRIPTION
## Summary

This PR removes unnecessary api calls to `api/entity_store/privileges` and `api/entity_store/engines` when the `entityStoreDisabled` flag is set to true. 

### Before 

https://github.com/user-attachments/assets/cd308b5e-b85b-417c-9c4c-c5bf73eb7879

### After 


https://github.com/user-attachments/assets/228242ab-614c-4471-9472-126ee1931d22



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



