### PR TITLE
[Serverless] Remove "userAndRoles" from es and security nav tree

### DIFF
--- a/x-pack/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/plugins/serverless_search/public/navigation_tree.ts
@@ -166,10 +166,6 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
             }),
           },
           {
-            id: 'cloudLinkUserAndRoles',
-            cloudLink: 'userAndRoles',
-          },
-          {
             id: 'cloudLinkDeployment',
             cloudLink: 'deployment',
             title: i18n.translate('xpack.serverlessSearch.nav.performance', {

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/side_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/side_navigation.ts
@@ -31,10 +31,7 @@ export const initSideNavigation = async (services: Services) => {
         ) as GroupDefinition;
         if (footerGroup) {
           footerGroup.title = PROJECT_SETTINGS_TITLE;
-          footerGroup.children.push(
-            { cloudLink: 'userAndRoles', openInNewTab: true },
-            { cloudLink: 'billingAndSub', openInNewTab: true }
-          );
+          footerGroup.children.push({ cloudLink: 'billingAndSub', openInNewTab: true });
         }
       })
     )

--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -256,7 +256,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
 
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Trained models' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Management' });
-      await solutionNavigation.sidenav.expectLinkExists({ text: 'Users and roles' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Performance' });
       await solutionNavigation.sidenav.expectLinkExists({ text: 'Billing and subscription' });
 

--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -280,7 +280,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
         'project_settings_project_nav',
         'ml:modelManagement',
         'management',
-        'cloudLinkUserAndRoles',
         'cloudLinkDeployment',
         'cloudLinkBilling',
       ]);


### PR DESCRIPTION
In this PR I've removed the "User and roles" link in the footer side nav of the "search" and "security" solution (only in serverless).

I didn't remove it in the observability solution side nav because I didn't see the "Manage organization members" card in the management home page.

Fixes https://github.com/elastic/kibana/issues/192501

## Screenshots

### Search (card present)

<img width="1151" alt="Screenshot 2024-12-18 at 12 14 05" src="https://github.com/user-attachments/assets/22fa820f-a4cd-4275-8e14-2d153dacf61f" />


### Observability (card not present)

<img width="1146" alt="Screenshot 2024-12-18 at 12 12 05" src="https://github.com/user-attachments/assets/c5f0c90e-0771-44aa-9931-7b4c0c06793b" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->