### PR TITLE
[7.12] [DOCS] Fix broken Canvas link #203852

### DIFF
--- a/src/plugins/expressions/README.asciidoc
+++ b/src/plugins/expressions/README.asciidoc
@@ -52,4 +52,4 @@ https://github.com/elastic/kibana/blob/master/docs/development/plugins/expressio
 
 
 ==== Other documentation
-https://www.elastic.co/guide/en/kibana/current/canvas-function-arguments.html[See Canvas documentation about expressions]
+<<canvas-function-arguments,See Canvas documentation about expressions>>


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.8` to `7.12`:

 - [[DOCS] Fix broken Canvas link (#203852)](https://github.com/elastic/kibana/pull/203852)
