### PR TITLE
[Automatic Import] Fix UI validation for Integration and Datastream name

### DIFF
--- a/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/data_stream_step.tsx
+++ b/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/data_stream_step.tsx
@@ -43,8 +43,8 @@ export const InputTypeOptions: Array<EuiComboBoxOptionOption<InputType>> = [
   { value: 'udp', label: 'UDP' },
 ];
 
-const isValidName = (name: string) => /^[a-z_]+$/.test(name);
-const getNameFromTitle = (title: string) => title.toLowerCase().replaceAll(/[^a-z]/g, '_');
+const isValidName = (name: string) => /^[a-z0-9_]+$/.test(name);
+const getNameFromTitle = (title: string) => title.toLowerCase().replaceAll(/[^a-z0-9]/g, '_');
 
 interface DataStreamStepProps {
   integrationSettings: State['integrationSettings'];

--- a/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/data_stream_step.tsx
+++ b/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/data_stream_step.tsx
@@ -43,8 +43,8 @@ export const InputTypeOptions: Array<EuiComboBoxOptionOption<InputType>> = [
   { value: 'udp', label: 'UDP' },
 ];
 
-const isValidName = (name: string) => /^[a-z0-9_]+$/.test(name);
-const getNameFromTitle = (title: string) => title.toLowerCase().replaceAll(/[^a-z0-9]/g, '_');
+const isValidName = (name: string) => /^[a-z_]+$/.test(name);
+const getNameFromTitle = (title: string) => title.toLowerCase().replaceAll(/[^a-z]/g, '_');
 
 interface DataStreamStepProps {
   integrationSettings: State['integrationSettings'];

--- a/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/translations.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/translations.ts
@@ -45,7 +45,7 @@ export const INTEGRATION_NAME_LABEL = i18n.translate(
 export const NO_SPACES_HELP = i18n.translate(
   'xpack.integrationAssistant.step.dataStream.noSpacesHelpText',
   {
-    defaultMessage: 'Name can only contain lowercase letters and underscore (_)',
+    defaultMessage: 'Name can only contain lowercase letters, numbers, and underscore (_)',
   }
 );
 export const PACKAGE_NAMES_FETCH_ERROR = i18n.translate(

--- a/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/translations.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/translations.ts
@@ -45,7 +45,7 @@ export const INTEGRATION_NAME_LABEL = i18n.translate(
 export const NO_SPACES_HELP = i18n.translate(
   'xpack.integrationAssistant.step.dataStream.noSpacesHelpText',
   {
-    defaultMessage: 'Name can only contain lowercase letters, numbers, and underscore (_)',
+    defaultMessage: 'Name can only contain lowercase letters and underscore (_)',
   }
 );
 export const PACKAGE_NAMES_FETCH_ERROR = i18n.translate(

--- a/x-pack/platform/plugins/shared/integration_assistant/server/integration_builder/build_integration.test.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/integration_builder/build_integration.test.ts
@@ -292,12 +292,6 @@ describe('isValidName', () => {
     expect(isValidName('anotherValidName')).toBe(true);
   });
 
-  it('should return false for names with numbers', () => {
-    expect(isValidName('invalid123')).toBe(false);
-    expect(isValidName('123invalid')).toBe(false);
-    expect(isValidName('invalid_123')).toBe(false);
-  });
-
   it('should return false for empty string', () => {
     expect(isValidName('')).toBe(false);
   });

--- a/x-pack/platform/plugins/shared/integration_assistant/server/integration_builder/build_integration.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/integration_builder/build_integration.ts
@@ -77,7 +77,7 @@ export async function buildPackage(integration: Integration): Promise<Buffer> {
   return zipBuffer;
 }
 export function isValidName(input: string): boolean {
-  const regex = /^[a-zA-Z_]+$/;
+  const regex = /^[a-zA-Z0-9_]+$/;
   return input.length > 0 && regex.test(input);
 }
 function createDirectories(

--- a/x-pack/platform/plugins/shared/integration_assistant/server/integration_builder/build_integration.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/integration_builder/build_integration.ts
@@ -36,7 +36,7 @@ export async function buildPackage(integration: Integration): Promise<Buffer> {
 
   if (!isValidName(integration.name)) {
     throw new Error(
-      `Invalid integration name: ${integration.name}, Should only contain letters and underscores`
+      `Invalid integration name: ${integration.name}, Should only contain letters, numbers and underscores`
     );
   }
 
@@ -49,7 +49,7 @@ export async function buildPackage(integration: Integration): Promise<Buffer> {
     const dataStreamName = dataStream.name;
     if (!isValidName(dataStreamName)) {
       throw new Error(
-        `Invalid datastream name: ${dataStreamName}, Should only contain letters and underscores`
+        `Invalid datastream name: ${dataStreamName}, Should only contain letters, numbers and underscores`
       );
     }
     const specificDataStreamDir = joinPath(dataStreamsDir, dataStreamName);


### PR DESCRIPTION
## Release Note

Fixes Integration and Datastream name validation

## Summary

https://github.com/elastic/kibana/pull/204409 implemented backend validation for integration and datastream names and this PR fixes allowing numbers on backend

<img width="858" alt="image" src="https://github.com/user-attachments/assets/8d61305a-eeb8-41d7-8fa0-f0b466fa7528" />


Closes https://github.com/elastic/kibana/issues/204935

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->