### PR TITLE
Updates auth access model for dynamic_index_pattern endpoint

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/server/routes/rules/route.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/routes/rules/route.ts
@@ -11,10 +11,13 @@ import { createObservabilityServerRoute } from '../create_observability_server_r
 
 const alertsDynamicIndexPatternRoute = createObservabilityServerRoute({
   endpoint: 'GET /api/observability/rules/alerts/dynamic_index_pattern 2023-10-31',
-  options: {
-    tags: [],
-    access: 'public',
+  security: {
+    authz: {
+      enabled: false,
+      reason: 'This endpoint returns alert index names for a set of registration contexts and has traditionally required no specific authorization',
+    },
   },
+  options: { access: 'public' },
   params: t.type({
     query: t.type({
       registrationContexts: t.array(t.string),
@@ -24,6 +27,7 @@ const alertsDynamicIndexPatternRoute = createObservabilityServerRoute({
   handler: async ({ dependencies, params }) => {
     const { namespace, registrationContexts } = params.query;
     const { ruleDataService } = dependencies;
+
     const indexNames = registrationContexts.flatMap((registrationContext) => {
       const indexName = ruleDataService
         .findIndexByName(registrationContext, Dataset.alerts)

--- a/x-pack/solutions/observability/plugins/observability/server/routes/rules/route.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/routes/rules/route.ts
@@ -14,7 +14,8 @@ const alertsDynamicIndexPatternRoute = createObservabilityServerRoute({
   security: {
     authz: {
       enabled: false,
-      reason: 'This endpoint returns alert index names for a set of registration contexts and has traditionally required no specific authorization',
+      reason:
+        'This endpoint returns alert index names for a set of registration contexts and has traditionally required no specific authorization',
     },
   },
   options: { access: 'public' },


### PR DESCRIPTION
Closes #203326

## Summary

Updating this obs alerting endpoint to use the new `security.authz` paradigm. Note: this endpoint may not be in use at all but it's been "available" now for three years so we likely can't just remove it without somehow confirming it's not needed.

## Testing

* Start this PR using config that points at the shared "edge" cluster via oblt-cli CCS
* Create a user with no roles at all
* Use that user/password in the following REST call: `curl -X GET -u "$USERNAME:$PASSWORD" "$KIBANA_BASE_URL/api/observability/rules/alerts/dynamic_index_pattern?registrationContexts=observability.metrics&registrationContexts=observability.logs&namespace=default" -H "elastic-api-version: 2023-10-31"`
* You should get results like this: `[".alerts-observability.metrics.alerts-default", ".alerts-observability.logs.alerts-default"]`


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->