### PR TITLE
[One Discover] Remove conversion to lower case for detail flyout log.level

### DIFF
--- a/packages/kbn-discover-utils/src/utils/get_log_document_overview.ts
+++ b/packages/kbn-discover-utils/src/utils/get_log_document_overview.ts
@@ -30,8 +30,7 @@ export function getLogDocumentOverview(
   };
 
   const levelArray = doc.flattened[fieldConstants.LOG_LEVEL_FIELD];
-  const level =
-    Array.isArray(levelArray) && levelArray.length ? levelArray[0].toLowerCase() : levelArray;
+  const level = Array.isArray(levelArray) && levelArray.length > 0 ? levelArray[0] : levelArray;
   const message = formatField(fieldConstants.MESSAGE_FIELD);
   const errorMessage = formatField(fieldConstants.ERROR_MESSAGE_FIELD);
   const eventOriginal = formatField(fieldConstants.EVENT_ORIGINAL_FIELD);


### PR DESCRIPTION
## 📓 Summary

Closes #203525 

This change removes the conversion to lowercase for the `log.level` field value shown in the flyout detail.
This will solve a bug while adding filters on the table from the badge in the detail since forcing the value to lowercase was creating a mismatching filter.

For `log.level` values normalization, we'll consider doing follow-up work, as this is now unrelated to the bug fix.

https://github.com/user-attachments/assets/4ee7cdd9-1111-4f40-8edc-ffc46acc9b29



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->