### PR TITLE
Sustainable Kibana Architecture: Relocate script v3

### DIFF
--- a/packages/kbn-relocate/README.md
+++ b/packages/kbn-relocate/README.md
@@ -14,12 +14,6 @@ You must have `elastic/kibana` remote configured under the name `upstream`.
 
 You must have a remote named `origin` pointing to your fork of the Kibana repo.
 
-It's highly recommended that you disable the pre-commit hook, as it often causes the script to fail:
-
-```sh
-mv .git/hooks/pre-commit .git/hooks/pre-commit.sample
-```
-
 ## Usage
 
 First of all, you need to decide whether you want to contribute to an existing PR or to create a new one. Use the `--pr` flag to specify the PR you are trying to update:

--- a/packages/kbn-relocate/README.md
+++ b/packages/kbn-relocate/README.md
@@ -10,15 +10,15 @@ You must have `gh` CLI tool installed. You can install it by running:
 brew install gh
 ```
 
-You must also configure your "default" kibana repo in `gh`, so that it can find PRs.:
-
-```sh
-gh repo set-default elastic/kibana
-```
-
 You must have `elastic/kibana` remote configured under the name `upstream`.
 
 You must have a remote named `origin` pointing to your fork of the Kibana repo.
+
+It's highly recommended that you disable the pre-commit hook, as it often causes the script to fail:
+
+```sh
+mv .git/hooks/pre-commit .git/hooks/pre-commit.sample
+```
 
 ## Usage
 

--- a/packages/kbn-relocate/constants.ts
+++ b/packages/kbn-relocate/constants.ts
@@ -96,4 +96,6 @@ This PR aims at relocating some of the Kibana modules (plugins and packages) int
 > * Try to obtain the missing reviews / approvals before applying manual fixes, and/or keep your changes in a .patch / git stash.
 > * Please use [#sustainable_kibana_architecture](https://elastic.slack.com/archives/C07TCKTA22E) Slack channel for feedback.
 
+Are you trying to rebase this PR to solve merge conflicts? Please follow the steps describe [here](https://elastic.slack.com/archives/C07TCKTA22E/p1734019532879269?thread_ts=1734019339.935419&cid=C07TCKTA22E).
+
 `;

--- a/packages/kbn-relocate/relocate.ts
+++ b/packages/kbn-relocate/relocate.ts
@@ -73,7 +73,7 @@ const relocateModules = async (toMove: Package[], log: ToolingLog): Promise<numb
 
     // single commit per module now
     await safeExec(`git add .`);
-    await safeExec(`git commit -m "Relocating module \\\`${module.id}\\\`"`);
+    await safeExec(`git commit --no-verify -m "Relocating module \\\`${module.id}\\\`"`);
     ++relocated;
   }
   return relocated;

--- a/packages/kbn-relocate/utils.git.ts
+++ b/packages/kbn-relocate/utils.git.ts
@@ -21,7 +21,9 @@ export function hasManualCommits(commits: Commit[]) {
     (commit) =>
       !commit.messageHeadline.startsWith('Relocating module ') &&
       !commit.messageHeadline.startsWith('Moving modules owned by ') &&
-      commit.authors.some((author) => author.login !== 'kibanamachine')
+      commit.authors.some(
+        (author) => author.login !== 'kibanamachine' && author.login !== 'elasticmachine'
+      )
   );
 
   return manualCommits.length > 0;

--- a/packages/kbn-relocate/utils.relocate.ts
+++ b/packages/kbn-relocate/utils.relocate.ts
@@ -119,6 +119,7 @@ const replaceReferencesInternal = async (
   );
 
   const matchingFiles = result.stdout.split('\n').filter(Boolean);
+  matchingFiles.push('.github/CODEOWNERS'); // to update references in the manual section, thanks pgayvallet!
 
   for (let i = 0; i < matchingFiles.length; ++i) {
     const file = matchingFiles[i];


### PR DESCRIPTION
## Summary

* Added link to rebase guideline in PR description.
* Do not count `elasticmachine` commits as manual.
* Replace references in CODEOWNERS file manual section.
* Update README prerequisites.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->