### PR TITLE
[8.17] [Discover] [Dataset Quality] Stringify ignored values before rendering (#203312)

### DIFF
--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview_degraded_fields.tsx
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview_degraded_fields.tsx
@@ -228,7 +228,7 @@ const getDegradedFieldsColumns = (): Array<EuiBasicTableColumn<DegradedField>> =
     sortable: true,
     field: 'values',
     render: (values: string[]) => {
-      return values.map((value, idx) => <EuiBadge key={idx}>{value}</EuiBadge>);
+      return values.map((value, idx) => <EuiBadge key={idx}>{JSON.stringify(value)}</EuiBadge>);
     },
   },
 ];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Discover] [Dataset Quality] Stringify ignored values before rendering (#203312)](https://github.com/elastic/kibana/pull/203312)

<!--- Backport version: 8.9.8 -->

### Questions?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)
