### PR TITLE
join command validation and autocomplete

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/index.ts
@@ -30,6 +30,18 @@ export type {
   ESQLAstNode,
 } from './src/types';
 
+export {
+  isBinaryExpression,
+  isColumn,
+  isDoubleLiteral,
+  isFunctionExpression,
+  isIdentifier,
+  isIntegerLiteral,
+  isLiteral,
+  isParamLiteral,
+  isProperNode,
+} from './src/ast/helpers';
+
 export { Builder, type AstNodeParserFields, type AstNodeTemplate } from './src/builder';
 
 export {

--- a/src/platform/packages/shared/kbn-esql-ast/src/ast/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/ast/helpers.ts
@@ -12,6 +12,7 @@ import type {
   ESQLBinaryExpression,
   ESQLColumn,
   ESQLFunction,
+  ESQLIdentifier,
   ESQLIntegerLiteral,
   ESQLLiteral,
   ESQLParamLiteral,
@@ -54,6 +55,9 @@ export const isParamLiteral = (node: unknown): node is ESQLParamLiteral =>
 
 export const isColumn = (node: unknown): node is ESQLColumn =>
   isProperNode(node) && node.type === 'column';
+
+export const isIdentifier = (node: unknown): node is ESQLIdentifier =>
+  isProperNode(node) && node.type === 'identifier';
 
 /**
  * Returns the group of a binary expression:

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/__tests__/helpers.ts
@@ -8,8 +8,9 @@
  */
 
 import { camelCase } from 'lodash';
-import { ESQLRealField } from '../validation/types';
+import { ESQLRealField, JoinIndexAutocompleteItem } from '../validation/types';
 import { fieldTypes } from '../definitions/types';
+import { ESQLCallbacks } from '../shared/types';
 
 export const fields: ESQLRealField[] = [
   ...fieldTypes.map((type) => ({ name: `${camelCase(type)}Field`, type })),
@@ -52,9 +53,22 @@ export const policies = [
   },
 ];
 
-export function getCallbackMocks() {
+export const joinIndices: JoinIndexAutocompleteItem[] = [
+  {
+    name: 'join_index',
+    mode: 'lookup',
+    aliases: [],
+  },
+  {
+    name: 'join_index_with_alias',
+    mode: 'lookup',
+    aliases: ['join_index_alias_1', 'join_index_alias_2'],
+  },
+];
+
+export function getCallbackMocks(): ESQLCallbacks {
   return {
-    getColumnsFor: jest.fn(async ({ query }) => {
+    getColumnsFor: jest.fn(async ({ query } = {}) => {
       if (/enrich/.test(query)) {
         return enrichFields;
       }
@@ -75,5 +89,6 @@ export function getCallbackMocks() {
       }))
     ),
     getPolicies: jest.fn(async () => policies),
+    getJoinIndices: jest.fn(async () => ({ indices: joinIndices })),
   };
 }

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.join.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.join.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { setup } from './helpers';
+
+const joinIndices = ['join_index', 'join_index_with_alias'];
+
+describe('autocomplete.suggest', () => {
+  describe('<type> JOIN <index> [ AS <alias> ] ON <condition> [, <condition> [, ...]]', () => {
+    describe('<type> ...', () => {
+      test('suggests command on first character', async () => {
+        const { suggest } = await setup();
+
+        const suggestions = await suggest('FROM index | LEFT J/');
+        const hasCommand = !!suggestions.find((s) => s.label.toUpperCase() === 'JOIN');
+
+        expect(hasCommand).toBe(true);
+      });
+    });
+
+    describe('... <index> ...', () => {
+      test('suggests valid join indices', async () => {
+        const { assertSuggestions } = await setup();
+
+        await assertSuggestions('FROM index | LEFT JOIN /', joinIndices);
+        await assertSuggestions('FROM index | right join /', joinIndices);
+        await assertSuggestions('FROM index | RIGHT JOIN j/', joinIndices);
+      });
+
+      test('after index suggests "AS" expression', async () => {
+        const { assertSuggestions } = await setup();
+
+        await assertSuggestions('FROM index | FROM join_index /', ['AS']);
+        // ...
+      });
+
+      test('suggests "ON" command option', async () => {
+        const { assertSuggestions } = await setup();
+
+        await assertSuggestions('FROM index | FROM join_index /', ['ON']);
+      });
+    });
+
+    describe('... = <alias> ...', () => {
+      test('suggests "ON" command option', async () => {
+        const { assertSuggestions } = await setup();
+
+        await assertSuggestions('FROM index | FROM join_index AS abc /', ['ON']);
+      });
+    });
+
+    describe('... ON <condition>', () => {
+      test('suggests comma after first condition was entered', async () => {
+        const { assertSuggestions } = await setup();
+
+        await assertSuggestions('FROM index | FROM join_index AS abc ON a = b/', [',']);
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { type ESQLAstItem, ESQLAst } from '@kbn/esql-ast';
+import { ESQLCommand } from '@kbn/esql-ast/src/types';
+import { type SupportedDataType } from '../../../definitions/types';
+import type { GetColumnsByTypeFn, SuggestionRawDefinition } from '../../types';
+
+export async function suggest(
+  innerText: string,
+  command: ESQLCommand<'join'>,
+  getColumnsByType: GetColumnsByTypeFn,
+  _columnExists: (column: string) => boolean,
+  _getSuggestedVariableName: () => string,
+  getExpressionType: (expression: ESQLAstItem | undefined) => SupportedDataType | 'unknown',
+  _getPreferences?: () => Promise<{ histogramBarTarget: number } | undefined>,
+  fullTextAst?: ESQLAst
+): Promise<SuggestionRawDefinition[]> {
+  const suggestions: SuggestionRawDefinition[] = [];
+
+  console.log('suggestions...');
+
+  return suggestions;
+}

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/util.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/util.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getPosition } from './util';
+
+test('returns correct position on complete modifier matches', () => {
+  expect(getPosition('L', {} as any).pos).toBe('type');
+  expect(getPosition('LE', {} as any).pos).toBe('type');
+  expect(getPosition('LEFT', {} as any).pos).toBe('type');
+  expect(getPosition('LEFT ', {} as any).pos).toBe('after_type');
+  expect(getPosition('LEFT  ', {} as any).pos).toBe('after_type');
+  expect(getPosition('LEFT  J', {} as any).pos).toBe('mnemonic');
+  expect(getPosition('LEFT  JO', {} as any).pos).toBe('mnemonic');
+  expect(getPosition('LEFT  JOI', {} as any).pos).toBe('mnemonic');
+  expect(getPosition('LEFT  JOIN', {} as any).pos).toBe('mnemonic');
+  expect(getPosition('LEFT  JOIN ', {} as any).pos).toBe('after_mnemonic');
+  expect(getPosition('LEFT  JOIN  ', {} as any).pos).toBe('after_mnemonic');
+  expect(getPosition('LEFT  JOIN  i', {} as any).pos).toBe('index');
+  expect(getPosition('LEFT  JOIN  index', {} as any).pos).toBe('index');
+  expect(getPosition('LEFT  JOIN  index ', {} as any).pos).toBe('after_index');
+  expect(getPosition('LEFT  JOIN  index  ', {} as any).pos).toBe('after_index');
+  expect(getPosition('LEFT  JOIN  index  A', {} as any).pos).toBe('as');
+  expect(getPosition('LEFT  JOIN  index  AS', {} as any).pos).toBe('as');
+  expect(getPosition('LEFT  JOIN  index  AS ', {} as any).pos).toBe('after_as');
+  expect(getPosition('LEFT  JOIN  index  AS  ', {} as any).pos).toBe('after_as');
+  expect(getPosition('LEFT  JOIN  index  AS a', {} as any).pos).toBe('alias');
+  expect(getPosition('LEFT  JOIN  index  AS al', {} as any).pos).toBe('alias');
+  expect(getPosition('LEFT  JOIN  index  AS alias', {} as any).pos).toBe('alias');
+});

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/util.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/util.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ESQLCommand } from '@kbn/esql-ast';
+
+const REGEX =
+  /^(?<type>\w+((?<after_type>\s+((?<mnemonic>(JOIN|JOI|JO|J)((?<after_mnemonic>\s+((?<index>\S+((?<after_index>\s+(?<as>(AS|A))?(?<after_as>\s+)?(((?<alias>\S+)?(?<after_alias>\s+)?((?<on>ON((?<after_on>\s+)?))?))?))?))?))?))?))?))?/i;
+
+/**
+ * Position of the caret in the JOIN command:
+ *
+ * ```
+ * <type> JOIN <index> [ AS <alias> ] ON <condition> [, <condition> [, ...]]
+ * |     ||   ||      |  | ||      |  | ||          |   |          |
+ * |     ||   ||      |  | ||      |  | ||          |   |          |
+ * |     ||   ||      |  | ||      |  | ||          |   |          after_condition
+ * |     ||   ||      |  | ||      |  | ||          |   condition
+ * |     ||   ||      |  | ||      |  | ||          after_condition
+ * |     ||   ||      |  | ||      |  | |condition
+ * |     ||   ||      |  | ||      |  | after_on
+ * |     ||   ||      |  | ||      |  on
+ * |     ||   ||      |  | ||      after_alias
+ * |     ||   ||      |  | |alias
+ * |     ||   ||      |  | after_as
+ * |     ||   ||      |  as
+ * |     ||   ||      after_index
+ * |     ||   |index
+ * |     ||   after_mnemonic
+ * |     |mnemonic
+ * |     after_type
+ * type
+ * ```
+ */
+export interface JoinCaretPosition {
+  pos:
+    | 'none'
+    | 'type'
+    | 'after_type'
+    | 'mnemonic'
+    | 'after_mnemonic'
+    | 'index'
+    | 'after_index'
+    | 'alias'
+    | 'after_alias'
+    | 'on'
+    | 'after_on'
+    | 'condition'
+    | 'after_condition';
+}
+
+const positions: Array<JoinCaretPosition['pos']> = [
+  'after_condition',
+  'condition',
+  'after_on',
+  'on',
+  'after_alias',
+  'alias',
+  'after_index',
+  'index',
+  'after_mnemonic',
+  'mnemonic',
+  'after_type',
+  'type',
+];
+
+export const getPosition = (text: string, command: ESQLCommand): JoinCaretPosition => {
+  const match = text.match(REGEX);
+
+  if (!match || !match.groups) {
+    return {
+      pos: 'none',
+    };
+  }
+
+  let pos: JoinCaretPosition['pos'] = 'none';
+
+  for (const position of positions) {
+    if (match.groups[position]) {
+      pos = position;
+      break;
+    }
+  }
+
+  return {
+    pos,
+  };
+};

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/helper.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/helper.ts
@@ -7,12 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type {
-  ESQLAstItem,
-  ESQLCommand,
-  ESQLFunction,
-  ESQLLiteral,
-  ESQLSource,
+import {
+  isIdentifier,
+  type ESQLAstItem,
+  type ESQLCommand,
+  type ESQLFunction,
+  type ESQLLiteral,
+  type ESQLSource,
 } from '@kbn/esql-ast';
 import { uniqBy } from 'lodash';
 import {
@@ -30,7 +31,6 @@ import {
   isAssignment,
   isColumnItem,
   isFunctionItem,
-  isIdentifier,
   isLiteralItem,
   isTimeIntervalItem,
 } from '../shared/helpers';

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/code_actions/actions.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/code_actions/actions.ts
@@ -9,7 +9,13 @@
 
 import { i18n } from '@kbn/i18n';
 import { distance } from 'fastest-levenshtein';
-import type { AstProviderFn, ESQLAst, EditorError, ESQLMessage } from '@kbn/esql-ast';
+import {
+  type AstProviderFn,
+  type ESQLAst,
+  type EditorError,
+  type ESQLMessage,
+  isIdentifier,
+} from '@kbn/esql-ast';
 import { uniqBy } from 'lodash';
 import {
   getFieldsByTypeHelper,
@@ -20,7 +26,6 @@ import {
   getAllFunctions,
   getCommandDefinition,
   isColumnItem,
-  isIdentifier,
   isSourceItem,
   shouldBeQuotedText,
 } from '../shared/helpers';

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/builtin.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/builtin.ts
@@ -628,6 +628,24 @@ const otherDefinitions: FunctionDefinition[] = [
     ],
   },
   {
+    type: 'builtin' as const,
+    name: 'as',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definition.asDoc', {
+      defaultMessage: 'Rename as (AS)',
+    }),
+    supportedCommands: ['rename', 'join'],
+    supportedOptions: [],
+    signatures: [
+      {
+        params: [
+          { name: 'oldName', type: 'any' },
+          { name: 'newName', type: 'any' },
+        ],
+        returnType: 'unknown',
+      },
+    ],
+  },
+  {
     // TODO — this shouldn't be a function or an operator...
     name: 'info',
     type: 'builtin',

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -38,6 +38,7 @@ import { suggest as suggestForKeep } from '../autocomplete/commands/keep';
 import { suggest as suggestForDrop } from '../autocomplete/commands/drop';
 import { suggest as suggestForStats } from '../autocomplete/commands/stats';
 import { suggest as suggestForWhere } from '../autocomplete/commands/where';
+import { suggest as suggestForJoin } from '../autocomplete/commands/join';
 
 const statsValidator = (command: ESQLCommand) => {
   const messages: ESQLMessage[] = [];
@@ -490,5 +491,23 @@ export const commandDefinitions: Array<CommandDefinition<any>> = [
       params: [],
       multipleParams: false,
     },
+  },
+  {
+    name: 'join',
+    description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.joinDoc', {
+      defaultMessage: 'Join table with another table.',
+    }),
+    examples: [
+      '… | <LEFT | RIGHT | LOOKUP> JOIN index ON index.field = index2.field',
+      '… | <LEFT | RIGHT | LOOKUP> JOIN index AS alias ON index.field = index2.field',
+      '… | <LEFT | RIGHT | LOOKUP> JOIN index AS alias ON index.field = index2.field, index.field2 = index2.field2',
+    ],
+    options: [],
+    modes: [],
+    signature: {
+      multipleParams: false,
+      params: [{ name: 'index', type: 'source', wildcards: true }],
+    },
+    suggest: suggestForJoin,
   },
 ];

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/context.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/context.ts
@@ -16,6 +16,7 @@ import {
   type ESQLCommandOption,
   type ESQLCommandMode,
   Walker,
+  isIdentifier,
 } from '@kbn/esql-ast';
 import { ENRICH_MODES } from '../definitions/settings';
 import { EDITOR_MARKER } from './constants';
@@ -26,7 +27,6 @@ import {
   isSettingItem,
   pipePrecedesCurrentWord,
   getFunctionDefinition,
-  isIdentifier,
 } from './helpers';
 
 function findNode(nodes: ESQLAstItem[], offset: number): ESQLSingleAstItem | undefined {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/helpers.ts
@@ -84,10 +84,6 @@ export function isColumnItem(arg: ESQLAstItem): arg is ESQLColumn {
   return isSingleItem(arg) && arg.type === 'column';
 }
 
-export function isIdentifier(arg: ESQLAstItem): arg is ESQLIdentifier {
-  return isSingleItem(arg) && arg.type === 'identifier';
-}
-
 export function isLiteralItem(arg: ESQLAstItem): arg is ESQLLiteral {
   return isSingleItem(arg) && arg.type === 'literal';
 }

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ESQLRealField } from '../validation/types';
+import type { ESQLRealField, JoinIndexAutocompleteItem } from '../validation/types';
 
 /** @internal **/
 type CallbackFn<Options = {}, Result = string> = (ctx?: Options) => Result[] | Promise<Result[]>;
@@ -46,6 +46,7 @@ export interface ESQLCallbacks {
   >;
   getPreferences?: () => Promise<{ histogramBarTarget: number }>;
   getFieldsMetadata?: Promise<PartialFieldsMetadataClient>;
+  getJoinIndices?: () => Promise<{ indices: JoinIndexAutocompleteItem[] }>;
 }
 
 export type ReasonTypes = 'missingCommand' | 'unsupportedFunction' | 'unknownFunction';

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.join.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.join.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as helpers from '../helpers';
+
+export const validationJoinCommandTestSuite = (setup: helpers.Setup) => {
+  describe('validation', () => {
+    describe('command', () => {
+      describe('<LEFT | RIGHT | LOOKUP> JOIN <index> [ AS <alias> ] ON <condition> [, <condition> [, ...]]', () => {
+        describe('... <index> [ = <alias> ]', () => {
+          test('validates the most basic query', async () => {
+            const { expectErrors } = await setup();
+
+            await expectErrors('FROM index | LEFT JOIN join_index ON stringField', []);
+          });
+
+          test('raises error, when index is not suitable for JOIN command', async () => {
+            const { expectErrors } = await setup();
+
+            await expectErrors('FROM index | LEFT JOIN index ON stringField', [
+              '[index] index is not a valid JOIN index. Please use a "lookup" mode index JOIN commands.',
+            ]);
+            await expectErrors('FROM index | LEFT JOIN non_existing_index_123 ON stringField', [
+              '[non_existing_index_123] index is not a valid JOIN index. Please use a "lookup" mode index JOIN commands.',
+            ]);
+          });
+        });
+      });
+    });
+  });
+};

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/validation.command.join.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/validation.command.join.test.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import * as helpers from './helpers';
+import { validationJoinCommandTestSuite } from './test_suites/validation.command.join';
+
+validationJoinCommandTestSuite(helpers.setup);

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/errors.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/errors.ts
@@ -443,6 +443,18 @@ function getMessageAndTypeFromId<K extends ErrorTypes>({
           }
         ),
       };
+    case 'invalidJoinIndex':
+      return {
+        message: i18n.translate(
+          'kbn-esql-validation-autocomplete.esql.validation.invalidJoinIndex',
+          {
+            defaultMessage:
+              '[{identifier}] index is not a valid JOIN index.' +
+              ' Please use a "lookup" mode index JOIN commands.',
+            values: { identifier: out.identifier },
+          }
+        ),
+      };
   }
   return { message: '' };
 }
@@ -532,6 +544,11 @@ export const errors = {
   aggInAggFunction: (fn: ESQLFunction): ESQLMessage =>
     errors.byId('aggInAggFunction', fn.location, {
       nestedAgg: fn.name,
+    }),
+
+  invalidJoinIndex: (identifier: ESQLIdentifier): ESQLMessage =>
+    errors.byId('invalidJoinIndex', identifier.location, {
+      identifier: identifier.name,
     }),
 };
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -2204,7 +2204,9 @@
     },
     {
       "query": "ROW a=1::LONG | LOOKUP JOIN t ON a",
-      "error": [],
+      "error": [
+        "[t] index is not a valid JOIN index. Please use a \"lookup\" mode index JOIN commands."
+      ],
       "warning": []
     },
     {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/types.ts
@@ -42,6 +42,13 @@ export interface ReferenceMaps {
   fields: Map<string, ESQLRealField>;
   policies: Map<string, ESQLPolicy>;
   query: string;
+  joinIndices: JoinIndexAutocompleteItem[];
+}
+
+export interface JoinIndexAutocompleteItem {
+  name: string;
+  mode: 'lookup' | string;
+  aliases: string[];
 }
 
 export interface ValidationErrors {
@@ -203,6 +210,10 @@ export interface ValidationErrors {
   onlyWhereCommandSupported: {
     message: string;
     type: { fn: string };
+  };
+  invalidJoinIndex: {
+    message: string;
+    type: { identifier: string };
   };
 }
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -505,8 +505,10 @@ describe('validation logic', () => {
       testErrorsAndWarnings('from index | limit 4', []);
     });
 
-    describe('lookup', () => {
-      testErrorsAndWarnings('ROW a=1::LONG | LOOKUP JOIN t ON a', []);
+    describe('join', () => {
+      testErrorsAndWarnings('ROW a=1::LONG | LOOKUP JOIN t ON a', [
+        '[t] index is not a valid JOIN index. Please use a "lookup" mode index JOIN commands.',
+      ]);
     });
 
     describe('keep', () => {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
@@ -21,8 +21,15 @@ import {
   ESQLMessage,
   ESQLSource,
   walk,
+  isBinaryExpression,
+  isIdentifier,
 } from '@kbn/esql-ast';
-import type { ESQLAstField, ESQLIdentifier } from '@kbn/esql-ast/src/types';
+import type {
+  ESQLAstField,
+  ESQLAstJoinCommand,
+  ESQLIdentifier,
+  ESQLProperNode,
+} from '@kbn/esql-ast/src/types';
 import {
   CommandModeDefinition,
   CommandOptionsDefinition,
@@ -55,7 +62,6 @@ import {
   getQuotedColumnName,
   isInlineCastItem,
   getSignaturesWithMatchingArity,
-  isIdentifier,
   isFunctionOperatorParam,
   isMaybeAggFunction,
   isParametrized,
@@ -1104,6 +1110,63 @@ const validateMetricsCommand = (
   return messages;
 };
 
+/**
+ * Validates the JOIN command:
+ *
+ *     <LEFT | RIGHT | LOOKUP> JOIN <target> ON <conditions>
+ *     <LEFT | RIGHT | LOOKUP> JOIN index [ = alias ] ON <condition> [, <condition> [, ...]]
+ */
+const validateJoinCommand = (
+  command: ESQLAstJoinCommand,
+  references: ReferenceMaps
+): ESQLMessage[] => {
+  const messages: ESQLMessage[] = [];
+  const { commandType, args } = command;
+  const { joinIndices } = references;
+
+  if (!['left', 'right', 'lookup'].includes(commandType)) {
+    return [errors.unexpected(command.location, 'JOIN command type')];
+  }
+
+  const target = args[0] as ESQLProperNode;
+  let index: ESQLIdentifier;
+  let alias: ESQLIdentifier | undefined;
+
+  if (isBinaryExpression(target)) {
+    if (target.name === 'as') {
+      alias = target.args[1] as ESQLIdentifier;
+      index = target.args[0] as ESQLIdentifier;
+
+      if (!isIdentifier(index) || !isIdentifier(alias)) {
+        return [errors.unexpected(target.location)];
+      }
+    } else {
+      return [errors.unexpected(target.location)];
+    }
+  } else if (isIdentifier(target)) {
+    index = target as ESQLIdentifier;
+  } else {
+    return [errors.unexpected(target.location)];
+  }
+
+  let isIndexFound = false;
+  for (const { name } of joinIndices) {
+    if (index.name === name) {
+      isIndexFound = true;
+      break;
+    }
+  }
+
+  if (!isIndexFound) {
+    const error = errors.invalidJoinIndex(index);
+    messages.push(error);
+
+    return messages;
+  }
+
+  return messages;
+};
+
 function validateCommand(
   command: ESQLCommand,
   references: ReferenceMaps,
@@ -1129,6 +1192,12 @@ function validateCommand(
     case 'metrics': {
       const metrics = command as ESQLAstMetricsCommand;
       messages.push(...validateMetricsCommand(metrics, references));
+      break;
+    }
+    case 'join': {
+      const join = command as ESQLAstJoinCommand;
+      const joinCommandErrors = validateJoinCommand(join, references);
+      messages.push(...joinCommandErrors);
       break;
     }
     default: {
@@ -1256,6 +1325,7 @@ export const ignoreErrorsMap: Record<keyof ESQLCallbacks, ErrorTypes[]> = {
   getPolicies: ['unknownPolicy'],
   getPreferences: [],
   getFieldsMetadata: [],
+  getJoinIndices: [],
 };
 
 /**
@@ -1325,13 +1395,15 @@ async function validateAst(
 
   const { ast } = parsingResult;
 
-  const [sources, availableFields, availablePolicies] = await Promise.all([
+  const [sources, availableFields, availablePolicies, joinIndices] = await Promise.all([
     // retrieve the list of available sources
     retrieveSources(ast, callbacks),
     // retrieve available fields (if a source command has been defined)
     retrieveFields(queryString, ast, callbacks),
     // retrieve available policies (if an enrich command has been defined)
     retrievePolicies(ast, callbacks),
+    // retrieve indices for join command
+    callbacks?.getJoinIndices?.(),
   ]);
 
   if (availablePolicies.size) {
@@ -1366,6 +1438,7 @@ async function validateAst(
       policies: availablePolicies,
       variables,
       query: queryString,
+      joinIndices: joinIndices?.indices || [],
     };
     const commandMessages = validateCommand(command, references, ast, index);
     messages.push(...commandMessages);


### PR DESCRIPTION
WIP

---

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



