### PR TITLE
SKA: Relocate script 6.1

### DIFF
--- a/packages/kbn-relocate/relocate.ts
+++ b/packages/kbn-relocate/relocate.ts
@@ -110,11 +110,13 @@ const findModules = ({ teams, paths, included, excluded }: FindModulesParams, lo
       .filter(({ manifest }) => !manifest.devOnly)
       // explicit exclusions
       .filter(({ id }) => !EXCLUDED_MODULES.includes(id) && !excluded.includes(id))
-      // we don't want to move test modules (just yet)
+      // we don't want to move test and example modules (just yet)
       .filter(
         ({ directory }) =>
           !directory.includes(`/${KIBANA_FOLDER}/test/`) &&
-          !directory.includes(`/${KIBANA_FOLDER}/x-pack/test/`)
+          !directory.includes(`/${KIBANA_FOLDER}/x-pack/test/`) &&
+          !directory.includes(`/${KIBANA_FOLDER}/examples/`) &&
+          !directory.includes(`/${KIBANA_FOLDER}/x-pack/examples/`)
       )
       // the module is under the umbrella specified by the user
       .filter(

--- a/packages/kbn-relocate/utils/transforms.ts
+++ b/packages/kbn-relocate/utils/transforms.ts
@@ -14,6 +14,8 @@ const TRANSFORMS: Record<string, string | TransformFunction> = {
   'x-pack/solutions/security/packages/security-solution/': 'x-pack/solutions/security/packages/',
   'x-pack/solutions/observability/plugins/observability_solution/':
     'x-pack/solutions/observability/plugins/',
+  'x-pack/solutions/observability/packages/observability/observability_utils/observability_':
+    'x-pack/solutions/observability/packages/',
   'x-pack/solutions/observability/packages/observability/':
     'x-pack/solutions/observability/packages/',
   'src/core/packages/core/': (path: string) => {


### PR DESCRIPTION
## Summary

* Exclude example modules from relocation.
* Add an extra path transform to simplify packages folders.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->