### PR TITLE
[8.x] [Security Solution] Preview navigation in document details flyout (#204292)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/correlations_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/correlations_overview.tsx
@@ -6,12 +6,10 @@
  */
 
 import { get } from 'lodash';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { EuiFlexGroup } from '@elastic/eui';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ALERT_RULE_TYPE } from '@kbn/rule-data-utils';
-
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import { useShowRelatedAlertsBySession } from '../../shared/hooks/use_show_related_alerts_by_session';
@@ -26,7 +24,6 @@ import { RelatedCases } from './related_cases';
 import { useShowRelatedCases } from '../../shared/hooks/use_show_related_cases';
 import { CORRELATIONS_TEST_ID } from './test_ids';
 import { useDocumentDetailsContext } from '../../shared/context';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
 import { LeftPanelInsightsTab } from '../../left';
 import { CORRELATIONS_TAB_ID } from '../../left/components/correlations_details';
 import { useTimelineDataFilters } from '../../../../timelines/containers/use_timeline_data_filters';
@@ -36,6 +33,7 @@ import {
   AlertsCasesTourSteps,
   SecurityStepId,
 } from '../../../../common/components/guided_onboarding_tour/tour_config';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
 /**
  * Correlations section under Insights section, overview tab.
@@ -43,34 +41,17 @@ import {
  * and the SummaryPanel component for data rendering.
  */
 export const CorrelationsOverview: React.FC = () => {
-  const {
-    dataAsNestedObject,
-    eventId,
-    indexName,
-    getFieldsData,
-    scopeId,
-    isPreview,
-    isPreviewMode,
-  } = useDocumentDetailsContext();
-  const { openLeftPanel } = useExpandableFlyoutApi();
+  const { dataAsNestedObject, eventId, getFieldsData, scopeId, isPreview, isPreviewMode } =
+    useDocumentDetailsContext();
   const { isTourShown, activeStep } = useTourContext();
 
   const { selectedPatterns } = useTimelineDataFilters(isActiveTimeline(scopeId));
 
-  const goToCorrelationsTab = useCallback(() => {
-    openLeftPanel({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInsightsTab,
-        subTab: CORRELATIONS_TAB_ID,
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
+  const { navigateToLeftPanel: goToCorrelationsTab, isEnabled: isLinkEnabled } =
+    useNavigateToLeftPanel({
+      tab: LeftPanelInsightsTab,
+      subTab: CORRELATIONS_TAB_ID,
     });
-  }, [eventId, openLeftPanel, indexName, scopeId]);
 
   useEffect(() => {
     if (isTourShown(SecurityStepId.alertsCases) && activeStep === AlertsCasesTourSteps.createCase) {
@@ -105,7 +86,7 @@ export const CorrelationsOverview: React.FC = () => {
 
   const link = useMemo(
     () =>
-      !isPreviewMode
+      isLinkEnabled
         ? {
             callback: goToCorrelationsTab,
             tooltip: (
@@ -116,7 +97,7 @@ export const CorrelationsOverview: React.FC = () => {
             ),
           }
         : undefined,
-    [isPreviewMode, goToCorrelationsTab]
+    [goToCorrelationsTab, isLinkEnabled]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/entities_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/entities_overview.tsx
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { INSIGHTS_ENTITIES_TEST_ID } from './test_ids';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
@@ -15,39 +14,28 @@ import { useDocumentDetailsContext } from '../../shared/context';
 import { getField } from '../../shared/utils';
 import { HostEntityOverview } from './host_entity_overview';
 import { UserEntityOverview } from './user_entity_overview';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
 import { LeftPanelInsightsTab } from '../../left';
 import { ENTITIES_TAB_ID } from '../../left/components/entities_details';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
 /**
  * Entities section under Insights section, overview tab. It contains a preview of host and user information.
  */
 export const EntitiesOverview: React.FC = () => {
-  const { eventId, getFieldsData, indexName, scopeId, isPreviewMode } = useDocumentDetailsContext();
-  const { openLeftPanel } = useExpandableFlyoutApi();
+  const { getFieldsData, isPreviewMode } = useDocumentDetailsContext();
   const hostName = getField(getFieldsData('host.name'));
   const userName = getField(getFieldsData('user.name'));
 
-  const goToEntitiesTab = useCallback(() => {
-    openLeftPanel({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInsightsTab,
-        subTab: ENTITIES_TAB_ID,
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
-  }, [eventId, openLeftPanel, indexName, scopeId]);
+  const { navigateToLeftPanel, isEnabled: isLinkEnabled } = useNavigateToLeftPanel({
+    tab: LeftPanelInsightsTab,
+    subTab: ENTITIES_TAB_ID,
+  });
 
   const link = useMemo(
     () =>
-      !isPreviewMode
+      isLinkEnabled
         ? {
-            callback: goToEntitiesTab,
+            callback: navigateToLeftPanel,
             tooltip: (
               <FormattedMessage
                 id="xpack.securitySolution.flyout.right.insights.entities.entitiesTooltip"
@@ -56,7 +44,7 @@ export const EntitiesOverview: React.FC = () => {
             ),
           }
         : undefined,
-    [goToEntitiesTab, isPreviewMode]
+    [navigateToLeftPanel, isLinkEnabled]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/insights_summary_row.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/insights_summary_row.test.tsx
@@ -9,18 +9,10 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { InsightsSummaryRow } from './insights_summary_row';
-import { useDocumentDetailsContext } from '../../shared/context';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
-import { LeftPanelInsightsTab } from '../../left';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
-jest.mock('@kbn/expandable-flyout');
-jest.mock('../../shared/context');
-
-const mockOpenLeftPanel = jest.fn();
-const scopeId = 'scopeId';
-const eventId = 'eventId';
-const indexName = 'indexName';
+const mockNavigateToLeftPanel = jest.fn();
+jest.mock('../../shared/hooks/use_navigate_to_left_panel');
 
 const testId = 'test';
 const textTestId = `${testId}Text`;
@@ -32,13 +24,10 @@ describe('<InsightsSummaryRow />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useDocumentDetailsContext as jest.Mock).mockReturnValue({
-      eventId,
-      indexName,
-      scopeId,
-      isPreviewMode: false,
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
+      navigateToLeftPanel: mockNavigateToLeftPanel,
+      isEnabled: true,
     });
-    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openLeftPanel: mockOpenLeftPanel });
   });
 
   it('should render loading skeleton if loading is true', () => {
@@ -113,26 +102,13 @@ describe('<InsightsSummaryRow />', () => {
     );
     getByTestId(buttonTestId).click();
 
-    expect(mockOpenLeftPanel).toHaveBeenCalledWith({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInsightsTab,
-        subTab: 'subTab',
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
+    expect(mockNavigateToLeftPanel).toHaveBeenCalled();
   });
 
-  it('should disabled the click when in preview mode', () => {
-    (useDocumentDetailsContext as jest.Mock).mockReturnValue({
-      eventId,
-      indexName,
-      scopeId,
-      isPreviewMode: true,
+  it('should disabled the click when navigation is disabled', () => {
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
+      navigateToLeftPanel: undefined,
+      isEnabled: false,
     });
 
     const { getByTestId } = render(
@@ -150,6 +126,6 @@ describe('<InsightsSummaryRow />', () => {
     expect(button).toHaveAttribute('disabled');
 
     button.click();
-    expect(mockOpenLeftPanel).not.toHaveBeenCalled();
+    expect(mockNavigateToLeftPanel).not.toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/insights_summary_row.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/insights_summary_row.tsx
@@ -6,15 +6,13 @@
  */
 
 import type { ReactElement, VFC } from 'react';
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { EuiBadge, EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiSkeletonText } from '@elastic/eui';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { useDocumentDetailsContext } from '../../shared/context';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
 import { LeftPanelInsightsTab } from '../../left';
 import { FormattedCount } from '../../../../common/components/formatted_number';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
 const LOADING = i18n.translate(
   'xpack.securitySolution.flyout.right.insights.insightSummaryLoadingAriaLabel',
@@ -66,23 +64,10 @@ export const InsightsSummaryRow: VFC<InsightsSummaryRowProps> = ({
   expandedSubTab,
   'data-test-subj': dataTestSubj,
 }) => {
-  const { eventId, indexName, scopeId, isPreviewMode } = useDocumentDetailsContext();
-  const { openLeftPanel } = useExpandableFlyoutApi();
-
-  const onClick = useCallback(() => {
-    openLeftPanel({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInsightsTab,
-        subTab: expandedSubTab,
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
-  }, [eventId, expandedSubTab, indexName, openLeftPanel, scopeId]);
+  const { navigateToLeftPanel: onClick, isEnabled: isLinkEnabled } = useNavigateToLeftPanel({
+    tab: LeftPanelInsightsTab,
+    subTab: expandedSubTab,
+  });
 
   const textDataTestSubj = useMemo(() => `${dataTestSubj}Text`, [dataTestSubj]);
   const loadingDataTestSubj = useMemo(() => `${dataTestSubj}Loading`, [dataTestSubj]);
@@ -100,7 +85,7 @@ export const InsightsSummaryRow: VFC<InsightsSummaryRowProps> = ({
               onClick={onClick}
               flush={'both'}
               size="xs"
-              disabled={isPreviewMode}
+              disabled={!isLinkEnabled}
               data-test-subj={buttonDataTestSubj}
             >
               <FormattedCount count={value} />
@@ -111,7 +96,7 @@ export const InsightsSummaryRow: VFC<InsightsSummaryRowProps> = ({
         )}
       </>
     );
-  }, [dataTestSubj, isPreviewMode, onClick, value]);
+  }, [dataTestSubj, onClick, value, isLinkEnabled]);
 
   if (loading) {
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_guide.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_guide.tsx
@@ -4,47 +4,35 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { EuiButton, EuiSkeletonText, EuiCallOut } from '@elastic/eui';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { useInvestigationGuide } from '../../shared/hooks/use_investigation_guide';
 import { useDocumentDetailsContext } from '../../shared/context';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
 import { LeftPanelInvestigationTab } from '../../left';
 import {
   INVESTIGATION_GUIDE_BUTTON_TEST_ID,
   INVESTIGATION_GUIDE_LOADING_TEST_ID,
   INVESTIGATION_GUIDE_TEST_ID,
 } from './test_ids';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
 /**
  * Render either the investigation guide button that opens Investigation section in the left panel,
  * or a no-data message if investigation guide hasn't been set up on the rule
  */
 export const InvestigationGuide: React.FC = () => {
-  const { openLeftPanel } = useExpandableFlyoutApi();
-  const { eventId, indexName, scopeId, dataFormattedForFieldBrowser, isPreview, isPreviewMode } =
-    useDocumentDetailsContext();
+  const { dataFormattedForFieldBrowser, isPreview } = useDocumentDetailsContext();
 
   const { loading, error, basicAlertData, ruleNote } = useInvestigationGuide({
     dataFormattedForFieldBrowser,
   });
 
-  const goToInvestigationsTab = useCallback(() => {
-    openLeftPanel({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInvestigationTab,
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
+  const { navigateToLeftPanel: goToInvestigationsTab, isEnabled: isLinkEnabled } =
+    useNavigateToLeftPanel({
+      tab: LeftPanelInvestigationTab,
     });
-  }, [eventId, indexName, openLeftPanel, scopeId]);
 
   const hasInvestigationGuide = useMemo(
     () => !error && basicAlertData && basicAlertData.ruleId && ruleNote,
@@ -88,7 +76,7 @@ export const InvestigationGuide: React.FC = () => {
       );
     }
 
-    if (hasInvestigationGuide && isPreviewMode) {
+    if (hasInvestigationGuide && !isLinkEnabled) {
       return (
         <EuiCallOut
           iconType="documentation"
@@ -154,7 +142,7 @@ export const InvestigationGuide: React.FC = () => {
         />
       </EuiCallOut>
     );
-  }, [loading, isPreview, isPreviewMode, goToInvestigationsTab, hasInvestigationGuide]);
+  }, [isPreview, loading, hasInvestigationGuide, isLinkEnabled, goToInvestigationsTab]);
 
   return <div data-test-subj={INVESTIGATION_GUIDE_TEST_ID}>{content}</div>;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.test.tsx
@@ -22,10 +22,12 @@ import { TestProvider } from '@kbn/expandable-flyout/src/test/provider';
 import { mockContextValue } from '../../shared/mocks/mock_context';
 import { useExpandSection } from '../hooks/use_expand_section';
 import { useHighlightedFields } from '../../shared/hooks/use_highlighted_fields';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 jest.mock('../../../../detection_engine/rule_management/logic/use_rule_with_fallback');
 jest.mock('../hooks/use_expand_section');
 jest.mock('../../shared/hooks/use_highlighted_fields');
+jest.mock('../../../../common/hooks/use_experimental_features');
 
 const panelContextValue = {
   ...mockContextValue,
@@ -49,6 +51,7 @@ describe('<InvestigationSection />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useRuleWithFallback as jest.Mock).mockReturnValue({ rule: { note: 'test note' } });
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
   });
 
   it('should render investigation component', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/notes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/notes.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { memo, useCallback, useEffect } from 'react';
+import React, { memo, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -18,9 +18,8 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
 import { FormattedCount } from '../../../../common/components/formatted_number';
 import { useDocumentDetailsContext } from '../../shared/context';
 import {
@@ -29,6 +28,7 @@ import {
   NOTES_COUNT_TEST_ID,
   NOTES_LOADING_TEST_ID,
   NOTES_TITLE_TEST_ID,
+  NOTES_VIEW_NOTES_BUTTON_TEST_ID,
 } from './test_ids';
 import type { State } from '../../../../common/store';
 import type { Note } from '../../../../../common/api/timeline';
@@ -42,6 +42,7 @@ import {
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { AlertHeaderBlock } from './alert_header_block';
 import { LeftPanelNotesTab } from '../../left';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
 export const FETCH_NOTES_ERROR = i18n.translate(
   'xpack.securitySolution.flyout.right.notes.fetchNotesErrorLabel',
@@ -55,6 +56,12 @@ export const ADD_NOTE_BUTTON = i18n.translate(
     defaultMessage: 'Add note',
   }
 );
+export const VIEW_NOTES_BUTTON_ARIA_LABEL = i18n.translate(
+  'xpack.securitySolution.flyout.right.notes.viewNoteButtonAriaLabel',
+  {
+    defaultMessage: 'View notes',
+  }
+);
 
 /**
  * Renders a block with the number of notes for the event
@@ -62,30 +69,23 @@ export const ADD_NOTE_BUTTON = i18n.translate(
 export const Notes = memo(() => {
   const { euiTheme } = useEuiTheme();
   const dispatch = useDispatch();
-  const { eventId, indexName, scopeId, isPreview, isPreviewMode } = useDocumentDetailsContext();
+  const { eventId, isPreview } = useDocumentDetailsContext();
   const { addError: addErrorToast } = useAppToasts();
+  const { kibanaSecuritySolutionsPrivileges } = useUserPrivileges();
 
-  const { openLeftPanel } = useExpandableFlyoutApi();
-  const openExpandedFlyoutNotesTab = useCallback(
-    () =>
-      openLeftPanel({
-        id: DocumentDetailsLeftPanelKey,
-        path: { tab: LeftPanelNotesTab },
-        params: {
-          id: eventId,
-          indexName,
-          scopeId,
-        },
-      }),
-    [eventId, indexName, openLeftPanel, scopeId]
-  );
+  const { navigateToLeftPanel: openExpandedFlyoutNotesTab, isEnabled: isLinkEnabled } =
+    useNavigateToLeftPanel({
+      tab: LeftPanelNotesTab,
+    });
+
+  const isNotesDisabled = !isLinkEnabled || isPreview;
 
   useEffect(() => {
     // only fetch notes if we are not in a preview panel, or not in a rule preview workflow
-    if (!isPreviewMode && !isPreview) {
+    if (!isNotesDisabled) {
       dispatch(fetchNotesByDocumentIds({ documentIds: [eventId] }));
     }
-  }, [dispatch, eventId, isPreview, isPreviewMode]);
+  }, [dispatch, eventId, isNotesDisabled]);
 
   const fetchStatus = useSelector((state: State) => selectFetchNotesByDocumentIdsStatus(state));
   const fetchError = useSelector((state: State) => selectFetchNotesByDocumentIdsError(state));
@@ -100,6 +100,60 @@ export const Notes = memo(() => {
       });
     }
   }, [addErrorToast, fetchError, fetchStatus]);
+
+  const viewNotesButton = useMemo(
+    () => (
+      <EuiButtonEmpty
+        onClick={openExpandedFlyoutNotesTab}
+        size="s"
+        disabled={isNotesDisabled}
+        aria-label={VIEW_NOTES_BUTTON_ARIA_LABEL}
+        data-test-subj={NOTES_VIEW_NOTES_BUTTON_TEST_ID}
+      >
+        <FormattedMessage
+          id="xpack.securitySolution.flyout.right.notes.viewNoteButtonLabel"
+          defaultMessage="View {count, plural, one {note} other {notes}}"
+          values={{ count: notes.length }}
+        />
+      </EuiButtonEmpty>
+    ),
+    [isNotesDisabled, notes.length, openExpandedFlyoutNotesTab]
+  );
+  const addNoteButton = useMemo(
+    () => (
+      <EuiButtonEmpty
+        iconType="plusInCircle"
+        onClick={openExpandedFlyoutNotesTab}
+        size="s"
+        disabled={isNotesDisabled}
+        aria-label={ADD_NOTE_BUTTON}
+        data-test-subj={NOTES_ADD_NOTE_BUTTON_TEST_ID}
+      >
+        {ADD_NOTE_BUTTON}
+      </EuiButtonEmpty>
+    ),
+    [isNotesDisabled, openExpandedFlyoutNotesTab]
+  );
+  const addNoteButtonIcon = useMemo(
+    () => (
+      <EuiButtonIcon
+        onClick={openExpandedFlyoutNotesTab}
+        iconType="plusInCircle"
+        disabled={isNotesDisabled || !kibanaSecuritySolutionsPrivileges.crud}
+        css={css`
+          margin-left: ${euiTheme.size.xs};
+        `}
+        aria-label={ADD_NOTE_BUTTON}
+        data-test-subj={NOTES_ADD_NOTE_ICON_BUTTON_TEST_ID}
+      />
+    ),
+    [
+      euiTheme.size.xs,
+      isNotesDisabled,
+      kibanaSecuritySolutionsPrivileges.crud,
+      openExpandedFlyoutNotesTab,
+    ]
+  );
 
   return (
     <AlertHeaderBlock
@@ -120,32 +174,14 @@ export const Notes = memo(() => {
           ) : (
             <>
               {notes.length === 0 ? (
-                <EuiButtonEmpty
-                  iconType="plusInCircle"
-                  onClick={openExpandedFlyoutNotesTab}
-                  size="s"
-                  disabled={isPreviewMode || isPreview}
-                  aria-label={ADD_NOTE_BUTTON}
-                  data-test-subj={NOTES_ADD_NOTE_BUTTON_TEST_ID}
-                >
-                  {ADD_NOTE_BUTTON}
-                </EuiButtonEmpty>
+                 <>{kibanaSecuritySolutionsPrivileges.crud ? addNoteButton : getEmptyTagValue()}</>
               ) : (
                 <EuiFlexGroup responsive={false} alignItems="center" gutterSize="none">
                   <EuiFlexItem data-test-subj={NOTES_COUNT_TEST_ID}>
                     <FormattedCount count={notes.length} />
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiButtonIcon
-                      onClick={openExpandedFlyoutNotesTab}
-                      iconType="plusInCircle"
-                      disabled={isPreviewMode || isPreview}
-                      css={css`
-                        margin-left: ${euiTheme.size.xs};
-                      `}
-                      aria-label={ADD_NOTE_BUTTON}
-                      data-test-subj={NOTES_ADD_NOTE_ICON_BUTTON_TEST_ID}
-                    />
+                    {kibanaSecuritySolutionsPrivileges.crud ? addNoteButtonIcon : viewNotesButton}
                   </EuiFlexItem>
                 </EuiFlexGroup>
               )}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/notes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/notes.tsx
@@ -174,7 +174,7 @@ export const Notes = memo(() => {
           ) : (
             <>
               {notes.length === 0 ? (
-                 <>{kibanaSecuritySolutionsPrivileges.crud ? addNoteButton : getEmptyTagValue()}</>
+                <>{kibanaSecuritySolutionsPrivileges.crud ? addNoteButton : getEmptyTagValue()}</>
               ) : (
                 <EuiFlexGroup responsive={false} alignItems="center" gutterSize="none">
                   <EuiFlexItem data-test-subj={NOTES_COUNT_TEST_ID}>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/prevalence_overview.tsx
@@ -6,18 +6,17 @@
  */
 
 import type { FC } from 'react';
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { EuiBadge, EuiFlexGroup } from '@elastic/eui';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import { usePrevalence } from '../../shared/hooks/use_prevalence';
 import { PREVALENCE_TEST_ID } from './test_ids';
 import { useDocumentDetailsContext } from '../../shared/context';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
 import { LeftPanelInsightsTab } from '../../left';
 import { PREVALENCE_TAB_ID } from '../../left/components/prevalence_details';
 import { InsightsSummaryRow } from './insights_summary_row';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
 const UNCOMMON = (
   <FormattedMessage
@@ -35,30 +34,14 @@ const DEFAULT_TO = 'now';
  * The component fetches the necessary data at once. The loading and error states are handled by the ExpandablePanel component.
  */
 export const PrevalenceOverview: FC = () => {
-  const {
-    eventId,
-    indexName,
-    dataFormattedForFieldBrowser,
-    scopeId,
-    investigationFields,
-    isPreviewMode,
-  } = useDocumentDetailsContext();
-  const { openLeftPanel } = useExpandableFlyoutApi();
+  const { dataFormattedForFieldBrowser, investigationFields, isPreviewMode } =
+    useDocumentDetailsContext();
 
-  const goPrevalenceTab = useCallback(() => {
-    openLeftPanel({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInsightsTab,
-        subTab: PREVALENCE_TAB_ID,
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
+  const { navigateToLeftPanel: goToPrevalenceTab, isEnabled: isLinkEnabled } =
+    useNavigateToLeftPanel({
+      tab: LeftPanelInsightsTab,
+      subTab: PREVALENCE_TAB_ID,
     });
-  }, [eventId, openLeftPanel, indexName, scopeId]);
 
   const { loading, error, data } = usePrevalence({
     dataFormattedForFieldBrowser,
@@ -82,9 +65,9 @@ export const PrevalenceOverview: FC = () => {
   );
   const link = useMemo(
     () =>
-      !isPreviewMode
+      isLinkEnabled
         ? {
-            callback: goPrevalenceTab,
+            callback: goToPrevalenceTab,
             tooltip: (
               <FormattedMessage
                 id="xpack.securitySolution.flyout.right.insights.prevalence.prevalenceTooltip"
@@ -93,7 +76,7 @@ export const PrevalenceOverview: FC = () => {
             ),
           }
         : undefined,
-    [goPrevalenceTab, isPreviewMode]
+    [goToPrevalenceTab, isLinkEnabled]
   );
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_ancestry.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_ancestry.test.tsx
@@ -16,22 +16,16 @@ import {
 } from './test_ids';
 import { RelatedAlertsByAncestry } from './related_alerts_by_ancestry';
 import { useFetchRelatedAlertsByAncestry } from '../../shared/hooks/use_fetch_related_alerts_by_ancestry';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
-import { LeftPanelInsightsTab } from '../../left';
-import { CORRELATIONS_TAB_ID } from '../../left/components/correlations_details';
-import { useDocumentDetailsContext } from '../../shared/context';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
-jest.mock('@kbn/expandable-flyout');
-jest.mock('../../shared/context');
 jest.mock('../../shared/hooks/use_fetch_related_alerts_by_ancestry');
 
-const mockOpenLeftPanel = jest.fn();
+const mockNavigateToLeftPanel = jest.fn();
+jest.mock('../../shared/hooks/use_navigate_to_left_panel');
+
 const documentId = 'documentId';
 const indices = ['indices'];
 const scopeId = 'scopeId';
-const eventId = 'eventId';
-const indexName = 'indexName';
 
 const TEXT_TEST_ID = SUMMARY_ROW_TEXT_TEST_ID(CORRELATIONS_RELATED_ALERTS_BY_ANCESTRY_TEST_ID);
 const BUTTON_TEST_ID = SUMMARY_ROW_BUTTON_TEST_ID(CORRELATIONS_RELATED_ALERTS_BY_ANCESTRY_TEST_ID);
@@ -49,14 +43,10 @@ const renderRelatedAlertsByAncestry = () =>
 describe('<RelatedAlertsByAncestry />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-
-    (useDocumentDetailsContext as jest.Mock).mockReturnValue({
-      eventId,
-      indexName,
-      scopeId,
-      isPreviewMode: false,
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
+      navigateToLeftPanel: mockNavigateToLeftPanel,
+      isEnabled: true,
     });
-    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openLeftPanel: mockOpenLeftPanel });
   });
 
   it('should render single related alert correctly', () => {
@@ -112,17 +102,6 @@ describe('<RelatedAlertsByAncestry />', () => {
     const { getByTestId } = renderRelatedAlertsByAncestry();
     getByTestId(BUTTON_TEST_ID).click();
 
-    expect(mockOpenLeftPanel).toHaveBeenCalledWith({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInsightsTab,
-        subTab: CORRELATIONS_TAB_ID,
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
+    expect(mockNavigateToLeftPanel).toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_same_source_event.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_same_source_event.test.tsx
@@ -16,21 +16,15 @@ import {
 } from './test_ids';
 import { useFetchRelatedAlertsBySameSourceEvent } from '../../shared/hooks/use_fetch_related_alerts_by_same_source_event';
 import { RelatedAlertsBySameSourceEvent } from './related_alerts_by_same_source_event';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
-import { LeftPanelInsightsTab } from '../../left';
-import { CORRELATIONS_TAB_ID } from '../../left/components/correlations_details';
-import { useDocumentDetailsContext } from '../../shared/context';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
-jest.mock('@kbn/expandable-flyout');
-jest.mock('../../shared/context');
 jest.mock('../../shared/hooks/use_fetch_related_alerts_by_same_source_event');
 
-const mockOpenLeftPanel = jest.fn();
+const mockNavigateToLeftPanel = jest.fn();
+jest.mock('../../shared/hooks/use_navigate_to_left_panel');
+
 const originalEventId = 'originalEventId';
 const scopeId = 'scopeId';
-const eventId = 'eventId';
-const indexName = 'indexName';
 
 const TEXT_TEST_ID = SUMMARY_ROW_TEXT_TEST_ID(
   CORRELATIONS_RELATED_ALERTS_BY_SAME_SOURCE_EVENT_TEST_ID
@@ -53,13 +47,10 @@ describe('<RelatedAlertsBySameSourceEvent />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useDocumentDetailsContext as jest.Mock).mockReturnValue({
-      eventId,
-      indexName,
-      scopeId,
-      isPreviewMode: false,
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
+      navigateToLeftPanel: mockNavigateToLeftPanel,
+      isEnabled: true,
     });
-    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openLeftPanel: mockOpenLeftPanel });
   });
 
   it('should render single related alert correctly', () => {
@@ -117,17 +108,6 @@ describe('<RelatedAlertsBySameSourceEvent />', () => {
     const { getByTestId } = renderRelatedAlertsBySameSourceEvent();
     getByTestId(BUTTON_TEST_ID).click();
 
-    expect(mockOpenLeftPanel).toHaveBeenCalledWith({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInsightsTab,
-        subTab: CORRELATIONS_TAB_ID,
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
+    expect(mockNavigateToLeftPanel).toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_session.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_alerts_by_session.test.tsx
@@ -16,19 +16,13 @@ import {
 } from './test_ids';
 import { RelatedAlertsBySession } from './related_alerts_by_session';
 import { useFetchRelatedAlertsBySession } from '../../shared/hooks/use_fetch_related_alerts_by_session';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
-import { LeftPanelInsightsTab } from '../../left';
-import { CORRELATIONS_TAB_ID } from '../../left/components/correlations_details';
-import { useDocumentDetailsContext } from '../../shared/context';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
-jest.mock('@kbn/expandable-flyout');
-jest.mock('../../shared/context');
 jest.mock('../../shared/hooks/use_fetch_related_alerts_by_session');
 
-const mockOpenLeftPanel = jest.fn();
-const eventId = 'eventId';
-const indexName = 'indexName';
+const mockNavigateToLeftPanel = jest.fn();
+jest.mock('../../shared/hooks/use_navigate_to_left_panel');
+
 const entityId = 'entityId';
 const scopeId = 'scopeId';
 
@@ -47,13 +41,10 @@ describe('<RelatedAlertsBySession />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useDocumentDetailsContext as jest.Mock).mockReturnValue({
-      eventId,
-      indexName,
-      scopeId,
-      isPreviewMode: false,
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
+      navigateToLeftPanel: mockNavigateToLeftPanel,
+      isEnabled: true,
     });
-    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openLeftPanel: mockOpenLeftPanel });
   });
 
   it('should render single related alerts correctly', () => {
@@ -109,17 +100,6 @@ describe('<RelatedAlertsBySession />', () => {
     const { getByTestId } = renderRelatedAlertsBySession();
     getByTestId(BUTTON_TEST_ID).click();
 
-    expect(mockOpenLeftPanel).toHaveBeenCalledWith({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInsightsTab,
-        subTab: CORRELATIONS_TAB_ID,
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
+    expect(mockNavigateToLeftPanel).toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_cases.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/related_cases.test.tsx
@@ -16,20 +16,14 @@ import {
 } from './test_ids';
 import { RelatedCases } from './related_cases';
 import { useFetchRelatedCases } from '../../shared/hooks/use_fetch_related_cases';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
-import { LeftPanelInsightsTab } from '../../left';
-import { CORRELATIONS_TAB_ID } from '../../left/components/correlations_details';
-import { useDocumentDetailsContext } from '../../shared/context';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
-jest.mock('@kbn/expandable-flyout');
-jest.mock('../../shared/context');
 jest.mock('../../shared/hooks/use_fetch_related_cases');
 
-const mockOpenLeftPanel = jest.fn();
+const mockNavigateToLeftPanel = jest.fn();
+jest.mock('../../shared/hooks/use_navigate_to_left_panel');
+
 const eventId = 'eventId';
-const indexName = 'indexName';
-const scopeId = 'scopeId';
 
 const TEXT_TEST_ID = SUMMARY_ROW_TEXT_TEST_ID(CORRELATIONS_RELATED_CASES_TEST_ID);
 const BUTTON_TEST_ID = SUMMARY_ROW_BUTTON_TEST_ID(CORRELATIONS_RELATED_CASES_TEST_ID);
@@ -46,13 +40,10 @@ describe('<RelatedCases />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useDocumentDetailsContext as jest.Mock).mockReturnValue({
-      eventId,
-      indexName,
-      scopeId,
-      isPreviewMode: false,
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
+      navigateToLeftPanel: mockNavigateToLeftPanel,
+      isEnabled: true,
     });
-    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openLeftPanel: mockOpenLeftPanel });
   });
 
   it('should render single related case correctly', () => {
@@ -108,17 +99,6 @@ describe('<RelatedCases />', () => {
     const { getByTestId } = renderRelatedCases();
     getByTestId(BUTTON_TEST_ID).click();
 
-    expect(mockOpenLeftPanel).toHaveBeenCalledWith({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInsightsTab,
-        subTab: CORRELATIONS_TAB_ID,
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
+    expect(mockNavigateToLeftPanel).toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_button.test.tsx
@@ -14,6 +14,9 @@ import { mockContextValue } from '../../shared/mocks/mock_context';
 import { ResponseButton } from './response_button';
 import type { SearchHit } from '../../../../../common/search_strategy';
 import { TestProvider } from '@kbn/expandable-flyout/src/test/provider';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+
+jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockValidSearchHit = {
   fields: {
@@ -42,6 +45,7 @@ const renderResponseButton = (panelContextValue: DocumentDetailsContext = mockCo
   );
 describe('<ResponseButton />', () => {
   it('should render response button correctly', () => {
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
     const panelContextValue = { ...mockContextValue, searchHit: mockValidSearchHit };
     const { getByTestId, queryByTestId } = renderResponseButton(panelContextValue);
     expect(getByTestId(RESPONSE_BUTTON_TEST_ID)).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_button.tsx
@@ -4,33 +4,20 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import { EuiButton } from '@elastic/eui';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useDocumentDetailsContext } from '../../shared/context';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
 import { LeftPanelResponseTab } from '../../left';
 import { RESPONSE_BUTTON_TEST_ID } from './test_ids';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
 /**
  * Response button that opens Response section in the left panel
  */
 export const ResponseButton: React.FC = () => {
-  const { openLeftPanel } = useExpandableFlyoutApi();
-  const { eventId, indexName, scopeId } = useDocumentDetailsContext();
-
-  const goToResponseTab = useCallback(() => {
-    openLeftPanel({
-      id: DocumentDetailsLeftPanelKey,
-      path: { tab: LeftPanelResponseTab },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
-  }, [eventId, indexName, openLeftPanel, scopeId]);
+  const { navigateToLeftPanel: goToResponseTab } = useNavigateToLeftPanel({
+    tab: LeftPanelResponseTab,
+  });
 
   return (
     <>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.test.tsx
@@ -18,8 +18,18 @@ import { mockContextValue } from '../../shared/mocks/mock_context';
 import { ResponseSection } from './response_section';
 import { TestProvider } from '@kbn/expandable-flyout/src/test/provider';
 import { useExpandSection } from '../hooks/use_expand_section';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import { useKibana as mockUseKibana } from '../../../../common/lib/kibana/__mocks__';
+import { useKibana } from '../../../../common/lib/kibana';
 
 jest.mock('../hooks/use_expand_section');
+jest.mock('../../../../common/lib/kibana');
+jest.mock('../../../../common/hooks/use_experimental_features');
+
+const mockedUseKibana = mockUseKibana();
+(useKibana as jest.Mock).mockReturnValue(mockedUseKibana);
+
+const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
 
 const PREVIEW_MESSAGE = 'Response is not available in alert preview.';
 const OPEN_FLYOUT_MESSAGE = 'Open alert details to access response actions.';
@@ -36,6 +46,10 @@ const renderResponseSection = () =>
   );
 
 describe('<ResponseSection />', () => {
+  beforeEach(() => {
+    mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+  });
+
   it('should render response component', () => {
     const { getByTestId } = renderResponseSection();
 
@@ -100,7 +114,7 @@ describe('<ResponseSection />', () => {
     expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).toHaveTextContent(PREVIEW_MESSAGE);
   });
 
-  it('should render open details flyout message if flyout is in preview', () => {
+  it('should render open details flyout message if flyout is in preview mode', () => {
     (useExpandSection as jest.Mock).mockReturnValue(true);
 
     const { getByTestId } = render(
@@ -139,5 +153,26 @@ describe('<ResponseSection />', () => {
       </IntlProvider>
     );
     expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('newExpandableFlyoutNavigationEnabled', () => {
+    beforeEach(() => {
+      mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+    });
+
+    it('should render if isPreviewMode is true', () => {
+      const { getByTestId } = render(
+        <IntlProvider locale="en">
+          <TestProvider>
+            <DocumentDetailsContext.Provider value={{ ...mockContextValue, isPreviewMode: true }}>
+              <ResponseSection />
+            </DocumentDetailsContext.Provider>
+          </TestProvider>
+        </IntlProvider>
+      );
+      expect(getByTestId(RESPONSE_SECTION_HEADER_TEST_ID)).toBeInTheDocument();
+      expect(getByTestId(RESPONSE_SECTION_HEADER_TEST_ID)).toHaveTextContent('Response');
+      expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
@@ -16,6 +16,7 @@ import { useDocumentDetailsContext } from '../../shared/context';
 import { getField } from '../../shared/utils';
 import { EventKind } from '../../shared/constants/event_kinds';
 import { RESPONSE_SECTION_TEST_ID } from './test_ids';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 const KEY = 'response';
 
@@ -27,6 +28,10 @@ export const ResponseSection = memo(() => {
 
   const expanded = useExpandSection({ title: KEY, defaultValue: false });
   const eventKind = getField(getFieldsData('event.kind'));
+
+  const isNewNavigationEnabled = useIsExperimentalFeatureEnabled(
+    'newExpandableFlyoutNavigationEnabled'
+  );
 
   const content = useMemo(() => {
     if (isPreview) {
@@ -53,7 +58,7 @@ export const ResponseSection = memo(() => {
       );
     }
 
-    if (isPreviewMode) {
+    if (!isNewNavigationEnabled && isPreviewMode) {
       return (
         <EuiCallOut
           iconType="documentation"
@@ -78,7 +83,7 @@ export const ResponseSection = memo(() => {
     }
 
     return <ResponseButton />;
-  }, [isPreview, isPreviewMode]);
+  }, [isPreview, isPreviewMode, isNewNavigationEnabled]);
 
   if (eventKind !== EventKind.signal) {
     return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.test.tsx
@@ -21,9 +21,15 @@ import {
   EXPANDABLE_PANEL_TOGGLE_ICON_TEST_ID,
 } from '../../../shared/components/test_ids';
 import { mockContextValue } from '../../shared/mocks/mock_context';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import { useInvestigateInTimeline } from '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
 
 jest.mock('../hooks/use_session_preview');
 jest.mock('../../../../common/hooks/use_license');
+jest.mock('../../../../common/hooks/use_experimental_features');
+jest.mock(
+  '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
+);
 
 const mockNavigateToSessionView = jest.fn();
 jest.mock('../../shared/hooks/use_navigate_to_session_view', () => {
@@ -36,6 +42,15 @@ jest.mock('@kbn/kibana-react-plugin/public', () => {
   return {
     ...original,
     useUiSetting$: () => mockUseUiSetting(),
+  };
+});
+
+jest.mock('react-redux', () => {
+  const original = jest.requireActual('react-redux');
+
+  return {
+    ...original,
+    useDispatch: () => jest.fn(),
   };
 });
 
@@ -62,6 +77,10 @@ const renderSessionPreview = (context = mockContextValue) =>
 describe('SessionPreviewContainer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
+    (useInvestigateInTimeline as jest.Mock).mockReturnValue({
+      investigateInTimelineAlertClick: jest.fn(),
+    });
   });
 
   it('should render component and link in header', () => {
@@ -226,6 +245,105 @@ describe('SessionPreviewContainer', () => {
       expect(
         queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when new navigation is enabled', () => {
+    describe('when visualization in flyout flag is enabled', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseUiSetting.mockReturnValue([true]);
+        (useSessionPreview as jest.Mock).mockReturnValue(sessionViewConfig);
+        (useLicense as jest.Mock).mockReturnValue({ isEnterprise: () => true });
+        (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+      });
+
+      it('should open left panel vizualization tab when visualization in flyout flag is on', () => {
+        const { getByTestId } = renderSessionPreview();
+
+        expect(
+          getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
+        ).toBeInTheDocument();
+        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID)).click();
+
+        expect(mockNavigateToSessionView).toHaveBeenCalled();
+      });
+
+      it('should not render link to session viewer if flyout is open in rule preview', () => {
+        const { getByTestId, queryByTestId } = renderSessionPreview({
+          ...mockContextValue,
+          isPreview: true,
+        });
+
+        expect(getByTestId(SESSION_PREVIEW_TEST_ID)).toBeInTheDocument();
+        expect(
+          getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(SESSION_PREVIEW_TEST_ID))
+        ).toBeInTheDocument();
+        expect(
+          queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
+        ).not.toBeInTheDocument();
+      });
+
+      it('should render link to session viewer if flyout is open in preview mode', () => {
+        const { getByTestId } = renderSessionPreview({
+          ...mockContextValue,
+          isPreviewMode: true,
+        });
+
+        expect(getByTestId(SESSION_PREVIEW_TEST_ID)).toBeInTheDocument();
+        expect(
+          getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
+        ).toBeInTheDocument();
+
+        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID)).click();
+        expect(mockNavigateToSessionView).toHaveBeenCalled();
+      });
+    });
+
+    describe('when visualization in flyout flag is not enabled', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseUiSetting.mockReturnValue([false]);
+        (useSessionPreview as jest.Mock).mockReturnValue(sessionViewConfig);
+        (useLicense as jest.Mock).mockReturnValue({ isEnterprise: () => true });
+        (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+      });
+
+      it('should open session viewer in timeline', () => {
+        const { getByTestId } = renderSessionPreview();
+        const { investigateInTimelineAlertClick } = useInvestigateInTimeline({});
+        expect(
+          getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
+        ).toBeInTheDocument();
+        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID)).click();
+
+        expect(investigateInTimelineAlertClick).toHaveBeenCalled();
+      });
+
+      it('should not render link to session viewer if flyout is open in rule preview', () => {
+        const { getByTestId, queryByTestId } = renderSessionPreview({
+          ...mockContextValue,
+          isPreview: true,
+        });
+
+        expect(getByTestId(SESSION_PREVIEW_TEST_ID)).toBeInTheDocument();
+        expect(
+          getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_TEXT_TEST_ID(SESSION_PREVIEW_TEST_ID))
+        ).toBeInTheDocument();
+        expect(
+          queryByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID))
+        ).not.toBeInTheDocument();
+      });
+
+      it('should render link to open session viewer in timeline if flyout is open in preview mode', () => {
+        const { getByTestId } = renderSessionPreview({
+          ...mockContextValue,
+          isPreviewMode: true,
+        });
+        const { investigateInTimelineAlertClick } = useInvestigateInTimeline({});
+        getByTestId(EXPANDABLE_PANEL_HEADER_TITLE_LINK_TEST_ID(SESSION_PREVIEW_TEST_ID)).click();
+        expect(investigateInTimelineAlertClick).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/suppressed_alerts.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/suppressed_alerts.test.tsx
@@ -16,17 +16,15 @@ import {
 } from './test_ids';
 import { SuppressedAlerts } from './suppressed_alerts';
 import { isSuppressionRuleInGA } from '../../../../../common/detection_engine/utils';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
-import { LeftPanelInsightsTab } from '../../left';
-import { CORRELATIONS_TAB_ID } from '../../left/components/correlations_details';
-import { useDocumentDetailsContext } from '../../shared/context';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
-jest.mock('@kbn/expandable-flyout');
 jest.mock('../../shared/context');
 jest.mock('../../../../../common/detection_engine/utils', () => ({
   isSuppressionRuleInGA: jest.fn().mockReturnValue(false),
 }));
+
+const mockNavigateToLeftPanel = jest.fn();
+jest.mock('../../shared/hooks/use_navigate_to_left_panel');
 
 const TEXT_TEST_ID = SUMMARY_ROW_TEXT_TEST_ID(CORRELATIONS_SUPPRESSED_ALERTS_TEST_ID);
 const BUTTON_TEST_ID = SUMMARY_ROW_BUTTON_TEST_ID(CORRELATIONS_SUPPRESSED_ALERTS_TEST_ID);
@@ -38,23 +36,16 @@ const renderSuppressedAlerts = (alertSuppressionCount: number) =>
     </IntlProvider>
   );
 
-const mockOpenLeftPanel = jest.fn();
-const scopeId = 'scopeId';
-const eventId = 'eventId';
-const indexName = 'indexName';
 const isSuppressionRuleInGAMock = isSuppressionRuleInGA as jest.Mock;
 
 describe('<SuppressedAlerts />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useDocumentDetailsContext as jest.Mock).mockReturnValue({
-      eventId,
-      indexName,
-      scopeId,
-      isPreviewMode: false,
+    (useNavigateToLeftPanel as jest.Mock).mockReturnValue({
+      navigateToLeftPanel: mockNavigateToLeftPanel,
+      isEnabled: true,
     });
-    (useExpandableFlyoutApi as jest.Mock).mockReturnValue({ openLeftPanel: mockOpenLeftPanel });
   });
 
   it('should render single suppressed alert correctly', () => {
@@ -87,17 +78,6 @@ describe('<SuppressedAlerts />', () => {
     const { getByTestId } = renderSuppressedAlerts(1);
     getByTestId(BUTTON_TEST_ID).click();
 
-    expect(mockOpenLeftPanel).toHaveBeenCalledWith({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInsightsTab,
-        subTab: CORRELATIONS_TAB_ID,
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
-    });
+    expect(mockNavigateToLeftPanel).toHaveBeenCalled();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/test_ids.ts
@@ -35,6 +35,8 @@ export const CHAT_BUTTON_TEST_ID = 'newChatByTitle' as const;
 
 export const NOTES_TITLE_TEST_ID = `${FLYOUT_HEADER_TEST_ID}NotesTitle` as const;
 export const NOTES_ADD_NOTE_BUTTON_TEST_ID = `${FLYOUT_HEADER_TEST_ID}NotesAddNoteButton` as const;
+export const NOTES_VIEW_NOTES_BUTTON_TEST_ID =
+  `${FLYOUT_HEADER_TEST_ID}NotesViewNotesButton` as const;
 export const NOTES_ADD_NOTE_ICON_BUTTON_TEST_ID =
   `${FLYOUT_HEADER_TEST_ID}NotesAddNoteIconButton` as const;
 export const NOTES_COUNT_TEST_ID = `${FLYOUT_HEADER_TEST_ID}NotesCount` as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/threat_intelligence_overview.tsx
@@ -6,9 +6,8 @@
  */
 
 import type { FC } from 'react';
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { EuiFlexGroup } from '@elastic/eui';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import { useFetchThreatIntelligence } from '../hooks/use_fetch_threat_intelligence';
@@ -19,9 +18,9 @@ import {
   INSIGHTS_THREAT_INTELLIGENCE_TEST_ID,
   INSIGHTS_THREAT_INTELLIGENCE_THREAT_MATCHES_TEST_ID,
 } from './test_ids';
-import { DocumentDetailsLeftPanelKey } from '../../shared/constants/panel_keys';
 import { LeftPanelInsightsTab } from '../../left';
 import { THREAT_INTELLIGENCE_TAB_ID } from '../../left/components/threat_intelligence_details';
+import { useNavigateToLeftPanel } from '../../shared/hooks/use_navigate_to_left_panel';
 
 const TITLE = (
   <FormattedMessage
@@ -42,24 +41,13 @@ const TOOLTIP = (
  * and the SummaryPanel component for data rendering.
  */
 export const ThreatIntelligenceOverview: FC = () => {
-  const { eventId, indexName, scopeId, dataFormattedForFieldBrowser, isPreviewMode } =
-    useDocumentDetailsContext();
-  const { openLeftPanel } = useExpandableFlyoutApi();
+  const { dataFormattedForFieldBrowser, isPreviewMode } = useDocumentDetailsContext();
 
-  const goToThreatIntelligenceTab = useCallback(() => {
-    openLeftPanel({
-      id: DocumentDetailsLeftPanelKey,
-      path: {
-        tab: LeftPanelInsightsTab,
-        subTab: THREAT_INTELLIGENCE_TAB_ID,
-      },
-      params: {
-        id: eventId,
-        indexName,
-        scopeId,
-      },
+  const { navigateToLeftPanel: goToThreatIntelligenceTab, isEnabled: isLinkEnabled } =
+    useNavigateToLeftPanel({
+      tab: LeftPanelInsightsTab,
+      subTab: THREAT_INTELLIGENCE_TAB_ID,
     });
-  }, [eventId, openLeftPanel, indexName, scopeId]);
 
   const { loading, threatMatchesCount, threatEnrichmentsCount } = useFetchThreatIntelligence({
     dataFormattedForFieldBrowser,
@@ -67,13 +55,13 @@ export const ThreatIntelligenceOverview: FC = () => {
 
   const link = useMemo(
     () =>
-      !isPreviewMode
+      isLinkEnabled
         ? {
             callback: goToThreatIntelligenceTab,
             tooltip: TOOLTIP,
           }
         : undefined,
-    [isPreviewMode, goToThreatIntelligenceTab]
+    [goToThreatIntelligenceTab, isLinkEnabled]
   );
 
   const threatMatchCountText = useMemo(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.test.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useNavigateToLeftPanel } from './use_navigate_to_left_panel';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { renderHook } from '@testing-library/react-hooks';
+import { useDocumentDetailsContext } from '../context';
+import { mockFlyoutApi } from '../mocks/mock_flyout_context';
+import { DocumentDetailsRightPanelKey, DocumentDetailsLeftPanelKey } from '../constants/panel_keys';
+import { useKibana as mockUseKibana } from '../../../../common/lib/kibana/__mocks__';
+import { useKibana } from '../../../../common/lib/kibana';
+
+const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
+jest.mock('../../../../common/hooks/use_experimental_features');
+
+jest.mock('../../../../common/lib/kibana');
+
+const mockedUseKibana = mockUseKibana();
+(useKibana as jest.Mock).mockReturnValue(mockedUseKibana);
+
+jest.mock('@kbn/expandable-flyout');
+jest.mock('../context');
+
+const eventId = 'eventId';
+const indexName = 'indexName';
+const scopeId = 'scopeId';
+
+describe('useNavigateToLeftPanel', () => {
+  describe('newExpandableFlyoutNavigationEnabled is not enabled', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockUseIsExperimentalFeatureEnabled.mockReturnValue(false);
+      jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
+    });
+
+    it('should enable navigation if isPreviewMode is false', () => {
+      (useDocumentDetailsContext as jest.Mock).mockReturnValue({
+        eventId,
+        indexName,
+        scopeId,
+        isPreviewMode: false,
+      });
+      const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
+      expect(hookResult.result.current.isEnabled).toEqual(true);
+
+      hookResult.result.current.navigateToLeftPanel();
+
+      expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
+        id: DocumentDetailsLeftPanelKey,
+        path: {
+          tab: 'tab',
+          subTab: 'subTab',
+        },
+        params: {
+          id: eventId,
+          indexName,
+          scopeId,
+        },
+      });
+      expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
+    });
+
+    it('should disable navigation if isPreviewMode is true', () => {
+      (useDocumentDetailsContext as jest.Mock).mockReturnValue({
+        eventId,
+        indexName,
+        scopeId,
+        isPreviewMode: true,
+      });
+
+      const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
+      expect(hookResult.result.current.isEnabled).toEqual(false);
+
+      hookResult.result.current.navigateToLeftPanel();
+
+      expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
+      expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('newExpandableFlyoutNavigationEnabled', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockUseIsExperimentalFeatureEnabled.mockReturnValue(true);
+    });
+
+    it('should enable navigation if isPreviewMode is false', () => {
+      (useDocumentDetailsContext as jest.Mock).mockReturnValue({
+        eventId,
+        indexName,
+        scopeId,
+        isPreviewMode: false,
+      });
+      const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
+      expect(hookResult.result.current.isEnabled).toEqual(true);
+
+      hookResult.result.current.navigateToLeftPanel();
+
+      expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
+        id: DocumentDetailsLeftPanelKey,
+        path: {
+          tab: 'tab',
+          subTab: 'subTab',
+        },
+        params: {
+          id: eventId,
+          indexName,
+          scopeId,
+        },
+      });
+      expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
+    });
+
+    it('should open new flyout if isPreviewMode is true', () => {
+      (useDocumentDetailsContext as jest.Mock).mockReturnValue({
+        eventId,
+        indexName,
+        scopeId,
+        isPreviewMode: true,
+      });
+      const hookResult = renderHook(() => useNavigateToLeftPanel({ tab: 'tab', subTab: 'subTab' }));
+      expect(hookResult.result.current.isEnabled).toEqual(true);
+
+      hookResult.result.current.navigateToLeftPanel();
+
+      expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
+      expect(mockFlyoutApi.openFlyout).toHaveBeenCalledWith({
+        right: {
+          id: DocumentDetailsRightPanelKey,
+          params: {
+            id: eventId,
+            indexName,
+            scopeId,
+          },
+        },
+        left: {
+          id: DocumentDetailsLeftPanelKey,
+          path: {
+            tab: 'tab',
+            subTab: 'subTab',
+          },
+          params: {
+            id: eventId,
+            indexName,
+            scopeId,
+          },
+        },
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_session_view.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_session_view.test.tsx
@@ -13,9 +13,11 @@ import { useKibana as mockUseKibana } from '../../../../common/lib/kibana/__mock
 import { useKibana } from '../../../../common/lib/kibana';
 import { DocumentDetailsRightPanelKey, DocumentDetailsLeftPanelKey } from '../constants/panel_keys';
 import { SESSION_VIEW_ID } from '../../left/components/session_view';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 jest.mock('@kbn/expandable-flyout');
 jest.mock('../../../../common/lib/kibana');
+jest.mock('../../../../common/hooks/use_experimental_features');
 
 const mockedUseKibana = mockUseKibana();
 (useKibana as jest.Mock).mockReturnValue(mockedUseKibana);
@@ -28,6 +30,7 @@ describe('useNavigateToSessionView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
   });
 
   it('when isFlyoutOpen is true, should return callback that opens left panel', () => {
@@ -35,7 +38,7 @@ describe('useNavigateToSessionView', () => {
       useNavigateToSessionView({ isFlyoutOpen: true, eventId, indexName, scopeId })
     );
     hookResult.result.current.navigateToSessionView();
-
+    expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
     expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
       id: DocumentDetailsLeftPanelKey,
       path: {
@@ -50,11 +53,28 @@ describe('useNavigateToSessionView', () => {
     });
   });
 
+  it('when isFlyoutOpen is true and in preview mode, navigation is disabled', () => {
+    const hookResult = renderHook(() =>
+      useNavigateToSessionView({
+        isFlyoutOpen: true,
+        eventId,
+        indexName,
+        scopeId,
+        isPreviewMode: true,
+      })
+    );
+    hookResult.result.current.navigateToSessionView();
+
+    expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
+    expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
+  });
+
   it('when isFlyoutOpen is false, should return callback that opens a new flyout', () => {
     const hookResult = renderHook(() =>
       useNavigateToSessionView({ isFlyoutOpen: false, eventId, indexName, scopeId })
     );
     hookResult.result.current.navigateToSessionView();
+    expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
     expect(mockFlyoutApi.openFlyout).toHaveBeenCalledWith({
       right: {
         id: DocumentDetailsRightPanelKey,
@@ -76,6 +96,98 @@ describe('useNavigateToSessionView', () => {
           scopeId,
         },
       },
+    });
+  });
+
+  describe('when new navigation is enabled', () => {
+    beforeEach(() => {
+      (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+    });
+    it('when isFlyoutOpen is true, should return callback that opens left panel', () => {
+      const hookResult = renderHook(() =>
+        useNavigateToSessionView({ isFlyoutOpen: true, eventId, indexName, scopeId })
+      );
+      hookResult.result.current.navigateToSessionView();
+      expect(mockFlyoutApi.openFlyout).not.toHaveBeenCalled();
+      expect(mockFlyoutApi.openLeftPanel).toHaveBeenCalledWith({
+        id: DocumentDetailsLeftPanelKey,
+        path: {
+          tab: 'visualize',
+          subTab: SESSION_VIEW_ID,
+        },
+        params: {
+          id: eventId,
+          indexName,
+          scopeId,
+        },
+      });
+    });
+
+    it('when isFlyoutOpen is true and in preview mode, should return callback that opens a new flyout', () => {
+      const hookResult = renderHook(() =>
+        useNavigateToSessionView({
+          isFlyoutOpen: true,
+          eventId,
+          indexName,
+          scopeId,
+          isPreviewMode: true,
+        })
+      );
+      hookResult.result.current.navigateToSessionView();
+
+      expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
+      expect(mockFlyoutApi.openFlyout).toHaveBeenCalledWith({
+        right: {
+          id: DocumentDetailsRightPanelKey,
+          params: {
+            id: eventId,
+            indexName,
+            scopeId,
+          },
+        },
+        left: {
+          id: DocumentDetailsLeftPanelKey,
+          path: {
+            tab: 'visualize',
+            subTab: SESSION_VIEW_ID,
+          },
+          params: {
+            id: eventId,
+            indexName,
+            scopeId,
+          },
+        },
+      });
+    });
+
+    it('when isFlyoutOpen is false, should return callback that opens a new flyout', () => {
+      const hookResult = renderHook(() =>
+        useNavigateToSessionView({ isFlyoutOpen: false, eventId, indexName, scopeId })
+      );
+      hookResult.result.current.navigateToSessionView();
+      expect(mockFlyoutApi.openLeftPanel).not.toHaveBeenCalled();
+      expect(mockFlyoutApi.openFlyout).toHaveBeenCalledWith({
+        right: {
+          id: DocumentDetailsRightPanelKey,
+          params: {
+            id: eventId,
+            indexName,
+            scopeId,
+          },
+        },
+        left: {
+          id: DocumentDetailsLeftPanelKey,
+          path: {
+            tab: 'visualize',
+            subTab: SESSION_VIEW_ID,
+          },
+          params: {
+            id: eventId,
+            indexName,
+            scopeId,
+          },
+        },
+      });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_navigation.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_navigation.tsx
@@ -63,12 +63,12 @@ export const FlyoutNavigation: FC<FlyoutNavigationProps> = memo(
     const { euiTheme } = useEuiTheme();
 
     const history = useExpandableFlyoutHistory();
-    const isFlyoutHistoryEnabled = useIsExperimentalFeatureEnabled(
+    const isNewNavigationEnabled = useIsExperimentalFeatureEnabled(
       'newExpandableFlyoutNavigationEnabled'
     );
     const historyArray = useMemo(() => getProcessedHistory({ history, maxCount: 10 }), [history]);
     // Don't show history in rule preview
-    const hasHistory = !isPreview && isFlyoutHistoryEnabled;
+    const hasHistory = !isPreview && isNewNavigationEnabled;
 
     const panels = useExpandableFlyoutState();
     const isExpanded: boolean = !!panels.left;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution] Preview navigation in document details flyout (#204292)](https://github.com/elastic/kibana/pull/204292)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"christineweng","email":"18648970+christineweng@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-12-16T22:34:26Z","message":"[Security Solution] Preview navigation in document details flyout (#204292)\n\n## Summary\r\n\r\nThis PR enables navigation when an user is viewing an alert/event\r\npreview.\r\n\r\n- To see the new navigation, enable feature flag\r\n`newExpandableFlyoutNavigationEnabled`\r\n- This PR only covers navigations available in the alert/event preview.\r\nLinks in host and user flyouts will be done in a separate PR\r\n\r\nHow navigation used to work:\r\n- When a document details flyout is open, many sections have nevigation\r\nlinks to open the details panel in the left\r\n- However, these navigations were disabled in a preview mode, and user\r\nis limited to stay in the original flyout context\r\n\r\nPreview navigations now available\r\n- When the feature flag is on, navigation links is available\r\n- For example, an user is on an alert preview, and click on `Entities`,\r\na new flyout will be opened (for the alert context) and the entities\r\ndetails section will be available.\r\n\r\n**Before**\r\n<img width=\"1483\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/a8a21b86-21c1-48d4-ae4e-4ca5b337a2b0\"\r\n/>\r\n\r\n**After**\r\n<img width=\"1449\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/2db865f3-3a31-440c-bc84-3003928c1f6a\"\r\n/>\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/ae62b553-1ec9-4663-9ed3-ff20b2355061\r\n\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"d638475c6760b844f8ef928a21d382ef279566df","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","v9.0.0","Team:Threat Hunting","release_note:feature","Team:Threat Hunting:Investigations","v8.18.0"],"number":204292,"url":"https://github.com/elastic/kibana/pull/204292","mergeCommit":{"message":"[Security Solution] Preview navigation in document details flyout (#204292)\n\n## Summary\r\n\r\nThis PR enables navigation when an user is viewing an alert/event\r\npreview.\r\n\r\n- To see the new navigation, enable feature flag\r\n`newExpandableFlyoutNavigationEnabled`\r\n- This PR only covers navigations available in the alert/event preview.\r\nLinks in host and user flyouts will be done in a separate PR\r\n\r\nHow navigation used to work:\r\n- When a document details flyout is open, many sections have nevigation\r\nlinks to open the details panel in the left\r\n- However, these navigations were disabled in a preview mode, and user\r\nis limited to stay in the original flyout context\r\n\r\nPreview navigations now available\r\n- When the feature flag is on, navigation links is available\r\n- For example, an user is on an alert preview, and click on `Entities`,\r\na new flyout will be opened (for the alert context) and the entities\r\ndetails section will be available.\r\n\r\n**Before**\r\n<img width=\"1483\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/a8a21b86-21c1-48d4-ae4e-4ca5b337a2b0\"\r\n/>\r\n\r\n**After**\r\n<img width=\"1449\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/2db865f3-3a31-440c-bc84-3003928c1f6a\"\r\n/>\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/ae62b553-1ec9-4663-9ed3-ff20b2355061\r\n\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"d638475c6760b844f8ef928a21d382ef279566df"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/204292","number":204292,"mergeCommit":{"message":"[Security Solution] Preview navigation in document details flyout (#204292)\n\n## Summary\r\n\r\nThis PR enables navigation when an user is viewing an alert/event\r\npreview.\r\n\r\n- To see the new navigation, enable feature flag\r\n`newExpandableFlyoutNavigationEnabled`\r\n- This PR only covers navigations available in the alert/event preview.\r\nLinks in host and user flyouts will be done in a separate PR\r\n\r\nHow navigation used to work:\r\n- When a document details flyout is open, many sections have nevigation\r\nlinks to open the details panel in the left\r\n- However, these navigations were disabled in a preview mode, and user\r\nis limited to stay in the original flyout context\r\n\r\nPreview navigations now available\r\n- When the feature flag is on, navigation links is available\r\n- For example, an user is on an alert preview, and click on `Entities`,\r\na new flyout will be opened (for the alert context) and the entities\r\ndetails section will be available.\r\n\r\n**Before**\r\n<img width=\"1483\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/a8a21b86-21c1-48d4-ae4e-4ca5b337a2b0\"\r\n/>\r\n\r\n**After**\r\n<img width=\"1449\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/2db865f3-3a31-440c-bc84-3003928c1f6a\"\r\n/>\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/ae62b553-1ec9-4663-9ed3-ff20b2355061\r\n\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"d638475c6760b844f8ef928a21d382ef279566df"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->