### PR TITLE
Fix/renovate pipeline

### DIFF
--- a/.buildkite/pipelines/pull_request/renovate.yml
+++ b/.buildkite/pipelines/pull_request/renovate.yml
@@ -1,22 +1,4 @@
 steps:
-  - command: .buildkite/scripts/lifecycle/pre_build.sh
-    label: Pre-Build
-    timeout_in_minutes: 10
-    agents:
-      machineType: n2-standard-2
-
-  - wait
-
-  - command: .buildkite/scripts/steps/ci_stats_ready.sh
-    label: Mark CI Stats as ready
-    agents:
-      machineType: n2-standard-2
-    timeout_in_minutes: 10
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
   - command: .buildkite/scripts/steps/renovate.sh
     label: 'Renovate validation'
     agents:

--- a/.buildkite/pipelines/pull_request/renovate.yml
+++ b/.buildkite/pipelines/pull_request/renovate.yml
@@ -1,5 +1,5 @@
 env:
-  DISABLE_CI_STATS_SHIPPING: 'true'
+  IGNORE_SHIP_CI_STATS_ERROR: 'true'
 steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh
     label: Pre-Build

--- a/.buildkite/pipelines/pull_request/renovate.yml
+++ b/.buildkite/pipelines/pull_request/renovate.yml
@@ -1,3 +1,5 @@
+env:
+  DISABLE_CI_STATS_SHIPPING: 'true'
 steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh
     label: Pre-Build

--- a/.buildkite/pipelines/pull_request/renovate.yml
+++ b/.buildkite/pipelines/pull_request/renovate.yml
@@ -1,5 +1,3 @@
-env:
-  IGNORE_SHIP_CI_STATS_ERROR: 'true'
 steps:
   - command: .buildkite/scripts/lifecycle/pre_build.sh
     label: Pre-Build
@@ -8,6 +6,16 @@ steps:
       machineType: n2-standard-2
 
   - wait
+
+  - command: .buildkite/scripts/steps/ci_stats_ready.sh
+    label: Mark CI Stats as ready
+    agents:
+      machineType: n2-standard-2
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
 
   - command: .buildkite/scripts/steps/renovate.sh
     label: 'Renovate validation'

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -41,7 +41,7 @@ const getPipeline = (filename: string, removeSteps = true) => {
 
     pipeline.push(getAgentImageConfig({ returnYaml: true }));
 
-    const onlyRunQuickChecks = true; // await areChangesSkippable([/^renovate\.json$/], REQUIRED_PATHS);
+    const onlyRunQuickChecks = await areChangesSkippable([/^renovate\.json$/], REQUIRED_PATHS);
     if (onlyRunQuickChecks) {
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/renovate.yml', false));
 

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -39,7 +39,8 @@ const getPipeline = (filename: string, removeSteps = true) => {
       return;
     }
 
-    const onlyRunQuickChecks = await areChangesSkippable([/^renovate\.json$/], REQUIRED_PATHS);
+    pipeline.push(getAgentImageConfig({ returnYaml: true }));
+    const onlyRunQuickChecks = true; // await areChangesSkippable([/^renovate\.json$/], REQUIRED_PATHS);
     if (onlyRunQuickChecks) {
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/renovate.yml', false));
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/post_build.yml'));
@@ -47,7 +48,6 @@ const getPipeline = (filename: string, removeSteps = true) => {
       return;
     }
 
-    pipeline.push(getAgentImageConfig({ returnYaml: true }));
     pipeline.push(getPipeline('.buildkite/pipelines/pull_request/base.yml', false));
 
     if (await doAnyChangesMatch([/^packages\/kbn-handlebars/])) {

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -40,11 +40,13 @@ const getPipeline = (filename: string, removeSteps = true) => {
     }
 
     pipeline.push(getAgentImageConfig({ returnYaml: true }));
+
     const onlyRunQuickChecks = true; // await areChangesSkippable([/^renovate\.json$/], REQUIRED_PATHS);
     if (onlyRunQuickChecks) {
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/renovate.yml', false));
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/post_build.yml'));
-      console.log('Isolated changes to renovate.json. Skipping main PR pipeline.');
+      // console.log('Isolated changes to renovate.json. Skipping main PR pipeline.');
+      console.log([...new Set(pipeline)].join('\n'));
       return;
     }
 

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -41,7 +41,7 @@ const getPipeline = (filename: string, removeSteps = true) => {
 
     pipeline.push(getAgentImageConfig({ returnYaml: true }));
 
-    const onlyRunQuickChecks = await areChangesSkippable([/^renovate\.json$/], REQUIRED_PATHS);
+    const onlyRunQuickChecks = true; // await areChangesSkippable([/^renovate\.json$/], REQUIRED_PATHS);
     if (onlyRunQuickChecks) {
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/renovate.yml', false));
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/post_build.yml'));

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -41,11 +41,11 @@ const getPipeline = (filename: string, removeSteps = true) => {
 
     pipeline.push(getAgentImageConfig({ returnYaml: true }));
 
-    const onlyRunQuickChecks = true; // await areChangesSkippable([/^renovate\.json$/], REQUIRED_PATHS);
+    const onlyRunQuickChecks = await areChangesSkippable([/^renovate\.json$/], REQUIRED_PATHS);
     if (onlyRunQuickChecks) {
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/renovate.yml', false));
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/post_build.yml'));
-      // console.log('Isolated changes to renovate.json. Skipping main PR pipeline.');
+
       console.log([...new Set(pipeline)].join('\n'));
       return;
     }

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -44,7 +44,6 @@ const getPipeline = (filename: string, removeSteps = true) => {
     const onlyRunQuickChecks = true; // await areChangesSkippable([/^renovate\.json$/], REQUIRED_PATHS);
     if (onlyRunQuickChecks) {
       pipeline.push(getPipeline('.buildkite/pipelines/pull_request/renovate.yml', false));
-      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/post_build.yml'));
 
       console.log([...new Set(pipeline)].join('\n'));
       return;


### PR DESCRIPTION
## Summary

Renovate pipeline isn't being uploaded to Buildkite properly and `pre` and `post` build steps were not necessary and create errors with CI stats.

[Successful CI run](https://buildkite.com/elastic/kibana-pull-request/builds/261627)




<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->