### PR TITLE
[8.x] [Ownership] Print owner match also, not just owner (#202704)

### DIFF
--- a/packages/kbn-code-owners/index.ts
+++ b/packages/kbn-code-owners/index.ts
@@ -7,5 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { PathWithOwners } from './src/file_code_owner';
-export { getPathsWithOwnersReversed, getCodeOwnersForFile } from './src/file_code_owner';
+export type { PathWithOwners, CodeOwnership } from './src/file_code_owner';
+export {
+  getPathsWithOwnersReversed,
+  getCodeOwnersForFile,
+  runGetOwnersForFileCli,
+} from './src/file_code_owner';

--- a/packages/kbn-code-owners/src/file_code_owner.ts
+++ b/packages/kbn-code-owners/src/file_code_owner.ts
@@ -8,9 +8,10 @@
  */
 
 import { REPO_ROOT } from '@kbn/repo-info';
-import { createFailError } from '@kbn/dev-cli-errors';
+import { createFailError, createFlagError } from '@kbn/dev-cli-errors';
 import { join as joinPath } from 'path';
 import { existsSync, readFileSync } from 'fs';
+import { run } from '@kbn/dev-cli-runner';
 
 import type { Ignore } from 'ignore';
 import ignore from 'ignore';
@@ -20,6 +21,12 @@ export interface PathWithOwners {
   teams: string;
   ignorePattern: Ignore;
 }
+export type CodeOwnership = Partial<Pick<PathWithOwners, 'path' | 'teams'>> | undefined;
+
+const existOrThrow = (targetFile: string) => {
+  if (existsSync(targetFile) === false)
+    throw createFailError(`Unable to determine code owners: file ${targetFile} Not Found`);
+};
 
 /**
  * Get the .github/CODEOWNERS entries, prepared for path matching.
@@ -61,10 +68,40 @@ export function getPathsWithOwnersReversed(): PathWithOwners[] {
 export function getCodeOwnersForFile(
   filePath: string,
   reversedCodeowners?: PathWithOwners[]
-): string | undefined {
+): CodeOwnership {
   const pathsWithOwners = reversedCodeowners ?? getPathsWithOwnersReversed();
-
   const match = pathsWithOwners.find((p) => p.ignorePattern.test(filePath).ignored);
-
-  return match?.teams;
+  if (match?.path && match.teams) return { path: match.path, teams: match.teams };
+  return;
+}
+const trimFrontSlash = (x: string): string => x.replace(/^\//, '');
+/**
+ * Run the getCodeOwnersForFile() method above.
+ * Report back to the cli with either success and the owner(s), or a failure.
+ *
+ * This function depends on a --file param being passed on the cli, like this:
+ * $ node scripts/get_owners_for_file.js --file SOME-FILE
+ */
+export async function runGetOwnersForFileCli() {
+  run(
+    async ({ flags, log }) => {
+      const targetFile = flags.file as string;
+      if (!targetFile) throw createFlagError(`Missing --file argument`);
+      existOrThrow(targetFile); // This call is duplicated in getPathsWithOwnersReversed(), so this is a short circuit
+      const result = getCodeOwnersForFile(targetFile);
+      if (result)
+        log.success(`Found matching entry in .github/CODEOWNERS:
+${trimFrontSlash(result?.path ? result.path : '')} ${result.teams}`);
+      else log.error(`Ownership of file [${targetFile}] is UNKNOWN`);
+    },
+    {
+      description: 'Report file ownership from GitHub CODEOWNERS file.',
+      flags: {
+        string: ['file'],
+        help: `
+      --file             Required, path to the file to report owners for.
+              `,
+      },
+    }
+  );
 }

--- a/packages/kbn-code-owners/tsconfig.json
+++ b/packages/kbn-code-owners/tsconfig.json
@@ -15,6 +15,7 @@
   ],
   "kbn_references": [
     "@kbn/repo-info",
-    "@kbn/dev-cli-errors"
+    "@kbn/dev-cli-errors",
+    "@kbn/dev-cli-runner"
   ]
 }

