### PR TITLE
[ES `body` removal] `@elastic/logstash`

### DIFF
--- a/x-pack/plugins/logstash/server/models/cluster/cluster.test.ts
+++ b/x-pack/plugins/logstash/server/models/cluster/cluster.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import { Cluster } from './cluster';
 
 describe('cluster', () => {

--- a/x-pack/plugins/logstash/server/models/cluster/cluster.ts
+++ b/x-pack/plugins/logstash/server/models/cluster/cluster.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 /**
  * This model deals with a cluster object from ES and converts it to Kibana downstream


### PR DESCRIPTION
## Summary

Attempt to remove the deprecated `body` in the ES client.





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->