### PR TITLE
[Fleet] Fix show all agent tags when agent list is filtered

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/hooks/use_fetch_agents_data.tsx
@@ -228,7 +228,6 @@ export function useFetchAgentsData() {
               full: false,
             }),
             sendGetAgentTags({
-              kuery: kuery && kuery !== '' ? kuery : undefined,
               showInactive,
             }),
             sendGetActionStatus({


### PR DESCRIPTION
## Summary

Closes #164674 

Remove `kuery` in request parameters to get all agents tags.

![image](https://github.com/user-attachments/assets/229ac48b-e33e-4c2d-8062-04ce6dc86c2a)


<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->