### PR TITLE
[dev] Fix bazel watch command

### DIFF
--- a/kbn_pm/src/commands/watch_command.mjs
+++ b/kbn_pm/src/commands/watch_command.mjs
@@ -27,6 +27,7 @@ export const command = {
   async run({ args, log }) {
     await Bazel.watch(log, {
       offline: args.getBooleanValue('offline') ?? true,
+      reactVersion: process.env.REACT_18 ? '18' : '17',
     });
   },
 };

--- a/kbn_pm/src/lib/bazel.mjs
+++ b/kbn_pm/src/lib/bazel.mjs
@@ -83,7 +83,7 @@ async function runBazel(log, inputArgs, opts = undefined) {
 /**
  *
  * @param {import('./log.mjs').Log} log
- * @param {{ offline: boolean } | undefined} opts
+ * @param {{ offline: boolean, reactVersion?: string } | undefined} opts
  */
 export async function watch(log, opts = undefined) {
   const ibazel = (await getBazelRunner()).runIBazel;
@@ -97,10 +97,12 @@ export async function watch(log, opts = undefined) {
     ...BAZEL_TARGETS,
     '--show_result=1',
     ...(opts?.offline ? ['--config=offline'] : []),
+    `--define=REACT_18=${opts?.reactVersion === '18' ? 'true' : 'false'}`,
   ];
   log.debug(`> ibazel ${args.join(' ')}`);
   await ibazel(args, {
     cwd: REPO_ROOT,
+    env: { ...process.env, REACT_18: opts?.reactVersion === '18' ? 'true' : 'false' },
     logPrefix: Color.info('[ibazel]'),
     onErrorExit(code, output) {
       throwBazelError(log, 'ibazel', code, output);


### PR DESCRIPTION
## Summary
After https://github.com/elastic/kibana/pull/193113 - the `yarn kbn watch` command fails with an error, because the required variable REACT_18 is not available.

This PR fixes that, by defining the variable for bazel.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->