--- a/packages/kbn-scout-reporting/src/reporting/playwright.ts
+++ b/packages/kbn-scout-reporting/src/reporting/playwright.ts
@@ -23,7 +23,11 @@ import { ToolingLog } from '@kbn/tooling-log';
 import { SCOUT_REPORT_OUTPUT_ROOT } from '@kbn/scout-info';
 import stripANSI from 'strip-ansi';
 import { REPO_ROOT } from '@kbn/repo-info';
-import { PathWithOwners, getPathsWithOwnersReversed, getCodeOwnersForFile } from '@kbn/code-owners';
+import {
+  type PathWithOwners,
+  getPathsWithOwnersReversed,
+  getCodeOwnersForFile,
+} from '@kbn/code-owners';
 import { generateTestRunId, getTestIDForTitle, ScoutReport, ScoutReportEventAction } from '.';
 import { environmentMetadata } from '../datasources';
 
@@ -60,7 +64,7 @@ export class ScoutPlaywrightReporter implements Reporter {
   }
 
   private getFileOwners(filePath: string): string[] {
-    const concatenatedOwners = getCodeOwnersForFile(filePath, this.pathsWithOwners);
+    const concatenatedOwners = getCodeOwnersForFile(filePath, this.pathsWithOwners)?.teams;
 
     if (concatenatedOwners === undefined) {
       return [];

--- a/packages/kbn-test/src/functional_test_runner/lib/mocha/reporter/scout_ftr_reporter.ts
+++ b/packages/kbn-test/src/functional_test_runner/lib/mocha/reporter/scout_ftr_reporter.ts
@@ -18,7 +18,11 @@ import {
   ScoutReportEventAction,
   datasources,
 } from '@kbn/scout-reporting';
-import { getCodeOwnersForFile, getPathsWithOwnersReversed, PathWithOwners } from '@kbn/code-owners';
+import {
+  getCodeOwnersForFile,
+  getPathsWithOwnersReversed,
+  type PathWithOwners,
+} from '@kbn/code-owners';
 import { Runner, Test } from '../../../fake_mocha_types';
 
 /**
@@ -64,7 +68,7 @@ export class ScoutFTRReporter {
   }
 
   private getFileOwners(filePath: string): string[] {
-    const concatenatedOwners = getCodeOwnersForFile(filePath, this.pathsWithOwners);
+    const concatenatedOwners = getCodeOwnersForFile(filePath, this.pathsWithOwners)?.teams;
 
     if (concatenatedOwners === undefined) {
       return [];

--- a/packages/kbn-test/src/functional_test_runner/run_check_ftr_code_owners.ts
+++ b/packages/kbn-test/src/functional_test_runner/run_check_ftr_code_owners.ts
@@ -10,7 +10,11 @@
 import { run } from '@kbn/dev-cli-runner';
 import { createFailError } from '@kbn/dev-cli-errors';
 import { getRepoFiles } from '@kbn/get-repo-files';
-import { getCodeOwnersForFile, getPathsWithOwnersReversed } from '@kbn/code-owners';
+import {
+  getCodeOwnersForFile,
+  getPathsWithOwnersReversed,
+  type CodeOwnership,
+} from '@kbn/code-owners';
 
 const TEST_DIRECTORIES = ['test', 'x-pack/test', 'x-pack/test_serverless'];
 
@@ -36,10 +40,8 @@ export async function runCheckFtrCodeOwnersCli() {
 
       const testFiles = await getRepoFiles(TEST_DIRECTORIES);
       for (const { repoRel } of testFiles) {
-        const owners = getCodeOwnersForFile(repoRel, reversedCodeowners);
-        if (owners === undefined || owners === '') {
-          missingOwners.add(repoRel);
-        }
+        const owners: CodeOwnership = getCodeOwnersForFile(repoRel, reversedCodeowners);
+        if (owners === undefined || owners.teams === '') missingOwners.add(repoRel);
       }
 
       const timeSpent = fmtMs(performance.now() - start);

--- a/packages/kbn-test/src/mocha/junit_report_generation.js
+++ b/packages/kbn-test/src/mocha/junit_report_generation.js
@@ -142,8 +142,9 @@ export function setupJUnitReportGeneration(runner, options = {}) {
       // adding code owners only for the failed test case
       if (failed) {
         const testCaseRelativePath = getPath(node);
+
         const owners = getCodeOwnersForFile(testCaseRelativePath, reversedCodeowners);
-        attrs.owners = owners || ''; // empty string when no codeowners are defined
+        attrs.owners = owners?.teams || ''; // empty string when no codeowners are defined
       }
 
       return testsuitesEl.ele('testcase', attrs);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Ownership] Print owner match also, not just owner (#202704)](https://github.com/elastic/kibana/pull/202704)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tre","email":"wayne.seymour@elastic.co"},"sourceCommit":{"committedDate":"2024-12-10T17:15:13Z","message":"[Ownership] Print owner match also, not just owner (#202704)\n\n## Summary\r\n\r\nResolves: https://github.com/elastic/kibana/issues/202666\r\n\r\n## For reviewers\r\nTo see the change, run this:\r\n`node scripts/get_owners_for_file.js --file\r\ntest/functional/apps/console/_autocomplete.ts`\r\n### Results:\r\n#### Before\r\n```\r\n succ elastic/kibana-management\r\n```\r\n#### After\r\n```\r\n succ Found matching entry in .github/CODEOWNERS:\r\n      test/functional/apps/console/*.ts elastic/kibana-management\r\n```\r\n\r\n---------\r\n\r\nCo-authored-by: Robert Oskamp <traeluki@gmail.com>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: David Olaru <dolaru@elastic.co>","sha":"e706b6689d0700d883791eb7cac3252d21335291","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor"],"number":202704,"url":"https://github.com/elastic/kibana/pull/202704","mergeCommit":{"message":"[Ownership] Print owner match also, not just owner (#202704)\n\n## Summary\r\n\r\nResolves: https://github.com/elastic/kibana/issues/202666\r\n\r\n## For reviewers\r\nTo see the change, run this:\r\n`node scripts/get_owners_for_file.js --file\r\ntest/functional/apps/console/_autocomplete.ts`\r\n### Results:\r\n#### Before\r\n```\r\n succ elastic/kibana-management\r\n```\r\n#### After\r\n```\r\n succ Found matching entry in .github/CODEOWNERS:\r\n      test/functional/apps/console/*.ts elastic/kibana-management\r\n```\r\n\r\n---------\r\n\r\nCo-authored-by: Robert Oskamp <traeluki@gmail.com>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: David Olaru <dolaru@elastic.co>","sha":"e706b6689d0700d883791eb7cac3252d21335291"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/202704","number":202704,"mergeCommit":{"message":"[Ownership] Print owner match also, not just owner (#202704)\n\n## Summary\r\n\r\nResolves: https://github.com/elastic/kibana/issues/202666\r\n\r\n## For reviewers\r\nTo see the change, run this:\r\n`node scripts/get_owners_for_file.js --file\r\ntest/functional/apps/console/_autocomplete.ts`\r\n### Results:\r\n#### Before\r\n```\r\n succ elastic/kibana-management\r\n```\r\n#### After\r\n```\r\n succ Found matching entry in .github/CODEOWNERS:\r\n      test/functional/apps/console/*.ts elastic/kibana-management\r\n```\r\n\r\n---------\r\n\r\nCo-authored-by: Robert Oskamp <traeluki@gmail.com>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: David Olaru <dolaru@elastic.co>","sha":"e706b6689d0700d883791eb7cac3252d21335291"}}]}] BACKPORT-->