### PR TITLE
[ML] AIOps: Field stats fix 

### DIFF
--- a/packages/kbn-unified-field-list/src/components/field_stats/field_top_values_bucket.tsx
+++ b/packages/kbn-unified-field-list/src/components/field_stats/field_top_values_bucket.tsx
@@ -211,8 +211,14 @@ const FieldTopValuesBucket: React.FC<FieldTopValuesBucketProps> = ({
   );
 };
 
+// copied from x-pack/plugins/banners/server/utils.ts
+const hexColorRegexp = /^#([0-9a-f]{6}|[0-9a-f]{3})$/i;
+const isHexColor = (color: string) => {
+  return hexColorRegexp.test(color);
+};
+
 const getPercentageColor = (euiTheme: EuiThemeComputed, color: string) =>
-  euiTheme.themeName?.toLowerCase().includes('borealis')
+  euiTheme.themeName?.toLowerCase().includes('borealis') && isHexColor(color)
     ? makeHighContrastColor(color)(euiTheme)
     : color; // FIXME: remove in 9.x when Borealis becomes the default theme
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced in https://github.com/elastic/kibana/pull/203579.

`EuiText` accepts EUI colors like `primary` as well as hex colors. The PR above introduced `getPercentageColor()` which assumed all colors passed in are hex colors. In case it was an EUI color token the code threw an error and the fields stats popover wouldn't fully render. This fix adds an additional check to apply `makeHighContrastColor` only if the color provided is a hex color.

Before:

![CleanShot 2024-12-16 at 14 50 15@2x](https://github.com/user-attachments/assets/53a5df17-da4a-4188-a80c-5dc52cae9f39)

After:

![CleanShot 2024-12-16 at 14 49 20@2x](https://github.com/user-attachments/assets/75fc093a-6cf6-4a21-bc10-05dd7d253c70)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
