### PR TITLE
[APM] fix logger on telemetry

### DIFF
--- a/x-pack/plugins/observability_solution/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
+++ b/x-pack/plugins/observability_solution/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
@@ -47,7 +47,7 @@ export function collectDataTelemetry({
         // catch error and log as debug in production env and warn in dev env
         const logLevel = isProd ? logger.debug : logger.warn;
         logLevel.call(logger, `Failed executing the APM telemetry task: "${task.name}"`);
-        logLevel(err);
+        logLevel.call(logger, err);
         return data;
       }
     });

--- a/x-pack/plugins/observability_solution/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
+++ b/x-pack/plugins/observability_solution/apm/server/lib/apm_telemetry/collect_data_telemetry/index.ts
@@ -46,7 +46,7 @@ export function collectDataTelemetry({
       } catch (err) {
         // catch error and log as debug in production env and warn in dev env
         const logLevel = isProd ? logger.debug : logger.warn;
-        logLevel(`Failed executing the APM telemetry task: "${task.name}"`);
+        logLevel.call(logger, `Failed executing the APM telemetry task: "${task.name}"`);
         logLevel(err);
         return data;
       }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/199249

This PR fixes the logger calls on APM telemetry

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->