### PR TITLE
[Search] add enterpriseSearch.appsDisabled config option

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -85,6 +85,7 @@ kibana_vars=(
     elasticsearch.username
     enterpriseSearch.accessCheckTimeout
     enterpriseSearch.accessCheckTimeoutWarning
+    enterpriseSearch.appsDisabled
     enterpriseSearch.host
     externalUrl.policy
     i18n.locale

--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -16,6 +16,7 @@ export const plugin = async (initializerContext: PluginInitializerContext) => {
 export const configSchema = schema.object({
   accessCheckTimeout: schema.number({ defaultValue: 5000 }),
   accessCheckTimeoutWarning: schema.number({ defaultValue: 300 }),
+  appsDisabled: schema.boolean({ defaultValue: false }),
   canDeployEntSearch: schema.boolean({ defaultValue: true }),
   customHeaders: schema.maybe(schema.object({}, { unknowns: 'allow' })),
   enabled: schema.boolean({ defaultValue: true }),

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
@@ -50,6 +50,7 @@ describe('checkAccess', () => {
   const mockDependencies = {
     request: { auth: { isAuthenticated: true } },
     config: {
+      appsDisabled: false,
       canDeployEntSearch: true,
       host: 'http://localhost:3002',
     },
@@ -150,6 +151,31 @@ describe('checkAccess', () => {
         expect(await checkAccess({ ...mockDependencies, security })).toEqual({
           hasAppSearchAccess: true,
           hasWorkplaceSearchAccess: true,
+        });
+      });
+
+      it('should disables apps for superuser when config.appsDisabled set to true', async () => {
+        const security = {
+          ...mockSecurity,
+          authz: {
+            mode: { useRbacForRequest: () => true },
+            checkPrivilegesWithRequest: () => ({
+              globally: () => ({
+                hasAllRequested: true,
+              }),
+            }),
+            actions: { ui: { get: () => {} } },
+          },
+        };
+        expect(
+          await checkAccess({
+            ...mockDependencies,
+            config: { ...mockDependencies.config, appsDisabled: true },
+            security,
+          })
+        ).toEqual({
+          hasAppSearchAccess: false,
+          hasWorkplaceSearchAccess: false,
         });
       });
 

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.ts
@@ -44,6 +44,10 @@ export const checkAccess = async ({
   request,
   log,
 }: CheckAccess): Promise<ProductAccess> => {
+  if (config.appsDisabled) {
+    // When `appsDisabled` is used we explicitly disable App Search & Workplace Search in Kibana
+    return DENY_ALL_PLUGINS;
+  }
   const isRbacEnabled = security.authz.mode.useRbacForRequest(request);
 
   // If security has been disabled, always hide app search and workplace search

--- a/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/enterprise_search_config_api.ts
@@ -13,7 +13,7 @@ import { kibanaPackageJson } from '@kbn/repo-info';
 import { ConfigType } from '..';
 import { isVersionMismatch } from '../../common/is_version_mismatch';
 import { stripTrailingSlash } from '../../common/strip_slashes';
-import { InitialAppData } from '../../common/types';
+import { InitialAppData, ProductAccess } from '../../common/types';
 
 import { entSearchHttpAgent } from './enterprise_search_http_agent';
 
@@ -97,13 +97,21 @@ export const callEnterpriseSearchConfigAPI = async ({
 
     warnMismatchedVersions(data?.version?.number, log);
 
+    // When `appsDisabled` is used we explicitly disable App Search & Workplace Search in Kibana
+    const access: ProductAccess = config.appsDisabled
+      ? {
+          hasAppSearchAccess: false,
+          hasWorkplaceSearchAccess: false,
+        }
+      : {
+          hasAppSearchAccess: !!data?.current_user?.access?.app_search,
+          hasWorkplaceSearchAccess: !!data?.current_user?.access?.workplace_search,
+        };
+
     return {
       enterpriseSearchVersion: data?.version?.number,
       kibanaVersion: kibanaPackageJson.version,
-      access: {
-        hasAppSearchAccess: !!data?.current_user?.access?.app_search,
-        hasWorkplaceSearchAccess: !!data?.current_user?.access?.workplace_search,
-      },
+      access,
       features: {
         hasConnectors: config.hasConnectors,
         hasDefaultIngestPipeline: config.hasDefaultIngestPipeline,


### PR DESCRIPTION
## Summary

Adding the enterpriseSearch.appsDisabled config option that will manually disable both App Search and Workplace Search in the Kibana UI when set to true. This will be used in environments where we never want new users to start using products that are deprecated or EOL.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)

