### PR TITLE
[Security Solution] Display Modified badge for customized fields in Rule Upgrade flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/rule_upgrade/field_upgrade.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/rule_upgrade/field_upgrade.tsx
@@ -16,12 +16,18 @@ import { useFieldUpgradeContext } from './field_upgrade_context';
 
 export function FieldUpgrade(): JSX.Element {
   const { euiTheme } = useEuiTheme();
-  const { fieldName, fieldUpgradeState, hasConflict } = useFieldUpgradeContext();
+  const { fieldName, fieldUpgradeState, hasConflict, isCustomized } = useFieldUpgradeContext();
 
   return (
     <>
       <SplitAccordion
-        header={<FieldUpgradeHeader fieldName={fieldName} fieldUpgradeState={fieldUpgradeState} />}
+        header={
+          <FieldUpgradeHeader
+            fieldName={fieldName}
+            fieldUpgradeState={fieldUpgradeState}
+            isCustomized={isCustomized}
+          />
+        }
         initialIsOpen={hasConflict}
         data-test-subj="ruleUpgradePerFieldDiff"
       >

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/rule_upgrade/field_upgrade_header.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/rule_upgrade/field_upgrade_header.tsx
@@ -11,25 +11,29 @@ import { EuiFlexGroup, EuiTitle } from '@elastic/eui';
 import { fieldToDisplayNameMap } from '../../diff_components/translations';
 import type { FieldUpgradeStateEnum } from '../../../../model/prebuilt_rule_upgrade';
 import { FieldUpgradeStateInfo } from './field_upgrade_state_info';
+import { ModifiedBadge } from '../badges/modified_badge';
+import { FIELD_MODIFIED_BADGE_DESCRIPTION } from './translations';
 
 interface FieldUpgradeHeaderProps {
   fieldName: string;
   fieldUpgradeState: FieldUpgradeStateEnum;
+  isCustomized: boolean;
 }
 
 export function FieldUpgradeHeader({
   fieldName,
   fieldUpgradeState,
+  isCustomized,
 }: FieldUpgradeHeaderProps): JSX.Element {
   return (
-    <EuiFlexGroup alignItems="center">
+    <EuiFlexGroup alignItems="center" gutterSize="m">
       <EuiTitle data-test-subj="ruleUpgradeFieldDiffLabel" size="xs">
         <h5>{fieldToDisplayNameMap[fieldName] ?? startCase(camelCase(fieldName))}</h5>
       </EuiTitle>
 
-      <EuiFlexGroup alignItems="center" gutterSize="s">
-        <FieldUpgradeStateInfo state={fieldUpgradeState} />
-      </EuiFlexGroup>
+      {isCustomized && <ModifiedBadge tooltip={FIELD_MODIFIED_BADGE_DESCRIPTION} />}
+
+      <FieldUpgradeStateInfo state={fieldUpgradeState} />
     </EuiFlexGroup>
   );
 }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/rule_upgrade/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/rule_upgrade/translations.tsx
@@ -110,6 +110,7 @@ export const RULE_IS_READY_FOR_UPGRADE_DESCRIPTION = i18n.translate(
 export const FIELD_MODIFIED_BADGE_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.detectionEngine.upgradeFlyout.fieldModifiedBadgeDescription',
   {
-    defaultMessage: 'The field value was edited and differs from the stock value',
+    defaultMessage:
+      "The field value was edited after rule's installation and differs from the value upon installation",
   }
 );

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/translations.tsx
@@ -136,6 +136,7 @@ export const FIELD_UPDATES = i18n.translate(
 export const RULE_MODIFIED_BADGE_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.detectionEngine.upgradeFlyout.ruleModifiedBadgeDescription',
   {
-    defaultMessage: 'The rule was edited and field values differs from the stock values',
+    defaultMessage:
+      'The rule was edited after installation and field values differs from the values upon installation',
   }
 );


### PR DESCRIPTION
**Resolves:** https://github.com/elastic/kibana/issues/203718

## Summary

This PR adds `Modified` badge to customized fields in rules upgrade flyout.

## Details

`_review` API endpoint contains fields diff providing enough information on what field values were involved in the comparison. In particular `diff_outcome` is used to determine if a field was customized i.e. the rule was edited and field value has a different value than a stock value. `Modified` badge is show for fields `CustomizedValueCanUpdate`, `CustomizedValueSameUpdate` and `CustomizedValueNoUpdate`.

## Screenshot

![image](https://github.com/user-attachments/assets/8f773f45-7ab5-4883-9ef7-fee8f3bde768)



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->