### PR TITLE
[8.x] [kbn-test] extract ES logs only for svl (#202927)

### DIFF
--- a/packages/kbn-scout/src/servers/run_elasticsearch.ts
+++ b/packages/kbn-scout/src/servers/run_elasticsearch.ts
@@ -12,8 +12,8 @@ import { resolve } from 'path';
 import type { ToolingLog } from '@kbn/tooling-log';
 import { REPO_ROOT } from '@kbn/repo-info';
 import type { ArtifactLicense, ServerlessProjectType } from '@kbn/es';
-import { isServerlessProjectType, extractAndArchiveLogs } from '@kbn/es/src/utils';
-import { createTestEsCluster, esTestConfig } from '@kbn/test';
+import { isServerlessProjectType } from '@kbn/es/src/utils';
+import { createTestEsCluster, esTestConfig, cleanupElasticsearch } from '@kbn/test';
 import { Config } from '../config';
 
 interface RunElasticsearchOptions {
@@ -82,8 +82,7 @@ export async function runElasticsearch(
     config,
   });
   return async () => {
-    await node.cleanup();
-    await extractAndArchiveLogs({ outputFolder: logsDir, log });
+    await cleanupElasticsearch(node, config.serverless, logsDir, log);
   };
 }
 

--- a/packages/kbn-test/index.ts
+++ b/packages/kbn-test/index.ts
@@ -22,6 +22,7 @@ export {
   remapPluginPaths,
   getKibanaCliArg,
   getKibanaCliLoggers,
+  cleanupElasticsearch,
 } from './src/functional_tests/lib';
 
 export { initLogsDir } from './src/functional_tests/lib';

--- a/packages/kbn-test/src/functional_tests/lib/index.ts
+++ b/packages/kbn-test/src/functional_tests/lib/index.ts
@@ -8,7 +8,7 @@
  */
 
 export { runKibanaServer } from './run_kibana_server';
-export { runElasticsearch } from './run_elasticsearch';
+export { runElasticsearch, cleanupElasticsearch } from './run_elasticsearch';
 export * from './run_ftr';
 export {
   parseRawFlags,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[kbn-test] extract ES logs only for svl (#202927)](https://github.com/elastic/kibana/pull/202927)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2024-12-04T23:19:41Z","message":"[kbn-test] extract ES logs only for svl (#202927)\n\n## Summary\r\n\r\nPR fixes the issue reported by @dolaru when running stateful FTR\r\nenvironment without docker setup locally:\r\n\r\n```\r\n info [es] killing node\r\n info [es] stopping node scout\r\n info [es] no debug files found, assuming es did not write any\r\n info [es] cleanup complete\r\nERROR UNHANDLED ERROR\r\nERROR Error: Command failed with exit code 1: docker ps -a --format {{.Names}}\r\n      error during connect: Get \"http://docker.example.com/v1.47/containers/json?all=1\": command [ssh -o ConnectTimeout=30 -T -l dolaru -- debian-12-vm docker system dial-stdio] has exited with exit status 255, make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=ssh: Could not resolve hostname dolaru-m2-mbp-debian.local: nodename nor servname provided, or not known\r\n          at makeError (/Users/dolaru/workspace/kibana/node_modules/execa/lib/error.js:60:11)\r\n          at handlePromise (/Users/dolaru/workspace/kibana/node_modules/execa/index.js:118:26)\r\n          at processTicksAndRejections (node:internal/process/task_queues:95:5)\r\n          at extractAndArchiveLogs (extract_and_archive_logs.ts:34:41)\r\n          at run_elasticsearch.ts:86:5\r\n```\r\n\r\nSince we don't need it for stateful ES instance, I added condition.\r\nkbn-scout had the same issue, so I exported `cleanupElasticsearch` from\r\n`kbn-test` to avoid code duplication","sha":"cdb5a2dca2f42edbe2be47c970423d7dbd1ce99e","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","backport:version","v8.18.0"],"number":202927,"url":"https://github.com/elastic/kibana/pull/202927","mergeCommit":{"message":"[kbn-test] extract ES logs only for svl (#202927)\n\n## Summary\r\n\r\nPR fixes the issue reported by @dolaru when running stateful FTR\r\nenvironment without docker setup locally:\r\n\r\n```\r\n info [es] killing node\r\n info [es] stopping node scout\r\n info [es] no debug files found, assuming es did not write any\r\n info [es] cleanup complete\r\nERROR UNHANDLED ERROR\r\nERROR Error: Command failed with exit code 1: docker ps -a --format {{.Names}}\r\n      error during connect: Get \"http://docker.example.com/v1.47/containers/json?all=1\": command [ssh -o ConnectTimeout=30 -T -l dolaru -- debian-12-vm docker system dial-stdio] has exited with exit status 255, make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=ssh: Could not resolve hostname dolaru-m2-mbp-debian.local: nodename nor servname provided, or not known\r\n          at makeError (/Users/dolaru/workspace/kibana/node_modules/execa/lib/error.js:60:11)\r\n          at handlePromise (/Users/dolaru/workspace/kibana/node_modules/execa/index.js:118:26)\r\n          at processTicksAndRejections (node:internal/process/task_queues:95:5)\r\n          at extractAndArchiveLogs (extract_and_archive_logs.ts:34:41)\r\n          at run_elasticsearch.ts:86:5\r\n```\r\n\r\nSince we don't need it for stateful ES instance, I added condition.\r\nkbn-scout had the same issue, so I exported `cleanupElasticsearch` from\r\n`kbn-test` to avoid code duplication","sha":"cdb5a2dca2f42edbe2be47c970423d7dbd1ce99e"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/202927","number":202927,"mergeCommit":{"message":"[kbn-test] extract ES logs only for svl (#202927)\n\n## Summary\r\n\r\nPR fixes the issue reported by @dolaru when running stateful FTR\r\nenvironment without docker setup locally:\r\n\r\n```\r\n info [es] killing node\r\n info [es] stopping node scout\r\n info [es] no debug files found, assuming es did not write any\r\n info [es] cleanup complete\r\nERROR UNHANDLED ERROR\r\nERROR Error: Command failed with exit code 1: docker ps -a --format {{.Names}}\r\n      error during connect: Get \"http://docker.example.com/v1.47/containers/json?all=1\": command [ssh -o ConnectTimeout=30 -T -l dolaru -- debian-12-vm docker system dial-stdio] has exited with exit status 255, make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=ssh: Could not resolve hostname dolaru-m2-mbp-debian.local: nodename nor servname provided, or not known\r\n          at makeError (/Users/dolaru/workspace/kibana/node_modules/execa/lib/error.js:60:11)\r\n          at handlePromise (/Users/dolaru/workspace/kibana/node_modules/execa/index.js:118:26)\r\n          at processTicksAndRejections (node:internal/process/task_queues:95:5)\r\n          at extractAndArchiveLogs (extract_and_archive_logs.ts:34:41)\r\n          at run_elasticsearch.ts:86:5\r\n```\r\n\r\nSince we don't need it for stateful ES instance, I added condition.\r\nkbn-scout had the same issue, so I exported `cleanupElasticsearch` from\r\n`kbn-test` to avoid code duplication","sha":"cdb5a2dca2f42edbe2be47c970423d7dbd1ce99e"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->