### PR TITLE
Dependency ownership for ML UI team, part 1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -261,6 +261,27 @@
       "enabled": true
     },
     {
+      "groupName": "@elastic/ml-ui dependencies",
+      "matchDepNames": [
+        "@types/he",
+        "he",
+        "react-popper-tooltip"
+      ],
+      "reviewers": [
+        "team:ml-ui"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "labels": [
+        "Team:ML",
+        ":ml",
+        "release_note:skip",
+        "backport:all-open"
+      ],
+      "enabled": true
+    },
+    {
       "groupName": "@elastic/fleet dependencies",
       "matchDepNames": [
         "exponential-backoff",


### PR DESCRIPTION
## Summary

This updates our `renovate.json` configuration to mark the ML UI team as owners of their set of dependencies.