### PR TITLE
[ci] Update VM cache for each ES snapshot

### DIFF
--- a/.buildkite/scripts/steps/es_serverless/promote_es_serverless_image.sh
+++ b/.buildkite/scripts/steps/es_serverless/promote_es_serverless_image.sh
@@ -72,7 +72,7 @@ EOT
 
 cat << EOF | buildkite-agent pipeline upload
 steps:
-  - label: "Builds Kibana VM images for cache update"
+  - label: "Update CI cache for ES serverless image"
     trigger: kibana-vm-images
     async: true
     build:

--- a/.buildkite/scripts/steps/es_serverless/promote_es_serverless_image.sh
+++ b/.buildkite/scripts/steps/es_serverless/promote_es_serverless_image.sh
@@ -72,7 +72,7 @@ EOT
 
 cat << EOF | buildkite-agent pipeline upload
 steps:
-  - label: "Update CI cache for ES serverless image"
+  - label: "Update cache for ES serverless image"
     trigger: kibana-vm-images
     async: true
     build:

--- a/.buildkite/scripts/steps/es_snapshots/promote.sh
+++ b/.buildkite/scripts/steps/es_snapshots/promote.sh
@@ -20,7 +20,7 @@ fi
 
 cat << EOF | buildkite-agent pipeline upload
 steps:
-  - label: "Update CI cache for ES $BUILDKITE_BRANCH snapshot"
+  - label: "Update cache for ES $BUILDKITE_BRANCH snapshot"
     trigger: kibana-vm-images
     async: true
     build:

--- a/.buildkite/scripts/steps/es_snapshots/promote.sh
+++ b/.buildkite/scripts/steps/es_snapshots/promote.sh
@@ -16,9 +16,11 @@ ts-node "$(dirname "${0}")/promote_manifest.ts" "$ES_SNAPSHOT_MANIFEST"
 if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
   echo "--- Trigger agent packer cache pipeline"
   ts-node .buildkite/scripts/steps/trigger_pipeline.ts kibana-agent-packer-cache main
-  cat << EOF | buildkite-agent pipeline upload
+fi
+
+cat << EOF | buildkite-agent pipeline upload
 steps:
-  - label: "Builds Kibana VM images for cache update"
+  - label: "Update CI cache for ES $BUILDKITE_BRANCH snapshot"
     trigger: kibana-vm-images
     async: true
     build:
@@ -26,4 +28,3 @@ steps:
         IMAGES_CONFIG: "kibana/images.yml"
         RETRY: "1"
 EOF
-fi


### PR DESCRIPTION
Currently we're rebuilding our cache after the ES snapshot on main has been promoted.  This makes an assumption that less frequent cache builds will save minutes over the chance of a build failure on main causing snapshots for all other passing branches to be out of date.

That assumption hasn't been correct so far, so I'm moving the trigger to all branches.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->