### PR TITLE
[Spaces] Remove forceSolutionVisibility yml setting

### DIFF
--- a/x-pack/plugins/spaces/server/config.test.ts
+++ b/x-pack/plugins/spaces/server/config.test.ts
@@ -23,9 +23,6 @@ describe('config schema', () => {
         "allowFeatureVisibility": true,
         "allowSolutionVisibility": true,
         "enabled": true,
-        "experimental": Object {
-          "forceSolutionVisibility": false,
-        },
         "maxSpaces": 1000,
       }
     `);
@@ -35,9 +32,6 @@ describe('config schema', () => {
         "allowFeatureVisibility": true,
         "allowSolutionVisibility": true,
         "enabled": true,
-        "experimental": Object {
-          "forceSolutionVisibility": false,
-        },
         "maxSpaces": 1000,
       }
     `);
@@ -47,9 +41,6 @@ describe('config schema', () => {
         "allowFeatureVisibility": true,
         "allowSolutionVisibility": true,
         "enabled": true,
-        "experimental": Object {
-          "forceSolutionVisibility": false,
-        },
         "maxSpaces": 1000,
       }
     `);

--- a/x-pack/plugins/spaces/server/config.ts
+++ b/x-pack/plugins/spaces/server/config.ts
@@ -54,13 +54,6 @@ export const ConfigSchema = schema.object({
       defaultValue: true,
     }),
   }),
-  experimental: schema.maybe(
-    offeringBasedSchema({
-      traditional: schema.object({
-        forceSolutionVisibility: schema.boolean({ defaultValue: false }),
-      }),
-    })
-  ),
 });
 
 export function createConfig$(context: PluginInitializerContext) {


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/191743 we introduced a temporary yml setting for the security team so they could enable the new side navigation in their internal deployment.

Since https://github.com/elastic/kibana/pull/203239 was merged we don't need this yml setting anymore. We can safely remove it as it was only ever used internally and I checked with the security team to make sure they are not using this setting in their deployment.

Fixes https://github.com/elastic/kibana/issues/193132

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->