### PR TITLE
[Monitoring] Make monitoring collection API public again

### DIFF
--- a/x-pack/platform/plugins/private/monitoring_collection/server/routes/api/v1/dynamic_route/get_metrics_by_type.ts
+++ b/x-pack/platform/plugins/private/monitoring_collection/server/routes/api/v1/dynamic_route/get_metrics_by_type.ts
@@ -37,7 +37,7 @@ export function registerDynamicRoute({
     {
       path: `${MONITORING_COLLECTION_BASE_PATH}/{type}`,
       options: {
-        access: 'internal',
+        access: 'public',
         authRequired: true,
         tags: ['api'], // ensures that unauthenticated calls receive a 401 rather than a 302 redirect to login page
       },


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/186882

## Summary

https://github.com/elastic/kibana/issues/186781 required all teams to make sure that all Kibana APIs in their respective plugins were using the appropriate access `internal` or `public`.

PR https://github.com/elastic/kibana/pull/186882 flagged the `/api/monitoring_collection/{type}` API endpoint as `internal`. The effect of that change was the [appearance of deprecation logging](https://github.com/elastic/kibana/pull/186882#issuecomment-2431021055) in Kibana logs, because that endpoint is called from the [`kibana` Metricbeat module](https://github.com/elastic/beats/blob/main/metricbeat/module/kibana/kibana.go#L42C1-L46C1) in order to monitor Kibana.

For this reason, we need to change the access mode of that API endpoint back to `public`.



<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->