### PR TITLE
[8.x] [eem] _search accepts kql filters (#203089)

### DIFF
--- a/x-pack/plugins/entity_manager/server/lib/v2/entity_client.ts
+++ b/x-pack/plugins/entity_manager/server/lib/v2/entity_client.ts
@@ -98,7 +98,7 @@ export class EntityClient {
           );
         }
 
-        const query = getEntityInstancesQuery({
+        const { query, filter } = getEntityInstancesQuery({
           source: {
             ...source,
             metadata_fields: availableMetadataFields,
@@ -109,10 +109,13 @@ export class EntityClient {
           sort,
           limit,
         });
-        this.options.logger.debug(`Entity query: ${query}`);
+        this.options.logger.debug(
+          () => `Entity query: ${query}\nfilter: ${JSON.stringify(filter, null, 2)}`
+        );
 
         const rawEntities = await runESQLQuery<EntityV2>('resolve entities', {
           query,
+          filter,
           esClient: this.options.clusterClient.asCurrentUser,
           logger: this.options.logger,
         });

--- a/x-pack/plugins/entity_manager/server/lib/v2/run_esql_query.ts
+++ b/x-pack/plugins/entity_manager/server/lib/v2/run_esql_query.ts
@@ -7,6 +7,7 @@
 
 import { withSpan } from '@kbn/apm-utils';
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { ESQLColumn, ESQLRow, ESQLSearchResponse } from '@kbn/es-types';
 
 export interface SourceAs<T> {
@@ -19,19 +20,24 @@ export async function runESQLQuery<T>(
     esClient,
     logger,
     query,
+    filter,
   }: {
     esClient: ElasticsearchClient;
     logger: Logger;
     query: string;
+    filter?: QueryDslQueryContainer;
   }
 ): Promise<T[]> {
-  logger.trace(() => `Request (${operationName}):\n${query}`);
+  logger.trace(
+    () => `Request (${operationName}):\nquery: ${query}\nfilter: ${JSON.stringify(filter, null, 2)}`
+  );
   return withSpan(
     { name: operationName, labels: { plugin: '@kbn/entityManager-plugin' } },
     async () =>
       esClient.esql.query(
         {
           query,
+          filter,
           format: 'json',
         },
         { querystring: { drop_null_columns: true } }
@@ -62,8 +68,7 @@ function rowToObject(row: ESQLRow, columns: ESQLColumn[]) {
       return object;
     }
 
-    // Removes the type suffix from the column name
-    const name = column.name.replace(/\.(text|keyword)$/, '');
+    const name = column.name;
     if (!object[name]) {
       object[name] = value;
     }

--- a/x-pack/plugins/observability_solution/entity_manager_app/public/pages/overview/index.tsx
+++ b/x-pack/plugins/observability_solution/entity_manager_app/public/pages/overview/index.tsx
@@ -70,7 +70,7 @@ function EntitySourceForm({
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiFormRow label="Filters (comma-separated ESQL filters)">
+        <EuiFormRow label="Filters (comma-separated KQL filters)">
           <EuiFieldText
             data-test-subj="entityManagerFormFilters"
             name="filters"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[eem] _search accepts kql filters (#203089)](https://github.com/elastic/kibana/pull/203089)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Lacabane","email":"kevin.lacabane@elastic.co"},"sourceCommit":{"committedDate":"2024-12-06T11:02:28Z","message":"[eem] _search accepts kql filters (#203089)\n\n## Summary\r\n\r\n`searchEntities` now accepts kql filters instead of esql and translates\r\nthat to dsl filters at the query level","sha":"5470fb71339bb76661ad0bd2dfe6cf617a03a0dc","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","backport:prev-minor","ci:project-deploy-observability","Team:obs-entities"],"number":203089,"url":"https://github.com/elastic/kibana/pull/203089","mergeCommit":{"message":"[eem] _search accepts kql filters (#203089)\n\n## Summary\r\n\r\n`searchEntities` now accepts kql filters instead of esql and translates\r\nthat to dsl filters at the query level","sha":"5470fb71339bb76661ad0bd2dfe6cf617a03a0dc"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203089","number":203089,"mergeCommit":{"message":"[eem] _search accepts kql filters (#203089)\n\n## Summary\r\n\r\n`searchEntities` now accepts kql filters instead of esql and translates\r\nthat to dsl filters at the query level","sha":"5470fb71339bb76661ad0bd2dfe6cf617a03a0dc"}}]}] BACKPORT-->