### PR TITLE
[8.16] [Search] Web crawler name consistency (#202738)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
@@ -55,7 +55,7 @@ export const connectorsBreadcrumbs = [
 
 export const crawlersBreadcrumbs = [
   i18n.translate('xpack.enterpriseSearch.content.crawlers.breadcrumb', {
-    defaultMessage: 'Web crawlers',
+    defaultMessage: 'Web Crawlers',
   }),
 ];
 
@@ -95,7 +95,7 @@ export const Connectors: React.FC<ConnectorsProps> = ({ isCrawler }) => {
                 defaultMessage: 'Elasticsearch connectors',
               })
             : i18n.translate('xpack.enterpriseSearch.crawlers.title', {
-                defaultMessage: 'Elasticsearch web crawlers',
+                defaultMessage: 'Elastic Web Crawler',
               }),
           rightSideGroupProps: {
             gutterSize: 's',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawler_empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawler_empty_state.tsx
@@ -49,7 +49,8 @@ export const CrawlerEmptyState: React.FC = () => {
               color="primary"
               fill
               iconType={GithubIcon}
-              href={CRAWLER.github_repo}
+              href={'https://github.com/elastic/crawler'}
+              target="_blank"
             >
               {i18n.translate(
                 'xpack.enterpriseSearch.crawlerEmptyState.openSourceCrawlerButtonLabel',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawler_empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawler_empty_state.tsx
@@ -11,7 +11,6 @@ import { useValues } from 'kea';
 import { EuiButton, EuiEmptyPrompt, EuiPanel } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { CRAWLER } from '../../../../../common/constants';
 import { HttpLogic } from '../../../shared/http';
 import { GithubIcon } from '../../../shared/icons/github_icon';
 import { KibanaLogic } from '../../../shared/kibana';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -289,7 +289,7 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
                 {i18n.translate(
                   'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.learnMoreCrawler.linkText',
                   {
-                    defaultMessage: 'Learn more about the Elastic web crawler',
+                    defaultMessage: 'Learn more about the Elastic Web Crawler',
                   }
                 )}
               </EuiLink>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/classic_nav_helpers.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/classic_nav_helpers.test.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockKibanaValues } from '../../__mocks__/kea_logic';
+
+import type { ChromeNavLink } from '@kbn/core-chrome-browser';
+import type { ClassicNavItem } from '@kbn/search-navigation/public';
+
+import '../../__mocks__/react_router';
+
+jest.mock('../react_router_helpers/link_events', () => ({
+  letBrowserHandleEvent: jest.fn(),
+}));
+
+import { generateSideNavItems } from './classic_nav_helpers';
+
+describe('generateSideNavItems', () => {
+  const deepLinksMap = {
+    enterpriseSearch: {
+      id: 'enterpriseSearch',
+      url: '/app/enterprise_search/overview',
+      title: 'Overview',
+    },
+    'enterpriseSearchContent:searchIndices': {
+      id: 'enterpriseSearchContent:searchIndices',
+      title: 'Indices',
+      url: '/app/enterprise_search/content/search_indices',
+    },
+    'enterpriseSearchContent:connectors': {
+      id: 'enterpriseSearchContent:connectors',
+      title: 'Connectors',
+      url: '/app/enterprise_search/content/connectors',
+    },
+    'enterpriseSearchContent:webCrawlers': {
+      id: 'enterpriseSearchContent:webCrawlers',
+      title: 'Web Crawlers',
+      url: '/app/enterprise_search/content/crawlers',
+    },
+  } as unknown as Record<string, ChromeNavLink | undefined>;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockKibanaValues.history.location.pathname = '/';
+  });
+
+  it('renders top-level items', () => {
+    const classicNavItems: ClassicNavItem[] = [
+      {
+        id: 'unit-test',
+        deepLink: {
+          link: 'enterpriseSearch',
+        },
+      },
+    ];
+
+    expect(generateSideNavItems(classicNavItems, deepLinksMap)).toEqual([
+      {
+        href: '/app/enterprise_search/overview',
+        id: 'unit-test',
+        isSelected: false,
+        name: 'Overview',
+        onClick: expect.any(Function),
+      },
+    ]);
+  });
+
+  it('renders items with children', () => {
+    const classicNavItems: ClassicNavItem[] = [
+      {
+        id: 'parent',
+        name: 'Parent',
+        items: [
+          {
+            id: 'unit-test',
+            deepLink: {
+              link: 'enterpriseSearch',
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(generateSideNavItems(classicNavItems, deepLinksMap)).toEqual([
+      {
+        id: 'parent',
+        items: [
+          {
+            href: '/app/enterprise_search/overview',
+            id: 'unit-test',
+            isSelected: false,
+            name: 'Overview',
+            onClick: expect.any(Function),
+          },
+        ],
+        name: 'Parent',
+      },
+    ]);
+  });
+
+  it('renders classic nav name over deep link title if provided', () => {
+    const classicNavItems: ClassicNavItem[] = [
+      {
+        deepLink: {
+          link: 'enterpriseSearch',
+        },
+        id: 'unit-test',
+        name: 'Home',
+      },
+    ];
+
+    expect(generateSideNavItems(classicNavItems, deepLinksMap)).toEqual([
+      {
+        href: '/app/enterprise_search/overview',
+        id: 'unit-test',
+        isSelected: false,
+        name: 'Home',
+        onClick: expect.any(Function),
+      },
+    ]);
+  });
+
+  it('removes item if deep link is not defined', () => {
+    const classicNavItems: ClassicNavItem[] = [
+      {
+        deepLink: {
+          link: 'enterpriseSearch',
+        },
+        id: 'unit-test',
+        name: 'Home',
+      },
+      {
+        deepLink: {
+          link: 'enterpriseSearchApplications:playground',
+        },
+        id: 'unit-test-missing',
+      },
+    ];
+
+    expect(generateSideNavItems(classicNavItems, deepLinksMap)).toEqual([
+      {
+        href: '/app/enterprise_search/overview',
+        id: 'unit-test',
+        isSelected: false,
+        name: 'Home',
+        onClick: expect.any(Function),
+      },
+    ]);
+  });
+
+  it('adds pre-rendered child items provided', () => {
+    const classicNavItems: ClassicNavItem[] = [
+      {
+        id: 'unit-test',
+        name: 'Indices',
+      },
+    ];
+    const subItems = {
+      'unit-test': [
+        {
+          href: '/app/unit-test',
+          id: 'child',
+          isSelected: true,
+          name: 'Index',
+          onClick: jest.fn(),
+        },
+      ],
+    };
+
+    expect(generateSideNavItems(classicNavItems, deepLinksMap, subItems)).toEqual([
+      {
+        id: 'unit-test',
+        items: [
+          {
+            href: '/app/unit-test',
+            id: 'child',
+            isSelected: true,
+            name: 'Index',
+            onClick: expect.any(Function),
+          },
+        ],
+        name: 'Indices',
+      },
+    ]);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -55,7 +55,7 @@ const baseNavItems = [
         href: '/app/enterprise_search/content/crawlers',
         id: 'crawlers',
         items: undefined,
-        name: 'Web crawlers',
+        name: 'Web Crawlers',
       },
     ],
     name: 'Content',
@@ -145,6 +145,85 @@ const baseNavItems = [
     name: 'Enterprise Search',
   },
 ];
+
+const mockNavLinks = [
+  {
+    id: 'enterpriseSearch',
+    url: '/app/enterprise_search/overview',
+  },
+  {
+    id: 'enterpriseSearchContent:searchIndices',
+    title: 'Indices',
+    url: '/app/enterprise_search/content/search_indices',
+  },
+  {
+    id: 'enterpriseSearchContent:connectors',
+    title: 'Connectors',
+    url: '/app/enterprise_search/content/connectors',
+  },
+  {
+    id: 'enterpriseSearchContent:webCrawlers',
+    title: 'Web Crawlers',
+    url: '/app/enterprise_search/content/crawlers',
+  },
+  {
+    id: 'enterpriseSearchApplications:playground',
+    title: 'Playground',
+    url: '/app/enterprise_search/applications/playground',
+  },
+  {
+    id: 'enterpriseSearchApplications:searchApplications',
+    title: 'Search Applications',
+    url: '/app/enterprise_search/applications/search_applications',
+  },
+  {
+    id: 'enterpriseSearchAnalytics',
+    title: 'Behavioral Analytics',
+    url: '/app/enterprise_search/analytics',
+  },
+  {
+    id: 'searchInferenceEndpoints:inferenceEndpoints',
+    title: 'Inference Endpoints',
+    url: '/app/elasticsearch/relevance/inference_endpoints',
+  },
+  {
+    id: 'appSearch:engines',
+    title: 'App Search',
+    url: '/app/enterprise_search/app_search',
+  },
+  {
+    id: 'workplaceSearch',
+    title: 'Workplace Search',
+    url: '/app/enterprise_search/workplace_search',
+  },
+  {
+    id: 'enterpriseSearchElasticsearch',
+    title: 'Elasticsearch',
+    url: '/app/enterprise_search/elasticsearch',
+  },
+  {
+    id: 'enterpriseSearchVectorSearch',
+    title: 'Vector Search',
+    url: '/app/enterprise_search/vector_search',
+  },
+  {
+    id: 'enterpriseSearchSemanticSearch',
+    title: 'Semantic Search',
+    url: '/app/enterprise_search/semantic_search',
+  },
+  {
+    id: 'enterpriseSearchAISearch',
+    title: 'AI Search',
+    url: '/app/enterprise_search/ai_search',
+  },
+];
+
+const defaultMockValues = {
+  hasEnterpriseLicense: true,
+  isSidebarEnabled: true,
+  productAccess: DEFAULT_PRODUCT_ACCESS,
+  productFeatures: DEFAULT_PRODUCT_FEATURES,
+};
 
 describe('useEnterpriseSearchContentNav', () => {
   beforeEach(() => {

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -129,7 +129,7 @@ const contentLinks: AppDeepLink[] = [
     id: 'webCrawlers',
     path: `/${CRAWLERS_PATH}`,
     title: i18n.translate('xpack.enterpriseSearch.navigation.contentWebcrawlersLinkLabel', {
-      defaultMessage: 'Web crawlers',
+      defaultMessage: 'Web Crawlers',
     }),
   },
 ];

--- a/x-pack/plugins/search_solution/search_navigation/public/classic_navigation.test.ts
+++ b/x-pack/plugins/search_solution/search_navigation/public/classic_navigation.test.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreStart, ScopedHistory } from '@kbn/core/public';
+import type { ChromeNavLink } from '@kbn/core-chrome-browser';
+
+import { classicNavigationFactory } from './classic_navigation';
+import { ClassicNavItem } from './types';
+
+describe('classicNavigationFactory', function () {
+  const mockedNavLinks: Array<Partial<ChromeNavLink>> = [
+    {
+      id: 'enterpriseSearch',
+      url: '/app/enterprise_search/overview',
+      title: 'Overview',
+    },
+    {
+      id: 'enterpriseSearchContent:searchIndices',
+      title: 'Indices',
+      url: '/app/enterprise_search/content/search_indices',
+    },
+    {
+      id: 'enterpriseSearchContent:connectors',
+      title: 'Connectors',
+      url: '/app/enterprise_search/content/connectors',
+    },
+    {
+      id: 'enterpriseSearchContent:webCrawlers',
+      title: 'Web Crawlers',
+      url: '/app/enterprise_search/content/crawlers',
+    },
+  ];
+  const mockedCoreStart = {
+    chrome: {
+      navLinks: {
+        getAll: () => mockedNavLinks,
+      },
+    },
+  };
+  const core = mockedCoreStart as unknown as CoreStart;
+  const mockHistory = {
+    location: {
+      pathname: '/',
+    },
+    createHref: jest.fn(),
+  };
+  const history = mockHistory as unknown as ScopedHistory;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHistory.location.pathname = '/';
+    mockHistory.createHref.mockReturnValue('/');
+  });
+
+  it('can render top-level items', () => {
+    const items: ClassicNavItem[] = [
+      {
+        id: 'unit-test',
+        deepLink: {
+          link: 'enterpriseSearch',
+        },
+      },
+    ];
+    expect(classicNavigationFactory(items, core, history)).toEqual({
+      icon: 'logoEnterpriseSearch',
+      items: [
+        {
+          href: '/app/enterprise_search/overview',
+          id: 'unit-test',
+          isSelected: false,
+          name: 'Overview',
+          onClick: expect.any(Function),
+        },
+      ],
+      name: 'Elasticsearch',
+    });
+  });
+
+  it('will set isSelected', () => {
+    mockHistory.location.pathname = '/overview';
+    mockHistory.createHref.mockReturnValue('/app/enterprise_search/overview');
+
+    const items: ClassicNavItem[] = [
+      {
+        id: 'unit-test',
+        deepLink: {
+          link: 'enterpriseSearch',
+        },
+      },
+    ];
+
+    const solutionNav = classicNavigationFactory(items, core, history);
+    expect(solutionNav!.items).toEqual([
+      {
+        href: '/app/enterprise_search/overview',
+        id: 'unit-test',
+        isSelected: true,
+        name: 'Overview',
+        onClick: expect.any(Function),
+      },
+    ]);
+  });
+  it('can render items with children', () => {
+    const items: ClassicNavItem[] = [
+      {
+        id: 'searchContent',
+        name: 'Content',
+        items: [
+          {
+            id: 'searchIndices',
+            deepLink: {
+              link: 'enterpriseSearchContent:searchIndices',
+            },
+          },
+          {
+            id: 'searchConnectors',
+            deepLink: {
+              link: 'enterpriseSearchContent:connectors',
+            },
+          },
+        ],
+      },
+    ];
+
+    const solutionNav = classicNavigationFactory(items, core, history);
+    expect(solutionNav!.items).toEqual([
+      {
+        id: 'searchContent',
+        items: [
+          {
+            href: '/app/enterprise_search/content/search_indices',
+            id: 'searchIndices',
+            isSelected: false,
+            name: 'Indices',
+            onClick: expect.any(Function),
+          },
+          {
+            href: '/app/enterprise_search/content/connectors',
+            id: 'searchConnectors',
+            isSelected: false,
+            name: 'Connectors',
+            onClick: expect.any(Function),
+          },
+        ],
+        name: 'Content',
+      },
+    ]);
+  });
+  it('returns name if provided over the deeplink title', () => {
+    const items: ClassicNavItem[] = [
+      {
+        id: 'searchIndices',
+        deepLink: {
+          link: 'enterpriseSearchContent:searchIndices',
+        },
+        name: 'Index Management',
+      },
+    ];
+    const solutionNav = classicNavigationFactory(items, core, history);
+    expect(solutionNav!.items).toEqual([
+      {
+        href: '/app/enterprise_search/content/search_indices',
+        id: 'searchIndices',
+        isSelected: false,
+        name: 'Index Management',
+        onClick: expect.any(Function),
+      },
+    ]);
+  });
+  it('removes item if deeplink not defined', () => {
+    const items: ClassicNavItem[] = [
+      {
+        id: 'unit-test',
+        deepLink: {
+          link: 'enterpriseSearch',
+        },
+      },
+      {
+        id: 'serverlessElasticsearch',
+        deepLink: {
+          link: 'serverlessElasticsearch',
+        },
+      },
+    ];
+
+    const solutionNav = classicNavigationFactory(items, core, history);
+    expect(solutionNav!.items).toEqual([
+      {
+        href: '/app/enterprise_search/overview',
+        id: 'unit-test',
+        isSelected: false,
+        name: 'Overview',
+        onClick: expect.any(Function),
+      },
+    ]);
+  });
+});

--- a/x-pack/plugins/serverless_search/common/i18n_string.ts
+++ b/x-pack/plugins/serverless_search/common/i18n_string.ts
@@ -65,6 +65,13 @@ export const CONNECTOR_LABEL: string = i18n.translate('xpack.serverlessSearch.co
   defaultMessage: 'Connector',
 });
 
+export const WEB_CRAWLERS_LABEL: string = i18n.translate(
+  'xpack.serverlessSearch.webCrawlersLabel',
+  {
+    defaultMessage: 'Web Crawlers',
+  }
+);
+
 export const DELETE_CONNECTOR_LABEL = i18n.translate(
   'xpack.serverlessSearch.connectors.deleteConnectorLabel',
   {

--- a/x-pack/plugins/serverless_search/public/application/components/web_crawlers/empty_web_crawlers_prompt.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/web_crawlers/empty_web_crawlers_prompt.tsx
@@ -1,0 +1,270 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiIcon,
+  EuiTitle,
+  EuiText,
+  EuiLink,
+  EuiButton,
+  EuiBadge,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { useKibanaServices } from '../../hooks/use_kibana';
+import { useAssetBasePath } from '../../hooks/use_asset_base_path';
+
+import { ELASTIC_MANAGED_WEB_CRAWLERS_PATH, BASE_WEB_CRAWLERS_PATH } from '../../constants';
+import { DecorativeHorizontalStepper } from '../common/decorative_horizontal_stepper';
+
+export const EmptyWebCrawlersPrompt: React.FC = () => {
+  const {
+    application: { navigateToUrl },
+  } = useKibanaServices();
+
+  const assetBasePath = useAssetBasePath();
+  const webCrawlersIcon = assetBasePath + '/web_crawlers.svg';
+  const githubIcon = assetBasePath + '/github_white.svg';
+
+  return (
+    <EuiFlexGroup alignItems="center" direction="column">
+      <EuiFlexItem>
+        <EuiPanel paddingSize="l" hasShadow={false} hasBorder>
+          <EuiFlexGroup
+            alignItems="center"
+            justifyContent="center"
+            direction="column"
+            gutterSize="l"
+          >
+            <EuiFlexItem>
+              <EuiIcon size="xxl" type={webCrawlersIcon} />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiTitle>
+                <h2>
+                  {i18n.translate('xpack.serverlessSearch.webCrawlersEmpty.title', {
+                    defaultMessage: 'Set up a web crawler',
+                  })}
+                </h2>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText textAlign="center" color="subdued">
+                <p>
+                  {i18n.translate('xpack.serverlessSearch.webCrawlersEmpty.description', {
+                    defaultMessage:
+                      "To set up and deploy a web crawler you'll be working between data source, your terminal, and the Kibana UI. The high level process looks like this:",
+                  })}
+                </p>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexGroup
+              alignItems="stretch"
+              justifyContent="center"
+              direction="column"
+              gutterSize="s"
+            >
+              <EuiFlexItem>
+                <EuiPanel color="subdued">
+                  <EuiFlexItem grow={false}>
+                    <DecorativeHorizontalStepper stepCount={3} />
+                  </EuiFlexItem>
+                  <EuiFlexGroup>
+                    <EuiFlexItem>
+                      <EuiFlexGroup
+                        justifyContent="flexStart"
+                        alignItems="center"
+                        direction="column"
+                      >
+                        <EuiFlexGroup
+                          gutterSize="s"
+                          direction="row"
+                          alignItems="center"
+                          justifyContent="center"
+                        >
+                          <EuiFlexItem grow={false}>
+                            <EuiIcon color="primary" size="l" type={webCrawlersIcon} />
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <EuiIcon size="m" type="sortRight" />
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <EuiIcon color="primary" size="l" type="launch" />
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                        <EuiFlexItem>
+                          <EuiText>
+                            <p>
+                              <FormattedMessage
+                                id="xpack.serverlessSearch.webCrawlersEmpty.guideTwoDescription"
+                                defaultMessage="Deploy web crawler code on your own infrastructure by running from {source}, or using {docker}"
+                                values={{
+                                  source: (
+                                    <EuiLink
+                                      target="_blank"
+                                      data-test-subj="serverlessSearchEmptyConnectorsPromptSourceLink"
+                                      href={'https://github.com/elastic/crawler'}
+                                    >
+                                      {i18n.translate(
+                                        'xpack.serverlessSearch.webCrawlersEmpty.sourceLabel',
+                                        { defaultMessage: 'source' }
+                                      )}
+                                    </EuiLink>
+                                  ),
+                                  docker: (
+                                    <EuiLink
+                                      target="_blank"
+                                      data-test-subj="serverlessSearchEmptyConnectorsPromptDockerLink"
+                                      href={
+                                        'https://github.com/elastic/crawler?tab=readme-ov-file#running-open-crawler-with-docker'
+                                      }
+                                    >
+                                      {i18n.translate(
+                                        'xpack.serverlessSearch.webCrawlersEmpty.dockerLabel',
+                                        { defaultMessage: 'Docker' }
+                                      )}
+                                    </EuiLink>
+                                  ),
+                                }}
+                              />
+                            </p>
+                          </EuiText>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiFlexGroup
+                        justifyContent="flexStart"
+                        alignItems="center"
+                        direction="column"
+                      >
+                        <EuiFlexItem grow={false}>
+                          <EuiFlexGroup
+                            justifyContent="center"
+                            alignItems="center"
+                            direction="row"
+                            gutterSize="s"
+                          >
+                            <EuiFlexItem grow={false}>
+                              <EuiIcon color="primary" size="l" type="globe" />
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiText>
+                            <p>
+                              {i18n.translate(
+                                'xpack.serverlessSearch.webCrawlersEmpty.guideOneDescription',
+                                {
+                                  defaultMessage: 'Set one or more domain URLs you want to crawl',
+                                }
+                              )}
+                            </p>
+                          </EuiText>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+
+                    <EuiFlexItem>
+                      <EuiFlexGroup
+                        justifyContent="flexStart"
+                        alignItems="center"
+                        direction="column"
+                      >
+                        <EuiFlexItem grow={false}>
+                          <EuiFlexGroup
+                            gutterSize="s"
+                            direction="row"
+                            alignItems="center"
+                            justifyContent="center"
+                          >
+                            <EuiFlexItem>
+                              <EuiIcon color="primary" size="l" type="globe" />
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <EuiIcon size="m" type="sortRight" />
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <EuiIcon color="primary" size="l" type={webCrawlersIcon} />
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <EuiIcon size="m" type="sortRight" />
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <EuiIcon color="primary" size="l" type="logoElasticsearch" />
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                        </EuiFlexItem>
+                        <EuiFlexItem>
+                          <EuiText>
+                            <p>
+                              {i18n.translate(
+                                'xpack.serverlessSearch.webCrawlersEmpty.guideThreeDescription',
+                                {
+                                  defaultMessage:
+                                    'Configure your web crawler and connect it to Elasticsearch',
+                                }
+                              )}
+                            </p>
+                          </EuiText>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiPanel>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiFlexGroup direction="row" gutterSize="m">
+              <EuiFlexItem>
+                <EuiButton
+                  data-test-subj="serverlessSearchEmptyConnectorsPromptCreateSelfManagedConnectorButton"
+                  fill
+                  iconType={githubIcon}
+                  href={'https://github.com/elastic/crawler'}
+                  target="_blank"
+                >
+                  {i18n.translate('xpack.serverlessSearch.webCrawlersEmpty.selfManagedButton', {
+                    defaultMessage: 'Self-managed web crawler',
+                  })}
+                </EuiButton>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFlexGroup direction="column" gutterSize="s" alignItems="center">
+                  <EuiFlexItem>
+                    <EuiButton
+                      data-test-subj="serverlessSearchEmptyConnectorsPromptCreateElasticManagedConnectorButton"
+                      onClick={() =>
+                        navigateToUrl(
+                          `${BASE_WEB_CRAWLERS_PATH}/${ELASTIC_MANAGED_WEB_CRAWLERS_PATH}`
+                        )
+                      }
+                    >
+                      {i18n.translate(
+                        'xpack.serverlessSearch.webCrawlersEmpty.elasticManagedButton',
+                        {
+                          defaultMessage: 'Elastic managed web crawler',
+                        }
+                      )}
+                    </EuiButton>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge color="accent">Coming soon</EuiBadge>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexGroup>
+        </EuiPanel>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/plugins/serverless_search/public/application/components/web_crawlers_elastic_managed.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/web_crawlers_elastic_managed.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiLink, EuiPageTemplate, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import React, { useMemo } from 'react';
+
+import { LEARN_MORE_LABEL } from '../../../common/i18n_string';
+
+import { useKibanaServices } from '../hooks/use_kibana';
+import { ElasticManagedWebCrawlersCommingSoon } from './web_crawlers/elastic_managed_web_crawler_coming_soon';
+
+export const WebCrawlersElasticManaged = () => {
+  const { console: consolePlugin } = useKibanaServices();
+
+  const embeddableConsole = useMemo(
+    () => (consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null),
+    [consolePlugin]
+  );
+
+  return (
+    <EuiPageTemplate offset={0} grow restrictWidth data-test-subj="svlSearchConnectorsPage">
+      <EuiPageTemplate.Header
+        pageTitle={i18n.translate('xpack.serverlessSearch.webcrawlers.title', {
+          defaultMessage: 'Web Crawlers',
+        })}
+        data-test-subj="serverlessSearchConnectorsTitle"
+        restrictWidth
+      >
+        <EuiText>
+          <p>
+            <FormattedMessage
+              id="xpack.serverlessSearch.webcrawlers.headerContent"
+              defaultMessage="Discover extract and index searchable content from websites and knowledge bases {learnMoreLink}"
+              values={{
+                learnMoreLink: (
+                  <EuiLink
+                    data-test-subj="serverlessSearchConnectorsOverviewLink"
+                    external
+                    target="_blank"
+                    href={'https://github.com/elastic/crawler'}
+                  >
+                    {LEARN_MORE_LABEL}
+                  </EuiLink>
+                ),
+              }}
+            />
+          </p>
+        </EuiText>
+      </EuiPageTemplate.Header>
+      <EuiPageTemplate.Section restrictWidth color="subdued">
+        <ElasticManagedWebCrawlersCommingSoon />
+      </EuiPageTemplate.Section>
+      {embeddableConsole}
+    </EuiPageTemplate>
+  );
+};

--- a/x-pack/plugins/serverless_search/public/application/components/web_crawlers_overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/web_crawlers_overview.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiLink, EuiPageTemplate, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import React, { useMemo } from 'react';
+
+import { LEARN_MORE_LABEL } from '../../../common/i18n_string';
+
+import { useKibanaServices } from '../hooks/use_kibana';
+import { EmptyWebCrawlersPrompt } from './web_crawlers/empty_web_crawlers_prompt';
+
+export const WebCrawlersOverview = () => {
+  const { console: consolePlugin } = useKibanaServices();
+
+  const embeddableConsole = useMemo(
+    () => (consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null),
+    [consolePlugin]
+  );
+
+  return (
+    <EuiPageTemplate offset={0} grow restrictWidth data-test-subj="svlSearchConnectorsPage">
+      <EuiPageTemplate.Header
+        pageTitle={i18n.translate('xpack.serverlessSearch.webcrawlers.title', {
+          defaultMessage: 'Web Crawlers',
+        })}
+        data-test-subj="serverlessSearchConnectorsTitle"
+        restrictWidth
+      >
+        <EuiText>
+          <p>
+            <FormattedMessage
+              id="xpack.serverlessSearch.webcrawlers.headerContent"
+              defaultMessage="Discover extract and index searchable content from websites and knowledge bases {learnMoreLink}"
+              values={{
+                learnMoreLink: (
+                  <EuiLink
+                    data-test-subj="serverlessSearchConnectorsLearnMoreLink"
+                    external
+                    target="_blank"
+                    href={'https://github.com/elastic/crawler'}
+                  >
+                    {LEARN_MORE_LABEL}
+                  </EuiLink>
+                ),
+              }}
+            />
+          </p>
+        </EuiText>
+      </EuiPageTemplate.Header>
+      <EuiPageTemplate.Section restrictWidth color="subdued">
+        <EmptyWebCrawlersPrompt />
+      </EuiPageTemplate.Section>
+      {embeddableConsole}
+    </EuiPageTemplate>
+  );
+};

--- a/x-pack/test/functional_search/tests/classic_navigation.ts
+++ b/x-pack/test/functional_search/tests/classic_navigation.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../ftr_provider_context';
+
+export default function searchSolutionNavigation({
+  getPageObjects,
+  getService,
+}: FtrProviderContext) {
+  const { common, searchClassicNavigation } = getPageObjects(['common', 'searchClassicNavigation']);
+  const spaces = getService('spaces');
+  const browser = getService('browser');
+
+  describe('Search Classic Navigation', () => {
+    let cleanUp: () => Promise<unknown>;
+    let spaceCreated: { id: string } = { id: '' };
+
+    before(async () => {
+      // Navigate to the spaces management page which will log us in Kibana
+      await common.navigateToUrl('management', 'kibana/spaces', {
+        shouldUseHashForSubUrl: false,
+      });
+
+      // Create a space with the search solution and navigate to its home page
+      ({ cleanUp, space: spaceCreated } = await spaces.create({ solution: 'classic' }));
+      await browser.navigateTo(spaces.getRootUrl(spaceCreated.id));
+      await common.navigateToApp('enterpriseSearch');
+    });
+
+    after(async () => {
+      // Clean up space created
+      await cleanUp();
+    });
+
+    it('renders expected navigation items', async () => {
+      await searchClassicNavigation.expectAllNavItems([
+        { id: 'Home', label: 'Home' },
+        { id: 'Content', label: 'Content' },
+        { id: 'Indices', label: 'Indices' },
+        { id: 'Connectors', label: 'Connectors' },
+        { id: 'Crawlers', label: 'Web Crawlers' },
+        { id: 'Build', label: 'Build' },
+        { id: 'Playground', label: 'Playground' },
+        { id: 'SearchApplications', label: 'Search Applications' },
+        { id: 'BehavioralAnalytics', label: 'Behavioral Analytics' },
+        { id: 'Relevance', label: 'Relevance' },
+        { id: 'InferenceEndpoints', label: 'Inference Endpoints' },
+        { id: 'GettingStarted', label: 'Getting started' },
+        { id: 'Elasticsearch', label: 'Elasticsearch' },
+        { id: 'VectorSearch', label: 'Vector Search' },
+        { id: 'SemanticSearch', label: 'Semantic Search' },
+        { id: 'AISearch', label: 'AI Search' },
+      ]);
+    });
+    it('has expected navigation', async () => {
+      const expectNoPageReload = await searchClassicNavigation.createNoPageReloadCheck();
+
+      await searchClassicNavigation.expectNavItemExists('Home');
+
+      // Check Content
+      // > Indices
+      await searchClassicNavigation.clickNavItem('Indices');
+      await searchClassicNavigation.expectNavItemActive('Indices');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Content');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Elasticsearch indices');
+      // > Connectors
+      await searchClassicNavigation.clickNavItem('Connectors');
+      await searchClassicNavigation.expectNavItemActive('Connectors');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Content');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Connectors');
+      // > Crawlers
+      await searchClassicNavigation.clickNavItem('Crawlers');
+      await searchClassicNavigation.expectNavItemActive('Crawlers');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Content');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Web Crawlers');
+
+      // Check Build
+      // > Playground
+      await searchClassicNavigation.clickNavItem('Playground');
+      await searchClassicNavigation.expectNavItemActive('Playground');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Build');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Playground');
+      // > SearchApplications
+      await searchClassicNavigation.clickNavItem('SearchApplications');
+      await searchClassicNavigation.expectNavItemActive('SearchApplications');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Build');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Search Applications');
+      // > BehavioralAnalytics
+      await searchClassicNavigation.clickNavItem('BehavioralAnalytics');
+      await searchClassicNavigation.expectNavItemActive('BehavioralAnalytics');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Build');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Behavioral Analytics');
+
+      // Check Relevance
+      // > InferenceEndpoints
+      await searchClassicNavigation.clickNavItem('InferenceEndpoints');
+      await searchClassicNavigation.expectNavItemActive('InferenceEndpoints');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Relevance');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Inference Endpoints');
+
+      // Check Getting started
+      // > Elasticsearch
+      await searchClassicNavigation.clickNavItem('Elasticsearch');
+      await searchClassicNavigation.expectNavItemActive('Elasticsearch');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists(
+        'Getting started with Elasticsearch'
+      );
+      // > VectorSearch
+      await searchClassicNavigation.clickNavItem('VectorSearch');
+      await searchClassicNavigation.expectNavItemActive('VectorSearch');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Getting started');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Vector Search');
+      // > SemanticSearch
+      await searchClassicNavigation.clickNavItem('SemanticSearch');
+      await searchClassicNavigation.expectNavItemActive('SemanticSearch');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Getting started');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Semantic Search');
+      // > AISearch
+      await searchClassicNavigation.clickNavItem('AISearch');
+      await searchClassicNavigation.expectNavItemActive('AISearch');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Getting started');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('AI Search');
+
+      await expectNoPageReload();
+    });
+  });
+}

--- a/x-pack/test/functional_search/tests/solution_navigation.ts
+++ b/x-pack/test/functional_search/tests/solution_navigation.ts
@@ -43,7 +43,7 @@ export default function searchSolutionNavigation({
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dashboards' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Indices' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Connectors' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Web crawlers' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Web Crawlers' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Search applications' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Behavioral Analytics' });
@@ -136,7 +136,7 @@ export default function searchSolutionNavigation({
         deepLinkId: 'enterpriseSearchContent:webCrawlers',
       });
       await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Content' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Web crawlers' });
+      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Web Crawlers' });
       await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
         deepLinkId: 'enterpriseSearchContent:webCrawlers',
       });

--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -113,5 +113,57 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       expect(await browser.getCurrentUrl()).not.contain('/app/management/cases');
       await testSubjects.missingOrFail('cases-all-title');
     });
