### PR TITLE
Feature/security fixes for es types

### DIFF
--- a/x-pack/packages/security/api_key_management/src/components/api_key_flyout.tsx
+++ b/x-pack/packages/security/api_key_management/src/components/api_key_flyout.tsx
@@ -237,7 +237,6 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
         (accumulator, roleName) => {
           const role = roles.find((r) => r.name === roleName);
           if (role) {
-            // @ts-expect-error
             accumulator[role.name] = role.elasticsearch;
           }
           return accumulator;

--- a/x-pack/packages/security/plugin_types_common/index.ts
+++ b/x-pack/packages/security/plugin_types_common/index.ts
@@ -12,6 +12,7 @@ export type {
   AuthenticationProvider,
 } from './src/authentication';
 export type {
+  RemoteClusterPrivilege,
   Role,
   RoleIndexPrivilege,
   RoleKibanaPrivilege,

--- a/x-pack/packages/security/plugin_types_common/src/api_keys/api_key.ts
+++ b/x-pack/packages/security/plugin_types_common/src/api_keys/api_key.ts
@@ -39,13 +39,9 @@ export interface CrossClusterApiKey extends BaseApiKey {
 /**
  * Fixing up `estypes.SecurityApiKey` type since some fields are marked as optional even though they are guaranteed to be returned.
  *
- * TODO: Remove this type when `@elastic/elasticsearch` has been updated.
+ * TODO: Remove this type when `@elastic/elasticsearch` has been updated to make `role_descriptors` required.
  */
 export interface BaseApiKey extends estypes.SecurityApiKey {
-  username: Required<estypes.SecurityApiKey>['username'];
-  realm: Required<estypes.SecurityApiKey>['realm'];
-  creation: Required<estypes.SecurityApiKey>['creation'];
-  metadata: Required<estypes.SecurityApiKey>['metadata'];
   role_descriptors: Required<estypes.SecurityApiKey>['role_descriptors'];
 }
 
@@ -119,9 +115,8 @@ interface BaseQueryApiKeyResult {
 /**
  * Interface representing a REST API key that is managed by Kibana.
  */
-// @ts-expect-error `type` can only be "rest" or "cross_cluster"
-export interface ManagedApiKey extends BaseApiKey {
-  type: 'managed';
+export interface ManagedApiKey extends Omit<BaseApiKey, 'type'> {
+  type: estypes.SecurityApiKeyType | 'managed';
 }
 
 /**

--- a/x-pack/packages/security/plugin_types_common/src/authorization/index.ts
+++ b/x-pack/packages/security/plugin_types_common/src/authorization/index.ts
@@ -8,6 +8,7 @@
 export type { FeaturesPrivileges } from './features_privileges';
 export type { RawKibanaFeaturePrivileges, RawKibanaPrivileges } from './raw_kibana_privileges';
 export type {
+  RemoteClusterPrivilege,
   Role,
   RoleKibanaPrivilege,
   RoleIndexPrivilege,

--- a/x-pack/packages/security/plugin_types_common/src/authorization/role.ts
+++ b/x-pack/packages/security/plugin_types_common/src/authorization/role.ts
@@ -28,9 +28,11 @@ export interface RoleKibanaPrivilege {
   _reserved?: string[];
 }
 
+export type RemoteClusterPrivilege = 'monitor_enrich' | 'monitor_stats';
+
 export interface RoleRemoteClusterPrivilege {
-  clusters: string[];
-  privileges: string[];
+  clusters: string | string[];
+  privileges: RemoteClusterPrivilege[];
 }
 
 export interface Role {

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/remote_cluster_privileges.test.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/remote_cluster_privileges.test.tsx
@@ -9,7 +9,10 @@ import React from 'react';
 
 import { coreMock } from '@kbn/core/public/mocks';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import type { SecurityLicenseFeatures } from '@kbn/security-plugin-types-common';
+import type {
+  RemoteClusterPrivilege,
+  SecurityLicenseFeatures,
+} from '@kbn/security-plugin-types-common';
 import { mountWithIntl, shallowWithIntl } from '@kbn/test-jest-helpers';
 import '@kbn/code-editor-mock/jest_helper';
 
@@ -69,7 +72,7 @@ test('it renders an RemoteClusterPrivilegesForm for each remote cluster privileg
               },
               {
                 clusters: ['cluster5', 'cluster6'],
-                privileges: ['monitor_enrich', 'custom-privilege'],
+                privileges: ['monitor_enrich', 'monitor_stats'],
               },
             ],
             indices: [],
@@ -98,11 +101,11 @@ test('it renders fields as disabled when not editable', async () => {
         remote_cluster: [
           {
             clusters: ['cluster1', 'cluster2'],
-            privileges: ['monitor_enrich'],
+            privileges: ['monitor_enrich'] as RemoteClusterPrivilege[],
           },
           {
             clusters: ['cluster3', 'cluster4'],
-            privileges: ['monitor_enrich'],
+            privileges: ['monitor_enrich'] as RemoteClusterPrivilege[],
           },
         ],
         indices: [],
@@ -144,11 +147,11 @@ test('it renders fields as disabled when `allowRemoteClusterPrivileges` is set t
         remote_cluster: [
           {
             clusters: ['cluster1', 'cluster2'],
-            privileges: ['monitor_enrich'],
+            privileges: ['monitor_enrich'] as RemoteClusterPrivilege[],
           },
           {
             clusters: ['cluster3', 'cluster4'],
-            privileges: ['monitor_enrich'],
+            privileges: ['monitor_enrich'] as RemoteClusterPrivilege[],
           },
         ],
         indices: [],

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/remote_cluster_privileges_form.test.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/remote_cluster_privileges_form.test.tsx
@@ -10,6 +10,7 @@ import type { EuiComboBoxProps } from '@elastic/eui';
 import React from 'react';
 
 import '@kbn/code-editor-mock/jest_helper';
+import type { RemoteClusterPrivilege } from '@kbn/security-plugin-types-common';
 import { mountWithIntl, shallowWithIntl } from '@kbn/test-jest-helpers';
 
 import { RemoteClusterPrivilegesForm } from './remote_cluster_privileges_form';
@@ -141,7 +142,7 @@ describe('delete button', () => {
   const props = {
     remoteClusterPrivilege: {
       clusters: ['cluster1'],
-      privileges: ['monitor_enrich'],
+      privileges: ['monitor_enrich'] as RemoteClusterPrivilege[],
     },
     formIndex: 0,
     availableRemoteClusterPrivileges: ['monitor_enrich'],

--- a/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/remote_cluster_privileges_form.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/privileges/es/remote_cluster_privileges_form.tsx
@@ -22,6 +22,7 @@ import React, { Fragment, useCallback } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { Cluster } from '@kbn/remote-clusters-plugin/public';
+import type { RemoteClusterPrivilege } from '@kbn/security-plugin-types-common';
 import { euiThemeVars } from '@kbn/ui-theme';
 
 import { RemoteClusterComboBox } from './remote_clusters_combo_box';
@@ -54,7 +55,7 @@ export const RemoteClusterPrivilegesForm: React.FunctionComponent<Props> = ({
 }) => {
   const onCreateClusterOption = useCallback(
     (option: string) => {
-      const nextClusters = (remoteClusterPrivilege.clusters ?? []).concat([option]);
+      const nextClusters = ([...remoteClusterPrivilege.clusters] ?? []).concat([option]);
 
       onChange({
         ...remoteClusterPrivilege,
@@ -79,7 +80,7 @@ export const RemoteClusterPrivilegesForm: React.FunctionComponent<Props> = ({
     (newPrivileges: EuiComboBoxOptionOption[]) => {
       onChange({
         ...remoteClusterPrivilege,
-        privileges: newPrivileges.map(fromOption),
+        privileges: newPrivileges.map(fromOption) as RemoteClusterPrivilege[],
       });
     },
     [remoteClusterPrivilege, onChange]
@@ -116,7 +117,7 @@ export const RemoteClusterPrivilegesForm: React.FunctionComponent<Props> = ({
                 >
                   <RemoteClusterComboBox
                     data-test-subj={`remoteClusterClustersInput${formIndex}`}
-                    selectedOptions={(remoteClusterPrivilege.clusters ?? []).map(toOption)}
+                    selectedOptions={([...remoteClusterPrivilege.clusters] ?? []).map(toOption)}
                     onCreateOption={onCreateClusterOption}
                     onChange={onClustersChange}
                     isDisabled={isRoleReadOnly}

--- a/x-pack/plugins/security/server/routes/authorization/roles/put.test.ts
+++ b/x-pack/plugins/security/server/routes/authorization/roles/put.test.ts
@@ -331,14 +331,12 @@ describe('PUT role', () => {
           put: [
             {
               name: 'foo-role',
-              body: {
-                cluster: [],
-                indices: [],
-                remote_cluster: undefined,
-                remote_indices: undefined,
-                run_as: [],
-                applications: [],
-              },
+              cluster: [],
+              indices: [],
+              remote_cluster: undefined,
+              remote_indices: undefined,
+              run_as: [],
+              applications: [],
             },
           ],
         },
@@ -366,19 +364,17 @@ describe('PUT role', () => {
           put: [
             {
               name: 'foo-role',
-              body: {
-                cluster: [],
-                indices: [],
-                remote_indices: undefined,
-                run_as: [],
-                applications: [
-                  {
-                    application,
-                    privileges: ['all'],
-                    resources: [GLOBAL_RESOURCE],
-                  },
-                ],
-              },
+              cluster: [],
+              indices: [],
+              remote_indices: undefined,
+              run_as: [],
+              applications: [
+                {
+                  application,
+                  privileges: ['all'],
+                  resources: [GLOBAL_RESOURCE],
+                },
+              ],
             },
           ],
         },
@@ -409,19 +405,17 @@ describe('PUT role', () => {
           put: [
             {
               name: 'foo-role',
-              body: {
-                cluster: [],
-                indices: [],
-                remote_indices: undefined,
-                run_as: [],
-                applications: [
-                  {
-                    application,
-                    privileges: ['feature_foo.foo'],
-                    resources: [GLOBAL_RESOURCE],
-                  },
-                ],
-              },
+              cluster: [],
+              indices: [],
+              remote_indices: undefined,
+              run_as: [],
+              applications: [
+                {
+                  application,
+                  privileges: ['feature_foo.foo'],
+                  resources: [GLOBAL_RESOURCE],
+                },
+              ],
             },
           ],
         },
@@ -450,19 +444,17 @@ describe('PUT role', () => {
           put: [
             {
               name: 'foo-role',
-              body: {
-                cluster: [],
-                indices: [],
-                remote_indices: undefined,
-                run_as: [],
-                applications: [
-                  {
-                    application,
-                    privileges: ['all'],
-                    resources: [GLOBAL_RESOURCE],
-                  },
-                ],
-              },
+              cluster: [],
+              indices: [],
+              remote_indices: undefined,
+              run_as: [],
+              applications: [
+                {
+                  application,
+                  privileges: ['all'],
+                  resources: [GLOBAL_RESOURCE],
+                },
+              ],
             },
           ],
         },
@@ -532,52 +524,50 @@ describe('PUT role', () => {
           put: [
             {
               name: 'foo-role',
-              body: {
-                applications: [
-                  {
-                    application,
-                    privileges: ['all', 'read'],
-                    resources: [GLOBAL_RESOURCE],
+              applications: [
+                {
+                  application,
+                  privileges: ['all', 'read'],
+                  resources: [GLOBAL_RESOURCE],
+                },
+                {
+                  application,
+                  privileges: ['space_all', 'space_read'],
+                  resources: ['space:test-space-1', 'space:test-space-2'],
+                },
+                {
+                  application,
+                  privileges: ['feature_foo.foo-privilege-1', 'feature_foo.foo-privilege-2'],
+                  resources: ['space:test-space-3'],
+                },
+              ],
+              cluster: ['test-cluster-privilege'],
+              description: 'test description',
+              indices: [
+                {
+                  field_security: {
+                    grant: ['test-field-security-grant-1', 'test-field-security-grant-2'],
+                    except: ['test-field-security-except-1', 'test-field-security-except-2'],
                   },
-                  {
-                    application,
-                    privileges: ['space_all', 'space_read'],
-                    resources: ['space:test-space-1', 'space:test-space-2'],
+                  names: ['test-index-name-1', 'test-index-name-2'],
+                  privileges: ['test-index-privilege-1', 'test-index-privilege-2'],
+                  query: `{ "match": { "title": "foo" } }`,
+                },
+              ],
+              remote_indices: [
+                {
+                  field_security: {
+                    grant: ['test-field-security-grant-1', 'test-field-security-grant-2'],
+                    except: ['test-field-security-except-1', 'test-field-security-except-2'],
                   },
-                  {
-                    application,
-                    privileges: ['feature_foo.foo-privilege-1', 'feature_foo.foo-privilege-2'],
-                    resources: ['space:test-space-3'],
-                  },
-                ],
-                cluster: ['test-cluster-privilege'],
-                description: 'test description',
-                indices: [
-                  {
-                    field_security: {
-                      grant: ['test-field-security-grant-1', 'test-field-security-grant-2'],
-                      except: ['test-field-security-except-1', 'test-field-security-except-2'],
-                    },
-                    names: ['test-index-name-1', 'test-index-name-2'],
-                    privileges: ['test-index-privilege-1', 'test-index-privilege-2'],
-                    query: `{ "match": { "title": "foo" } }`,
-                  },
-                ],
-                remote_indices: [
-                  {
-                    field_security: {
-                      grant: ['test-field-security-grant-1', 'test-field-security-grant-2'],
-                      except: ['test-field-security-except-1', 'test-field-security-except-2'],
-                    },
-                    clusters: ['test-cluster-name-1', 'test-cluster-name-2'],
-                    names: ['test-index-name-1', 'test-index-name-2'],
-                    privileges: ['test-index-privilege-1', 'test-index-privilege-2'],
-                    query: `{ "match": { "title": "foo" } }`,
-                  },
-                ],
-                metadata: { foo: 'test-metadata' },
-                run_as: ['test-run-as-1', 'test-run-as-2'],
-              },
+                  clusters: ['test-cluster-name-1', 'test-cluster-name-2'],
+                  names: ['test-index-name-1', 'test-index-name-2'],
+                  privileges: ['test-index-privilege-1', 'test-index-privilege-2'],
+                  query: `{ "match": { "title": "foo" } }`,
+                },
+              ],
+              metadata: { foo: 'test-metadata' },
+              run_as: ['test-run-as-1', 'test-run-as-2'],
             },
           ],
         },
@@ -666,40 +656,38 @@ describe('PUT role', () => {
           put: [
             {
               name: 'foo-role',
-              body: {
-                applications: [
-                  {
-                    application,
-                    privileges: ['feature_foo.foo-privilege-1', 'feature_bar.bar-privilege-1'],
-                    resources: [GLOBAL_RESOURCE],
+              applications: [
+                {
+                  application,
+                  privileges: ['feature_foo.foo-privilege-1', 'feature_bar.bar-privilege-1'],
+                  resources: [GLOBAL_RESOURCE],
+                },
+                {
+                  application,
+                  privileges: ['space_all'],
+                  resources: ['space:test-space-1', 'space:test-space-2'],
+                },
+                {
+                  application,
+                  privileges: ['feature_bar.bar-privilege-2'],
+                  resources: ['space:test-space-3'],
+                },
+              ],
+              cluster: ['test-cluster-privilege'],
+              indices: [
+                {
+                  field_security: {
+                    grant: ['test-field-security-grant-1', 'test-field-security-grant-2'],
+                    except: ['test-field-security-except-1', 'test-field-security-except-2'],
                   },
-                  {
-                    application,
-                    privileges: ['space_all'],
-                    resources: ['space:test-space-1', 'space:test-space-2'],
-                  },
-                  {
-                    application,
-                    privileges: ['feature_bar.bar-privilege-2'],
-                    resources: ['space:test-space-3'],
-                  },
-                ],
-                cluster: ['test-cluster-privilege'],
-                indices: [
-                  {
-                    field_security: {
-                      grant: ['test-field-security-grant-1', 'test-field-security-grant-2'],
-                      except: ['test-field-security-except-1', 'test-field-security-except-2'],
-                    },
-                    names: ['test-index-name-1', 'test-index-name-2'],
-                    privileges: ['test-index-privilege-1', 'test-index-privilege-2'],
-                    query: `{ "match": { "title": "foo" } }`,
-                  },
-                ],
-                remote_indices: undefined,
-                metadata: { foo: 'test-metadata' },
-                run_as: ['test-run-as-1', 'test-run-as-2'],
-              },
+                  names: ['test-index-name-1', 'test-index-name-2'],
+                  privileges: ['test-index-privilege-1', 'test-index-privilege-2'],
+                  query: `{ "match": { "title": "foo" } }`,
+                },
+              ],
+              remote_indices: undefined,
+              metadata: { foo: 'test-metadata' },
+              run_as: ['test-run-as-1', 'test-run-as-2'],
             },
           ],
         },
@@ -775,35 +763,33 @@ describe('PUT role', () => {
           put: [
             {
               name: 'foo-role',
-              body: {
-                applications: [
-                  {
-                    application,
-                    privileges: ['all', 'read'],
-                    resources: [GLOBAL_RESOURCE],
-                  },
-                  {
-                    application: 'logstash-foo',
-                    privileges: ['logstash-privilege'],
-                    resources: ['logstash-resource'],
-                  },
-                  {
-                    application: 'beats-foo',
-                    privileges: ['beats-privilege'],
-                    resources: ['beats-resource'],
-                  },
-                ],
-                cluster: ['test-cluster-privilege'],
-                indices: [
-                  {
-                    names: ['test-index-name-1', 'test-index-name-2'],
-                    privileges: ['test-index-privilege-1', 'test-index-privilege-2'],
-                  },
-                ],
-                remote_indices: undefined,
-                metadata: { foo: 'test-metadata' },
-                run_as: ['test-run-as-1', 'test-run-as-2'],
-              },
+              applications: [
+                {
+                  application,
+                  privileges: ['all', 'read'],
+                  resources: [GLOBAL_RESOURCE],
+                },
+                {
+                  application: 'logstash-foo',
+                  privileges: ['logstash-privilege'],
+                  resources: ['logstash-resource'],
+                },
+                {
+                  application: 'beats-foo',
+                  privileges: ['beats-privilege'],
+                  resources: ['beats-resource'],
+                },
+              ],
+              cluster: ['test-cluster-privilege'],
+              indices: [
+                {
+                  names: ['test-index-name-1', 'test-index-name-2'],
+                  privileges: ['test-index-privilege-1', 'test-index-privilege-2'],
+                },
+              ],
+              remote_indices: undefined,
+              metadata: { foo: 'test-metadata' },
+              run_as: ['test-run-as-1', 'test-run-as-2'],
             },
           ],
         },
@@ -835,20 +821,18 @@ describe('PUT role', () => {
           put: [
             {
               name: 'foo-role',
-              body: {
-                cluster: [],
-                indices: [],
-                remote_indices: undefined,
-                run_as: [],
-                applications: [
-                  {
-                    application: 'kibana-.kibana',
-                    privileges: ['feature_feature_1.sub_feature_privilege_1'],
-                    resources: ['*'],
-                  },
-                ],
-                metadata: undefined,
-              },
+              cluster: [],
+              indices: [],
+              remote_indices: undefined,
+              run_as: [],
+              applications: [
+                {
+                  application: 'kibana-.kibana',
+                  privileges: ['feature_feature_1.sub_feature_privilege_1'],
+                  resources: ['*'],
+                },
+              ],
+              metadata: undefined,
             },
           ],
         },
@@ -880,20 +864,18 @@ describe('PUT role', () => {
           put: [
             {
               name: 'foo-role',
-              body: {
-                cluster: [],
-                indices: [],
-                remote_indices: undefined,
-                run_as: [],
-                applications: [
-                  {
-                    application: 'kibana-.kibana',
-                    privileges: ['feature_feature_1.unknown_sub_feature_privilege_1'],
-                    resources: ['*'],
-                  },
-                ],
-                metadata: undefined,
-              },
+              cluster: [],
+              indices: [],
+              remote_indices: undefined,
+              run_as: [],
+              applications: [
+                {
+                  application: 'kibana-.kibana',
+                  privileges: ['feature_feature_1.unknown_sub_feature_privilege_1'],
+                  resources: ['*'],
+                },
+              ],
+              metadata: undefined,
             },
           ],
         },
@@ -925,20 +907,18 @@ describe('PUT role', () => {
           put: [
             {
               name: 'foo-role',
-              body: {
-                cluster: [],
-                indices: [],
-                remote_indices: undefined,
-                run_as: [],
-                applications: [
-                  {
-                    application: 'kibana-.kibana',
-                    privileges: ['feature_unknown_feature.sub_feature_privilege_1'],
-                    resources: ['*'],
-                  },
-                ],
-                metadata: undefined,
-              },
+              cluster: [],
+              indices: [],
+              remote_indices: undefined,
+              run_as: [],
+              applications: [
+                {
+                  application: 'kibana-.kibana',
+                  privileges: ['feature_unknown_feature.sub_feature_privilege_1'],
+                  resources: ['*'],
+                },
+              ],
+              metadata: undefined,
             },
           ],
         },
@@ -975,24 +955,22 @@ describe('PUT role', () => {
           put: [
             {
               name: 'foo-role-remote-cluster',
-              body: {
-                applications: [],
-                cluster: [],
-                indices: [],
-                remote_indices: undefined,
-                run_as: [],
-                remote_cluster: [
-                  {
-                    clusters: ['cluster1', 'cluster2'],
-                    privileges: ['monitor_enrich'],
-                  },
-                  {
-                    clusters: ['cluster3', 'cluster4'],
-                    privileges: ['monitor_enrich'],
-                  },
-                ],
-                metadata: undefined,
-              },
+              applications: [],
+              cluster: [],
+              indices: [],
+              remote_indices: undefined,
+              run_as: [],
+              remote_cluster: [
+                {
+                  clusters: ['cluster1', 'cluster2'],
+                  privileges: ['monitor_enrich'],
+                },
+                {
+                  clusters: ['cluster3', 'cluster4'],
+                  privileges: ['monitor_enrich'],
+                },
+              ],
+              metadata: undefined,
             },
           ],
         },


### PR DESCRIPTION
## Summary

Root [PR](https://github.com/elastic/kibana/pull/204175)

Merging the security changes into the root PR

ES types and arguments changed for the new client version

## Changes

- `RemoteClusterPrivilege` is now specifically typed to values `monitor_enrich` | `monitor_stats`
- PUT role deprecated `body`, all properties now moved up to top-level
- API Key `type` specified as `'rest' | 'cross_cluster'` on ES side

