### PR TITLE
[8.x] [Ownership] Add code owner to ftr failure report (#203076)

### DIFF
--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/__fixtures__/ftr_report.xml
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/__fixtures__/ftr_report.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites name="ftr" timestamp="2019-06-05T23:37:10" time="903.670" tests="129" failures="5" skipped="71" command-line="node scripts/functional_tests --config=x-pack/test/api_integration/apis/status/config.ts">
   <testsuite timestamp="2019-06-05T23:37:10" time="903.670" tests="129" failures="5" skipped="71" command-line="node scripts/functional_tests --config=x-pack/test/api_integration/apis/status/config.ts">
-    <testcase name="maps app  maps loaded from sample data ecommerce &quot;before all&quot; hook" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/maps/sample_data·js" time="154.378">
+    <testcase name="maps app  maps loaded from sample data ecommerce &quot;before all&quot; hook" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/maps/sample_data·js" time="154.378" owners="elastic/kibana-presentation">
       <system-out>
         <![CDATA[[00:00:00]       │
 [00:07:04]         └-: maps app
@@ -18,7 +18,7 @@ Wait timed out after 10055ms
     at onFailure (/var/lib/jenkins/workspace/elastic+kibana+master/JOB/x-pack-ciGroup7/node/immutable/kibana/test/common/services/retry/retry_for_success.ts:68:13)]]>
       </failure>
     </testcase>
-    <testcase name="maps app &quot;after all&quot; hook" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/maps" time="0.179" metadata-json="{&quot;messages&quot;:[&quot;foo&quot;],&quot;screenshots&quot;:[{&quot;name&quot;:&quot;failure[dashboard app using current data dashboard snapshots compare TSVB snapshot]&quot;,&quot;url&quot;:&quot;https://storage.googleapis.com/kibana-ci-artifacts/jobs/elastic+kibana+7.x/1632/kibana-oss-tests/test/functional/screenshots/failure/dashboard%20app%20using%20current%20data%20dashboard%20snapshots%20compare%20TSVB%20snapshot.png&quot;}]}">
+    <testcase name="maps app &quot;after all&quot; hook" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/maps" time="0.179" metadata-json="{&quot;messages&quot;:[&quot;foo&quot;],&quot;screenshots&quot;:[{&quot;name&quot;:&quot;failure[dashboard app using current data dashboard snapshots compare TSVB snapshot]&quot;,&quot;url&quot;:&quot;https://storage.googleapis.com/kibana-ci-artifacts/jobs/elastic+kibana+7.x/1632/kibana-oss-tests/test/functional/screenshots/failure/dashboard%20app%20using%20current%20data%20dashboard%20snapshots%20compare%20TSVB%20snapshot.png&quot;}]}" owners="elastic/kibana-presentation">
       <system-out>
         <![CDATA[[00:00:00]       │
 [00:07:04]         └-: maps app
@@ -32,7 +32,7 @@ Wait timed out after 10055ms
     at process._tickCallback (internal/process/next_tick.js:68:7) name: 'NoSuchSessionError', remoteStacktrace: '' }]]>
       </failure>
     </testcase>
-    <testcase name="InfraOps app feature controls infrastructure security global infrastructure all privileges shows infrastructure navlink" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/infra/feature_controls/infrastructure_security·ts">
+    <testcase name="InfraOps app feature controls infrastructure security global infrastructure all privileges shows infrastructure navlink" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/infra/feature_controls/infrastructure_security·ts" owners="elastic/kibana-presentation">
       <system-out>
         <![CDATA[[00:00:00]       │
 [00:05:13]         └-: InfraOps app
@@ -41,7 +41,7 @@ Wait timed out after 10055ms
       </system-out>
       <skipped/>
     </testcase>
-    <testcase name="machine learning anomaly detection saved search  with lucene query job creation opens the advanced section" classname="Firefox XPack UI Functional Tests.x-pack/test/functional/apps/machine_learning/anomaly_detection/saved_search_job·ts" time="6.040">
+    <testcase name="machine learning anomaly detection saved search  with lucene query job creation opens the advanced section" classname="Firefox XPack UI Functional Tests.x-pack/test/functional/apps/machine_learning/anomaly_detection/saved_search_job·ts" time="6.040" owners="elastic/ml-ui">
       <system-out><![CDATA[[00:21:57]         └-: machine learning...]]></system-out>
       <failure><![CDATA[{ NoSuchSessionError: Tried to run command without establishing a connection
     at Object.throwDecodedError (/dev/shm/workspace/kibana/node_modules/selenium-webdriver/lib/error.js:550:15)

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/add_messages_to_report.test.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/add_messages_to_report.test.ts
@@ -63,7 +63,7 @@ it('rewrites ftr reports with minimal changes', async () => {
      ‹?xml version="1.0" encoding="utf-8"?›
      ‹testsuites name="ftr" timestamp="2019-06-05T23:37:10" time="903.670" tests="129" failures="5" skipped="71" command-line="node scripts/functional_tests --config=x-pack/test/api_integration/apis/status/config.ts"›
        ‹testsuite timestamp="2019-06-05T23:37:10" time="903.670" tests="129" failures="5" skipped="71" command-line="node scripts/functional_tests --config=x-pack/test/api_integration/apis/status/config.ts"›
-         ‹testcase name="maps app  maps loaded from sample data ecommerce &quot;before all&quot; hook" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/maps/sample_data·js" time="154.378"›
+         ‹testcase name="maps app  maps loaded from sample data ecommerce &quot;before all&quot; hook" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/maps/sample_data·js" time="154.378" owners="elastic/kibana-presentation"›
     -      ‹system-out›
     -        ‹![CDATA[[00:00:00]       │
     +      ‹system-out›Failed Tests Reporter:
@@ -88,7 +88,7 @@ it('rewrites ftr reports with minimal changes', async () => {
     +    at onFailure (/var/lib/jenkins/workspace/elastic+kibana+master/JOB/x-pack-ciGroup7/node/immutable/kibana/test/common/services/retry/retry_for_success.ts:68:13)
            ‹/failure›
          ‹/testcase›
-         ‹testcase name="maps app &quot;after all&quot; hook" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/maps" time="0.179" metadata-json="{&quot;messages&quot;:[&quot;foo&quot;],&quot;screenshots&quot;:[{&quot;name&quot;:&quot;failure[dashboard app using current data dashboard snapshots compare TSVB snapshot]&quot;,&quot;url&quot;:&quot;https://storage.googleapis.com/kibana-ci-artifacts/jobs/elastic+kibana+7.x/1632/kibana-oss-tests/test/functional/screenshots/failure/dashboard%20app%20using%20current%20data%20dashboard%20snapshots%20compare%20TSVB%20snapshot.png&quot;}]}"›
+         ‹testcase name="maps app &quot;after all&quot; hook" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/maps" time="0.179" metadata-json="{&quot;messages&quot;:[&quot;foo&quot;],&quot;screenshots&quot;:[{&quot;name&quot;:&quot;failure[dashboard app using current data dashboard snapshots compare TSVB snapshot]&quot;,&quot;url&quot;:&quot;https://storage.googleapis.com/kibana-ci-artifacts/jobs/elastic+kibana+7.x/1632/kibana-oss-tests/test/functional/screenshots/failure/dashboard%20app%20using%20current%20data%20dashboard%20snapshots%20compare%20TSVB%20snapshot.png&quot;}]}" owners="elastic/kibana-presentation"›
            ‹system-out›
     -        ‹![CDATA[[00:00:00]       │
     +        [00:00:00]       │
@@ -106,7 +106,7 @@ it('rewrites ftr reports with minimal changes', async () => {
     +    at process._tickCallback (internal/process/next_tick.js:68:7) name: 'NoSuchSessionError', remoteStacktrace: '' }
            ‹/failure›
          ‹/testcase›
-         ‹testcase name="InfraOps app feature controls infrastructure security global infrastructure all privileges shows infrastructure navlink" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/infra/feature_controls/infrastructure_security·ts"›
+         ‹testcase name="InfraOps app feature controls infrastructure security global infrastructure all privileges shows infrastructure navlink" classname="Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/infra/feature_controls/infrastructure_security·ts" owners="elastic/kibana-presentation"›
            ‹system-out›
     -        ‹![CDATA[[00:00:00]       │
     +        [00:00:00]       │
@@ -117,7 +117,7 @@ it('rewrites ftr reports with minimal changes', async () => {
            ‹/system-out›
            ‹skipped/›
          ‹/testcase›
-         ‹testcase name="machine learning anomaly detection saved search  with lucene query job creation opens the advanced section" classname="Firefox XPack UI Functional Tests.x-pack/test/functional/apps/machine_learning/anomaly_detection/saved_search_job·ts" time="6.040"›
+         ‹testcase name="machine learning anomaly detection saved search  with lucene query job creation opens the advanced section" classname="Firefox XPack UI Functional Tests.x-pack/test/functional/apps/machine_learning/anomaly_detection/saved_search_job·ts" time="6.040" owners="elastic/ml-ui"›
     -      ‹system-out›‹![CDATA[[00:21:57]         └-: machine learning...]]›‹/system-out›
     -      ‹failure›‹![CDATA[{ NoSuchSessionError: Tried to run command without establishing a connection
     +      ‹system-out›[00:21:57]         └-: machine learning...‹/system-out›

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_failures.test.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_failures.test.ts
@@ -28,6 +28,7 @@ it('discovers failures in ftr report', async () => {
           ",
         "likelyIrrelevant": false,
         "name": "maps app  maps loaded from sample data ecommerce \\"before all\\" hook",
+        "owners": "elastic/kibana-presentation",
         "system-out": "
             [00:00:00]       │
     [00:07:04]         └-: maps app
@@ -49,6 +50,7 @@ it('discovers failures in ftr report', async () => {
         "likelyIrrelevant": true,
         "metadata-json": "{\\"messages\\":[\\"foo\\"],\\"screenshots\\":[{\\"name\\":\\"failure[dashboard app using current data dashboard snapshots compare TSVB snapshot]\\",\\"url\\":\\"https://storage.googleapis.com/kibana-ci-artifacts/jobs/elastic+kibana+7.x/1632/kibana-oss-tests/test/functional/screenshots/failure/dashboard%20app%20using%20current%20data%20dashboard%20snapshots%20compare%20TSVB%20snapshot.png\\"}]}",
         "name": "maps app \\"after all\\" hook",
+        "owners": "elastic/kibana-presentation",
         "system-out": "
             [00:00:00]       │
     [00:07:04]         └-: maps app
@@ -67,6 +69,7 @@ it('discovers failures in ftr report', async () => {
         at process._tickCallback (internal/process/next_tick.js:68:7) name: 'NoSuchSessionError', remoteStacktrace: '' }",
         "likelyIrrelevant": true,
         "name": "machine learning anomaly detection saved search  with lucene query job creation opens the advanced section",
+        "owners": "elastic/ml-ui",
         "system-out": "[00:21:57]         └-: machine learning...",
         "time": "6.040",
       },
@@ -87,6 +90,7 @@ it('discovers failures in jest report', async () => {
           ",
         "likelyIrrelevant": false,
         "name": "launcher can reconnect if process died",
+        "owners": undefined,
         "system-out": "",
         "time": "7.060",
       },
@@ -116,6 +120,7 @@ it('discovers failures in mocha report', async () => {
           ",
         "likelyIrrelevant": true,
         "name": "code in multiple nodes \\"before all\\" hook",
+        "owners": undefined,
         "system-out": "
             
           ",
@@ -131,6 +136,7 @@ it('discovers failures in mocha report', async () => {
           ",
         "likelyIrrelevant": true,
         "name": "code in multiple nodes \\"after all\\" hook",
+        "owners": undefined,
         "system-out": "
             
           ",

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_failures.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/get_failures.ts
@@ -18,6 +18,7 @@ export type TestFailure = FailedTestCase['$'] & {
   githubIssue?: string;
   failureCount?: number;
   commandLine?: string;
+  owners?: any;
 };
 
 const getText = (node?: Array<string | { _: string }>) => {
@@ -78,6 +79,7 @@ export function getFailures(report: TestReport) {
   for (const testCase of makeFailedTestCaseIter(report)) {
     const failure = getText(testCase.failure);
     const likelyIrrelevant = isLikelyIrrelevant(testCase.$.name, failure);
+    const owners = testCase.$.owners;
 
     const failureObj = {
       // unwrap xml weirdness
@@ -87,6 +89,7 @@ export function getFailures(report: TestReport) {
       likelyIrrelevant,
       'system-out': getText(testCase['system-out']),
       commandLine,
+      owners,
     };
 
     // cleaning up duplicates

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/report_failures_to_file.ts
@@ -180,6 +180,12 @@ export async function reportFailuresToFile(
                 : ''
             }
             <div>
+                <strong>Owners</strong>:
+                <pre>${escape(
+                  failure?.owners ? (failure?.owners as string) : 'Unable to determine code owners'
+                )}</pre>
+            </div>
+            <div>
                 <strong>Failures in tracked branches</strong>:
                     <span class="badge rounded-pill bg-danger">${failure.failureCount || 0}</span>
             </div>

--- a/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/test_report.ts
+++ b/packages/kbn-failed-test-reporter-cli/failed_tests_reporter/test_report.ts
@@ -11,7 +11,6 @@ import Fs from 'fs';
 import { promisify } from 'util';
 
 import xml2js from 'xml2js';
-
 const readAsync = promisify(Fs.readFile);
 
 export type TestReport =
@@ -40,6 +39,8 @@ export interface TestSuite {
     'metadata-json'?: string;
     /* the command that ran this suite */
     'command-line'?: string;
+    /* the codeowners of the file */
+    owners?: string;
   };
   testcase?: TestCase[];
 }
@@ -56,6 +57,8 @@ export interface TestCase {
     'metadata-json'?: string;
     /* the command that ran this suite */
     'command-line'?: string;
+    /* the codeowners of the file */
+    owners?: string;
   };
   /* contents of system-out elements */
   'system-out'?: Array<string | { _: string }>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Ownership] Add code owner to ftr failure report (#203076)](https://github.com/elastic/kibana/pull/203076)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tre","email":"wayne.seymour@elastic.co"},"sourceCommit":{"committedDate":"2024-12-16T17:05:20Z","message":"[Ownership] Add code owner to ftr failure report (#203076)\n\n## Summary\r\n\r\nResolves: https://github.com/elastic/kibana/issues/202687\r\n\r\n### For Reviewers \r\n#### To test locally, make a test fail, something like \r\n```\r\ndiff --git a/test/functional/apps/console/_autocomplete.ts b/test/functional/apps/console/_autocomplete.ts\r\nindex 0e29b29e96e..78976e6d54b 100644\r\n--- a/test/functional/apps/console/_autocomplete.ts\r\n+++ b/test/functional/apps/console/_autocomplete.ts\r\n@@ -50,14 +50,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {\r\n       await PageObjects.console.setAutocompleteTrace(false);\r\n     });\r\n \r\n-    it('should provide basic auto-complete functionality', async () => {\r\n+    it.only('should provide basic auto-complete functionality', async () => {\r\n       await PageObjects.console.enterText(`GET _search\\n`);\r\n       await PageObjects.console.pressEnter();\r\n       await PageObjects.console.enterText(`{\\n\\t\"query\": {`);\r\n       await PageObjects.console.pressEnter();\r\n       await PageObjects.console.sleepForDebouncePeriod();\r\n       await PageObjects.console.promptAutocomplete();\r\n-      expect(PageObjects.console.isAutocompleteVisible()).to.be.eql(true);\r\n+      expect(false).to.be.eql(true);\r\n     });\r\n \r\n     it('should not show duplicate suggestions', async () => {\r\n```\r\n\r\n#### Then run the tests:\r\n`TEST_BROWSER_HEADLESS=1 CI=1 node scripts/functional_tests\r\n--config=test/functional/apps/console/config.ts --bail`\r\n\r\n#### Then run the reporter to see the html file\r\n`JOB_NAME=elastic+kibana+7.x node scripts/report_failed_tests\r\n--build-url=\"${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}\"\r\n'target/junit/**/*.xml' --no-github-update --no-index-errors`\r\n\r\n#### Lastly, inspect the HTML File\r\n`grep elastic target/test_failures/*.html -B 2`\r\n```\r\n            <div>\r\n                <strong>Owners</strong>:\r\n                <pre>elastic/kibana-management</pre>\r\n--\r\n            </div>\r\n            <div>\r\n                     <a href=\"https://github.com/elastic/kibana/issues/156926\">https://github.com/elastic/kibana/issues/156926</a>\r\n--\r\n              <h5>Stdout</h5>\r\n              <pre>Failed Tests Reporter:\r\n  - Test has failed 1 times on tracked branches: https://github.com/elastic/kibana/issues/156926\r\n\r\nFailed Tests Reporter:\r\n  - Test has failed 1 times on tracked branches: https://github.com/elastic/kibana/issues/156926\r\n\r\nFailed Tests Reporter:\r\n  - Test has failed 1 times on tracked branches: https://github.com/elastic/kibana/issues/156926\r\n```\r\n\r\nNotice the `<pre>elastic/kibana-management</pre>` in the output of grep\r\n\r\nAlso, you can continue verification of the ownership value, via: `node\r\nscripts/get_owners_for_file.js --file\r\ntest/functional/apps/console/_autocomplete.ts`\r\n```\r\n succ Found matching entry in .github/CODEOWNERS:\r\n      test/functional/apps/console/*.ts elastic/kibana-management\r\n```\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"82f0e2cd54f8fd84c75beebe2853fbf63ff1dab9","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","FTR"],"number":203076,"url":"https://github.com/elastic/kibana/pull/203076","mergeCommit":{"message":"[Ownership] Add code owner to ftr failure report (#203076)\n\n## Summary\r\n\r\nResolves: https://github.com/elastic/kibana/issues/202687\r\n\r\n### For Reviewers \r\n#### To test locally, make a test fail, something like \r\n```\r\ndiff --git a/test/functional/apps/console/_autocomplete.ts b/test/functional/apps/console/_autocomplete.ts\r\nindex 0e29b29e96e..78976e6d54b 100644\r\n--- a/test/functional/apps/console/_autocomplete.ts\r\n+++ b/test/functional/apps/console/_autocomplete.ts\r\n@@ -50,14 +50,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {\r\n       await PageObjects.console.setAutocompleteTrace(false);\r\n     });\r\n \r\n-    it('should provide basic auto-complete functionality', async () => {\r\n+    it.only('should provide basic auto-complete functionality', async () => {\r\n       await PageObjects.console.enterText(`GET _search\\n`);\r\n       await PageObjects.console.pressEnter();\r\n       await PageObjects.console.enterText(`{\\n\\t\"query\": {`);\r\n       await PageObjects.console.pressEnter();\r\n       await PageObjects.console.sleepForDebouncePeriod();\r\n       await PageObjects.console.promptAutocomplete();\r\n-      expect(PageObjects.console.isAutocompleteVisible()).to.be.eql(true);\r\n+      expect(false).to.be.eql(true);\r\n     });\r\n \r\n     it('should not show duplicate suggestions', async () => {\r\n```\r\n\r\n#### Then run the tests:\r\n`TEST_BROWSER_HEADLESS=1 CI=1 node scripts/functional_tests\r\n--config=test/functional/apps/console/config.ts --bail`\r\n\r\n#### Then run the reporter to see the html file\r\n`JOB_NAME=elastic+kibana+7.x node scripts/report_failed_tests\r\n--build-url=\"${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}\"\r\n'target/junit/**/*.xml' --no-github-update --no-index-errors`\r\n\r\n#### Lastly, inspect the HTML File\r\n`grep elastic target/test_failures/*.html -B 2`\r\n```\r\n            <div>\r\n                <strong>Owners</strong>:\r\n                <pre>elastic/kibana-management</pre>\r\n--\r\n            </div>\r\n            <div>\r\n                     <a href=\"https://github.com/elastic/kibana/issues/156926\">https://github.com/elastic/kibana/issues/156926</a>\r\n--\r\n              <h5>Stdout</h5>\r\n              <pre>Failed Tests Reporter:\r\n  - Test has failed 1 times on tracked branches: https://github.com/elastic/kibana/issues/156926\r\n\r\nFailed Tests Reporter:\r\n  - Test has failed 1 times on tracked branches: https://github.com/elastic/kibana/issues/156926\r\n\r\nFailed Tests Reporter:\r\n  - Test has failed 1 times on tracked branches: https://github.com/elastic/kibana/issues/156926\r\n```\r\n\r\nNotice the `<pre>elastic/kibana-management</pre>` in the output of grep\r\n\r\nAlso, you can continue verification of the ownership value, via: `node\r\nscripts/get_owners_for_file.js --file\r\ntest/functional/apps/console/_autocomplete.ts`\r\n```\r\n succ Found matching entry in .github/CODEOWNERS:\r\n      test/functional/apps/console/*.ts elastic/kibana-management\r\n```\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"82f0e2cd54f8fd84c75beebe2853fbf63ff1dab9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203076","number":203076,"mergeCommit":{"message":"[Ownership] Add code owner to ftr failure report (#203076)\n\n## Summary\r\n\r\nResolves: https://github.com/elastic/kibana/issues/202687\r\n\r\n### For Reviewers \r\n#### To test locally, make a test fail, something like \r\n```\r\ndiff --git a/test/functional/apps/console/_autocomplete.ts b/test/functional/apps/console/_autocomplete.ts\r\nindex 0e29b29e96e..78976e6d54b 100644\r\n--- a/test/functional/apps/console/_autocomplete.ts\r\n+++ b/test/functional/apps/console/_autocomplete.ts\r\n@@ -50,14 +50,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {\r\n       await PageObjects.console.setAutocompleteTrace(false);\r\n     });\r\n \r\n-    it('should provide basic auto-complete functionality', async () => {\r\n+    it.only('should provide basic auto-complete functionality', async () => {\r\n       await PageObjects.console.enterText(`GET _search\\n`);\r\n       await PageObjects.console.pressEnter();\r\n       await PageObjects.console.enterText(`{\\n\\t\"query\": {`);\r\n       await PageObjects.console.pressEnter();\r\n       await PageObjects.console.sleepForDebouncePeriod();\r\n       await PageObjects.console.promptAutocomplete();\r\n-      expect(PageObjects.console.isAutocompleteVisible()).to.be.eql(true);\r\n+      expect(false).to.be.eql(true);\r\n     });\r\n \r\n     it('should not show duplicate suggestions', async () => {\r\n```\r\n\r\n#### Then run the tests:\r\n`TEST_BROWSER_HEADLESS=1 CI=1 node scripts/functional_tests\r\n--config=test/functional/apps/console/config.ts --bail`\r\n\r\n#### Then run the reporter to see the html file\r\n`JOB_NAME=elastic+kibana+7.x node scripts/report_failed_tests\r\n--build-url=\"${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}\"\r\n'target/junit/**/*.xml' --no-github-update --no-index-errors`\r\n\r\n#### Lastly, inspect the HTML File\r\n`grep elastic target/test_failures/*.html -B 2`\r\n```\r\n            <div>\r\n                <strong>Owners</strong>:\r\n                <pre>elastic/kibana-management</pre>\r\n--\r\n            </div>\r\n            <div>\r\n                     <a href=\"https://github.com/elastic/kibana/issues/156926\">https://github.com/elastic/kibana/issues/156926</a>\r\n--\r\n              <h5>Stdout</h5>\r\n              <pre>Failed Tests Reporter:\r\n  - Test has failed 1 times on tracked branches: https://github.com/elastic/kibana/issues/156926\r\n\r\nFailed Tests Reporter:\r\n  - Test has failed 1 times on tracked branches: https://github.com/elastic/kibana/issues/156926\r\n\r\nFailed Tests Reporter:\r\n  - Test has failed 1 times on tracked branches: https://github.com/elastic/kibana/issues/156926\r\n```\r\n\r\nNotice the `<pre>elastic/kibana-management</pre>` in the output of grep\r\n\r\nAlso, you can continue verification of the ownership value, via: `node\r\nscripts/get_owners_for_file.js --file\r\ntest/functional/apps/console/_autocomplete.ts`\r\n```\r\n succ Found matching entry in .github/CODEOWNERS:\r\n      test/functional/apps/console/*.ts elastic/kibana-management\r\n```\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"82f0e2cd54f8fd84c75beebe2853fbf63ff1dab9"}}]}] BACKPORT-->