### PR TITLE
Flaky #199782

### DIFF
--- a/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
+++ b/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
@@ -17,9 +17,15 @@ import type {
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 
 const getApiDeprecations = (allDeprecations: DomainDeprecationDetails[]) => {
-  return allDeprecations.filter(
-    (deprecation) => deprecation.deprecationType === 'api'
-  ) as unknown as Array<DomainDeprecationDetails<ApiDeprecationDetails>>;
+  return (
+    allDeprecations
+      .filter(
+        (deprecation): deprecation is DomainDeprecationDetails<ApiDeprecationDetails> =>
+          deprecation.deprecationType === 'api'
+      )
+      // Ensure consistent sorting
+      .sort((a, b) => a.title.localeCompare(b.title))
+  );
 };
 
 export default function ({ getService }: FtrProviderContext) {

--- a/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
+++ b/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
@@ -28,8 +28,7 @@ export default function ({ getService }: FtrProviderContext) {
   const retry = getService('retry');
   const es = getService('es');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/199782
-  describe.skip('Kibana API Deprecations', function () {
+  describe('Kibana API Deprecations', function () {
     // bail on first error in this suite since cases sequentially depend on each other
     this.bail(true);
 


### PR DESCRIPTION
## Summary

Resolves #199782

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7587


### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed





<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->