### PR TITLE
[fleet] Require elastic packages with minimum spec version 3.0 by default

### DIFF
--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -26,6 +26,7 @@ import { BULK_CREATE_MAX_ARTIFACTS_BYTES } from './services/artifacts/artifacts'
 const DEFAULT_BUNDLED_PACKAGE_LOCATION = path.join(__dirname, '../target/bundled_packages');
 const DEFAULT_GPG_KEY_PATH = path.join(__dirname, '../target/keys/GPG-KEY-elasticsearch');
 
+const REGISTRY_SPEC_MIN_VERSION = '3.0';
 const REGISTRY_SPEC_MAX_VERSION = '3.3';
 
 export const config: PluginConfigDescriptor = {
@@ -230,11 +231,12 @@ export const config: PluginConfigDescriptor = {
             excludePackages: schema.arrayOf(schema.string(), { defaultValue: [] }),
             spec: schema.object(
               {
-                min: schema.maybe(schema.string()),
+                min: schema.string({ defaultValue: REGISTRY_SPEC_MIN_VERSION }),
                 max: schema.string({ defaultValue: REGISTRY_SPEC_MAX_VERSION }),
               },
               {
                 defaultValue: {
+                  min: REGISTRY_SPEC_MIN_VERSION,
                   max: REGISTRY_SPEC_MAX_VERSION,
                 },
               }
@@ -261,6 +263,7 @@ export const config: PluginConfigDescriptor = {
               capabilities: [],
               excludePackages: [],
               spec: {
+                min: REGISTRY_SPEC_MIN_VERSION,
                 max: REGISTRY_SPEC_MAX_VERSION,
               },
             },


### PR DESCRIPTION
## Summary

Introduce a minimum spec version by default, set to 3.0. This would be used starting on 9.0. 

This is already the minimum spec version for packages in serverless, via the `xpack.fleet.internal.registry.spec.min` setting.

Restricting by default the use of old spec versions will help us stop supporting them at some point in the future.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

- Users have custom packages using older versions of the spec. For these cases they could migrate their packages to 3.0, or use `xpack.fleet.internal.registry.spec.min` to allow older versions of the spec.
- Some package maintained by elastic is not migrated. We would have time to migrate all required packages to 3.0. This would be needed in any case for their availability in serverless offerings.