### PR TITLE
[DOCS] Fix broken Canvas link

### DIFF
--- a/src/plugins/expressions/README.asciidoc
+++ b/src/plugins/expressions/README.asciidoc
@@ -56,4 +56,4 @@ https://github.com/elastic/kibana/blob/main/docs/development/plugins/expressions
 
 
 ==== Other documentation
-https://www.elastic.co/guide/en/kibana/current/canvas-function-arguments.html[See Canvas documentation about expressions]
+<<canvas-function-arguments,See Canvas documentation about expressions>>


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/193475

This PR fixes a hard-coded link that is causing documentation build errors per https://github.com/elastic/docs/pull/3135#issuecomment-2518382045




