### PR TITLE
[8.x] [ES `body` removal] `@elastic/fleet` (#204867)

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SecurityRoleDescriptor } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { SecurityRoleDescriptor } from '@elastic/elasticsearch/lib/api/types';
 
 import type { agentPolicyStatuses } from '../../constants';
 import type { MonitoringType, PolicySecretReference, ValueOf } from '..';

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import type {
   ASSETS_SAVED_OBJECT_TYPE,

--- a/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/data_streams/handlers.ts
@@ -8,7 +8,7 @@ import type { Dictionary } from 'lodash';
 import { keyBy, keys, merge } from 'lodash';
 import type { RequestHandler } from '@kbn/core/server';
 import pMap from 'p-map';
-import type { IndicesDataStreamsStatsDataStreamsStatsItem } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { IndicesDataStreamsStatsDataStreamsStatsItem } from '@elastic/elasticsearch/lib/api/types';
 import { ByteSizeValue } from '@kbn/config-schema';
 
 import type { DataStream } from '../../types';

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -8,7 +8,7 @@
 import type {
   SecurityIndicesPrivileges,
   SecurityRoleDescriptor,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+} from '@elastic/elasticsearch/lib/api/types';
 
 import {
   FLEET_APM_PACKAGE,

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -22,7 +22,7 @@ import type {
 } from '@kbn/core/server';
 import { SavedObjectsUtils } from '@kbn/core/server';
 
-import type { BulkResponseItem } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { BulkResponseItem } from '@elastic/elasticsearch/lib/api/types';
 
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
 

--- a/x-pack/plugins/fleet/server/services/agents/action.mock.ts
+++ b/x-pack/plugins/fleet/server/services/agents/action.mock.ts
@@ -152,7 +152,7 @@ export function createClientMock() {
 
   esClientMock.mget.mockResponseImplementation((params) => {
     // @ts-expect-error
-    const docs = params?.body.docs.map(({ _id }) => {
+    const docs = params?.docs.map(({ _id }) => {
       let result;
       switch (_id) {
         case agentInHostedDoc._id:

--- a/x-pack/plugins/fleet/server/services/agents/actions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/actions.test.ts
@@ -135,7 +135,7 @@ describe('Agent actions', () => {
 
         expect(esClient.create).toBeCalledWith(
           expect.objectContaining({
-            body: expect.objectContaining({
+            document: expect.objectContaining({
               signed: {
                 data: expect.any(String),
                 signature: expect.any(String),
@@ -180,7 +180,7 @@ describe('Agent actions', () => {
 
       expect(esClient.create).toBeCalledWith(
         expect.objectContaining({
-          body: expect.not.objectContaining({
+          document: expect.not.objectContaining({
             signed: expect.any(Object),
           }),
         })
@@ -235,7 +235,7 @@ describe('Agent actions', () => {
       await bulkCreateAgentActions(esClient, newActions);
       expect(esClient.bulk).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.arrayContaining([
+          operations: expect.arrayContaining([
             expect.arrayContaining([
               expect.objectContaining({
                 signed: {
@@ -274,7 +274,7 @@ describe('Agent actions', () => {
       await bulkCreateAgentActions(esClient, newActions);
       expect(esClient.bulk).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.arrayContaining([
+          operations: expect.arrayContaining([
             expect.arrayContaining([
               expect.not.objectContaining({
                 signed: {
@@ -350,7 +350,7 @@ describe('Agent actions', () => {
       expect(esClient.create).toBeCalledTimes(2);
       expect(esClient.create).toBeCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
+          document: expect.objectContaining({
             type: 'CANCEL',
             data: { target_id: 'action1' },
             agents: ['agent1', 'agent2'],
@@ -359,7 +359,7 @@ describe('Agent actions', () => {
       );
       expect(esClient.create).toBeCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
+          document: expect.objectContaining({
             type: 'CANCEL',
             data: { target_id: 'action1' },
             agents: ['agent3', 'agent4'],

--- a/x-pack/plugins/fleet/server/services/agents/actions.ts
+++ b/x-pack/plugins/fleet/server/services/agents/actions.ts
@@ -78,7 +78,7 @@ export async function createAgentAction(
   await esClient.create({
     index: AGENT_ACTIONS_INDEX,
     id: uuidv4(),
-    body,
+    document: body,
     refresh: 'wait_for',
   });
 
@@ -112,7 +112,7 @@ export async function bulkCreateAgentActions(
   const messageSigningService = appContextService.getMessageSigningService();
   await esClient.bulk({
     index: AGENT_ACTIONS_INDEX,
-    body: await Promise.all(
+    operations: await Promise.all(
       actions.flatMap(async (action) => {
         const body: FleetServerAgentAction = {
           '@timestamp': new Date().toISOString(),
@@ -221,7 +221,7 @@ export async function bulkCreateAgentActionResults(
 
   await esClient.bulk({
     index: AGENT_ACTIONS_RESULTS_INDEX,
-    body: bulkBody,
+    operations: bulkBody,
     refresh: 'wait_for',
   });
 }

--- a/x-pack/plugins/fleet/server/services/agents/agent_service.ts
+++ b/x-pack/plugins/fleet/server/services/agents/agent_service.ts
@@ -13,9 +13,9 @@ import type {
   SavedObjectsClientContract,
 } from '@kbn/core/server';
 
-import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/types';
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
 

--- a/x-pack/plugins/fleet/server/services/agents/crud.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/crud.test.ts
@@ -107,9 +107,7 @@ describe('Agents CRUD test', () => {
       expect(searchMock).toHaveBeenCalledWith(
         expect.objectContaining({
           aggs: { tags: { terms: { field: 'tags', size: 10000 } } },
-          body: {
-            query: expect.any(Object),
-          },
+          query: expect.any(Object),
           index: '.fleet-agents',
           size: 0,
           fields: ['status'],
@@ -164,7 +162,7 @@ describe('Agents CRUD test', () => {
         })
       );
 
-      expect(searchMock.mock.calls.at(-1)[0].body.query).toEqual(
+      expect(searchMock.mock.calls.at(-1)[0].query).toEqual(
         toElasticsearchQuery(
           _joinFilters(['fleet-agents.policy_id: 123', 'NOT status:unenrolled'])!
         )

--- a/x-pack/plugins/fleet/server/services/agents/crud.ts
+++ b/x-pack/plugins/fleet/server/services/agents/crud.ts
@@ -6,13 +6,13 @@
  */
 
 import { groupBy } from 'lodash';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
 import type { SavedObjectsClientContract, ElasticsearchClient } from '@kbn/core/server';
 import type { KueryNode } from '@kbn/es-query';
 import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
-import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/types';
 
 import type { AgentSOAttributes, Agent, ListWithKuery } from '../../types';
 import { appContextService, agentPolicyService } from '..';
@@ -169,13 +169,13 @@ export async function getAgentTags(
   }
 
   const kueryNode = _joinFilters(filters);
-  const body = kueryNode ? { query: toElasticsearchQuery(kueryNode) } : {};
+  const query = kueryNode ? { query: toElasticsearchQuery(kueryNode) } : {};
   const runtimeFields = await buildAgentStatusRuntimeField(soClient);
   try {
     const result = await esClient.search<{}, { tags: { buckets: Array<{ key: string }> } }>({
       index: AGENTS_INDEX,
       size: 0,
-      body,
+      ...query,
       fields: Object.keys(runtimeFields),
       runtime_mappings: runtimeFields,
       aggs: {
@@ -546,17 +546,15 @@ export async function getAgentVersionsForAgentPolicyIds(
       FleetServerAgent,
       Record<'agent_versions', { buckets: Array<{ key: string; doc_count: number }> }>
     >({
-      body: {
-        query: {
-          bool: {
-            filter: [
-              {
-                terms: {
-                  policy_id: agentPolicyIds,
-                },
+      query: {
+        bool: {
+          filter: [
+            {
+              terms: {
+                policy_id: agentPolicyIds,
               },
-            ],
-          },
+            },
+          ],
         },
       },
       index: AGENTS_INDEX,
@@ -628,7 +626,7 @@ export async function updateAgent(
   await esClient.update({
     id: agentId,
     index: AGENTS_INDEX,
-    body: { doc: agentSOAttributesToFleetServerAgentDoc(data) },
+    doc: agentSOAttributesToFleetServerAgentDoc(data),
     refresh: 'wait_for',
   });
 }
@@ -645,7 +643,7 @@ export async function bulkUpdateAgents(
     return;
   }
 
-  const body = updateData.flatMap(({ agentId, data }) => [
+  const operations = updateData.flatMap(({ agentId, data }) => [
     {
       update: {
         _id: agentId,
@@ -658,7 +656,7 @@ export async function bulkUpdateAgents(
   ]);
 
   const res = await esClient.bulk({
-    body,
+    operations,
     index: AGENTS_INDEX,
     refresh: 'wait_for',
   });
@@ -676,9 +674,7 @@ export async function deleteAgent(esClient: ElasticsearchClient, agentId: string
     await esClient.update({
       id: agentId,
       index: AGENTS_INDEX,
-      body: {
-        doc: { active: false },
-      },
+      doc: { active: false },
     });
   } catch (err) {
     if (isESClientError(err) && err.meta.statusCode === 404) {

--- a/x-pack/plugins/fleet/server/services/agents/helpers.ts
+++ b/x-pack/plugins/fleet/server/services/agents/helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import type { SortResults } from '@elastic/elasticsearch/lib/api/types';
 import type { SearchHit } from '@kbn/es-types';
 

--- a/x-pack/plugins/fleet/server/services/agents/request_diagnostics.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/request_diagnostics.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import { appContextService } from '../app_context';
 import { createAppContextStartContractMock } from '../../mocks';
@@ -33,7 +33,7 @@ describe('requestDiagnostics', () => {
 
       expect(esClient.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
+          document: expect.objectContaining({
             agents: ['agent-in-regular-policy'],
             type: 'REQUEST_DIAGNOSTICS',
             expiration: expect.anything(),
@@ -53,7 +53,7 @@ describe('requestDiagnostics', () => {
 
       expect(esClient.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
+          document: expect.objectContaining({
             agents: ['agent-in-regular-policy-newer', 'agent-in-regular-policy-newer2'],
             type: 'REQUEST_DIAGNOSTICS',
             expiration: expect.anything(),
@@ -70,7 +70,7 @@ describe('requestDiagnostics', () => {
 
       expect(esClient.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
+          document: expect.objectContaining({
             agents: ['agent-in-regular-policy-newer', 'agent-in-regular-policy'],
             type: 'REQUEST_DIAGNOSTICS',
             expiration: expect.anything(),
@@ -80,14 +80,14 @@ describe('requestDiagnostics', () => {
       );
       const calledWithActionResults = esClient.bulk.mock.calls[0][0] as estypes.BulkRequest;
       // bulk write two line per create
-      expect(calledWithActionResults.body?.length).toBe(2);
+      expect(calledWithActionResults.operations?.length).toBe(2);
       const expectedObject = expect.objectContaining({
         '@timestamp': expect.anything(),
         action_id: expect.anything(),
         agent_id: 'agent-in-regular-policy',
         error: 'Agent agent-in-regular-policy does not support request diagnostics action.',
       });
-      expect(calledWithActionResults.body?.[1] as any).toEqual(expectedObject);
+      expect(calledWithActionResults.operations?.[1]).toEqual(expectedObject);
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/agents/update_agent_tags.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/update_agent_tags.test.ts
@@ -112,7 +112,7 @@ describe('update_agent_tags', () => {
     await updateAgentTags(soClient, esClient, { agentIds: ['agent1'] }, ['one'], []);
 
     const agentAction = esClient.create.mock.calls[0][0] as any;
-    expect(agentAction?.body).toEqual(
+    expect(agentAction?.document).toEqual(
       expect.objectContaining({
         action_id: expect.anything(),
         agents: [expect.any(String)],
@@ -122,11 +122,11 @@ describe('update_agent_tags', () => {
     );
 
     const actionResults = esClient.bulk.mock.calls[0][0] as any;
-    const agentIds = actionResults?.body
+    const agentIds = actionResults?.operations
       ?.filter((i: any) => i.agent_id)
       .map((i: any) => i.agent_id);
     expect(agentIds.length).toEqual(1);
-    expect(actionResults.body[1].error).not.toBeDefined();
+    expect(actionResults.operations[1].error).not.toBeDefined();
   });
 
   it('should skip hosted agent from total when agentIds are passed', async () => {
@@ -144,7 +144,7 @@ describe('update_agent_tags', () => {
     );
 
     const agentAction = esClientMock.create.mock.calls[0][0] as any;
-    expect(agentAction?.body).toEqual(
+    expect(agentAction?.document).toEqual(
       expect.objectContaining({
         action_id: expect.anything(),
         agents: [expect.any(String)],
@@ -165,7 +165,7 @@ describe('update_agent_tags', () => {
     await updateAgentTags(soClient, esClient, { agentIds: ['agent1'] }, ['one'], []);
 
     const agentAction = esClient.create.mock.calls[0][0] as any;
-    expect(agentAction?.body).toEqual(
+    expect(agentAction?.document).toEqual(
       expect.objectContaining({
         action_id: expect.anything(),
         agents: ['failure1'],
@@ -175,7 +175,7 @@ describe('update_agent_tags', () => {
     );
 
     const errorResults = esClient.bulk.mock.calls[0][0] as any;
-    expect(errorResults.body[1].error).toEqual('error reason');
+    expect(errorResults.operations[1].error).toEqual('error reason');
   });
 
   it('should throw error on version conflicts', async () => {
@@ -217,10 +217,10 @@ describe('update_agent_tags', () => {
     ).rejects.toThrowError('Version conflict of 100 agents');
 
     const agentAction = esClient.create.mock.calls[0][0] as any;
-    expect(agentAction?.body.agents.length).toEqual(100);
+    expect(agentAction?.document.agents.length).toEqual(100);
 
     const errorResults = esClient.bulk.mock.calls[0][0] as any;
-    expect(errorResults.body[1].error).toEqual('version conflict on last retry');
+    expect(errorResults.operations[1].error).toEqual('version conflict on last retry');
   });
 
   it('should combine action agents from updated, failures and version conflicts on last retry', async () => {
@@ -249,7 +249,7 @@ describe('update_agent_tags', () => {
     ).rejects.toThrowError('Version conflict of 1 agents');
 
     const agentAction = esClient.create.mock.calls[0][0] as any;
-    expect(agentAction?.body.agents.length).toEqual(3);
+    expect(agentAction?.document.agents.length).toEqual(3);
   });
 
   it('should run add tags async when actioning more agents than batch size', async () => {
@@ -367,7 +367,7 @@ describe('update_agent_tags', () => {
     );
 
     const agentAction = esClient.create.mock.calls[0][0] as any;
-    expect(agentAction?.body).toEqual(
+    expect(agentAction?.document).toEqual(
       expect.objectContaining({
         action_id: expect.anything(),
         agents: [expect.any(String)],

--- a/x-pack/plugins/fleet/server/services/agents/upgrade.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/upgrade.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import { appContextService } from '../app_context';
 import type { Agent } from '../../types';
@@ -58,10 +58,10 @@ describe('sendUpgradeAgentsActions (plural)', () => {
 
     // calls ES update with correct values
     const calledWith = esClient.bulk.mock.calls[0][0];
-    const ids = (calledWith as estypes.BulkRequest)?.body
+    const ids = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.update !== undefined)
       .map((i: any) => i.update._id);
-    const docs = (calledWith as estypes.BulkRequest)?.body
+    const docs = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.doc)
       .map((i: any) => i.doc);
 
@@ -80,10 +80,10 @@ describe('sendUpgradeAgentsActions (plural)', () => {
     // calls ES update with correct values
     const onlyRegular = [agentInRegularDoc._id, agentInRegularDoc2._id];
     const calledWith = esClient.bulk.mock.calls[0][0];
-    const ids = (calledWith as estypes.BulkRequest)?.body
+    const ids = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.update !== undefined)
       .map((i: any) => i.update._id);
-    const docs = (calledWith as estypes.BulkRequest)?.body
+    const docs = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.doc)
       .map((i: any) => i.doc);
     expect(ids).toEqual(onlyRegular);
@@ -95,7 +95,7 @@ describe('sendUpgradeAgentsActions (plural)', () => {
     // hosted policy is updated in action results with error
     const calledWithActionResults = esClient.bulk.mock.calls[1][0] as estypes.BulkRequest;
     // bulk write two line per create
-    expect(calledWithActionResults.body?.length).toBe(2);
+    expect(calledWithActionResults.operations?.length).toBe(2);
     const expectedObject = expect.objectContaining({
       '@timestamp': expect.anything(),
       action_id: expect.anything(),
@@ -103,7 +103,7 @@ describe('sendUpgradeAgentsActions (plural)', () => {
       error:
         'Cannot upgrade agent in hosted agent policy hosted-agent-policy in Fleet because the agent policy is managed by an external orchestration solution, such as Elastic Cloud, Kubernetes, etc. Please make changes using your orchestration solution.',
     });
-    expect(calledWithActionResults.body?.[1] as any).toEqual(expectedObject);
+    expect(calledWithActionResults.operations?.[1]).toEqual(expectedObject);
   });
 
   it('can upgrade from hosted agent policy with force=true', async () => {
@@ -118,10 +118,10 @@ describe('sendUpgradeAgentsActions (plural)', () => {
 
     // calls ES update with correct values
     const calledWith = esClient.bulk.mock.calls[0][0];
-    const ids = (calledWith as estypes.BulkRequest)?.body
+    const ids = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.update !== undefined)
       .map((i: any) => i.update._id);
-    const docs = (calledWith as estypes.BulkRequest)?.body
+    const docs = (calledWith as estypes.BulkRequest)?.operations
       ?.filter((i: any) => i.doc)
       .map((i: any) => i.doc);
     expect(ids).toEqual(idsToAction);

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/index/update_settings.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/index/update_settings.ts
@@ -7,7 +7,7 @@
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 
-import type { IndicesIndexSettings } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { IndicesIndexSettings } from '@elastic/elasticsearch/lib/api/types';
 
 import { appContextService } from '../../..';
 

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -10,7 +10,7 @@ import type {
   IndicesIndexSettings,
   MappingDynamicTemplate,
   MappingTypeMapping,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+} from '@elastic/elasticsearch/lib/api/types';
 
 import pMap from 'p-map';
 import { isResponseError } from '@kbn/es-errors';

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/utils.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/utils.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
 
 import { USER_SETTINGS_TEMPLATE_SUFFIX } from '../../../../constants';
 

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/reauthorize.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/reauthorize.ts
@@ -11,7 +11,7 @@ import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-ser
 
 import { sortBy, uniqBy } from 'lodash';
 import { isPopulatedObject } from '@kbn/ml-is-populated-object';
-import type { ErrorResponseBase } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { ErrorResponseBase } from '@elastic/elasticsearch/lib/api/types';
 
 import type { SecondaryAuthorizationHeader } from '../../../../../common/types/models/transform_api_key';
 import { updateEsAssetReferences } from '../../packages/es_assets_reference';

--- a/x-pack/plugins/fleet/server/services/experimental_datastream_features_helper.ts
+++ b/x-pack/plugins/fleet/server/services/experimental_datastream_features_helper.ts
@@ -5,10 +5,7 @@
  * 2.0.
  */
 
-import type {
-  MappingProperty,
-  PropertyName,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { MappingProperty, PropertyName } from '@elastic/elasticsearch/lib/api/types';
 
 import type { ExperimentalDataStreamFeature } from '../../common/types';
 

--- a/x-pack/plugins/fleet/server/services/files/client_from_host.ts
+++ b/x-pack/plugins/fleet/server/services/files/client_from_host.ts
@@ -9,7 +9,7 @@ import type { Readable } from 'stream';
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/core/server';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 import type { FileClient } from '@kbn/files-plugin/server';
 import { createEsFileClient } from '@kbn/files-plugin/server';

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -28,7 +28,7 @@ import { asyncForEach, asyncMap } from '@kbn/std';
 import type {
   AggregationsTermsInclude,
   AggregationsTermsExclude,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+} from '@elastic/elasticsearch/lib/api/types';
 import { isResponseError } from '@kbn/es-errors';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import { DEFAULT_NAMESPACE_STRING } from '@kbn/core-saved-objects-utils-server';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ES `body` removal] `@elastic/fleet` (#204867)](https://github.com/elastic/kibana/pull/204867)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Alejandro Fernández Haro","email":"alejandro.haro@elastic.co"},"sourceCommit":{"committedDate":"2024-12-19T20:09:27Z","message":"[ES `body` removal] `@elastic/fleet` (#204867)\n\n## Summary\n\nAttempt to remove the deprecated `body` in the ES client.","sha":"d7ef161d8d8ddcfe652bb607a0c01002e985eae6","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","backport:prev-minor"],"number":204867,"url":"https://github.com/elastic/kibana/pull/204867","mergeCommit":{"message":"[ES `body` removal] `@elastic/fleet` (#204867)\n\n## Summary\n\nAttempt to remove the deprecated `body` in the ES client.","sha":"d7ef161d8d8ddcfe652bb607a0c01002e985eae6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/204867","number":204867,"mergeCommit":{"message":"[ES `body` removal] `@elastic/fleet` (#204867)\n\n## Summary\n\nAttempt to remove the deprecated `body` in the ES client.","sha":"d7ef161d8d8ddcfe652bb607a0c01002e985eae6"}}]}] BACKPORT-->