### PR TITLE
[UA] More descriptive backup your data text

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -953,7 +953,7 @@ x-pack/plugins/stack_connectors @elastic/response-ops
 x-pack/plugins/task_manager @elastic/response-ops
 x-pack/plugins/telemetry_collection_xpack @elastic/kibana-core
 x-pack/plugins/triggers_actions_ui @elastic/response-ops
-x-pack/plugins/upgrade_assistant @elastic/kibana-management
+x-pack/plugins/upgrade_assistant @elastic/kibana-core
 x-pack/solutions/observability/packages/alert_details @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/alerting_test_data @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/get_padded_alert_time_range_util @elastic/obs-ux-management-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -953,7 +953,7 @@ x-pack/plugins/stack_connectors @elastic/response-ops
 x-pack/plugins/task_manager @elastic/response-ops
 x-pack/plugins/telemetry_collection_xpack @elastic/kibana-core
 x-pack/plugins/triggers_actions_ui @elastic/response-ops
-x-pack/plugins/upgrade_assistant @elastic/kibana-core
+x-pack/plugins/upgrade_assistant @elastic/kibana-management
 x-pack/solutions/observability/packages/alert_details @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/alerting_test_data @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/get_padded_alert_time_range_util @elastic/obs-ux-management-team

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/cloud_backup.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/cloud_backup.tsx
@@ -145,8 +145,16 @@ export const CloudBackup: React.FunctionComponent<Props> = ({
 
   return (
     <>
+      <EuiText>
+        <p>
+          {i18n.translate('xpack.upgradeAssistant.overview.cloudBackup.description', {
+            defaultMessage: 'Back up your data using snapshots before proceeding.',
+          })}
+        </p>
+      </EuiText>
+      <EuiSpacer size="m" />
       {statusMessage}
-      <EuiSpacer size="s" />
+      <EuiSpacer size="m" />
       {/* eslint-disable-next-line @elastic/eui/href-or-on-click */}
       <EuiButton
         href={cloudSnapshotsUrl}

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/on_prem_backup.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/backup_step/on_prem_backup.tsx
@@ -27,6 +27,7 @@ const SnapshotRestoreAppLink: React.FunctionComponent = () => {
     // eslint-disable-next-line @elastic/eui/href-or-on-click
     <EuiButton
       href={snapshotRestoreUrl}
+      target="_blank"
       onClick={() => {
         uiMetricService.trackUiMetric(METRIC_TYPE.CLICK, UIM_BACKUP_DATA_ON_PREM_CLICK);
       }}
@@ -46,12 +47,12 @@ export const OnPremBackup: React.FunctionComponent = () => {
       <EuiText>
         <p>
           {i18n.translate('xpack.upgradeAssistant.overview.backupStepDescription', {
-            defaultMessage: 'Make sure you have a current snapshot before making any changes.',
+            defaultMessage: 'Make sure you have a current snapshot before proceeding.',
           })}
         </p>
       </EuiText>
 
-      <EuiSpacer size="s" />
+      <EuiSpacer size="m" />
 
       <SnapshotRestoreAppLink />
     </>


### PR DESCRIPTION
## Summary

Close https://github.com/elastic/kibana-team/issues/1359

### Notes

Did not update links as, per the issue request, the "Create snapshot" button already links to either the snapshots page on Cloud or the Snapshot & Restore on prem.

### On prem

* Slight tweak to wording
* Made link open in a new tab

<img width="1099" alt="Screenshot 2024-12-16 at 14 04 58" src="https://github.com/user-attachments/assets/46486e30-42e5-4ba1-bd90-4ba3454d5093" />


### Cloud
* Added always visible descriptive paragraph

#### Success

<img width="1264" alt="Screenshot 2024-12-16 at 14 00 26" src="https://github.com/user-attachments/assets/fa855def-257c-4ed0-a17c-b71bcb99bd76" />

#### Error

<img width="566" alt="Screenshot 2024-12-16 at 13 57 53" src="https://github.com/user-attachments/assets/b65b8d8e-887a-4523-b566-e951381d46cd" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->