### PR TITLE
[8.x] [Renovate/Core] Use `prev-minor` backport strategy (#204709)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,10 +63,22 @@
     },
     {
       "groupName": "@elastic/elasticsearch",
-      "matchDepNames": ["@elastic/elasticsearch"],
-      "reviewers": ["team:kibana-operations", "team:kibana-core"],
-      "matchBaseBranches": ["main"],
-      "labels": ["release_note:skip", "backport:skip", "Team:Operations", "Team:Core"],
+      "matchDepNames": [
+        "@elastic/elasticsearch"
+      ],
+      "reviewers": [
+        "team:kibana-operations",
+        "team:kibana-core"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "labels": [
+        "release_note:skip",
+        "backport:prev-minor",
+        "Team:Operations",
+        "Team:Core"
+      ],
       "enabled": true
     },
     {
@@ -103,43 +115,117 @@
     },
     {
       "groupName": "APM",
-      "matchDepNames": ["elastic-apm-node", "@elastic/apm-rum", "@elastic/apm-rum-react"],
-      "reviewers": ["team:kibana-core"],
-      "matchBaseBranches": ["main"],
-      "labels": ["release_note:skip", "Team:Core", "backport:skip"],
+      "matchDepNames": [
+        "elastic-apm-node",
+        "@elastic/apm-rum",
+        "@elastic/apm-rum-react",
+        "@elastic/apm-rum-core"
+      ],
+      "reviewers": [
+        "team:kibana-core"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "labels": [
+        "release_note:skip",
+        "Team:Core",
+        "backport:prev-minor"
+      ],
       "enabled": true
     },
     {
       "groupName": "RxJS",
-      "matchDepNames": ["rxjs"],
-      "reviewers": ["team:kibana-core"],
-      "matchBaseBranches": ["main"],
-      "labels": ["release_note:skip", "Team:Core", "backport:skip"],
+      "matchDepNames": [
+        "rxjs"
+      ],
+      "reviewers": [
+        "team:kibana-core"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "labels": [
+        "release_note:skip",
+        "Team:Core",
+        "backport:prev-minor"
+      ],
+      "enabled": true
+    },
+    {
+      "groupName": "stack traces",
+      "matchDepNames": [
+        "trace",
+        "clarify"
+      ],
+      "reviewers": [
+        "team:kibana-core"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "labels": [
+        "release_note:skip",
+        "Team:Core",
+        "backport:skip"
+      ],
       "enabled": true
     },
     {
       "groupName": "@elastic/ebt",
-      "matchDepNames": ["@elastic/ebt"],
-      "reviewers": ["team:kibana-core"],
-      "matchBaseBranches": ["main"],
-      "labels": ["release_note:skip", "Team:Core", "backport:skip"],
+      "matchDepNames": [
+        "@elastic/ebt"
+      ],
+      "reviewers": [
+        "team:kibana-core"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "labels": [
+        "release_note:skip",
+        "Team:Core",
+        "backport:prev-minor"
+      ],
       "enabled": true
     },
     {
-      "groupName": "ansi-regex",
-      "matchDepNames": ["ansi-regex"],
-      "reviewers": ["team:kibana-core"],
-      "matchBaseBranches": ["main"],
-      "labels": ["release_note:skip", "Team:Core", "backport:skip"],
-      "minimumReleaseAge": "7 days",
+      "groupName": "lodash",
+      "matchDepNames": [
+        "lodash",
+        "@types/lodash"
+      ],
+      "reviewers": [
+        "team:kibana-core"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "labels": [
+        "release_note:skip",
+        "Team:Core",
+        "backport:prev-minor"
+      ],
       "enabled": true
     },
     {
       "groupName": "OpenAPI Spec",
-      "matchDepNames": ["@redocly/cli"],
-      "reviewers": ["team:kibana-core"],
-      "matchBaseBranches": ["main"],
-      "labels": ["release_note:skip", "Team:Core", "backport:skip"],
+      "matchDepNames": [
+        "@apidevtools/swagger-parser",
+        "@redocly/cli",
+        "openapi-types"
+      ],
+      "reviewers": [
+        "team:kibana-core"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "labels": [
+        "release_note:skip",
+        "Team:Core",
+        "backport:prev-minor"
+      ],
       "minimumReleaseAge": "7 days",
       "enabled": true
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Renovate/Core] Use `prev-minor` backport strategy (#204709)](https://github.com/elastic/kibana/pull/204709)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alejandro Fernández Haro","email":"alejandro.haro@elastic.co"},"sourceCommit":{"committedDate":"2024-12-19T10:02:46Z","message":"[Renovate/Core] Use `prev-minor` backport strategy (#204709)\n\n## Summary\n\nSpeaking to @azasypkin, we noticed that we are not backporting many of\nour dependency updates. These were mostly set to `backport:skip` before\nthe 9 vs. 8.x branch split. But we need it at the moment.\n\nWe'll need to revisit our backport strategy once we release 9.0.\n\n### Identify risks\n\n- [ ] Some deps like `@elastic/elasticsearch` might be bumped to 9.0 and\nshouldn't be backported. We'll update the renovate file when that\noccurs.","sha":"997884e1ba14a4e68647f13b90b7a9337c20d35a","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","Team:Security","release_note:skip","dependencies","v9.0.0","backport:prev-minor"],"number":204709,"url":"https://github.com/elastic/kibana/pull/204709","mergeCommit":{"message":"[Renovate/Core] Use `prev-minor` backport strategy (#204709)\n\n## Summary\n\nSpeaking to @azasypkin, we noticed that we are not backporting many of\nour dependency updates. These were mostly set to `backport:skip` before\nthe 9 vs. 8.x branch split. But we need it at the moment.\n\nWe'll need to revisit our backport strategy once we release 9.0.\n\n### Identify risks\n\n- [ ] Some deps like `@elastic/elasticsearch` might be bumped to 9.0 and\nshouldn't be backported. We'll update the renovate file when that\noccurs.","sha":"997884e1ba14a4e68647f13b90b7a9337c20d35a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/204709","number":204709,"mergeCommit":{"message":"[Renovate/Core] Use `prev-minor` backport strategy (#204709)\n\n## Summary\n\nSpeaking to @azasypkin, we noticed that we are not backporting many of\nour dependency updates. These were mostly set to `backport:skip` before\nthe 9 vs. 8.x branch split. But we need it at the moment.\n\nWe'll need to revisit our backport strategy once we release 9.0.\n\n### Identify risks\n\n- [ ] Some deps like `@elastic/elasticsearch` might be bumped to 9.0 and\nshouldn't be backported. We'll update the renovate file when that\noccurs.","sha":"997884e1ba14a4e68647f13b90b7a9337c20d35a"}}]}] BACKPORT-->