### PR TITLE
[eem] _count guards against no valid sources 

### DIFF
--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/v2/entity_client.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/v2/entity_client.ts
@@ -144,6 +144,10 @@ export class EntityClient {
           errors: results.filter(isRejectedResult).map((result) => result.reason.message as string),
         }));
 
+        if (validSources.length === 0) {
+          return { type, value: 0, errors };
+        }
+
         const { query, filter } = getEntityCountQuery({
           sources: validSources,
           filters,


### PR DESCRIPTION
The query generation expects at least 1 source to be passed

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->