### PR TITLE
Make Borealis the default theme in non-serverless

### DIFF
--- a/packages/core/rendering/core-rendering-server-internal/src/bootstrap/bootstrap_renderer.ts
+++ b/packages/core/rendering/core-rendering-server-internal/src/bootstrap/bootstrap_renderer.ts
@@ -10,7 +10,11 @@
 import { createHash } from 'crypto';
 import { PackageInfo } from '@kbn/config';
 import type { KibanaRequest, HttpAuth } from '@kbn/core-http-server';
-import { type DarkModeValue, parseDarkModeValue } from '@kbn/core-ui-settings-common';
+import {
+  type DarkModeValue,
+  DEFAULT_THEME_NAME,
+  parseDarkModeValue,
+} from '@kbn/core-ui-settings-common';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-server';
 import type { UiPlugins } from '@kbn/core-plugins-base-server-internal';
 import { InternalUserSettingsServiceSetup } from '@kbn/core-user-settings-server-internal';
@@ -58,7 +62,11 @@ export const bootstrapRendererFactory: BootstrapRendererFactory = ({
 
   return async function bootstrapRenderer({ uiSettingsClient, request, isAnonymousPage = false }) {
     let darkMode: DarkModeValue = false;
-    let themeName: string = 'amsterdam';
+    let themeName: string = DEFAULT_THEME_NAME;
+
+    if (packageInfo.buildFlavor !== 'serverless') {
+      themeName = 'borealis';
+    }
 
     try {
       const authenticated = isAuthenticated(request);

--- a/packages/core/ui-settings/core-ui-settings-common/src/theme.ts
+++ b/packages/core/ui-settings/core-ui-settings-common/src/theme.ts
@@ -35,7 +35,7 @@ export type ThemeTags = readonly ThemeTag[];
  * An array of theme tags available in Kibana by default when not customized
  * using KBN_OPTIMIZER_THEMES environment variable.
  */
-export const DEFAULT_THEME_TAGS: ThemeTags = ThemeAmsterdamTags;
+export const DEFAULT_THEME_TAGS: ThemeTags = SUPPORTED_THEME_TAGS;
 
 export const FALLBACK_THEME_TAG: ThemeTag = 'v8light';
 
@@ -43,18 +43,14 @@ const isValidTag = (tag: unknown) =>
   SUPPORTED_THEME_TAGS.includes(tag as (typeof SUPPORTED_THEME_TAGS)[number]);
 
 export function parseThemeTags(input?: unknown): ThemeTags {
-  if (!input) {
-    return DEFAULT_THEME_TAGS;
-  }
-
-  if (input === '*') {
-    // TODO: Replace with SUPPORTED_THEME_TAGS when Borealis is in public beta
+  if (!input || input === '*') {
     return DEFAULT_THEME_TAGS;
   }
 
   // TODO: remove when Borealis is in public beta
+  // This is left here for backwards compatibility during Borealis testing.
   if (input === 'experimental') {
-    return SUPPORTED_THEME_TAGS;
+    return DEFAULT_THEME_TAGS;
   }
 
   let rawTags: string[];

--- a/packages/core/ui-settings/core-ui-settings-server-internal/src/settings/index.test.ts
+++ b/packages/core/ui-settings/core-ui-settings-server-internal/src/settings/index.test.ts
@@ -18,14 +18,14 @@ import { getAnnouncementsSettings } from './announcements';
 
 describe('getCoreSettings', () => {
   it('should not have setting overlaps', () => {
-    const coreSettingsLength = Object.keys(getCoreSettings()).length;
+    const coreSettingsLength = Object.keys(getCoreSettings({ isServerless: false })).length;
     const summedLength = [
       getAccessibilitySettings(),
       getAnnouncementsSettings(),
       getDateFormatSettings(),
       getMiscUiSettings(),
       getNotificationsSettings(),
-      getThemeSettings(),
+      getThemeSettings({ isServerless: false }),
       getStateSettings(),
     ].reduce((sum, settings) => sum + Object.keys(settings).length, 0);
 

--- a/packages/core/ui-settings/core-ui-settings-server-internal/src/settings/index.ts
+++ b/packages/core/ui-settings/core-ui-settings-server-internal/src/settings/index.ts
@@ -17,12 +17,13 @@ import { getStateSettings } from './state';
 import { getAnnouncementsSettings } from './announcements';
 
 interface GetCoreSettingsOptions {
+  isServerless: boolean;
   isDist?: boolean;
   isThemeSwitcherEnabled?: boolean;
 }
 
 export const getCoreSettings = (
-  options?: GetCoreSettingsOptions
+  options: GetCoreSettingsOptions
 ): Record<string, UiSettingsParams> => {
   return {
     ...getAccessibilitySettings(),

--- a/packages/core/ui-settings/core-ui-settings-server-internal/src/settings/theme.ts
+++ b/packages/core/ui-settings/core-ui-settings-server-internal/src/settings/theme.ts
@@ -57,7 +57,7 @@ export const getThemeSettings = (
 
   // Make `theme:name` readonly in serverless unless the theme switcher is enabled
   let isThemeNameReadonly = options.isServerless;
-  if (Object.hasOwn(options, 'isThemeSwitcherEnabled')) {
+  if (options.isThemeSwitcherEnabled !== undefined) {
     isThemeNameReadonly = !options.isThemeSwitcherEnabled;
   }
 

--- a/packages/core/ui-settings/core-ui-settings-server-internal/src/settings/theme.ts
+++ b/packages/core/ui-settings/core-ui-settings-server-internal/src/settings/theme.ts
@@ -44,7 +44,7 @@ const getThemeInfo = ({ isDist = true, isServerless }: GetThemeSettingsOptions):
   return themeInfo;
 };
 
-interface GetThemeSettingsOptions {
+export interface GetThemeSettingsOptions {
   isServerless: boolean;
   isDist?: boolean;
   isThemeSwitcherEnabled?: boolean;
@@ -57,7 +57,7 @@ export const getThemeSettings = (
 
   // Make `theme:name` readonly in serverless unless the theme switcher is enabled
   let isThemeNameReadonly = options.isServerless;
-  if (Object.hasOwn(options, 'themeSwitcherEnabled')) {
+  if (Object.hasOwn(options, 'isThemeSwitcherEnabled')) {
     isThemeNameReadonly = !options.isThemeSwitcherEnabled;
   }
 

--- a/packages/core/ui-settings/core-ui-settings-server-internal/src/settings/theme.ts
+++ b/packages/core/ui-settings/core-ui-settings-server-internal/src/settings/theme.ts
@@ -55,6 +55,12 @@ export const getThemeSettings = (
 ): Record<string, UiSettingsParams> => {
   const { defaultDarkMode, defaultThemeName } = getThemeInfo(options);
 
+  // Make `theme:name` readonly in serverless unless the theme switcher is enabled
+  let isThemeNameReadonly = options.isServerless;
+  if (Object.hasOwn(options, 'themeSwitcherEnabled')) {
+    isThemeNameReadonly = !options.isThemeSwitcherEnabled;
+  }
+
   return {
     'theme:darkMode': {
       name: i18n.translate('core.ui_settings.params.darkModeTitle', {
@@ -126,9 +132,7 @@ export const getThemeSettings = (
         }),
       },
       value: defaultThemeName,
-      readonly: Object.hasOwn(options, 'isThemeSwitcherEnabled')
-        ? !options.isThemeSwitcherEnabled
-        : true,
+      readonly: isThemeNameReadonly,
       requiresPageReload: true,
       schema: schema.oneOf([
         schema.literal('amsterdam'),

--- a/packages/core/ui-settings/core-ui-settings-server-internal/src/ui_settings_service.ts
+++ b/packages/core/ui-settings/core-ui-settings-server-internal/src/ui_settings_service.ts
@@ -53,6 +53,7 @@ export class UiSettingsService
   private readonly config$: Observable<UiSettingsConfigType>;
   private readonly isDist: boolean;
   private readonly isDev: boolean;
+  private readonly isServerless: boolean;
   private readonly uiSettingsDefaults = new Map<string, UiSettingsParams>();
   private readonly uiSettingsGlobalDefaults = new Map<string, UiSettingsParams>();
   private overrides: Record<string, any> = {};
@@ -63,6 +64,7 @@ export class UiSettingsService
     this.isDist = coreContext.env.packageInfo.dist;
     this.config$ = coreContext.configService.atPath<UiSettingsConfigType>(uiConfigDefinition.path);
     this.isDev = coreContext.env.mode.dev;
+    this.isServerless = coreContext.env.packageInfo.buildFlavor === 'serverless';
   }
 
   public async preboot(): Promise<InternalUiSettingsServicePreboot> {
@@ -74,6 +76,7 @@ export class UiSettingsService
     this.register(
       getCoreSettings({
         isDist: this.isDist,
+        isServerless: this.isServerless,
         isThemeSwitcherEnabled: experimental?.themeSwitcherEnabled,
       })
     );

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -2,7 +2,7 @@ pageLoadAssetSize:
   actions: 20000
   advancedSettings: 27596
   aiAssistantManagementSelection: 19146
-  aiops: 17680
+  aiops: 32733
   alerting: 106936
   apm: 64385
   assetInventory: 18478
@@ -65,7 +65,7 @@ pageLoadAssetSize:
   expressionTagcloud: 27505
   expressionXY: 45000
   features: 21723
-  fieldFormats: 65209
+  fieldFormats: 80485
   fieldsMetadata: 21885
   files: 22673
   filesManagement: 18683


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



