### PR TITLE
[One Discover] Revert token change from vis palette

### DIFF
--- a/packages/kbn-discover-utils/src/data_types/logs/utils/get_log_level_color.test.ts
+++ b/packages/kbn-discover-utils/src/data_types/logs/utils/get_log_level_color.test.ts
@@ -13,9 +13,7 @@ import { LogLevelCoalescedValue } from './get_log_level_coalesed_value';
 
 const euiTheme = {
   colors: {
-    vis: {
-      euiColorVisGrey0: '#d3dae6',
-    },
+    mediumShade: '#d3dae6',
   },
 };
 

--- a/packages/kbn-discover-utils/src/data_types/logs/utils/get_log_level_color.ts
+++ b/packages/kbn-discover-utils/src/data_types/logs/utils/get_log_level_color.ts
@@ -25,7 +25,7 @@ export const getLogLevelColor = (
 
   switch (logLevelCoalescedValue) {
     case LogLevelCoalescedValue.trace:
-      return euiTheme.colors.vis.euiColorVisGrey0;
+      return euiTheme.colors.mediumShade;
     case LogLevelCoalescedValue.debug:
       return euiPaletteForTemperature6[2]; // lighter, closer to the default color for all other unknown log levels
     case LogLevelCoalescedValue.info:
@@ -45,6 +45,6 @@ export const getLogLevelColor = (
     case LogLevelCoalescedValue.fatal:
       return euiPaletteRed9[13];
     default:
-      return euiTheme.colors.vis.euiColorVisGrey0;
+      return euiTheme.colors.mediumShade;
   }
 };


### PR DESCRIPTION
## 📓 Summary

Related to https://github.com/elastic/kibana/pull/202985

This change reverts a suggestion that was applied but that should only be valid for v9.



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->