### PR TITLE
[ML] Data frame analytics: Updates Results Explorer flyout footer buttons alignment

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/data_frame_analytics/pages/components/analytics_selector/analytics_id_selector.tsx
@@ -281,7 +281,18 @@ export function AnalyticsIdSelector({
       </EuiFlyoutHeader>
       <EuiFlyoutBody data-test-subj={'mlJobSelectorFlyoutBody'}>{renderTabs()}</EuiFlyoutBody>
       <EuiFlyoutFooter>
-        <EuiFlexGroup>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              iconType="cross"
+              onClick={closeFlyout}
+              data-test-subj="mlFlyoutAnalyticsSelectorButtonClose"
+            >
+              {i18n.translate('xpack.ml.analyticsSelector.closeFlyoutButton', {
+                defaultMessage: 'Close',
+              })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButton
               onClick={applySelection}
@@ -294,17 +305,6 @@ export function AnalyticsIdSelector({
                 defaultMessage="Apply"
               />
             </EuiButton>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
-              iconType="cross"
-              onClick={closeFlyout}
-              data-test-subj="mlFlyoutAnalyticsSelectorButtonClose"
-            >
-              {i18n.translate('xpack.ml.analyticsSelector.closeFlyoutButton', {
-                defaultMessage: 'Close',
-              })}
-            </EuiButtonEmpty>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlyoutFooter>


### PR DESCRIPTION
Fix for: [#204601](https://github.com/elastic/kibana/issues/204601)

After:

Results explorer:

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/fd35934a-7136-4d77-8ef6-9b490b9c2436" />

Analytics map:

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/9ecaf66b-1aa0-4d6a-b537-926a0421bed7" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->