### PR TITLE
[Defend Workflows][Staged Artifact Rollout] Propagate global telemetry config to endpoint policies

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/models/policy_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/models/policy_config.ts
@@ -19,7 +19,8 @@ export const policyFactory = (
   licenseUid = '',
   clusterUuid = '',
   clusterName = '',
-  serverless = false
+  serverless = false,
+  isGlobalTelemetryEnabled = false
 ): PolicyConfig => {
   const policy: PolicyConfig = {
     meta: {
@@ -31,6 +32,7 @@ export const policyFactory = (
       serverless,
     },
     global_manifest_version: 'latest',
+    global_telemetry_enabled: isGlobalTelemetryEnabled,
     windows: {
       events: {
         credential_access: true,

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/models/policy_config_helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/models/policy_config_helpers.test.ts
@@ -333,6 +333,7 @@ describe('Policy Config helpers', () => {
 // the logic for disabling protections is also modified due to type check.
 export const eventsOnlyPolicy = (): PolicyConfig => ({
   global_manifest_version: 'latest',
+  global_telemetry_enabled: false,
   meta: {
     license: '',
     cloud: false,

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/index.ts
@@ -973,6 +973,7 @@ export interface PolicyConfig {
     heartbeatinterval?: number;
   };
   global_manifest_version: 'latest' | string;
+  global_telemetry_enabled: boolean;
   windows: {
     advanced?: {
       [key: string]: unknown;

--- a/x-pack/solutions/security/plugins/security_solution/common/telemetry_config/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/telemetry_config/mocks.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TelemetryConfigProvider } from './telemetry_config_provider';
+
+export const createTelemetryConfigProviderMock = (): jest.Mocked<TelemetryConfigProvider> => ({
+  start: jest.fn(),
+  stop: jest.fn(),
+  getObservable: jest.fn(),
+  isOptedIn: true,
+});

--- a/x-pack/solutions/security/plugins/security_solution/common/telemetry_config/telemetry_config_provider.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/telemetry_config/telemetry_config_provider.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Observable } from 'rxjs';
+import { TelemetryConfigProvider } from './telemetry_config_provider';
+
+describe('TelemetryConfigProvider', () => {
+  let telemetryConfigProvider: TelemetryConfigProvider;
+
+  beforeEach(() => {
+    telemetryConfigProvider = new TelemetryConfigProvider();
+  });
+
+  describe('isOptedIn', () => {
+    it('returns undefined when object is uninitialized', () => {
+      expect(telemetryConfigProvider.isOptedIn).toBe(undefined);
+    });
+
+    it.each([true, false])('returns pushed %s value after subscribed', (value) => {
+      const observable$ = new Observable<boolean>((subscriber) => {
+        subscriber.next(value);
+      });
+
+      telemetryConfigProvider.start(observable$);
+
+      expect(telemetryConfigProvider.isOptedIn).toBe(value);
+    });
+  });
+
+  it('stop() unsubscribes from Observable', async () => {
+    const unsubscribeMock = jest.fn();
+    const observableMock = {
+      subscribe: () => ({
+        unsubscribe: unsubscribeMock,
+      }),
+    } as unknown as Observable<boolean>;
+
+    telemetryConfigProvider.start(observableMock);
+    expect(unsubscribeMock).not.toBeCalled();
+
+    telemetryConfigProvider.stop();
+    expect(unsubscribeMock).toBeCalled();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/common/telemetry_config/telemetry_config_provider.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/telemetry_config/telemetry_config_provider.ts
@@ -27,4 +27,8 @@ export class TelemetryConfigProvider {
   public get isOptedIn() {
     return this._isOptedIn;
   }
+
+  public getObservable() {
+    return this.isOptedIn$;
+  }
 }

--- a/x-pack/solutions/security/plugins/security_solution/common/telemetry_config/telemetry_config_provider.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/telemetry_config/telemetry_config_provider.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Observable, Subscription } from 'rxjs';
+
+export class TelemetryConfigProvider {
+  private isOptedIn$?: Observable<boolean>;
+  private _isOptedIn?: boolean;
+
+  private subscription?: Subscription;
+
+  public start(isOptedIn$: Observable<boolean>) {
+    this.isOptedIn$ = isOptedIn$;
+    this.subscription = this.isOptedIn$.subscribe((isOptedIn) => {
+      this._isOptedIn = isOptedIn;
+    });
+  }
+
+  public stop() {
+    this.subscription?.unsubscribe();
+  }
+
+  public get isOptedIn() {
+    return this._isOptedIn;
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/kibana.jsonc
+++ b/x-pack/solutions/security/plugins/security_solution/kibana.jsonc
@@ -60,7 +60,8 @@
       "entityManager",
       "inference",
       "discoverShared",
-      "productDocBase"
+      "productDocBase",
+      "telemetry"
     ],
     "optionalPlugins": [
       "encryptedSavedObjects",
@@ -72,7 +73,6 @@
       "lists",
       "home",
       "management",
-      "telemetry",
       "dataViewFieldEditor",
       "osquery",
       "savedObjectsTaggingOss",

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/store/policy_details/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/store/policy_details/index.test.ts
@@ -272,6 +272,7 @@ describe('policy details: ', () => {
               policy: {
                 value: {
                   global_manifest_version: 'latest',
+                  global_telemetry_enabled: false,
                   meta: {
                     license: '',
                     cloud: false,

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/endpoint_app_context_services.ts
@@ -26,6 +26,7 @@ import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { FleetActionsClientInterface } from '@kbn/fleet-plugin/server/services/actions/types';
 import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
+import type { TelemetryConfigProvider } from '../../common/telemetry_config/telemetry_config_provider';
 import { SavedObjectsClientFactory } from './services/saved_objects';
 import type { ResponseActionsClient } from './services';
 import { getResponseActionsClient, NormalizedExternalConnectorClient } from './services';
@@ -86,6 +87,7 @@ export interface EndpointAppContextServiceStartContract {
   productFeaturesService: ProductFeaturesService;
   savedObjectsServiceStart: SavedObjectsServiceStart;
   connectorActions: ActionsPluginStartContract;
+  telemetryConfigProvider: TelemetryConfigProvider;
 }
 
 /**
@@ -154,6 +156,7 @@ export class EndpointAppContextService {
       manifestManager,
       alerting,
       licenseService,
+      telemetryConfigProvider,
       exceptionListsClient,
       featureUsageService,
       esClient,
@@ -184,7 +187,8 @@ export class EndpointAppContextService {
         licenseService,
         exceptionListsClient,
         this.setupDependencies.cloud,
-        productFeaturesService
+        productFeaturesService,
+        telemetryConfigProvider
       )
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/telemetry_watch.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/telemetry_watch.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@kbn/core/server/mocks';
 import { createPackagePolicyServiceMock } from '@kbn/fleet-plugin/server/mocks';
 import type { PackagePolicyClient } from '@kbn/fleet-plugin/server';
-import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import type { PackagePolicy, UpdatePackagePolicy } from '@kbn/fleet-plugin/common';
 import { createPackagePolicyMock } from '@kbn/fleet-plugin/common/mocks';
 import { policyFactory } from '../../../../common/endpoint/models/policy_config';
 import type { PolicyConfig } from '../../../../common/endpoint/types';
@@ -128,7 +128,7 @@ describe('Telemetry config watcher', () => {
 
       await telemetryWatcher.watch(value);
 
-      expect(packagePolicySvcMock.update).not.toHaveBeenCalled();
+      expect(packagePolicySvcMock.bulkUpdate).not.toHaveBeenCalled();
     }
   );
 
@@ -137,9 +137,10 @@ describe('Telemetry config watcher', () => {
 
     await telemetryWatcher.watch(value);
 
-    expect(packagePolicySvcMock.update).toHaveBeenCalled();
-    const updatedPolicy: PolicyConfig =
-      packagePolicySvcMock.update.mock.calls[0][3].inputs[0].config?.policy.value;
-    expect(updatedPolicy.global_telemetry_enabled).toBe(value);
+    expect(packagePolicySvcMock.bulkUpdate).toHaveBeenCalled();
+    const policyUpdates: UpdatePackagePolicy[] = packagePolicySvcMock.bulkUpdate.mock.calls[0][2];
+    expect(policyUpdates.length).toBe(1);
+    const updatedPolicyConfigs: PolicyConfig = policyUpdates[0].inputs[0].config?.policy.value;
+    expect(updatedPolicyConfigs.global_telemetry_enabled).toBe(value);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/telemetry_watch.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/telemetry_watch.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Subject } from 'rxjs';
+import {
+  elasticsearchServiceMock,
+  loggingSystemMock,
+  savedObjectsServiceMock,
+} from '@kbn/core/server/mocks';
+import { createPackagePolicyServiceMock } from '@kbn/fleet-plugin/server/mocks';
+import type { PackagePolicyClient } from '@kbn/fleet-plugin/server';
+import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import { createPackagePolicyMock } from '@kbn/fleet-plugin/common/mocks';
+import { policyFactory } from '../../../../common/endpoint/models/policy_config';
+import type { PolicyConfig } from '../../../../common/endpoint/types';
+import { TelemetryConfigWatcher } from './telemetry_watch';
+import { TelemetryConfigProvider } from '../../../../common/telemetry_config/telemetry_config_provider';
+
+const MockPPWithEndpointPolicy = (cb?: (p: PolicyConfig) => PolicyConfig): PackagePolicy => {
+  const packagePolicy = createPackagePolicyMock();
+  if (!cb) {
+    // eslint-disable-next-line no-param-reassign
+    cb = (p) => p;
+  }
+  const policyConfig = cb(policyFactory());
+  packagePolicy.inputs[0].config = { policy: { value: policyConfig } };
+  return packagePolicy;
+};
+
+describe('Telemetry config watcher', () => {
+  const logger = loggingSystemMock.create().get('telemetry_watch.test');
+  const soStartMock = savedObjectsServiceMock.createStartContract();
+  const esStartMock = elasticsearchServiceMock.createStart();
+  let packagePolicySvcMock: jest.Mocked<PackagePolicyClient>;
+  let telemetryWatcher: TelemetryConfigWatcher;
+
+  const preparePackagePolicyMock = ({
+    isGlobalTelemetryEnabled,
+  }: {
+    isGlobalTelemetryEnabled: boolean;
+  }) => {
+    packagePolicySvcMock.list.mockResolvedValueOnce({
+      items: [
+        MockPPWithEndpointPolicy((pc: PolicyConfig): PolicyConfig => {
+          pc.global_telemetry_enabled = isGlobalTelemetryEnabled;
+          return pc;
+        }),
+      ],
+      total: 1,
+      page: 1,
+      perPage: 100,
+    });
+  };
+
+  beforeEach(() => {
+    packagePolicySvcMock = createPackagePolicyServiceMock();
+
+    telemetryWatcher = new TelemetryConfigWatcher(
+      packagePolicySvcMock,
+      soStartMock,
+      esStartMock,
+      logger
+    );
+  });
+
+  it('is activated on telemetry config changes', () => {
+    const telemetryConfigEmitter: Subject<boolean> = new Subject();
+    const telemetryConfigProvider = new TelemetryConfigProvider();
+
+    // spy on the watch() function
+    const mockWatch = jest.fn();
+    telemetryWatcher.watch = mockWatch;
+
+    telemetryConfigProvider.start(telemetryConfigEmitter);
+    telemetryWatcher.start(telemetryConfigProvider);
+
+    telemetryConfigEmitter.next(true);
+
+    expect(mockWatch).toBeCalledTimes(1);
+
+    telemetryWatcher.stop();
+    telemetryConfigProvider.stop();
+    telemetryConfigEmitter.complete();
+  });
+
+  it('pages through all endpoint policies', async () => {
+    const TOTAL = 247;
+
+    // set up the mocked package policy service to return and do what we want
+    packagePolicySvcMock.list
+      .mockResolvedValueOnce({
+        items: Array.from({ length: 100 }, () => MockPPWithEndpointPolicy()),
+        total: TOTAL,
+        page: 1,
+        perPage: 100,
+      })
+      .mockResolvedValueOnce({
+        items: Array.from({ length: 100 }, () => MockPPWithEndpointPolicy()),
+        total: TOTAL,
+        page: 2,
+        perPage: 100,
+      })
+      .mockResolvedValueOnce({
+        items: Array.from({ length: TOTAL - 200 }, () => MockPPWithEndpointPolicy()),
+        total: TOTAL,
+        page: 3,
+        perPage: 100,
+      });
+
+    await telemetryWatcher.watch(true); // manual trigger
+
+    expect(packagePolicySvcMock.list).toBeCalledTimes(3);
+
+    // Assert: on the first call to packagePolicy.list, we asked for page 1
+    expect(packagePolicySvcMock.list.mock.calls[0][1].page).toBe(1);
+    expect(packagePolicySvcMock.list.mock.calls[1][1].page).toBe(2); // second call, asked for page 2
+    expect(packagePolicySvcMock.list.mock.calls[2][1].page).toBe(3); // etc
+  });
+
+  it.each([true, false])(
+    'does not update policies if both global telemetry config and policy fields are %s',
+    async (value) => {
+      preparePackagePolicyMock({ isGlobalTelemetryEnabled: value });
+
+      await telemetryWatcher.watch(value);
+
+      expect(packagePolicySvcMock.update).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([true, false])('updates `global_telemetry_config` field to %s', async (value) => {
+    preparePackagePolicyMock({ isGlobalTelemetryEnabled: !value });
+
+    await telemetryWatcher.watch(value);
+
+    expect(packagePolicySvcMock.update).toHaveBeenCalled();
+    const updatedPolicy: PolicyConfig =
+      packagePolicySvcMock.update.mock.calls[0][3].inputs[0].config?.policy.value;
+    expect(updatedPolicy.global_telemetry_enabled).toBe(value);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/telemetry_watch.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/policy/telemetry_watch.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Subscription } from 'rxjs';
+
+import type {
+  ElasticsearchClient,
+  ElasticsearchServiceStart,
+  KibanaRequest,
+  Logger,
+  SavedObjectsClientContract,
+  SavedObjectsServiceStart,
+} from '@kbn/core/server';
+import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
+import type { PackagePolicyClient } from '@kbn/fleet-plugin/server';
+import { SECURITY_EXTENSION_ID } from '@kbn/core-saved-objects-server';
+import type { TelemetryConfigProvider } from '../../../../common/telemetry_config/telemetry_config_provider';
+import type { PolicyData } from '../../../../common/endpoint/types';
+import { getPolicyDataForUpdate } from '../../../../common/endpoint/service/policy';
+
+export class TelemetryConfigWatcher {
+  private logger: Logger;
+  private esClient: ElasticsearchClient;
+  private policyService: PackagePolicyClient;
+  private subscription: Subscription | undefined;
+  private soStart: SavedObjectsServiceStart;
+  constructor(
+    policyService: PackagePolicyClient,
+    soStart: SavedObjectsServiceStart,
+    esStart: ElasticsearchServiceStart,
+    logger: Logger
+  ) {
+    this.policyService = policyService;
+    this.esClient = esStart.client.asInternalUser;
+    this.logger = logger;
+    this.soStart = soStart;
+  }
+
+  /**
+   * The policy watcher is not called as part of a HTTP request chain, where the
+   * request-scoped SOClient could be passed down. It is called via license observable
+   * changes. We are acting as the 'system' in response to license changes, so we are
+   * intentionally using the system user here. Be very aware of what you are using this
+   * client to do
+   */
+  private makeInternalSOClient(soStart: SavedObjectsServiceStart): SavedObjectsClientContract {
+    const fakeRequest = {
+      headers: {},
+      getBasePath: () => '',
+      path: '/',
+      route: { settings: {} },
+      url: { href: {} },
+      raw: { req: { url: '/' } },
+    } as unknown as KibanaRequest;
+    return soStart.getScopedClient(fakeRequest, { excludedExtensions: [SECURITY_EXTENSION_ID] });
+  }
+
+  public start(telemetryConfigProvider: TelemetryConfigProvider) {
+    this.subscription = telemetryConfigProvider.getObservable()?.subscribe(this.watch.bind(this));
+  }
+
+  public stop() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+  }
+
+  public async watch(isTelemetryEnabled: boolean) {
+    let page = 1;
+    let response: {
+      items: PackagePolicy[];
+      total: number;
+      page: number;
+      perPage: number;
+    };
+
+    this.logger.debug(
+      `Checking Endpoint policies to update due to changed telemetry config setting: ${isTelemetryEnabled}`
+    );
+
+    do {
+      try {
+        response = await this.policyService.list(this.makeInternalSOClient(this.soStart), {
+          page: page++,
+          perPage: 2,
+          kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: endpoint`,
+        });
+      } catch (e) {
+        this.logger.warn(
+          `Unable to verify endpoint policies in line with license change: failed to fetch package policies: ${e.message}`
+        );
+        return;
+      }
+
+      for (const policy of response.items as PolicyData[]) {
+        const updatePolicy = getPolicyDataForUpdate(policy);
+        const policyConfig = updatePolicy.inputs[0].config.policy.value;
+
+        try {
+          if (isTelemetryEnabled !== policyConfig.global_telemetry_enabled) {
+            policyConfig.global_telemetry_enabled = isTelemetryEnabled;
+
+            try {
+              await this.policyService.update(
+                this.makeInternalSOClient(this.soStart),
+                this.esClient,
+                policy.id,
+                updatePolicy
+              );
+            } catch (e) {
+              // try again for transient issues
+              try {
+                await this.policyService.update(
+                  this.makeInternalSOClient(this.soStart),
+                  this.esClient,
+                  policy.id,
+                  updatePolicy
+                );
+              } catch (ee) {
+                this.logger.warn(`Unable to update telemetry config state in policy ${policy.id}`);
+                this.logger.warn(ee);
+              }
+            }
+          }
+        } catch (error) {
+          this.logger.warn(
+            `Failure while attempting to verify telemetry config state for policy [${policy.id}]`
+          );
+          this.logger.warn(error);
+        }
+      }
+    } while (response.page * response.perPage < response.total);
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/mocks/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/mocks/mocks.ts
@@ -50,6 +50,7 @@ import { unsecuredActionsClientMock } from '@kbn/actions-plugin/server/unsecured
 import type { PluginStartContract as ActionPluginStartContract } from '@kbn/actions-plugin/server';
 import type { Mutable } from 'utility-types';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
+import { createTelemetryConfigProviderMock } from '../../../common/telemetry_config/mocks';
 import { createSavedObjectsClientFactoryMock } from '../services/saved_objects/saved_objects_client_factory.mocks';
 import { EndpointMetadataService } from '../services/metadata';
 import { createEndpointFleetServicesFactoryMock } from '../services/fleet/endpoint_fleet_services_factory.mocks';
@@ -216,6 +217,7 @@ export const createMockEndpointAppContextServiceStartContract =
       connectorActions: {
         getUnsecuredActionsClient: jest.fn().mockReturnValue(unsecuredActionsClientMock.create()),
       } as unknown as jest.Mocked<ActionPluginStartContract>,
+      telemetryConfigProvider: createTelemetryConfigProviderMock(),
     };
 
     return startContract;

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
@@ -83,6 +83,7 @@ import type {
 import type { EndpointMetadataService } from '../endpoint/services/metadata';
 import { createEndpointMetadataServiceTestContextMock } from '../endpoint/services/metadata/mocks';
 import { createPolicyDataStreamsIfNeeded as _createPolicyDataStreamsIfNeeded } from './handlers/create_policy_datastreams';
+import { TelemetryConfigProvider } from '../../common/telemetry_config/telemetry_config_provider';
 
 jest.mock('uuid', () => ({
   v4: (): string => 'NEW_UUID',
@@ -118,6 +119,7 @@ describe('Fleet integrations', () => {
   });
   const generator = new EndpointDocGenerator();
   const cloudService = cloudMock.createSetup();
+  const telemetryConfigProvider = new TelemetryConfigProvider();
   let productFeaturesService: ProductFeaturesService;
   let endpointMetadataService: EndpointMetadataService;
   let logger: Logger;
@@ -189,7 +191,8 @@ describe('Fleet integrations', () => {
         licenseService,
         exceptionListClient,
         cloudService,
-        productFeaturesService
+        productFeaturesService,
+        telemetryConfigProvider
       );
 
       return callback(

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/fleet_integration.ts
@@ -31,6 +31,7 @@ import type {
   PostAgentPolicyUpdateCallback,
   PutPackagePolicyPostUpdateCallback,
 } from '@kbn/fleet-plugin/server/types';
+import type { TelemetryConfigProvider } from '../../common/telemetry_config/telemetry_config_provider';
 import type { EndpointInternalFleetServicesInterface } from '../endpoint/services/fleet';
 import type { EndpointAppContextService } from '../endpoint/endpoint_app_context_services';
 import { createPolicyDataStreamsIfNeeded } from './handlers/create_policy_datastreams';
@@ -123,7 +124,8 @@ export const getPackagePolicyCreateCallback = (
   licenseService: LicenseService,
   exceptionsClient: ExceptionListClient | undefined,
   cloud: CloudSetup,
-  productFeatures: ProductFeaturesService
+  productFeatures: ProductFeaturesService,
+  telemetryConfigProvider: TelemetryConfigProvider
 ): PostPackagePolicyCreateCallback => {
   return async (
     newPackagePolicy,
@@ -196,7 +198,8 @@ export const getPackagePolicyCreateCallback = (
       endpointIntegrationConfig,
       cloud,
       esClientInfo,
-      productFeatures
+      productFeatures,
+      telemetryConfigProvider
     );
 
     return {

--- a/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/handlers/create_default_policy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/fleet_integration/handlers/create_default_policy.ts
@@ -8,6 +8,7 @@
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { InfoResponse } from '@elastic/elasticsearch/lib/api/types';
 import { ProductFeatureSecurityKey } from '@kbn/security-solution-features/keys';
+import type { TelemetryConfigProvider } from '../../../common/telemetry_config/telemetry_config_provider';
 import {
   policyFactory as policyConfigFactory,
   policyFactoryWithoutPaidFeatures as policyConfigFactoryWithoutPaidFeatures,
@@ -36,7 +37,8 @@ export const createDefaultPolicy = (
   config: AnyPolicyCreateConfig | undefined,
   cloud: CloudSetup,
   esClientInfo: InfoResponse,
-  productFeatures: ProductFeaturesService
+  productFeatures: ProductFeaturesService,
+  telemetryConfigProvider: TelemetryConfigProvider
 ): PolicyConfig => {
   // Pass license and cloud information to use in Policy creation
   const factoryPolicy = policyConfigFactory(
@@ -45,7 +47,8 @@ export const createDefaultPolicy = (
     licenseService.getLicenseUID(),
     esClientInfo?.cluster_uuid,
     esClientInfo?.cluster_name,
-    cloud?.isServerlessEnabled
+    cloud?.isServerlessEnabled,
+    telemetryConfigProvider.isOptedIn
   );
 
   let defaultPolicyPerType: PolicyConfig =

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -613,6 +613,7 @@ export class Plugin implements ISecuritySolutionPlugin {
       cases: plugins.cases,
       manifestManager,
       licenseService,
+      telemetryConfigProvider: this.telemetryConfigProvider,
       exceptionListsClient: exceptionListClient,
       registerListsServerExtension: this.lists?.registerExtension,
       featureUsageService,

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -131,6 +131,7 @@ import { getCriblPackagePolicyPostCreateOrUpdateCallback } from './security_inte
 import { scheduleEntityAnalyticsMigration } from './lib/entity_analytics/migrations';
 import { SiemMigrationsService } from './lib/siem_migrations/siem_migrations_service';
 import { TelemetryConfigProvider } from '../common/telemetry_config/telemetry_config_provider';
+import { TelemetryConfigWatcher } from './endpoint/lib/policy/telemetry_watch';
 
 export type { SetupPlugins, StartPlugins, PluginSetup, PluginStart } from './plugin_contract';
 
@@ -152,6 +153,7 @@ export class Plugin implements ISecuritySolutionPlugin {
   private licensing$!: Observable<ILicense>;
   private policyWatcher?: PolicyWatcher;
   private telemetryConfigProvider: TelemetryConfigProvider;
+  private telemetryWatcher?: TelemetryConfigWatcher;
 
   private manifestTask: ManifestTask | undefined;
   private completeExternalResponseActionsTask: CompleteExternalResponseActionsTask;
@@ -671,6 +673,14 @@ export class Plugin implements ISecuritySolutionPlugin {
         logger
       );
       this.policyWatcher.start(licenseService);
+
+      this.telemetryWatcher = new TelemetryConfigWatcher(
+        plugins.fleet.packagePolicyService,
+        core.savedObjects,
+        core.elasticsearch,
+        logger
+      );
+      this.telemetryWatcher.start(this.telemetryConfigProvider);
     }
 
     if (plugins.taskManager) {

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin_contract.ts
@@ -83,7 +83,7 @@ export interface SecuritySolutionPluginStartDependencies {
   security: SecurityPluginStart;
   spaces?: SpacesPluginStart;
   taskManager?: TaskManagerPluginStart;
-  telemetry?: TelemetryPluginStart;
+  telemetry: TelemetryPluginStart;
   share: SharePluginStart;
   actions: ActionsPluginStartContract;
   inference: InferenceServerStart;


### PR DESCRIPTION
> [!note]
> No need for review this. It's waiting for
> - #206728
>
> to be merged, then I'll rebase this and open a new PR to have a cleaner one.


## Summary


The goal to propagate `isOptedIn` from the Telemetry plugin to Endpoint policies as a field named `global_telemetry_config`.

For this:
- telemetry plugin is marked as required for security solution
- a new `TelemetryConfigProvider` subscribes to the Observable, and persists the pushed value to functions that need it
(note: here we could have used the already public `getIsOptedIn()`, but that's _rumored_ to be deprecated, and we need the Observable for watching changes anyway)
- the config value is added to newly created policies
- a new `TelemetryConfigWatcher` is subscribed to the `isOptedIn$` observable, and updates package policies accordingly
  - as this is performed on Kibana startup, it acts as a backfill functionality as well, for 9.0. ✅ 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
