### PR TITLE
fix(codeql): update CodeQL `ingore-paths` config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,23 +1,44 @@
 paths-ignore:
+  - '**/*-mocks/**'
+  - '**/*.cy.*'
+  - '**/*.mock.*'
+  - '**/*.mocks.*'
   - '**/*.test.*'
-  - packages/kbn-ambient-common-types
-  - packages/kbn-ambient-ftr-types
-  - packages/kbn-ambient-storybook-types
-  - packages/kbn-ambient-ui-types
+  - '**/.storybook/**'
+  - '**/__fixtures__/**'
+  - '**/__jest__/**'
+  - '**/__mocks__/**'
+  - '**/__snapshots__/**'
+  - '**/__stories__/**'
+  - '**/__tests__/**'
+  - '**/cypress/**'
+  - '**/e2e/**'
+  - '**/ftr_e2e/**'
+  - '**/integration_tests/**'
+  - '**/jest.config.*'
+  - '**/jest.integration.config.*'
+  - '**/mocks.*'
+  - '**/mocks/**'
+  - '**/storybook/**'
+  - '**/test_helpers/**'
+  - '**/test_utils/**'
+  - api_docs
+  - dev_docs
+  - docs
+  - examples
+  - kbn_pm
+  - legacy_rfcs
+  - oas_docs
+  - packages/*/scripts
+  - packages/core/test-helpers/core-test-helpers-kbn-server
+  - packages/kbn-ambient-*-types
   - packages/kbn-apm-synthtrace
   - packages/kbn-axe-config
-  - packages/kbn-babel-plugin-package-imports
-  - packages/kbn-babel-preset
-  - packages/kbn-babel-register
-  - packages/kbn-babel-transform
-  - packages/kbn-bazel-packages
-  - packages/kbn-bazel-runner
-  - packages/kbn-ci-stats-core
-  - packages/kbn-ci-stats-performance-metrics
-  - packages/kbn-ci-stats-reporter
+  - packages/kbn-babel-*
+  - packages/kbn-bazel-*
+  - packages/kbn-ci-*
   - packages/kbn-cli-dev-mode
-  - packages/core/test-helpers/core-test-helpers-kbn-server
-  - packages/kbn-cypress-config
+  - packages/kbn-cypress-*
   - packages/kbn-dev-cli-errors
   - packages/kbn-dev-cli-runner
   - packages/kbn-dev-proc-runner
@@ -25,65 +46,50 @@ paths-ignore:
   - packages/kbn-docs-utils
   - packages/kbn-es
   - packages/kbn-es-archiver
-  - packages/kbn-eslint-config
-  - packages/kbn-eslint-plugin-disable
-  - packages/kbn-eslint-plugin-eslint
-  - packages/kbn-eslint-plugin-imports
-  - packages/*/scripts
+  - packages/kbn-eslint-*
   - packages/kbn-expect
   - packages/kbn-failed-test-reporter-cli
   - packages/kbn-find-used-node-modules
-  - packages/kbn-ftr-common-functional-services
-  - packages/kbn-ftr-screenshot-filename
+  - packages/kbn-ftr-*
   - packages/kbn-generate
   - packages/kbn-get-repo-files
   - packages/kbn-import-resolver
-  - packages/kbn-jest-serializers
+  - packages/kbn-jest-*
   - packages/kbn-journeys
   - packages/kbn-kibana-manifest-schema
   - packages/kbn-managed-vscode-config
   - packages/kbn-managed-vscode-config-cli
   - packages/kbn-optimizer
-  - packages/kbn-optimizer-webpack-helpers
-  - packages/kbn-package-map
+  - packages/kbn-optimizer-*
   - packages/kbn-peggy
   - packages/kbn-peggy-loader
   - packages/kbn-performance-testing-dataset-extractor
   - packages/kbn-plugin-generator
   - packages/kbn-plugin-helpers
+  - packages/kbn-relocate
   - packages/kbn-repo-path
   - packages/kbn-repo-source-classifier
   - packages/kbn-repo-source-classifier-cli
+  - packages/kbn-scout
+  - packages/kbn-scout-*
   - packages/kbn-some-dev-log
   - packages/kbn-sort-package-json
-  - packages/kbn-spec-to-console
   - packages/kbn-stdio-dev-helpers
   - packages/kbn-storybook
   - packages/kbn-telemetry-tools
   - packages/kbn-test
-  - packages/kbn-test-jest-helpers
-  - packages/kbn-test-eui-helpers
-  - packages/kbn-test-subj-selector
+  - packages/kbn-test-*
   - packages/kbn-tooling-log
-  - packages/kbn-ts-project-linter
-  - packages/kbn-ts-project-linter-cli
-  - packages/kbn-ts-projects
-  - packages/kbn-ts-type-check-cli
+  - packages/kbn-ts-*
   - packages/kbn-web-worker-stub
   - packages/kbn-yarn-lock-validator
   - scripts
   - test
-  - x-pack/platform/plugins/private/canvas/scripts
-  - x-pack/solutions/security/plugins/cloud_security_posture/common/scripts
-  - x-pack/solutions/security/plugins/elastic_assistant/scripts
-  - x-pack/platform/plugins/shared/event_log/scripts
-  - x-pack/platform/plugins/shared/fleet/scripts
-  - x-pack/solutions/security/plugins/lists/scripts
-  - x-pack/solutions/security/plugins/lists/server/scripts
-  - x-pack/plugins/observability_solution/*/scripts
-  - x-pack/platform/plugins/shared/osquery/scripts
-  - x-pack/platform/plugins/shared/rule_registry/scripts
-  - x-pack/solutions/security/plugins/security_solution/scripts
-  - x-pack/solutions/security/plugins/threat_intelligence/scripts
+  - typings
+  - x-pack/examples
+  - x-pack/performance
+  - x-pack/platform/**/scripts
   - x-pack/scripts
+  - x-pack/solutions/**/scripts
   - x-pack/test
+  - x-pack/test_serverless


### PR DESCRIPTION
## Summary

This PR updates `ignore-paths` path CodeQL config to remove the paths that no longer exist and exclude other well-known test/dev-only paths.

Non-existent paths can be seen in the CodeQL logs from the most recent run:
```
2024-12-26T21:29:09.2376056Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-babel-plugin-package-imports, which does not exist.
2024-12-26T21:29:09.2377637Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-bazel-packages, which does not exist.
2024-12-26T21:29:09.2387717Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-package-map, which does not exist.
2024-12-26T21:29:09.2390381Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-spec-to-console, which does not exist.
2024-12-26T21:29:09.2396606Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-ts-project-linter, which does not exist.
2024-12-26T21:29:09.2402596Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-ts-project-linter-cli, which does not exist.
```

<!--ONMERGE {"backportTargets":["7.17","8.16","8.17","8.x"]} ONMERGE-->