### PR TITLE
[CI] skip flaky integration test

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/actions/actions_test_suite.ts
@@ -772,7 +772,9 @@ export const runActionTestSuite = ({
 
   // Reindex doesn't return any errors on its own, so we have to test
   // together with waitForReindexTask
-  describe('reindex & waitForReindexTask', () => {
+  // Flaky: https://github.com/elastic/kibana/issues/166190
+  // Reported here: https://github.com/elastic/kibana/issues/167273
+  describe.skip('reindex & waitForReindexTask', () => {
     it('resolves right when reindex succeeds without reindex script', async () => {
       const res = (await reindex({
         client,


### PR DESCRIPTION
## Summary
Skips suite "reindex & waitForReindexTask"
- Errors are reported here: https://github.com/elastic/kibana/issues/167273
- Original issue, I believe: https://github.com/elastic/kibana/issues/166190
- PR that recently unskipped the test: https://github.com/elastic/kibana/pull/204561

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->