### PR TITLE
[ES `body` removal] `@elastic/appex-sharedux`

### DIFF
--- a/src/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
+++ b/src/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.test.ts
@@ -14,7 +14,7 @@ import { encode, decode } from '@kbn/cbor';
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { ContentStream, ContentStreamEncoding, ContentStreamParameters } from './content_stream';
 import type { GetResponse } from '@elastic/elasticsearch/lib/api/types';
-import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import * as estypes from '@elastic/elasticsearch/lib/api/types';
 import { FileDocument } from '../../../../file_client/file_metadata_client/adapters/es_index';
 import { IndexRequest } from '@elastic/elasticsearch/lib/api/types';
 

--- a/src/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
+++ b/src/plugins/files/server/blob_storage_service/adapters/es/content_stream/content_stream.ts
@@ -15,7 +15,7 @@ import { ByteSizeValue } from '@kbn/config-schema';
 import { defaults } from 'lodash';
 import { Duplex, Writable, Readable } from 'stream';
 
-import { GetResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { GetResponse } from '@elastic/elasticsearch/lib/api/types';
 import { inspect } from 'util';
 import { wrapErrorAndReThrow } from '../../../../file_client/utils';
 import type { FileChunkDocument } from '../mappings';

--- a/src/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
+++ b/src/plugins/files/server/blob_storage_service/adapters/es/mappings.ts
@@ -7,10 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type {
-  MappingTypeMapping,
-  MappingProperty,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { MappingTypeMapping, MappingProperty } from '@elastic/elasticsearch/lib/api/types';
 
 /**
  * These are the fields we expect to find a given document acting as a file chunk.

--- a/src/plugins/files/server/file_client/create_es_file_client.test.ts
+++ b/src/plugins/files/server/file_client/create_es_file_client.test.ts
@@ -16,7 +16,7 @@ import { MockedLogger } from '@kbn/logging-mocks';
 import { createEsFileClient } from './create_es_file_client';
 import { FileClient } from './types';
 import { ElasticsearchBlobStorageClient } from '../blob_storage_service';
-import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import * as estypes from '@elastic/elasticsearch/lib/api/types';
 import { FileDocument } from './file_metadata_client/adapters/es_index';
 
 describe('When initializing file client via createESFileClient()', () => {

--- a/x-pack/plugins/reporting/server/lib/store/store.test.ts
+++ b/x-pack/plugins/reporting/server/lib/store/store.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import * as estypes from '@elastic/elasticsearch/lib/api/types';
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { JOB_STATUS } from '@kbn/reporting-common';
 import { ReportDocument } from '@kbn/reporting-common/types';
@@ -212,7 +212,7 @@ describe('ReportingStore', () => {
 
     const [[updateCall]] = mockEsClient.update.mock.calls;
 
-    const response = (updateCall as estypes.UpdateRequest).body?.doc as Report;
+    const response = (updateCall as estypes.UpdateRequest)?.doc as Report;
     expect(response.migration_version).toBe(`7.14.0`);
     expect(response.status).toBe(`processing`);
     expect(updateCall.if_seq_no).toBe(42);
@@ -242,7 +242,7 @@ describe('ReportingStore', () => {
     await store.setReportFailed(report, { errors: 'yes' } as any);
 
     const [[updateCall]] = mockEsClient.update.mock.calls;
-    const response = (updateCall as estypes.UpdateRequest).body?.doc as Report;
+    const response = (updateCall as estypes.UpdateRequest)?.doc as Report;
     expect(response.migration_version).toBe(`7.14.0`);
     expect(response.status).toBe(`failed`);
     expect(updateCall.if_seq_no).toBe(43);
@@ -272,7 +272,7 @@ describe('ReportingStore', () => {
     await store.setReportError(report, { errors: 'yes' } as any);
 
     const [[updateCall]] = mockEsClient.update.mock.calls;
-    const response = (updateCall as estypes.UpdateRequest).body?.doc as Report;
+    const response = (updateCall as estypes.UpdateRequest)?.doc as Report;
     expect(response.migration_version).toBe(`7.14.0`);
     expect(updateCall.if_seq_no).toBe(43);
     expect(updateCall.if_primary_term).toBe(10002);
@@ -301,7 +301,7 @@ describe('ReportingStore', () => {
     await store.setReportCompleted(report, { certainly_completed: 'yes' } as any);
 
     const [[updateCall]] = mockEsClient.update.mock.calls;
-    const response = (updateCall as estypes.UpdateRequest).body?.doc as Report;
+    const response = (updateCall as estypes.UpdateRequest)?.doc as Report;
     expect(response.migration_version).toBe(`7.14.0`);
     expect(response.status).toBe(`completed`);
     expect(updateCall.if_seq_no).toBe(44);
@@ -336,7 +336,7 @@ describe('ReportingStore', () => {
     } as any);
 
     const [[updateCall]] = mockEsClient.update.mock.calls;
-    const response = (updateCall as estypes.UpdateRequest).body?.doc as Report;
+    const response = (updateCall as estypes.UpdateRequest)?.doc as Report;
 
     expect(response.migration_version).toBe(`7.14.0`);
     expect(response.status).toBe(`completed_with_warnings`);

--- a/x-pack/plugins/reporting/server/lib/store/store.ts
+++ b/x-pack/plugins/reporting/server/lib/store/store.ts
@@ -86,7 +86,7 @@ const esDocForUpdate = (
     if_seq_no: report._seq_no,
     if_primary_term: report._primary_term,
     refresh: 'wait_for' as estypes.Refresh,
-    body: { doc },
+    doc,
   };
 };
 

--- a/x-pack/plugins/reporting/server/lib/tasks/execute_report.ts
+++ b/x-pack/plugins/reporting/server/lib/tasks/execute_report.ts
@@ -12,7 +12,7 @@ import { Writable } from 'stream';
 import { finished } from 'stream/promises';
 import { setTimeout } from 'timers/promises';
 
-import { UpdateResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { UpdateResponse } from '@elastic/elasticsearch/lib/api/types';
 import type { Logger } from '@kbn/core/server';
 import {
   CancellationToken,


### PR DESCRIPTION
## Summary

Attempt to remove the deprecated `body` in the ES client.





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->