### PR TITLE
Refactoring setup_technology remove useEffect

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
@@ -246,12 +246,12 @@ describe('useSetupTechnology', () => {
       })
     );
 
-    expect(generateNewAgentPolicyWithDefaults).toHaveBeenCalled();
-
     act(() => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
     });
+
     await waitFor(() => {
+      expect(generateNewAgentPolicyWithDefaults).toHaveBeenCalled();
       expect(updatePackagePolicyMock).toHaveBeenCalledWith({ supports_agentless: true });
       expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENTLESS);
       expect(setNewAgentPolicy).toHaveBeenCalledWith({
@@ -290,12 +290,11 @@ describe('useSetupTechnology', () => {
       initialProps,
     });
 
-    expect(generateNewAgentPolicyWithDefaults).toHaveBeenCalled();
-
     act(() => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
     });
 
+    expect(generateNewAgentPolicyWithDefaults).toHaveBeenCalled();
     expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENTLESS);
     expect(updatePackagePolicyMock).toHaveBeenCalledWith({ supports_agentless: true });
     expect(setNewAgentPolicy).toHaveBeenCalledWith({
@@ -386,18 +385,19 @@ describe('useSetupTechnology', () => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
     });
 
-    expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENTLESS);
-    expect(updatePackagePolicyMock).toHaveBeenCalledWith({ supports_agentless: true });
+    await waitFor(() => {
+      expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENTLESS);
+      expect(updatePackagePolicyMock).toHaveBeenCalledWith({ supports_agentless: true });
+    });
 
     act(() => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENT_BASED);
     });
 
-    expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
-    expect(updatePackagePolicyMock).toHaveBeenCalledWith({ supports_agentless: false });
-
     await waitFor(() => {
+      expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
       expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
+      expect(updatePackagePolicyMock).toHaveBeenCalledWith({ supports_agentless: false });
       expect(setSelectedPolicyTabMock).toHaveBeenCalledWith(SelectedPolicyTab.NEW);
     });
   });

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
@@ -87,22 +87,11 @@ export function useSetupTechnology({
       ? SetupTechnology.AGENTLESS
       : SetupTechnology.AGENT_BASED;
   }, [packageInfo]);
-  // const updatedPackagePolicy = useRef<NewPackagePolicy>(packagePolicy);
   const [agentlessPolicyTemplateName, setAgentlessPolicyTemplateName] = useState<
     string | undefined
   >();
   const [selectedSetupTechnology, setSelectedSetupTechnology] =
     useState<SetupTechnology>(defaultSetupTechnology);
-  // const [newAgentlessPolicy, setNewAgentlessPolicy] = useState<AgentPolicy | NewAgentPolicy>(() => {
-  //   const agentless = generateNewAgentPolicyWithDefaults({
-  //     inactivity_timeout: 3600,
-  //     supports_agentless: true,
-  //     monitoring_enabled: ['logs', 'metrics'],
-  //   });
-  //   return agentless;
-  // });
-
-  // useEffect(() => {
   if (
     isEditPage &&
     selectedSetupTechnology !== SetupTechnology.AGENTLESS &&
@@ -127,21 +116,12 @@ export function useSetupTechnology({
       ...getAdditionalAgentlessPolicyInfo(agentlessPolicyTemplateName, packageInfo),
       name: getAgentlessAgentPolicyNameFromPackagePolicyName(packagePolicy.name),
     };
-    // setNewAgentlessPolicy(nextNewAgentlessPolicy);
     setNewAgentPolicy(nextNewAgentlessPolicy as NewAgentPolicy);
     updateAgentPolicies([nextNewAgentlessPolicy] as AgentPolicy[]);
     updatePackagePolicy({
       supports_agentless: true,
     });
   }
-  // if (
-  //   selectedSetupTechnology === SetupTechnology.AGENTLESS &&
-  //   !packagePolicy.supports_agentless
-  // ) {
-  //   updatePackagePolicy({
-  //     supports_agentless: true,
-  //   });
-  // } else
   if (
     !isEditPage &&
     selectedSetupTechnology !== SetupTechnology.AGENTLESS &&
@@ -158,22 +138,6 @@ export function useSetupTechnology({
       supports_agentless: false,
     });
   }
-  // }, [
-  //   isAgentlessEnabled,
-  //   isEditPage,
-  //   // newAgentlessPolicy,
-  //   newAgentPolicy,
-  //   packagePolicy.name,
-  //   packagePolicy.supports_agentless,
-  //   selectedSetupTechnology,
-  //   updateAgentPolicies,
-  //   setNewAgentPolicy,
-  //   agentPolicies,
-  //   setSelectedSetupTechnology,
-  //   updatePackagePolicy,
-  //   packageInfo,
-  //   agentlessPolicyTemplateName,
-  // ]);
 
   const handleSetupTechnologyChange = useCallback(
     (setupTechnology: SetupTechnology, policyTemplateName?: string) => {
@@ -184,42 +148,14 @@ export function useSetupTechnology({
       if (setupTechnology === SetupTechnology.AGENTLESS) {
         if (isAgentlessEnabled) {
           setAgentlessPolicyTemplateName(policyTemplateName);
-          // const agentlessPolicy = {
-          //   ...newAgentlessPolicy,
-          //   ...getAdditionalAgentlessPolicyInfo(policyTemplateName, packageInfo),
-          // } as NewAgentPolicy;
-
-          // setNewAgentPolicy(agentlessPolicy);
-          // setNewAgentlessPolicy(agentlessPolicy);
           setSelectedPolicyTab(SelectedPolicyTab.NEW);
-          // updateAgentPolicies([agentlessPolicy] as AgentPolicy[]);
         }
-        // updatePackagePolicy({
-        //   supports_agentless: true,
-        // });
       } else if (setupTechnology === SetupTechnology.AGENT_BASED) {
-        // setNewAgentPolicy({
-        //   ...orginalAgentPolicyRef.current,
-        //   supports_agentless: false,
-        // });
-        // updatePackagePolicy({
-        //   supports_agentless: false,
-        // });
         setSelectedPolicyTab(SelectedPolicyTab.NEW);
-        // updateAgentPolicies([orginalAgentPolicyRef.current] as AgentPolicy[]);
       }
       setSelectedSetupTechnology(setupTechnology);
     },
-    [
-      isAgentlessEnabled,
-      selectedSetupTechnology,
-      // updatePackagePolicy,
-      // setNewAgentPolicy,
-      // newAgentlessPolicy,
-      // packageInfo,
-      setSelectedPolicyTab,
-      // updateAgentPolicies,
-    ]
+    [isAgentlessEnabled, selectedSetupTechnology, setSelectedPolicyTab]
   );
 
   return {


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



