### PR TITLE
[8.last] [UA] Enable UA ES featuresets

### DIFF
--- a/x-pack/plugins/upgrade_assistant/server/config.ts
+++ b/x-pack/plugins/upgrade_assistant/server/config.ts
@@ -33,12 +33,12 @@ const configSchema = schema.object({
      * to change the constant `MachineLearningField.MIN_CHECKED_SUPPORTED_SNAPSHOT_VERSION`
      * to something higher than 7.0.0 in the Elasticsearch code.
      */
-    mlSnapshots: schema.boolean({ defaultValue: false }),
+    mlSnapshots: schema.boolean({ defaultValue: true }),
     /**
      * Migrating system indices should only be enabled for major version upgrades.
      * Currently this is manually set to `true` on every `x.last` version.
      */
-    migrateSystemIndices: schema.boolean({ defaultValue: false }),
+    migrateSystemIndices: schema.boolean({ defaultValue: true }),
     /**
      * Deprecations with reindexing corrective actions are only enabled for major version upgrades.
      * Currently this is manually set to `true` on every `x.last` version.
@@ -46,12 +46,12 @@ const configSchema = schema.object({
      * The reindex action includes some logic that is specific to the 8.0 upgrade
      * End users could get into a bad situation if this is enabled before this logic is fixed.
      */
-    reindexCorrectiveActions: schema.boolean({ defaultValue: false }),
+    reindexCorrectiveActions: schema.boolean({ defaultValue: true }),
     /**
      * Migrating deprecated data streams should only be enabled for major version upgrades.
      * Currently this is manually set to `true` on every `x.last` version.
      */
-    migrateDataStreams: schema.boolean({ defaultValue: false }),
+    migrateDataStreams: schema.boolean({ defaultValue: true }),
   }),
   /**
    * This config allows to hide the UI without disabling the plugin.

--- a/x-pack/plugins/upgrade_assistant/server/lib/reindexing/index_settings.ts
+++ b/x-pack/plugins/upgrade_assistant/server/lib/reindexing/index_settings.ts
@@ -43,8 +43,8 @@ export const transformFlatSettings = (flatSettings: FlatSettings) => {
  * introduced by the upgrade assistant
  *
  * Examples:
- *   .reindex-v7-foo => .foo
- *   reindex-v7-foo => foo
+ *   .reindex-v8-foo => .foo
+ *   reindex-v8-foo => foo
  *
  * @param indexName
  */
@@ -63,8 +63,8 @@ export const sourceNameForIndex = (indexName: string): string => {
 /**
  * Provides the index name to re-index into
  *
- * .foo -> .reindexed-v7-foo
- * foo => reindexed-v7-foo
+ * .foo -> .reindexed-v8-foo
+ * foo => reindexed-v8-foo
  */
 export const generateNewIndexName = (indexName: string): string => {
   const sourceName = sourceNameForIndex(indexName);
@@ -136,7 +136,7 @@ export const getReindexWarnings = (
 ): ReindexWarning[] => {
   const warnings = [] as ReindexWarning[];
 
-  if (versionService.getMajorVersion() === 7) {
+  if (versionService.getMajorVersion() === 8) {
     const customTypeWarning = getCustomTypeWarning(flatSettings);
     const deprecatedSettingWarning = getDeprecatedSettingWarning(flatSettings);
 

--- a/x-pack/plugins/upgrade_assistant/server/lib/reindexing/reindex_actions.ts
+++ b/x-pack/plugins/upgrade_assistant/server/lib/reindexing/reindex_actions.ts
@@ -210,7 +210,7 @@ export const reindexActionsFactory = (
     async getFlatSettings(indexName: string) {
       let flatSettings;
 
-      if (versionService.getMajorVersion() === 7) {
+      if (versionService.getMajorVersion() === 8) {
         // On 7.x, we need to get index settings with mapping type
         flatSettings = await esClient.indices.get({
           index: indexName,


### PR DESCRIPTION
## Summary
This is not a backport. we only need to enable these featureset flags in `8.last` (`8.x` branch)
- [x] Turns on our 4 ES feature set flags for UA
- [x] Change the version guard for reindexing system indices from `7` to `8`

Although the version check is redundant since we can use featureset guards instead which offers a better human control over this. I decided to keep things as is to avoid unexpected bugs that might come up from bigger changes.

## Reindexing system indices screenshots (ES snapshot from 7.17 -> 8.18)
![image](https://github.com/user-attachments/assets/6dc0f9dd-f7ce-4ce7-86e0-ace1ac66e9b5)
![image](https://github.com/user-attachments/assets/bf80f75a-7790-4f0d-9e5e-12cc65710775)
![image](https://github.com/user-attachments/assets/28735b40-8575-4bab-bda0-ec0e06e48987)


Closes https://github.com/elastic/kibana/issues/202213

