### PR TITLE
[ECO][Inventory] Temporary skip Cypress tests

### DIFF
--- a/x-pack/plugins/observability_solution/inventory/e2e/cypress/e2e/alert_count/alert_count.cy.ts
+++ b/x-pack/plugins/observability_solution/inventory/e2e/cypress/e2e/alert_count/alert_count.cy.ts
@@ -33,7 +33,8 @@ const verifyAlertsTableCount = (alertsCount: string) => {
   verifyNumber(cy.getByTestSubj('toolbar-alerts-count'), alertsCount);
 };
 
-describe('Alert count', () => {
+// Temporary skipping those test, will be enabled in the future once we fix them https://github.com/elastic/kibana/issues/204558
+describe.skip('Alert count', () => {
   beforeEach(() => {
     cy.loginAsSuperUser();
 

--- a/x-pack/plugins/observability_solution/inventory/e2e/cypress/e2e/home.cy.ts
+++ b/x-pack/plugins/observability_solution/inventory/e2e/cypress/e2e/home.cy.ts
@@ -11,7 +11,8 @@ import { generateEntities, generateLogs, generateTraces } from './generate_data'
 const start = '2024-10-16T00:00:00.000Z';
 const end = '2024-10-16T00:15:00.000Z';
 
-describe('Home page', () => {
+// Temporary skipping those test, will be enabled in the future once we fix them https://github.com/elastic/kibana/issues/204558
+describe.skip('Home page', () => {
   beforeEach(() => {
     cy.loginAsSuperUser();
   });


### PR DESCRIPTION
## Summary

Related to #204558

Skipping cypress Inventory tests to avoid having the pipeline broken while we adapt them



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->