### PR TITLE
[8.x] [One Discover] Revert token change from vis palette (#204054)

### DIFF
--- a/packages/kbn-discover-utils/src/data_types/logs/utils/get_log_level_color.test.ts
+++ b/packages/kbn-discover-utils/src/data_types/logs/utils/get_log_level_color.test.ts
@@ -13,7 +13,7 @@ import { LogLevelCoalescedValue } from './get_log_level_coalesed_value';
 
 const euiTheme = {
   colors: {
-    lightShade: '#ffffff',
+    mediumShade: '#d3dae6',
   },
 };
 
@@ -32,20 +32,20 @@ describe('getLogLevelColor', () => {
       '#d6bf57'
     );
     expect(getLogLevelColor(LogLevelCoalescedValue.error, euiTheme as EuiThemeComputed)).toBe(
-      '#df9352'
+      '#e18774'
     );
     expect(getLogLevelColor(LogLevelCoalescedValue.critical, euiTheme as EuiThemeComputed)).toBe(
-      '#e7664c'
+      '#dd7b67'
     );
     expect(getLogLevelColor(LogLevelCoalescedValue.alert, euiTheme as EuiThemeComputed)).toBe(
-      '#da5e47'
+      '#d76f5b'
     );
     expect(getLogLevelColor(LogLevelCoalescedValue.emergency, euiTheme as EuiThemeComputed)).toBe(
-      '#cc5642'
+      '#d2634e'
     );
     // other
     expect(getLogLevelColor(LogLevelCoalescedValue.trace, euiTheme as EuiThemeComputed)).toBe(
-      '#ffffff'
+      '#d3dae6'
     );
   });
 });

--- a/packages/kbn-discover-utils/src/data_types/logs/utils/get_log_level_color.ts
+++ b/packages/kbn-discover-utils/src/data_types/logs/utils/get_log_level_color.ts
@@ -7,7 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiThemeComputed, euiPaletteForTemperature, euiPaletteForStatus } from '@elastic/eui';
+import {
+  EuiThemeComputed,
+  euiPaletteForTemperature,
+  euiPaletteForStatus,
+  euiPaletteRed,
+} from '@elastic/eui';
 import { LogLevelCoalescedValue } from './get_log_level_coalesed_value';
 
 export const getLogLevelColor = (
@@ -16,8 +21,11 @@ export const getLogLevelColor = (
 ): string | undefined => {
   const euiPaletteForTemperature6 = euiPaletteForTemperature(6);
   const euiPaletteForStatus9 = euiPaletteForStatus(9);
+  const euiPaletteRed9 = euiPaletteRed(14);
 
   switch (logLevelCoalescedValue) {
+    case LogLevelCoalescedValue.trace:
+      return euiTheme.colors.mediumShade;
     case LogLevelCoalescedValue.debug:
       return euiPaletteForTemperature6[2]; // lighter, closer to the default color for all other unknown log levels
     case LogLevelCoalescedValue.info:
@@ -27,15 +35,16 @@ export const getLogLevelColor = (
     case LogLevelCoalescedValue.warning:
       return euiPaletteForStatus9[4];
     case LogLevelCoalescedValue.error:
-      return euiPaletteForStatus9[5];
+      return euiPaletteRed9[9];
     case LogLevelCoalescedValue.critical:
-      return euiPaletteForStatus9[6];
+      return euiPaletteRed9[10];
     case LogLevelCoalescedValue.alert:
-      return euiPaletteForStatus9[7];
+      return euiPaletteRed9[11];
     case LogLevelCoalescedValue.emergency:
+      return euiPaletteRed9[12];
     case LogLevelCoalescedValue.fatal:
-      return euiPaletteForStatus9[8];
+      return euiPaletteRed9[13];
     default:
-      return euiTheme.colors.lightShade;
+      return euiTheme.colors.mediumShade;
   }
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[One Discover] Revert token change from vis palette (#204054)](https://github.com/elastic/kibana/pull/204054)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Marco Antonio Ghiani","email":"marcoantonio.ghiani01@gmail.com"},"sourceCommit":{"committedDate":"2024-12-12T17:01:49Z","message":"[One Discover] Revert token change from vis palette (#204054)\n\n## 📓 Summary\r\n\r\nRelated to https://github.com/elastic/kibana/pull/202985\r\n\r\nThis change reverts a suggestion that was applied but that should only\r\nbe valid for v9.\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>","sha":"08da9468b28afdad386b91a26507cd45e1c85098","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:DataDiscovery","backport:prev-minor","Project:OneDiscover"],"number":204054,"url":"https://github.com/elastic/kibana/pull/204054","mergeCommit":{"message":"[One Discover] Revert token change from vis palette (#204054)\n\n## 📓 Summary\r\n\r\nRelated to https://github.com/elastic/kibana/pull/202985\r\n\r\nThis change reverts a suggestion that was applied but that should only\r\nbe valid for v9.\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>","sha":"08da9468b28afdad386b91a26507cd45e1c85098"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/204054","number":204054,"mergeCommit":{"message":"[One Discover] Revert token change from vis palette (#204054)\n\n## 📓 Summary\r\n\r\nRelated to https://github.com/elastic/kibana/pull/202985\r\n\r\nThis change reverts a suggestion that was applied but that should only\r\nbe valid for v9.\r\n\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>","sha":"08da9468b28afdad386b91a26507cd45e1c85098"}}]}] BACKPORT-->