### PR TITLE
Implement feature flag to toggle Asset Inventory plugin

### DIFF
--- a/x-pack/solutions/security/plugins/asset_inventory/README.md
+++ b/x-pack/solutions/security/plugins/asset_inventory/README.md
@@ -8,6 +8,14 @@ Centralized asset inventory experience within the Elastic Security solution. A c
 
 See the [kibana contributing guide](https://github.com/elastic/kibana/blob/main/CONTRIBUTING.md) for instructions setting up your development environment.
 
+### Feature flag
+
+First, enable the `assetInventoryStoreEnabled` experimental feature flag by adding the following to your `kibana.dev.yml`:
+
+```yml
+xpack.securitySolution.enableExperimental: ['assetInventoryStoreEnabled']
+```
+
 ## Testing
 
 For general guidelines, read [Kibana Testing Guide](https://www.elastic.co/guide/en/kibana/current/development-tests.html) for more details

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -266,8 +266,12 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables CrowdStrike's RunScript RTR command
    */
-
   crowdstrikeRunScriptEnabled: false,
+
+  /**
+   * Enables the Asset Inventory feature
+   */
+  assetInventoryStoreEnabled: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/201705.

Reuse security_solution's config to control visibility of Asset Inventory plugin.

### Definition of done

- [x] Use the existing `xpack.securitySolution.enableExperimental` configuration to add a new feature flag
  - Done in `x-pack/plugins/security_solution/common/experimental_features.ts`
- [x] Implement the feature flag `xpack.securitySolution.enableExperimental: ['assetInventoryStoreEnabled']`.
  - This can only be done locally in `kibana.dev.yml`, but I can add it to `kibana.yml` instead.
- [x] Update any relevant documentation to explain how to enable the feature.
  - Updated plugin's `README` file.

### How to test

In your [kibana.yml](https://github.com/elastic/kibana/blob/main/config/kibana.yml) file, add the following entry at the bottom:

```
xpack.securitySolution.enableExperimental: ['assetInventoryStoreEnabled']
```

### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)