### PR TITLE
[Discover][Embeddable] Search embeddable to keep all SO fields

### DIFF
--- a/src/plugins/discover/public/embeddable/initialize_search_embeddable_api.tsx
+++ b/src/plugins/discover/public/embeddable/initialize_search_embeddable_api.tsx
@@ -97,6 +97,7 @@ export const initializeSearchEmbeddableApi = async (
   const density$ = new BehaviorSubject<DataGridDensity | undefined>(initialState.density);
   const sort$ = new BehaviorSubject<SortOrder[] | undefined>(initialState.sort);
   const savedSearchViewMode$ = new BehaviorSubject<VIEW_MODE | undefined>(initialState.viewMode);
+  const breakdownField$ = new BehaviorSubject<string | undefined>(initialState.breakdownField);
 
   /**
    * This is the state that comes from the search source that needs individual publishing subjects for the API
@@ -136,6 +137,7 @@ export const initializeSearchEmbeddableApi = async (
     viewMode: savedSearchViewMode$,
     density: density$,
     inspectorAdapters: inspectorAdapters$,
+    breakdownField: breakdownField$,
   };
 
   /** The saved search should be the source of truth for all state  */
@@ -228,6 +230,7 @@ export const initializeSearchEmbeddableApi = async (
       ],
       viewMode: [savedSearchViewMode$, (value) => savedSearchViewMode$.next(value)],
       density: [density$, (value) => density$.next(value)],
+      breakdownField: [breakdownField$, (value) => breakdownField$.next(value)],
     },
   };
 };

--- a/src/plugins/discover/public/embeddable/types.ts
+++ b/src/plugins/discover/public/embeddable/types.ts
@@ -44,6 +44,7 @@ export type SearchEmbeddableState = Pick<
   | 'viewMode'
   | 'grid'
   | 'density'
+  | 'breakdownField'
 > & {
   rows: DataTableRecord[];
   columnsMeta: DataTableColumnsMeta | undefined;

--- a/src/plugins/discover/public/embeddable/utils/get_discover_locator_params.test.ts
+++ b/src/plugins/discover/public/embeddable/utils/get_discover_locator_params.test.ts
@@ -40,6 +40,7 @@ describe('getDiscoverLocatorParams', () => {
       sort: savedSearchMock.sort,
       viewMode: savedSearchMock.viewMode,
       hideAggregatedPreview: savedSearchMock.hideAggregatedPreview,
+      breakdownField: savedSearchMock.breakdownField,
     });
   });
 });

--- a/src/plugins/discover/public/embeddable/utils/get_discover_locator_params.ts
+++ b/src/plugins/discover/public/embeddable/utils/get_discover_locator_params.ts
@@ -32,6 +32,7 @@ export const getDiscoverLocatorParams = (
         sort: savedSearch?.sort,
         viewMode: savedSearch?.viewMode,
         hideAggregatedPreview: savedSearch?.hideAggregatedPreview,
+        breakdownField: savedSearch?.breakdownField,
       };
 
   return locatorParams;


### PR DESCRIPTION
## Summary

This PR makes it so unlinking a search panel from the library retains all SO attributes.
Closes: #196732



