### PR TITLE
[8.x] [Obs AI Assistant] Add security configs to API (#201439)

### DIFF
--- a/x-pack/plugins/observability_solution/observability/server/routes/assistant/route.ts
+++ b/x-pack/plugins/observability_solution/observability/server/routes/assistant/route.ts
@@ -12,8 +12,12 @@ import { createObservabilityServerRoute } from '../create_observability_server_r
 const getObservabilityAlertDetailsContextRoute = createObservabilityServerRoute({
   endpoint: 'GET /internal/observability/assistant/alert_details_contextual_insights',
   options: {
-    tags: [],
     access: 'internal',
+  },
+  security: {
+    authz: {
+      requiredPrivileges: ['ai_assistant'],
+    },
   },
   params: t.type({
     query: alertDetailsContextRt,

--- a/x-pack/plugins/observability_solution/observability/server/routes/types.ts
+++ b/x-pack/plugins/observability_solution/observability/server/routes/types.ts
@@ -24,7 +24,7 @@ export interface ObservabilityRouteHandlerResources {
 }
 
 export interface ObservabilityRouteCreateOptions {
-  tags: string[];
+  tags?: string[];
   access?: 'public' | 'internal';
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Obs AI Assistant] Add security configs to API (#201439)](https://github.com/elastic/kibana/pull/201439)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2024-11-28T17:20:31Z","message":"[Obs AI Assistant] Add security configs to API (#201439)\n\n## Summary\r\n\r\n### Problem\r\nThe API\r\n`/internal/observability/assistant/alert_details_contextual_insights`\r\ndoes not provide explicit authorization settings.\r\n\r\n### Solution\r\nAdd access privileges (`ai_assistant`) to the above API\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"650c5ca2122168b6e717e588d3b294bbd8e663ad","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["enhancement","release_note:skip","backport missing","v9.0.0","Team:Obs AI Assistant","ci:project-deploy-observability","Team:obs-ux-management","backport:version","Authz: API migration","v8.18.0"],"number":201439,"url":"https://github.com/elastic/kibana/pull/201439","mergeCommit":{"message":"[Obs AI Assistant] Add security configs to API (#201439)\n\n## Summary\r\n\r\n### Problem\r\nThe API\r\n`/internal/observability/assistant/alert_details_contextual_insights`\r\ndoes not provide explicit authorization settings.\r\n\r\n### Solution\r\nAdd access privileges (`ai_assistant`) to the above API\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"650c5ca2122168b6e717e588d3b294bbd8e663ad"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/201439","number":201439,"mergeCommit":{"message":"[Obs AI Assistant] Add security configs to API (#201439)\n\n## Summary\r\n\r\n### Problem\r\nThe API\r\n`/internal/observability/assistant/alert_details_contextual_insights`\r\ndoes not provide explicit authorization settings.\r\n\r\n### Solution\r\nAdd access privileges (`ai_assistant`) to the above API\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"650c5ca2122168b6e717e588d3b294bbd8e663ad"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->