### PR TITLE
[Index Management] Fix schema for index templates

### DIFF
--- a/x-pack/plugins/index_management/common/types/templates.ts
+++ b/x-pack/plugins/index_management/common/types/templates.ts
@@ -51,7 +51,7 @@ export interface TemplateDeserialized {
   priority?: number; // Composable template only
   allowAutoCreate: string;
   order?: number; // Legacy template only
-  indexMode: IndexMode;
+  indexMode?: IndexMode;
   ilmPolicy?: {
     name: string;
   };

--- a/x-pack/plugins/index_management/public/application/components/template_form/steps/step_review.tsx
+++ b/x-pack/plugins/index_management/public/application/components/template_form/steps/step_review.tsx
@@ -271,15 +271,19 @@ export const StepReview: React.FunctionComponent<Props> = React.memo(
               </EuiDescriptionListDescription>
 
               {/* Index mode */}
-              <EuiDescriptionListTitle data-test-subj="indexModeTitle">
-                <FormattedMessage
-                  id="xpack.idxMgmt.templateForm.stepReview.summaryTab.indexModeLabel"
-                  defaultMessage="Index mode"
-                />
-              </EuiDescriptionListTitle>
-              <EuiDescriptionListDescription data-test-subj="indexModeValue">
-                {indexModeLabels[indexMode]}
-              </EuiDescriptionListDescription>
+              {indexMode && (
+                <>
+                  <EuiDescriptionListTitle data-test-subj="indexModeTitle">
+                    <FormattedMessage
+                      id="xpack.idxMgmt.templateForm.stepReview.summaryTab.indexModeLabel"
+                      defaultMessage="Index mode"
+                    />
+                  </EuiDescriptionListTitle>
+                  <EuiDescriptionListDescription data-test-subj="indexModeValue">
+                    {indexModeLabels[indexMode]}
+                  </EuiDescriptionListDescription>
+                </>
+              )}
 
               {/* Mappings */}
               <EuiDescriptionListTitle>

--- a/x-pack/plugins/index_management/public/application/sections/home/template_list/template_details/tabs/tab_summary.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/template_list/template_details/tabs/tab_summary.tsx
@@ -226,15 +226,19 @@ export const TabSummary: React.FunctionComponent<Props> = ({ templateDetails }) 
             )}
 
             {/* Index mode */}
-            <EuiDescriptionListTitle>
-              <FormattedMessage
-                id="xpack.idxMgmt.templateDetails.stepReview.summaryTab.indexModeLabel"
-                defaultMessage="Index mode"
-              />
-            </EuiDescriptionListTitle>
-            <EuiDescriptionListDescription>
-              {indexModeLabels[indexMode]}
-            </EuiDescriptionListDescription>
+            {indexMode && (
+              <>
+                <EuiDescriptionListTitle>
+                  <FormattedMessage
+                    id="xpack.idxMgmt.templateDetails.stepReview.summaryTab.indexModeLabel"
+                    defaultMessage="Index mode"
+                  />
+                </EuiDescriptionListTitle>
+                <EuiDescriptionListDescription>
+                  {indexModeLabels[indexMode]}
+                </EuiDescriptionListDescription>
+              </>
+            )}
 
             {/* Allow auto create */}
             {isLegacy !== true &&

--- a/x-pack/plugins/index_management/server/routes/api/templates/validate_schemas.ts
+++ b/x-pack/plugins/index_management/server/routes/api/templates/validate_schemas.ts
@@ -13,7 +13,7 @@ export const templateSchema = schema.object({
   version: schema.maybe(schema.number()),
   order: schema.maybe(schema.number()),
   priority: schema.maybe(schema.number()),
-  indexMode: schema.string(),
+  indexMode: schema.maybe(schema.string()),
   // Not present for legacy templates
   allowAutoCreate: schema.maybe(schema.string()),
   template: schema.maybe(

--- a/x-pack/test/api_integration/apis/management/index_management/lib/templates.helpers.ts
+++ b/x-pack/test/api_integration/apis/management/index_management/lib/templates.helpers.ts
@@ -59,7 +59,6 @@ export function templatesHelpers(getService: FtrProviderContext['getService']) {
       name,
       indexPatterns,
       version: 1,
-      indexMode: 'standard',
       template: { ...getTemplateMock(isMappingsSourceFieldEnabled) },
       _kbnMeta: {
         isLegacy,


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/203553

## Summary

This PR fixes the template schema so that the server allows creating a template with undefined index mode. The issue is that when we exposed the index mode info in https://github.com/elastic/kibana/pull/197874, we assumed that, by default, the index mode is `standard` so `indexMode` was added as a required field. However, in https://github.com/elastic/kibana/pull/199521, we added the index mode field only if data streams toggle is enabled, so the `indexMode` is `undefined`.

The PR also fixes a smaller issuer where Index mode is displayed even when it is undefined (when data streams are disabled):
**Before:**
<img width="905" alt="Screenshot 2024-12-10 at 19 01 09" src="https://github.com/user-attachments/assets/e22cab14-eade-4591-8da8-f9aec5ad6c43">

**Now:**
<img width="905" alt="Screenshot 2024-12-10 at 18 19 29" src="https://github.com/user-attachments/assets/e7768cdc-9610-4a25-b403-0320b7137db5">


**How to test:**
1. Go to Index Management -> Index templates and start creating an index template.
2. Specify the name and the index pattern and disable the "Data streams" toggle.
3. Go to Review step and verify that index mode is not displayed in the summary and that creating the index template is successful.




<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->