### PR TITLE
[ES|QL] Fixes the multiple comments bug

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -181,7 +181,7 @@ export const ESQLEditor = memo(function ESQLEditor({
             startLineNumber: lineNumber,
             startColumn: 0,
             endLineNumber: lineNumber,
-            endColumn: (commentedLine?.length ?? 0) + 1,
+            endColumn: (lineContent?.length ?? 0) + 1,
           },
           text: commentedLine,
         });

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -169,25 +169,25 @@ export const ESQLEditor = memo(function ESQLEditor({
     const currentSelection = editor1?.current?.getSelection();
     const startLineNumber = currentSelection?.startLineNumber;
     const endLineNumber = currentSelection?.endLineNumber;
+    const edits = [];
     if (startLineNumber && endLineNumber) {
       for (let lineNumber = startLineNumber; lineNumber <= endLineNumber; lineNumber++) {
         const lineContent = editorModel.current?.getLineContent(lineNumber) ?? '';
         const hasComment = lineContent?.startsWith('//');
         const commentedLine = hasComment ? lineContent?.replace('//', '') : `//${lineContent}`;
 
-        // executeEdits allows to keep edit in history
-        editor1.current?.executeEdits('comment', [
-          {
-            range: {
-              startLineNumber: lineNumber,
-              startColumn: 0,
-              endLineNumber: lineNumber,
-              endColumn: (lineContent?.length ?? 0) + 1,
-            },
-            text: commentedLine,
+        edits.push({
+          range: {
+            startLineNumber: lineNumber,
+            startColumn: 0,
+            endLineNumber: lineNumber,
+            endColumn: (commentedLine?.length ?? 0) + 1,
           },
-        ]);
+          text: commentedLine,
+        });
       }
+      // executeEdits allows to keep edit in history
+      editor1.current?.executeEdits('comment', edits);
     }
   }, []);
 


### PR DESCRIPTION
## Summary

![meow](https://github.com/user-attachments/assets/aea64a3c-97de-417a-bd67-5434e70cf22a)

Sometimes commenting multiple lines doesnt work as expected.

This PR fixes it. The problem was that we were (un)commenting line by line and this apparently can be buggy. With this PR we gather the edits and apply all of them in one `executeEdits `

<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->