### PR TITLE
[ES `body` removal] `@elastic/appex-qa`

### DIFF
--- a/packages/kbn-es-archiver/src/lib/indices/create_index_stream.ts
+++ b/packages/kbn-es-archiver/src/lib/indices/create_index_stream.ts
@@ -10,7 +10,7 @@
 import { Transform, Readable } from 'stream';
 import { inspect } from 'util';
 
-import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import * as estypes from '@elastic/elasticsearch/lib/api/types';
 import type { Client } from '@elastic/elasticsearch';
 import { ToolingLog } from '@kbn/tooling-log';
 

--- a/packages/kbn-performance-testing-dataset-extractor/src/es_client.ts
+++ b/packages/kbn-performance-testing-dataset-extractor/src/es_client.ts
@@ -9,7 +9,7 @@
 
 import { Client } from '@elastic/elasticsearch';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
-import { SearchRequest, MsearchRequestItem } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { SearchRequest, MsearchRequestItem } from '@elastic/elasticsearch/lib/api/types';
 import { ToolingLog } from '@kbn/tooling-log';
 
 interface ClientOptions {
@@ -116,26 +116,24 @@ export class ESClient {
   async getTransactions<T>(queryFilters: QueryDslQueryContainer[]) {
     const searchRequest: SearchRequest = {
       index: this.tracesIndex,
-      body: {
-        sort: [
-          {
-            '@timestamp': {
-              order: 'asc',
-              unmapped_type: 'boolean',
-            },
+      sort: [
+        {
+          '@timestamp': {
+            order: 'asc',
+            unmapped_type: 'boolean',
           },
-        ],
-        size: 10000,
-        query: {
-          bool: {
-            filter: [
-              {
-                bool: {
-                  filter: queryFilters,
-                },
+        },
+      ],
+      size: 10000,
+      query: {
+        bool: {
+          filter: [
+            {
+              bool: {
+                filter: queryFilters,
               },
-            ],
-          },
+            },
+          ],
         },
       },
     };

--- a/x-pack/test/api_integration/deployment_agnostic/services/alerting_api.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/services/alerting_api.ts
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import type {
-  AggregationsAggregate,
-  SearchResponse,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { AggregationsAggregate, SearchResponse } from '@elastic/elasticsearch/lib/api/types';
 import { MetricThresholdParams } from '@kbn/infra-plugin/common/alerting/metrics';
 import { ThresholdParams } from '@kbn/observability-plugin/common/custom_threshold_rule/types';
 import { ApmRuleParamsType } from '@kbn/apm-plugin/common/rules/schema';


### PR DESCRIPTION
## Summary

Attempt to remove the deprecated `body` in the ES client.





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->