### PR TITLE
[8.x] [Search] Web crawler name consistency (#202738)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
@@ -55,7 +55,7 @@ export const connectorsBreadcrumbs = [
 
 export const crawlersBreadcrumbs = [
   i18n.translate('xpack.enterpriseSearch.content.crawlers.breadcrumb', {
-    defaultMessage: 'Web crawlers',
+    defaultMessage: 'Web Crawlers',
   }),
 ];
 
@@ -95,7 +95,7 @@ export const Connectors: React.FC<ConnectorsProps> = ({ isCrawler }) => {
                 defaultMessage: 'Elasticsearch connectors',
               })
             : i18n.translate('xpack.enterpriseSearch.crawlers.title', {
-                defaultMessage: 'Elasticsearch web crawlers',
+                defaultMessage: 'Elastic Web Crawler',
               }),
           rightSideGroupProps: {
             gutterSize: 's',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawler_empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawler_empty_state.tsx
@@ -49,7 +49,8 @@ export const CrawlerEmptyState: React.FC = () => {
               color="primary"
               fill
               iconType={GithubIcon}
-              href={CRAWLER.github_repo}
+              href={'https://github.com/elastic/crawler'}
+              target="_blank"
             >
               {i18n.translate(
                 'xpack.enterpriseSearch.crawlerEmptyState.openSourceCrawlerButtonLabel',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawler_empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/crawler_empty_state.tsx
@@ -11,7 +11,6 @@ import { useValues } from 'kea';
 import { EuiButton, EuiEmptyPrompt, EuiPanel } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { CRAWLER } from '../../../../../common/constants';
 import { HttpLogic } from '../../../shared/http';
 import { GithubIcon } from '../../../shared/icons/github_icon';
 import { KibanaLogic } from '../../../shared/kibana';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -289,7 +289,7 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
                 {i18n.translate(
                   'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.learnMoreCrawler.linkText',
                   {
-                    defaultMessage: 'Learn more about the Elastic web crawler',
+                    defaultMessage: 'Learn more about the Elastic Web Crawler',
                   }
                 )}
               </EuiLink>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/classic_nav_helpers.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/classic_nav_helpers.test.ts
@@ -37,7 +37,7 @@ describe('generateSideNavItems', () => {
     },
     'enterpriseSearchContent:webCrawlers': {
       id: 'enterpriseSearchContent:webCrawlers',
-      title: 'Web crawlers',
+      title: 'Web Crawlers',
       url: '/app/enterprise_search/content/crawlers',
     },
   } as unknown as Record<string, ChromeNavLink | undefined>;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -62,7 +62,7 @@ const baseNavItems = [
         href: '/app/enterprise_search/content/crawlers',
         id: 'crawlers',
         items: undefined,
-        name: 'Web crawlers',
+        name: 'Web Crawlers',
       },
     ],
     name: 'Content',
@@ -184,7 +184,7 @@ const mockNavLinks = [
   },
   {
     id: 'enterpriseSearchContent:webCrawlers',
-    title: 'Web crawlers',
+    title: 'Web Crawlers',
     url: '/app/enterprise_search/content/crawlers',
   },
   {

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -127,7 +127,7 @@ const contentLinks: AppDeepLink[] = [
     id: 'webCrawlers',
     path: `/${CRAWLERS_PATH}`,
     title: i18n.translate('xpack.enterpriseSearch.navigation.contentWebcrawlersLinkLabel', {
-      defaultMessage: 'Web crawlers',
+      defaultMessage: 'Web Crawlers',
     }),
   },
 ];

--- a/x-pack/plugins/search_solution/search_navigation/public/classic_navigation.test.ts
+++ b/x-pack/plugins/search_solution/search_navigation/public/classic_navigation.test.ts
@@ -30,7 +30,7 @@ describe('classicNavigationFactory', function () {
     },
     {
       id: 'enterpriseSearchContent:webCrawlers',
-      title: 'Web crawlers',
+      title: 'Web Crawlers',
       url: '/app/enterprise_search/content/crawlers',
     },
   ];

--- a/x-pack/plugins/serverless_search/common/i18n_string.ts
+++ b/x-pack/plugins/serverless_search/common/i18n_string.ts
@@ -65,6 +65,13 @@ export const CONNECTOR_LABEL: string = i18n.translate('xpack.serverlessSearch.co
   defaultMessage: 'Connector',
 });
 
+export const WEB_CRAWLERS_LABEL: string = i18n.translate(
+  'xpack.serverlessSearch.webCrawlersLabel',
+  {
+    defaultMessage: 'Web crawlers',
+  }
+);
+
 export const DELETE_CONNECTOR_LABEL = i18n.translate(
   'xpack.serverlessSearch.connectors.deleteConnectorLabel',
   {

--- a/x-pack/test/functional_search/tests/classic_navigation.ts
+++ b/x-pack/test/functional_search/tests/classic_navigation.ts
@@ -42,7 +42,7 @@ export default function searchSolutionNavigation({
         { id: 'Content', label: 'Content' },
         { id: 'Indices', label: 'Indices' },
         { id: 'Connectors', label: 'Connectors' },
-        { id: 'Crawlers', label: 'Web crawlers' },
+        { id: 'Crawlers', label: 'Web Crawlers' },
         { id: 'Build', label: 'Build' },
         { id: 'Playground', label: 'Playground' },
         { id: 'SearchApplications', label: 'Search Applications' },
@@ -76,7 +76,7 @@ export default function searchSolutionNavigation({
       await searchClassicNavigation.clickNavItem('Crawlers');
       await searchClassicNavigation.expectNavItemActive('Crawlers');
       await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Content');
-      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Web crawlers');
+      await searchClassicNavigation.breadcrumbs.expectBreadcrumbExists('Web Crawlers');
 
       // Check Build
       // > Playground

--- a/x-pack/test/functional_search/tests/solution_navigation.ts
+++ b/x-pack/test/functional_search/tests/solution_navigation.ts
@@ -43,7 +43,7 @@ export default function searchSolutionNavigation({
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dashboards' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Indices' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Connectors' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Web crawlers' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Web Crawlers' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Search applications' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Behavioral Analytics' });
@@ -136,7 +136,7 @@ export default function searchSolutionNavigation({
         deepLinkId: 'enterpriseSearchContent:webCrawlers',
       });
       await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Content' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Web crawlers' });
+      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Web Crawlers' });
       await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
         deepLinkId: 'enterpriseSearchContent:webCrawlers',
       });

--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -261,6 +261,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Data' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Index Management' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Connectors' });
+      await solutionNavigation.sidenav.expectLinkExists({ text: 'Web crawlers' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Build' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Dev Tools' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Playground' });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Search] Web crawler name consistency (#202738)](https://github.com/elastic/kibana/pull/202738)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"José Luis González","email":"joseluisgj@gmail.com"},"sourceCommit":{"committedDate":"2024-12-05T11:32:33Z","message":"[Search] Web crawler name consistency (#202738)\n\n## Summary\r\n\r\nThis PR fixes the areas where we display the Web Crawler naming bearing\r\nin mind these agreements :\r\n- We should be capitalizing when referring to the product name: Elastic\r\nWeb Crawler / Web Crawler /Elastic Open Web Crawler\r\n- We can use lower case when referring to the feature or concept of web\r\ncrawler( crawler in short): \"Use the web crawler to ...\"\r\n\r\nESS:\r\n![CleanShot 2024-12-03 at 15 19\r\n19@2x](https://github.com/user-attachments/assets/d5cba886-09b3-4c34-b6e5-565cb67b9e08)\r\n\r\nES3:\r\n![CleanShot 2024-12-03 at 15 19\r\n56@2x](https://github.com/user-attachments/assets/2a6b6a8a-697c-4001-96d8-c826b6769836)\r\n\r\n\r\nNotes: Also fixing buttons that take users to the Open Web Crawler repo\r\nto open the links in a new tab and don't lose the product focus.","sha":"4899c971fb8ca8309b963ba0135e66812be2584c","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","v9.0.0","Team:Search","backport:version","v8.17.0","v8.18.0","v8.16.2"],"number":202738,"url":"https://github.com/elastic/kibana/pull/202738","mergeCommit":{"message":"[Search] Web crawler name consistency (#202738)\n\n## Summary\r\n\r\nThis PR fixes the areas where we display the Web Crawler naming bearing\r\nin mind these agreements :\r\n- We should be capitalizing when referring to the product name: Elastic\r\nWeb Crawler / Web Crawler /Elastic Open Web Crawler\r\n- We can use lower case when referring to the feature or concept of web\r\ncrawler( crawler in short): \"Use the web crawler to ...\"\r\n\r\nESS:\r\n![CleanShot 2024-12-03 at 15 19\r\n19@2x](https://github.com/user-attachments/assets/d5cba886-09b3-4c34-b6e5-565cb67b9e08)\r\n\r\nES3:\r\n![CleanShot 2024-12-03 at 15 19\r\n56@2x](https://github.com/user-attachments/assets/2a6b6a8a-697c-4001-96d8-c826b6769836)\r\n\r\n\r\nNotes: Also fixing buttons that take users to the Open Web Crawler repo\r\nto open the links in a new tab and don't lose the product focus.","sha":"4899c971fb8ca8309b963ba0135e66812be2584c"}},"sourceBranch":"main","suggestedTargetBranches":["8.17","8.x","8.16"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/202738","number":202738,"mergeCommit":{"message":"[Search] Web crawler name consistency (#202738)\n\n## Summary\r\n\r\nThis PR fixes the areas where we display the Web Crawler naming bearing\r\nin mind these agreements :\r\n- We should be capitalizing when referring to the product name: Elastic\r\nWeb Crawler / Web Crawler /Elastic Open Web Crawler\r\n- We can use lower case when referring to the feature or concept of web\r\ncrawler( crawler in short): \"Use the web crawler to ...\"\r\n\r\nESS:\r\n![CleanShot 2024-12-03 at 15 19\r\n19@2x](https://github.com/user-attachments/assets/d5cba886-09b3-4c34-b6e5-565cb67b9e08)\r\n\r\nES3:\r\n![CleanShot 2024-12-03 at 15 19\r\n56@2x](https://github.com/user-attachments/assets/2a6b6a8a-697c-4001-96d8-c826b6769836)\r\n\r\n\r\nNotes: Also fixing buttons that take users to the Open Web Crawler repo\r\nto open the links in a new tab and don't lose the product focus.","sha":"4899c971fb8ca8309b963ba0135e66812be2584c"}},{"branch":"8.17","label":"v8.17.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.16","label":"v8.16.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->