### PR TITLE
[ES `body` removal] `@elastic/fleet`

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SecurityRoleDescriptor } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { SecurityRoleDescriptor } from '@elastic/elasticsearch/lib/api/types';
 
 import type { agentPolicyStatuses } from '../../constants';
 import type { MonitoringType, PolicySecretReference, ValueOf } from '..';

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import type {
   ASSETS_SAVED_OBJECT_TYPE,

--- a/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
@@ -8,7 +8,7 @@ import type { Dictionary } from 'lodash';
 import { keyBy, keys, merge } from 'lodash';
 import type { RequestHandler } from '@kbn/core/server';
 import pMap from 'p-map';
-import type { IndicesDataStreamsStatsDataStreamsStatsItem } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { IndicesDataStreamsStatsDataStreamsStatsItem } from '@elastic/elasticsearch/lib/api/types';
 import { ByteSizeValue } from '@kbn/config-schema';
 
 import type { DataStream } from '../../types';

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -8,7 +8,7 @@
 import type {
   SecurityIndicesPrivileges,
   SecurityRoleDescriptor,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+} from '@elastic/elasticsearch/lib/api/types';
 
 import {
   FLEET_APM_PACKAGE,

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -22,7 +22,7 @@ import type {
 } from '@kbn/core/server';
 import { SavedObjectsUtils } from '@kbn/core/server';
 
-import type { BulkResponseItem } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { BulkResponseItem } from '@elastic/elasticsearch/lib/api/types';
 
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
 

--- a/x-pack/plugins/fleet/server/services/agents/action.mock.ts
+++ b/x-pack/plugins/fleet/server/services/agents/action.mock.ts
@@ -152,7 +152,7 @@ export function createClientMock() {
 
   esClientMock.mget.mockResponseImplementation((params) => {
     // @ts-expect-error
-    const docs = params?.body.docs.map(({ _id }) => {
+    const docs = params?.docs.map(({ _id }) => {
       let result;
       switch (_id) {
         case agentInHostedDoc._id:

--- a/x-pack/plugins/fleet/server/services/agents/actions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/actions.test.ts
@@ -135,7 +135,7 @@ describe('Agent actions', () => {
 
         expect(esClient.create).toBeCalledWith(
           expect.objectContaining({
-            body: expect.objectContaining({
+            document: expect.objectContaining({
               signed: {
                 data: expect.any(String),
                 signature: expect.any(String),
@@ -180,7 +180,7 @@ describe('Agent actions', () => {
 
       expect(esClient.create).toBeCalledWith(
         expect.objectContaining({
-          body: expect.not.objectContaining({
+          document: expect.not.objectContaining({
             signed: expect.any(Object),
           }),
         })
@@ -235,7 +235,7 @@ describe('Agent actions', () => {
       await bulkCreateAgentActions(esClient, newActions);
       expect(esClient.bulk).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.arrayContaining([
+          operations: expect.arrayContaining([
             expect.arrayContaining([
               expect.objectContaining({
                 signed: {
@@ -274,7 +274,7 @@ describe('Agent actions', () => {
       await bulkCreateAgentActions(esClient, newActions);
       expect(esClient.bulk).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.arrayContaining([
+          operations: expect.arrayContaining([
             expect.arrayContaining([
               expect.not.objectContaining({
                 signed: {
@@ -350,7 +350,7 @@ describe('Agent actions', () => {
       expect(esClient.create).toBeCalledTimes(2);
       expect(esClient.create).toBeCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
+          document: expect.objectContaining({
             type: 'CANCEL',
             data: { target_id: 'action1' },
             agents: ['agent1', 'agent2'],
@@ -359,7 +359,7 @@ describe('Agent actions', () => {
       );
       expect(esClient.create).toBeCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
+          document: expect.objectContaining({
             type: 'CANCEL',
             data: { target_id: 'action1' },
             agents: ['agent3', 'agent4'],

--- a/x-pack/plugins/fleet/server/services/agents/actions.ts
+++ b/x-pack/plugins/fleet/server/services/agents/actions.ts
@@ -81,7 +81,7 @@ export async function createAgentAction(
   await esClient.create({
     index: AGENT_ACTIONS_INDEX,
     id: uuidv4(),
-    body,
+    document: body,
     refresh: 'wait_for',
   });
 
@@ -153,7 +153,7 @@ export async function bulkCreateAgentActions(
 
   await esClient.bulk({
     index: AGENT_ACTIONS_INDEX,
-    body: fleetServerAgentActions,
+    operations: fleetServerAgentActions,
   });
 
   for (const action of actions) {
@@ -231,7 +231,7 @@ export async function bulkCreateAgentActionResults(
 
   await esClient.bulk({
     index: AGENT_ACTIONS_RESULTS_INDEX,
-    body: bulkBody,
+    operations: bulkBody,
     refresh: 'wait_for',
   });
 }

--- a/x-pack/plugins/fleet/server/services/agents/agent_service.ts
+++ b/x-pack/plugins/fleet/server/services/agents/agent_service.ts
@@ -13,9 +13,9 @@ import type {
   SavedObjectsClientContract,
 } from '@kbn/core/server';
 
-import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/types';
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
 

--- a/x-pack/plugins/fleet/server/services/agents/crud.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/crud.test.ts
@@ -107,9 +107,7 @@ describe('Agents CRUD test', () => {
       expect(searchMock).toHaveBeenCalledWith(
         expect.objectContaining({
           aggs: { tags: { terms: { field: 'tags', size: 10000 } } },
-          body: {
-            query: expect.any(Object),
-          },
+          query: expect.any(Object),
           index: '.fleet-agents',
           size: 0,
           fields: ['status'],
@@ -164,7 +162,7 @@ describe('Agents CRUD test', () => {
         })
       );
 
-      expect(searchMock.mock.calls.at(-1)[0].body.query).toEqual(
+      expect(searchMock.mock.calls.at(-1)[0].query).toEqual(
         toElasticsearchQuery(
           _joinFilters(['fleet-agents.policy_id: 123', 'NOT status:unenrolled'])!
         )

--- a/x-pack/plugins/fleet/server/services/agents/crud.ts
+++ b/x-pack/plugins/fleet/server/services/agents/crud.ts
@@ -6,13 +6,13 @@
  */
 
 import { groupBy } from 'lodash';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
 import type { SavedObjectsClientContract, ElasticsearchClient } from '@kbn/core/server';
 import type { KueryNode } from '@kbn/es-query';
 import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
-import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/types';
 
 import type { AgentSOAttributes, Agent, ListWithKuery } from '../../types';
 import { appContextService, agentPolicyService } from '..';

--- a/x-pack/plugins/fleet/server/services/agents/helpers.ts
+++ b/x-pack/plugins/fleet/server/services/agents/helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
 import type { SearchHit } from '@kbn/es-types';
 

--- a/x-pack/plugins/fleet/server/services/agents/reassign.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/reassign.test.ts
@@ -103,7 +103,7 @@ describe('reassignAgent', () => {
       // only 1 are regular and bulk write two line per update
       expect((calledWith as estypes.BulkRequest).operations?.length).toBe(2);
       // @ts-expect-error
-      expect(calledWith.body[0].update._id).toEqual(agentInRegularDoc._id);
+      expect(calledWith.operations[0].update._id).toEqual(agentInRegularDoc._id);
 
       // hosted policy is updated in action results with error
       const calledWithActionResults = esClient.bulk.mock.calls[1][0] as estypes.BulkRequest;

--- a/x-pack/plugins/fleet/server/services/agents/reassign.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/reassign.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import { HostedAgentPolicyRestrictionRelatedError } from '../../errors';
 
@@ -40,7 +40,7 @@ describe('reassignAgent', () => {
       expect(esClient.update).toBeCalledTimes(1);
       const calledWith = esClient.update.mock.calls[0];
       expect(calledWith[0]?.id).toBe(agentInRegularDoc._id);
-      expect((calledWith[0] as estypes.UpdateRequest)?.body?.doc).toHaveProperty(
+      expect((calledWith[0] as estypes.UpdateRequest)?.doc).toHaveProperty(
         'policy_id',
         regularAgentPolicySO.id
       );
@@ -101,14 +101,14 @@ describe('reassignAgent', () => {
       // calls ES update with correct values
       const calledWith = esClient.bulk.mock.calls[0][0];
       // only 1 are regular and bulk write two line per update
-      expect((calledWith as estypes.BulkRequest).body?.length).toBe(2);
+      expect((calledWith as estypes.BulkRequest).operations?.length).toBe(2);
       // @ts-expect-error
       expect(calledWith.body[0].update._id).toEqual(agentInRegularDoc._id);
 
       // hosted policy is updated in action results with error
       const calledWithActionResults = esClient.bulk.mock.calls[1][0] as estypes.BulkRequest;
       // bulk write two line per create
-      expect(calledWithActionResults.body?.length).toBe(4);
+      expect(calledWithActionResults.operations?.length).toBe(4);
       const expectedObject = expect.objectContaining({
         '@timestamp': expect.anything(),
         action_id: expect.anything(),
@@ -116,7 +116,7 @@ describe('reassignAgent', () => {
         error:
           'Cannot reassign an agent from hosted agent policy hosted-agent-policy in Fleet because the agent policy is managed by an external orchestration solution, such as Elastic Cloud, Kubernetes, etc. Please make changes using your orchestration solution.',
       });
-      expect(calledWithActionResults.body?.[1] as any).toEqual(expectedObject);
+      expect(calledWithActionResults.operations?.[1]).toEqual(expectedObject);
     });
 
     it('should report errors from ES agent update call', async () => {
@@ -147,7 +147,7 @@ describe('reassignAgent', () => {
         agent_id: agentInRegularDoc._id,
         error: 'version conflict',
       });
-      expect(calledWithActionResults.body?.[1] as any).toEqual(expectedObject);
+      expect(calledWithActionResults.operations?.[1]).toEqual(expectedObject);
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/agents/request_diagnostics.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/request_diagnostics.test.ts
@@ -33,7 +33,7 @@ describe('requestDiagnostics', () => {
 
       expect(esClient.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
+          document: expect.objectContaining({
             agents: ['agent-in-regular-policy'],
             type: 'REQUEST_DIAGNOSTICS',
             expiration: expect.anything(),
@@ -53,7 +53,7 @@ describe('requestDiagnostics', () => {
 
       expect(esClient.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
+          document: expect.objectContaining({
             agents: ['agent-in-regular-policy-newer', 'agent-in-regular-policy-newer2'],
             type: 'REQUEST_DIAGNOSTICS',
             expiration: expect.anything(),
@@ -70,7 +70,7 @@ describe('requestDiagnostics', () => {
 
       expect(esClient.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
+          document: expect.objectContaining({
             agents: ['agent-in-regular-policy-newer', 'agent-in-regular-policy'],
             type: 'REQUEST_DIAGNOSTICS',
             expiration: expect.anything(),

--- a/x-pack/plugins/fleet/server/services/agents/request_diagnostics.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/request_diagnostics.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import { appContextService } from '../app_context';
 import { createAppContextStartContractMock } from '../../mocks';
@@ -80,14 +80,14 @@ describe('requestDiagnostics', () => {
       );
       const calledWithActionResults = esClient.bulk.mock.calls[0][0] as estypes.BulkRequest;
       // bulk write two line per create
-      expect(calledWithActionResults.body?.length).toBe(2);
+      expect(calledWithActionResults.operations?.length).toBe(2);
       const expectedObject = expect.objectContaining({
         '@timestamp': expect.anything(),
         action_id: expect.anything(),
         agent_id: 'agent-in-regular-policy',
         error: 'Agent agent-in-regular-policy does not support request diagnostics action.',
       });
-      expect(calledWithActionResults.body?.[1] as any).toEqual(expectedObject);
+      expect(calledWithActionResults.operations?.[1]).toEqual(expectedObject);
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import { AGENT_ACTIONS_INDEX, AGENT_ACTIONS_RESULTS_INDEX } from '../../../common';
 
@@ -48,9 +48,7 @@ describe('unenroll', () => {
       expect(esClient.update).toBeCalledTimes(1);
       const calledWith = esClient.update.mock.calls[0];
       expect(calledWith[0]?.id).toBe(agentInRegularDoc._id);
-      expect((calledWith[0] as estypes.UpdateRequest)?.body).toHaveProperty(
-        'doc.unenrollment_started_at'
-      );
+      expect(calledWith[0] as estypes.UpdateRequest).toHaveProperty('doc.unenrollment_started_at');
     });
 
     it('cannot unenroll from hosted agent policy by default', async () => {
@@ -78,9 +76,7 @@ describe('unenroll', () => {
       expect(esClient.update).toBeCalledTimes(1);
       const calledWith = esClient.update.mock.calls[0];
       expect(calledWith[0]?.id).toBe(agentInHostedDoc._id);
-      expect((calledWith[0] as estypes.UpdateRequest)?.body).toHaveProperty(
-        'doc.unenrollment_started_at'
-      );
+      expect(calledWith[0] as estypes.UpdateRequest).toHaveProperty('doc.unenrollment_started_at');
     });
 
     it('can unenroll from hosted agent policy with force=true and revoke=true', async () => {
@@ -90,7 +86,7 @@ describe('unenroll', () => {
       expect(esClient.update).toBeCalledTimes(1);
       const calledWith = esClient.update.mock.calls[0];
       expect(calledWith[0]?.id).toBe(agentInHostedDoc._id);
-      expect((calledWith[0] as estypes.UpdateRequest)?.body).toHaveProperty('doc.unenrolled_at');
+      expect(calledWith[0] as estypes.UpdateRequest).toHaveProperty('doc.unenrolled_at');
     });
   });
 
@@ -102,10 +98,10 @@ describe('unenroll', () => {
 
       // calls ES update with correct values
       const calledWith = esClient.bulk.mock.calls[0][0];
-      const ids = (calledWith as estypes.BulkRequest)?.body
+      const ids = (calledWith as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.update !== undefined)
         .map((i: any) => i.update._id);
-      const docs = (calledWith as estypes.BulkRequest)?.body
+      const docs = (calledWith as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.doc)
         .map((i: any) => i.doc);
       expect(ids).toEqual(idsToUnenroll);
@@ -123,10 +119,10 @@ describe('unenroll', () => {
       // calls ES update with correct values
       const onlyRegular = [agentInRegularDoc._id, agentInRegularDoc2._id];
       const calledWith = esClient.bulk.mock.calls[0][0];
-      const ids = (calledWith as estypes.BulkRequest)?.body
+      const ids = (calledWith as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.update !== undefined)
         .map((i: any) => i.update._id);
-      const docs = (calledWith as estypes.BulkRequest)?.body
+      const docs = (calledWith as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.doc)
         .map((i: any) => i.doc);
       expect(ids).toEqual(onlyRegular);
@@ -137,7 +133,7 @@ describe('unenroll', () => {
       // hosted policy is updated in action results with error
       const calledWithActionResults = esClient.bulk.mock.calls[1][0] as estypes.BulkRequest;
       // bulk write two line per create
-      expect(calledWithActionResults.body?.length).toBe(2);
+      expect(calledWithActionResults.operations?.length).toBe(2);
       const expectedObject = expect.objectContaining({
         '@timestamp': expect.anything(),
         action_id: expect.anything(),
@@ -145,7 +141,7 @@ describe('unenroll', () => {
         error:
           'Cannot unenroll agent-in-hosted-policy from a hosted agent policy hosted-agent-policy in Fleet because the agent policy is managed by an external orchestration solution, such as Elastic Cloud, Kubernetes, etc. Please make changes using your orchestration solution.',
       });
-      expect(calledWithActionResults.body?.[1] as any).toEqual(expectedObject);
+      expect(calledWithActionResults.operations?.[1]).toEqual(expectedObject);
     });
 
     it('force unenroll updates in progress unenroll actions', async () => {
@@ -186,7 +182,8 @@ describe('unenroll', () => {
       });
 
       expect(esClient.bulk.mock.calls.length).toEqual(3);
-      const bulkBody = (esClient.bulk.mock.calls[2][0] as estypes.BulkRequest)?.body?.[1] as any;
+      const bulkBody = (esClient.bulk.mock.calls[2][0] as estypes.BulkRequest)
+        ?.operations?.[1] as any;
       expect(bulkBody.agent_id).toEqual(agentInRegularDoc._id);
       expect(bulkBody.action_id).toEqual('other-action');
     });
@@ -248,10 +245,10 @@ describe('unenroll', () => {
       // calls ES update with correct values
       const onlyRegular = [agentInRegularDoc._id, agentInRegularDoc2._id];
       const calledWith = esClient.bulk.mock.calls[0][0];
-      const ids = (calledWith as estypes.BulkRequest)?.body
+      const ids = (calledWith as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.update !== undefined)
         .map((i: any) => i.update._id);
-      const docs = (calledWith as estypes.BulkRequest)?.body
+      const docs = (calledWith as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.doc)
         .map((i: any) => i.doc);
       expect(ids).toEqual(onlyRegular);
@@ -260,13 +257,13 @@ describe('unenroll', () => {
       }
 
       const errorResults = esClient.bulk.mock.calls[2][0];
-      const errorIds = (errorResults as estypes.BulkRequest)?.body
+      const errorIds = (errorResults as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.agent_id)
         .map((i: any) => i.agent_id);
       expect(errorIds).toEqual([agentInHostedDoc._id]);
 
       const actionResults = esClient.bulk.mock.calls[1][0];
-      const resultIds = (actionResults as estypes.BulkRequest)?.body
+      const resultIds = (actionResults as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.agent_id)
         .map((i: any) => i.agent_id);
       expect(resultIds).toEqual(onlyRegular);
@@ -283,10 +280,10 @@ describe('unenroll', () => {
 
       // calls ES update with correct values
       const calledWith = esClient.bulk.mock.calls[0][0];
-      const ids = (calledWith as estypes.BulkRequest)?.body
+      const ids = (calledWith as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.update !== undefined)
         .map((i: any) => i.update._id);
-      const docs = (calledWith as estypes.BulkRequest)?.body
+      const docs = (calledWith as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.doc)
         .map((i: any) => i.doc);
       expect(ids).toEqual(idsToUnenroll);
@@ -311,10 +308,10 @@ describe('unenroll', () => {
 
       // calls ES update with correct values
       const calledWith = esClient.bulk.mock.calls[0][0];
-      const ids = (calledWith as estypes.BulkRequest)?.body
+      const ids = (calledWith as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.update !== undefined)
         .map((i: any) => i.update._id);
-      const docs = (calledWith as estypes.BulkRequest)?.body
+      const docs = (calledWith as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.doc)
         .map((i: any) => i.doc);
       expect(ids).toEqual(idsToUnenroll);
@@ -323,7 +320,7 @@ describe('unenroll', () => {
       }
 
       const actionResults = esClient.bulk.mock.calls[1][0];
-      const resultIds = (actionResults as estypes.BulkRequest)?.body
+      const resultIds = (actionResults as estypes.BulkRequest)?.operations
         ?.filter((i: any) => i.agent_id)
         .map((i: any) => i.agent_id);
       expect(resultIds).toEqual(idsToUnenroll);

--- a/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/unenroll.test.ts
@@ -269,7 +269,7 @@ describe('unenroll', () => {
       expect(resultIds).toEqual(onlyRegular);
 
       const action = esClient.create.mock.calls[0][0] as any;
-      expect(action.body.type).toEqual('FORCE_UNENROLL');
+      expect(action.document.type).toEqual('FORCE_UNENROLL');
     });
 
     it('can unenroll from hosted agent policy with force=true', async () => {
@@ -326,7 +326,7 @@ describe('unenroll', () => {
       expect(resultIds).toEqual(idsToUnenroll);
 
       const action = esClient.create.mock.calls[0][0] as any;
-      expect(action.body.type).toEqual('FORCE_UNENROLL');
+      expect(action.document.type).toEqual('FORCE_UNENROLL');
     });
   });
 

--- a/x-pack/plugins/fleet/server/services/agents/update_agent_tags.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/update_agent_tags.test.ts
@@ -112,7 +112,7 @@ describe('update_agent_tags', () => {
     await updateAgentTags(soClient, esClient, { agentIds: ['agent1'] }, ['one'], []);
 
     const agentAction = esClient.create.mock.calls[0][0] as any;
-    expect(agentAction?.body).toEqual(
+    expect(agentAction?.document).toEqual(
       expect.objectContaining({
         action_id: expect.anything(),
         agents: [expect.any(String)],
@@ -122,11 +122,11 @@ describe('update_agent_tags', () => {
     );
 
     const actionResults = esClient.bulk.mock.calls[0][0] as any;
-    const agentIds = actionResults?.body
+    const agentIds = actionResults?.operations
       ?.filter((i: any) => i.agent_id)
       .map((i: any) => i.agent_id);
     expect(agentIds.length).toEqual(1);
-    expect(actionResults.body[1].error).not.toBeDefined();
+    expect(actionResults.operations[1].error).not.toBeDefined();
   });
 
   it('should skip hosted agent from total when agentIds are passed', async () => {
@@ -144,7 +144,7 @@ describe('update_agent_tags', () => {
     );
 
     const agentAction = esClientMock.create.mock.calls[0][0] as any;
-    expect(agentAction?.body).toEqual(
+    expect(agentAction?.document).toEqual(
       expect.objectContaining({
         action_id: expect.anything(),
         agents: [expect.any(String)],
@@ -165,7 +165,7 @@ describe('update_agent_tags', () => {
     await updateAgentTags(soClient, esClient, { agentIds: ['agent1'] }, ['one'], []);
 
     const agentAction = esClient.create.mock.calls[0][0] as any;
-    expect(agentAction?.body).toEqual(
+    expect(agentAction?.document).toEqual(
       expect.objectContaining({
         action_id: expect.anything(),
         agents: ['failure1'],
@@ -175,7 +175,7 @@ describe('update_agent_tags', () => {
     );
 
     const errorResults = esClient.bulk.mock.calls[0][0] as any;
-    expect(errorResults.body[1].error).toEqual('error reason');
+    expect(errorResults.operations[1].error).toEqual('error reason');
   });
 
   it('should throw error on version conflicts', async () => {
@@ -217,10 +217,10 @@ describe('update_agent_tags', () => {
     ).rejects.toThrowError('Version conflict of 100 agents');
 
     const agentAction = esClient.create.mock.calls[0][0] as any;
-    expect(agentAction?.body.agents.length).toEqual(100);
+    expect(agentAction?.document.agents.length).toEqual(100);
 
     const errorResults = esClient.bulk.mock.calls[0][0] as any;
-    expect(errorResults.body[1].error).toEqual('version conflict on last retry');
+    expect(errorResults.operations[1].error).toEqual('version conflict on last retry');
   });
 
   it('should combine action agents from updated, failures and version conflicts on last retry', async () => {
@@ -249,7 +249,7 @@ describe('update_agent_tags', () => {
     ).rejects.toThrowError('Version conflict of 1 agents');
 
     const agentAction = esClient.create.mock.calls[0][0] as any;
-    expect(agentAction?.body.agents.length).toEqual(3);
+    expect(agentAction?.document.agents.length).toEqual(3);
   });
 
   it('should run add tags async when actioning more agents than batch size', async () => {
@@ -367,7 +367,7 @@ describe('update_agent_tags', () => {
     );
 
     const agentAction = esClient.create.mock.calls[0][0] as any;
-    expect(agentAction?.body).toEqual(
+    expect(agentAction?.document).toEqual(
       expect.objectContaining({
         action_id: expect.anything(),
         agents: [expect.any(String)],

--- a/x-pack/plugins/fleet/server/services/agents/upgrade.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/upgrade.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import { appContextService } from '../app_context';
 import type { Agent } from '../../types';
@@ -58,10 +58,10 @@ describe('sendUpgradeAgentsActions (plural)', () => {
 
     // calls ES update with correct values
     const calledWith = esClient.bulk.mock.calls[0][0];
-    const ids = (calledWith as estypes.BulkRequest)?.body
+    const ids = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.update !== undefined)
       .map((i: any) => i.update._id);
-    const docs = (calledWith as estypes.BulkRequest)?.body
+    const docs = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.doc)
       .map((i: any) => i.doc);
 
@@ -80,10 +80,10 @@ describe('sendUpgradeAgentsActions (plural)', () => {
     // calls ES update with correct values
     const onlyRegular = [agentInRegularDoc._id, agentInRegularDoc2._id];
     const calledWith = esClient.bulk.mock.calls[0][0];
-    const ids = (calledWith as estypes.BulkRequest)?.body
+    const ids = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.update !== undefined)
       .map((i: any) => i.update._id);
-    const docs = (calledWith as estypes.BulkRequest)?.body
+    const docs = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.doc)
       .map((i: any) => i.doc);
     expect(ids).toEqual(onlyRegular);
@@ -95,7 +95,7 @@ describe('sendUpgradeAgentsActions (plural)', () => {
     // hosted policy is updated in action results with error
     const calledWithActionResults = esClient.bulk.mock.calls[1][0] as estypes.BulkRequest;
     // bulk write two line per create
-    expect(calledWithActionResults.body?.length).toBe(2);
+    expect(calledWithActionResults.operations?.length).toBe(2);
     const expectedObject = expect.objectContaining({
       '@timestamp': expect.anything(),
       action_id: expect.anything(),
@@ -103,7 +103,7 @@ describe('sendUpgradeAgentsActions (plural)', () => {
       error:
         'Cannot upgrade agent in hosted agent policy hosted-agent-policy in Fleet because the agent policy is managed by an external orchestration solution, such as Elastic Cloud, Kubernetes, etc. Please make changes using your orchestration solution.',
     });
-    expect(calledWithActionResults.body?.[1] as any).toEqual(expectedObject);
+    expect(calledWithActionResults.operations?.[1]).toEqual(expectedObject);
   });
 
   it('can upgrade from hosted agent policy with force=true', async () => {
@@ -118,10 +118,10 @@ describe('sendUpgradeAgentsActions (plural)', () => {
 
     // calls ES update with correct values
     const calledWith = esClient.bulk.mock.calls[0][0];
-    const ids = (calledWith as estypes.BulkRequest)?.body
+    const ids = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.update !== undefined)
       .map((i: any) => i.update._id);
-    const docs = (calledWith as estypes.BulkRequest)?.body
+    const docs = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.doc)
       .map((i: any) => i.doc);
     expect(ids).toEqual(idsToAction);

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/index/update_settings.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/index/update_settings.ts
@@ -7,7 +7,7 @@
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 
-import type { IndicesIndexSettings } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { IndicesIndexSettings } from '@elastic/elasticsearch/lib/api/types';
 
 import { appContextService } from '../../..';
 

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -10,7 +10,7 @@ import type {
   IndicesIndexSettings,
   MappingDynamicTemplate,
   MappingTypeMapping,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+} from '@elastic/elasticsearch/lib/api/types';
 
 import pMap from 'p-map';
 import { isResponseError } from '@kbn/es-errors';

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/utils.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/utils.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
 
 import { USER_SETTINGS_TEMPLATE_SUFFIX } from '../../../../constants';
 

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/reauthorize.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/reauthorize.ts
@@ -12,7 +12,7 @@ import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-ser
 import { sortBy, uniqBy } from 'lodash';
 import pMap from 'p-map';
 import { isPopulatedObject } from '@kbn/ml-is-populated-object';
-import type { ErrorResponseBase } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { ErrorResponseBase } from '@elastic/elasticsearch/lib/api/types';
 
 import type { SecondaryAuthorizationHeader } from '../../../../../common/types/models/transform_api_key';
 import { updateEsAssetReferences } from '../../packages/es_assets_reference';

--- a/x-pack/plugins/fleet/server/services/experimental_datastream_features_helper.ts
+++ b/x-pack/plugins/fleet/server/services/experimental_datastream_features_helper.ts
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import type {
-  MappingProperty,
-  PropertyName,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { MappingProperty, PropertyName } from '@elastic/elasticsearch/lib/api/types';
 
 import type { ExperimentalDataStreamFeature } from '../../common/types';
 

--- a/x-pack/plugins/fleet/server/services/files/client_from_host.ts
+++ b/x-pack/plugins/fleet/server/services/files/client_from_host.ts
@@ -9,7 +9,7 @@ import type { Readable } from 'stream';
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/core/server';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import type { FileClient } from '@kbn/files-plugin/server';
 import { createEsFileClient } from '@kbn/files-plugin/server';

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -28,7 +28,7 @@ import { asyncForEach, asyncMap } from '@kbn/std';
 import type {
   AggregationsTermsInclude,
   AggregationsTermsExclude,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+} from '@elastic/elasticsearch/lib/api/types';
 import { isResponseError } from '@kbn/es-errors';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import { DEFAULT_NAMESPACE_STRING } from '@kbn/core-saved-objects-utils-server';


### PR DESCRIPTION
## Summary

Attempt to remove the deprecated `body` in the ES client.





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->