### PR TITLE
[FTR] Split Configs Manually

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
@@ -13,13 +13,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/home_page'),
-      require.resolve('../../common/dev_tools'),
-      require.resolve('../../common/platform_security'),
-      require.resolve('../../common/reporting'),
-      require.resolve('../../common/grok_debugger'),
-      require.resolve('../../common/console'),
-      require.resolve('../../common/painless_lab'),
+      require.resolve('../../common/management'),
+      require.resolve('../../common/spaces'),
+      require.resolve('../../common/data_usage'),
     ],
     junit: {
       reportName: 'Serverless Observability Functional Tests - Common Group 1',

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group1.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group1.ts
@@ -14,13 +14,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     ...baseTestConfig.getAll(),
     testFiles: [
       require.resolve('../../common/home_page'),
-      require.resolve('../../common/management'),
       require.resolve('../../common/dev_tools'),
       require.resolve('../../common/platform_security'),
       require.resolve('../../common/reporting'),
       require.resolve('../../common/console'),
-      require.resolve('../../common/spaces'),
-      require.resolve('../../common/data_usage'),
     ],
     junit: {
       reportName: 'Serverless Search Functional Tests - Common Group 1',

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
@@ -13,16 +13,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/home_page'),
-      require.resolve('../../common/dev_tools'),
-      require.resolve('../../common/platform_security'),
-      require.resolve('../../common/reporting'),
-      require.resolve('../../common/grok_debugger'),
-      require.resolve('../../common/console'),
-      require.resolve('../../common/painless_lab'),
+      require.resolve('../../common/management'),
+      require.resolve('../../common/spaces'),
+      require.resolve('../../common/data_usage'),
     ],
     junit: {
-      reportName: 'Serverless Observability Functional Tests - Common Group 1',
+      reportName: 'Serverless Search Functional Tests - Common Group 1',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group1.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group1.ts
@@ -14,15 +14,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     ...baseTestConfig.getAll(),
     testFiles: [
       require.resolve('../../common/home_page'),
-      require.resolve('../../common/management'),
       require.resolve('../../common/dev_tools'),
       require.resolve('../../common/platform_security'),
       require.resolve('../../common/reporting'),
       require.resolve('../../common/grok_debugger'),
       require.resolve('../../common/console'),
       require.resolve('../../common/painless_lab'),
-      require.resolve('../../common/spaces'),
-      require.resolve('../../common/data_usage'),
     ],
     junit: {
       reportName: 'Serverless Security Functional Tests - Common Group 1',

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
@@ -13,16 +13,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/home_page'),
-      require.resolve('../../common/dev_tools'),
-      require.resolve('../../common/platform_security'),
-      require.resolve('../../common/reporting'),
-      require.resolve('../../common/grok_debugger'),
-      require.resolve('../../common/console'),
-      require.resolve('../../common/painless_lab'),
+      require.resolve('../../common/management'),
+      require.resolve('../../common/spaces'),
+      require.resolve('../../common/data_usage'),
     ],
     junit: {
-      reportName: 'Serverless Observability Functional Tests - Common Group 1',
+      reportName: 'Serverless Security Functional Tests - Common Group 1',
     },
   };
 }


### PR DESCRIPTION
## Summary


We are bumping up against the time limit in MKI runs. We are seeing this error: `Error: Timeout of 360000ms exceeded. For async tests and hooks, ensure "done()" is called;` Also, the 3 failing configs are each going over the 2 hour time limit. So, let's split these three configs:
1. `x-pack/test_serverless/functional/test_suites/search/common_configs/config.group1.ts`
1. `x-pack/test_serverless/functional/test_suites/security/common_configs/config.group1.ts`
1. `x-pack/test_serverless/functional/test_suites/security/common_configs/config.group1.ts`

At a glance, the management folder seems to have more tests than others.
So I've added it and 2 others to the new configs.

