### PR TITLE
[8.x] [Search] Deprecate canDeployEntSearch config value (#204272)

### DIFF
--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -128,7 +128,6 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'data_visualizer.resultLinks.fileBeat.enabled (boolean)',
         'dev_tools.deeplinks.navLinkStatus (string?)',
         'discover.experimental.enabledProfiles (array?)',
-        'enterpriseSearch.canDeployEntSearch (boolean?)',
         'enterpriseSearch.host (string?)',
         'enterpriseSearch.ui.enabled (boolean?)',
         'home.disableWelcomeScreen (boolean?)',

--- a/x-pack/plugins/enterprise_search/common/types/index.ts
+++ b/x-pack/plugins/enterprise_search/common/types/index.ts
@@ -62,7 +62,6 @@ export interface Meta {
 }
 
 export interface ClientConfigType {
-  canDeployEntSearch: boolean;
   host?: string;
   ui: {
     enabled: boolean;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
@@ -114,7 +114,7 @@ export const NativeConnectorConfiguration: React.FC = () => {
               </EuiBadge>
             </EuiFlexItem>
           </EuiFlexGroup>
-          {config.host && config.canDeployEntSearch && errorConnectingMessage && (
+          {config.host && errorConnectingMessage && (
             <>
               <EuiCallOut
                 color="warning"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
@@ -142,13 +142,13 @@ export const SearchIndices: React.FC = () => {
         {productFeatures.hasDefaultIngestPipeline && showDefaultSettingsFlyout && (
           <DefaultSettingsFlyout closeFlyout={() => setShowDefaultSettingsFlyout(false)} />
         )}
-        {config.host && config.canDeployEntSearch && errorConnectingMessage && (
+        {config.host && errorConnectingMessage && (
           <>
             <CannotConnect />
             <EuiSpacer />
           </>
         )}
-        {!config.host && config.canDeployEntSearch && (
+        {!config.host && (
           <>
             <EuiCallOut
               title={i18n.translate('xpack.enterpriseSearch.noEntSearchConfigured.title', {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/header_actions/syncs_context_menu.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/header_actions/syncs_context_menu.tsx
@@ -80,9 +80,7 @@ export const SyncsContextMenu: React.FC<SyncsContextMenuProps> = ({ disabled = f
   const shouldShowIncrementalSync =
     productFeatures.hasIncrementalSyncEnabled && hasIncrementalSyncFeature;
 
-  const isEnterpriseSearchNotAvailable = Boolean(
-    config.host && config.canDeployEntSearch && errorConnectingMessage
-  );
+  const isEnterpriseSearchNotAvailable = Boolean(config.host && errorConnectingMessage);
   const isSyncsDisabled =
     (connector?.is_native && isEnterpriseSearchNotAvailable) ||
     ingestionStatus === IngestionStatus.INCOMPLETE ||

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.test.tsx
@@ -39,16 +39,9 @@ describe('EnterpriseSearchContent', () => {
 
   it('renders EnterpriseSearchContentConfigured when config.host is set & available', () => {
     setMockValues({
-      config: { canDeployEntSearch: true, host: 'some.url' },
+      config: { host: 'some.url' },
       errorConnectingMessage: '',
     });
-    const wrapper = shallow(<EnterpriseSearchContent />);
-
-    expect(wrapper.find(EnterpriseSearchContentConfigured)).toHaveLength(1);
-  });
-
-  it('renders EnterpriseSearchContentConfigured when config.host is not set & Ent Search cannot be deployed', () => {
-    setMockValues({ config: { canDeployEntSearch: false, host: '' }, errorConnectingMessage: '' });
     const wrapper = shallow(<EnterpriseSearchContent />);
 
     expect(wrapper.find(EnterpriseSearchContentConfigured)).toHaveLength(1);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
@@ -40,7 +40,7 @@ export const EnterpriseSearchContent: React.FC<InitialAppData> = (props) => {
   const incompatibleVersions = isVersionMismatch(enterpriseSearchVersion, kibanaVersion);
 
   const showView = () => {
-    if (config.host && config.canDeployEntSearch && incompatibleVersions) {
+    if (config.host && incompatibleVersions) {
       return (
         <VersionMismatchPage
           enterpriseSearchVersion={enterpriseSearchVersion}
@@ -58,7 +58,7 @@ export const EnterpriseSearchContent: React.FC<InitialAppData> = (props) => {
         <SetupGuide />
       </Route>
       <Route exact path={ERROR_STATE_PATH}>
-        {config.host && config.canDeployEntSearch && errorConnectingMessage ? (
+        {config.host && errorConnectingMessage ? (
           <ErrorStatePrompt />
         ) : (
           <Redirect to={SEARCH_INDICES_PATH} />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/enterprise_search_product_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/enterprise_search_product_card.test.tsx
@@ -17,7 +17,7 @@ import { WorkplaceSearchProductCard } from './workplace_search_product_card';
 
 describe('EnterpriseSearchProductCard', () => {
   beforeEach(() => {
-    setMockValues({ config: { canDeployEntSearch: true, host: 'localhost' } });
+    setMockValues({ config: { host: 'localhost' } });
   });
 
   it('renders both services with access', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.test.tsx
@@ -22,7 +22,7 @@ import { ProductSelector } from '.';
 
 describe('ProductSelector', () => {
   it('renders the overview page, product cards, & setup guide CTAs with no host set', () => {
-    setMockValues({ config: { canDeployEntSearch: true, host: '' } });
+    setMockValues({ config: { host: '' } });
     const wrapper = shallow(<ProductSelector />);
 
     expect(wrapper.find(ElasticsearchProductCard)).toHaveLength(1);
@@ -30,7 +30,7 @@ describe('ProductSelector', () => {
   });
 
   it('renders the trial callout', () => {
-    setMockValues({ config: { canDeployEntSearch: true, host: 'localhost' } });
+    setMockValues({ config: { host: 'localhost' } });
     const wrapper = shallow(<ProductSelector />);
 
     expect(wrapper.find(TrialCallout)).toHaveLength(1);
@@ -55,7 +55,7 @@ describe('ProductSelector', () => {
 
   describe('access checks when host is set', () => {
     beforeEach(() => {
-      setMockValues({ config: { canDeployEntSearch: true, host: 'localhost' } });
+      setMockValues({ config: { host: 'localhost' } });
     });
 
     it('does not render the Setup CTA when there is a host', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.tsx
@@ -121,7 +121,7 @@ export const ProductSelector: React.FC = () => {
             <EuiFlexItem>
               <SearchLabsBanner />
             </EuiFlexItem>
-            {!config.host && config.canDeployEntSearch && (
+            {!config.host && (
               <EuiFlexItem>
                 <SetupGuideCta />
               </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/test_helpers/test_utils.test_helper.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/test_helpers/test_utils.test_helper.tsx
@@ -44,7 +44,6 @@ export const mockKibanaProps: KibanaLogicProps = {
     isCloudEnabled: false,
   },
   config: {
-    canDeployEntSearch: true,
     host: 'http://localhost:3002',
     ui: {
       enabled: true,

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -441,55 +441,53 @@ export class EnterpriseSearchPlugin implements Plugin {
 
     registerLocators(share!);
 
-    if (config.canDeployEntSearch) {
-      core.application.register({
-        appRoute: APP_SEARCH_PLUGIN.URL,
-        category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
-        deepLinks: appSearchLinks,
-        euiIconType: ENTERPRISE_SEARCH_OVERVIEW_PLUGIN.LOGO,
-        id: APP_SEARCH_PLUGIN.ID,
-        mount: async (params: AppMountParameters) => {
-          const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
-          const { chrome, http } = kibanaDeps.core;
-          chrome.docTitle.change(APP_SEARCH_PLUGIN.NAME);
+    core.application.register({
+      appRoute: APP_SEARCH_PLUGIN.URL,
+      category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
+      deepLinks: appSearchLinks,
+      euiIconType: ENTERPRISE_SEARCH_OVERVIEW_PLUGIN.LOGO,
+      id: APP_SEARCH_PLUGIN.ID,
+      mount: async (params: AppMountParameters) => {
+        const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
+        const { chrome, http } = kibanaDeps.core;
+        chrome.docTitle.change(APP_SEARCH_PLUGIN.NAME);
 
-          await this.getInitialData(http);
-          const pluginData = this.getPluginData();
+        await this.getInitialData(http);
+        const pluginData = this.getPluginData();
 
-          const { renderApp } = await import('./applications');
-          const { AppSearch } = await import('./applications/app_search');
+        const { renderApp } = await import('./applications');
+        const { AppSearch } = await import('./applications/app_search');
 
-          return renderApp(AppSearch, kibanaDeps, pluginData);
-        },
-        title: APP_SEARCH_PLUGIN.NAME,
-        visibleIn: [],
-      });
+        return renderApp(AppSearch, kibanaDeps, pluginData);
+      },
+      title: APP_SEARCH_PLUGIN.NAME,
+      visibleIn: [],
+    });
 
-      core.application.register({
-        appRoute: WORKPLACE_SEARCH_PLUGIN.URL,
-        category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
-        euiIconType: ENTERPRISE_SEARCH_OVERVIEW_PLUGIN.LOGO,
-        id: WORKPLACE_SEARCH_PLUGIN.ID,
-        mount: async (params: AppMountParameters) => {
-          const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
-          const { chrome, http } = kibanaDeps.core;
-          chrome.docTitle.change(WORKPLACE_SEARCH_PLUGIN.NAME);
+    core.application.register({
+      appRoute: WORKPLACE_SEARCH_PLUGIN.URL,
+      category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
+      euiIconType: ENTERPRISE_SEARCH_OVERVIEW_PLUGIN.LOGO,
+      id: WORKPLACE_SEARCH_PLUGIN.ID,
+      mount: async (params: AppMountParameters) => {
+        const kibanaDeps = await this.getKibanaDeps(core, params, cloud);
+        const { chrome, http } = kibanaDeps.core;
+        chrome.docTitle.change(WORKPLACE_SEARCH_PLUGIN.NAME);
 
-          // The Workplace Search Personal dashboard needs the chrome hidden. We hide it globally
-          // here first to prevent a flash of chrome on the Personal dashboard and unhide it for admin routes.
-          if (this.config.host) chrome.setIsVisible(false);
-          await this.getInitialData(http);
-          const pluginData = this.getPluginData();
+        // The Workplace Search Personal dashboard needs the chrome hidden. We hide it globally
+        // here first to prevent a flash of chrome on the Personal dashboard and unhide it for admin routes.
+        if (this.config.host) chrome.setIsVisible(false);
+        await this.getInitialData(http);
+        const pluginData = this.getPluginData();
 
-          const { renderApp } = await import('./applications');
-          const { WorkplaceSearch } = await import('./applications/workplace_search');
+        const { renderApp } = await import('./applications');
+        const { WorkplaceSearch } = await import('./applications/workplace_search');
 
-          return renderApp(WorkplaceSearch, kibanaDeps, pluginData);
-        },
-        title: WORKPLACE_SEARCH_PLUGIN.NAME,
-        visibleIn: [],
-      });
-    }
+        return renderApp(WorkplaceSearch, kibanaDeps, pluginData);
+      },
+      title: WORKPLACE_SEARCH_PLUGIN.NAME,
+      visibleIn: [],
+    });
 
     if (plugins.home) {
       plugins.home.featureCatalogue.registerSolution({
@@ -511,27 +509,25 @@ export class EnterpriseSearchPlugin implements Plugin {
         title: ANALYTICS_PLUGIN.NAME,
       });
 
-      if (config.canDeployEntSearch) {
-        plugins.home.featureCatalogue.register({
-          category: 'data',
-          description: APP_SEARCH_PLUGIN.DESCRIPTION,
-          icon: 'appSearchApp',
-          id: APP_SEARCH_PLUGIN.ID,
-          path: APP_SEARCH_PLUGIN.URL,
-          showOnHomePage: false,
-          title: APP_SEARCH_PLUGIN.NAME,
-        });
+      plugins.home.featureCatalogue.register({
+        category: 'data',
+        description: APP_SEARCH_PLUGIN.DESCRIPTION,
+        icon: 'appSearchApp',
+        id: APP_SEARCH_PLUGIN.ID,
+        path: APP_SEARCH_PLUGIN.URL,
+        showOnHomePage: false,
+        title: APP_SEARCH_PLUGIN.NAME,
+      });
 
-        plugins.home.featureCatalogue.register({
-          category: 'data',
-          description: WORKPLACE_SEARCH_PLUGIN.DESCRIPTION,
-          icon: 'workplaceSearchApp',
-          id: WORKPLACE_SEARCH_PLUGIN.ID,
-          path: WORKPLACE_SEARCH_PLUGIN.URL,
-          showOnHomePage: false,
-          title: WORKPLACE_SEARCH_PLUGIN.NAME,
-        });
-      }
+      plugins.home.featureCatalogue.register({
+        category: 'data',
+        description: WORKPLACE_SEARCH_PLUGIN.DESCRIPTION,
+        icon: 'workplaceSearchApp',
+        id: WORKPLACE_SEARCH_PLUGIN.ID,
+        path: WORKPLACE_SEARCH_PLUGIN.URL,
+        showOnHomePage: false,
+        title: WORKPLACE_SEARCH_PLUGIN.NAME,
+      });
 
       plugins.home.featureCatalogue.register({
         category: 'data',

--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -17,7 +17,6 @@ export const configSchema = schema.object({
   accessCheckTimeout: schema.number({ defaultValue: 5000 }),
   accessCheckTimeoutWarning: schema.number({ defaultValue: 300 }),
   appsDisabled: schema.boolean({ defaultValue: false }),
-  canDeployEntSearch: schema.boolean({ defaultValue: true }),
   customHeaders: schema.maybe(schema.object({}, { unknowns: 'allow' })),
   enabled: schema.boolean({ defaultValue: true }),
   hasConnectors: schema.boolean({ defaultValue: true }),
@@ -45,8 +44,8 @@ export const configSchema = schema.object({
 export type ConfigType = TypeOf<typeof configSchema>;
 
 export const config: PluginConfigDescriptor<ConfigType> = {
+  deprecations: ({ unused }) => [unused('canDeployEntSearch', { level: 'warning' })],
   exposeToBrowser: {
-    canDeployEntSearch: true,
     host: true,
     ui: true,
   },

--- a/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/check_access.test.ts
@@ -51,7 +51,6 @@ describe('checkAccess', () => {
     request: { auth: { isAuthenticated: true } },
     config: {
       appsDisabled: false,
-      canDeployEntSearch: true,
       host: 'http://localhost:3002',
     },
     globalConfigService: new GlobalConfigService(),

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -320,12 +320,12 @@ export class EnterpriseSearchPlugin implements Plugin {
 
         return {
           navLinks: {
-            appSearch: hasAppSearchAccess && config.canDeployEntSearch,
-            workplaceSearch: hasWorkplaceSearchAccess && config.canDeployEntSearch,
+            appSearch: hasAppSearchAccess,
+            workplaceSearch: hasWorkplaceSearchAccess,
           },
           catalogue: {
-            appSearch: hasAppSearchAccess && config.canDeployEntSearch,
-            workplaceSearch: hasWorkplaceSearchAccess && config.canDeployEntSearch,
+            appSearch: hasAppSearchAccess,
+            workplaceSearch: hasWorkplaceSearchAccess,
           },
         };
       },

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -179,7 +179,8 @@ export class EnterpriseSearchPlugin implements Plugin {
       ENTERPRISE_SEARCH_OVERVIEW_PLUGIN.ID,
       ENTERPRISE_SEARCH_CONTENT_PLUGIN.ID,
       ELASTICSEARCH_PLUGIN.ID,
-      ...(config.canDeployEntSearch ? [APP_SEARCH_PLUGIN.ID, WORKPLACE_SEARCH_PLUGIN.ID] : []),
+      APP_SEARCH_PLUGIN.ID,
+      WORKPLACE_SEARCH_PLUGIN.ID,
       SEARCH_EXPERIENCES_PLUGIN.ID,
       VECTOR_SEARCH_PLUGIN.ID,
       SEMANTIC_SEARCH_PLUGIN.ID,
@@ -349,9 +350,9 @@ export class EnterpriseSearchPlugin implements Plugin {
     };
 
     registerConfigDataRoute(dependencies);
-    if (config.canDeployEntSearch) registerAppSearchRoutes(dependencies);
+    registerAppSearchRoutes(dependencies);
     registerEnterpriseSearchRoutes(dependencies);
-    if (config.canDeployEntSearch) registerWorkplaceSearchRoutes(dependencies);
+    registerWorkplaceSearchRoutes(dependencies);
     // Enterprise Search Routes
     if (config.hasConnectors) registerConnectorRoutes(dependencies);
     if (config.hasWebCrawler) registerCrawlerRoutes(dependencies);
@@ -368,10 +369,8 @@ export class EnterpriseSearchPlugin implements Plugin {
      * Bootstrap the routes, saved objects, and collector for telemetry
      */
     savedObjects.registerType(enterpriseSearchTelemetryType);
-    if (config.canDeployEntSearch) {
-      savedObjects.registerType(appSearchTelemetryType);
-      savedObjects.registerType(workplaceSearchTelemetryType);
-    }
+    savedObjects.registerType(appSearchTelemetryType);
+    savedObjects.registerType(workplaceSearchTelemetryType);
     let savedObjectsStarted: SavedObjectsServiceStart;
 
     void getStartServices().then(([coreStart]) => {
@@ -380,10 +379,8 @@ export class EnterpriseSearchPlugin implements Plugin {
       if (usageCollection) {
         registerESTelemetryUsageCollector(usageCollection, savedObjectsStarted, this.logger);
         registerCNTelemetryUsageCollector(usageCollection, this.logger);
-        if (config.canDeployEntSearch) {
-          registerASTelemetryUsageCollector(usageCollection, savedObjectsStarted, this.logger);
-          registerWSTelemetryUsageCollector(usageCollection, savedObjectsStarted, this.logger);
-        }
+        registerASTelemetryUsageCollector(usageCollection, savedObjectsStarted, this.logger);
+        registerWSTelemetryUsageCollector(usageCollection, savedObjectsStarted, this.logger);
       }
     });
     registerTelemetryRoute({ ...dependencies, getSavedObjectsService: () => savedObjectsStarted });
@@ -419,9 +416,7 @@ export class EnterpriseSearchPlugin implements Plugin {
     /**
      * Register a config for the search guide
      */
-    if (config.canDeployEntSearch) {
-      guidedOnboarding?.registerGuideConfig(appSearchGuideId, appSearchGuideConfig);
-    }
+    guidedOnboarding?.registerGuideConfig(appSearchGuideId, appSearchGuideConfig);
     if (config.hasWebCrawler) {
       guidedOnboarding?.registerGuideConfig(websiteSearchGuideId, websiteSearchGuideConfig);
     }

--- a/x-pack/plugins/enterprise_search/server/utils/search_result_provider.test.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/search_result_provider.test.ts
@@ -292,7 +292,6 @@ describe('Search search provider', () => {
     it('does not return results for legacy app search', () => {
       const searchProvider = getSearchResultProvider(
         {
-          canDeployEntSearch: true,
           hasConnectors: false,
           hasWebCrawler: false,
         } as any,
@@ -315,7 +314,6 @@ describe('Search search provider', () => {
     it('does not return results for legacy workplace search', () => {
       const searchProvider = getSearchResultProvider(
         {
-          canDeployEntSearch: true,
           hasConnectors: false,
           hasWebCrawler: false,
         } as any,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Search] Deprecate canDeployEntSearch config value (#204272)](https://github.com/elastic/kibana/pull/204272)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Rodney Norris","email":"rodney.norris@elastic.co"},"sourceCommit":{"committedDate":"2024-12-17T13:16:33Z","message":"[Search] Deprecate canDeployEntSearch config value (#204272)","sha":"9f53fbbcc38cf709f0202e39b5fce7004a88e87b","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Search","backport:prev-minor","v8.18.0"],"number":204272,"url":"https://github.com/elastic/kibana/pull/204272","mergeCommit":{"message":"[Search] Deprecate canDeployEntSearch config value (#204272)","sha":"9f53fbbcc38cf709f0202e39b5fce7004a88e87b"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/204272","number":204272,"mergeCommit":{"message":"[Search] Deprecate canDeployEntSearch config value (#204272)","sha":"9f53fbbcc38cf709f0202e39b5fce7004a88e87b"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->