### PR TITLE
[8.x] [Deprecations] Logs Sources settings in all spaces (#203042)

### DIFF
--- a/packages/core/deprecations/core-deprecations-server-internal/src/deprecations_route_handler_context.ts
+++ b/packages/core/deprecations/core-deprecations-server-internal/src/deprecations_route_handler_context.ts
@@ -13,6 +13,7 @@ import type {
   DeprecationsRequestHandlerContext,
   DeprecationsClient,
 } from '@kbn/core-deprecations-server';
+import type { KibanaRequest } from '@kbn/core-http-server';
 import type { InternalDeprecationsServiceStart } from './deprecations_service';
 
 /**
@@ -25,14 +26,16 @@ export class CoreDeprecationsRouteHandlerContext implements DeprecationsRequestH
   constructor(
     private readonly deprecationsStart: InternalDeprecationsServiceStart,
     private readonly elasticsearchRouterHandlerContext: CoreElasticsearchRouteHandlerContext,
-    private readonly savedObjectsRouterHandlerContext: CoreSavedObjectsRouteHandlerContext
+    private readonly savedObjectsRouterHandlerContext: CoreSavedObjectsRouteHandlerContext,
+    private readonly request: KibanaRequest
   ) {}
 
   public get client() {
     if (this.#client == null) {
       this.#client = this.deprecationsStart.asScopedToClient(
         this.elasticsearchRouterHandlerContext.client,
-        this.savedObjectsRouterHandlerContext.client
+        this.savedObjectsRouterHandlerContext.client,
+        this.request
       );
     }
     return this.#client;

--- a/packages/core/deprecations/core-deprecations-server-internal/src/deprecations_service.test.ts
+++ b/packages/core/deprecations/core-deprecations-server-internal/src/deprecations_service.test.ts
@@ -12,7 +12,7 @@ import {
   registerConfigDeprecationsInfoMock,
 } from './deprecations_service.test.mocks';
 import { mockCoreContext } from '@kbn/core-base-server-mocks';
-import { httpServiceMock } from '@kbn/core-http-server-mocks';
+import { httpServerMock, httpServiceMock } from '@kbn/core-http-server-mocks';
 import { coreUsageDataServiceMock } from '@kbn/core-usage-data-server-mocks';
 import { configServiceMock } from '@kbn/config-mocks';
 import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
@@ -83,12 +83,13 @@ describe('DeprecationsService', () => {
       it('returns client with #getAllDeprecations method', async () => {
         const esClient = elasticsearchServiceMock.createScopedClusterClient();
         const savedObjectsClient = savedObjectsClientMock.create();
+        const request = httpServerMock.createKibanaRequest();
         const deprecationsService = new DeprecationsService(coreContext);
 
         await deprecationsService.setup(deprecationsCoreSetupDeps);
 
         const start = deprecationsService.start();
-        const deprecationsClient = start.asScopedToClient(esClient, savedObjectsClient);
+        const deprecationsClient = start.asScopedToClient(esClient, savedObjectsClient, request);
 
         expect(deprecationsClient.getAllDeprecations).toBeDefined();
       });

--- a/packages/core/deprecations/core-deprecations-server-internal/src/deprecations_service.ts
+++ b/packages/core/deprecations/core-deprecations-server-internal/src/deprecations_service.ts
@@ -20,6 +20,7 @@ import type {
   DeprecationsClient,
 } from '@kbn/core-deprecations-server';
 import { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
+import type { KibanaRequest } from '@kbn/core-http-server';
 import { DeprecationsFactory } from './deprecations_factory';
 import { registerRoutes } from './routes';
 import { config as deprecationConfig, DeprecationConfigType } from './deprecation_config';
@@ -36,7 +37,8 @@ export interface InternalDeprecationsServiceStart {
    */
   asScopedToClient(
     esClient: IScopedClusterClient,
-    savedObjectsClient: SavedObjectsClientContract
+    savedObjectsClient: SavedObjectsClientContract,
+    request: KibanaRequest
   ): DeprecationsClient;
 }
 
