### PR TITLE
[8.x] [EDR Workflows] Add RunScript API route (supporting CrowdStrike) (#203101)

### DIFF
--- a/x-pack/plugins/security_solution/common/api/endpoint/actions/response_actions/run_script/index.ts
+++ b/x-pack/plugins/security_solution/common/api/endpoint/actions/response_actions/run_script/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './run_script';

--- a/x-pack/plugins/security_solution/common/api/endpoint/actions/response_actions/run_script/run_script.ts
+++ b/x-pack/plugins/security_solution/common/api/endpoint/actions/response_actions/run_script/run_script.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TypeOf } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
+import { BaseActionRequestSchema } from '../../common/base';
+
+const { parameters, ...restBaseSchema } = BaseActionRequestSchema;
+const NonEmptyString = schema.string({
+  minLength: 1,
+  validate: (value) => {
+    if (!value.trim().length) {
+      return 'Raw cannot be an empty string';
+    }
+  },
+});
+export const RunScriptActionRequestSchema = {
+  body: schema.object({
+    ...restBaseSchema,
+    parameters: schema.object(
+      {
+        /**
+         * The script to run
+         */
+        Raw: schema.maybe(NonEmptyString),
+        /**
+         * The path to the script on the host to run
+         */
+        HostPath: schema.maybe(NonEmptyString),
+        /**
+         * The path to the script in the cloud to run
+         */
+        CloudFile: schema.maybe(NonEmptyString),
+        /**
+         * The command line to run
+         */
+        CommandLine: schema.maybe(NonEmptyString),
+        /**
+         * The max timeout value before the command is killed. Number represents milliseconds
+         */
+        Timeout: schema.maybe(schema.number({ min: 1 })),
+      },
+      {
+        validate: (params) => {
+          if (!params.Raw && !params.HostPath && !params.CloudFile) {
+            return 'At least one of Raw, HostPath, or CloudFile must be provided';
+          }
+        },
+      }
+    ),
+  }),
+};
+
+export type RunScriptActionRequestBody = TypeOf<typeof RunScriptActionRequestSchema.body>;

