### PR TITLE
🌊 Streams: Fix redirect bug

### DIFF
--- a/x-pack/plugins/streams_app/public/components/stream_detail_management/index.tsx
+++ b/x-pack/plugins/streams_app/public/components/stream_detail_management/index.tsx
@@ -80,7 +80,7 @@ export function StreamDetailManagement({
     );
   }
 
-  if (!definition?.managed) {
+  if (definition && !definition.managed) {
     return (
       <RedirectTo
         path="/{key}/management/{subtab}"


### PR DESCRIPTION
As discussed here: https://github.com/elastic/kibana/pull/202372#discussion_r1875857095

There is a bug redirecting the user away from any management tab but `route`. This was happening because while loading the definition it would behave as if the stream is unmanaged. This fixes this problem.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->