### PR TITLE
Max allowed file size while Uploading image via Kibana dashboard Image …

### DIFF
--- a/docs/user/dashboard/create-visualizations.asciidoc
+++ b/docs/user/dashboard/create-visualizations.asciidoc
@@ -33,6 +33,11 @@ Use one of the editors to create visualizations of your data. Each editor offers
 | <<add-image,Image>>
 | Personalize your dashboard with custom images
 
+[IMPORTANT]
+====
+Image uploads are limited to 10 MiB. 
+====
+
 | <<dashboard-links,Links>>
 | Add links to other dashboards or to external websites
 

--- a/docs/user/dashboard/create-visualizations.asciidoc
+++ b/docs/user/dashboard/create-visualizations.asciidoc
@@ -33,10 +33,6 @@ Use one of the editors to create visualizations of your data. Each editor offers
 | <<add-image,Image>>
 | Personalize your dashboard with custom images
 
-[IMPORTANT]
-====
-Image uploads are limited to 10 MiB. 
-====
 
 | <<dashboard-links,Links>>
 | Add links to other dashboards or to external websites
@@ -281,7 +277,14 @@ For detailed information about writing on GitHub, click *Help* on the top-right 
 [[add-image]]
 == Image panels
 
-To personalize your dashboards, add your own logos and graphics with the *Image* panel. You can upload images from your computer, select previously uploaded images, or add images from an external link.
+To personalize your dashboards, add your own logos and graphics with the *Image* panel.
+
+[IMPORTANT]
+====
+Image uploads are limited to 10 MiB. 
+====
+
+You can upload images from your computer, select previously uploaded images, or add images from an external link.
 
 . From your dashboard, select *Add panel*.
 
@@ -294,7 +297,6 @@ image::images/dashboard_addImageEditor_8.7.0.png[Add image editor]
 
 To manage your uploaded image files, go to the *Files* management page using the navigation menu or the 
 <<kibana-navigation-search,global search field>>.
-
 
 [WARNING]
 ============================================================================


### PR DESCRIPTION
## Summary

As per the [source code](https://github.com/elastic/kibana/blob/ed6a1a4e45e95b775bc3861c8cdbf06804c0e4af/src/plugins/files/common/default_image_file_kind.ts#L15) 10MiB is hardcoded limit for image upload in [Kibana dashboard Image panels](https://www.elastic.co/guide/en/kibana/8.16/add-image.html). It's good to be evident in public/customer facing documentation also.
