### PR TITLE
[SKIP ON MKI] `x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/create_monitor_private_location.ts`

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/create_monitor_private_location.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/create_monitor_private_location.ts
@@ -31,6 +31,8 @@ import { SyntheticsMonitorTestService } from '../../../services/synthetics_monit
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   describe('PrivateLocationAddMonitor', function () {
+    // see details: https://github.com/elastic/kibana/issues/204204
+    this.tags(['failsOnMKI']);
     const kibanaServer = getService('kibanaServer');
     const supertestAPI = getService('supertestWithoutAuth');
     const supertestWithAuth = getService('supertest');


### PR DESCRIPTION

## Summary

see details: https://github.com/elastic/kibana/issues/204204