### PR TITLE
Dependency ownership for Stack Monitoring team, part 1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2484,8 +2484,15 @@
     },
     {
       "groupName": "OpenTelemetry modules",
-      "matchDepPrefixes": [
-        "@opentelemetry/"
+      "matchDepNames": [
+        "@grpc/grpc-js",
+        "@opentelemetry/api",
+        "@opentelemetry/api-metrics",
+        "@opentelemetry/exporter-metrics-otlp-grpc",
+        "@opentelemetry/exporter-prometheus",
+        "@opentelemetry/resources",
+        "@opentelemetry/sdk-metrics-base",
+        "@opentelemetry/semantic-conventions"
       ],
       "reviewers": [
         "team:stack-monitoring"
@@ -2494,7 +2501,9 @@
         "main"
       ],
       "labels": [
-        "Team:Monitoring"
+        "Team:Monitoring",
+        "backport:all-open",
+        "release_note:skip"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true


### PR DESCRIPTION
## Summary

This updates our `renovate.json` configuration to mark the Stack Monitoring team as owners of their set of dependencies.