### PR TITLE
fix(tests, interactive setup): switch interactive setup tests config to non-deprecated `secure_password` setting

### DIFF
--- a/packages/kbn-es/src/settings.test.ts
+++ b/packages/kbn-es/src/settings.test.ts
@@ -14,6 +14,7 @@ const mockSettings = [
   'xpack.security.authc.realms.oidc.oidc1.rp.client_secret=secret',
   'xpack.security.authc.realms.oidc.oidc1.rp.client_id=client id',
   'xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret=jwt_secret',
+  'xpack.security.http.ssl.keystore.secure_password=some_password',
   'discovery.type=single-node',
 ];
 
@@ -23,6 +24,7 @@ test('`parseSettings` parses and returns all settings by default', () => {
     ['xpack.security.authc.realms.oidc.oidc1.rp.client_secret', 'secret'],
     ['xpack.security.authc.realms.oidc.oidc1.rp.client_id', 'client id'],
     ['xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret', 'jwt_secret'],
+    ['xpack.security.http.ssl.keystore.secure_password', 'some_password'],
     ['discovery.type', 'single-node'],
   ]);
 });
@@ -33,6 +35,7 @@ test('`parseSettings` parses and returns all settings with `SettingsFilter.All` 
     ['xpack.security.authc.realms.oidc.oidc1.rp.client_secret', 'secret'],
     ['xpack.security.authc.realms.oidc.oidc1.rp.client_id', 'client id'],
     ['xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret', 'jwt_secret'],
+    ['xpack.security.http.ssl.keystore.secure_password', 'some_password'],
     ['discovery.type', 'single-node'],
   ]);
 });
@@ -41,6 +44,7 @@ test('`parseSettings` parses and returns only secure settings with `SettingsFilt
   expect(parseSettings(mockSettings, { filter: SettingsFilter.SecureOnly })).toEqual([
     ['xpack.security.authc.realms.oidc.oidc1.rp.client_secret', 'secret'],
     ['xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret', 'jwt_secret'],
+    ['xpack.security.http.ssl.keystore.secure_password', 'some_password'],
   ]);
 });
 

--- a/packages/kbn-es/src/settings.ts
+++ b/packages/kbn-es/src/settings.ts
@@ -13,6 +13,7 @@
 const SECURE_SETTINGS_LIST = [
   /^xpack\.security\.authc\.realms\.oidc\.[a-zA-Z0-9_]+\.rp\.client_secret$/,
   /^xpack\.security\.authc\.realms\.jwt\.[a-zA-Z0-9_]+\.client_authentication\.shared_secret$/,
+  /^xpack\.security\.http\.ssl\.keystore\.secure_password$/,
 ];
 
 function isSecureSetting(settingName: string) {

--- a/test/interactive_setup_api_integration/enrollment_flow.config.ts
+++ b/test/interactive_setup_api_integration/enrollment_flow.config.ts
@@ -38,7 +38,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         ...manualConfigurationFlowTestsConfig.get('esTestCluster.serverArgs'),
         'xpack.security.enrollment.enabled=true',
         `xpack.security.http.ssl.keystore.path=${caPath}`,
-        'xpack.security.http.ssl.keystore.password=storepass',
+        'xpack.security.http.ssl.keystore.secure_password=storepass',
       ],
     },
 

--- a/test/interactive_setup_functional/enrollment_token.config.ts
+++ b/test/interactive_setup_functional/enrollment_token.config.ts
@@ -41,7 +41,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         ...manualConfigurationConfig.get('esTestCluster.serverArgs'),
         'xpack.security.enrollment.enabled=true',
         `xpack.security.http.ssl.keystore.path=${caPath}`,
-        'xpack.security.http.ssl.keystore.password=storepass',
+        'xpack.security.http.ssl.keystore.secure_password=storepass',
       ],
     },
 


### PR DESCRIPTION
## Summary

Switch interactive setup tests config to non-deprecated `secure_password` setting as was flagged in https://github.com/elastic/kibana-team/issues/1173#issuecomment-2545077579

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->