### PR TITLE
[8.x] [ResponseOps][Connectors]Migrate remaining routes. (#204042)

### DIFF
--- a/x-pack/plugins/stack_connectors/server/routes/get_inference_services.ts
+++ b/x-pack/plugins/stack_connectors/server/routes/get_inference_services.ts
@@ -20,6 +20,13 @@ export const getInferenceServicesRoute = (router: IRouter) => {
   router.get(
     {
       path: `${INTERNAL_BASE_STACK_CONNECTORS_API_PATH}/_inference/_services`,
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route is opted out of authorization as it relies on ES authorization instead.',
+        },
+      },
       options: {
         access: 'internal',
       },

--- a/x-pack/plugins/stack_connectors/server/routes/get_well_known_email_service.ts
+++ b/x-pack/plugins/stack_connectors/server/routes/get_well_known_email_service.ts
@@ -26,6 +26,13 @@ export const getWellKnownEmailServiceRoute = (router: IRouter) => {
   router.get(
     {
       path: `${INTERNAL_BASE_STACK_CONNECTORS_API_PATH}/_email_config/{service}`,
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route is opted out from authorization as returning SMTP connection details does not require any.',
+        },
+      },
       validate: {
         params: paramSchema,
       },

--- a/x-pack/plugins/stack_connectors/server/routes/valid_slack_api_channels.ts
+++ b/x-pack/plugins/stack_connectors/server/routes/valid_slack_api_channels.ts
@@ -34,6 +34,13 @@ export const validSlackApiChannelsRoute = (
   router.post(
     {
       path: `${INTERNAL_BASE_STACK_CONNECTORS_API_PATH}/_slack_api/channels/_valid`,
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            "This route is opted out from authorization as it relies on Slack's own authorization.",
+        },
+      },
       validate: {
         body: bodySchema,
       },

--- a/x-pack/plugins/triggers_actions_ui/server/routes/config.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/routes/config.ts
@@ -38,6 +38,13 @@ export function createConfigRoute({
   router.get(
     {
       path,
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route is opted out from authorization as it uses the alerting client authorization.',
+        },
+      },
       validate: false,
       options: {
         access: 'internal',

--- a/x-pack/plugins/triggers_actions_ui/server/routes/health.ts
+++ b/x-pack/plugins/triggers_actions_ui/server/routes/health.ts
@@ -25,6 +25,13 @@ export function createHealthRoute(
   router.get(
     {
       path,
+      security: {
+        authz: {
+          enabled: false,
+          reason:
+            'This route is opted out from authorization as the health route does not require any.',
+        },
+      },
       validate: false,
       options: {
         access: 'internal',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ResponseOps][Connectors]Migrate remaining routes. (#204042)](https://github.com/elastic/kibana/pull/204042)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Antonio","email":"antonio.coelho@elastic.co"},"sourceCommit":{"committedDate":"2024-12-16T11:54:49Z","message":"[ResponseOps][Connectors]Migrate remaining routes. (#204042)\n\nConnected with https://github.com/elastic/kibana-team/issues/1322\r\n\r\n## Summary\r\n\r\nThis PR migrates the remaining response-ops routes that do not use\r\naccess tags.\r\n\r\n\r\n[Documentation.](https://docs.elastic.dev/kibana-dev-docs/key-concepts/security-api-authorization#opting-out-of-authorization-for-specific-routes)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"be8e29836bd805f613a25d4bc467c43a1c7a3649","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","backport missing","v9.0.0","backport:prev-minor","v8.18.0"],"number":204042,"url":"https://github.com/elastic/kibana/pull/204042","mergeCommit":{"message":"[ResponseOps][Connectors]Migrate remaining routes. (#204042)\n\nConnected with https://github.com/elastic/kibana-team/issues/1322\r\n\r\n## Summary\r\n\r\nThis PR migrates the remaining response-ops routes that do not use\r\naccess tags.\r\n\r\n\r\n[Documentation.](https://docs.elastic.dev/kibana-dev-docs/key-concepts/security-api-authorization#opting-out-of-authorization-for-specific-routes)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"be8e29836bd805f613a25d4bc467c43a1c7a3649"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/204042","number":204042,"mergeCommit":{"message":"[ResponseOps][Connectors]Migrate remaining routes. (#204042)\n\nConnected with https://github.com/elastic/kibana-team/issues/1322\r\n\r\n## Summary\r\n\r\nThis PR migrates the remaining response-ops routes that do not use\r\naccess tags.\r\n\r\n\r\n[Documentation.](https://docs.elastic.dev/kibana-dev-docs/key-concepts/security-api-authorization#opting-out-of-authorization-for-specific-routes)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"be8e29836bd805f613a25d4bc467c43a1c7a3649"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->