### PR TITLE
[ResponseOps][Cases] Manual migration of routes without access tags

### DIFF
--- a/x-pack/plugins/cases/server/routes/api/cases/alerts/get_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/alerts/get_cases.ts
@@ -10,10 +10,12 @@ import type { caseApiV1 } from '../../../../../common/types/api';
 import { CASE_ALERTS_URL } from '../../../../../common/constants';
 import { createCaseError } from '../../../../common/error';
 import { createCasesRoute } from '../../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../../constants';
 
 export const getCasesByAlertIdRoute = createCasesRoute({
   method: 'get',
   path: CASE_ALERTS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       alert_id: schema.string({ minLength: 1 }),

--- a/x-pack/plugins/cases/server/routes/api/cases/categories/get_categories.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/categories/get_categories.ts
@@ -9,10 +9,12 @@ import { INTERNAL_GET_CASE_CATEGORIES_URL } from '../../../../../common/constant
 import { createCaseError } from '../../../../common/error';
 import { createCasesRoute } from '../../create_cases_route';
 import type { caseApiV1 } from '../../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../../constants';
 
 export const getCategoriesRoute = createCasesRoute({
   method: 'get',
   path: INTERNAL_GET_CASE_CATEGORIES_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'internal',
   },

--- a/x-pack/plugins/cases/server/routes/api/cases/delete_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/delete_cases.ts
@@ -10,10 +10,12 @@ import { schema } from '@kbn/config-schema';
 import { CASES_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const deleteCaseRoute = createCasesRoute({
   method: 'delete',
   path: CASES_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'public',
     summary: `Delete cases`,

--- a/x-pack/plugins/cases/server/routes/api/cases/find_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/find_cases.ts
@@ -9,10 +9,12 @@ import { CASES_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { caseApiV1 } from '../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const findCaseRoute = createCasesRoute({
   method: 'get',
   path: `${CASES_URL}/_find`,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'public',
     summary: `Search cases`,

--- a/x-pack/plugins/cases/server/routes/api/cases/get_case.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/get_case.ts
@@ -14,6 +14,7 @@ import { getWarningHeader, logDeprecatedEndpoint } from '../utils';
 import { CASE_DETAILS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 const params = {
   params: schema.object({
@@ -31,6 +32,7 @@ export const getCaseRoute = ({ isServerless }: { isServerless?: boolean }) =>
   createCasesRoute({
     method: 'get',
     path: CASE_DETAILS_URL,
+    security: DEFAULT_CASES_ROUTE_SECURITY,
     params,
     routerOptions: {
       access: 'public',

--- a/x-pack/plugins/cases/server/routes/api/cases/patch_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/patch_cases.ts
@@ -10,10 +10,12 @@ import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { caseApiV1 } from '../../../../common/types/api';
 import type { caseDomainV1 } from '../../../../common/types/domain';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const patchCaseRoute = createCasesRoute({
   method: 'patch',
   path: CASES_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'public',
     summary: 'Update cases',

--- a/x-pack/plugins/cases/server/routes/api/cases/post_case.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/post_case.ts
@@ -10,10 +10,12 @@ import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { caseApiV1 } from '../../../../common/types/api';
 import type { caseDomainV1 } from '../../../../common/types/domain';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const postCaseRoute = createCasesRoute({
   method: 'post',
   path: CASES_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'public',
     summary: `Create a case`,

--- a/x-pack/plugins/cases/server/routes/api/cases/push_case.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/push_case.ts
@@ -12,10 +12,12 @@ import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import { caseApiV1 } from '../../../../common/types/api';
 import type { caseDomainV1 } from '../../../../common/types/domain';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const pushCaseRoute: CaseRoute = createCasesRoute({
   method: 'post',
   path: CASE_PUSH_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'public',
     summary: `Push a case to an external service`,

--- a/x-pack/plugins/cases/server/routes/api/cases/reporters/get_reporters.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/reporters/get_reporters.ts
@@ -9,10 +9,12 @@ import { CASE_REPORTERS_URL } from '../../../../../common/constants';
 import { createCaseError } from '../../../../common/error';
 import { createCasesRoute } from '../../create_cases_route';
 import type { caseApiV1 } from '../../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../../constants';
 
 export const getReportersRoute = createCasesRoute({
   method: 'get',
   path: CASE_REPORTERS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'public',
     summary: `Get case creators`,

--- a/x-pack/plugins/cases/server/routes/api/cases/tags/get_tags.ts
+++ b/x-pack/plugins/cases/server/routes/api/cases/tags/get_tags.ts
@@ -9,10 +9,12 @@ import { CASE_TAGS_URL } from '../../../../../common/constants';
 import { createCaseError } from '../../../../common/error';
 import { createCasesRoute } from '../../create_cases_route';
 import type { caseApiV1 } from '../../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../../constants';
 
 export const getTagsRoute = createCasesRoute({
   method: 'get',
   path: CASE_TAGS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'public',
     summary: `Get case tags`,

--- a/x-pack/plugins/cases/server/routes/api/comments/delete_all_comments.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/delete_all_comments.ts
@@ -9,10 +9,12 @@ import { schema } from '@kbn/config-schema';
 import { CASE_COMMENTS_URL } from '../../../../common/constants';
 import { createCasesRoute } from '../create_cases_route';
 import { createCaseError } from '../../../common/error';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const deleteAllCommentsRoute = createCasesRoute({
   method: 'delete',
   path: CASE_COMMENTS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'public',
     summary: `Delete all case comments and alerts`,

--- a/x-pack/plugins/cases/server/routes/api/comments/delete_comment.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/delete_comment.ts
@@ -10,10 +10,12 @@ import { schema } from '@kbn/config-schema';
 import { CASE_COMMENT_DETAILS_URL } from '../../../../common/constants';
 import { createCasesRoute } from '../create_cases_route';
 import { createCaseError } from '../../../common/error';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const deleteCommentRoute = createCasesRoute({
   method: 'delete',
   path: CASE_COMMENT_DETAILS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/comments/find_comments.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/find_comments.ts
@@ -11,10 +11,12 @@ import type { attachmentApiV1 } from '../../../../common/types/api';
 import { CASE_FIND_ATTACHMENTS_URL } from '../../../../common/constants';
 import { createCasesRoute } from '../create_cases_route';
 import { createCaseError } from '../../../common/error';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const findCommentsRoute = createCasesRoute({
   method: 'get',
   path: CASE_FIND_ATTACHMENTS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/comments/get_alerts.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/get_alerts.ts
@@ -11,10 +11,12 @@ import type { alertApiV1 } from '../../../../common/types/api';
 import { CASE_DETAILS_ALERTS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const getAllAlertsAttachedToCaseRoute = createCasesRoute({
   method: 'get',
   path: CASE_DETAILS_ALERTS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string({ minLength: 1 }),

--- a/x-pack/plugins/cases/server/routes/api/comments/get_all_comment.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/get_all_comment.ts
@@ -12,6 +12,7 @@ import { CASE_COMMENTS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { attachmentDomainV1 } from '../../../../common/types/domain';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 /**
  * @deprecated since version 8.1.0
@@ -26,6 +27,7 @@ export const getAllCommentsRoute = ({
   createCasesRoute({
     method: 'get',
     path: CASE_COMMENTS_URL,
+    security: DEFAULT_CASES_ROUTE_SECURITY,
     params: {
       params: schema.object({
         case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/comments/get_comment.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/get_comment.ts
@@ -11,10 +11,12 @@ import { CASE_COMMENT_DETAILS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { attachmentDomainV1 } from '../../../../common/types/domain';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const getCommentRoute = createCasesRoute({
   method: 'get',
   path: CASE_COMMENT_DETAILS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/comments/patch_comment.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/patch_comment.ts
@@ -12,10 +12,12 @@ import { CASE_COMMENTS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { caseDomainV1 } from '../../../../common/types/domain';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const patchCommentRoute = createCasesRoute({
   method: 'patch',
   path: CASE_COMMENTS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/comments/post_comment.ts
+++ b/x-pack/plugins/cases/server/routes/api/comments/post_comment.ts
@@ -11,10 +11,12 @@ import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { caseDomainV1 } from '../../../../common/types/domain';
 import type { attachmentApiV1 } from '../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const postCommentRoute = createCasesRoute({
   method: 'post',
   path: CASE_COMMENTS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/configure/get_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/get_configure.ts
@@ -9,10 +9,12 @@ import { CASE_CONFIGURE_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { configureApiV1 } from '../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const getCaseConfigureRoute = createCasesRoute({
   method: 'get',
   path: CASE_CONFIGURE_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'public',
     summary: 'Get case settings',

--- a/x-pack/plugins/cases/server/routes/api/configure/patch_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/patch_configure.ts
@@ -11,10 +11,12 @@ import { CASE_CONFIGURE_DETAILS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { configureApiV1 } from '../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const patchCaseConfigureRoute = createCasesRoute({
   method: 'patch',
   path: CASE_CONFIGURE_DETAILS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'public',
     summary: 'Update case settings',

--- a/x-pack/plugins/cases/server/routes/api/configure/post_configure.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/post_configure.ts
@@ -11,10 +11,12 @@ import { CASE_CONFIGURE_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { configureApiV1 } from '../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const postCaseConfigureRoute = createCasesRoute({
   method: 'post',
   path: CASE_CONFIGURE_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'public',
     summary: 'Add case settings',

--- a/x-pack/plugins/cases/server/routes/api/constants.ts
+++ b/x-pack/plugins/cases/server/routes/api/constants.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RouteSecurity } from '@kbn/core-http-server';
+
+/**
+ * This constant is used as the default value for the security object in routes
+ * where a reason for opting out needs to be provided.
+ */
+export const DEFAULT_CASES_ROUTE_SECURITY: RouteSecurity = {
+  authz: {
+    enabled: false,
+    reason:
+      "This route is opted out from authorization because cases uses it's own authorization model inside the cases client.",
+  },
+};

--- a/x-pack/plugins/cases/server/routes/api/files/post_file.ts
+++ b/x-pack/plugins/cases/server/routes/api/files/post_file.ts
@@ -20,10 +20,12 @@ import { CASE_FILES_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { caseDomainV1 } from '../../../../common/types/domain';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const postFileRoute = createCasesRoute({
   method: 'post',
   path: CASE_FILES_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/index.ts
+++ b/x-pack/plugins/cases/server/routes/api/index.ts
@@ -9,6 +9,7 @@
  * Default page number when interacting with the saved objects API.
  */
 export const DEFAULT_PAGE = 1;
+
 /**
  * Default number of results when interacting with the saved objects API.
  */

--- a/x-pack/plugins/cases/server/routes/api/internal/bulk_create_attachments.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/bulk_create_attachments.ts
@@ -12,10 +12,12 @@ import { createCasesRoute } from '../create_cases_route';
 import { escapeHatch } from '../utils';
 import type { attachmentApiV1 } from '../../../../common/types/api';
 import type { caseDomainV1 } from '../../../../common/types/domain';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const bulkCreateAttachmentsRoute = createCasesRoute({
   method: 'post',
   path: INTERNAL_BULK_CREATE_ATTACHMENTS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/internal/bulk_delete_file_attachments.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/bulk_delete_file_attachments.ts
@@ -14,10 +14,12 @@ import { createCaseError } from '../../../common/error';
 import { escapeHatch } from '../utils';
 import type { attachmentApiV1 } from '../../../../common/types/api';
 import { BulkDeleteFileAttachmentsRequestRt } from '../../../../common/types/api/attachment/v1';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const bulkDeleteFileAttachments = createCasesRoute({
   method: 'post',
   path: INTERNAL_DELETE_FILE_ATTACHMENTS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/internal/bulk_get_attachments.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/bulk_get_attachments.ts
@@ -14,10 +14,12 @@ import { INTERNAL_BULK_GET_ATTACHMENTS_URL } from '../../../../common/constants'
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import { escapeHatch } from '../utils';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const bulkGetAttachmentsRoute = createCasesRoute({
   method: 'post',
   path: INTERNAL_BULK_GET_ATTACHMENTS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/internal/bulk_get_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/bulk_get_cases.ts
@@ -10,10 +10,12 @@ import { INTERNAL_BULK_GET_CASES_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import { escapeHatch } from '../utils';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const bulkGetCasesRoute = createCasesRoute({
   method: 'post',
   path: INTERNAL_BULK_GET_CASES_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     body: escapeHatch,
   },

--- a/x-pack/plugins/cases/server/routes/api/internal/get_case_metrics.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/get_case_metrics.ts
@@ -12,10 +12,12 @@ import type { metricsApiV1 } from '../../../../common/types/api';
 import { INTERNAL_CASE_METRICS_DETAILS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const getCaseMetricRoute = createCasesRoute({
   method: 'get',
   path: INTERNAL_CASE_METRICS_DETAILS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string({ minLength: 1 }),

--- a/x-pack/plugins/cases/server/routes/api/internal/get_case_user_actions_stats.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/get_case_user_actions_stats.ts
@@ -9,10 +9,12 @@ import type { userActionApiV1 } from '../../../../common/types/api';
 import { INTERNAL_GET_CASE_USER_ACTIONS_STATS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const getCaseUserActionStatsRoute = createCasesRoute({
   method: 'get',
   path: INTERNAL_GET_CASE_USER_ACTIONS_STATS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/internal/get_case_users.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/get_case_users.ts
@@ -10,10 +10,12 @@ import { INTERNAL_CASE_USERS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { userApiV1 } from '../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const getCaseUsersRoute = createCasesRoute({
   method: 'get',
   path: INTERNAL_CASE_USERS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/internal/get_cases_metrics.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/get_cases_metrics.ts
@@ -12,10 +12,12 @@ import type { metricsApiV1 } from '../../../../common/types/api';
 import { INTERNAL_CASE_METRICS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const getCasesMetricRoute = createCasesRoute({
   method: 'get',
   path: INTERNAL_CASE_METRICS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'internal',
   },

--- a/x-pack/plugins/cases/server/routes/api/internal/get_connectors.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/get_connectors.ts
@@ -10,10 +10,12 @@ import { INTERNAL_CONNECTORS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { connectorApiV1 } from '../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const getConnectorsRoute = createCasesRoute({
   method: 'get',
   path: INTERNAL_CONNECTORS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/internal/replace_custom_field.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/replace_custom_field.ts
@@ -11,10 +11,12 @@ import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { customFieldsApiV1 } from '../../../../common/types/api';
 import type { customFieldDomainV1 } from '../../../../common/types/domain';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const replaceCustomFieldRoute = createCasesRoute({
   method: 'put',
   path: INTERNAL_PUT_CUSTOM_FIELDS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/internal/search_cases.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/search_cases.ts
@@ -10,10 +10,12 @@ import { CASES_INTERNAL_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { caseApiV1 } from '../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const searchCasesRoute = createCasesRoute({
   method: 'post',
   path: `${CASES_INTERNAL_URL}/_search`,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   routerOptions: {
     access: 'internal',
   },

--- a/x-pack/plugins/cases/server/routes/api/register_routes.ts
+++ b/x-pack/plugins/cases/server/routes/api/register_routes.ts
@@ -74,7 +74,7 @@ export const registerRoutes = (deps: RegisterRoutesDeps) => {
   const { router, routes, logger, kibanaVersion, telemetryUsageCounter } = deps;
 
   routes.forEach((route) => {
-    const { method, path, params, options, routerOptions, handler } = route;
+    const { method, path, params, options, routerOptions, handler, security } = route;
 
     (router[method] as RouteRegistrar<typeof method, CasesRequestHandlerContext>)(
       {
@@ -85,6 +85,7 @@ export const registerRoutes = (deps: RegisterRoutesDeps) => {
           query: params?.query ?? escapeHatch,
           body: params?.body ?? schema.nullable(escapeHatch),
         },
+        security,
       },
       async (context, request, response) => {
         let responseHeaders = {};

--- a/x-pack/plugins/cases/server/routes/api/stats/get_status.ts
+++ b/x-pack/plugins/cases/server/routes/api/stats/get_status.ts
@@ -12,6 +12,7 @@ import { CASE_STATUS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import type { statsApiV1 } from '../../../../common/types/api';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 /**
  * @deprecated since version 8.1.0
@@ -26,6 +27,7 @@ export const getStatusRoute = ({
   createCasesRoute({
     method: 'get',
     path: CASE_STATUS_URL,
+    security: DEFAULT_CASES_ROUTE_SECURITY,
     options: { deprecated: true },
     routerOptions: {
       access: isServerless ? 'internal' : 'public',

--- a/x-pack/plugins/cases/server/routes/api/types.ts
+++ b/x-pack/plugins/cases/server/routes/api/types.ts
@@ -14,6 +14,7 @@ import type {
   RouteValidatorConfig,
   RouteConfigOptions,
   RouteMethod,
+  RouteSecurity,
 } from '@kbn/core/server';
 
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
@@ -55,4 +56,9 @@ export interface CaseRoute<P = unknown, Q = unknown, B = unknown> {
    */
   routerOptions?: RouteConfigOptions<RouteMethod>;
   handler: (args: CaseRouteHandlerArguments<P, Q, B>) => Promise<IKibanaResponse>;
+  /**
+   * Defines the security requirements for a route, including authorization and authentication.
+   * By default cases does not use this.
+   */
+  security?: RouteSecurity;
 }

--- a/x-pack/plugins/cases/server/routes/api/user_actions/find_user_actions.ts
+++ b/x-pack/plugins/cases/server/routes/api/user_actions/find_user_actions.ts
@@ -11,10 +11,12 @@ import type { userActionApiV1 } from '../../../../common/types/api';
 import { CASE_FIND_USER_ACTIONS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 export const findUserActionsRoute = createCasesRoute({
   method: 'get',
   path: CASE_FIND_USER_ACTIONS_URL,
+  security: DEFAULT_CASES_ROUTE_SECURITY,
   params: {
     params: schema.object({
       case_id: schema.string(),

--- a/x-pack/plugins/cases/server/routes/api/user_actions/get_all_user_actions.ts
+++ b/x-pack/plugins/cases/server/routes/api/user_actions/get_all_user_actions.ts
@@ -12,6 +12,7 @@ import type { userActionApiV1 } from '../../../../common/types/api';
 import { CASE_USER_ACTIONS_URL } from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
+import { DEFAULT_CASES_ROUTE_SECURITY } from '../constants';
 
 /**
  * @deprecated since version 8.1.0
@@ -26,6 +27,7 @@ export const getUserActionsRoute = ({
   createCasesRoute({
     method: 'get',
     path: CASE_USER_ACTIONS_URL,
+    security: DEFAULT_CASES_ROUTE_SECURITY,
     params: {
       params: schema.object({
         case_id: schema.string(),


### PR DESCRIPTION
## Summary

Since most cases routes do not use access tags they need to be migrated to include a `reason` in the security params.

[Documentation.](https://docs.elastic.dev/kibana-dev-docs/key-concepts/security-api-authorization#opting-out-of-authorization-for-specific-routes)

## Routes updated in this PR

- `Cases`
    - [x]  GET `${CASES_URL}/_find`
    - [x]  DELETE `/api/cases`
    - [x]  PATCH `/api/cases`
    - [x]  POST `/api/cases`
    - [x]  GET `${CASES_URL}/{case_id}`
    - [x]  POST `${CASE_DETAILS_URL}/connector/{connector_id}/_push`
    - `Alerts`
        - [x]  GET `${CASES_URL}/alerts/{alert_id}`
    - `Categories`
        - [x]  GET `${CASES_INTERNAL_URL}/categories`
    - `Reporters`
        - [x]  GET `${CASES_URL}/reporters`
    - `Tags`
        - [x]  GET `CASE_TAGS_URL`
- `Comments`
    - [x]  DELETE `${CASE_DETAILS_URL}/comments`
    - [x]  DELETE `${CASE_DETAILS_URL}/comments/{comment_id}`
    - [x]  GET `${CASE_COMMENTS_URL}/_find`
    - [x]  GET `CASE_DETAILS_ALERT_URL`
    - [x]  GET `CASE_COMMENTS_URL`
    - [x]  GET `CASE_COMMENT_DETAILS_URL`
    - [x]  PATCH `CASE_COMMENTS_URL`
    - [x]  POST `CASE_COMMENTS_URL`
- `Configure`
    - [x]  POST `CASE_CONFIGURE_URL`
    - [x]  PATCH `CASE_CONFIGURE_URL`
    - [x]  GET `CASE_CONFIGURE_URL`
- `Files`
    - [x]  GET `CASES_FILES_URL`
- `Internal`
    - [x]  POST `INTERNAL_BULK_CREATE_ATTACHMENTS_URL`
    - [x]  POST `INTERNAL_DELETE_FILE_ATTACHMENTS_URL`
    - [x]  POST `INTERNAL_BULK_GET_ATTACHMENTS_URL`
    - [x]  POST `INTERNAL_BULK_GET_CASES_URL`
    - [x]  GET `INTERNAL_CASE_METRICS_DETAILS_URL`
    - [x]  GET `INTERNAL_GET_CASE_USER_ACTIONS_STATS_URL`
    - [x]  GET `INTERNAL_CASE_USERS_URL`
    - [x]  GET `INTERNAL_CASE_METRICS_URL`
    - [x]  GET `INTERNAL_CONNECTORS_URL`
    - [x]  PUT `INTERNAL_PUT_CUSTOM_FIELDS_URL`
    - [x]  POST `${CASES_INTERNAL_URL}/_search`
- `Stats`
    - [x]  GET `CASE_STATUS_URL`
- `User Actions`
    - [x]  GET `CASE_FIND_USER_ACTIONS_URL`
    - [x]  GET `CASE_USER_ACTIONS_URL`





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->