### PR TITLE
[painless lab] Add mandatory authz info to internal REST api

### DIFF
--- a/x-pack/platform/plugins/private/painless_lab/server/routes/api/execute.ts
+++ b/x-pack/platform/plugins/private/painless_lab/server/routes/api/execute.ts
@@ -17,6 +17,12 @@ export function registerExecuteRoute({ router, license }: RouteDependencies) {
   router.post(
     {
       path: `${API_BASE_PATH}/execute`,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'Relies on es client for authorization',
+        },
+      },
       validate: {
         body: bodySchema,
       },


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/pull/204531

Simply adding authz info