+
+    it('renders expected side navigation items', async () => {
+      await solutionNavigation.sidenav.openSection('project_settings_project_nav');
+      // Verify all expected top-level links exist
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Data' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Index Management' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Connectors' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Web Crawlers' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Build' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Dev Tools' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Relevance' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Inference Endpoints' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Analyze' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Discover' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Dashboards' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Other tools' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Maps' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Getting Started' });
+
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Trained models' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Management' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Users and roles' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Performance' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Billing and subscription' });
+
+      await solutionNavigation.sidenav.openSection('project_settings_project_nav');
+      await solutionNavigation.sidenav.expectOnlyDefinedLinks([
+        'search_project_nav',
+        'data',
+        'management:index_management',
+        'serverlessConnectors',
+        'serverlessWebCrawlers',
+        'build',
+        'dev_tools',
+        'searchPlayground',
+        'relevance',
+        'searchInferenceEndpoints',
+        'analyze',
+        'discover',
+        'dashboards',
+        'otherTools',
+        'maps',
+        'gettingStarted',
+        'project_settings_project_nav',
+        'ml:modelManagement',
+        'management',
+        'cloudLinkUserAndRoles',
+        'cloudLinkDeployment',
+        'cloudLinkBilling',
+      ]);
+    });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Search] Web crawler name consistency (#202738)](https://github.com/elastic/kibana/pull/202738)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"José Luis González","email":"joseluisgj@gmail.com"},"sourceCommit":{"committedDate":"2024-12-05T11:32:33Z","message":"[Search] Web crawler name consistency (#202738)\n\n## Summary\r\n\r\nThis PR fixes the areas where we display the Web Crawler naming bearing\r\nin mind these agreements :\r\n- We should be capitalizing when referring to the product name: Elastic\r\nWeb Crawler / Web Crawler /Elastic Open Web Crawler\r\n- We can use lower case when referring to the feature or concept of web\r\ncrawler( crawler in short): \"Use the web crawler to ...\"\r\n\r\nESS:\r\n![CleanShot 2024-12-03 at 15 19\r\n19@2x](https://github.com/user-attachments/assets/d5cba886-09b3-4c34-b6e5-565cb67b9e08)\r\n\r\nES3:\r\n![CleanShot 2024-12-03 at 15 19\r\n56@2x](https://github.com/user-attachments/assets/2a6b6a8a-697c-4001-96d8-c826b6769836)\r\n\r\n\r\nNotes: Also fixing buttons that take users to the Open Web Crawler repo\r\nto open the links in a new tab and don't lose the product focus.","sha":"4899c971fb8ca8309b963ba0135e66812be2584c","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","v9.0.0","Team:Search","backport:version","v8.17.0","v8.18.0","v8.16.2"],"number":202738,"url":"https://github.com/elastic/kibana/pull/202738","mergeCommit":{"message":"[Search] Web crawler name consistency (#202738)\n\n## Summary\r\n\r\nThis PR fixes the areas where we display the Web Crawler naming bearing\r\nin mind these agreements :\r\n- We should be capitalizing when referring to the product name: Elastic\r\nWeb Crawler / Web Crawler /Elastic Open Web Crawler\r\n- We can use lower case when referring to the feature or concept of web\r\ncrawler( crawler in short): \"Use the web crawler to ...\"\r\n\r\nESS:\r\n![CleanShot 2024-12-03 at 15 19\r\n19@2x](https://github.com/user-attachments/assets/d5cba886-09b3-4c34-b6e5-565cb67b9e08)\r\n\r\nES3:\r\n![CleanShot 2024-12-03 at 15 19\r\n56@2x](https://github.com/user-attachments/assets/2a6b6a8a-697c-4001-96d8-c826b6769836)\r\n\r\n\r\nNotes: Also fixing buttons that take users to the Open Web Crawler repo\r\nto open the links in a new tab and don't lose the product focus.","sha":"4899c971fb8ca8309b963ba0135e66812be2584c"}},"sourceBranch":"main","suggestedTargetBranches":["8.17","8.x","8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/202738","number":202738,"mergeCommit":{"message":"[Search] Web crawler name consistency (#202738)\n\n## Summary\r\n\r\nThis PR fixes the areas where we display the Web Crawler naming bearing\r\nin mind these agreements :\r\n- We should be capitalizing when referring to the product name: Elastic\r\nWeb Crawler / Web Crawler /Elastic Open Web Crawler\r\n- We can use lower case when referring to the feature or concept of web\r\ncrawler( crawler in short): \"Use the web crawler to ...\"\r\n\r\nESS:\r\n![CleanShot 2024-12-03 at 15 19\r\n19@2x](https://github.com/user-attachments/assets/d5cba886-09b3-4c34-b6e5-565cb67b9e08)\r\n\r\nES3:\r\n![CleanShot 2024-12-03 at 15 19\r\n56@2x](https://github.com/user-attachments/assets/2a6b6a8a-697c-4001-96d8-c826b6769836)\r\n\r\n\r\nNotes: Also fixing buttons that take users to the Open Web Crawler repo\r\nto open the links in a new tab and don't lose the product focus.","sha":"4899c971fb8ca8309b963ba0135e66812be2584c"}},{"branch":"8.17","label":"v8.17.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.16","label":"v8.16.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->