### PR TITLE
[Stack Connectors][SentinelOne + Crowdstrike] Fix the validation of external API responses that return non-JSON (ex. stream)

### DIFF
--- a/x-pack/plugins/stack_connectors/common/crowdstrike/schema.ts
+++ b/x-pack/plugins/stack_connectors/common/crowdstrike/schema.ts
@@ -17,6 +17,8 @@ export const CrowdstrikeSecretsSchema = schema.object({
   clientSecret: schema.string(),
 });
 
+export const CrowdstrikeApiDoNotValidateResponsesSchema = schema.any();
+
 export const RelaxedCrowdstrikeBaseApiResponseSchema = schema.maybe(
   schema.object({}, { unknowns: 'allow' })
 );

--- a/x-pack/plugins/stack_connectors/common/sentinelone/schema.ts
+++ b/x-pack/plugins/stack_connectors/common/sentinelone/schema.ts
@@ -16,6 +16,8 @@ export const SentinelOneSecretsSchema = schema.object({
   token: schema.string(),
 });
 
+export const SentinelOneApiDoNotValidateResponsesSchema = schema.any();
+
 export const SentinelOneBaseApiResponseSchema = schema.maybe(
   schema.object({}, { unknowns: 'allow' })
 );

--- a/x-pack/plugins/stack_connectors/server/connector_types/crowdstrike/crowdstrike.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/crowdstrike/crowdstrike.ts
@@ -26,13 +26,14 @@ import type {
 import {
   CrowdstrikeHostActionsParamsSchema,
   CrowdstrikeGetAgentsParamsSchema,
-  CrowdstrikeGetTokenResponseSchema,
   CrowdstrikeHostActionsResponseSchema,
   RelaxedCrowdstrikeBaseApiResponseSchema,
   CrowdstrikeRTRCommandParamsSchema,
   CrowdstrikeExecuteRTRResponseSchema,
   CrowdstrikeGetScriptsParamsSchema,
   CrowdStrikeExecuteRTRResponse,
+  CrowdstrikeApiDoNotValidateResponsesSchema,
+  CrowdstrikeGetTokenResponseSchema,
 } from '../../../common/crowdstrike/schema';
 import { SUB_ACTION } from '../../../common/crowdstrike/constants';
 import { CrowdstrikeError } from './error';
@@ -229,7 +230,8 @@ export class CrowdstrikeConnector extends SubActionConnector<
           'Content-Type': 'application/x-www-form-urlencoded',
           authorization: 'Basic ' + CrowdstrikeConnector.base64encodedToken,
         },
-        responseSchema: CrowdstrikeGetTokenResponseSchema,
+        responseSchema:
+          CrowdstrikeApiDoNotValidateResponsesSchema as unknown as typeof CrowdstrikeGetTokenResponseSchema,
       },
       connectorUsageCollector
     );
@@ -265,7 +267,7 @@ export class CrowdstrikeConnector extends SubActionConnector<
           // where the external system might add/remove/change values in the response that we have no
           // control over.
           responseSchema:
-            RelaxedCrowdstrikeBaseApiResponseSchema as unknown as SubActionRequestParams<R>['responseSchema'],
+            CrowdstrikeApiDoNotValidateResponsesSchema as unknown as SubActionRequestParams<R>['responseSchema'],
           headers: {
             ...req.headers,
             Authorization: `Bearer ${CrowdstrikeConnector.token}`,

--- a/x-pack/plugins/stack_connectors/server/connector_types/sentinelone/sentinelone.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/sentinelone/sentinelone.ts
@@ -43,7 +43,7 @@ import {
   SentinelOneGetRemoteScriptResultsParamsSchema,
   SentinelOneDownloadRemoteScriptResultsParamsSchema,
   SentinelOneDownloadRemoteScriptResultsResponseSchema,
-  SentinelOneBaseApiResponseSchema,
+  SentinelOneApiDoNotValidateResponsesSchema,
 } from '../../../common/sentinelone/schema';
 import { SUB_ACTION } from '../../../common/sentinelone/constants';
 import {
@@ -405,7 +405,7 @@ export class SentinelOneConnector extends SubActionConnector<
         // where the external system might add/remove/change values in the response that we have no
         // control over.
         responseSchema:
-          SentinelOneBaseApiResponseSchema as unknown as SubActionRequestParams<R>['responseSchema'],
+          SentinelOneApiDoNotValidateResponsesSchema as unknown as SubActionRequestParams<R>['responseSchema'],
         params: {
           ...req.params,
           APIToken: this.secrets.token,


### PR DESCRIPTION
## Summary

- Changes the validation for API responses from SentinelOne and Crowdstrike to allow anything
    - The prior fix changed it to validate that the responses were `JSON`, but the some APIs can return non-JSON: example: a `stream` as is the case for file download.






<!--ONMERGE {"backportTargets":["8.15","8.16","8.17","8.x"]} ONMERGE-->