### PR TITLE
[ci/es-forward-testing] Revert skip_intermediate_builds

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-9-dot-0.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing-9-dot-0.yml
@@ -27,6 +27,7 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_forward_9_dot_0.yml # Note: this file exists in 8.x only and should be moved into 8.18 once the branch is cut
+      skip_intermediate_builds: false
       provider_settings:
         prefix_pull_request_fork_branch_names: false
         trigger_mode: none

--- a/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-forward-testing.yml
@@ -27,6 +27,7 @@ spec:
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_forward.yml # Note: this file exists in 7.17 only
+      skip_intermediate_builds: false
       provider_settings:
         prefix_pull_request_fork_branch_names: false
         trigger_mode: none


### PR DESCRIPTION
These pipelines can run against multiple branches at the same time.  We don't want these builds to skipped.

See https://github.com/elastic/kibana/pull/199540
See https://buildkite.com/elastic/kibana-es-forward-compatibility-testing/