### PR TITLE
Make `task_cost_check` test resilient to changes in order

### DIFF
--- a/x-pack/plugins/task_manager/server/integration_tests/__snapshots__/task_cost_check.test.ts.snap
+++ b/x-pack/plugins/task_manager/server/integration_tests/__snapshots__/task_cost_check.test.ts.snap
@@ -4,7 +4,35 @@ exports[`Task cost checks detects tasks with cost definitions 1`] = `
 Array [
   Object {
     "cost": 1,
+    "taskType": "actions:.bedrock",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.cases",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.cases-webhook",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.crowdstrike",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.d3security",
+  },
+  Object {
+    "cost": 1,
     "taskType": "actions:.email",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.gemini",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.gen-ai",
   },
   Object {
     "cost": 1,
@@ -12,15 +40,43 @@ Array [
   },
   Object {
     "cost": 1,
+    "taskType": "actions:.jira",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.observability-ai-assistant",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.opsgenie",
+  },
+  Object {
+    "cost": 1,
     "taskType": "actions:.pagerduty",
   },
   Object {
     "cost": 1,
-    "taskType": "actions:.swimlane",
+    "taskType": "actions:.resilient",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.sentinelone",
   },
   Object {
     "cost": 1,
     "taskType": "actions:.server-log",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.servicenow",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.servicenow-itom",
+  },
+  Object {
+    "cost": 1,
+    "taskType": "actions:.servicenow-sir",
   },
   Object {
     "cost": 1,
@@ -32,31 +88,7 @@ Array [
   },
   Object {
     "cost": 1,
-    "taskType": "actions:.webhook",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.cases-webhook",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.xmatters",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.servicenow",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.servicenow-sir",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.servicenow-itom",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.jira",
+    "taskType": "actions:.swimlane",
   },
   Object {
     "cost": 1,
@@ -64,11 +96,7 @@ Array [
   },
   Object {
     "cost": 1,
-    "taskType": "actions:.torq",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.opsgenie",
+    "taskType": "actions:.thehive",
   },
   Object {
     "cost": 1,
@@ -76,43 +104,15 @@ Array [
   },
   Object {
     "cost": 1,
-    "taskType": "actions:.gen-ai",
+    "taskType": "actions:.torq",
   },
   Object {
     "cost": 1,
-    "taskType": "actions:.bedrock",
+    "taskType": "actions:.webhook",
   },
   Object {
     "cost": 1,
-    "taskType": "actions:.gemini",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.d3security",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.resilient",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.thehive",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.sentinelone",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.crowdstrike",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.cases",
-  },
-  Object {
-    "cost": 1,
-    "taskType": "actions:.observability-ai-assistant",
+    "taskType": "actions:.xmatters",
   },
   Object {
     "cost": 10,

--- a/x-pack/plugins/task_manager/server/integration_tests/task_cost_check.test.ts
+++ b/x-pack/plugins/task_manager/server/integration_tests/task_cost_check.test.ts
@@ -12,6 +12,7 @@ import {
 import { TaskCost, TaskDefinition } from '../task';
 import { setupTestServers } from './lib';
 import { TaskTypeDictionary } from '../task_type_dictionary';
+import { sortBy } from 'lodash';
 
 jest.mock('../task_type_dictionary', () => {
   const actual = jest.requireActual('../task_type_dictionary');
@@ -50,14 +51,17 @@ describe('Task cost checks', () => {
 
   it('detects tasks with cost definitions', async () => {
     const taskTypes = taskTypeDictionary.getAllDefinitions();
-    const taskTypesWithCost = taskTypes
-      .map((taskType: TaskDefinition) =>
-        !!taskType.cost ? { taskType: taskType.type, cost: taskType.cost } : null
-      )
-      .filter(
-        (tt: { taskType: string; cost: TaskCost } | null) =>
-          null != tt && tt.cost !== TaskCost.Normal
-      );
+    const taskTypesWithCost = sortBy(
+      taskTypes
+        .map((taskType: TaskDefinition) =>
+          !!taskType.cost ? { taskType: taskType.type, cost: taskType.cost } : null
+        )
+        .filter(
+          (tt: { taskType: string; cost: TaskCost } | null) =>
+            null != tt && tt.cost !== TaskCost.Normal
+        ),
+      'taskType'
+    );
     expect(taskTypesWithCost).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary

Addresses failures such as https://buildkite.com/elastic/kibana-pull-request/builds/259739#0193bb07-c759-4749-965e-10e63ac0810a.

We believe the order in which task types are registered might have been affected by the relocation of the `@kbn/observability-ai-assistant-app-plugin` in the scope of _Sustainable Kibana Architecture_.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->