### PR TITLE
[8.17] [Security Solution] Adds normalization for `query` fields before diff algorithm comparison (#203482)

### DIFF
--- a/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/diff/convert_rule_to_diffable.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/diff/convert_rule_to_diffable.ts
@@ -118,7 +118,7 @@ const extractDiffableCommonFields = (
     version: rule.version,
 
     // Main domain fields
-    name: rule.name,
+    name: rule.name.trim(),
     tags: rule.tags ?? [],
     description: rule.description,
     severity: rule.severity,

--- a/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/diff/extract_rule_data_query.test.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/diff/extract_rule_data_query.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { KqlQueryType } from '../../../api/detection_engine';
+import {
+  extractRuleEqlQuery,
+  extractRuleEsqlQuery,
+  extractRuleKqlQuery,
+} from './extract_rule_data_query';
+
+describe('extract rule data queries', () => {
+  describe('extractRuleKqlQuery', () => {
+    it('extracts a trimmed version of the query field for inline query types', () => {
+      const extractedKqlQuery = extractRuleKqlQuery('\nevent.kind:alert\n', 'kuery', [], undefined);
+
+      expect(extractedKqlQuery).toEqual({
+        type: KqlQueryType.inline_query,
+        query: 'event.kind:alert',
+        language: 'kuery',
+        filters: [],
+      });
+    });
+  });
+
+  describe('extractRuleEqlQuery', () => {
+    it('extracts a trimmed version of the query field', () => {
+      const extractedEqlQuery = extractRuleEqlQuery({
+        query: '\n\nquery where true\n\n',
+        language: 'eql',
+        filters: [],
+        eventCategoryOverride: undefined,
+        timestampField: undefined,
+        tiebreakerField: undefined,
+      });
+
+      expect(extractedEqlQuery).toEqual({
+        query: 'query where true',
+        language: 'eql',
+        filters: [],
+        event_category_override: undefined,
+        timestamp_field: undefined,
+        tiebreaker_field: undefined,
+      });
+    });
+  });
+
+  describe('extractRuleEsqlQuery', () => {
+    it('extracts a trimmed version of the query field', () => {
+      const extractedEsqlQuery = extractRuleEsqlQuery('\nFROM * where true\t\n', 'esql');
+
+      expect(extractedEsqlQuery).toEqual({
+        query: 'FROM * where true',
+        language: 'esql',
+      });
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/diff/extract_rule_data_query.test.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/diff/extract_rule_data_query.test.ts
@@ -28,22 +28,12 @@ describe('extract rule data queries', () => {
 
   describe('extractRuleEqlQuery', () => {
     it('extracts a trimmed version of the query field', () => {
-      const extractedEqlQuery = extractRuleEqlQuery({
-        query: '\n\nquery where true\n\n',
-        language: 'eql',
-        filters: [],
-        eventCategoryOverride: undefined,
-        timestampField: undefined,
-        tiebreakerField: undefined,
-      });
+      const extractedEqlQuery = extractRuleEqlQuery('\n\nquery where true\n\n', 'eql', []);
 
       expect(extractedEqlQuery).toEqual({
         query: 'query where true',
         language: 'eql',
         filters: [],
-        event_category_override: undefined,
-        timestamp_field: undefined,
-        tiebreaker_field: undefined,
       });
     });
   });

--- a/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/diff/extract_rule_data_query.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/diff/extract_rule_data_query.ts
@@ -43,7 +43,7 @@ export const extractInlineKqlQuery = (
 ): InlineKqlQuery => {
   return {
     type: KqlQueryType.inline_query,
-    query: query ?? '',
+    query: query?.trim() ?? '',
     language: language ?? 'kuery',
     filters: filters ?? [],
   };
@@ -55,7 +55,7 @@ export const extractRuleEqlQuery = (
   filters: RuleFilterArray | undefined
 ): RuleEqlQuery => {
   return {
-    query,
+    query: query.trim(),,
     language,
     filters: filters ?? [],
   };
@@ -66,7 +66,7 @@ export const extractRuleEsqlQuery = (
   language: EsqlQueryLanguage
 ): RuleEsqlQuery => {
   return {
-    query,
+    query: query.trim(),
     language,
   };
 };

--- a/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/diff/extract_rule_data_query.ts
+++ b/x-pack/plugins/security_solution/common/detection_engine/prebuilt_rules/diff/extract_rule_data_query.ts
@@ -55,7 +55,7 @@ export const extractRuleEqlQuery = (
   filters: RuleFilterArray | undefined
 ): RuleEqlQuery => {
   return {
-    query: query.trim(),,
+    query: query.trim(),
     language,
     filters: filters ?? [],
   };

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/management/trial_license_complete_tier/upgrade_review_prebuilt_rules.eql_query_fields.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/management/trial_license_complete_tier/upgrade_review_prebuilt_rules.eql_query_fields.ts
@@ -80,6 +80,46 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(reviewResponse.stats.num_rules_with_conflicts).toBe(0);
           expect(reviewResponse.stats.num_rules_with_non_solvable_conflicts).toBe(0);
         });
+
+        it('should trim all whitespace before version comparison', async () => {
+          // Install base prebuilt detection rule
+          await createHistoricalPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
+          await installPrebuiltRules(es, supertest);
+
+          // Customize an eql_query field on the installed rule
+          await updateRule(supertest, {
+            ...getPrebuiltRuleMock(),
+            rule_id: 'rule-1',
+            type: 'eql',
+            query: '\nquery where true\n',
+            language: 'eql',
+            filters: [],
+          } as RuleUpdateProps);
+
+          // Add a v2 rule asset to make the upgrade possible, do NOT update the related eql_query field, and create the new rule assets
+          const updatedRuleAssetSavedObjects = [
+            createRuleAssetSavedObject({
+              rule_id: 'rule-1',
+              version: 2,
+              type: 'eql',
+              query: '\nquery where true',
+              language: 'eql',
+              filters: [],
+            }),
+          ];
+          await createHistoricalPrebuiltRuleAssetSavedObjects(es, updatedRuleAssetSavedObjects);
+
+          // Call the upgrade review prebuilt rules endpoint and check that there is 1 rule eligible for update but eql_query field is NOT returned
+          const reviewResponse = await reviewPrebuiltRulesToUpgrade(supertest);
+          const fieldDiffObject = reviewResponse.rules[0].diff.fields as AllFieldsDiff;
+          expect(fieldDiffObject.eql_query).toBeUndefined();
+
+          expect(reviewResponse.rules[0].diff.num_fields_with_updates).toBe(1); // `version` is considered an updated field
+          expect(reviewResponse.rules[0].diff.num_fields_with_conflicts).toBe(0);
+          expect(reviewResponse.rules[0].diff.num_fields_with_non_solvable_conflicts).toBe(0);
+          expect(reviewResponse.stats.num_rules_with_conflicts).toBe(0);
+          expect(reviewResponse.stats.num_rules_with_non_solvable_conflicts).toBe(0);
+        });
       });
 
       describe("when rule field doesn't have an update but has a custom value - scenario ABA", () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/management/trial_license_complete_tier/upgrade_review_prebuilt_rules.esql_query_fields.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/management/trial_license_complete_tier/upgrade_review_prebuilt_rules.esql_query_fields.ts
@@ -78,6 +78,44 @@ export default ({ getService }: FtrProviderContext): void => {
           expect(reviewResponse.stats.num_rules_with_conflicts).toBe(0);
           expect(reviewResponse.stats.num_rules_with_non_solvable_conflicts).toBe(0);
         });
+
+        it('should trim all whitespace before version comparison', async () => {
+          // Install base prebuilt detection rule
+          await createHistoricalPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
+          await installPrebuiltRules(es, supertest);
+
+          // Customize an esql_query field on the installed rule
+          await updateRule(supertest, {
+            ...getPrebuiltRuleMock(),
+            rule_id: 'rule-1',
+            type: 'esql',
+            query: '\tFROM query WHERE true\t',
+            language: 'esql',
+          } as RuleUpdateProps);
+
+          // Add a v2 rule asset to make the upgrade possible, do NOT update the related esql_query field, and create the new rule assets
+          const updatedRuleAssetSavedObjects = [
+            createRuleAssetSavedObject({
+              rule_id: 'rule-1',
+              version: 2,
+              type: 'esql',
+              query: '\n\nFROM query WHERE true\n\n',
+              language: 'esql',
+            }),
+          ];
+          await createHistoricalPrebuiltRuleAssetSavedObjects(es, updatedRuleAssetSavedObjects);
+
+          // Call the upgrade review prebuilt rules endpoint and check that there is 1 rule eligible for update but esql_query field is NOT returned
+          const reviewResponse = await reviewPrebuiltRulesToUpgrade(supertest);
+          const fieldDiffObject = reviewResponse.rules[0].diff.fields as AllFieldsDiff;
+          expect(fieldDiffObject.esql_query).toBeUndefined();
+
+          expect(reviewResponse.rules[0].diff.num_fields_with_updates).toBe(1); // `version` is considered an updated field
+          expect(reviewResponse.rules[0].diff.num_fields_with_conflicts).toBe(0);
+          expect(reviewResponse.rules[0].diff.num_fields_with_non_solvable_conflicts).toBe(0);
+          expect(reviewResponse.stats.num_rules_with_conflicts).toBe(0);
+          expect(reviewResponse.stats.num_rules_with_non_solvable_conflicts).toBe(0);
+        });
       });
 
       describe("when rule field doesn't have an update but has a custom value - scenario ABA", () => {

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/management/trial_license_complete_tier/upgrade_review_prebuilt_rules.kql_query_fields.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/management/trial_license_complete_tier/upgrade_review_prebuilt_rules.kql_query_fields.ts
@@ -133,6 +133,52 @@ export default ({ getService }: FtrProviderContext): void => {
             expect(reviewResponse.stats.num_rules_with_non_solvable_conflicts).toBe(0);
           });
         });
+
+        describe('when all query versions have different surrounding whitespace', () => {
+          it('should not show in the upgrade/_review API response', async () => {
+            // Install base prebuilt detection rule
+            await createHistoricalPrebuiltRuleAssetSavedObjects(
+              es,
+              getQueryRuleAssetSavedObjects()
+            );
+            await installPrebuiltRules(es, supertest);
+
+            // Customize a kql_query field on the installed rule
+            await updateRule(supertest, {
+              ...getPrebuiltRuleMock(),
+              rule_id: 'rule-1',
+              type: 'query',
+              query: '\nquery string = true',
+              language: 'kuery',
+              filters: [],
+              saved_id: undefined,
+            } as RuleUpdateProps);
+
+            // Add a v2 rule asset to make the upgrade possible, do NOT update the related kql_query field, and create the new rule assets
+            const updatedRuleAssetSavedObjects = [
+              createRuleAssetSavedObject({
+                rule_id: 'rule-1',
+                version: 2,
+                type: 'query',
+                query: 'query string = true\n',
+                language: 'kuery',
+                filters: [],
+              }),
+            ];
+            await createHistoricalPrebuiltRuleAssetSavedObjects(es, updatedRuleAssetSavedObjects);
+
+            // Call the upgrade review prebuilt rules endpoint and check that there is 1 rule eligible for update but kql_query field is NOT returned
+            const reviewResponse = await reviewPrebuiltRulesToUpgrade(supertest);
+            const fieldDiffObject = reviewResponse.rules[0].diff.fields as AllFieldsDiff;
+            expect(fieldDiffObject.kql_query).toBeUndefined();
+
+            expect(reviewResponse.rules[0].diff.num_fields_with_updates).toBe(1); // `version` is considered an updated field
+            expect(reviewResponse.rules[0].diff.num_fields_with_conflicts).toBe(0);
+            expect(reviewResponse.rules[0].diff.num_fields_with_non_solvable_conflicts).toBe(0);
+            expect(reviewResponse.stats.num_rules_with_conflicts).toBe(0);
+            expect(reviewResponse.stats.num_rules_with_non_solvable_conflicts).toBe(0);
+          });
+        });
       });
 
       describe("when rule field doesn't have an update but has a custom value - scenario ABA", () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Security Solution] Adds normalization for `query` fields before diff algorithm comparison (#203482)](https://github.com/elastic/kibana/pull/203482)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Davis Plumlee","email":"56367316+dplumlee@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-12-13T03:58:50Z","message":"[Security Solution] Adds normalization for `query` fields before diff algorithm comparison (#203482)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/203151\r\n\r\nAdds a normalization for the `kql_query`, `eql_query`, and `esql_query`\r\nfields that trims the whitespace from the beginning and end of query\r\nstrings for a more robust comparison in the diff algorithms. Since\r\nwhitespace before or after the query string is purely a formatting\r\nchoice and doesn't impact the query itself, we discard the excess\r\nwhitespace characters before the direct string comparison.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed","sha":"0294838a95975ac6b5ee37a94ecacfe2e9a19955","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","v9.0.0","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","Feature:Prebuilt Detection Rules","backport:version","v8.18.0","v8.17.1"],"number":203482,"url":"https://github.com/elastic/kibana/pull/203482","mergeCommit":{"message":"[Security Solution] Adds normalization for `query` fields before diff algorithm comparison (#203482)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/203151\r\n\r\nAdds a normalization for the `kql_query`, `eql_query`, and `esql_query`\r\nfields that trims the whitespace from the beginning and end of query\r\nstrings for a more robust comparison in the diff algorithms. Since\r\nwhitespace before or after the query string is purely a formatting\r\nchoice and doesn't impact the query itself, we discard the excess\r\nwhitespace characters before the direct string comparison.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed","sha":"0294838a95975ac6b5ee37a94ecacfe2e9a19955"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203482","number":203482,"mergeCommit":{"message":"[Security Solution] Adds normalization for `query` fields before diff algorithm comparison (#203482)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/203151\r\n\r\nAdds a normalization for the `kql_query`, `eql_query`, and `esql_query`\r\nfields that trims the whitespace from the beginning and end of query\r\nstrings for a more robust comparison in the diff algorithms. Since\r\nwhitespace before or after the query string is purely a formatting\r\nchoice and doesn't impact the query itself, we discard the excess\r\nwhitespace characters before the direct string comparison.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed","sha":"0294838a95975ac6b5ee37a94ecacfe2e9a19955"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/204159","number":204159,"state":"OPEN"},{"branch":"8.17","label":"v8.17.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->