### PR TITLE
[Fleet] Remove adopted showDevToolRequest feature flag

### DIFF
--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -10,7 +10,6 @@ export type ExperimentalFeatures = typeof allowedExperimentalValues;
 const _allowedExperimentalValues = {
   createPackagePolicyMultiPageLayout: true,
   packageVerification: true,
-  showDevtoolsRequest: true,
   diagnosticFileUploadEnabled: true,
   displayAgentMetrics: true,
   showIntegrationsSubcategories: true,

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/devtools_request.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/devtools_request.tsx
@@ -11,7 +11,6 @@ import { i18n } from '@kbn/i18n';
 import { omit } from 'lodash';
 import { set } from '@kbn/safer-lodash-set';
 
-import { ExperimentalFeaturesService } from '../../../../../services';
 import {
   generateCreatePackagePolicyDevToolsRequest,
   generateCreateAgentPolicyDevToolsRequest,
@@ -39,12 +38,7 @@ export function useDevToolsRequest({
   packageInfo?: PackageInfo;
   packagePolicyId?: string;
 }) {
-  const { showDevtoolsRequest: isShowDevtoolRequestExperimentEnabled } =
-    ExperimentalFeaturesService.get();
-
-  const showDevtoolsRequest =
-    !HIDDEN_API_REFERENCE_PACKAGES.includes(packageInfo?.name ?? '') &&
-    isShowDevtoolRequestExperimentEnabled;
+  const showDevtoolsRequest = !HIDDEN_API_REFERENCE_PACKAGES.includes(packageInfo?.name ?? '');
 
   const [devtoolRequest, devtoolRequestDescription] = useMemo(() => {
     if (selectedPolicyTab === SelectedPolicyTab.NEW) {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/settings/index.tsx
@@ -40,7 +40,6 @@ import {
   ConfirmDeployAgentPolicyModal,
 } from '../../../components';
 import { DevtoolsRequestFlyoutButton } from '../../../../../components';
-import { ExperimentalFeaturesService } from '../../../../../services';
 import { generateUpdateAgentPolicyDevToolsRequest } from '../../../services';
 import { UNKNOWN_SPACE } from '../../../../../../../../common/constants';
 
@@ -155,7 +154,6 @@ export const SettingsView = memo<{ agentPolicy: AgentPolicy }>(
       setIsLoading(false);
     };
 
-    const { showDevtoolsRequest } = ExperimentalFeaturesService.get();
     const devtoolRequest = useMemo(
       () =>
         generateUpdateAgentPolicyDevToolsRequest(
@@ -235,28 +233,26 @@ export const SettingsView = memo<{ agentPolicy: AgentPolicy }>(
                         />
                       </EuiButtonEmpty>
                     </EuiFlexItem>
-                    {showDevtoolsRequest ? (
-                      <EuiFlexItem grow={false}>
-                        <DevtoolsRequestFlyoutButton
-                          isDisabled={
-                            isLoading ||
-                            Object.keys(validation).length > 0 ||
-                            hasAdvancedSettingsErrors ||
-                            hasInvalidSpaceError
+                    <EuiFlexItem grow={false}>
+                      <DevtoolsRequestFlyoutButton
+                        isDisabled={
+                          isLoading ||
+                          Object.keys(validation).length > 0 ||
+                          hasAdvancedSettingsErrors ||
+                          hasInvalidSpaceError
+                        }
+                        btnProps={{
+                          color: 'text',
+                        }}
+                        description={i18n.translate(
+                          'xpack.fleet.editAgentPolicy.devtoolsRequestDescription',
+                          {
+                            defaultMessage: 'This Kibana request updates an agent policy.',
                           }
-                          btnProps={{
-                            color: 'text',
-                          }}
-                          description={i18n.translate(
-                            'xpack.fleet.editAgentPolicy.devtoolsRequestDescription',
-                            {
-                              defaultMessage: 'This Kibana request updates an agent policy.',
-                            }
-                          )}
-                          request={devtoolRequest}
-                        />
-                      </EuiFlexItem>
-                    ) : null}
+                        )}
+                        request={devtoolRequest}
+                      />
+                    </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiButton
                         onClick={onSubmit}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/list_page/components/create_agent_policy.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/list_page/components/create_agent_policy.tsx
@@ -31,7 +31,6 @@ import { useAuthz, useStartServices, sendCreateAgentPolicy } from '../../../../h
 import { AgentPolicyForm, agentPolicyFormValidation } from '../../components';
 import { DevtoolsRequestFlyoutButton } from '../../../../components';
 import { generateCreateAgentPolicyDevToolsRequest } from '../../services';
-import { ExperimentalFeaturesService } from '../../../../services';
 import { generateNewAgentPolicyWithDefaults } from '../../../../../../../common/services/generate_new_agent_policy';
 
 const FlyoutWithHigherZIndex = styled(EuiFlyout)`
@@ -109,7 +108,6 @@ export const CreateAgentPolicyFlyout: React.FunctionComponent<Props> = ({
       />
     </EuiFlyoutBody>
   );
-  const { showDevtoolsRequest } = ExperimentalFeaturesService.get();
   const agentPolicyContent = useMemo(
     () => generateCreateAgentPolicyDevToolsRequest(agentPolicy, withSysMonitoring),
     [agentPolicy, withSysMonitoring]
@@ -128,25 +126,23 @@ export const CreateAgentPolicyFlyout: React.FunctionComponent<Props> = ({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="none">
-            {showDevtoolsRequest ? (
-              <EuiFlexItem grow={false}>
-                <DevtoolsRequestFlyoutButton
-                  isDisabled={
-                    isLoading ||
-                    Object.keys(validation).length > 0 ||
-                    hasAdvancedSettingsErrors ||
-                    hasInvalidSpaceError
+            <EuiFlexItem grow={false}>
+              <DevtoolsRequestFlyoutButton
+                isDisabled={
+                  isLoading ||
+                  Object.keys(validation).length > 0 ||
+                  hasAdvancedSettingsErrors ||
+                  hasInvalidSpaceError
+                }
+                description={i18n.translate(
+                  'xpack.fleet.createAgentPolicy.devtoolsRequestDescription',
+                  {
+                    defaultMessage: 'This Kibana request creates a new agent policy.',
                   }
-                  description={i18n.translate(
-                    'xpack.fleet.createAgentPolicy.devtoolsRequestDescription',
-                    {
-                      defaultMessage: 'This Kibana request creates a new agent policy.',
-                    }
-                  )}
-                  request={agentPolicyContent}
-                />
-              </EuiFlexItem>
-            ) : null}
+                )}
+                request={agentPolicyContent}
+              />
+            </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiButton
                 fill


### PR DESCRIPTION
## Summary

Remove `showDevToolRequest` feature flag, as that feature flag is now adopted since a few versions there is no reason to turn it off anymore.

Related to https://github.com/elastic/kibana/issues/190844

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->