### PR TITLE
[ES|QL] Give the ability to disable the autofocus on the editor

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -84,6 +84,7 @@ export const ESQLEditor = memo(function ESQLEditor({
   hideQueryHistory,
   hasOutline,
   displayDocumentationAsFlyout,
+  disableAutoFocus,
 }: ESQLEditorProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const datePickerOpenStatusRef = useRef<boolean>(false);
@@ -727,8 +728,10 @@ export const ESQLEditor = memo(function ESQLEditor({
                     editor.onDidChangeModelContent(showSuggestionsIfEmptyQuery);
 
                     // Auto-focus the editor and move the cursor to the end.
-                    editor.focus();
-                    editor.setPosition({ column: Infinity, lineNumber: Infinity });
+                    if (!disableAutoFocus) {
+                      editor.focus();
+                      editor.setPosition({ column: Infinity, lineNumber: Infinity });
+                    }
                   }}
                 />
               </div>

--- a/src/platform/packages/private/kbn-esql-editor/src/types.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/types.ts
@@ -66,6 +66,9 @@ export interface ESQLEditorProps {
 
   /** adds a documentation icon in the footer which opens the inline docs as a flyout **/
   displayDocumentationAsFlyout?: boolean;
+
+  /** The component by default focuses on the editor when it is mounted, this flag disables it**/
+  disableAutoFocus?: boolean;
 }
 
 export interface ESQLEditorDeps {


### PR DESCRIPTION
## Summary

Right now, the editor autofocuses by default. But there are cases that a consumer won't want this (autofocus might trigger the suggestions). 

This PR introduces a new property which allows the consumers to disable this feature.

(I need this for the ES|QL variables feature)

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->