### PR TITLE
[Rules migration] Allow partial `RuleResponse` object to be passed to `RuleOverviewTab`

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_overview_tab.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_overview_tab.tsx
@@ -88,7 +88,7 @@ const ExpandableSection = ({ title, isOpen, toggle, children }: ExpandableSectio
 };
 
 interface RuleOverviewTabProps {
-  rule: RuleResponse;
+  rule: Partial<RuleResponse>;
   columnWidths?: EuiDescriptionListProps['columnWidths'];
   expandedOverviewSections: Record<keyof typeof defaultOverviewOpenSections, boolean>;
   toggleOverviewSection: Record<keyof typeof defaultOverviewOpenSections, () => void>;

--- a/x-pack/plugins/security_solution/public/siem_migrations/rules/components/rule_details_flyout/index.tsx
+++ b/x-pack/plugins/security_solution/public/siem_migrations/rules/components/rule_details_flyout/index.tsx
@@ -126,7 +126,7 @@ export const MigrationRuleDetailsFlyout: React.FC<MigrationRuleDetailsFlyoutProp
     const ruleDetailsToOverview = useMemo(() => {
       const elasticRule = ruleMigration?.elastic_rule;
       if (isMigrationCustomRule(elasticRule)) {
-        return convertMigrationCustomRuleToSecurityRulePayload(elasticRule, false) as RuleResponse; // TODO: we need to adjust RuleOverviewTab to allow partial RuleResponse as a parameter;
+        return convertMigrationCustomRuleToSecurityRulePayload(elasticRule, false);
       }
       return matchedPrebuiltRule;
     }, [ruleMigration, matchedPrebuiltRule]);


### PR DESCRIPTION
## Summary

These changes allow `Partial<RuleResponse>` to be used as a parameter for `RuleOverviewTab` component.

We re-use this component for "SIEM Migrations" feature to display translated state of the rule which has just a few fields that represent the `RuleResponse` object. The set of fields used in `RuleMigration` object is a minimum set of fields enough for the rule creation.

Right now, `RuleOverviewTab` component requires the complete `RuleResponse` object to be passed even though internally each section (`RuleAboutSection`, `RuleDefinitionSection`, `RuleScheduleSection` and `RuleSetupGuideSection`) of the rule's overview expects `Partial<RuleResponse>`. To be able to use this component we force type casting at the moment and would like to get rid of it.

@elastic/security-detection-rule-management do you have objects regarding this change in `RuleOverviewTab` intefrace?

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
  - Rule management cypress tests ([100 ESS & 100 Serverless](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7601))


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->