### PR TITLE
Replace 'ent-search-generic' with 'search-default' pipeline

### DIFF
--- a/packages/kbn-search-connectors/lib/collect_connector_stats_test_data.ts
+++ b/packages/kbn-search-connectors/lib/collect_connector_stats_test_data.ts
@@ -29,7 +29,7 @@ export const spoConnector: Connector = {
   last_indexed_document_count: 1000,
   pipeline: {
     extract_binary_content: false,
-    name: 'ent-search-generic-ingestion',
+    name: 'search-default-ingestion',
     reduce_whitespace: true,
     run_ml_inference: false,
   },
@@ -99,7 +99,7 @@ export const mysqlConnector: Connector = {
   last_indexed_document_count: 2000,
   pipeline: {
     extract_binary_content: true,
-    name: 'ent-search-generic-ingestion',
+    name: 'search-default-ingestion',
     reduce_whitespace: true,
     run_ml_inference: false,
   },

--- a/packages/kbn-search-connectors/lib/create_connector_document.test.ts
+++ b/packages/kbn-search-connectors/lib/create_connector_document.test.ts
@@ -21,7 +21,7 @@ describe('createConnectorDocument', () => {
         name: 'indexName-name',
         pipeline: {
           extract_binary_content: true,
-          name: 'ent-search-generic-ingestion',
+          name: 'search-default-ingestion',
           reduce_whitespace: true,
           run_ml_inference: false,
         },
@@ -103,7 +103,7 @@ describe('createConnectorDocument', () => {
       name: 'indexName-name',
       pipeline: {
         extract_binary_content: true,
-        name: 'ent-search-generic-ingestion',
+        name: 'search-default-ingestion',
         reduce_whitespace: true,
         run_ml_inference: false,
       },

--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -235,7 +235,7 @@ export const ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT = 25;
 
 export const ENTERPRISE_SEARCH_CONNECTOR_CRAWLER_SERVICE_TYPE = 'elastic-crawler';
 
-export const DEFAULT_PIPELINE_NAME = 'ent-search-generic-ingestion';
+export const DEFAULT_PIPELINE_NAME = 'search-default-ingestion';
 export const DEFAULT_PIPELINE_VALUES: IngestPipelineParams = {
   extract_binary_content: true,
   name: DEFAULT_PIPELINE_NAME,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_json_configurations_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_json_configurations_logic.test.ts
@@ -53,7 +53,7 @@ describe('IndexPipelinesConfigurationsLogic', () => {
     });
     it('fetchIndexPipelinesDataSuccess selects index ingest pipeline if found', async () => {
       const pipelines = {
-        'ent-search-generic-ingest': {
+        'search-default-ingest': {
           version: 1,
         },
         [indexName]: {
@@ -68,7 +68,7 @@ describe('IndexPipelinesConfigurationsLogic', () => {
     });
     it('fetchIndexPipelinesDataSuccess selects first pipeline as default pipeline', async () => {
       const pipelines = {
-        'ent-search-generic-ingest': {
+        'search-default-ingest': {
           version: 1,
         },
       };
@@ -76,7 +76,7 @@ describe('IndexPipelinesConfigurationsLogic', () => {
       await nextTick();
 
       expect(IndexPipelinesConfigurationsLogic.values.selectedPipelineId).toEqual(
-        'ent-search-generic-ingest'
+        'search-default-ingest'
       );
     });
   });
@@ -84,7 +84,7 @@ describe('IndexPipelinesConfigurationsLogic', () => {
   describe('selectors', () => {
     it('pipelineNames returns names of pipelines', async () => {
       const pipelines = {
-        'ent-search-generic-ingest': {
+        'search-default-ingest': {
           version: 1,
         },
         [indexName]: {
@@ -96,13 +96,13 @@ describe('IndexPipelinesConfigurationsLogic', () => {
       await nextTick();
 
       expect(IndexPipelinesConfigurationsLogic.values.pipelineNames).toEqual([
-        'ent-search-generic-ingest',
+        'search-default-ingest',
         indexName,
       ]);
     });
     it('selectedPipeline returns full pipeline', async () => {
       const pipelines = {
-        'ent-search-generic-ingest': {
+        'search-default-ingest': {
           version: 1,
         },
         foo: {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.test.ts
@@ -21,7 +21,7 @@ import { PipelinesLogic } from './pipelines_logic';
 
 const DEFAULT_PIPELINE_VALUES = {
   extract_binary_content: true,
-  name: 'ent-search-generic-ingestion',
+  name: 'search-default-ingestion',
   reduce_whitespace: true,
   run_ml_inference: true,
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/header_actions/syncs_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/shared/header_actions/syncs_logic.test.ts
@@ -126,7 +126,7 @@ const mockConnector: Connector = {
   name: 'test',
   pipeline: {
     extract_binary_content: true,
-    name: 'ent-search-generic-ingestion',
+    name: 'search-default-ingestion',
     reduce_whitespace: true,
     run_ml_inference: true,
   },

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.test.ts
@@ -52,7 +52,7 @@ describe('addConnector lib function', () => {
         _meta: {
           pipeline: {
             default_extract_binary_content: true,
-            default_name: 'ent-search-generic-ingestion',
+            default_name: 'search-default-ingestion',
             default_reduce_whitespace: true,
             default_run_ml_inference: true,
           },
@@ -89,7 +89,7 @@ describe('addConnector lib function', () => {
       name: 'index_name',
       pipeline: {
         extract_binary_content: true,
-        name: 'ent-search-generic-ingestion',
+        name: 'search-default-ingestion',
         reduce_whitespace: true,
         run_ml_inference: true,
       },
@@ -134,7 +134,7 @@ describe('addConnector lib function', () => {
       name: 'index_name',
       pipeline: {
         extract_binary_content: true,
-        name: 'ent-search-generic-ingestion',
+        name: 'search-default-ingestion',
         reduce_whitespace: true,
         run_ml_inference: true,
       },
@@ -264,7 +264,7 @@ describe('addConnector lib function', () => {
       name: '',
       pipeline: {
         extract_binary_content: true,
-        name: 'ent-search-generic-ingestion',
+        name: 'search-default-ingestion',
         reduce_whitespace: true,
         run_ml_inference: true,
       },


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/search-team/issues/8812
This PR replaces usage of `ent-search-generic-ingestion` pipeline with `search-default-ingestion` pipeline. The function of these two is identical, the only difference being their name. This merely removes a reference to "ent-search" (Enterprise Search) for 9.0 where Enterprise Search will no longer be available.

### Related PRs
- Elasticsearch changes: https://github.com/elastic/elasticsearch/pull/118899
- Connectors changes: https://github.com/elastic/connectors/pull/3049



