### PR TITLE
Update docs link for ip location processor

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/shared/map_processor_type_to_form.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/shared/map_processor_type_to_form.tsx
@@ -481,7 +481,7 @@ export const mapProcessorTypeToDescriptor: MapProcessorTypeToDescriptor = {
   ip_location: {
     category: processorCategories.DATA_ENRICHMENT,
     FieldsComponent: IpLocation,
-    docLinkPath: '/geoip-processor.html',
+    docLinkPath: '/ip-location-processor.html',
     label: i18n.translate('xpack.ingestPipelines.processors.label.ipLocation', {
       defaultMessage: 'IP Location',
     }),


### PR DESCRIPTION
Closes [#199755](https://github.com/elastic/kibana/issues/199755)

## Summary
This PR updates the documentation for the IP Location processor




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->