### PR TITLE
[8.17] [8.x] [ftr][deployment-agnostic] move APM tests in its own config file (#200562) (#200924)

### DIFF
--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -24,6 +24,7 @@ disabled:
   - x-pack/test_serverless/functional/test_suites/observability/config.screenshots.ts
   # serverless config files that run deployment-agnostic tests
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts
+  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts
 
 # Serverless tests only run on main
 defaultQueue: 'n2-4-spot'

--- a/.buildkite/ftr_oblt_stateful_configs.yml
+++ b/.buildkite/ftr_oblt_stateful_configs.yml
@@ -52,3 +52,4 @@ enabled:
   - x-pack/test/functional/apps/apm/config.ts
   # stateful configs that run deployment-agnostic tests
   - x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.stateful.config.ts
+  - x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.apm.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.apm.index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+  describe('Serverless Observability - Deployment-agnostic APM API integration tests', function () {
+    // load new oblt APM-only deployment-agnostic test here
+    loadTestFile(require.resolve('../../apis/observability/apm'));
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerlessTestConfig } from '../../default_configs/serverless.config.base';
+
+export default createServerlessTestConfig({
+  serverlessProject: 'oblt',
+  testFiles: [require.resolve('./oblt.apm.index.ts')],
+  junit: {
+    reportName: 'Serverless Observability - Deployment-agnostic APM API Integration Tests',
+  },
+});

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.index.ts
@@ -7,8 +7,8 @@
 import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
-  describe('Serverless Observability - Deployment-agnostic api integration tests', () => {
-    // load new oblt and platform deployment-agnostic test here
+  describe('Serverless Observability - Deployment-agnostic API integration tests', function () {
+    // load new oblt (except APM) and platform deployment-agnostic test here
     loadTestFile(require.resolve('../../apis/console'));
     loadTestFile(require.resolve('../../apis/core'));
     loadTestFile(require.resolve('../../apis/management'));
@@ -18,6 +18,5 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('../../apis/painless_lab'));
     loadTestFile(require.resolve('../../apis/saved_objects_management'));
     loadTestFile(require.resolve('../../apis/observability/slo'));
-    loadTestFile(require.resolve('../../apis/observability/apm'));
   });
 }

--- a/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.apm.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.apm.index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+  describe('Stateful Observability - Deployment-agnostic APM API integration tests', () => {
+    loadTestFile(require.resolve('../../apis/observability/apm'));
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createStatefulTestConfig } from '../../default_configs/stateful.config.base';
+
+export default createStatefulTestConfig({
+  testFiles: [require.resolve('./oblt.apm.index.ts')],
+  junit: {
+    reportName: 'Stateful Observability - Deployment-agnostic APM API Integration Tests',
+  },
+});

--- a/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.index.ts
@@ -8,12 +8,11 @@
 import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
-  describe('apis', () => {
-    // load new oblt deployment-agnostic test here
+  describe('Stateful Observability - Deployment-agnostic API integration tests', () => {
+    // load new oblt (except APM) deployment-agnostic tests here
     loadTestFile(require.resolve('../../apis/observability/alerting'));
     loadTestFile(require.resolve('../../apis/observability/dataset_quality'));
     loadTestFile(require.resolve('../../apis/observability/slo'));
     loadTestFile(require.resolve('../../apis/observability/infra'));
-    loadTestFile(require.resolve('../../apis/observability/apm'));
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.17`:
 - [[8.x] [ftr][deployment-agnostic] move APM tests in its own config file (#200562) (#200924)](https://github.com/elastic/kibana/pull/200924)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2024-11-26T10:27:33Z","message":"[8.x] [ftr][deployment-agnostic] move APM tests in its own config file (#200562) (#200924)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[ftr][deployment-agnostic] move APM tests in its own config file\n(#200562)](https://github.com/elastic/kibana/pull/200562)\n\n<!--- Backport version: 8.9.8 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Dzmitry\nLemechko\",\"email\":\"dzmitry.lemechko@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-11-20T09:09:44Z\",\"message\":\"[ftr][deployment-agnostic]\nmove APM tests in its own config file (#200562)\\n\\n##\nSummary\\r\\n\\r\\nPart of #199182\\r\\n\\r\\nWith great progress of #193245 the\nnumber of tests in Observability\\r\\ndeployment-agnostic config files is\ngrowing and so does config run time\\r\\nby reaching **30**\nminutes.\\r\\n\\r\\nAs we try to keep pipeline runtime reasonable, this PR\nadds a new\\r\\nconfigs `oblt.apm.stateful.config.ts`\nand\\r\\n`oblt.apm.serverless.config.ts` that load only APM-related tests\nfrom\\r\\nhttps://github.com/elastic/kibana/blob/main/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts\\r\\n\\r\\nIt\nshould help to speed up execution, we will double check\nconfig\\r\\nruntime when APM test migration is completed.\\r\\n\\r\\nFor\nreviewers: no extra work is expected from Oblt teams if new tests\\r\\nare\nstill imported\nin\\r\\n`x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts`\",\"sha\":\"a85127605c7bf7e0e349bc7bb687b69f72b6fe18\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"FTR\",\"backport:version\",\"v8.17.0\"],\"number\":200562,\"url\":\"https://github.com/elastic/kibana/pull/200562\",\"mergeCommit\":{\"message\":\"[ftr][deployment-agnostic]\nmove APM tests in its own config file (#200562)\\n\\n##\nSummary\\r\\n\\r\\nPart of #199182\\r\\n\\r\\nWith great progress of #193245 the\nnumber of tests in Observability\\r\\ndeployment-agnostic config files is\ngrowing and so does config run time\\r\\nby reaching **30**\nminutes.\\r\\n\\r\\nAs we try to keep pipeline runtime reasonable, this PR\nadds a new\\r\\nconfigs `oblt.apm.stateful.config.ts`\nand\\r\\n`oblt.apm.serverless.config.ts` that load only APM-related tests\nfrom\\r\\nhttps://github.com/elastic/kibana/blob/main/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts\\r\\n\\r\\nIt\nshould help to speed up execution, we will double check\nconfig\\r\\nruntime when APM test migration is completed.\\r\\n\\r\\nFor\nreviewers: no extra work is expected from Oblt teams if new tests\\r\\nare\nstill imported\nin\\r\\n`x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts`\",\"sha\":\"a85127605c7bf7e0e349bc7bb687b69f72b6fe18\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.x\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"labelRegex\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/200562\",\"number\":200562,\"mergeCommit\":{\"message\":\"[ftr][deployment-agnostic]\nmove APM tests in its own config file (#200562)\\n\\n##\nSummary\\r\\n\\r\\nPart of #199182\\r\\n\\r\\nWith great progress of #193245 the\nnumber of tests in Observability\\r\\ndeployment-agnostic config files is\ngrowing and so does config run time\\r\\nby reaching **30**\nminutes.\\r\\n\\r\\nAs we try to keep pipeline runtime reasonable, this PR\nadds a new\\r\\nconfigs `oblt.apm.stateful.config.ts`\nand\\r\\n`oblt.apm.serverless.config.ts` that load only APM-related tests\nfrom\\r\\nhttps://github.com/elastic/kibana/blob/main/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts\\r\\n\\r\\nIt\nshould help to speed up execution, we will double check\nconfig\\r\\nruntime when APM test migration is completed.\\r\\n\\r\\nFor\nreviewers: no extra work is expected from Oblt teams if new tests\\r\\nare\nstill imported\nin\\r\\n`x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts`\",\"sha\":\"a85127605c7bf7e0e349bc7bb687b69f72b6fe18\"}},{\"branch\":\"8.x\",\"label\":\"v8.17.0\",\"labelRegex\":\"^v8.17.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->","sha":"e1691eb91d710e3ccbb1422176505bf306c8eb44","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport"],"number":200924,"url":"https://github.com/elastic/kibana/pull/200924","mergeCommit":{"message":"[8.x] [ftr][deployment-agnostic] move APM tests in its own config file (#200562) (#200924)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[ftr][deployment-agnostic] move APM tests in its own config file\n(#200562)](https://github.com/elastic/kibana/pull/200562)\n\n<!--- Backport version: 8.9.8 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Dzmitry\nLemechko\",\"email\":\"dzmitry.lemechko@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-11-20T09:09:44Z\",\"message\":\"[ftr][deployment-agnostic]\nmove APM tests in its own config file (#200562)\\n\\n##\nSummary\\r\\n\\r\\nPart of #199182\\r\\n\\r\\nWith great progress of #193245 the\nnumber of tests in Observability\\r\\ndeployment-agnostic config files is\ngrowing and so does config run time\\r\\nby reaching **30**\nminutes.\\r\\n\\r\\nAs we try to keep pipeline runtime reasonable, this PR\nadds a new\\r\\nconfigs `oblt.apm.stateful.config.ts`\nand\\r\\n`oblt.apm.serverless.config.ts` that load only APM-related tests\nfrom\\r\\nhttps://github.com/elastic/kibana/blob/main/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts\\r\\n\\r\\nIt\nshould help to speed up execution, we will double check\nconfig\\r\\nruntime when APM test migration is completed.\\r\\n\\r\\nFor\nreviewers: no extra work is expected from Oblt teams if new tests\\r\\nare\nstill imported\nin\\r\\n`x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts`\",\"sha\":\"a85127605c7bf7e0e349bc7bb687b69f72b6fe18\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.17.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"FTR\",\"backport:version\",\"v8.17.0\"],\"number\":200562,\"url\":\"https://github.com/elastic/kibana/pull/200562\",\"mergeCommit\":{\"message\":\"[ftr][deployment-agnostic]\nmove APM tests in its own config file (#200562)\\n\\n##\nSummary\\r\\n\\r\\nPart of #199182\\r\\n\\r\\nWith great progress of #193245 the\nnumber of tests in Observability\\r\\ndeployment-agnostic config files is\ngrowing and so does config run time\\r\\nby reaching **30**\nminutes.\\r\\n\\r\\nAs we try to keep pipeline runtime reasonable, this PR\nadds a new\\r\\nconfigs `oblt.apm.stateful.config.ts`\nand\\r\\n`oblt.apm.serverless.config.ts` that load only APM-related tests\nfrom\\r\\nhttps://github.com/elastic/kibana/blob/main/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts\\r\\n\\r\\nIt\nshould help to speed up execution, we will double check\nconfig\\r\\nruntime when APM test migration is completed.\\r\\n\\r\\nFor\nreviewers: no extra work is expected from Oblt teams if new tests\\r\\nare\nstill imported\nin\\r\\n`x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts`\",\"sha\":\"a85127605c7bf7e0e349bc7bb687b69f72b6fe18\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.x\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"labelRegex\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/200562\",\"number\":200562,\"mergeCommit\":{\"message\":\"[ftr][deployment-agnostic]\nmove APM tests in its own config file (#200562)\\n\\n##\nSummary\\r\\n\\r\\nPart of #199182\\r\\n\\r\\nWith great progress of #193245 the\nnumber of tests in Observability\\r\\ndeployment-agnostic config files is\ngrowing and so does config run time\\r\\nby reaching **30**\nminutes.\\r\\n\\r\\nAs we try to keep pipeline runtime reasonable, this PR\nadds a new\\r\\nconfigs `oblt.apm.stateful.config.ts`\nand\\r\\n`oblt.apm.serverless.config.ts` that load only APM-related tests\nfrom\\r\\nhttps://github.com/elastic/kibana/blob/main/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts\\r\\n\\r\\nIt\nshould help to speed up execution, we will double check\nconfig\\r\\nruntime when APM test migration is completed.\\r\\n\\r\\nFor\nreviewers: no extra work is expected from Oblt teams if new tests\\r\\nare\nstill imported\nin\\r\\n`x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/index.ts`\",\"sha\":\"a85127605c7bf7e0e349bc7bb687b69f72b6fe18\"}},{\"branch\":\"8.x\",\"label\":\"v8.17.0\",\"labelRegex\":\"^v8.17.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->","sha":"e1691eb91d710e3ccbb1422176505bf306c8eb44"}},"sourceBranch":"8.x","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->