### PR TITLE
[ML] Data frame analytics: Adds missing space between lines in delete job modal

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_management/components/action_delete/delete_action_modal.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/analytics_management/components/action_delete/delete_action_modal.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EUI_MODAL_CONFIRM_BUTTON,
+  EuiSpacer,
 } from '@elastic/eui';
 
 import type { DeleteAction } from './use_delete_action';
@@ -79,16 +80,22 @@ export const DeleteActionModal: FC<DeleteAction> = ({
         </EuiFlexItem>
         <EuiFlexItem>
           {userCanDeleteIndex && dataViewExists && (
-            <EuiSwitch
-              data-test-subj="mlAnalyticsJobDeleteDataViewSwitch"
-              label={i18n.translate('xpack.ml.dataframe.analyticsList.deleteTargetDataViewTitle', {
-                defaultMessage: 'Delete data view {dataView}',
-                values: { dataView: indexName },
-              })}
-              checked={deleteDataView}
-              onChange={toggleDeleteDataView}
-              disabled={userCanDeleteDataView === false}
-            />
+            <>
+              <EuiSpacer size="s" />
+              <EuiSwitch
+                data-test-subj="mlAnalyticsJobDeleteDataViewSwitch"
+                label={i18n.translate(
+                  'xpack.ml.dataframe.analyticsList.deleteTargetDataViewTitle',
+                  {
+                    defaultMessage: 'Delete data view {dataView}',
+                    values: { dataView: indexName },
+                  }
+                )}
+                checked={deleteDataView}
+                onChange={toggleDeleteDataView}
+                disabled={userCanDeleteDataView === false}
+              />
+            </>
           )}
         </EuiFlexItem>
       </EuiFlexGroup>


### PR DESCRIPTION
Fix for: [#204598](https://github.com/elastic/kibana/issues/204598)

After:

<img width="995" alt="image" src="https://github.com/user-attachments/assets/4c5404af-aa0d-4860-beb9-0ada9312f125" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->