### PR TITLE
[Security Solution] Implement concurrency control for Prebuilt Upgrade workflow

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/translations.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/translations.tsx
@@ -140,3 +140,37 @@ export const RULE_MODIFIED_BADGE_DESCRIPTION = i18n.translate(
       'The rule was edited after installation and field values differs from the values upon installation',
   }
 );
+
+export const RULE_NEW_REVISION_DETECTED_WARNING = i18n.translate(
+  'xpack.securitySolution.detectionEngine.upgradeFlyout.ruleNewRevisionDetectedWarning',
+  {
+    defaultMessage: 'Installed rule changed',
+  }
+);
+
+export const RULE_NEW_REVISION_DETECTED_WARNING_DESCRIPTION = (ruleName: string) =>
+  i18n.translate(
+    'xpack.securitySolution.detectionEngine.upgradeFlyout.ruleNewVersionDetectedWarningDescription',
+    {
+      defaultMessage:
+        'Someone edited the installed rule "{ruleName}". Upgrade resolved conflicts were reset.',
+      values: { ruleName },
+    }
+  );
+
+export const RULE_NEW_VERSION_DETECTED_WARNING = i18n.translate(
+  'xpack.securitySolution.detectionEngine.upgradeFlyout.ruleNewRevisionDetectedWarning',
+  {
+    defaultMessage: 'New prebuilt rules package was installed',
+  }
+);
+
+export const RULE_NEW_VERSION_DETECTED_WARNING_DESCRIPTION = (ruleName: string) =>
+  i18n.translate(
+    'xpack.securitySolution.detectionEngine.upgradeFlyout.ruleNewRevisionDetectedWarningDescription',
+    {
+      defaultMessage:
+        'Newer prebuilt rules package were installed in background. It contains a newer rule version for "{ruleName}". Upgrade resolved conflicts were reset.',
+      values: { ruleName },
+    }
+  );

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
@@ -112,6 +112,13 @@ interface UpgradePrebuiltRulesTableContextProviderProps {
   children: React.ReactNode;
 }
 
