### PR TITLE
more lovable text colors

### DIFF
--- a/packages/kbn-monaco/src/esql/lib/esql_theme.ts
+++ b/packages/kbn-monaco/src/esql/lib/esql_theme.ts
@@ -45,7 +45,7 @@ export const buildESQLTheme = ({
       // source commands
       ...buildRuleGroup(
         ['from', 'row', 'show'],
-        euiThemeVars.euiColorPrimaryText,
+        euiThemeVars.euiColorPrimary,
         true // isBold
       ),
 
@@ -88,12 +88,12 @@ export const buildESQLTheme = ({
           'desc',
           'nulls_order',
         ],
-        euiThemeVars.euiColorAccentText,
+        euiThemeVars.euiColorAccent,
         true // isBold
       ),
 
       // functions
-      ...buildRuleGroup(['functions'], euiThemeVars.euiColorPrimaryText),
+      ...buildRuleGroup(['functions'], euiThemeVars.euiColorPrimary),
 
       // operators
       ...buildRuleGroup(
@@ -116,7 +116,7 @@ export const buildESQLTheme = ({
           'percent', // '%'
           'cast_op', // '::'
         ],
-        euiThemeVars.euiColorPrimaryText
+        euiThemeVars.euiColorPrimary
       ),
 
       // comments
@@ -156,7 +156,7 @@ export const buildESQLTheme = ({
           'closing_metrics_line_comment',
           'closing_metrics_multiline_comment',
         ],
-        euiThemeVars.euiColorDisabledText
+        euiThemeVars.euiColorDisabled
       ),
 
       // values


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/issues/199715
Closes https://github.com/elastic/kibana/issues/200160

## Summary

The Kibana ES|QL + Discover teams reviewed the ES|QL editor text colors and found them to be dull relative to current theme settings. This PR makes a slight change to use base colors instead of text colors.

**Note**
Longer term - and this consideration was preexisting - we could explore adding a text-editor-specific set of tokens for use in Monaco editors. That said, these theme files are not React based, so this might be a challenge to handle via EUI tokens once the old javascript based theme tokens are deprecated.

### Before and after

**Editor in 8.X (Amsterdam theme)**
<img width="420" src="https://github.com/user-attachments/assets/23726e98-9277-4ef4-ae21-c843fc929aa3" />

**Editor on main (Borealis theme)**
<img width="400" src="https://github.com/user-attachments/assets/2b973b8b-d292-46d2-a5d2-0a787f8c686a" />

**Editor after this PR (Borealis theme)**
_Light mode_
<img width="600" src="https://github.com/user-attachments/assets/d34f2961-44b9-4f79-8690-dc44035f8146" />

_Dark mode_
<img width="420" src="https://github.com/user-attachments/assets/e4ccbfb9-4dc1-4c41-ad95-6cc54a8de575" />

