### PR TITLE
[8.x] [Security Solution][Endpoint] Cypress test improvements to capture Agent diagnostics file when test fails (#202965)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/cypress.d.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/cypress.d.ts
@@ -11,6 +11,7 @@
 
 import type { CasePostRequest } from '@kbn/cases-plugin/common/api';
 import type { UsageRecord } from '@kbn/security-solution-serverless/server/types';
+import type { HostVmTransferResponse } from '../../../scripts/endpoint/common/types';
 import type {
   DeletedEndpointHeartbeats,
   IndexedEndpointHeartbeats,
@@ -30,6 +31,7 @@ import type {
   UninstallAgentFromHostTaskOptions,
   IsAgentAndEndpointUninstalledFromHostTaskOptions,
   LogItTaskOptions,
+  CaptureHostVmAgentDiagnosticsOptions,
 } from './types';
 import type {
   DeleteIndexedFleetEndpointPoliciesResponse,
@@ -267,6 +269,12 @@ declare global {
         arg: LogItTaskOptions,
         options?: Partial<Loggable & Timeoutable>
       ): Chainable<null>;
+
+      task(
+        name: 'captureHostVmAgentDiagnostics',
+        arg: CaptureHostVmAgentDiagnosticsOptions,
+        options?: Partial<Loggable & Timeoutable>
+      ): Chainable<Omit<HostVmTransferResponse, 'delete'>>;
     }
   }
 }

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/file_operations.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/file_operations.cy.ts
@@ -67,6 +67,15 @@ describe.skip('Response console', { tags: ['@ess', '@serverless'] }, () => {
       }
     });
 
