### PR TITLE
[ES|QL] Fix param parsing in qualified name identifier pattern nodes

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/commands.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/commands.test.ts
@@ -141,6 +141,35 @@ describe('commands', () => {
       ]);
     });
 
+    it('KEEP (with param)', () => {
+      const query = 'FROM index | KEEP abc, ?param';
+      const { ast } = parse(query);
+
+      expect(ast).toMatchObject([
+        {},
+        {
+          type: 'command',
+          name: 'keep',
+          args: [
+            {
+              type: 'column',
+              name: 'abc',
+            },
+            {
+              type: 'column',
+              args: [
+                {
+                  type: 'literal',
+                  literalType: 'param',
+                  value: 'param',
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+
     it('SORT', () => {
       const query = 'FROM index | SORT 1';
       const { ast } = parse(query);

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/factories.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/factories.ts
@@ -526,11 +526,21 @@ export function createColumn(ctx: ParserRuleContext): ESQLColumn {
   if (ctx instanceof QualifiedNamePatternContext) {
     const list = ctx.identifierPattern_list();
 
-    for (const identifier of list) {
-      const name = parseIdentifier(identifier.getText());
-      const node = Builder.identifier({ name }, createParserFields(identifier));
+    for (const identifierPattern of list) {
+      const ID_PATTERN = identifierPattern.ID_PATTERN();
 
-      args.push(node);
+      if (ID_PATTERN) {
+        const name = parseIdentifier(ID_PATTERN.getText());
+        const node = Builder.identifier({ name }, createParserFields(identifierPattern));
+
+        args.push(node);
+      } else {
+        const parameter = createParam(identifierPattern.parameter());
+
+        if (parameter) {
+          args.push(parameter);
+        }
+      }
     }
   } else if (ctx instanceof QualifiedNameContext) {
     const list = ctx.identifierOrParameter_list();


### PR DESCRIPTION
## Summary

- Handle params in "identifier pattern" parser nodes.


### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->