### PR TITLE
Fix code scanning alert no. 494: Incomplete string escaping or encoding

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/components/rule_condition_chart/helpers.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/components/rule_condition_chart/helpers.ts
@@ -18,7 +18,7 @@ export const getLensOperationFromRuleMetric = (metric: GenericMetric): LensOpera
   const { aggType, field, filter = '' } = metric;
   let operation: string = aggType;
   const operationArgs: string[] = [];
-  const escapedFilter = filter.replace(/'/g, "\\'");
+  const escapedFilter = filter.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 
   if (aggType === Aggregators.RATE) {
     return {


### PR DESCRIPTION
Fixes [https://github.com/elastic/kibana/security/code-scanning/494](https://github.com/elastic/kibana/security/code-scanning/494)
Fixes #1311

Escape first backslash occurrences and all single quotes in the `filter` string.



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->