### PR TITLE
[ES `body` removal] `@elastic/kibana-security`

### DIFF
--- a/x-pack/plugins/security/server/routes/deprecations/kibana_user_role.test.ts
+++ b/x-pack/plugins/security/server/routes/deprecations/kibana_user_role.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { errors } from '@elastic/elasticsearch';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import type { RequestHandler, RouteConfig } from '@kbn/core/server';
 import { kibanaResponseFactory } from '@kbn/core/server';

--- a/x-pack/plugins/security/server/routes/deprecations/kibana_user_role.ts
+++ b/x-pack/plugins/security/server/routes/deprecations/kibana_user_role.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import type { RouteDefinitionParams } from '..';
 import { KIBANA_ADMIN_ROLE_NAME, KIBANA_USER_ROLE_NAME } from '../../deprecations';

--- a/x-pack/plugins/security/server/session_management/session_index.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.ts
@@ -8,15 +8,13 @@
 import type {
   AggregateName,
   AggregationsMultiTermsAggregate,
+  BulkOperationContainer,
   CreateRequest,
   IndicesCreateRequest,
   MsearchRequestItem,
   SearchHit,
-} from '@elastic/elasticsearch/lib/api/types';
-import type {
-  BulkOperationContainer,
   SortResults,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+} from '@elastic/elasticsearch/lib/api/types';
 import semver from 'semver';
 
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';

--- a/x-pack/plugins/security/server/user_profile/user_profile_service.ts
+++ b/x-pack/plugins/security/server/user_profile/user_profile_service.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import type { SecurityActivateUserProfileRequest } from '@elastic/elasticsearch/lib/api/types';
-import type { SecurityUserProfile } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type {
+  SecurityActivateUserProfileRequest,
+  SecurityUserProfile,
+} from '@elastic/elasticsearch/lib/api/types';
 
 import type { IClusterClient, Logger } from '@kbn/core/server';
 import type {

--- a/x-pack/test/spaces_api_integration/common/suites/copy_to_space.ts
+++ b/x-pack/test/spaces_api_integration/common/suites/copy_to_space.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import type { SuperTest } from 'supertest';
 
 import type {


### PR DESCRIPTION
## Summary

Attempt to remove the deprecated `body` in the ES client.





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->