### PR TITLE
Fix incorrect paths in eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1309,14 +1309,14 @@ module.exports = {
       overrides: [
         {
           files: [
-            'x-pack/solutions/security/packages/features/**/*.{js,mjs,ts,tsx}',
-            'x-pack/solutions/security/packages/navigation/**/*.{js,mjs,ts,tsx}',
+            'x-pack/plugins/cases/**/*.{js,mjs,ts,tsx}',
+            'x-pack/plugins/ecs_data_quality_dashboard/**/*.{js,mjs,ts,tsx}',
             'x-pack/plugins/security_solution/**/*.{js,mjs,ts,tsx}',
             'x-pack/plugins/security_solution_ess/**/*.{js,mjs,ts,tsx}',
             'x-pack/plugins/security_solution_serverless/**/*.{js,mjs,ts,tsx}',
-            'x-pack/plugins/cases/**/*.{js,mjs,ts,tsx}',
-            'x-pack/plugins/ecs_data_quality_dashboard/**/*.{js,mjs,ts,tsx}',
-            'x-pack/x-pack/solutions/security/packages/data-stream-adapter/**/*.{js,mjs,ts,tsx}',
+            'x-pack/solutions/security/packages/data-stream-adapter/**/*.{js,mjs,ts,tsx}',
+            'x-pack/solutions/security/packages/features/**/*.{js,mjs,ts,tsx}',
+            'x-pack/solutions/security/packages/navigation/**/*.{js,mjs,ts,tsx}',
             'packages/kbn-cell-actions/**/*.{js,mjs,ts,tsx}',
           ],
           rules: {

--- a/x-pack/solutions/security/packages/data-stream-adapter/src/data_stream_adapter.ts
+++ b/x-pack/solutions/security/packages/data-stream-adapter/src/data_stream_adapter.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { IndexAdapter, SetIndexTemplateParams, type InstallParams } from '@kbn/index-adapter';
+import type { SetIndexTemplateParams } from '@kbn/index-adapter';
+import { IndexAdapter, type InstallParams } from '@kbn/index-adapter';
 import { createOrUpdateDataStream } from './create_or_update_data_stream';
 
 export class DataStreamAdapter extends IndexAdapter {


### PR DESCRIPTION
## Summary

They were already wrong [before the relocation](https://github.com/elastic/kibana/pull/183149/files#diff-e2954b558f2aa82baff0e30964490d12942e0e251c1aa56c3294de6ec67b7cf5):

`x-pack/packages/kbn-data-stream-adapter` // was never under x-pack

I use the opportunity to sort them alphabetically.

cc @semd 

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->