### PR TITLE
[ES|QL] Improves the comments color in dark mode

### DIFF
--- a/packages/kbn-monaco/src/esql/lib/esql_theme.ts
+++ b/packages/kbn-monaco/src/esql/lib/esql_theme.ts
@@ -156,7 +156,7 @@ export const buildESQLTheme = ({
           'closing_metrics_line_comment',
           'closing_metrics_multiline_comment',
         ],
-        euiThemeVars.euiColorDisabled
+        euiThemeVars.euiTextSubduedColor
       ),
 
       // values


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/202152

Fixes the comments color in dark mode 

<img width="928" alt="image" src="https://github.com/user-attachments/assets/7d007cfa-f6d4-45e9-817d-57178c64d0a4" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->