### PR TITLE
[Index management] Only display index mode info in index templates with data streams

### DIFF
--- a/x-pack/plugins/index_management/common/lib/template_serialization.test.ts
+++ b/x-pack/plugins/index_management/common/lib/template_serialization.test.ts
@@ -18,7 +18,6 @@ const defaultSerializedTemplate: TemplateSerialized = {
 const defaultDeserializedTemplate: TemplateDeserialized = {
   name: 'my_template',
   indexPatterns: ['test'],
-  indexMode: STANDARD_INDEX_MODE,
   _kbnMeta: {
     type: 'default',
     hasDatastream: true,

--- a/x-pack/plugins/index_management/common/lib/template_serialization.ts
+++ b/x-pack/plugins/index_management/common/lib/template_serialization.ts
@@ -91,10 +91,12 @@ export function deserializeTemplate(
 
   const ilmPolicyName = settings?.index?.lifecycle?.name;
 
-  const indexMode = (settings?.index?.mode ??
-    (indexPatterns.some((pattern) => pattern === 'logs-*-*')
-      ? LOGSDB_INDEX_MODE
-      : STANDARD_INDEX_MODE)) as IndexMode;
+  const indexMode =
+    settings?.index?.mode ??
+    (dataStream &&
+      (indexPatterns.some((pattern) => pattern === 'logs-*-*')
+        ? LOGSDB_INDEX_MODE
+        : STANDARD_INDEX_MODE));
 
   const deserializedTemplate: TemplateDeserialized = {
     name,

--- a/x-pack/plugins/index_management/common/types/templates.ts
+++ b/x-pack/plugins/index_management/common/types/templates.ts
@@ -51,7 +51,7 @@ export interface TemplateDeserialized {
   priority?: number; // Composable template only
   allowAutoCreate: string;
   order?: number; // Legacy template only
-  indexMode: IndexMode;
+  indexMode?: IndexMode;
   ilmPolicy?: {
     name: string;
   };

--- a/x-pack/plugins/index_management/public/application/components/template_form/steps/step_review.tsx
+++ b/x-pack/plugins/index_management/public/application/components/template_form/steps/step_review.tsx
@@ -271,15 +271,19 @@ export const StepReview: React.FunctionComponent<Props> = React.memo(
               </EuiDescriptionListDescription>
 
               {/* Index mode */}
-              <EuiDescriptionListTitle data-test-subj="indexModeTitle">
-                <FormattedMessage
-                  id="xpack.idxMgmt.templateForm.stepReview.summaryTab.indexModeLabel"
-                  defaultMessage="Index mode"
-                />
-              </EuiDescriptionListTitle>
-              <EuiDescriptionListDescription data-test-subj="indexModeValue">
-                {indexModeLabels[indexMode]}
-              </EuiDescriptionListDescription>
+              {indexMode && (
+                <>
+                  <EuiDescriptionListTitle data-test-subj="indexModeTitle">
+                    <FormattedMessage
+                      id="xpack.idxMgmt.templateForm.stepReview.summaryTab.indexModeLabel"
+                      defaultMessage="Index mode"
+                    />
+                  </EuiDescriptionListTitle>
+                  <EuiDescriptionListDescription data-test-subj="indexModeValue">
+                    {indexModeLabels[indexMode]}
+                  </EuiDescriptionListDescription>
+                </>
+              )}
 
               {/* Mappings */}
               <EuiDescriptionListTitle>

--- a/x-pack/plugins/index_management/public/application/sections/home/template_list/template_details/tabs/tab_summary.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/template_list/template_details/tabs/tab_summary.tsx
@@ -54,17 +54,19 @@ export const TabSummary: React.FunctionComponent<Props> = ({ templateDetails }) 
     composedOf,
     order,
     indexPatterns = [],
-    indexMode,
     ilmPolicy,
     _meta,
     _kbnMeta: { isLegacy, hasDatastream },
     allowAutoCreate,
+    template,
   } = templateDetails;
 
   const numIndexPatterns = indexPatterns.length;
 
   const { history, core } = useAppContext();
   const ilmPolicyLink = useIlmLocator(ILM_PAGES_POLICY_EDIT, ilmPolicy?.name);
+
+  const indexMode = template?.settings?.index?.mode;
 
   return (
     <>
@@ -226,15 +228,19 @@ export const TabSummary: React.FunctionComponent<Props> = ({ templateDetails }) 
             )}
 
             {/* Index mode */}
-            <EuiDescriptionListTitle>
-              <FormattedMessage
-                id="xpack.idxMgmt.templateDetails.stepReview.summaryTab.indexModeLabel"
-                defaultMessage="Index mode"
-              />
-            </EuiDescriptionListTitle>
-            <EuiDescriptionListDescription>
-              {indexModeLabels[indexMode]}
-            </EuiDescriptionListDescription>
+            {indexMode && (
+              <>
+                <EuiDescriptionListTitle>
+                  <FormattedMessage
+                    id="xpack.idxMgmt.templateDetails.stepReview.summaryTab.indexModeLabel"
+                    defaultMessage="Index mode"
+                  />
+                </EuiDescriptionListTitle>
+                <EuiDescriptionListDescription>
+                  {indexModeLabels[indexMode]}
+                </EuiDescriptionListDescription>
+              </>
+            )}
 
             {/* Allow auto create */}
             {isLegacy !== true &&


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/203589

## Summary

TBD



