### PR TITLE
[7.17] fix(codeql): update CodeQL `ingore-paths` config (#205197)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,25 +1,88 @@
 paths-ignore:
+  - '**/*-mocks/**'
+  - '**/*.cy.*'
+  - '**/*.mock.*'
+  - '**/*.mocks.*'
   - '**/*.test.*'
-  - packages/elastic-datemath/npm_module_types
-  - packages/kbn-babel-code-parser
-  - packages/kbn-babel-preset
+  - '**/.storybook/**'
+  - '**/__fixtures__/**'
+  - '**/__jest__/**'
+  - '**/__mocks__/**'
+  - '**/__snapshots__/**'
+  - '**/__stories__/**'
+  - '**/__tests__/**'
+  - '**/cypress/**'
+  - '**/e2e/**'
+  - '**/ftr_e2e/**'
+  - '**/integration_tests/**'
+  - '**/jest.config.*'
+  - '**/jest.integration.config.*'
+  - '**/mocks.*'
+  - '**/mocks/**'
+  - '**/storybook/**'
+  - '**/test_helpers/**'
+  - '**/test_utils/**'
+  - api_docs
+  - dev_docs
+  - docs
+  - examples
+  - kbn_pm
+  - rfcs
+  - packages/*/scripts
+  - packages/core/test-helpers/core-test-helpers-kbn-server
+  - packages/kbn-ambient-*-types
+  - packages/kbn-apm-synthtrace
+  - packages/kbn-axe-config
+  - packages/kbn-babel-*
+  - packages/kbn-bazel-*
+  - packages/kbn-ci-*
   - packages/kbn-cli-dev-mode
+  - packages/kbn-cypress-*
+  - packages/kbn-dev-cli-errors
+  - packages/kbn-dev-cli-runner
+  - packages/kbn-dev-proc-runner
   - packages/kbn-dev-utils
   - packages/kbn-docs-utils
   - packages/kbn-es
   - packages/kbn-es-archiver
-  - packages/kbn-eslint-config
-  - packages/kbn-eslint-import-resolver-kibana
-  - packages/kbn-eslint-plugin-eslint
+  - packages/kbn-eslint-*
   - packages/kbn-expect
+  - packages/kbn-failed-test-reporter-cli
+  - packages/kbn-find-used-node-modules
+  - packages/kbn-ftr-*
+  - packages/kbn-generate
+  - packages/kbn-get-repo-files
+  - packages/kbn-import-resolver
+  - packages/kbn-jest-*
+  - packages/kbn-journeys
+  - packages/kbn-kibana-manifest-schema
+  - packages/kbn-managed-vscode-config
+  - packages/kbn-managed-vscode-config-cli
   - packages/kbn-optimizer
+  - packages/kbn-optimizer-*
+  - packages/kbn-peggy
+  - packages/kbn-peggy-loader
+  - packages/kbn-performance-testing-dataset-extractor
   - packages/kbn-plugin-generator
   - packages/kbn-plugin-helpers
-  - packages/kbn-pm
+  - packages/kbn-repo-path
+  - packages/kbn-repo-source-classifier
+  - packages/kbn-repo-source-classifier-cli
+  - packages/kbn-some-dev-log
+  - packages/kbn-sort-package-json
   - packages/kbn-spec-to-console
+  - packages/kbn-stdio-dev-helpers
   - packages/kbn-storybook
   - packages/kbn-telemetry-tools
   - packages/kbn-test
-  - packages/kbn-test-subj-selector
+  - packages/kbn-test-*
+  - packages/kbn-tooling-log
+  - packages/kbn-ts-*
+  - packages/kbn-web-worker-stub
+  - packages/kbn-yarn-lock-validator
+  - scripts
   - test
+  - typings
+  - x-pack/examples
+  - x-pack/scripts
   - x-pack/test


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [fix(codeql): update CodeQL `ingore-paths` config (#205197)](https://github.com/elastic/kibana/pull/205197)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2024-12-27T12:58:15Z","message":"fix(codeql): update CodeQL `ingore-paths` config (#205197)\n\n## Summary\n\nThis PR updates `ignore-paths` path CodeQL config to remove the paths\nthat no longer exist and exclude other well-known test/dev-only paths.\n\nNon-existent paths can be seen in the CodeQL logs from the most recent\nrun:\n```\n2024-12-26T21:29:09.2376056Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-babel-plugin-package-imports, which does not exist.\n2024-12-26T21:29:09.2377637Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-bazel-packages, which does not exist.\n2024-12-26T21:29:09.2387717Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-package-map, which does not exist.\n2024-12-26T21:29:09.2390381Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-spec-to-console, which does not exist.\n2024-12-26T21:29:09.2396606Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-ts-project-linter, which does not exist.\n2024-12-26T21:29:09.2402596Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-ts-project-linter-cli, which does not exist.\n```","sha":"04ff8aafe599f929710069ff75e12bfdd4d67ce2","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","v9.0.0","backport:all-open"],"number":205197,"url":"https://github.com/elastic/kibana/pull/205197","mergeCommit":{"message":"fix(codeql): update CodeQL `ingore-paths` config (#205197)\n\n## Summary\n\nThis PR updates `ignore-paths` path CodeQL config to remove the paths\nthat no longer exist and exclude other well-known test/dev-only paths.\n\nNon-existent paths can be seen in the CodeQL logs from the most recent\nrun:\n```\n2024-12-26T21:29:09.2376056Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-babel-plugin-package-imports, which does not exist.\n2024-12-26T21:29:09.2377637Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-bazel-packages, which does not exist.\n2024-12-26T21:29:09.2387717Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-package-map, which does not exist.\n2024-12-26T21:29:09.2390381Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-spec-to-console, which does not exist.\n2024-12-26T21:29:09.2396606Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-ts-project-linter, which does not exist.\n2024-12-26T21:29:09.2402596Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-ts-project-linter-cli, which does not exist.\n```","sha":"04ff8aafe599f929710069ff75e12bfdd4d67ce2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205197","number":205197,"mergeCommit":{"message":"fix(codeql): update CodeQL `ingore-paths` config (#205197)\n\n## Summary\n\nThis PR updates `ignore-paths` path CodeQL config to remove the paths\nthat no longer exist and exclude other well-known test/dev-only paths.\n\nNon-existent paths can be seen in the CodeQL logs from the most recent\nrun:\n```\n2024-12-26T21:29:09.2376056Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-babel-plugin-package-imports, which does not exist.\n2024-12-26T21:29:09.2377637Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-bazel-packages, which does not exist.\n2024-12-26T21:29:09.2387717Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-package-map, which does not exist.\n2024-12-26T21:29:09.2390381Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-spec-to-console, which does not exist.\n2024-12-26T21:29:09.2396606Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-ts-project-linter, which does not exist.\n2024-12-26T21:29:09.2402596Z [2024-12-26 21:29:09] [build-stderr] Skipping path /home/runner/work/kibana/kibana/packages/kbn-ts-project-linter-cli, which does not exist.\n```","sha":"04ff8aafe599f929710069ff75e12bfdd4d67ce2"}},{"url":"https://github.com/elastic/kibana/pull/205202","number":205202,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->