### PR TITLE
fix(NA): include ca-certificates package for wolfi based images

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -134,7 +134,7 @@ RUN for iter in {1..10}; do \
     (exit $exit_code)
 {{/ubuntu}}
 {{#wolfi}}
-RUN apk --no-cache add bash curl fontconfig libstdc++ libnss findutils shadow
+RUN apk --no-cache add bash curl fontconfig libstdc++ libnss findutils shadow ca-certificates
 {{/wolfi}}
 
 # Bring in Kibana from the initial stage.


### PR DESCRIPTION
In the transition to wolfi based images on cloud we forgot to add the `ca-certificates` package which seems to be used by customers in air-gapped networks who rely on that utility to inject their enterprise/agency CA.

This PR re-adds this dependency install to wolfi.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->