### PR TITLE
[SecuritySolution] Fix serviceEntityStoreEnabled experimental flag initial value

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -246,7 +246,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables the Service Entity Store. The Entity Store feature will install the service engine by default.
    */
-  serviceEntityStoreEnabled: true,
+  serviceEntityStoreEnabled: false,
 
   /**
    * Enables the siem migrations feature


### PR DESCRIPTION
## Summary

Fix serviceEntityStoreEnabled experimental flag initial value.




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->