### PR TITLE
[FTR] Split Configs Manually

### DIFF
--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -26,6 +26,7 @@ enabled:
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group6.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group7.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group8.ts
+  - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
   - x-pack/test_serverless/functional/test_suites/observability/config.screenshots.ts
   - x-pack/test_serverless/functional/test_suites/observability/config.telemetry.ts
   # serverless config files that run deployment-agnostic tests

--- a/.buildkite/ftr_search_serverless_configs.yml
+++ b/.buildkite/ftr_search_serverless_configs.yml
@@ -20,5 +20,6 @@ enabled:
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group6.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group7.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group8.ts
+  - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
   # serverless config files that run deployment-agnostic tests
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/search.serverless.config.ts

--- a/.buildkite/ftr_security_serverless_configs.yml
+++ b/.buildkite/ftr_security_serverless_configs.yml
@@ -46,6 +46,7 @@ enabled:
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group7.ts
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group8.ts
+  - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/actions/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/basic_license_essentials_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/trial_license_complete_tier/configs/serverless.config.ts

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
@@ -13,13 +13,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/home_page'),
-      require.resolve('../../common/dev_tools'),
-      require.resolve('../../common/platform_security'),
-      require.resolve('../../common/reporting'),
-      require.resolve('../../common/grok_debugger'),
-      require.resolve('../../common/console'),
-      require.resolve('../../common/painless_lab'),
+      require.resolve('../../common/management'),
+      require.resolve('../../common/spaces'),
+      require.resolve('../../common/data_usage'),
     ],
     junit: {
       reportName: 'Serverless Observability Functional Tests - Common Group 1',

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
@@ -18,7 +18,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       require.resolve('../../common/data_usage'),
     ],
     junit: {
-      reportName: 'Serverless Observability Functional Tests - Common Group 1',
+      reportName: 'Serverless Observability Functional Tests - Common Group 9',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group1.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group1.ts
@@ -14,13 +14,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     ...baseTestConfig.getAll(),
     testFiles: [
       require.resolve('../../common/home_page'),
-      require.resolve('../../common/management'),
       require.resolve('../../common/dev_tools'),
       require.resolve('../../common/platform_security'),
       require.resolve('../../common/reporting'),
       require.resolve('../../common/console'),
-      require.resolve('../../common/spaces'),
-      require.resolve('../../common/data_usage'),
     ],
     junit: {
       reportName: 'Serverless Search Functional Tests - Common Group 1',

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
@@ -18,7 +18,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       require.resolve('../../common/data_usage'),
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 1',
+      reportName: 'Serverless Search Functional Tests - Common Group 9',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
@@ -13,16 +13,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/home_page'),
-      require.resolve('../../common/dev_tools'),
-      require.resolve('../../common/platform_security'),
-      require.resolve('../../common/reporting'),
-      require.resolve('../../common/grok_debugger'),
-      require.resolve('../../common/console'),
-      require.resolve('../../common/painless_lab'),
+      require.resolve('../../common/management'),
+      require.resolve('../../common/spaces'),
+      require.resolve('../../common/data_usage'),
     ],
     junit: {
-      reportName: 'Serverless Observability Functional Tests - Common Group 1',
+      reportName: 'Serverless Search Functional Tests - Common Group 1',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group1.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group1.ts
@@ -14,15 +14,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     ...baseTestConfig.getAll(),
     testFiles: [
       require.resolve('../../common/home_page'),
-      require.resolve('../../common/management'),
       require.resolve('../../common/dev_tools'),
       require.resolve('../../common/platform_security'),
       require.resolve('../../common/reporting'),
       require.resolve('../../common/grok_debugger'),
       require.resolve('../../common/console'),
       require.resolve('../../common/painless_lab'),
-      require.resolve('../../common/spaces'),
-      require.resolve('../../common/data_usage'),
     ],
     junit: {
       reportName: 'Serverless Security Functional Tests - Common Group 1',

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
@@ -13,16 +13,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/home_page'),
-      require.resolve('../../common/dev_tools'),
-      require.resolve('../../common/platform_security'),
-      require.resolve('../../common/reporting'),
-      require.resolve('../../common/grok_debugger'),
-      require.resolve('../../common/console'),
-      require.resolve('../../common/painless_lab'),
+      require.resolve('../../common/management'),
+      require.resolve('../../common/spaces'),
+      require.resolve('../../common/data_usage'),
     ],
     junit: {
-      reportName: 'Serverless Observability Functional Tests - Common Group 1',
+      reportName: 'Serverless Security Functional Tests - Common Group 1',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
@@ -18,7 +18,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
       require.resolve('../../common/data_usage'),
     ],
     junit: {
-      reportName: 'Serverless Security Functional Tests - Common Group 1',
+      reportName: 'Serverless Security Functional Tests - Common Group 9',
     },
   };
 }


### PR DESCRIPTION

## Summary


We are bumping up against the time limit in MKI runs. We are seeing this error: `Error: Timeout of 360000ms exceeded. For async tests and hooks, ensure "done()" is called;` Also, the 3 failing configs are each going over the 2 hour time limit. So, let's split these three configs:
1. `x-pack/test_serverless/functional/test_suites/search/common_configs/config.group1.ts`
1. `x-pack/test_serverless/functional/test_suites/security/common_configs/config.group1.ts`
1. `x-pack/test_serverless/functional/test_suites/security/common_configs/config.group1.ts`

At a glance, the management folder seems to have more tests than others.
So I've added it and 2 others to the new configs.

