### PR TITLE
[8.16] Upgrade express 4.21.1→ 4.21.2 (#203504)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1732,7 +1732,7 @@
     "exit-hook": "^2.2.0",
     "expect": "^29.7.0",
     "expose-loader": "^0.7.5",
-    "express": "^4.21.0",
+    "express": "^4.21.2",
     "faker": "^5.1.0",
     "fetch-mock": "^7.3.9",
     "file-loader": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17771,10 +17771,10 @@ expr-eval@^2.0.2:
   resolved "https://registry.yarnpkg.com/expr-eval/-/expr-eval-2.0.2.tgz#fa6f044a7b0c93fde830954eb9c5b0f7fbc7e201"
   integrity sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==
 
-express@^4.17.1, express@^4.17.3, express@^4.18.2, express@^4.21.0:
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.21.0.tgz#d57cb706d49623d4ac27833f1cbc466b668eb915"
-  integrity sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==
+express@^4.17.1, express@^4.17.3, express@^4.18.2, express@^4.21.2:
+  version "4.21.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.21.2.tgz#cf250e48362174ead6cea4a566abef0162c1ec32"
+  integrity sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==
   dependencies:
     accepts "~1.3.8"
     array-flatten "1.1.1"
@@ -17795,7 +17795,7 @@ express@^4.17.1, express@^4.17.3, express@^4.18.2, express@^4.21.0:
     methods "~1.1.2"
     on-finished "2.4.1"
     parseurl "~1.3.3"
-    path-to-regexp "0.1.10"
+    path-to-regexp "0.1.12"
     proxy-addr "~2.0.7"
     qs "6.13.0"
     range-parser "~1.2.1"
@@ -25159,10 +25159,10 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.10.tgz#67e9108c5c0551b9e5326064387de4763c4d5f8b"
-  integrity sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==
+path-to-regexp@0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
+  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
 path-to-regexp@^1.7.0:
   version "1.9.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Upgrade express 4.21.1→ 4.21.2 (#203504)](https://github.com/elastic/kibana/pull/203504)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2024-12-10T19:42:27Z","message":"Upgrade express 4.21.1→ 4.21.2 (#203504)\n\n## Summary\r\n\r\nUpgrade `express` from v4.21.1 to v4.21.2","sha":"75760bbb13555845369db4c0d07f6bbb32afa0ee","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","v9.0.0","backport:all-open"],"number":203504,"url":"https://github.com/elastic/kibana/pull/203504","mergeCommit":{"message":"Upgrade express 4.21.1→ 4.21.2 (#203504)\n\n## Summary\r\n\r\nUpgrade `express` from v4.21.1 to v4.21.2","sha":"75760bbb13555845369db4c0d07f6bbb32afa0ee"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203504","number":203504,"mergeCommit":{"message":"Upgrade express 4.21.1→ 4.21.2 (#203504)\n\n## Summary\r\n\r\nUpgrade `express` from v4.21.1 to v4.21.2","sha":"75760bbb13555845369db4c0d07f6bbb32afa0ee"}}]}] BACKPORT-->