### PR TITLE
[8.x] [kbn-test] add forceNewSession option to re-generate session cookie (#199018)

### DIFF
--- a/packages/kbn-ftr-common-functional-services/services/saml_auth/saml_auth_provider.ts
+++ b/packages/kbn-ftr-common-functional-services/services/saml_auth/saml_auth_provider.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { SamlSessionManager } from '@kbn/test';
+import { GetCookieOptions, SamlSessionManager } from '@kbn/test';
 import expect from '@kbn/expect';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { resolve } from 'path';
@@ -91,16 +91,39 @@ export function SamlAuthProvider({ getService }: FtrProviderContext) {
   };
 
   return {
-    async getInteractiveUserSessionCookieWithRoleScope(role: string) {
+    /**
+     * Returns a Cookie string containing the session token for the specified role.
+     * This string can be used to update browser cookies and login with the designated role.
+     *
+     * @param role - The SAML role for which the session token is required.
+     * @param options - Optional settings to control session behavior, such as forcing a new session.
+     * @returns A string with the Cookie token
+     *
+     * @throws If the specified role is a custom role without a predefined descriptor.
+     */
+    async getInteractiveUserSessionCookieWithRoleScope(role: string, options?: GetCookieOptions) {
       // Custom role has no descriptors by default, check if it was added before authentication
       throwIfRoleNotSet(role, CUSTOM_ROLE, supportedRoleDescriptors);
-      return sessionManager.getInteractiveUserSessionCookieWithRoleScope(role);
+      return sessionManager.getInteractiveUserSessionCookieWithRoleScope(role, options);
     },
 
-    async getM2MApiCookieCredentialsWithRoleScope(role: string): Promise<CookieCredentials> {
+    /**
+     * Returns an object containing a Cookie header with the session token for the specified role.
+     * This header can be used for authenticating API requests as the designated role.
+     *
+     * @param role - The SAML role for which the session token is required.
+     * @param options - Optional settings to control session behavior, such as forcing a new session.
+     * @returns An object with the Cookie header for API authentication.
+     *
+     * @throws If the specified role is a custom role without a predefined descriptor.
+     */
+    async getM2MApiCookieCredentialsWithRoleScope(
+      role: string,
+      options?: GetCookieOptions
+    ): Promise<CookieCredentials> {
       // Custom role has no descriptors by default, check if it was added before authentication
       throwIfRoleNotSet(role, CUSTOM_ROLE, supportedRoleDescriptors);
-      return sessionManager.getApiCredentialsForRole(role);
+      return sessionManager.getApiCredentialsForRole(role, options);
     },
 
     async getEmail(role: string) {
@@ -195,7 +218,7 @@ export function SamlAuthProvider({ getService }: FtrProviderContext) {
 
       expect(status).to.be(204);
 
-      // Update descriptors for custome role, it will be used to create API key
+      // Update descriptors for the custom role, it will be used to create API key
       supportedRoleDescriptors.set(CUSTOM_ROLE, customRoleDescriptors);
     },
 

--- a/packages/kbn-test/index.ts
+++ b/packages/kbn-test/index.ts
@@ -25,7 +25,12 @@ export {
 } from './src/functional_tests/lib';
 
 export { initLogsDir } from './src/functional_tests/lib';
-export { SamlSessionManager, type SamlSessionManagerOptions, type HostOptions } from './src/auth';
+export {
+  SamlSessionManager,
+  type SamlSessionManagerOptions,
+  type HostOptions,
+  type GetCookieOptions,
+} from './src/auth';
 
 export type {
   CreateTestEsClusterOptions,

--- a/packages/kbn-test/src/auth/index.ts
+++ b/packages/kbn-test/src/auth/index.ts
@@ -9,6 +9,7 @@
 
 export {
   SamlSessionManager,
-  type SamlSessionManagerOptions,
+  type GetCookieOptions,
   type HostOptions,
+  type SamlSessionManagerOptions,
 } from './session_manager';

--- a/packages/kbn-test/src/auth/types.ts
+++ b/packages/kbn-test/src/auth/types.ts
@@ -61,3 +61,8 @@ export interface RetryParams {
   attemptsCount: number;
   attemptDelay: number;
 }
+
+export interface GetSessionByRole {
+  role: string;
+  forceNewSession: boolean;
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[kbn-test] add forceNewSession option to re-generate session cookie (#199018)](https://github.com/elastic/kibana/pull/199018)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2024-11-06T12:09:07Z","message":"[kbn-test] add forceNewSession option to re-generate session cookie (#199018)\n\n## Summary\r\n\r\nCurrently FTR caches `Cookies` of Cloud SAML sessions for the complete\r\nFTR config run, meaning we only perform actual login once for the\r\nspecified role. It helps to optimise tests run time and improve\r\nstability.\r\n\r\nWhile it works most of the time, according to\r\nhttps://github.com/elastic/kibana/issues/71866 Reporting test suite\r\nstability depends on token validity (`20m`) and to stabilize it, this PR\r\nadds `forceNewSession` option to force request a new SAML session when\r\nit is required for specific tests.\r\n\r\n\r\n```\r\n      cookieCredentials = await samlAuth.getM2MApiCookieCredentialsWithRoleScope('admin', {\r\n        forceNewSession: true,\r\n      });\r\n```\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7608d76ac3b7688bea295b206a0ad075a2c69fb8","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","FTR"],"number":199018,"url":"https://github.com/elastic/kibana/pull/199018","mergeCommit":{"message":"[kbn-test] add forceNewSession option to re-generate session cookie (#199018)\n\n## Summary\r\n\r\nCurrently FTR caches `Cookies` of Cloud SAML sessions for the complete\r\nFTR config run, meaning we only perform actual login once for the\r\nspecified role. It helps to optimise tests run time and improve\r\nstability.\r\n\r\nWhile it works most of the time, according to\r\nhttps://github.com/elastic/kibana/issues/71866 Reporting test suite\r\nstability depends on token validity (`20m`) and to stabilize it, this PR\r\nadds `forceNewSession` option to force request a new SAML session when\r\nit is required for specific tests.\r\n\r\n\r\n```\r\n      cookieCredentials = await samlAuth.getM2MApiCookieCredentialsWithRoleScope('admin', {\r\n        forceNewSession: true,\r\n      });\r\n```\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7608d76ac3b7688bea295b206a0ad075a2c69fb8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/199018","number":199018,"mergeCommit":{"message":"[kbn-test] add forceNewSession option to re-generate session cookie (#199018)\n\n## Summary\r\n\r\nCurrently FTR caches `Cookies` of Cloud SAML sessions for the complete\r\nFTR config run, meaning we only perform actual login once for the\r\nspecified role. It helps to optimise tests run time and improve\r\nstability.\r\n\r\nWhile it works most of the time, according to\r\nhttps://github.com/elastic/kibana/issues/71866 Reporting test suite\r\nstability depends on token validity (`20m`) and to stabilize it, this PR\r\nadds `forceNewSession` option to force request a new SAML session when\r\nit is required for specific tests.\r\n\r\n\r\n```\r\n      cookieCredentials = await samlAuth.getM2MApiCookieCredentialsWithRoleScope('admin', {\r\n        forceNewSession: true,\r\n      });\r\n```\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7608d76ac3b7688bea295b206a0ad075a2c69fb8"}}]}] BACKPORT-->