### PR TITLE
[8.16] [Stack Connectors][SentinelOne + Crowdstrike] Fix the validation of external API responses that return non-JSON (ex. stream) (#203820)

### DIFF
--- a/x-pack/plugins/stack_connectors/common/crowdstrike/schema.ts
+++ b/x-pack/plugins/stack_connectors/common/crowdstrike/schema.ts
@@ -17,6 +17,8 @@ export const CrowdstrikeSecretsSchema = schema.object({
   clientSecret: schema.string(),
 });
 
+export const CrowdstrikeApiDoNotValidateResponsesSchema = schema.any();
+
 export const RelaxedCrowdstrikeBaseApiResponseSchema = schema.maybe(
   schema.object({}, { unknowns: 'allow' })
 );

--- a/x-pack/plugins/stack_connectors/common/sentinelone/schema.ts
+++ b/x-pack/plugins/stack_connectors/common/sentinelone/schema.ts
@@ -16,6 +16,8 @@ export const SentinelOneSecretsSchema = schema.object({
   token: schema.string(),
 });
 
+export const SentinelOneApiDoNotValidateResponsesSchema = schema.any();
+
 export const SentinelOneBaseApiResponseSchema = schema.maybe(
   schema.object({}, { unknowns: 'allow' })
 );

--- a/x-pack/plugins/stack_connectors/server/connector_types/crowdstrike/crowdstrike.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/crowdstrike/crowdstrike.ts
@@ -24,9 +24,14 @@ import type {
 import {
   CrowdstrikeHostActionsParamsSchema,
   CrowdstrikeGetAgentsParamsSchema,
-  CrowdstrikeGetTokenResponseSchema,
   CrowdstrikeHostActionsResponseSchema,
   RelaxedCrowdstrikeBaseApiResponseSchema,
+  CrowdstrikeRTRCommandParamsSchema,
+  CrowdstrikeExecuteRTRResponseSchema,
+  CrowdstrikeGetScriptsParamsSchema,
+  CrowdStrikeExecuteRTRResponse,
+  CrowdstrikeApiDoNotValidateResponsesSchema,
+  CrowdstrikeGetTokenResponseSchema,
 } from '../../../common/crowdstrike/schema';
 import { SUB_ACTION } from '../../../common/crowdstrike/constants';
 import { CrowdstrikeError } from './error';
@@ -174,7 +179,8 @@ export class CrowdstrikeConnector extends SubActionConnector<
           'Content-Type': 'application/x-www-form-urlencoded',
           authorization: 'Basic ' + CrowdstrikeConnector.base64encodedToken,
         },
-        responseSchema: CrowdstrikeGetTokenResponseSchema,
+        responseSchema:
+          CrowdstrikeApiDoNotValidateResponsesSchema as unknown as typeof CrowdstrikeGetTokenResponseSchema,
       },
       connectorUsageCollector
     );
@@ -210,7 +216,7 @@ export class CrowdstrikeConnector extends SubActionConnector<
           // where the external system might add/remove/change values in the response that we have no
           // control over.
           responseSchema:
-            RelaxedCrowdstrikeBaseApiResponseSchema as unknown as SubActionRequestParams<R>['responseSchema'],
+            CrowdstrikeApiDoNotValidateResponsesSchema as unknown as SubActionRequestParams<R>['responseSchema'],
           headers: {
             ...req.headers,
             Authorization: `Bearer ${CrowdstrikeConnector.token}`,

--- a/x-pack/plugins/stack_connectors/server/connector_types/crowdstrike/crowdstrike.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/crowdstrike/crowdstrike.ts
@@ -26,10 +26,6 @@ import {
   CrowdstrikeGetAgentsParamsSchema,
   CrowdstrikeHostActionsResponseSchema,
   RelaxedCrowdstrikeBaseApiResponseSchema,
-  CrowdstrikeRTRCommandParamsSchema,
-  CrowdstrikeExecuteRTRResponseSchema,
-  CrowdstrikeGetScriptsParamsSchema,
-  CrowdStrikeExecuteRTRResponse,
   CrowdstrikeApiDoNotValidateResponsesSchema,
   CrowdstrikeGetTokenResponseSchema,
 } from '../../../common/crowdstrike/schema';

--- a/x-pack/plugins/stack_connectors/server/connector_types/sentinelone/sentinelone.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/sentinelone/sentinelone.ts
@@ -43,7 +43,7 @@ import {
   SentinelOneGetRemoteScriptResultsParamsSchema,
   SentinelOneDownloadRemoteScriptResultsParamsSchema,
   SentinelOneDownloadRemoteScriptResultsResponseSchema,
-  SentinelOneBaseApiResponseSchema,
+  SentinelOneApiDoNotValidateResponsesSchema,
 } from '../../../common/sentinelone/schema';
 import { SUB_ACTION } from '../../../common/sentinelone/constants';
 import {
@@ -405,7 +405,7 @@ export class SentinelOneConnector extends SubActionConnector<
         // where the external system might add/remove/change values in the response that we have no
         // control over.
         responseSchema:
-          SentinelOneBaseApiResponseSchema as unknown as SubActionRequestParams<R>['responseSchema'],
+          SentinelOneApiDoNotValidateResponsesSchema as unknown as SubActionRequestParams<R>['responseSchema'],
         params: {
           ...req.params,
           APIToken: this.secrets.token,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Stack Connectors][SentinelOne + Crowdstrike] Fix the validation of external API responses that return non-JSON (ex. stream) (#203820)](https://github.com/elastic/kibana/pull/203820)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-12-11T19:48:57Z","message":"[Stack Connectors][SentinelOne + Crowdstrike] Fix the validation of external API responses that return non-JSON (ex. stream) (#203820)\n\n## Summary\r\n\r\n- Changes the validation for API responses from SentinelOne and\r\nCrowdstrike to allow anything\r\n- The prior fix changed it to validate that the responses were `JSON`,\r\nbut the some APIs can return non-JSON: example: a `stream` as is the\r\ncase for file download.","sha":"520c7c6d58356770708a0567d8fac3c55d75f8cc","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","v9.0.0","Team:Defend Workflows","backport:prev-major","v8.18.0","v8.16.2","v8.17.1"],"number":203820,"url":"https://github.com/elastic/kibana/pull/203820","mergeCommit":{"message":"[Stack Connectors][SentinelOne + Crowdstrike] Fix the validation of external API responses that return non-JSON (ex. stream) (#203820)\n\n## Summary\r\n\r\n- Changes the validation for API responses from SentinelOne and\r\nCrowdstrike to allow anything\r\n- The prior fix changed it to validate that the responses were `JSON`,\r\nbut the some APIs can return non-JSON: example: a `stream` as is the\r\ncase for file download.","sha":"520c7c6d58356770708a0567d8fac3c55d75f8cc"}},"sourceBranch":"main","suggestedTargetBranches":["8.16","8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203820","number":203820,"mergeCommit":{"message":"[Stack Connectors][SentinelOne + Crowdstrike] Fix the validation of external API responses that return non-JSON (ex. stream) (#203820)\n\n## Summary\r\n\r\n- Changes the validation for API responses from SentinelOne and\r\nCrowdstrike to allow anything\r\n- The prior fix changed it to validate that the responses were `JSON`,\r\nbut the some APIs can return non-JSON: example: a `stream` as is the\r\ncase for file download.","sha":"520c7c6d58356770708a0567d8fac3c55d75f8cc"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/203920","number":203920,"state":"OPEN"},{"branch":"8.16","label":"v8.16.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->