### PR TITLE
[FieldFormatters] Add support for rawValue in url label

### DIFF
--- a/src/plugins/field_formats/common/converters/url.test.ts
+++ b/src/plugins/field_formats/common/converters/url.test.ts
@@ -139,9 +139,17 @@ describe('UrlFormat', () => {
       expect(url.convert('url', TEXT_CONTEXT_TYPE)).toBe('external url');
     });
 
-    test('can use the raw value', () => {
+    test('can use the raw value with {{value}}', () => {
       const url = new UrlFormat({
         labelTemplate: 'external {{value}}',
+      });
+
+      expect(url.convert('url?', TEXT_CONTEXT_TYPE)).toBe('external url?');
+    });
+
+    test('can use the raw value with {{rawValue}}', () => {
+      const url = new UrlFormat({
+        labelTemplate: 'external {{rawValue}}',
       });
 
       expect(url.convert('url?', TEXT_CONTEXT_TYPE)).toBe('external url?');

--- a/src/plugins/field_formats/common/converters/url.ts
+++ b/src/plugins/field_formats/common/converters/url.ts
@@ -86,6 +86,7 @@ export class UrlFormat extends FieldFormat {
     return this.compileTemplate(template)({
       value,
       url,
+      rawValue: value,
     });
   }
 


### PR DESCRIPTION
## Summary

This PR adds support for ``{{rawValue}}`` in url label.

Closes: #188973



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->