### PR TITLE
[Security Solution] Reduce flakiness in functions for installing Fleet package with prebuilt rules

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_fleet_package_by_url.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_fleet_package_by_url.ts
@@ -13,8 +13,7 @@ import expect from 'expect';
 import { refreshSavedObjectIndices } from '../../refresh_index';
 
 const MAX_RETRIES = 2;
-const ATTEMPT_TIMEOUT = 120000;
-const TOTAL_TIMEOUT = ATTEMPT_TIMEOUT * (1 + MAX_RETRIES);
+const TOTAL_TIMEOUT = 6 * 60000; // 6 mins, applies to all attempts (1 + MAX_RETRIES)
 
 /**
  * Installs latest available non-prerelease prebuilt rules package `security_detection_engine`.

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_fleet_package_by_url.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_fleet_package_by_url.ts
@@ -14,6 +14,7 @@ import { refreshSavedObjectIndices } from '../../refresh_index';
 
 const MAX_RETRIES = 2;
 const ATTEMPT_TIMEOUT = 120000;
+const TOTAL_TIMEOUT = ATTEMPT_TIMEOUT * (1 + MAX_RETRIES);
 
 /**
  * Installs latest available non-prerelease prebuilt rules package `security_detection_engine`.
@@ -46,7 +47,7 @@ export const installPrebuiltRulesPackageViaFleetAPI = async (
     },
     {
       retryCount: MAX_RETRIES,
-      timeout: ATTEMPT_TIMEOUT,
+      timeout: TOTAL_TIMEOUT,
     }
   );
 
@@ -87,7 +88,7 @@ export const installPrebuiltRulesPackageByVersion = async (
     },
     {
       retryCount: MAX_RETRIES,
-      timeout: ATTEMPT_TIMEOUT,
+      timeout: TOTAL_TIMEOUT,
     }
   );
 

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_prebuilt_rules_fleet_package.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_prebuilt_rules_fleet_package.ts
@@ -19,6 +19,7 @@ import { refreshSavedObjectIndices } from '../../refresh_index';
 
 const MAX_RETRIES = 2;
 const ATTEMPT_TIMEOUT = 120000;
+const TOTAL_TIMEOUT = ATTEMPT_TIMEOUT * (1 + MAX_RETRIES);
 
 /**
  * Installs the `security_detection_engine` package via fleet API. This will
@@ -60,7 +61,7 @@ export const installPrebuiltRulesFleetPackage = async ({
       },
       {
         retryCount: MAX_RETRIES,
-        timeout: ATTEMPT_TIMEOUT,
+        timeout: TOTAL_TIMEOUT,
       }
     );
 
@@ -94,7 +95,7 @@ export const installPrebuiltRulesFleetPackage = async ({
       },
       {
         retryCount: MAX_RETRIES,
-        timeout: ATTEMPT_TIMEOUT,
+        timeout: TOTAL_TIMEOUT,
       }
     );
 

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_prebuilt_rules_fleet_package.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/utils/rules/prebuilt_rules/install_prebuilt_rules_fleet_package.ts
@@ -18,8 +18,7 @@ import expect from 'expect';
 import { refreshSavedObjectIndices } from '../../refresh_index';
 
 const MAX_RETRIES = 2;
-const ATTEMPT_TIMEOUT = 120000;
-const TOTAL_TIMEOUT = ATTEMPT_TIMEOUT * (1 + MAX_RETRIES);
+const TOTAL_TIMEOUT = 6 * 60000; // 6 mins, applies to all attempts (1 + MAX_RETRIES)
 
 /**
  * Installs the `security_detection_engine` package via fleet API. This will


### PR DESCRIPTION
**Fixes: https://github.com/elastic/kibana/issues/204812**

## Summary

This PR increases the total timeout for installing the prebuilt rules package from the API integration tests from 2 minutes to 6 minutes, where 6 minutes = 2 minutes * 3 attempts.

Logic before the fix:
- If the first attempt takes more than 2 minutes, it will continue to run.
- If the first attempt takes less than 2 minutes, there will be a second one.
- If the first attempt takes more than 2 minutes, there won't be a second one.

Logic after the fix:
- If the first attempt takes more than 2 minutes, it will continue to run.
- If the first attempt takes less than 2 minutes, there will be a second one.
- If the first attempt takes more than 2 minutes but less than 6, there will be a second one.
- If the first attempt takes more than 6 minutes, there won't be a second one.

Context: https://github.com/elastic/kibana/issues/204812#issuecomment-2552010657

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->