--- a/x-pack/plugins/security_solution/common/api/endpoint/actions/response_actions/run_script/run_script.yaml
+++ b/x-pack/plugins/security_solution/common/api/endpoint/actions/response_actions/run_script/run_script.yaml
@@ -1,0 +1,74 @@
+openapi: 3.0.0
+info:
+  title: RunScript Action Schema
+  version: '2023-10-31'
+paths:
+  /api/endpoint/action/runscript:
+    post:
+      summary: Run a script
+      operationId: RunScriptAction
+      description: Run a shell command on an endpoint.
+      x-codegen-enabled: true
+      x-labels: [ ess, serverless ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunScriptRouteRequestBody'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '../../../model/schema/common.schema.yaml#/components/schemas/SuccessResponse'
+
+components:
+  schemas:
+    RunScriptRouteRequestBody:
+      allOf:
+        - $ref: '../../../model/schema/common.schema.yaml#/components/schemas/BaseActionSchema'
+        - type: object
+          required:
+            - parameters
+          properties:
+            parameters:
+              oneOf:
+                - type: object
+                  properties:
+                    Raw:
+                      type: string
+                      minLength: 1
+                      description: Raw script content.
+                    required:
+                      - Raw
+                - type: object
+                  properties:
+                    HostPath:
+                      type: string
+                      minLength: 1
+                      description: Absolute or relative path of script on host machine.
+                    required:
+                      - HostPath
+                - type: object
+                  properties:
+                    CloudFile:
+                      type: string
+                      minLength: 1
+                      description: Script name in cloud storage.
+                    required:
+                      - CloudFile
+                - type: object
+                  properties:
+                    CommandLine:
+                      type: string
+                      minLength: 1
+                      description: Command line arguments.
+                    required:
+                      - CommandLine
+              properties:
+                Timeout:
+                  type: integer
+                  minimum: 1
+                  description: Timeout in seconds.

--- a/x-pack/plugins/security_solution/common/api/endpoint/index.ts
+++ b/x-pack/plugins/security_solution/common/api/endpoint/index.ts
@@ -24,6 +24,7 @@ export * from './actions/response_actions/get_file';
 export * from './actions/response_actions/execute';
 export * from './actions/response_actions/upload';
 export * from './actions/response_actions/scan';
+export * from './actions/response_actions/run_script';
 
 export * from './metadata';
 

--- a/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/actions.ts
@@ -96,6 +96,11 @@ export interface ResponseActionScanOutputContent {
   code: string;
 }
 
+export interface ResponseActionRunScriptOutputContent {
+  output: string;
+  code: string;
+}
+
 export const ActivityLogItemTypes = {
   ACTION: 'action' as const,
   RESPONSE: 'response' as const,
@@ -216,13 +221,29 @@ export interface ResponseActionScanParameters {
   path: string;
 }
 
+// Currently reflecting CrowdStrike's RunScript parameters
+interface ActionsRunScriptParametersBase {
+  Raw?: string;
+  HostPath?: string;
+  CloudFile?: string;
+  CommandLine?: string;
+  Timeout?: number;
+}
+
+// Enforce at least one of the script parameters is required
+export type ResponseActionRunScriptParameters = AtLeastOne<
+  ActionsRunScriptParametersBase,
+  'Raw' | 'HostPath' | 'CloudFile'
+>;
+
 export type EndpointActionDataParameterTypes =
   | undefined
   | ResponseActionParametersWithProcessData
   | ResponseActionsExecuteParameters
   | ResponseActionGetFileParameters
   | ResponseActionUploadParameters
-  | ResponseActionScanParameters;
+  | ResponseActionScanParameters
+  | ResponseActionRunScriptParameters;
 
 /** Output content of the different response actions */
 export type EndpointActionResponseDataOutput =
@@ -233,7 +254,8 @@ export type EndpointActionResponseDataOutput =
   | GetProcessesActionOutputContent
   | SuspendProcessActionOutputContent
   | KillProcessActionOutputContent
-  | ResponseActionScanOutputContent;
+  | ResponseActionScanOutputContent
+  | ResponseActionRunScriptOutputContent;
 
 /**
  * The data stored with each Response Action under `EndpointActions.data` property
@@ -571,3 +593,7 @@ export interface ResponseActionUploadOutputContent {
   /** The free space available (after saving the file) of the drive where the file was saved to, In Bytes  */
   disk_free_space: number;
 }
+
+type AtLeastOne<T, K extends keyof T = keyof T> = K extends keyof T
+  ? Required<Pick<T, K>> & Partial<Omit<T, K>>
+  : never;

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/console_commands_definition.ts
@@ -538,7 +538,7 @@ export const getEndpointConsoleCommands = ({
         capabilities: endpointCapabilities,
         privileges: endpointPrivileges,
       },
-      exampleUsage: `runscript --Raw=\`\`\`Get-ChildItem .\`\`\` -CommandLine=""`,
+      exampleUsage: `runscript --Raw="Get-ChildItem ." --CommandLine=""`,
       helpUsage: CROWDSTRIKE_CONSOLE_COMMANDS.runscript.helpUsage,
       exampleInstruction: CROWDSTRIKE_CONSOLE_COMMANDS.runscript.about,
       validate: capabilitiesAndPrivilegesValidator(agentType),

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/endpoint_action_response_codes.ts
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/lib/endpoint_action_response_codes.ts
@@ -294,7 +294,7 @@ const CODES = Object.freeze({
   ),
 
   // Dev:
-  // scan success/competed
+  // scan success/completed
   ra_scan_success_done: i18n.translate(
     'xpack.securitySolution.endpointActionResponseCodes.scan.success',
     { defaultMessage: 'Scan complete' }

--- a/x-pack/plugins/security_solution/public/management/cypress/screens/responder.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/screens/responder.ts
@@ -29,6 +29,8 @@ export const getConsoleHelpPanelResponseActionTestSubj = (): Record<
     execute: 'endpointResponseActionsConsole-commandList-Responseactions-execute',
     upload: 'endpointResponseActionsConsole-commandList-Responseactions-upload',
     scan: 'endpointResponseActionsConsole-commandList-Responseactions-scan',
+    // Not implemented in Endpoint yet
+    // runscript: 'endpointResponseActionsConsole-commandList-Responseactions-runscript',
   };
 };
 

--- a/x-pack/plugins/security_solution/server/endpoint/routes/actions/response_actions.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/actions/response_actions.ts
@@ -8,11 +8,6 @@
 import type { RequestHandler } from '@kbn/core/server';
 import type { TypeOf } from '@kbn/config-schema';
 
-import { responseActionsWithLegacyActionProperty } from '../../services/actions/constants';
-import { stringify } from '../../utils/stringify';
-import { getResponseActionsClient, NormalizedExternalConnectorClient } from '../../services';
-import type { ResponseActionsClient } from '../../services/actions/clients/lib/types';
-import { CustomHttpRequestError } from '../../../utils/custom_http_request_error';
 import type {
   ResponseActionAgentType,
   ResponseActionsApiCommandNames,

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/crowdstrike/crowdstrike_actions_client.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/crowdstrike/crowdstrike_actions_client.ts
@@ -26,9 +26,12 @@ import type {
   EndpointActionDataParameterTypes,
   EndpointActionResponseDataOutput,
   LogsEndpointAction,
+  ResponseActionRunScriptOutputContent,
+  ResponseActionRunScriptParameters,
 } from '../../../../../../common/endpoint/types';
 import type {
   IsolationRouteRequestBody,
+  RunScriptActionRequestBody,
   UnisolationRouteRequestBody,
 } from '../../../../../../common/api/endpoint';
 import type {
@@ -294,6 +297,19 @@ export class CrowdstrikeActionsClient extends ResponseActionsClientImpl {
     });
 
     return this.fetchActionDetails(actionRequestDoc.EndpointActions.action_id);
+  }
+
+  public async runscript(
+    actionRequest: RunScriptActionRequestBody,
+    options?: CommonResponseActionMethodOptions
+  ): Promise<
+    ActionDetails<ResponseActionRunScriptOutputContent, ResponseActionRunScriptParameters>
+  > {
+    // TODO: just a placeholder for now
+    return Promise.resolve({ output: 'runscript', code: 200 }) as never as ActionDetails<
+      ResponseActionRunScriptOutputContent,
+      ResponseActionRunScriptParameters
+    >;
   }
 
   private async completeCrowdstrikeAction(

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/endpoint/endpoint_actions_client.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/endpoint/endpoint_actions_client.test.ts
@@ -347,7 +347,8 @@ describe('EndpointActionsClient', () => {
 
   type ResponseActionsMethodsOnly = keyof Omit<
     ResponseActionsClient,
-    'processPendingActions' | 'getFileDownload' | 'getFileInfo'
+    // TODO: not yet implemented
+    'processPendingActions' | 'getFileDownload' | 'getFileInfo' | 'runscript'
   >;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -375,6 +376,9 @@ describe('EndpointActionsClient', () => {
     upload: responseActionsClientMock.createUploadOptions(getCommonResponseActionOptions()),
 
     scan: responseActionsClientMock.createScanOptions(getCommonResponseActionOptions()),
+
+    // TODO: not yet implemented
+    // runscript: responseActionsClientMock.createRunScriptOptions(getCommonResponseActionOptions()),
   };
 
   it.each(Object.keys(responseActionMethods) as ResponseActionsMethodsOnly[])(

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/lib/base_response_actions_client.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/lib/base_response_actions_client.ts
@@ -71,6 +71,8 @@ import type {
   SuspendProcessActionOutputContent,
   UploadedFileInfo,
   WithAllKeys,
+  ResponseActionRunScriptOutputContent,
+  ResponseActionRunScriptParameters,
 } from '../../../../../../common/endpoint/types';
 import type {
   ExecuteActionRequestBody,
@@ -79,6 +81,7 @@ import type {
   KillProcessRequestBody,
   ResponseActionGetFileRequestBody,
   ResponseActionsRequestBody,
+  RunScriptActionRequestBody,
   ScanActionRequestBody,
   SuspendProcessRequestBody,
   UnisolationRouteRequestBody,
@@ -839,6 +842,15 @@ export abstract class ResponseActionsClientImpl implements ResponseActionsClient
     options?: CommonResponseActionMethodOptions
   ): Promise<ActionDetails<ResponseActionScanOutputContent, ResponseActionScanParameters>> {
     throw new ResponseActionsNotSupportedError('scan');
+  }
+
+  public async runscript(
+    actionRequest: RunScriptActionRequestBody,
+    options?: CommonResponseActionMethodOptions
+  ): Promise<
+    ActionDetails<ResponseActionRunScriptOutputContent, ResponseActionRunScriptParameters>
+  > {
+    throw new ResponseActionsNotSupportedError('runscript');
   }
 
   public async processPendingActions(_: ProcessPendingActionsMethodOptions): Promise<void> {

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/lib/types.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/lib/types.ts
@@ -23,6 +23,8 @@ import type {
   UploadedFileInfo,
   ResponseActionScanOutputContent,
   ResponseActionScanParameters,
+  ResponseActionRunScriptOutputContent,
+  ResponseActionRunScriptParameters,
 } from '../../../../../../common/endpoint/types';
 import type {
   IsolationRouteRequestBody,
@@ -35,6 +37,7 @@ import type {
   ScanActionRequestBody,
   KillProcessRequestBody,
   SuspendProcessRequestBody,
+  RunScriptActionRequestBody,
 } from '../../../../../../common/api/endpoint';
 
 type OmitUnsupportedAttributes<T extends BaseActionRequestBody> = Omit<
@@ -155,4 +158,16 @@ export interface ResponseActionsClient {
     actionRequest: OmitUnsupportedAttributes<ScanActionRequestBody>,
     options?: CommonResponseActionMethodOptions
   ) => Promise<ActionDetails<ResponseActionScanOutputContent, ResponseActionScanParameters>>;
+
+  /**
+   * Run a script
+   * @param actionRequest
+   * @param options
+   */
+  runscript: (
+    actionRequest: OmitUnsupportedAttributes<RunScriptActionRequestBody>,
+    options?: CommonResponseActionMethodOptions
+  ) => Promise<
+    ActionDetails<ResponseActionRunScriptOutputContent, ResponseActionRunScriptParameters>
+  >;
 }

--- a/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/mocks.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/actions/clients/mocks.ts
@@ -49,6 +49,7 @@ import type {
   ResponseActionGetFileRequestBody,
   UploadActionApiRequestBody,
   ScanActionRequestBody,
+  RunScriptActionRequestBody,
 } from '../../../../../common/api/endpoint';
 
 export interface ResponseActionsClientOptionsMock extends ResponseActionsClientOptions {
@@ -70,6 +71,7 @@ const createResponseActionClientMock = (): jest.Mocked<ResponseActionsClient> =>
     getFileInfo: jest.fn().mockReturnValue(Promise.resolve()),
     getFileDownload: jest.fn().mockReturnValue(Promise.resolve()),
     scan: jest.fn().mockReturnValue(Promise.resolve()),
+    runscript: jest.fn().mockReturnValue(Promise.resolve()),
   };
 };
 
@@ -240,6 +242,18 @@ const createScanOptionsMock = (
   return merge(options, overrides);
 };
 
+const createRunScriptOptionsMock = (
+  overrides: Partial<RunScriptActionRequestBody> = {}
+): RunScriptActionRequestBody => {
+  const options: RunScriptActionRequestBody = {
+    ...createNoParamsResponseActionOptionsMock(),
+    parameters: {
+      Raw: 'ls',
+    },
+  };
+  return merge(options, overrides);
+};
+
 const createConnectorMock = (
   overrides: DeepPartial<ConnectorWithExtraFindData> = {}
 ): ConnectorWithExtraFindData => {
@@ -316,6 +330,7 @@ export const responseActionsClientMock = Object.freeze({
   createExecuteOptions: createExecuteOptionsMock,
   createUploadOptions: createUploadOptionsMock,
   createScanOptions: createScanOptionsMock,
+  createRunScriptOptions: createRunScriptOptionsMock,
 
   createIndexedResponse: createEsIndexTransportResponseMock,
 

--- a/x-pack/plugins/security_solution/server/endpoint/services/feature_usage/feature_keys.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/feature_usage/feature_keys.ts
@@ -24,9 +24,9 @@ export const FEATURE_KEYS = {
   UPLOAD: 'Upload file',
   EXECUTE: 'Execute command',
   SCAN: 'Scan files',
+  RUN_SCRIPT: 'Run script',
   ALERTS_BY_PROCESS_ANCESTRY: 'Get related alerts by process ancestry',
   ENDPOINT_EXCEPTIONS: 'Endpoint exceptions',
-  RUN_SCRIPT: 'Run script',
 } as const;
 
 export type FeatureKeys = keyof typeof FEATURE_KEYS;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[EDR Workflows] Add RunScript API route (supporting CrowdStrike) (#203101)](https://github.com/elastic/kibana/pull/203101)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2024-12-11T08:18:35Z","message":"[EDR Workflows] Add RunScript API route (supporting CrowdStrike) (#203101)","sha":"e993f2388111cf16798014e7c857f23df5ab7cdb","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.0.0","Team:Defend Workflows","release_note:feature","backport:version","v8.18.0"],"number":203101,"url":"https://github.com/elastic/kibana/pull/203101","mergeCommit":{"message":"[EDR Workflows] Add RunScript API route (supporting CrowdStrike) (#203101)","sha":"e993f2388111cf16798014e7c857f23df5ab7cdb"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203101","number":203101,"mergeCommit":{"message":"[EDR Workflows] Add RunScript API route (supporting CrowdStrike) (#203101)","sha":"e993f2388111cf16798014e7c857f23df5ab7cdb"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->