### PR TITLE
[ES|QL] Make sure that the commands are not overwritten

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -612,22 +612,30 @@ async function getExpressionSuggestionsByType(
           (fragment) => Boolean(getColumnByName(fragment, references)),
           (_fragment: string, rangeToReplace?: { start: number; end: number }) => {
             // COMMAND fie<suggest>
-            return fieldSuggestions.map((suggestion) => ({
-              ...suggestion,
-              text: suggestion.text + (['grok', 'dissect'].includes(command.name) ? ' ' : ''),
-              command: TRIGGER_SUGGESTION_COMMAND,
-              rangeToReplace,
-            }));
+            return fieldSuggestions.map((suggestion) => {
+              // if there is already a command, we don't want to override it
+              if (suggestion.command) return suggestion;
+              return {
+                ...suggestion,
+                text: suggestion.text + (['grok', 'dissect'].includes(command.name) ? ' ' : ''),
+                command: TRIGGER_SUGGESTION_COMMAND,
+                rangeToReplace,
+              };
+            });
           },
           (fragment: string, rangeToReplace: { start: number; end: number }) => {
             // COMMAND field<suggest>
             if (['grok', 'dissect'].includes(command.name)) {
-              return fieldSuggestions.map((suggestion) => ({
-                ...suggestion,
-                text: suggestion.text + ' ',
-                command: TRIGGER_SUGGESTION_COMMAND,
-                rangeToReplace,
-              }));
+              return fieldSuggestions.map((suggestion) => {
+                // if there is already a command, we don't want to override it
+                if (suggestion.command) return suggestion;
+                return {
+                  ...suggestion,
+                  text: suggestion.text + ' ',
+                  command: TRIGGER_SUGGESTION_COMMAND,
+                  rangeToReplace,
+                };
+              });
             }
 
             const finalSuggestions = [{ ...pipeCompleteItem, text: ' | ' }];

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/drop/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/drop/index.ts
@@ -41,12 +41,16 @@ export async function suggest(
     (fragment) => columnExists(fragment),
     (_fragment: string, rangeToReplace?: { start: number; end: number }) => {
       // KEEP fie<suggest>
-      return fieldSuggestions.map((suggestion) => ({
-        ...suggestion,
-        text: suggestion.text,
-        command: TRIGGER_SUGGESTION_COMMAND,
-        rangeToReplace,
-      }));
+      return fieldSuggestions.map((suggestion) => {
+        // if there is already a command, we don't want to override it
+        if (suggestion.command) return suggestion;
+        return {
+          ...suggestion,
+          text: suggestion.text,
+          command: TRIGGER_SUGGESTION_COMMAND,
+          rangeToReplace,
+        };
+      });
     },
     (fragment: string, rangeToReplace: { start: number; end: number }) => {
       // KEEP field<suggest>

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/keep/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/keep/index.ts
@@ -41,12 +41,16 @@ export async function suggest(
     (fragment) => columnExists(fragment),
     (_fragment: string, rangeToReplace?: { start: number; end: number }) => {
       // KEEP fie<suggest>
-      return fieldSuggestions.map((suggestion) => ({
-        ...suggestion,
-        text: suggestion.text,
-        command: TRIGGER_SUGGESTION_COMMAND,
-        rangeToReplace,
-      }));
+      return fieldSuggestions.map((suggestion) => {
+        // if there is already a command, we don't want to override it
+        if (suggestion.command) return suggestion;
+        return {
+          ...suggestion,
+          text: suggestion.text,
+          command: TRIGGER_SUGGESTION_COMMAND,
+          rangeToReplace,
+        };
+      });
     },
     (fragment: string, rangeToReplace: { start: number; end: number }) => {
       // KEEP field<suggest>

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/sort/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/sort/index.ts
@@ -128,11 +128,15 @@ export async function suggest(
       // SORT fie<suggest>
       return [
         ...pushItUpInTheList(
-          fieldSuggestions.map((suggestion) => ({
-            ...suggestion,
-            command: TRIGGER_SUGGESTION_COMMAND,
-            rangeToReplace,
-          })),
+          fieldSuggestions.map((suggestion) => {
+            // if there is already a command, we don't want to override it
+            if (suggestion.command) return suggestion;
+            return {
+              ...suggestion,
+              command: TRIGGER_SUGGESTION_COMMAND,
+              rangeToReplace,
+            };
+          }),
           true
         ),
         ...functionSuggestions,


### PR DESCRIPTION
## Summary

Makes sure that a command in field suggestions won't get overwritten. Atm we don't have any command but we are going to have on the dashboard variables so this is a prerequisite for this

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->