### PR TITLE
[ES `body` removal] `@elastic/kibana-presentation`

### DIFF
--- a/src/plugins/controls/server/options_list/options_list_suggestions_route.ts
+++ b/src/plugins/controls/server/options_list/options_list_suggestions_route.ts
@@ -14,7 +14,7 @@ import { CoreSetup, ElasticsearchClient } from '@kbn/core/server';
 import { getKbnServerError, reportServerError } from '@kbn/kibana-utils-plugin/server';
 import { PluginSetup as UnifiedSearchPluginSetup } from '@kbn/unified-search-plugin/server';
 
-import type { SearchRequest } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { SearchRequest } from '@elastic/elasticsearch/lib/api/types';
 import { OptionsListRequestBody, OptionsListResponse } from '../../common/options_list/types';
 import { getValidationAggregationBuilder } from './options_list_validation_queries';
 import { getSuggestionAggregationBuilder } from './suggestion_queries';
@@ -118,7 +118,7 @@ export const setupOptionsListSuggestionsRoute = (
       ? {}
       : validationBuilder.buildAggregation(request);
 
-    const body: SearchRequest['body'] = {
+    const body: SearchRequest = {
       size: 0,
       ...timeoutSettings,
       query: {

--- a/x-pack/plugins/canvas/types/strategy.ts
+++ b/x-pack/plugins/canvas/types/strategy.ts
@@ -6,7 +6,7 @@
  */
 
 import { TransportResult } from '@elastic/elasticsearch';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import type { IKibanaSearchRequest } from '@kbn/search-types';
 import { ExpressionValueFilter } from '.';
 export interface EssqlSearchStrategyRequest extends IKibanaSearchRequest {

--- a/x-pack/plugins/stack_alerts/server/rule_types/geo_containment/lib/es_query_builder.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/geo_containment/lib/es_query_builder.ts
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { ElasticsearchClient } from '@kbn/core/server';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import { OTHER_CATEGORY } from '../constants';
 import { getQueryDsl } from './get_query_dsl';
 import type { GeoContainmentRuleParams } from '../types';


### PR DESCRIPTION
## Summary

Attempt to remove the deprecated `body` in the ES client.





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->