### PR TITLE
[ResponseOps][Cases] Migrate cases APIs with access tags.

### DIFF
--- a/x-pack/plugins/cases/server/routes/api/configure/get_connectors.ts
+++ b/x-pack/plugins/cases/server/routes/api/configure/get_connectors.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import { CASE_CONFIGURE_CONNECTORS_URL } from '../../../../common/constants';
+import {
+  CASE_CONFIGURE_CONNECTORS_URL,
+  GET_CONNECTORS_CONFIGURE_API_TAG,
+} from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 
@@ -15,8 +18,13 @@ import { createCasesRoute } from '../create_cases_route';
 export const getConnectorsRoute = createCasesRoute({
   method: 'get',
   path: `${CASE_CONFIGURE_CONNECTORS_URL}/_find`,
+  security: {
+    authz: {
+      requiredPrivileges: [GET_CONNECTORS_CONFIGURE_API_TAG],
+    },
+  },
   routerOptions: {
-    tags: ['access:casesGetConnectorsConfigure', 'oas-tag:cases'],
+    tags: ['oas-tag:cases'],
     access: 'public',
     summary: 'Get case connectors',
     description: 'Retrieves information about connectors that are supported for use in cases.',

--- a/x-pack/plugins/cases/server/routes/api/internal/suggest_user_profiles.ts
+++ b/x-pack/plugins/cases/server/routes/api/internal/suggest_user_profiles.ts
@@ -7,7 +7,10 @@
 
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type { UserProfileService } from '../../../services';
-import { INTERNAL_SUGGEST_USER_PROFILES_URL } from '../../../../common/constants';
+import {
+  INTERNAL_SUGGEST_USER_PROFILES_URL,
+  SUGGEST_USER_PROFILES_API_TAG,
+} from '../../../../common/constants';
 import { createCaseError } from '../../../common/error';
 import { createCasesRoute } from '../create_cases_route';
 import { escapeHatch } from '../utils';
@@ -17,8 +20,12 @@ export const suggestUserProfilesRoute = (userProfileService: UserProfileService)
   createCasesRoute({
     method: 'post',
     path: INTERNAL_SUGGEST_USER_PROFILES_URL,
+    security: {
+      authz: {
+        requiredPrivileges: [SUGGEST_USER_PROFILES_API_TAG],
+      },
+    },
     routerOptions: {
-      tags: ['access:casesSuggestUserProfiles'],
       access: 'internal',
     },
     params: {


### PR DESCRIPTION
Closes #198398

## Summary

Connected with https://github.com/elastic/kibana-team/issues/1321

This PR migrates the cases routes that use `access:` tags according to the [documented guidelines](https://docs.elastic.dev/kibana-dev-docs/key-concepts/security-api-authorization#configuring-authorization-on-routes).


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->