+    afterEach(function () {
+      if (Cypress.env('IS_CI') && this.currentTest?.isFailed() && createdHost) {
+        cy.task('captureHostVmAgentDiagnostics', {
+          hostname: createdHost.hostname,
+          fileNamePrefix: this.currentTest?.fullTitle(),
+        });
+      }
+    });
+
     it('"get-file --path" - should retrieve a file', () => {
       const downloadsFolder = Cypress.config('downloadsFolder');
 

--- a/x-pack/plugins/security_solution/public/management/cypress/support/data_loaders.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/support/data_loaders.ts
@@ -11,6 +11,10 @@ import type { CasePostRequest } from '@kbn/cases-plugin/common';
 import execa from 'execa';
 import type { KbnClient } from '@kbn/test';
 import type { ToolingLog } from '@kbn/tooling-log';
+import { REPO_ROOT } from '@kbn/repo-info';
+// This is a Cypress module and only used by Cypress, so disabling "should" be safe
+// eslint-disable-next-line import/no-nodejs-modules
+import { mkdir } from 'node:fs/promises';
 import type { IndexedEndpointHeartbeats } from '../../../../common/endpoint/data_loaders/index_endpoint_hearbeats';
 import {
   deleteIndexedEndpointHeartbeats,
@@ -53,6 +57,7 @@ import type {
   LoadUserAndRoleCyTaskOptions,
   CreateUserAndRoleCyTaskOptions,
   LogItTaskOptions,
+  CaptureHostVmAgentDiagnosticsOptions,
 } from '../types';
 import type {
   DeletedIndexedEndpointRuleAlerts,
@@ -75,6 +80,7 @@ import {
   deleteAgentPolicy,
   fetchAgentPolicyEnrollmentKey,
   getOrCreateDefaultAgentPolicy,
+  setAgentLoggingLevel,
 } from '../../../../scripts/endpoint/common/fleet_services';
 import { startElasticAgentWithDocker } from '../../../../scripts/endpoint/common/elastic_agent_service';
 import type { IndexedFleetEndpointPolicyResponse } from '../../../../common/endpoint/data_loaders/index_fleet_endpoint_policy';
@@ -433,6 +439,7 @@ ${s1Info.status}
                   log,
                   kbnClient,
                 });
+            await setAgentLoggingLevel(kbnClient, newHost.agentId, 'debug', log);
             await waitForEndpointToStreamData(kbnClient, newHost.agentId, 360000);
             return newHost;
           } catch (err) {
@@ -530,6 +537,66 @@ ${s1Info.status}
     startEndpointHost: async (hostName) => {
       await startEndpointHost(hostName);
       return null;
+    },
+
+    /**
+     * Generates an Agent Diagnostics archive (ZIP) directly on the Host VM and saves it to a directory
+     * that is then included with the list of Artifacts that are captured with Buildkite job.
+     *
+     * ### Usage:
+     *
+     * This task is best used from a `afterEach()` by checking if the test failed and if so (and it
+     * was a test that was running against a host VM), then capture the diagnostics file
+     *
+     * @param hostname
+     *
+     * @example
+     *
+     * describe('something', () => {
+     *   let hostVm;
+     *
+     *   afterEach(function() { // << Important: Note the use of `function()` here instead of arrow function
+     *     if (this.currentTest?.isFailed() && hostVm) {
+     *       cy.task('captureHostVmAgentDiagnostics', { hostname: hostVm.hostname });
+     *     }
+     *   });
+     *
+     *   //...
+     * })
+     */
+    captureHostVmAgentDiagnostics: async ({
+      hostname,
+      fileNamePrefix = '',
+    }: CaptureHostVmAgentDiagnosticsOptions) => {
+      const { log } = await stackServicesPromise;
+
+      log.info(`Capturing agent diagnostics for host VM [${hostname}]`);
+
+      const vmClient = getHostVmClient(hostname, undefined, undefined, log);
+      const fileName = `elastic-agent-diagnostics-${hostname}-${new Date()
+        .toISOString()
+        .replace(/:/g, '.')}.zip`;
+      const vmDiagnosticsFile = `/tmp/${fileName}`;
+      const localDiagnosticsDir = `${REPO_ROOT}/target/test_failures`;
+      const localDiagnosticsFile = `${localDiagnosticsDir}/${
+        fileNamePrefix
+          ? // Insure the file name prefix does not have characters that can't be used in file names
+            `${fileNamePrefix.replace(/[><:"/\\|?*'`{} ]/g, '_')}-`
+          : ''
+      }${fileName}`;
+
+      await mkdir(localDiagnosticsDir, { recursive: true });
+
+      // generate diagnostics file on the host and then download it
+      await vmClient.exec(
+        `sudo /opt/Elastic/Agent/elastic-agent diagnostics --file ${vmDiagnosticsFile}`
+      );
+      return vmClient.download(vmDiagnosticsFile, localDiagnosticsFile).then((response) => {
+        log.info(`Agent diagnostic file for host [${hostname}] has been downloaded and is available at:
+  ${response.filePath}
+`);
+        return { filePath: response.filePath };
+      });
     },
   });
 };

--- a/x-pack/plugins/security_solution/public/management/cypress/support/setup_tooling_log_level.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/support/setup_tooling_log_level.ts
@@ -16,10 +16,20 @@ export const setupToolingLogLevel = (config: Cypress.PluginConfigOptions) => {
   const log = createToolingLogger();
   const defaultToolingLogLevel = config.env.TOOLING_LOG_LEVEL;
 
-  log.info(`Cypress config 'env.TOOLING_LOG_LEVEL': ${defaultToolingLogLevel}`);
+  log.info(`
+
+Cypress Configuration File: ${config.configFile}
+
+'env.TOOLING_LOG_LEVEL' set to: ${defaultToolingLogLevel}
+
+*** FYI: ***  To help with test failures, an environmental variable named 'TOOLING_LOG_LEVEL' can be set
+              with a value of 'verbose' in order to capture more data in the logs. This environment
+              property can be set either in the runtime environment (ex. local shell or buildkite) or
+              directly in the Cypress configuration file \`env: {}\` section.
+
+  `);
 
   if (defaultToolingLogLevel && defaultToolingLogLevel !== createToolingLogger.defaultLogLevel) {
     createToolingLogger.defaultLogLevel = defaultToolingLogLevel;
-    log.info(`Default log level for 'createToolingLogger()' set to ${defaultToolingLogLevel}`);
   }
 };

--- a/x-pack/plugins/security_solution/public/management/cypress/types.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/types.ts
@@ -81,3 +81,8 @@ export interface LogItTaskOptions {
   level: keyof Pick<ToolingLog, 'info' | 'debug' | 'verbose'>;
   data: any;
 }
+
+export interface CaptureHostVmAgentDiagnosticsOptions {
+  hostname: string;
+  fileNamePrefix?: string;
+}

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_server/fleet_server_services.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_server/fleet_server_services.ts
@@ -277,6 +277,7 @@ const startFleetServerWithDocker = async ({
   const isServerless = await isServerlessKibanaFlavor(kbnClient);
   const esURL = new URL(await getFleetElasticsearchOutputHost(kbnClient));
   const containerName = `dev-fleet-server.${port}`;
+  let fleetServerVersionInfo = '';
 
   log.info(
     `Starting a new fleet server using Docker\n    Agent version: ${agentVersion}\n    Server URL: ${fleetServerUrl}`
@@ -284,10 +285,11 @@ const startFleetServerWithDocker = async ({
 
   let retryAttempt = isServerless ? 0 : 1;
   const attemptServerlessFleetServerSetup = async (): Promise<StartedServer> => {
+    fleetServerVersionInfo = '';
+
     return log.indent(4, async () => {
       const hostname = `dev-fleet-server.${port}.${Math.random().toString(32).substring(2, 6)}`;
       let containerId = '';
-      let fleetServerVersionInfo = '';
 
       if (isLocalhost(esURL.hostname)) {
         esURL.hostname = localhostRealIp;
@@ -361,8 +363,17 @@ const startFleetServerWithDocker = async ({
         }
 
         fleetServerVersionInfo = isServerless
-          ? // `/usr/bin/fleet-server` process does not seem to support a `--version` type of argument
-            'Running latest standalone fleet server'
+          ? (
+              await execa
+                .command(`docker exec ${containerName} /usr/bin/fleet-server --version`)
+                .catch((err) => {
+                  log.verbose(
+                    `Failed to retrieve fleet-server (serverless/standalone) version information from running instance.`,
+                    err
+                  );
+                  return { stdout: 'Unable to retrieve version information (serverless)' };
+                })
+            ).stdout
           : (
               await execa('docker', [
                 'exec',
@@ -424,7 +435,7 @@ Kill container:       ${chalk.cyan(`docker kill ${containerId}`)}
 
   const response: StartedServer = await attemptServerlessFleetServerSetup();
 
-  log.info(`Done. Fleet server up and running`);
+  log.info(`Done. Fleet server up and running (version: ${fleetServerVersionInfo})`);
 
   return response;
 };

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/types.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/types.ts
@@ -14,8 +14,12 @@ export interface HostVm {
   exec: (command: string) => Promise<HostVmExecResponse>;
   mount: (localDir: string, hostVmDir: string) => Promise<HostVmMountResponse>;
   unmount: (hostVmDir: string) => Promise<void>;
-  /** Uploads/copies a file from the local machine to the VM */
+  /** @deprecated use `upload` */
   transfer: (localFilePath: string, destFilePath: string) => Promise<HostVmTransferResponse>;
+  /** Uploads/copies a file from the local machine to the VM */
+  upload: (localFilePath: string, destFilePath: string) => Promise<HostVmTransferResponse>;
+  /** Downloads a file from the host VM to the local machine */
+  download: (vmFilePath: string, localFilePath: string) => Promise<HostVmTransferResponse>;
   destroy: () => Promise<void>;
   info: () => string;
   stop: () => void;
@@ -33,8 +37,8 @@ export interface HostVmMountResponse {
   unmount: () => Promise<void>;
 }
 export interface HostVmTransferResponse {
-  /** The file path of the file on the host vm */
+  /** The path of the file that was either uploaded to the host VM or downloaded to the local machine from the VM */
   filePath: string;
-  /** Delete the file from the host VM */
+  /** Delete the file from the host VM or from the local machine depending on what client method was used */
   delete: () => Promise<HostVmExecResponse>;
 }

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/vm_services.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/vm_services.ts
@@ -8,15 +8,19 @@
 import type { ToolingLog } from '@kbn/tooling-log';
 import execa from 'execa';
 import chalk from 'chalk';
+import path from 'path';
 import { userInfo } from 'os';
-import { join as pathJoin, dirname } from 'path';
+import { unlink as deleteFile } from 'fs/promises';
+import { dump } from './utils';
 import type { DownloadedAgentInfo } from './agent_downloads_service';
 import { BaseDataGenerator } from '../../../common/endpoint/data_generators/base_data_generator';
 import { createToolingLogger } from '../../../common/endpoint/data_loaders/utils';
 import type { HostVm, HostVmExecResponse, SupportedVmManager } from './types';
 
 const baseGenerator = new BaseDataGenerator();
-export const DEFAULT_VAGRANTFILE = pathJoin(__dirname, 'vagrant', 'Vagrantfile');
+export const DEFAULT_VAGRANTFILE = path.join(__dirname, 'vagrant', 'Vagrantfile');
+
+const MAX_BUFFER = 1024 * 1024 * 5; // 5MB
 
 export interface BaseVmCreateOptions {
   name: string;
@@ -75,9 +79,16 @@ export const createMultipassHostVmClient = (
   log: ToolingLog = createToolingLogger()
 ): HostVm => {
   const exec = async (command: string): Promise<HostVmExecResponse> => {
-    const execResponse = await execa.command(`multipass exec ${name} -- ${command}`);
+    const execResponse = await execa
+      .command(`multipass exec ${name} -- ${command}`, { maxBuffer: MAX_BUFFER })
+      .catch((e) => {
+        log.error(dump(e));
+        throw e;
+      });
 
-    log.verbose(execResponse);
+    log.verbose(
+      `exec response from host [${name}] for command [${command}]:\n${dump(execResponse)}`
+    );
 
     return {
       stdout: execResponse.stdout,
@@ -125,16 +136,37 @@ export const createMultipassHostVmClient = (
     log.verbose(`multipass stop response:\n`, response);
   };
 
-  const transfer: HostVm['transfer'] = async (localFilePath, destFilePath) => {
+  const upload: HostVm['upload'] = async (localFilePath, destFilePath) => {
     const response = await execa.command(
       `multipass transfer ${localFilePath} ${name}:${destFilePath}`
     );
-    log.verbose(`Transferred file to VM [${name}]:`, response);
+    log.verbose(`Uploaded file to VM [${name}]:`, response);
 
     return {
       filePath: destFilePath,
       delete: async () => {
         return exec(`rm ${destFilePath}`);
+      },
+    };
+  };
+
+  const download: HostVm['download'] = async (vmFilePath: string, localFilePath: string) => {
+    const localFileAbsolutePath = path.resolve(localFilePath);
+    const response = await execa.command(
+      `multipass transfer ${name}:${vmFilePath} ${localFilePath}`
+    );
+    log.verbose(`Downloaded file from VM [${name}]:`, response);
+
+    return {
+      filePath: localFileAbsolutePath,
+      delete: async () => {
+        return deleteFile(localFileAbsolutePath).then(() => {
+          return {
+            stdout: 'success',
+            stderr: '',
+            exitCode: 0,
+          };
+        });
       },
     };
   };
@@ -147,7 +179,9 @@ export const createMultipassHostVmClient = (
     info,
     mount,
     unmount,
-    transfer,
+    transfer: upload,
+    upload,
+    download,
     start,
     stop,
   };
@@ -217,7 +251,7 @@ const createVagrantVm = async ({
 }: CreateVagrantVmOptions): Promise<HostVm> => {
   log.debug(`Using Vagrantfile: ${vagrantFile}`);
 
-  const VAGRANT_CWD = dirname(vagrantFile);
+  const VAGRANT_CWD = path.dirname(vagrantFile);
 
   // Destroy the VM running (if any) with the provided vagrant file before re-creating it
   try {
@@ -273,18 +307,24 @@ export const createVagrantHostVmClient = (
   vagrantFile: string = DEFAULT_VAGRANTFILE,
   log: ToolingLog = createToolingLogger()
 ): HostVm => {
-  const VAGRANT_CWD = dirname(vagrantFile);
+  const VAGRANT_CWD = path.dirname(vagrantFile);
   const execaOptions: execa.Options = {
     env: {
       VAGRANT_CWD,
     },
     stdio: ['inherit', 'pipe', 'pipe'],
+    maxBuffer: MAX_BUFFER,
   };
 
   log.debug(`Creating Vagrant VM client for [${name}] with vagrantfile [${vagrantFile}]`);
 
   const exec = async (command: string): Promise<HostVmExecResponse> => {
-    const execResponse = await execa.command(`vagrant ssh -- ${command}`, execaOptions);
+    const execResponse = await execa
+      .command(`vagrant ssh -- ${command}`, execaOptions)
+      .catch((e) => {
+        log.error(dump(e));
+        throw e;
+      });
 
     log.verbose(execResponse);
 
@@ -328,17 +368,45 @@ export const createVagrantHostVmClient = (
     log.verbose('vagrant suspend response:\n', response);
   };
 
-  const transfer: HostVm['transfer'] = async (localFilePath, destFilePath) => {
+  const upload: HostVm['upload'] = async (localFilePath, destFilePath) => {
     const response = await execa.command(
       `vagrant upload ${localFilePath} ${destFilePath}`,
       execaOptions
     );
-    log.verbose(`Transferred file to VM [${name}]:`, response);
+    log.verbose(`Uploaded file to VM [${name}]:`, response);
 
     return {
       filePath: destFilePath,
       delete: async () => {
         return exec(`rm ${destFilePath}`);
+      },
+    };
+  };
+
+  const download: HostVm['download'] = async (vmFilePath, localFilePath) => {
+    const localFileAbsolutePath = path.resolve(localFilePath);
+
+    // Vagrant will auto-mount the directory that includes the Vagrant file to the VM under `/vagrant`,
+    // and it keeps that sync'd to the local system. So we first copy the file in the VM there so we
+    // can retrieve it from the local machine
+    await exec(`cp ${vmFilePath} /vagrant`).catch((e) => {
+      log.error(`Error while attempting to copy file on VM:\n${dump(e)}`);
+      throw e;
+    });
+
+    // Now move the file from the local vagrant directory to the desired location
+    await execa.command(`mv ${VAGRANT_CWD}/${path.basename(vmFilePath)} ${localFileAbsolutePath}`);
+
+    return {
+      filePath: localFileAbsolutePath,
+      delete: async () => {
+        return deleteFile(localFileAbsolutePath).then(() => {
+          return {
+            stdout: 'success',
+            stderr: '',
+            exitCode: 0,
+          };
+        });
       },
     };
   };
@@ -351,7 +419,9 @@ export const createVagrantHostVmClient = (
     info,
     mount,
     unmount,
-    transfer,
+    transfer: upload,
+    upload,
+    download,
     start,
     stop,
   };

--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
@@ -32,7 +32,7 @@ import { createKbnClient } from '../endpoint/common/stack_services';
 import type { StartedFleetServer } from '../endpoint/common/fleet_server/fleet_server_services';
 import { startFleetServer } from '../endpoint/common/fleet_server/fleet_server_services';
 import { renderSummaryTable } from './print_run';
-import { parseTestFileConfig, retrieveIntegrations } from './utils';
+import { parseTestFileConfig, retrieveIntegrations, setDefaultToolingLoggingLevel } from './utils';
 import { getFTRConfig } from './get_ftr_config';
 
 export const cli = () => {
@@ -68,9 +68,9 @@ ${JSON.stringify(argv, null, 2)}
       const cypressConfigFilePath = require.resolve(`../../${argv.configFile}`) as string;
       const cypressConfigFile = await import(cypressConfigFilePath);
 
-      if (cypressConfigFile.env?.TOOLING_LOG_LEVEL) {
-        createToolingLogger.defaultLogLevel = cypressConfigFile.env.TOOLING_LOG_LEVEL;
-      }
+      // Adjust tooling log level based on the `TOOLING_LOG_LEVEL` property, which can be
+      // defined in the cypress config file or set in the `env`
+      setDefaultToolingLoggingLevel(cypressConfigFile?.env?.TOOLING_LOG_LEVEL);
 
       const log = prefixedOutputLogger('cy.parallel()', createToolingLogger());
 

--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel_serverless.ts
@@ -28,7 +28,12 @@ import { INITIAL_REST_VERSION } from '@kbn/data-views-plugin/server/constants';
 import { catchAxiosErrorFormatAndThrow } from '../../common/endpoint/format_axios_error';
 import { createToolingLogger } from '../../common/endpoint/data_loaders/utils';
 import { renderSummaryTable } from './print_run';
-import { getOnBeforeHook, parseTestFileConfig, retrieveIntegrations } from './utils';
+import {
+  getOnBeforeHook,
+  parseTestFileConfig,
+  retrieveIntegrations,
+  setDefaultToolingLoggingLevel,
+} from './utils';
 import { prefixedOutputLogger } from '../endpoint/common/utils';
 
 import type { ProductType, Credentials, ProjectHandler } from './project_handler/project_handler';
@@ -357,9 +362,8 @@ ${JSON.stringify(argv, null, 2)}
         cypressConfigFile.env.grepTags = '@serverlessQA --@skipInServerless --@skipInServerlessMKI';
       }
 
-      if (cypressConfigFile.env?.TOOLING_LOG_LEVEL) {
-        createToolingLogger.defaultLogLevel = cypressConfigFile.env.TOOLING_LOG_LEVEL;
-      }
+      setDefaultToolingLoggingLevel(cypressConfigFile?.env?.TOOLING_LOG_LEVEL);
+
       // eslint-disable-next-line require-atomic-updates
       log = prefixedOutputLogger('cy.parallel(svl)', createToolingLogger());
 

--- a/x-pack/plugins/security_solution/scripts/run_cypress/utils.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/utils.ts
@@ -12,6 +12,8 @@ import generate from '@babel/generator';
 import type { ExpressionStatement, ObjectExpression, ObjectProperty } from '@babel/types';
 import { schema, type TypeOf } from '@kbn/config-schema';
 import chalk from 'chalk';
+import type { ToolingLogTextWriterConfig } from '@kbn/tooling-log';
+import { createToolingLogger } from '../../common/endpoint/data_loaders/utils';
 
 /**
  * Retrieve test files using a glob pattern.
@@ -155,4 +157,23 @@ export const getOnBeforeHook = (module: unknown, beforeSpecFilePath: string): Fu
   }
 
   return module.onBeforeHook;
+};
+
+/**
+ * Sets the default log level for `ToolingLog` instances created by `createToolingLogger()`:
+ * `x-pack/plugins/security_solution/common/endpoint/data_loaders/utils.ts:148`.
+ * It will first check the NodeJs `process.env` to see if an Environment Variable was set
+ * and then, if provided, it will use the value defined in the Cypress Config. file.
+ */
+export const setDefaultToolingLoggingLevel = (defaultFallbackLoggingLevel?: string) => {
+  const logLevel =
+    process.env.TOOLING_LOG_LEVEL ||
+    process.env.CYPRESS_TOOLING_LOG_LEVEL ||
+    defaultFallbackLoggingLevel ||
+    '';
+
+  if (logLevel) {
+    createToolingLogger('info').info(`Setting tooling log level to [${logLevel}]`);
+    createToolingLogger.defaultLogLevel = logLevel as ToolingLogTextWriterConfig['level'];
+  }
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][Endpoint] Cypress test improvements to capture Agent diagnostics file when test fails (#202965)](https://github.com/elastic/kibana/pull/202965)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-12-12T15:21:23Z","message":"[Security Solution][Endpoint] Cypress test improvements to capture Agent diagnostics file when test fails (#202965)\n\n## Summary\r\n\r\n- the Cypress `parallel` runner was updated to set tooling logging level\r\nfirst from Env. variables before falling back to the value defined in\r\nthe Cypress configuration file\r\n- The env. value to set, if wanting to enable a specific logging level,\r\nis `TOOLING_LOG_LEVEL`. The values supported are the same as those used\r\nwith `ToolingLog`\r\n([here](https://github.com/elastic/kibana/blob/b6287708f687d4e3288851052c0c6ae4ade8ce60/packages/kbn-tooling-log/src/log_levels.ts#L10)):\r\n`silent`, `error`, `warning`, `success`, `info`, `debug`, `verbose`\r\n- This change makes it easier to run Cypress tests locally with (for\r\nexample) a logging level of `verbose` for our tooling without having to\r\nmodify the Cypress configuration file. Example: `export\r\nTOOLING_LOG_LEVEL=verbose && yarn cypress:dw:open`\r\n- Added two new methods to our scripting VM service clients (for Vagrant\r\nand Multipass):\r\n- `download`: allow you to pull files out of the VM and save them\r\nlocally\r\n- `upload`: uploads a local file to the VM. (upload already existed as\r\n`transfer` - which has now been marked as deprecated).\r\n- Added new service function on our Fleet scripting module to enable us\r\nto set the logging level on a Fleet Agent\r\n- Cypress tests were adjusted to automatically set the agent logging to\r\ndebug when running in CI\r\n- A new Cypress task that allows for an Agent Diagnostic file (which\r\nincludes the Endpoint Log) to be retrieved from the host VM and stored\r\nwith the CI job (under the artifacts tab)\r\n    - A few tests were updated to include this step for failed test","sha":"2ab8a5ced075da08f3aeb9526a76b60b1a964602","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","Team:Defend Workflows","backport:prev-minor","v8.18.0"],"number":202965,"url":"https://github.com/elastic/kibana/pull/202965","mergeCommit":{"message":"[Security Solution][Endpoint] Cypress test improvements to capture Agent diagnostics file when test fails (#202965)\n\n## Summary\r\n\r\n- the Cypress `parallel` runner was updated to set tooling logging level\r\nfirst from Env. variables before falling back to the value defined in\r\nthe Cypress configuration file\r\n- The env. value to set, if wanting to enable a specific logging level,\r\nis `TOOLING_LOG_LEVEL`. The values supported are the same as those used\r\nwith `ToolingLog`\r\n([here](https://github.com/elastic/kibana/blob/b6287708f687d4e3288851052c0c6ae4ade8ce60/packages/kbn-tooling-log/src/log_levels.ts#L10)):\r\n`silent`, `error`, `warning`, `success`, `info`, `debug`, `verbose`\r\n- This change makes it easier to run Cypress tests locally with (for\r\nexample) a logging level of `verbose` for our tooling without having to\r\nmodify the Cypress configuration file. Example: `export\r\nTOOLING_LOG_LEVEL=verbose && yarn cypress:dw:open`\r\n- Added two new methods to our scripting VM service clients (for Vagrant\r\nand Multipass):\r\n- `download`: allow you to pull files out of the VM and save them\r\nlocally\r\n- `upload`: uploads a local file to the VM. (upload already existed as\r\n`transfer` - which has now been marked as deprecated).\r\n- Added new service function on our Fleet scripting module to enable us\r\nto set the logging level on a Fleet Agent\r\n- Cypress tests were adjusted to automatically set the agent logging to\r\ndebug when running in CI\r\n- A new Cypress task that allows for an Agent Diagnostic file (which\r\nincludes the Endpoint Log) to be retrieved from the host VM and stored\r\nwith the CI job (under the artifacts tab)\r\n    - A few tests were updated to include this step for failed test","sha":"2ab8a5ced075da08f3aeb9526a76b60b1a964602"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/202965","number":202965,"mergeCommit":{"message":"[Security Solution][Endpoint] Cypress test improvements to capture Agent diagnostics file when test fails (#202965)\n\n## Summary\r\n\r\n- the Cypress `parallel` runner was updated to set tooling logging level\r\nfirst from Env. variables before falling back to the value defined in\r\nthe Cypress configuration file\r\n- The env. value to set, if wanting to enable a specific logging level,\r\nis `TOOLING_LOG_LEVEL`. The values supported are the same as those used\r\nwith `ToolingLog`\r\n([here](https://github.com/elastic/kibana/blob/b6287708f687d4e3288851052c0c6ae4ade8ce60/packages/kbn-tooling-log/src/log_levels.ts#L10)):\r\n`silent`, `error`, `warning`, `success`, `info`, `debug`, `verbose`\r\n- This change makes it easier to run Cypress tests locally with (for\r\nexample) a logging level of `verbose` for our tooling without having to\r\nmodify the Cypress configuration file. Example: `export\r\nTOOLING_LOG_LEVEL=verbose && yarn cypress:dw:open`\r\n- Added two new methods to our scripting VM service clients (for Vagrant\r\nand Multipass):\r\n- `download`: allow you to pull files out of the VM and save them\r\nlocally\r\n- `upload`: uploads a local file to the VM. (upload already existed as\r\n`transfer` - which has now been marked as deprecated).\r\n- Added new service function on our Fleet scripting module to enable us\r\nto set the logging level on a Fleet Agent\r\n- Cypress tests were adjusted to automatically set the agent logging to\r\ndebug when running in CI\r\n- A new Cypress task that allows for an Agent Diagnostic file (which\r\nincludes the Endpoint Log) to be retrieved from the host VM and stored\r\nwith the CI job (under the artifacts tab)\r\n    - A few tests were updated to include this step for failed test","sha":"2ab8a5ced075da08f3aeb9526a76b60b1a964602"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->