### PR TITLE
[APM][Profiling] Add x-elastic-internal-origin: Kibana header to agentless axios

### DIFF
--- a/x-pack/plugins/observability_solution/apm/scripts/diagnostics_bundle/cli.ts
+++ b/x-pack/plugins/observability_solution/apm/scripts/diagnostics_bundle/cli.ts
@@ -164,7 +164,12 @@ async function getHostnameWithBasePath(kibanaHostname?: string) {
   const parsedHostName = parseHostName(kibanaHostname);
 
   try {
-    await axios.get(parsedHostName, { maxRedirects: 0 });
+    await axios.get(parsedHostName, {
+      maxRedirects: 0,
+      headers: {
+        'x-elastic-internal-origin': 'Kibana',
+      },
+    });
   } catch (e) {
     if (isAxiosError(e) && e.response?.status === 302) {
       const location = e.response?.headers?.location ?? '';

--- a/x-pack/plugins/observability_solution/apm/scripts/diagnostics_bundle/diagnostics_bundle.ts
+++ b/x-pack/plugins/observability_solution/apm/scripts/diagnostics_bundle/diagnostics_bundle.ts
@@ -54,6 +54,7 @@ export async function initDiagnosticsBundle({
     headers: {
       'kbn-xsrf': 'true',
       'elastic-api-version': '2023-10-31',
+      'x-elastic-internal-origin': 'Kibana',
       ...apiKeyHeader,
     },
   };
@@ -104,8 +105,8 @@ async function getApmIndices(kbnClientOpts: AxiosRequestConfig) {
 async function getFleetPackageInfo(kbnClientOpts: AxiosRequestConfig) {
   const res = await axios.get('/api/fleet/epm/packages/apm', kbnClientOpts);
   return {
-    version: res.data.response.version,
-    isInstalled: res.data.response.status,
+    version: res.data.item.version,
+    isInstalled: res.data.item.status,
   };
 }
 

--- a/x-pack/plugins/observability_solution/apm/server/test_helpers/create_apm_users/helpers/call_kibana.ts
+++ b/x-pack/plugins/observability_solution/apm/server/test_helpers/create_apm_users/helpers/call_kibana.ts
@@ -8,6 +8,10 @@ import axios, { AxiosRequestConfig, AxiosError } from 'axios';
 import { once } from 'lodash';
 import { Elasticsearch, Kibana } from '../create_apm_users';
 
+const DEFAULT_HEADERS = {
+  'kbn-xsrf': 'true',
+  'x-elastic-internal-origin': 'Kibana',
+};
 export async function callKibana<T>({
   elasticsearch,
   kibana,
@@ -24,14 +28,18 @@ export async function callKibana<T>({
     ...options,
     baseURL: baseUrl,
     auth: { username, password },
-    headers: { 'kbn-xsrf': 'true', ...options.headers },
+    headers: { ...DEFAULT_HEADERS, ...options.headers },
   });
   return data;
 }
 
 const getBaseUrl = once(async (kibanaHostname: string) => {
   try {
-    await axios.request({ url: kibanaHostname, maxRedirects: 0 });
+    await axios.request({
+      url: kibanaHostname,
+      maxRedirects: 0,
+      headers: DEFAULT_HEADERS,
+    });
   } catch (e) {
     if (isAxiosError(e)) {
       const location = e.response?.headers?.location ?? '';

--- a/x-pack/plugins/observability_solution/profiling/e2e/cypress_test_runner.ts
+++ b/x-pack/plugins/observability_solution/profiling/e2e/cypress_test_runner.ts
@@ -13,6 +13,10 @@ import { FtrProviderContext } from './ftr_provider_context';
 import { loadProfilingData } from './load_profiling_data';
 import { setupProfilingResources } from './setup_profiling_resources';
 
+const DEFAULT_HEADERS = {
+  'kbn-xsrf': true,
+  'x-elastic-internal-origin': 'Kibana',
+};
 export async function cypressTestRunner({
   ftrProviderContext: { getService },
   cypressExecution,
@@ -42,11 +46,11 @@ export async function cypressTestRunner({
   });
 
   // Ensure Fleet setup is complete
-  await axios.post(`${kibanaUrlWithAuth}/api/fleet/setup`, {}, { headers: { 'kbn-xsrf': true } });
+  await axios.post(`${kibanaUrlWithAuth}/api/fleet/setup`, {}, { headers: DEFAULT_HEADERS });
 
   const profilingResources = await axios.get<{ has_setup: boolean; has_data: boolean }>(
     `${kibanaUrlWithAuth}/internal/profiling/setup/es_resources`,
-    { headers: { 'kbn-xsrf': true } }
+    { headers: DEFAULT_HEADERS }
   );
 
   // Only runs the setup once. This is useful when runing the tests with --times args

--- a/x-pack/plugins/observability_solution/profiling/e2e/setup_profiling_resources.ts
+++ b/x-pack/plugins/observability_solution/profiling/e2e/setup_profiling_resources.ts
@@ -17,7 +17,7 @@ export async function setupProfilingResources({
   await axios.post(
     `${kibanaUrlWithAuth}/internal/profiling/setup/es_resources`,
     {},
-    { headers: { 'kbn-xsrf': true } }
+    { headers: { 'kbn-xsrf': true, 'x-elastic-internal-origin': 'Kibana' } }
   );
   // eslint-disable-next-line no-console
   console.log('[Done] Setting up Universal profiling resources.');


### PR DESCRIPTION
closes [203571](https://github.com/elastic/kibana/issues/203571)

## Summary

Kibana 9.0 requires all request made with `axios` have the request header `x-elastic-internal-origin` set to `Kibana` to avoid appearing as an “external” integration.  Any [requests without it will be blocked in Kibana 9.0](https://docs.google.com/document/d/1W7csjn6QYjrBjmbXMzSz_JUD4KcmWz8jTTtAWFwgUJM/edit?tab=t.0#heading=h.brxkig5phxcz)


<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.9","8.x"]} ONMERGE-->