### PR TITLE
[FieldFormatters] Change bytes field title to Bytes and Bits

### DIFF
--- a/src/plugins/field_formats/common/converters/bytes.ts
+++ b/src/plugins/field_formats/common/converters/bytes.ts
@@ -15,7 +15,7 @@ import { FIELD_FORMAT_IDS } from '../types';
 export class BytesFormat extends NumeralFormat {
   static id = FIELD_FORMAT_IDS.BYTES;
   static title = i18n.translate('fieldFormats.bytes.title', {
-    defaultMessage: 'Bytes',
+    defaultMessage: 'Bytes and Bits',
   });
 
   id = BytesFormat.id;


### PR DESCRIPTION
## Summary

This PR updates the `title` of `Bytes` field to `Bytes and Bits` as suggested in https://github.com/elastic/kibana/issues/154188#issuecomment-2474336830

Closes: #154188



