### PR TITLE
[Fleet] Agent upgrade form validation fix

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -296,6 +296,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
       isSubmitting ||
       (isUpdating && updatingAgents === 0) ||
       !selectedVersion[0].value ||
+      !semverValid(selectedVersion[0].value) ||
       (isSingleAgent && !isAgentUpgradeableToVersion(agents[0], selectedVersion[0].value)) ||
       (isSingleAgent &&
         !isSingleAgentFleetServer &&
@@ -566,7 +567,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
           <EuiFieldText
             fullWidth
             placeholder="Enter version"
-            value={selectedVersionStr}
+            value={selectedVersion[0].value}
             data-test-subj="agentUpgradeModal.VersionInput"
             onChange={(e) => {
               const newValue = e.target.value;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -230,7 +230,6 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
     },
   ];
   const [selectedVersion, setSelectedVersion] = useState(preselected);
-  const [selectedVersionStr, setSelectedVersionStr] = useState('');
 
   // latest agent version might be earlier than kibana version
   const latestAgentVersion = useAgentVersion();
@@ -571,7 +570,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
             data-test-subj="agentUpgradeModal.VersionInput"
             onChange={(e) => {
               const newValue = e.target.value;
-              setSelectedVersionStr(newValue);
+
               setSelectedVersion([{ label: newValue, value: newValue }]);
             }}
             isInvalid={!!semverErrors}


### PR DESCRIPTION
## Summary

Closes #197399 

Implemented a fix when trying to bulk upgrade agents that are on the current version (see issue for further explanation). Instead of a combobox, a text field would be shown but the current version (in line with the kibana version) wasn't automatically being added to the field as intended due to the wrong variable being passed as the `value` prop. However the correct version was being applied to the behind-the-scenes check, allowing the user to submit even though it looked like nothing had been entered in the field. 

- Fixed `value` prop on input to use the correct pre-filled value initially
- Added a check so that if there were errors with the version being typed in, the button would also get disabled to stop submissions with invalid versions


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

n/a




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->