### PR TITLE
chore(NA): adds forward compatibility v9 pipeline

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-v9.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-v9.yml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: bk-kibana-es-forward-compatibility-testing-v9
+  description: Forward compatibility testing between Kibana 8.18 and ES 9+
+  links:
+    - url: 'https://buildkite.com/elastic/kibana-es-forward-compatibility-testing-v9'
+      title: Pipeline link
+spec:
+  type: buildkite-pipeline
+  system: buildkite
+  owner: 'group:kibana-operations'
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: kibana / ES Forward Compatibility Testing 9.0
+      description: Forward compatibility testing between Kibana 8.18 and ES 9+
+    spec:
+      env:
+        SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        REPORT_FAILED_TESTS_TO_GITHUB: 'true'
+      allow_rebuilds: false
+      branch_configuration: main
+      default_branch: main
+      repository: elastic/kibana
+      pipeline_file: .buildkite/pipelines/es_forward_v9.yml # Note: this file exists in 8.x only and should be moved into 8.18 once the branch is cut
+      provider_settings:
+        prefix_pull_request_fork_branch_names: false
+        trigger_mode: none
+      teams:
+        kibana-operations:
+          access_level: MANAGE_BUILD_AND_READ
+        appex-qa:
+          access_level: MANAGE_BUILD_AND_READ
+        kibana-tech-leads:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: BUILD_AND_READ
+      tags:
+        - kibana

--- a/.buildkite/pipeline-resource-definitions/trigger-version-dependent-jobs.yml
+++ b/.buildkite/pipeline-resource-definitions/trigger-version-dependent-jobs.yml
@@ -51,6 +51,11 @@ spec:
           message: Trigger ES forward compatibility tests
           env:
             TRIGGER_PIPELINE_SET: es-forward
+        Trigger ES forward compatibility tests v9:
+          cronline: 0 5 * * *
+          message: Trigger ES forward compatibility tests v9
+          env:
+            TRIGGER_PIPELINE_SET: es-forward-v9
         Trigger artifact staging builds:
           cronline: 0 7 * * * America/New_York
           message: Trigger artifact staging builds

--- a/.buildkite/scripts/pipelines/trigger_version_dependent_jobs/pipeline.ts
+++ b/.buildkite/scripts/pipelines/trigger_version_dependent_jobs/pipeline.ts
@@ -12,6 +12,7 @@ import { getVersionsFile, BuildkiteTriggerStep } from '#pipeline-utils';
 
 const pipelineSets = {
   'es-forward': 'kibana-es-forward-compatibility-testing',
+  'es-forward-v9': 'kibana-es-forward-compatibility-testing-v9',
   'artifacts-snapshot': 'kibana-artifacts-snapshot',
   'artifacts-staging': 'kibana-artifacts-staging',
   'artifacts-trigger': 'kibana-artifacts-trigger',
@@ -38,6 +39,10 @@ async function main() {
   switch (pipelineSetName) {
     case 'es-forward': {
       pipelineSteps.push(...getESForwardPipelineTriggers());
+      break;
+    }
+    case 'es-forward-v9': {
+      pipelineSteps.push(...getESForwardV9PipelineTriggers());
       break;
     }
     case 'artifacts-snapshot': {
@@ -80,6 +85,38 @@ export function getESForwardPipelineTriggers(): BuildkiteTriggerStep[] {
       build: {
         message: process.env.MESSAGE || `ES forward-compatibility test for ES ${version}`,
         branch: KIBANA_7_17.branch,
+        commit: 'HEAD',
+        env: {
+          ES_SNAPSHOT_MANIFEST: `https://storage.googleapis.com/kibana-ci-es-snapshots-daily/${version}/manifest-latest-verified.json`,
+          DRY_RUN: process.env.DRY_RUN,
+        },
+      },
+    } as BuildkiteTriggerStep;
+  });
+}
+
+/**
+ * This pipeline is testing the forward compatibility of Kibana with different versions of Elasticsearch for v9.
+ * Should be triggered for combinations of (Kibana@8.18 + ES@9.x {current open branches on the same major})
+ */
+export function getESForwardV9PipelineTriggers(): BuildkiteTriggerStep[] {
+  const versions = getVersionsFile();
+  const KIBANA_8_X = versions.versions.find((v) => v.branch === '8.x');
+  if (!KIBANA_8_X) {
+    throw new Error(
+      'Update ES forward compatibility v9 pipeline to remove 8.x and add version 8.18'
+    );
+  }
+  const targetESVersions = versions.versions.filter((v) => v.branch.startsWith('9.'));
+
+  return targetESVersions.map(({ version }) => {
+    return {
+      trigger: pipelineSets['es-forward-v9'],
+      async: true,
+      label: `Triggering Kibana ${KIBANA_8_X.version} + ES ${version} forward compatibility`,
+      build: {
+        message: process.env.MESSAGE || `ES forward-compatibility test for ES ${version}`,
+        branch: KIBANA_8_X.branch,
         commit: 'HEAD',
         env: {
           ES_SNAPSHOT_MANIFEST: `https://storage.googleapis.com/kibana-ci-es-snapshots-daily/${version}/manifest-latest-verified.json`,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-operations/issues/215

This PR adds a pipeline setup to test forward compatibility of Kibana 8.18 against ES 9.0.