### PR TITLE
[Authz] Types cleanup for AuthorizationServiceSetup

### DIFF
--- a/x-pack/packages/security/plugin_types_server/src/plugin.ts
+++ b/x-pack/packages/security/plugin_types_server/src/plugin.ts
@@ -45,7 +45,7 @@ export interface SecurityPluginStart {
   /**
    * Authorization services to manage and access the permissions a particular user has.
    */
-  authz: Omit<AuthorizationServiceSetup, 'getCurrentUser' | 'getSecurityConfig'>;
+  authz: AuthorizationServiceSetup;
   /**
    * User profiles services to retrieve user profiles.
    *

--- a/x-pack/plugins/security/server/plugin.ts
+++ b/x-pack/plugins/security/server/plugin.ts
@@ -80,7 +80,7 @@ export interface SecurityPluginSetup extends SecurityPluginSetupWithoutDeprecate
   /**
    * @deprecated Use `authz` methods from the `SecurityServiceStart` contract instead.
    */
-  authz: Omit<AuthorizationServiceSetup, 'getCurrentUser' | 'getSecurityConfig'>;
+  authz: AuthorizationServiceSetup;
 }
 
 export interface PluginSetupDependencies {


### PR DESCRIPTION
## Summary

Types cleanup for AuthorizationServiceSetup.

__Relates: https://github.com/elastic/kibana/issues/196271__




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->