+/**
+ * Provides necessary data and actions for Rules Upgrade table.
+ *
+ * It periodically re-fetches prebuilt rules upgrade review data to detect possible cases of:
+ *  - editing prebuilt rules (revision change)
+ *  - releasing a new prebuilt rules package (version change)
+ */
 export const UpgradePrebuiltRulesTableContextProvider = ({
   children,
 }: UpgradePrebuiltRulesTableContextProviderProps) => {
@@ -137,9 +144,6 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
     isLoading,
     isRefetching,
   } = usePrebuiltRulesUpgradeReview({
-    // Refetch review prebuilt rules upgrade data to detect possible cases of:
-    // - editing prebuilt rules (revision change)
-    // - releasing a new prebuilt rules package (version change)
     refetchInterval: REVIEW_PREBUILT_RULES_UPGRADE_REFRESH_INTERVAL,
     keepPreviousData: true, // Use this option so that the state doesn't jump between "success" and "loading" on page change
   });

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
@@ -137,7 +137,7 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
     isLoading,
     isRefetching,
   } = usePrebuiltRulesUpgradeReview({
-    // Refetch review prebuilt rules upgrade data in case of
+    // Refetch review prebuilt rules upgrade data to detect possible cases of:
     // - editing prebuilt rules (revision change)
     // - releasing a new prebuilt rules package (version change)
     refetchInterval: REVIEW_PREBUILT_RULES_UPGRADE_REFRESH_INTERVAL,

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table_context.tsx
@@ -39,6 +39,8 @@ import { UpgradeFlyoutSubHeader } from './upgrade_flyout_subheader';
 import * as ruleDetailsI18n from '../../../../rule_management/components/rule_details/translations';
 import * as i18n from './translations';
 
+const REVIEW_PREBUILT_RULES_UPGRADE_REFRESH_INTERVAL = 5 * 60 * 1000;
+
 export interface UpgradePrebuiltRulesTableState {
   /**
    * Rule upgrade state after applying `filterOptions`
@@ -135,7 +137,10 @@ export const UpgradePrebuiltRulesTableContextProvider = ({
     isLoading,
     isRefetching,
   } = usePrebuiltRulesUpgradeReview({
-    refetchInterval: false, // Disable automatic refetching since request is expensive
+    // Refetch review prebuilt rules upgrade data in case of
+    // - editing prebuilt rules (revision change)
+    // - releasing a new prebuilt rules package (version change)
+    refetchInterval: REVIEW_PREBUILT_RULES_UPGRADE_REFRESH_INTERVAL,
     keepPreviousData: true, // Use this option so that the state doesn't jump between "success" and "loading" on page change
   });
   const { rulesUpgradeState, setRuleFieldResolvedValue } =

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_prebuilt_rules_upgrade_state.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_prebuilt_rules_upgrade_state.test.ts
@@ -1,0 +1,366 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FieldUpgradeStateEnum } from '../../../../rule_management/model/prebuilt_rule_upgrade';
+import type { RuleResponse } from '../../../../../../common/api/detection_engine';
+import {
+  type RuleUpgradeInfoForReview,
+  ThreeWayDiffConflict,
+  ThreeWayDiffOutcome,
+  ThreeWayMergeOutcome,
+} from '../../../../../../common/api/detection_engine';
+import { act, renderHook } from '@testing-library/react';
+import { usePrebuiltRulesUpgradeState } from './use_prebuilt_rules_upgrade_state';
+
+jest.mock('../../../../rule_management/hooks/use_is_prebuilt_rules_customization_enabled', () => ({
+  useIsPrebuiltRulesCustomizationEnabled: jest.fn(() => true),
+}));
+
+describe('usePrebuiltRulesUpgradeState', () => {
+  it('returns rule upgrade state', () => {
+    const ruleUpgradeInfosMock: RuleUpgradeInfoForReview[] = [createRuleUpgradeInfoMock()];
+
+    const {
+      result: {
+        current: { rulesUpgradeState },
+      },
+    } = renderHook(usePrebuiltRulesUpgradeState, {
+      initialProps: ruleUpgradeInfosMock,
+    });
+
+    expect(rulesUpgradeState).toEqual({
+      'test-rule-id-1': expect.any(Object),
+    });
+  });
+
+  describe('fields upgrade state', () => {
+    it('returns empty state when there are no fields to upgrade', () => {
+      const ruleUpgradeInfosMock: RuleUpgradeInfoForReview[] = [createRuleUpgradeInfoMock()];
+
+      const { result } = renderHook(usePrebuiltRulesUpgradeState, {
+        initialProps: ruleUpgradeInfosMock,
+      });
+
+      expect(result.current.rulesUpgradeState).toEqual({
+        'test-rule-id-1': expect.objectContaining({
+          fieldsUpgradeState: {},
+        }),
+      });
+    });
+
+    it('returns NO CONFLICT fields', () => {
+      const ruleUpgradeInfosMock: RuleUpgradeInfoForReview[] = [
+        createRuleUpgradeInfoMock({
+          diff: {
+            num_fields_with_updates: 1,
+            num_fields_with_conflicts: 0,
+            num_fields_with_non_solvable_conflicts: 0,
+            fields: {
+              name: {
+                base_version: 'base',
+                current_version: 'base',
+                target_version: 'target',
+                merged_version: 'target',
+                diff_outcome: ThreeWayDiffOutcome.StockValueCanUpdate,
+                merge_outcome: ThreeWayMergeOutcome.Target,
+                has_base_version: true,
+                has_update: true,
+                conflict: ThreeWayDiffConflict.NONE,
+              },
+            },
+          },
+        }),
+      ];
+
+      const { result } = renderHook(usePrebuiltRulesUpgradeState, {
+        initialProps: ruleUpgradeInfosMock,
+      });
+
+      expect(result.current.rulesUpgradeState).toEqual({
+        'test-rule-id-1': expect.objectContaining({
+          fieldsUpgradeState: {
+            name: { state: FieldUpgradeStateEnum.NoConflict },
+          },
+        }),
+      });
+    });
+
+    it('returns SOLVABLE CONFLICT fields', () => {
+      const ruleUpgradeInfosMock: RuleUpgradeInfoForReview[] = [
+        createRuleUpgradeInfoMock({
+          diff: {
+            num_fields_with_updates: 1,
+            num_fields_with_conflicts: 1,
+            num_fields_with_non_solvable_conflicts: 0,
+            fields: {
+              name: {
+                base_version: 'base',
+                current_version: 'current',
+                target_version: 'target',
+                merged_version: 'target',
+                diff_outcome: ThreeWayDiffOutcome.StockValueCanUpdate,
+                merge_outcome: ThreeWayMergeOutcome.Merged,
+                has_base_version: true,
+                has_update: true,
+                conflict: ThreeWayDiffConflict.SOLVABLE,
+              },
+            },
+          },
+        }),
+      ];
+
+      const { result } = renderHook(usePrebuiltRulesUpgradeState, {
+        initialProps: ruleUpgradeInfosMock,
+      });
+
+      expect(result.current.rulesUpgradeState).toEqual({
+        'test-rule-id-1': expect.objectContaining({
+          fieldsUpgradeState: {
+            name: { state: FieldUpgradeStateEnum.SolvableConflict },
+          },
+        }),
+      });
+    });
+
+    it('returns NON SOLVABLE CONFLICT fields', () => {
+      const ruleUpgradeInfosMock: RuleUpgradeInfoForReview[] = [
+        createRuleUpgradeInfoMock({
+          diff: {
+            num_fields_with_updates: 1,
+            num_fields_with_conflicts: 1,
+            num_fields_with_non_solvable_conflicts: 1,
+            fields: {
+              name: {
+                base_version: 'base',
+                current_version: 'current',
+                target_version: 'target',
+                merged_version: 'target',
+                diff_outcome: ThreeWayDiffOutcome.StockValueCanUpdate,
+                merge_outcome: ThreeWayMergeOutcome.Merged,
+                has_base_version: true,
+                has_update: true,
+                conflict: ThreeWayDiffConflict.NON_SOLVABLE,
+              },
+            },
+          },
+        }),
+      ];
+
+      const { result } = renderHook(usePrebuiltRulesUpgradeState, {
+        initialProps: ruleUpgradeInfosMock,
+      });
+
+      expect(result.current.rulesUpgradeState).toEqual({
+        'test-rule-id-1': expect.objectContaining({
+          fieldsUpgradeState: {
+            name: { state: FieldUpgradeStateEnum.NonSolvableConflict },
+          },
+        }),
+      });
+    });
+
+    it('returns ACCEPTED fields after resolving a conflict', () => {
+      const ruleUpgradeInfosMock: RuleUpgradeInfoForReview[] = [
+        createRuleUpgradeInfoMock({
+          rule_id: 'test-rule-id-1',
+          diff: {
+            num_fields_with_updates: 1,
+            num_fields_with_conflicts: 1,
+            num_fields_with_non_solvable_conflicts: 1,
+            fields: {
+              name: {
+                base_version: 'base',
+                current_version: 'current',
+                target_version: 'target',
+                merged_version: 'target',
+                diff_outcome: ThreeWayDiffOutcome.StockValueCanUpdate,
+                merge_outcome: ThreeWayMergeOutcome.Merged,
+                has_base_version: true,
+                has_update: true,
+                conflict: ThreeWayDiffConflict.NON_SOLVABLE,
+              },
+            },
+          },
+        }),
+      ];
+
+      const { result } = renderHook(usePrebuiltRulesUpgradeState, {
+        initialProps: ruleUpgradeInfosMock,
+      });
+
+      act(() => {
+        result.current.setRuleFieldResolvedValue({
+          ruleId: 'test-rule-id-1',
+          fieldName: 'name',
+          resolvedValue: 'resolved',
+        });
+      });
+
+      expect(result.current.rulesUpgradeState).toEqual({
+        'test-rule-id-1': expect.objectContaining({
+          fieldsUpgradeState: {
+            name: { state: FieldUpgradeStateEnum.Accepted, resolvedValue: 'resolved' },
+          },
+        }),
+      });
+    });
+  });
+
+  // Test handling revision and version changes
+  // - user edited a rule (revision change)
+  // - a new prebuilt rules package got released (version change)
+  describe('concurrency control', () => {
+    it('invalidates resolved conflicts upon revision change', () => {
+      const createMock = ({ revision }: { revision: number }) => [
+        createRuleUpgradeInfoMock({
+          rule_id: 'test-rule-id-1',
+          revision,
+          current_rule: createRuleResponseMock({
+            name: 'current',
+            revision,
+          }),
+          diff: {
+            num_fields_with_updates: 1,
+            num_fields_with_conflicts: 1,
+            num_fields_with_non_solvable_conflicts: 1,
+            fields: {
+              name: {
+                base_version: 'base',
+                current_version: 'current',
+                target_version: 'target',
+                merged_version: 'target',
+                diff_outcome: ThreeWayDiffOutcome.StockValueCanUpdate,
+                merge_outcome: ThreeWayMergeOutcome.Merged,
+                has_base_version: true,
+                has_update: true,
+                conflict: ThreeWayDiffConflict.NON_SOLVABLE,
+              },
+            },
+          },
+        }),
+      ];
+
+      const { result, rerender } = renderHook(usePrebuiltRulesUpgradeState, {
+        initialProps: createMock({ revision: 1 }),
+      });
+
+      act(() => {
+        result.current.setRuleFieldResolvedValue({
+          ruleId: 'test-rule-id-1',
+          fieldName: 'name',
+          resolvedValue: 'resolved',
+        });
+      });
+
+      expect(result.current.rulesUpgradeState).toEqual({
+        'test-rule-id-1': expect.objectContaining({
+          fieldsUpgradeState: {
+            name: { state: FieldUpgradeStateEnum.Accepted, resolvedValue: 'resolved' },
+          },
+        }),
+      });
+
+      rerender(createMock({ revision: 2 }));
+
+      expect(result.current.rulesUpgradeState).toEqual({
+        'test-rule-id-1': expect.objectContaining({
+          fieldsUpgradeState: {
+            name: { state: FieldUpgradeStateEnum.NonSolvableConflict },
+          },
+        }),
+      });
+    });
+
+    it('invalidates resolved conflicts upon version change', () => {
+      const createMock = ({ version }: { version: number }) => [
+        createRuleUpgradeInfoMock({
+          rule_id: 'test-rule-id-1',
+          revision: 1,
+          target_rule: createRuleResponseMock({
+            name: 'target',
+            version,
+          }),
+          diff: {
+            num_fields_with_updates: 1,
+            num_fields_with_conflicts: 1,
+            num_fields_with_non_solvable_conflicts: 1,
+            fields: {
+              name: {
+                base_version: 'base',
+                current_version: 'current',
+                target_version: 'target',
+                merged_version: 'target',
+                diff_outcome: ThreeWayDiffOutcome.StockValueCanUpdate,
+                merge_outcome: ThreeWayMergeOutcome.Merged,
+                has_base_version: true,
+                has_update: true,
+                conflict: ThreeWayDiffConflict.NON_SOLVABLE,
+              },
+            },
+          },
+        }),
+      ];
+
+      const { result, rerender } = renderHook(usePrebuiltRulesUpgradeState, {
+        initialProps: createMock({ version: 1 }),
+      });
+
+      act(() => {
+        result.current.setRuleFieldResolvedValue({
+          ruleId: 'test-rule-id-1',
+          fieldName: 'name',
+          resolvedValue: 'resolved',
+        });
+      });
+
+      expect(result.current.rulesUpgradeState).toEqual({
+        'test-rule-id-1': expect.objectContaining({
+          fieldsUpgradeState: {
+            name: { state: FieldUpgradeStateEnum.Accepted, resolvedValue: 'resolved' },
+          },
+        }),
+      });
+
+      rerender(createMock({ version: 2 }));
+
+      expect(result.current.rulesUpgradeState).toEqual({
+        'test-rule-id-1': expect.objectContaining({
+          fieldsUpgradeState: {
+            name: { state: FieldUpgradeStateEnum.NonSolvableConflict },
+          },
+        }),
+      });
+    });
+  });
+});
+
+function createRuleUpgradeInfoMock(
+  rewrites?: Partial<RuleUpgradeInfoForReview>
+): RuleUpgradeInfoForReview {
+  return {
+    id: 'test-id-1',
+    rule_id: 'test-rule-id-1',
+    current_rule: createRuleResponseMock(),
+    target_rule: createRuleResponseMock(),
+    diff: {
+      num_fields_with_updates: 0,
+      num_fields_with_conflicts: 0,
+      num_fields_with_non_solvable_conflicts: 0,
+      fields: {},
+    },
+    revision: 1,
+    ...rewrites,
+  };
+}
+
+function createRuleResponseMock(rewrites?: Partial<RuleResponse>): RuleResponse {
+  return {
+    version: 1,
+    revision: 1,
+    ...rewrites,
+  } as RuleResponse;
+}


### PR DESCRIPTION
**Resolves:** https://github.com/elastic/kibana/issues/200134

## Summary

This PR implements concurrency control to make sure user has the recent rule updates data in Rule Upgrade flyout. Any modifications saved in Rule Upgrade flyout are reset upon new `revision` or `version` detected.

## Details

Concurrency control is important to provide better UX. Multiple users work in Kibana in parallel and new prebuilt rules package version can be released in any time. Attempts to upgrade a rule with outdated `revision` and/or `version` results in failed request. Users may experience multiple rule upgrade failure in that case causing a lot of confusion. More experienced users may guess to reload the page to continue.

Typical reasons leading to `revision` and/or `version` change are the following

- Current rule has been edited will bump rule's `revision`. For example the rule currently shown in Rule Upgrade flyout has been edited by someone else.
- Prebuilt rules package got released will give provide rule assets with higher `version`. Rules having upgrades in the currently installed package and in a new one are affected.

This PR mitigates the described issues by implementing concurrency control. It sets up `_review` API endpoint refetch interval to 5 minutes to fetch fresh data. In case a higher `revision` or `version` is detected for some rule this rule's resolved conflicts and customizations performed in Rule Upgrade flyout get cleared.

## Screenshots

- `revision` change (refresh interval was reduced to 30 seconds to make the video shorter)

https://github.com/user-attachments/assets/98d2a22f-9338-482a-a7b2-1e170b9642ce

- `version` change (refresh interval was reduced to 1 minute to make the video shorter)

https://github.com/user-attachments/assets/2b7c23f0-5a50-471e-aa7f-8d9b2aecc957

## How to test locally

There are two cases for testing

- `revision` change
- `version` change

### Test `revision` change

Revision change means the rule has been edited. Use the following steps to test it 

- Ensure the `prebuiltRulesCustomizationEnabled` feature flag is enabled
- Allow internal APIs via adding `server.restrictInternalApis: false` to `kibana.dev.yaml`
- Clear Elasticsearch data
- Run Elasticsearch and Kibana locally (do not open Kibana in a web browser)
- Install an outdated version of the `security_detection_engine` Fleet package
```bash
curl -X POST --user elastic:changeme  -H 'Content-Type: application/json' -H 'kbn-xsrf: 123' -H "elastic-api-version: 2023-10-31" -d '{"force":true}' http://localhost:5601/kbn/api/fleet/epm/packages/security_detection_engine/8.14.1
```

- Install prebuilt rules
```bash
curl -X POST --user elastic:changeme  -H 'Content-Type: application/json' -H 'kbn-xsrf: 123' -H "elastic-api-version: 1" -d '{"mode":"ALL_RULES"}' http://localhost:5601/kbn/internal/detection_engine/prebuilt_rules/installation/_perform
```
- Open `Detection Rules (SIEM)` Page -> `Rule Updates`
- Open Rule upgrade flyout for some rule
- Make changes to rule field(s) and save them (do not upgrade the rule)
- Open the other web browser tab with Kibana
- Navigate to the same rule's editing page
- Change any field and save the changes
- Return back to the first tab and wait for data to be refetched (data refresh interval is 5 minutes, wait for `_review` request in the Dev Tool's Network tab)
- Make sure the changes you made for field(s) got reverted

### Test `version` change

Version change means a new package version was released. Do the following to test it

- Ensure the `prebuiltRulesCustomizationEnabled` feature flag is enabled
- Allow internal APIs via adding `server.restrictInternalApis: false` to `kibana.dev.yaml`
- Clear Elasticsearch data
- Run Elasticsearch and Kibana locally (do not open Kibana in a web browser)
- Set `xpack.securitySolution.prebuiltRulesPackageVersion: 8.15.2` in `kibana.dev.yaml`
- Install an outdated version of the `security_detection_engine` Fleet package
```bash
curl -X POST --user elastic:changeme  -H 'Content-Type: application/json' -H 'kbn-xsrf: 123' -H "elastic-api-version: 2023-10-31" -d '{"force":true}' http://localhost:5601/kbn/api/fleet/epm/packages/security_detection_engine/8.14.1
```

- Install prebuilt rules
```bash
curl -X POST --user elastic:changeme  -H 'Content-Type: application/json' -H 'kbn-xsrf: 123' -H "elastic-api-version: 1" -d '{"mode":"ALL_RULES"}' http://localhost:5601/kbn/internal/detection_engine/prebuilt_rules/installation/_perform
```
- Open `Detection Rules (SIEM)` Page -> `Rule Updates`
- Open Rule upgrade flyout for a rule having updates in packages `v8.15.2` and `.8.17.1-beta.1` for example `Suspicious Web Browser Sensitive File Access`
- Make changes to rule field(s) and save them (do not upgrade the rule)
- Set `xpack.securitySolution.prebuiltRulesPackageVersion: 8.17.1-beta.1` in `kibana.dev.yaml`
- Open the other web browser tab with Kibana
- Navigate to Security Solution plugin to install the
  OR
  install the package `8.17.1-beta.1` via API request
```bash
curl -X POST --user elastic:changeme  -H 'Content-Type: application/json' -H 'kbn-xsrf: 123' -H "elastic-api-version: 2023-10-31" -d '{"force":true}' http://localhost:5601/kbn/api/fleet/epm/packages/security_detection_engine/8.17.1-beta.1
```
- Return back to the first tab and wait for data to be refetched (data refresh interval is 5 minutes, wait for `_review` request in the Dev Tool's Network tab)
- Make sure the changes you made for field(s) got the recent target rule values

Alternatively you can spin up EPR locally and publish package updates with rule's version bumped.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->