### PR TITLE
[Upgrade Assistant] Transfer ownership to Core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -964,7 +964,7 @@ x-pack/plugins/stack_connectors @elastic/response-ops
 x-pack/plugins/task_manager @elastic/response-ops
 x-pack/plugins/telemetry_collection_xpack @elastic/kibana-core
 x-pack/plugins/triggers_actions_ui @elastic/response-ops
-x-pack/plugins/upgrade_assistant @elastic/kibana-management
+x-pack/plugins/upgrade_assistant @elastic/kibana-core
 x-pack/plugins/watcher @elastic/kibana-management
 x-pack/solutions/observability/packages/alert_details @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/alerting_test_data @elastic/obs-ux-management-team

--- a/x-pack/plugins/upgrade_assistant/kibana.jsonc
+++ b/x-pack/plugins/upgrade_assistant/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/upgrade-assistant-plugin",
-  "owner": "@elastic/kibana-management",
+  "owner": "@elastic/kibana-core",
   "group": "platform",
   "visibility": "private",
   "plugin": {


### PR DESCRIPTION
## Summary

Core team will own _Upgrade Assistant_.