### PR TITLE
[ES|QL] Clears the history component cache correctly

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/history_local_storage.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/history_local_storage.test.ts
@@ -8,15 +8,28 @@
  */
 import { addQueriesToCache, getCachedQueries } from './history_local_storage';
 
+class LocalStorageMock {
+  public store: Record<string, unknown>;
+  constructor(defaultStore: Record<string, unknown>) {
+    this.store = defaultStore;
+  }
+  clear() {
+    this.store = {};
+  }
+  getItem(key: string) {
+    return this.store[key] || null;
+  }
+  setItem(key: string, value: unknown) {
+    this.store[key] = String(value);
+  }
+}
+
 describe('history local storage', function () {
-  const mockGetItem = jest.fn();
-  const mockSetItem = jest.fn();
+  const storage = new LocalStorageMock({}) as unknown as Storage;
   Object.defineProperty(window, 'localStorage', {
-    value: {
-      getItem: (...args: string[]) => mockGetItem(...args),
-      setItem: (...args: string[]) => mockSetItem(...args),
-    },
+    value: storage,
   });
+
   it('should add queries to cache correctly ', function () {
     addQueriesToCache({
       queryString: 'from kibana_sample_data_flights | limit 10',
@@ -37,11 +50,6 @@ describe('history local storage', function () {
     expect(historyItems.length).toBe(2);
     expect(historyItems[1].timeRan).toBeDefined();
     expect(historyItems[1].status).toBe('success');
-
-    expect(mockSetItem).toHaveBeenCalledWith(
-      'QUERY_HISTORY_ITEM_KEY',
-      JSON.stringify(historyItems)
-    );
   });
 
   it('should update queries to cache correctly if they are the same with different format', function () {
@@ -54,11 +62,6 @@ describe('history local storage', function () {
     expect(historyItems.length).toBe(2);
     expect(historyItems[1].timeRan).toBeDefined();
     expect(historyItems[1].status).toBe('success');
-
-    expect(mockSetItem).toHaveBeenCalledWith(
-      'QUERY_HISTORY_ITEM_KEY',
-      JSON.stringify(historyItems)
-    );
   });
 
   it('should allow maximum x queries ', function () {

--- a/src/platform/packages/private/kbn-esql-editor/src/history_local_storage.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/history_local_storage.ts
@@ -87,11 +87,11 @@ export const addQueriesToCache = (
 
     // queries to store in the localstorage
     allQueries = sortedByDate.slice(0, maxQueriesAllowed);
-    // clear and reset the queries in the cache
-    cachedQueries.clear();
     allQueries.forEach((queryItem) => {
       cachedQueries.set(queryItem.queryString, queryItem);
     });
   }
+  // clear and reset the queries in the cache
+  cachedQueries.clear();
   localStorage.setItem(QUERY_HISTORY_ITEM_KEY, JSON.stringify(allQueries));
 };

--- a/src/platform/packages/private/kbn-esql-editor/src/history_local_storage.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/history_local_storage.ts
@@ -66,15 +66,11 @@ export const addQueriesToCache = (
   // the cachedQueries Map might not contain all
   // the localStorage queries
   const queries = getHistoryItems('desc');
-  if (queries.length > 0) {
-    queries.forEach((queryItem) => {
-      const trimmedQueryString = getTrimmedQuery(queryItem.queryString);
-      cachedQueries.set(trimmedQueryString, queryItem);
-    });
-  } else {
-    // if there are no queries in the localStorage, clear the cache
-    cachedQueries.clear();
-  }
+cachedQueries.clear();
+queries.forEach((queryItem) => {
+  const trimmedQueryString = getTrimmedQuery(queryItem.queryString);
+  cachedQueries.set(trimmedQueryString, queryItem);
+});
   const trimmedQueryString = getTrimmedQuery(item.queryString);
 
   if (item.queryString) {

--- a/src/platform/packages/private/kbn-esql-editor/src/history_local_storage.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/history_local_storage.ts
@@ -66,10 +66,15 @@ export const addQueriesToCache = (
   // the cachedQueries Map might not contain all
   // the localStorage queries
   const queries = getHistoryItems('desc');
-  queries.forEach((queryItem) => {
-    const trimmedQueryString = getTrimmedQuery(queryItem.queryString);
-    cachedQueries.set(trimmedQueryString, queryItem);
-  });
+  if (queries.length > 0) {
+    queries.forEach((queryItem) => {
+      const trimmedQueryString = getTrimmedQuery(queryItem.queryString);
+      cachedQueries.set(trimmedQueryString, queryItem);
+    });
+  } else {
+    // if there are no queries in the localStorage, clear the cache
+    cachedQueries.clear();
+  }
   const trimmedQueryString = getTrimmedQuery(item.queryString);
 
   if (item.queryString) {
@@ -87,11 +92,12 @@ export const addQueriesToCache = (
 
     // queries to store in the localstorage
     allQueries = sortedByDate.slice(0, maxQueriesAllowed);
+
+    // clear and reset the queries in the cache
+    cachedQueries.clear();
     allQueries.forEach((queryItem) => {
       cachedQueries.set(queryItem.queryString, queryItem);
     });
   }
-  // clear and reset the queries in the cache
-  cachedQueries.clear();
   localStorage.setItem(QUERY_HISTORY_ITEM_KEY, JSON.stringify(allQueries));
 };

--- a/src/platform/packages/private/kbn-esql-editor/src/history_local_storage.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/history_local_storage.ts
@@ -66,11 +66,11 @@ export const addQueriesToCache = (
   // the cachedQueries Map might not contain all
   // the localStorage queries
   const queries = getHistoryItems('desc');
-cachedQueries.clear();
-queries.forEach((queryItem) => {
-  const trimmedQueryString = getTrimmedQuery(queryItem.queryString);
-  cachedQueries.set(trimmedQueryString, queryItem);
-});
+  cachedQueries.clear();
+  queries.forEach((queryItem) => {
+    const trimmedQueryString = getTrimmedQuery(queryItem.queryString);
+    cachedQueries.set(trimmedQueryString, queryItem);
+  });
   const trimmedQueryString = getTrimmedQuery(item.queryString);
 
   if (item.queryString) {


### PR DESCRIPTION
## Summary

Clears the cache when there are no items in the localStorage (which means that the user has cleared it). It can create unpredictable bugs.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->