### PR TITLE
Backport typo fix to 8.17

### DIFF
--- a/docs/user/dashboard/lens.asciidoc
+++ b/docs/user/dashboard/lens.asciidoc
@@ -671,7 +671,7 @@ For area, line, and bar charts, press Shift, then click the series in the legend
 .*How do I visualize saved searches?*
 [%collapsible]
 ====
-Visualizing saved searches in unsupported.
+Visualizing saved Discover sessions is unsupported.
 ====
 
 [discrete]


### PR DESCRIPTION
Cherry-picking because of a merge conflict.

Rel: [#204847](https://github.com/elastic/kibana/pull/204847)