@@ -117,13 +119,19 @@ export class DeprecationsService
 
   private createScopedDeprecations(): (
     esClient: IScopedClusterClient,
-    savedObjectsClient: SavedObjectsClientContract
+    savedObjectsClient: SavedObjectsClientContract,
+    request: KibanaRequest
   ) => DeprecationsClient {
-    return (esClient: IScopedClusterClient, savedObjectsClient: SavedObjectsClientContract) => {
+    return (
+      esClient: IScopedClusterClient,
+      savedObjectsClient: SavedObjectsClientContract,
+      request: KibanaRequest
+    ) => {
       return {
         getAllDeprecations: this.deprecationsFactory!.getAllDeprecations.bind(null, {
           savedObjectsClient,
           esClient,
+          request,
         }),
       };
     };

--- a/packages/core/deprecations/core-deprecations-server-internal/src/mocks/deprecations_registry.mock.ts
+++ b/packages/core/deprecations/core-deprecations-server-internal/src/mocks/deprecations_registry.mock.ts
@@ -12,6 +12,7 @@ import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-m
 import type { GetDeprecationsContext } from '@kbn/core-deprecations-server';
 import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
 import type { DeprecationsRegistry } from '../deprecations_registry';
+import { httpServerMock } from '@kbn/core-http-server-mocks';
 
 type DeprecationsRegistryContract = PublicMethodsOf<DeprecationsRegistry>;
 
@@ -28,6 +29,7 @@ const createGetDeprecationsContextMock = () => {
   const mocked: jest.Mocked<GetDeprecationsContext> = {
     esClient: elasticsearchClientMock.createScopedClusterClient(),
     savedObjectsClient: savedObjectsClientMock.create(),
+    request: httpServerMock.createKibanaRequest(),
   };
 
   return mocked;

--- a/packages/core/deprecations/core-deprecations-server/src/contracts.ts
+++ b/packages/core/deprecations/core-deprecations-server/src/contracts.ts
@@ -11,6 +11,7 @@ import type { MaybePromise } from '@kbn/utility-types';
 import type { DeprecationsDetails } from '@kbn/core-deprecations-common';
 import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import type { KibanaRequest } from '@kbn/core-http-server';
 
 /**
  * The deprecations service provides a way for the Kibana platform to communicate deprecated
@@ -121,6 +122,7 @@ export interface GetDeprecationsContext {
   esClient: IScopedClusterClient;
   /** Saved Objects client scoped to the current user and space */
   savedObjectsClient: SavedObjectsClientContract;
+  request: KibanaRequest;
 }
 
 /**

--- a/packages/core/deprecations/core-deprecations-server/tsconfig.json
+++ b/packages/core/deprecations/core-deprecations-server/tsconfig.json
@@ -15,6 +15,7 @@
     "@kbn/core-deprecations-common",
     "@kbn/core-elasticsearch-server",
     "@kbn/core-saved-objects-api-server",
+    "@kbn/core-http-server",
   ],
   "exclude": [
     "target/**/*",

--- a/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.ts
+++ b/packages/core/http/core-http-request-handler-context-server-internal/src/core_route_handler_context.ts
@@ -111,7 +111,8 @@ export class CoreRouteHandlerContext implements CoreRequestHandlerContext {
       this.#deprecations = new CoreDeprecationsRouteHandlerContext(
         this.coreStart.deprecations,
         this.elasticsearch,
-        this.savedObjects
+        this.savedObjects,
+        this.request
       );
     }
     return this.#deprecations;

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repository.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repository.test.ts
@@ -15,24 +15,23 @@ import {
 
 import { SavedObjectsRepository } from './repository';
 import { loggerMock } from '@kbn/logging-mocks';
-import { SavedObjectsSerializer } from '@kbn/core-saved-objects-base-server-internal';
 import { kibanaMigratorMock } from '../mocks';
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
 
 import {
   mockTimestamp,
-  mappings,
   createRegistry,
   createDocumentMigrator,
-  createSpySerializer,
 } from '../test_helpers/repository.test.common';
+import type { ISavedObjectsRepository } from '@kbn/core-saved-objects-api-server';
+import { ISavedObjectsSpacesExtension } from '@kbn/core-saved-objects-server';
+import { savedObjectsExtensionsMock } from '../mocks/saved_objects_extensions.mock';
 
 describe('SavedObjectsRepository', () => {
   let client: ReturnType<typeof elasticsearchClientMock.createElasticsearchClient>;
-  let repository: SavedObjectsRepository;
+  let repository: ISavedObjectsRepository;
   let migrator: ReturnType<typeof kibanaMigratorMock.create>;
   let logger: ReturnType<typeof loggerMock.create>;
-  let serializer: jest.Mocked<SavedObjectsSerializer>;
 
   const registry = createRegistry();
   const documentMigrator = createDocumentMigrator(registry);
@@ -46,23 +45,13 @@ describe('SavedObjectsRepository', () => {
     migrator.runMigrations = jest.fn().mockResolvedValue([{ status: 'skipped' }]);
     logger = loggerMock.create();
 
-    // create a mock serializer "shim" so we can track function calls, but use the real serializer's implementation
-    serializer = createSpySerializer(registry);
-
-    const allTypes = registry.getAllTypes().map((type) => type.name);
-    const allowedTypes = [...new Set(allTypes.filter((type) => !registry.isHidden(type)))];
-
-    // @ts-expect-error must use the private constructor to use the mocked serializer
-    repository = new SavedObjectsRepository({
-      index: '.kibana-test',
-      mappings,
-      client,
+    repository = SavedObjectsRepository.createRepository(
       migrator,
-      typeRegistry: registry,
-      serializer,
-      allowedTypes,
-      logger,
-    });
+      registry,
+      '.kibana-test',
+      client,
+      logger
+    );
 
     mockGetCurrentTime.mockReturnValue(mockTimestamp);
     mockGetSearchDsl.mockClear();
@@ -85,6 +74,62 @@ describe('SavedObjectsRepository', () => {
 
     it('properly handles non-`default` namespace', async () => {
       expect(repository.getCurrentNamespace('space-a')).toBe('space-a');
+    });
+  });
+
+  describe('#asScopedToNamespace', () => {
+    it('returns a new client with undefined spacesExtensions (not available)', () => {
+      const scopedRepository = repository.asScopedToNamespace('space-a');
+      expect(scopedRepository).toBeInstanceOf(SavedObjectsRepository);
+      expect(scopedRepository).not.toStrictEqual(repository);
+
+      // Checking extensions.spacesExtension are both undefined
+      // @ts-expect-error type is ISavedObjectsRepository, but in reality is SavedObjectsRepository
+      expect(repository.extensions.spacesExtension).toBeUndefined();
+      // @ts-expect-error type is ISavedObjectsRepository, but in reality is SavedObjectsRepository
+      expect(scopedRepository.extensions.spacesExtension).toBeUndefined();
+      // @ts-expect-error type is ISavedObjectsRepository, but in reality is SavedObjectsRepository
+      expect(scopedRepository.extensions.spacesExtension).toStrictEqual(
+        // @ts-expect-error type is ISavedObjectsRepository, but in reality is SavedObjectsRepository
+        repository.extensions.spacesExtension
+      );
+    });
+  });
+
+  describe('with spacesExtension', () => {
+    let spacesExtension: jest.Mocked<ISavedObjectsSpacesExtension>;
+
+    beforeEach(() => {
+      spacesExtension = savedObjectsExtensionsMock.createSpacesExtension();
+      repository = SavedObjectsRepository.createRepository(
+        migrator,
+        registry,
+        '.kibana-test',
+        client,
+        logger,
+        [],
+        { spacesExtension }
+      );
+    });
+
+    describe('#asScopedToNamespace', () => {
+      it('returns a new client with space-scoped spacesExtensions', () => {
+        const scopedRepository = repository.asScopedToNamespace('space-a');
+        expect(scopedRepository).toBeInstanceOf(SavedObjectsRepository);
+        expect(scopedRepository).not.toStrictEqual(repository);
+        expect(spacesExtension.asScopedToNamespace).toHaveBeenCalledWith('space-a');
+
+        // Checking extensions.spacesExtension are both defined but different
+        // @ts-expect-error type is ISavedObjectsRepository, but in reality is SavedObjectsRepository
+        expect(repository.extensions.spacesExtension).not.toBeUndefined();
+        // @ts-expect-error type is ISavedObjectsRepository, but in reality is SavedObjectsRepository
+        expect(scopedRepository.extensions.spacesExtension).not.toBeUndefined();
+        // @ts-expect-error type is ISavedObjectsRepository, but in reality is SavedObjectsRepository
+        expect(scopedRepository.extensions.spacesExtension).not.toStrictEqual(
+          // @ts-expect-error type is ISavedObjectsRepository, but in reality is SavedObjectsRepository
+          repository.extensions.spacesExtension
+        );
+      });
     });
   });
 });

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repository.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/lib/repository.ts
@@ -168,7 +168,7 @@ export class SavedObjectsRepository implements ISavedObjectsRepository {
     });
   }
 
-  private constructor(options: SavedObjectsRepositoryOptions) {
+  private constructor(private readonly options: SavedObjectsRepositoryOptions) {
     const {
       index,
       mappings,
@@ -563,5 +563,18 @@ export class SavedObjectsRepository implements ISavedObjectsRepository {
    */
   getCurrentNamespace(namespace?: string) {
     return this.helpers.common.getCurrentNamespace(namespace);
+  }
+
+  /**
+   * {@inheritDoc ISavedObjectsRepository.asScopedToNamespace}
+   */
+  asScopedToNamespace(namespace: string) {
+    return new SavedObjectsRepository({
+      ...this.options,
+      extensions: {
+        ...this.options.extensions,
+        spacesExtension: this.extensions.spacesExtension?.asScopedToNamespace(namespace),
+      },
+    });
   }
 }

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/mocks/repository.mock.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/mocks/repository.mock.ts
@@ -34,6 +34,7 @@ const createRepositoryMock = () => {
     collectMultiNamespaceReferences: jest.fn(),
     updateObjectsSpaces: jest.fn(),
     getCurrentNamespace: jest.fn(),
+    asScopedToNamespace: jest.fn().mockImplementation(createRepositoryMock),
   };
 
   return mock;

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/mocks/saved_objects_extensions.mock.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/mocks/saved_objects_extensions.mock.ts
@@ -47,6 +47,7 @@ const createSecurityExtension = (): jest.Mocked<ISavedObjectsSecurityExtension> 
 const createSpacesExtension = (): jest.Mocked<ISavedObjectsSpacesExtension> => ({
   getCurrentNamespace: jest.fn(),
   getSearchableNamespaces: jest.fn(),
+  asScopedToNamespace: jest.fn().mockImplementation(createSpacesExtension),
 });
 
 const create = () => ({

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/saved_objects_client.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/saved_objects_client.test.ts
@@ -335,4 +335,12 @@ describe('SavedObjectsClient', () => {
     expect(client.getCurrentNamespace()).toEqual('ns');
     expect(mockRepository.getCurrentNamespace).toHaveBeenCalledWith();
   });
+
+  test('#asScopedToNamespace', () => {
+    const client = new SavedObjectsClient(mockRepository);
+
+    const rescopedClient = client.asScopedToNamespace('ns');
+    expect(rescopedClient).not.toStrictEqual(client);
+    expect(mockRepository.asScopedToNamespace).toHaveBeenCalledWith('ns');
+  });
 });

--- a/packages/core/saved-objects/core-saved-objects-api-server-internal/src/saved_objects_client.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-internal/src/saved_objects_client.ts
@@ -216,4 +216,9 @@ export class SavedObjectsClient implements SavedObjectsClientContract {
   getCurrentNamespace() {
     return this._repository.getCurrentNamespace();
   }
+
+  /** {@inheritDoc SavedObjectsClientContract.asScopedToNamespace} */
+  asScopedToNamespace(namespace: string) {
+    return new SavedObjectsClient(this._repository.asScopedToNamespace(namespace));
+  }
 }

--- a/packages/core/saved-objects/core-saved-objects-api-server-mocks/src/repository.mock.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-mocks/src/repository.mock.ts
@@ -33,6 +33,7 @@ const create = () => {
     collectMultiNamespaceReferences: jest.fn(),
     updateObjectsSpaces: jest.fn(),
     getCurrentNamespace: jest.fn(),
+    asScopedToNamespace: jest.fn().mockImplementation(create),
   };
 
   mock.createPointInTimeFinder = savedObjectsPointInTimeFinderMock.create({

--- a/packages/core/saved-objects/core-saved-objects-api-server-mocks/src/saved_objects_client.mock.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-mocks/src/saved_objects_client.mock.ts
@@ -8,12 +8,10 @@
  */
 
 import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
-import { SavedObjectsErrorHelpers } from '@kbn/core-saved-objects-server';
 import { savedObjectsPointInTimeFinderMock } from './point_in_time_finder.mock';
 
 const create = () => {
-  const mock = {
-    errors: SavedObjectsErrorHelpers,
+  const mock: jest.Mocked<SavedObjectsClientContract> = {
     create: jest.fn(),
     bulkCreate: jest.fn(),
     checkConflicts: jest.fn(),
@@ -33,7 +31,8 @@ const create = () => {
     collectMultiNamespaceReferences: jest.fn(),
     updateObjectsSpaces: jest.fn(),
     getCurrentNamespace: jest.fn(),
-  } as unknown as jest.Mocked<SavedObjectsClientContract>;
+    asScopedToNamespace: jest.fn().mockImplementation(create),
+  };
 
   mock.createPointInTimeFinder = savedObjectsPointInTimeFinderMock.create({
     savedObjectsMock: mock,

--- a/packages/core/saved-objects/core-saved-objects-api-server-mocks/src/saved_objects_extensions.mock.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server-mocks/src/saved_objects_extensions.mock.ts
@@ -48,6 +48,7 @@ const createSecurityExtension = (): jest.Mocked<ISavedObjectsSecurityExtension> 
 const createSpacesExtension = (): jest.Mocked<ISavedObjectsSpacesExtension> => ({
   getCurrentNamespace: jest.fn(),
   getSearchableNamespaces: jest.fn(),
+  asScopedToNamespace: jest.fn().mockImplementation(createSpacesExtension),
 });
 
 const create = (): jest.Mocked<SavedObjectsExtensions> => ({

--- a/packages/core/saved-objects/core-saved-objects-api-server/src/saved_objects_client.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server/src/saved_objects_client.ts
@@ -427,4 +427,10 @@ export interface SavedObjectsClientContract {
    * Returns the namespace associated with the client. If the namespace is the default one, this method returns `undefined`.
    */
   getCurrentNamespace(): string | undefined;
+
+  /**
+   * Returns a clone of the current Saved Objects client but scoped to the specified namespace.
+   * @param namespace Space to which the client should be scoped to.
+   */
+  asScopedToNamespace(namespace: string): SavedObjectsClientContract;
 }

--- a/packages/core/saved-objects/core-saved-objects-api-server/src/saved_objects_repository.ts
+++ b/packages/core/saved-objects/core-saved-objects-api-server/src/saved_objects_repository.ts
@@ -552,4 +552,10 @@ export interface ISavedObjectsRepository {
    * namespace.
    */
   getCurrentNamespace(namespace?: string): string | undefined;
+
+  /**
+   * Returns a new Saved Objects repository scoped to the specified namespace.
+   * @param namespace Space to which the repository should be scoped to.
+   */
+  asScopedToNamespace(namespace: string): ISavedObjectsRepository;
 }

--- a/packages/core/saved-objects/core-saved-objects-server/src/extensions/spaces.ts
+++ b/packages/core/saved-objects/core-saved-objects-server/src/extensions/spaces.ts
@@ -25,4 +25,9 @@ export interface ISavedObjectsSpacesExtension {
    * If a wildcard '*' is used, it is expanded to an explicit list of namespace strings.
    */
   getSearchableNamespaces: (namespaces: string[] | undefined) => Promise<string[]>;
+  /**
+   * Returns a new Saved Objects Spaces Extension scoped to the specified namespace.
+   * @param namespace Space to which the extension should be scoped to.
+   */
+  asScopedToNamespace(namespace: string): ISavedObjectsSpacesExtension;
 }

--- a/x-pack/plugins/observability_solution/logs_shared/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/logs_shared/kibana.jsonc
@@ -11,12 +11,13 @@
     "requiredPlugins": [
       "charts",
       "data",
-      "fieldFormats", 
+      "fieldFormats",
       "dataViews",
       "discoverShared",
       "logsDataAccess",
       "observabilityShared",
       "share",
+      "spaces",
       "usageCollection",
       "embeddable",
     ],
@@ -27,4 +28,3 @@
     "extraPublicDirs": ["common"]
   }
 }
- 

--- a/x-pack/plugins/observability_solution/logs_shared/server/deprecations/constants.ts
+++ b/x-pack/plugins/observability_solution/logs_shared/server/deprecations/constants.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Number of spaces to address concurrently.
+ * We don't want to loop through all the spaces concurrently to avoid putting too much pressure on the memory in case that there are too many spaces.
+ */
+export const CONCURRENT_SPACES_TO_CHECK = 500;

--- a/x-pack/plugins/observability_solution/logs_shared/server/deprecations/log_sources_setting.ts
+++ b/x-pack/plugins/observability_solution/logs_shared/server/deprecations/log_sources_setting.ts
@@ -6,39 +6,50 @@
  */
 import { DeprecationsDetails } from '@kbn/core-deprecations-common';
 import { GetDeprecationsContext } from '@kbn/core-deprecations-server';
+import pMap from 'p-map';
+import type { Space } from '@kbn/spaces-plugin/common';
 import { i18n } from '@kbn/i18n';
-import { defaultLogViewId } from '../../common/log_views';
 import { MIGRATE_LOG_VIEW_SETTINGS_URL } from '../../common/http_api/deprecations';
+import { CONCURRENT_SPACES_TO_CHECK } from './constants';
+import { defaultLogViewId } from '../../common/log_views';
 import { logSourcesKibanaAdvancedSettingRT } from '../../common';
 import { LogsSharedPluginStartServicesAccessor } from '../types';
 
-export const getLogSourcesSettingDeprecationInfo = async ({
-  getStartServices,
-  context,
-}: {
+export interface LogSourcesSettingDeprecationParams {
   context: GetDeprecationsContext;
   getStartServices: LogsSharedPluginStartServicesAccessor;
-}): Promise<DeprecationsDetails[]> => {
-  const [_, pluginStartDeps, pluginStart] = await getStartServices();
-  const logSourcesService =
-    pluginStartDeps.logsDataAccess.services.logSourcesServiceFactory.getLogSourcesService(
-      context.savedObjectsClient
-    );
-  const logViewsClient = pluginStart.logViews.getClient(
-    context.savedObjectsClient,
-    context.esClient.asCurrentUser,
-    logSourcesService
-  );
+}
 
-  const logView = await logViewsClient.getLogView(defaultLogViewId);
+export const getLogSourcesSettingDeprecationInfo = async (
+  params: LogSourcesSettingDeprecationParams
+): Promise<DeprecationsDetails[]> => {
+  const [_, pluginStartDeps] = await params.getStartServices();
 
-  if (logView && !logSourcesKibanaAdvancedSettingRT.is(logView.attributes.logIndices)) {
+  const allAvailableSpaces = await pluginStartDeps.spaces.spacesService
+    .createSpacesClient(params.context.request)
+    .getAll({ purpose: 'any' });
+
+  const deprecationPerSpaceFactory = getLogSourcesSettingDeprecationInfoForSpaceFactory(params);
+
+  const results = await pMap(allAvailableSpaces, deprecationPerSpaceFactory, {
+    concurrency: CONCURRENT_SPACES_TO_CHECK, // limit the number of spaces handled concurrently to make sure that we cover large deployments
+  });
+
+  const offendingSpaces = results.filter(Boolean) as string[];
+
+  if (offendingSpaces.length) {
+    const shortList =
+      offendingSpaces.length < 4
+        ? offendingSpaces.join(', ')
+        : `${offendingSpaces.slice(0, 3).join(', ')}, ...`;
+    const fullList = offendingSpaces.join(', ');
     return [
       {
         title: i18n.translate(
           'xpack.logsShared.deprecations.migrateLogViewSettingsToLogSourcesSetting.title',
           {
-            defaultMessage: 'Log sources setting',
+            defaultMessage: 'Log sources setting in {count} spaces: {shortList}',
+            values: { count: offendingSpaces.length, shortList },
           }
         ),
         level: 'warning',
@@ -47,19 +58,21 @@ export const getLogSourcesSettingDeprecationInfo = async ({
           'xpack.logsShared.deprecations.migrateLogViewSettingsToLogSourcesSetting.message',
           {
             defaultMessage:
-              'Indices and Data view options previously provided via the Logs UI settings page are now deprecated. Please migrate to using the Kibana log sources advanced setting.',
+              'Indices and Data view options previously provided via the Logs UI settings page are now deprecated. Please migrate to using the Kibana log sources advanced setting in each of the following spaces: {fullList}.',
+            values: { fullList },
           }
         ),
         correctiveActions: {
-          manualSteps: [
+          manualSteps: offendingSpaces.map((spaceName) =>
             i18n.translate(
               'xpack.logsShared.deprecations.migrateLogViewSettingsToLogSourcesSetting.message.manualStepMessage',
               {
                 defaultMessage:
-                  'Update the Log sources Kibana advanced setting (via Management > Advanced Settings) to match the setting previously provided via the Logs UI settings page. Then via the Logs UI settings page use the Kibana log sources advanced setting option.',
+                  'While in the space "{spaceName}" update the Log sources Kibana advanced setting (via Management > Advanced Settings) to match the setting previously provided via the Logs UI settings page. Then via the Logs UI settings page use the Kibana log sources advanced setting option.',
+                values: { spaceName },
               }
-            ),
-          ],
+            )
+          ),
           api: {
             method: 'PUT',
             path: MIGRATE_LOG_VIEW_SETTINGS_URL,
@@ -70,4 +83,32 @@ export const getLogSourcesSettingDeprecationInfo = async ({
   } else {
     return [];
   }
+};
+
+export const getLogSourcesSettingDeprecationInfoForSpaceFactory = ({
+  getStartServices,
+  context,
+}: LogSourcesSettingDeprecationParams): ((space: Space) => Promise<string | undefined>) => {
+  return async (space) => {
+    const [_, pluginStartDeps, pluginStart] = await getStartServices();
+
+    // Get a new Saved Object Client scoped to the space.id
+    const spaceScopedSavedObjectsClient = context.savedObjectsClient.asScopedToNamespace(space.id);
+
+    const logSourcesService =
+      pluginStartDeps.logsDataAccess.services.logSourcesServiceFactory.getLogSourcesService(
+        spaceScopedSavedObjectsClient
+      );
+    const logViewsClient = pluginStart.logViews.getClient(
+      spaceScopedSavedObjectsClient,
+      context.esClient.asCurrentUser,
+      logSourcesService
+    );
+
+    const logView = await logViewsClient.getLogView(defaultLogViewId);
+
+    if (logView && !logSourcesKibanaAdvancedSettingRT.is(logView.attributes.logIndices)) {
+      return space.name;
+    }
+  };
 };

--- a/x-pack/plugins/observability_solution/logs_shared/server/routes/deprecations/migrate_log_view_settings.ts
+++ b/x-pack/plugins/observability_solution/logs_shared/server/routes/deprecations/migrate_log_view_settings.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import pMap from 'p-map';
+import { CONCURRENT_SPACES_TO_CHECK } from '../../deprecations/constants';
 import { defaultLogViewId } from '../../../common/log_views';
 import { MIGRATE_LOG_VIEW_SETTINGS_URL } from '../../../common/http_api/deprecations';
 import { logSourcesKibanaAdvancedSettingRT } from '../../../common';
@@ -23,17 +25,54 @@ export const initMigrateLogViewSettingsRoute = ({
     { path: MIGRATE_LOG_VIEW_SETTINGS_URL, validate: false },
     async (context, request, response) => {
       try {
+        const { elasticsearch, savedObjects } = await context.core;
         const [_, pluginStartDeps, pluginStart] = await getStartServices();
 
-        const logSourcesService =
-          await pluginStartDeps.logsDataAccess.services.logSourcesServiceFactory.getScopedLogSourcesService(
-            request
-          );
-        const logViewsClient = pluginStart.logViews.getScopedClient(request);
+        const allAvailableSpaces = await pluginStartDeps.spaces.spacesService
+          .createSpacesClient(request)
+          .getAll({ purpose: 'any' });
 
-        const logView = await logViewsClient.getLogView(defaultLogViewId);
+        const updated = await pMap(
+          allAvailableSpaces,
+          async (space) => {
+            const spaceScopedSavedObjectsClient = savedObjects.client.asScopedToNamespace(space.id);
 
-        if (!logView || logSourcesKibanaAdvancedSettingRT.is(logView.attributes.logIndices)) {
+            const logSourcesServicePromise =
+              pluginStartDeps.logsDataAccess.services.logSourcesServiceFactory.getLogSourcesService(
+                spaceScopedSavedObjectsClient
+              );
+            const logViewsClient = pluginStart.logViews.getClient(
+              spaceScopedSavedObjectsClient,
+              elasticsearch.client.asCurrentUser,
+              logSourcesServicePromise
+            );
+
+            const logView = await logViewsClient.getLogView(defaultLogViewId);
+
+            if (!logView || logSourcesKibanaAdvancedSettingRT.is(logView.attributes.logIndices)) {
+              return false;
+            }
+
+            const indices = (
+              await logViewsClient.getResolvedLogView({
+                type: 'log-view-reference',
+                logViewId: defaultLogViewId,
+              })
+            ).indices;
+
+            const logSourcesService = await logSourcesServicePromise;
+            await logSourcesService.setLogSources([{ indexPattern: indices }]);
+            await logViewsClient.putLogView(defaultLogViewId, {
+              logIndices: { type: 'kibana_advanced_setting' },
+            });
+
+            return true;
+          },
+          { concurrency: CONCURRENT_SPACES_TO_CHECK }
+        );
+
+        if (!updated.includes(true)) {
+          // Only throw if none of the spaces was able to migrate
           return response.customError({
             body: new Error(
               "Unable to migrate log view settings. A log view either doesn't exist or is already using the Kibana advanced setting."
@@ -42,17 +81,6 @@ export const initMigrateLogViewSettingsRoute = ({
           });
         }
 
-        const indices = (
-          await logViewsClient.getResolvedLogView({
-            type: 'log-view-reference',
-            logViewId: defaultLogViewId,
-          })
-        ).indices;
-
-        await logSourcesService.setLogSources([{ indexPattern: indices }]);
-        await logViewsClient.putLogView(defaultLogViewId, {
-          logIndices: { type: 'kibana_advanced_setting' },
-        });
         return response.ok();
       } catch (error) {
         throw error;

--- a/x-pack/plugins/observability_solution/logs_shared/server/types.ts
+++ b/x-pack/plugins/observability_solution/logs_shared/server/types.ts
@@ -12,6 +12,7 @@ import {
 } from '@kbn/data-plugin/server';
 import { PluginStart as DataViewsPluginStart } from '@kbn/data-views-plugin/server';
 import { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import { LogsSharedDomainLibs } from './lib/logs_shared_types';
 import { LogViewsServiceSetup, LogViewsServiceStart } from './services/log_views/types';
 
@@ -38,6 +39,7 @@ export interface LogsSharedServerPluginStartDeps {
   data: DataPluginStart;
   dataViews: DataViewsPluginStart;
   logsDataAccess: LogsDataAccessPluginStart;
+  spaces: SpacesPluginStart;
 }
 
 export interface UsageCollector {

--- a/x-pack/plugins/observability_solution/logs_shared/tsconfig.json
+++ b/x-pack/plugins/observability_solution/logs_shared/tsconfig.json
@@ -51,5 +51,6 @@
     "@kbn/field-formats-plugin",
     "@kbn/embeddable-plugin",
     "@kbn/saved-search-plugin",
+    "@kbn/spaces-plugin",
   ]
 }

--- a/x-pack/plugins/reporting/server/deprecations/migrate_existing_indices_ilm_policy.test.ts
+++ b/x-pack/plugins/reporting/server/deprecations/migrate_existing_indices_ilm_policy.test.ts
@@ -6,7 +6,11 @@
  */
 
 import type { GetDeprecationsContext } from '@kbn/core/server';
-import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import {
+  elasticsearchServiceMock,
+  httpServerMock,
+  savedObjectsClientMock,
+} from '@kbn/core/server/mocks';
 
 import { getDeprecationsInfo } from './migrate_existing_indices_ilm_policy';
 
@@ -20,7 +24,11 @@ describe("Migrate existing indices' ILM policy deprecations", () => {
 
   beforeEach(async () => {
     esClient = elasticsearchServiceMock.createScopedClusterClient();
-    deprecationsCtx = { esClient, savedObjectsClient: savedObjectsClientMock.create() };
+    deprecationsCtx = {
+      esClient,
+      savedObjectsClient: savedObjectsClientMock.create(),
+      request: httpServerMock.createKibanaRequest(),
+    };
   });
 
   const createIndexSettings = (lifecycleName: string) => ({

--- a/x-pack/plugins/security/server/deprecations/kibana_user_role.test.ts
+++ b/x-pack/plugins/security/server/deprecations/kibana_user_role.test.ts
@@ -12,6 +12,7 @@ import type { PackageInfo, RegisterDeprecationsConfig } from '@kbn/core/server';
 import {
   deprecationsServiceMock,
   elasticsearchServiceMock,
+  httpServerMock,
   loggingSystemMock,
   savedObjectsClientMock,
 } from '@kbn/core/server/mocks';
@@ -39,6 +40,7 @@ function getContextMock() {
   return {
     esClient: elasticsearchServiceMock.createScopedClusterClient(),
     savedObjectsClient: savedObjectsClientMock.create(),
+    request: httpServerMock.createKibanaRequest(),
   };
 }
 

--- a/x-pack/plugins/spaces/server/saved_objects/saved_objects_spaces_extension.test.ts
+++ b/x-pack/plugins/spaces/server/saved_objects/saved_objects_spaces_extension.test.ts
@@ -141,3 +141,13 @@ describe('#getSearchableNamespaces', () => {
     ]);
   });
 });
+
+describe('#asScopedToNamespace', () => {
+  test('returns a extension scoped to the provided namespace', () => {
+    const { spacesExtension } = setup();
+    const rescopedExtension = spacesExtension.asScopedToNamespace('space-a');
+    expect(rescopedExtension).toBeInstanceOf(SavedObjectsSpacesExtension);
+    expect(rescopedExtension).not.toStrictEqual(spacesExtension);
+    expect(rescopedExtension.getCurrentNamespace(undefined)).toStrictEqual('namespace-for-space-a');
+  });
+});

--- a/x-pack/plugins/spaces/server/saved_objects/saved_objects_spaces_extension.ts
+++ b/x-pack/plugins/spaces/server/saved_objects/saved_objects_spaces_extension.ts
@@ -52,4 +52,11 @@ export class SavedObjectsSpacesExtension implements ISavedObjectsSpacesExtension
       );
     }
   }
+
+  asScopedToNamespace(namespace: string) {
+    return new SavedObjectsSpacesExtension({
+      activeSpaceId: namespace,
+      spacesClient: this.spacesClient,
+    });
+  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Deprecations] Logs Sources settings in all spaces (#203042)](https://github.com/elastic/kibana/pull/203042)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alejandro Fernández Haro","email":"alejandro.haro@elastic.co"},"sourceCommit":{"committedDate":"2024-12-16T12:40:56Z","message":"[Deprecations] Logs Sources settings in all spaces (#203042)","sha":"2ed34427c056e935f77c6dded03afc11f82d301c","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","Team:Security","release_note:skip","v9.0.0","backport:prev-minor","ci:project-deploy-observability","Team:obs-ux-logs"],"number":203042,"url":"https://github.com/elastic/kibana/pull/203042","mergeCommit":{"message":"[Deprecations] Logs Sources settings in all spaces (#203042)","sha":"2ed34427c056e935f77c6dded03afc11f82d301c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203042","number":203042,"mergeCommit":{"message":"[Deprecations] Logs Sources settings in all spaces (#203042)","sha":"2ed34427c056e935f77c6dded03afc11f82d301c"}}]}] BACKPORT-->