### PR TITLE
[8.17] Fix context.pageName by fixing missing executionContext and add enableExecutionContextTracking flag (#204547)

### DIFF
--- a/packages/react/kibana_context/render/render_provider.tsx
+++ b/packages/react/kibana_context/render/render_provider.tsx
@@ -25,9 +25,13 @@ export type KibanaRenderContextProviderProps = Omit<KibanaRootContextProviderPro
 export const KibanaRenderContextProvider: FC<
   PropsWithChildren<KibanaRenderContextProviderProps>
 > = ({ children, ...props }) => {
+  const { analytics, executionContext, i18n, theme, userProfile, colorMode, modify } = props;
   return (
-    <KibanaRootContextProvider globalStyles={false} {...props}>
-      <KibanaErrorBoundaryProvider analytics={props.analytics}>
+    <KibanaRootContextProvider
+      globalStyles={false}
+      {...{ executionContext, i18n, theme, userProfile, modify, colorMode }}
+    >
+      <KibanaErrorBoundaryProvider analytics={analytics}>
         <KibanaErrorBoundary>{children}</KibanaErrorBoundary>
       </KibanaErrorBoundaryProvider>
     </KibanaRootContextProvider>

--- a/packages/react/kibana_context/render/render_provider.tsx
+++ b/packages/react/kibana_context/render/render_provider.tsx
@@ -25,13 +25,9 @@ export type KibanaRenderContextProviderProps = Omit<KibanaRootContextProviderPro
 export const KibanaRenderContextProvider: FC<
   PropsWithChildren<KibanaRenderContextProviderProps>
 > = ({ children, ...props }) => {
-  const { analytics, executionContext, i18n, theme, userProfile, colorMode, modify } = props;
   return (
-    <KibanaRootContextProvider
-      globalStyles={false}
-      {...{ executionContext, i18n, theme, userProfile, modify, colorMode }}
-    >
-      <KibanaErrorBoundaryProvider analytics={analytics}>
+    <KibanaRootContextProvider globalStyles={false} {...props}>
+      <KibanaErrorBoundaryProvider analytics={props.analytics}>
         <KibanaErrorBoundary>{children}</KibanaErrorBoundary>
       </KibanaErrorBoundaryProvider>
     </KibanaRootContextProvider>

--- a/packages/react/kibana_context/root/root_provider.test.tsx
+++ b/packages/react/kibana_context/root/root_provider.test.tsx
@@ -15,21 +15,26 @@ import { useEuiTheme } from '@elastic/eui';
 import type { UseEuiTheme } from '@elastic/eui';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
 import type { KibanaTheme } from '@kbn/react-kibana-context-common';
-import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
-import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
+import type { ExecutionContextStart } from '@kbn/core-execution-context-browser';
+import { executionContextServiceMock } from '@kbn/core-execution-context-browser-mocks';
 import { i18nServiceMock } from '@kbn/core-i18n-browser-mocks';
+import { I18nStart } from '@kbn/core-i18n-browser';
+import type { UserProfileService } from '@kbn/core-user-profile-browser';
+import { userProfileServiceMock } from '@kbn/core-user-profile-browser-mocks';
 import { KibanaRootContextProvider } from './root_provider';
 import { I18nStart } from '@kbn/core-i18n-browser';
 
 describe('KibanaRootContextProvider', () => {
   let euiTheme: UseEuiTheme | undefined;
   let i18nMock: I18nStart;
-  let analytics: AnalyticsServiceStart;
+  let userProfile: UserProfileService;
+  let executionContext: ExecutionContextStart;
 
   beforeEach(() => {
     euiTheme = undefined;
-    analytics = analyticsServiceMock.createAnalyticsServiceStart();
     i18nMock = i18nServiceMock.createStartContract();
+    userProfile = userProfileServiceMock.createStart();
+    executionContext = executionContextServiceMock.createStartContract();
   });
 
   const flushPromises = async () => {
@@ -62,8 +67,9 @@ describe('KibanaRootContextProvider', () => {
 
     const wrapper = mountWithIntl(
       <KibanaRootContextProvider
-        analytics={analytics}
         i18n={i18nMock}
+        userProfile={userProfile}
+        executionContext={executionContext}
         theme={{ theme$: of(coreTheme) }}
       >
         <InnerComponent />
@@ -80,8 +86,9 @@ describe('KibanaRootContextProvider', () => {
 
     const wrapper = mountWithIntl(
       <KibanaRootContextProvider
-        analytics={analytics}
         i18n={i18nMock}
+        userProfile={userProfile}
+        executionContext={executionContext}
         theme={{ theme$: coreTheme$ }}
       >
         <InnerComponent />

--- a/packages/react/kibana_context/root/root_provider.test.tsx
+++ b/packages/react/kibana_context/root/root_provider.test.tsx
@@ -19,21 +19,16 @@ import type { ExecutionContextStart } from '@kbn/core-execution-context-browser'
 import { executionContextServiceMock } from '@kbn/core-execution-context-browser-mocks';
 import { i18nServiceMock } from '@kbn/core-i18n-browser-mocks';
 import { I18nStart } from '@kbn/core-i18n-browser';
-import type { UserProfileService } from '@kbn/core-user-profile-browser';
-import { userProfileServiceMock } from '@kbn/core-user-profile-browser-mocks';
 import { KibanaRootContextProvider } from './root_provider';
-import { I18nStart } from '@kbn/core-i18n-browser';
 
 describe('KibanaRootContextProvider', () => {
   let euiTheme: UseEuiTheme | undefined;
   let i18nMock: I18nStart;
-  let userProfile: UserProfileService;
   let executionContext: ExecutionContextStart;
 
   beforeEach(() => {
     euiTheme = undefined;
     i18nMock = i18nServiceMock.createStartContract();
-    userProfile = userProfileServiceMock.createStart();
     executionContext = executionContextServiceMock.createStartContract();
   });
 
@@ -68,7 +63,6 @@ describe('KibanaRootContextProvider', () => {
     const wrapper = mountWithIntl(
       <KibanaRootContextProvider
         i18n={i18nMock}
-        userProfile={userProfile}
         executionContext={executionContext}
         theme={{ theme$: of(coreTheme) }}
       >
@@ -87,7 +81,6 @@ describe('KibanaRootContextProvider', () => {
     const wrapper = mountWithIntl(
       <KibanaRootContextProvider
         i18n={i18nMock}
-        userProfile={userProfile}
         executionContext={executionContext}
         theme={{ theme$: coreTheme$ }}
       >

--- a/packages/react/kibana_context/root/root_provider.tsx
+++ b/packages/react/kibana_context/root/root_provider.tsx
@@ -11,6 +11,8 @@ import React, { FC, PropsWithChildren } from 'react';
 
 import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
 import type { I18nStart } from '@kbn/core-i18n-browser';
+import type { ExecutionContextStart } from '@kbn/core-execution-context-browser';
+import { SharedUXRouterContext } from '@kbn/shared-ux-router';
 
 // @ts-expect-error EUI exports this component internally, but Kibana isn't picking it up its types
 import { useIsNestedEuiProvider } from '@elastic/eui/lib/components/provider/nested';
@@ -25,6 +27,8 @@ export interface KibanaRootContextProviderProps extends KibanaEuiProviderProps {
   i18n: I18nStart;
   /** The `AnalyticsServiceStart` API from `CoreStart`. */
   analytics?: Pick<AnalyticsServiceStart, 'reportEvent'>;
+  /** The `ExecutionContextStart` API from `CoreStart`. */
+  executionContext?: ExecutionContextStart;
 }
 
 /**
@@ -44,19 +48,26 @@ export interface KibanaRootContextProviderProps extends KibanaEuiProviderProps {
 export const KibanaRootContextProvider: FC<PropsWithChildren<KibanaRootContextProviderProps>> = ({
   children,
   i18n,
+  executionContext,
   ...props
 }) => {
   const hasEuiProvider = useIsNestedEuiProvider();
+  const rootContextProvider = (
+    <SharedUXRouterContext.Provider value={{ services: { executionContext } }}>
+      <i18n.Context>{children}</i18n.Context>
+    </SharedUXRouterContext.Provider>
+  );
 
   if (hasEuiProvider) {
     emitEuiProviderWarning(
       'KibanaRootContextProvider has likely been nested in this React tree, either by direct reference or by KibanaRenderContextProvider.  The result of this nesting is a nesting of EuiProvider, which has negative effects.  Check your React tree for nested Kibana context providers.'
     );
-    return <i18n.Context>{children}</i18n.Context>;
+    return rootContextProvider;
   } else {
+    const { theme, userProfile, globalStyles, colorMode, modify } = props;
     return (
-      <KibanaEuiProvider {...props}>
-        <i18n.Context>{children}</i18n.Context>
+      <KibanaEuiProvider {...{ theme, userProfile, globalStyles, colorMode, modify }}>
+        {rootContextProvider}
       </KibanaEuiProvider>
     );
   }

--- a/packages/react/kibana_context/root/root_provider.tsx
+++ b/packages/react/kibana_context/root/root_provider.tsx
@@ -64,11 +64,6 @@ export const KibanaRootContextProvider: FC<PropsWithChildren<KibanaRootContextPr
     );
     return rootContextProvider;
   } else {
-    const { theme, userProfile, globalStyles, colorMode, modify } = props;
-    return (
-      <KibanaEuiProvider {...{ theme, userProfile, globalStyles, colorMode, modify }}>
-        {rootContextProvider}
-      </KibanaEuiProvider>
-    );
+    return <KibanaEuiProvider {...props}>{rootContextProvider}</KibanaEuiProvider>;
   }
 };

--- a/packages/react/kibana_context/root/tsconfig.json
+++ b/packages/react/kibana_context/root/tsconfig.json
@@ -22,8 +22,6 @@
     "@kbn/core-i18n-browser",
     "@kbn/core-base-common",
     "@kbn/core-analytics-browser",
-    "@kbn/core-user-profile-browser",
-    "@kbn/core-user-profile-browser-mocks",
     "@kbn/core-execution-context-browser",
     "@kbn/core-execution-context-browser-mocks",
     "@kbn/shared-ux-router"

--- a/packages/react/kibana_context/root/tsconfig.json
+++ b/packages/react/kibana_context/root/tsconfig.json
@@ -22,6 +22,10 @@
     "@kbn/core-i18n-browser",
     "@kbn/core-base-common",
     "@kbn/core-analytics-browser",
-    "@kbn/core-analytics-browser-mocks",
+    "@kbn/core-user-profile-browser",
+    "@kbn/core-user-profile-browser-mocks",
+    "@kbn/core-execution-context-browser",
+    "@kbn/core-execution-context-browser-mocks",
+    "@kbn/shared-ux-router"
   ]
 }

--- a/packages/shared-ux/router/impl/BUILD.bazel
+++ b/packages/shared-ux/router/impl/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+
+SRCS = glob(
+  [
+    "**/*.ts",
+    "**/*.tsx",
+  ],
+  exclude = [
+    "**/test_helpers.ts",
+    "**/*.config.js",
+    "**/*.mock.*",
+    "**/*.test.*",
+    "**/*.stories.*",
+    "**/__snapshots__/**",
+    "**/integration_tests/**",
+    "**/mocks/**",
+    "**/scripts/**",
+    "**/storybook/**",
+    "**/test_fixtures/**",
+    "**/test_helpers/**",
+  ],
+)
+
+DEPS = [
+  
+]
+
+js_library(
+  name = "shared-ux-router",
+  package_name = "@kbn/shared-ux-router",
+  srcs = ["package.json"] + SRCS,
+  deps = DEPS,
+  visibility = ["//visibility:public"],
+)

--- a/packages/shared-ux/router/impl/__snapshots__/route.test.tsx.snap
+++ b/packages/shared-ux/router/impl/__snapshots__/route.test.tsx.snap
@@ -33,3 +33,5 @@ exports[`Route renders 1`] = `
   <MatchPropagator />
 </Route>
 `;
+
+exports[`Route renders with enableExecutionContextTracking as false 1`] = `<Route />`;

--- a/packages/shared-ux/router/impl/route.test.tsx
+++ b/packages/shared-ux/router/impl/route.test.tsx
@@ -9,11 +9,30 @@
 
 import React, { Component, FC } from 'react';
 import { shallow } from 'enzyme';
+import { useSharedUXRoutesContext } from './routes_context';
 import { Route } from './route';
 import { createMemoryHistory } from 'history';
 
+jest.mock('./routes_context', () => ({
+  useSharedUXRoutesContext: jest.fn().mockImplementation(() => ({
+    enableExecutionContextTracking: true,
+  })),
+}));
+
 describe('Route', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('renders', () => {
+    const example = shallow(<Route />);
+    expect(example).toMatchSnapshot();
+  });
+
+  test('renders with enableExecutionContextTracking as false', () => {
+    (useSharedUXRoutesContext as jest.Mock).mockImplementationOnce(() => ({
+      enableExecutionContextTracking: false,
+    }));
     const example = shallow(<Route />);
     expect(example).toMatchSnapshot();
   });

--- a/packages/shared-ux/router/impl/route.tsx
+++ b/packages/shared-ux/router/impl/route.tsx
@@ -15,6 +15,7 @@ import {
   RouteProps,
   useRouteMatch,
 } from 'react-router-dom';
+import { useSharedUXRoutesContext } from './routes_context';
 import { useKibanaSharedUX } from './services';
 import { useSharedUXExecutionContext } from './use_execution_context';
 
@@ -30,17 +31,18 @@ export const Route = <T extends {}>({
   render,
   ...rest
 }: RouteProps<string, { [K: string]: string } & T>) => {
+  const { enableExecutionContextTracking } = useSharedUXRoutesContext();
   const component = useMemo(() => {
     if (!Component) {
       return undefined;
     }
     return (props: RouteComponentProps) => (
       <>
-        <MatchPropagator />
+        {enableExecutionContextTracking && <MatchPropagator />}
         <Component {...props} />
       </>
     );
-  }, [Component]);
+  }, [Component, enableExecutionContextTracking]);
 
   if (component) {
     return <ReactRouterRoute {...rest} component={component} />;
@@ -52,7 +54,7 @@ export const Route = <T extends {}>({
         {...rest}
         render={(props) => (
           <>
-            <MatchPropagator />
+            {enableExecutionContextTracking && <MatchPropagator />}
             {/* @ts-ignore  else condition exists if renderFunction is undefined*/}
             {renderFunction(props)}
           </>
@@ -62,7 +64,7 @@ export const Route = <T extends {}>({
   }
   return (
     <ReactRouterRoute {...rest}>
-      <MatchPropagator />
+      {enableExecutionContextTracking && <MatchPropagator />}
       {children}
     </ReactRouterRoute>
   );
@@ -74,6 +76,12 @@ export const Route = <T extends {}>({
 export const MatchPropagator = () => {
   const { executionContext } = useKibanaSharedUX().services;
   const match = useRouteMatch();
+
+  if (!executionContext && process.env.NODE_ENV !== 'production') {
+    throw new Error(
+      'Default execution context tracking is enabled but the executionContext service is not available'
+    );
+  }
 
   useSharedUXExecutionContext(executionContext, {
     type: 'application',

--- a/packages/shared-ux/router/impl/routes_context.ts
+++ b/packages/shared-ux/router/impl/routes_context.ts
@@ -7,8 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { Route } from './route';
-export { HashRouter, BrowserRouter, MemoryRouter, Router } from './router';
-export { Routes } from './routes';
+import { createContext, useContext } from 'react';
+import { SharedUXRoutesContextType } from './types';
 
-export { SharedUXRouterContext } from './services';
+const defaultContextValue = {};
+
+export const SharedUXRoutesContext = createContext<SharedUXRoutesContextType>(defaultContextValue);
+
+export const useSharedUXRoutesContext = (): SharedUXRoutesContextType =>
+  useContext(SharedUXRoutesContext as unknown as React.Context<SharedUXRoutesContextType>);

--- a/packages/shared-ux/router/impl/services.ts
+++ b/packages/shared-ux/router/impl/services.ts
@@ -50,7 +50,7 @@ export interface SharedUXExecutionContextSetup {
  */
 export interface SharedUXExecutionContextSetup {
   /** {@link SharedUXExecutionContextSetup} */
-  executionContext: SharedUXExecutionContextStart;
+  executionContext?: SharedUXExecutionContextStart;
 }
 
 export type KibanaServices = Partial<SharedUXExecutionContextSetup>;
@@ -63,12 +63,14 @@ const defaultContextValue = {
   services: {},
 };
 
-export const sharedUXContext =
+export const SharedUXRouterContext =
   createContext<SharedUXRouterContextValue<KibanaServices>>(defaultContextValue);
 
 export const useKibanaSharedUX = <Extra extends object = {}>(): SharedUXRouterContextValue<
   KibanaServices & Extra
 > =>
   useContext(
-    sharedUXContext as unknown as React.Context<SharedUXRouterContextValue<KibanaServices & Extra>>
+    SharedUXRouterContext as unknown as React.Context<
+      SharedUXRouterContextValue<KibanaServices & Extra>
+    >
   );

--- a/packages/shared-ux/router/impl/types.ts
+++ b/packages/shared-ux/router/impl/types.ts
@@ -33,3 +33,11 @@ export declare interface SharedUXExecutionContext {
   /** an inner context spawned from the current context. */
   child?: SharedUXExecutionContext;
 }
+
+export declare interface SharedUXRoutesContextType {
+  /**
+   * This flag is used to enable the default execution context tracking for a specific router.
+   * Enable this flag in case you don't have a custom implementation for execution context tracking.
+   * */
+  readonly enableExecutionContextTracking?: boolean;
+}

--- a/packages/shared-ux/router/impl/use_execution_context.ts
+++ b/packages/shared-ux/router/impl/use_execution_context.ts
@@ -8,7 +8,7 @@
  */
 
 import useDeepCompareEffect from 'react-use/lib/useDeepCompareEffect';
-import { SharedUXExecutionContextSetup } from './services';
+import type { SharedUXExecutionContextSetup } from './services';
 import { SharedUXExecutionContext } from './types';
 
 /**

--- a/x-pack/plugins/observability_solution/observability/public/application/index.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/application/index.tsx
@@ -28,7 +28,7 @@ import { HideableReactQueryDevTools } from './hideable_react_query_dev_tools';
 function App() {
   return (
     <>
-      <Routes>
+      <Routes enableExecutionContextTracking={true}>
         {Object.keys(routes).map((key) => {
           const path = key as keyof typeof routes;
           const { handler, exact } = routes[path];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Fix context.pageName by fixing missing executionContext and add enableExecutionContextTracking flag (#204547)](https://github.com/elastic/kibana/pull/204547)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2024-12-18T12:59:23Z","message":"Fix context.pageName by fixing missing executionContext and add enableExecutionContextTracking flag (#204547)\n\nResolves https://github.com/elastic/kibana/issues/195778\r\n\r\n## 🐞 Summary\r\nThis PR fixes missing executionContext in sharedux router by adding\r\n`SharedUXContext` to the `KibanaRootContextProvider` (inside of the\r\n`KibanaRenderContextProvider`). (More context provided in this\r\nhttps://github.com/elastic/kibana/issues/195778#issuecomment-2426936142)\r\n\r\nIt also introduces `enableExecutionContextTracking` to enable tracking\r\nlogic to avoid creating a race condition for the existing custom\r\nexecution context tracking implementations.\r\n\r\nI enabled this flag for the observability plugin and here is the\r\ndifference:\r\n\r\n|Item|Screenshot|\r\n|---|---|\r\n\r\n|Before|![image](https://github.com/user-attachments/assets/83283d23-3347-45be-95c1-120cdfabb9c5)|\r\n\r\n|After|![image](https://github.com/user-attachments/assets/9de51645-6bf1-4537-baeb-6878e7bb3590)|\r\n\r\n### 🧪 How to test\r\n- Go to the observability alerts page and check the kibana-browser\r\nrequest as shown above\r\n\r\n### ✨ Possible future improvements\r\n\r\nAllowing this logic to be provided by the consumer so that we can get\r\nrid of custom implementations (Example: [APM custom execution\r\ncontext](https://github.com/elastic/kibana/blob/e9671937bacfaa911d32de0e8885e7f26425888a/x-pack/plugins/observability_solution/apm/public/components/routing/app_root/update_execution_context_on_route_change.ts#L21,L25))\r\n\r\n---------\r\n\r\nCo-authored-by: Anton Dosov <anton.dosov@elastic.co>\r\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: Elena Stoeva <elenastoeva99@gmail.com>","sha":"53748fdefa1d59d58a4708258a1476dc140b1588","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor","Team:obs-ux-management","backport:version","v8.17.1"],"number":204547,"url":"https://github.com/elastic/kibana/pull/204547","mergeCommit":{"message":"Fix context.pageName by fixing missing executionContext and add enableExecutionContextTracking flag (#204547)\n\nResolves https://github.com/elastic/kibana/issues/195778\r\n\r\n## 🐞 Summary\r\nThis PR fixes missing executionContext in sharedux router by adding\r\n`SharedUXContext` to the `KibanaRootContextProvider` (inside of the\r\n`KibanaRenderContextProvider`). (More context provided in this\r\nhttps://github.com/elastic/kibana/issues/195778#issuecomment-2426936142)\r\n\r\nIt also introduces `enableExecutionContextTracking` to enable tracking\r\nlogic to avoid creating a race condition for the existing custom\r\nexecution context tracking implementations.\r\n\r\nI enabled this flag for the observability plugin and here is the\r\ndifference:\r\n\r\n|Item|Screenshot|\r\n|---|---|\r\n\r\n|Before|![image](https://github.com/user-attachments/assets/83283d23-3347-45be-95c1-120cdfabb9c5)|\r\n\r\n|After|![image](https://github.com/user-attachments/assets/9de51645-6bf1-4537-baeb-6878e7bb3590)|\r\n\r\n### 🧪 How to test\r\n- Go to the observability alerts page and check the kibana-browser\r\nrequest as shown above\r\n\r\n### ✨ Possible future improvements\r\n\r\nAllowing this logic to be provided by the consumer so that we can get\r\nrid of custom implementations (Example: [APM custom execution\r\ncontext](https://github.com/elastic/kibana/blob/e9671937bacfaa911d32de0e8885e7f26425888a/x-pack/plugins/observability_solution/apm/public/components/routing/app_root/update_execution_context_on_route_change.ts#L21,L25))\r\n\r\n---------\r\n\r\nCo-authored-by: Anton Dosov <anton.dosov@elastic.co>\r\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: Elena Stoeva <elenastoeva99@gmail.com>","sha":"53748fdefa1d59d58a4708258a1476dc140b1588"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/204547","number":204547,"mergeCommit":{"message":"Fix context.pageName by fixing missing executionContext and add enableExecutionContextTracking flag (#204547)\n\nResolves https://github.com/elastic/kibana/issues/195778\r\n\r\n## 🐞 Summary\r\nThis PR fixes missing executionContext in sharedux router by adding\r\n`SharedUXContext` to the `KibanaRootContextProvider` (inside of the\r\n`KibanaRenderContextProvider`). (More context provided in this\r\nhttps://github.com/elastic/kibana/issues/195778#issuecomment-2426936142)\r\n\r\nIt also introduces `enableExecutionContextTracking` to enable tracking\r\nlogic to avoid creating a race condition for the existing custom\r\nexecution context tracking implementations.\r\n\r\nI enabled this flag for the observability plugin and here is the\r\ndifference:\r\n\r\n|Item|Screenshot|\r\n|---|---|\r\n\r\n|Before|![image](https://github.com/user-attachments/assets/83283d23-3347-45be-95c1-120cdfabb9c5)|\r\n\r\n|After|![image](https://github.com/user-attachments/assets/9de51645-6bf1-4537-baeb-6878e7bb3590)|\r\n\r\n### 🧪 How to test\r\n- Go to the observability alerts page and check the kibana-browser\r\nrequest as shown above\r\n\r\n### ✨ Possible future improvements\r\n\r\nAllowing this logic to be provided by the consumer so that we can get\r\nrid of custom implementations (Example: [APM custom execution\r\ncontext](https://github.com/elastic/kibana/blob/e9671937bacfaa911d32de0e8885e7f26425888a/x-pack/plugins/observability_solution/apm/public/components/routing/app_root/update_execution_context_on_route_change.ts#L21,L25))\r\n\r\n---------\r\n\r\nCo-authored-by: Anton Dosov <anton.dosov@elastic.co>\r\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>\r\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani@elastic.co>\r\nCo-authored-by: Elena Stoeva <elenastoeva99@gmail.com>","sha":"53748fdefa1d59d58a4708258a1476dc140b1588"}},{"branch":"8.17","label":"v8.17.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"url":"https://github.com/elastic/kibana/pull/204798","number":204798,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->