### PR TITLE
Fix typo in documentation

### DIFF
--- a/dev_docs/tutorials/performance/adding_custom_performance_metrics.mdx
+++ b/dev_docs/tutorials/performance/adding_custom_performance_metrics.mdx
@@ -298,7 +298,7 @@ This event will be indexed with the following structure:
 
 The meta field supports telemetry on time ranges, providing calculated metrics for enhanced context. This includes:
 
-- **Query range in ceconds:**
+- **Query range in seconds:**
 
   - Calculated as the time difference in seconds between `rangeFrom` and `rangeTo`.
 


### PR DESCRIPTION
## Summary
Fix typo 
related : https://github.com/elastic/kibana/pull/204179#pullrequestreview-2512105404




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->