### PR TITLE
[Security Solution] Fix flaky test for multiLineStringDiffAlgorithm

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/algorithms/multi_line_string_diff_algorithm.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/algorithms/multi_line_string_diff_algorithm.test.ts
@@ -174,11 +174,11 @@ describe('multiLineStringDiffAlgorithm', () => {
       const result = multiLineStringDiffAlgorithm(mockVersions);
       const endTime = performance.now();
 
-      // If the regex merge in this function takes over 1 sec, this test fails
+      // If the regex merge in this function takes over 2 sec, this test fails
       // Performance measurements: https://github.com/elastic/kibana/pull/199388
       // NOTE: despite the fact that this test runs in ~50ms locally, on CI it
-      // runs slower and can be flaky even with a 500ms threshold.
-      expect(endTime - startTime).toBeLessThan(1000);
+      // runs ~10x slower and can be flaky even with a 1000ms threshold.
+      expect(endTime - startTime).toBeLessThan(2000);
 
       expect(result).toEqual(
         expect.objectContaining({


### PR DESCRIPTION
**Fixes: https://github.com/elastic/kibana/issues/205014**

## Summary

This test on CI runs at least 10x slower than locally, and apparently even 1000ms timeout is not enough.

Bumping it to 2000ms and hopefully that will be it. Not sure if it makes sense to bump it even higher, because we need this threshold to be reasonably low, and more than 2 seconds doesn't sound low for local test runs.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->