### PR TITLE
fix(tests): adapt tests using `apm_user` to ensure they can run against Elasticsearch 9.0.0

### DIFF
--- a/x-pack/test/accessibility/apps/group1/roles.ts
+++ b/x-pack/test/accessibility/apps/group1/roles.ts
@@ -35,13 +35,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await a11y.testAppSnapshot();
     });
 
-    it('a11y test for searching a user', async () => {
-      await testSubjects.setValue('searchRoles', 'apm_user');
+    it('a11y test for searching a role', async () => {
+      await testSubjects.setValue('searchRoles', 'viewer');
       await a11y.testAppSnapshot();
       await testSubjects.setValue('searchRoles', '');
     });
 
-    it('a11y test for toggle button for show reserved users only', async () => {
+    it('a11y test for toggle button for show reserved roles only', async () => {
       await retry.waitFor(
         'show reserved roles toggle button is visible',
         async () => await testSubjects.exists('showReservedRolesSwitch')

--- a/x-pack/test/accessibility/apps/group1/users.ts
+++ b/x-pack/test/accessibility/apps/group1/users.ts
@@ -62,7 +62,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         confirm_password: 'password',
         full_name: 'a11y user',
         email: 'example@example.com',
-        roles: ['apm_user'],
+        roles: ['viewer'],
       });
       await testSubjects.click('rolesDropdown');
       await a11y.testAppSnapshot();
@@ -75,7 +75,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         confirm_password: 'password',
         full_name: 'DeleteA11y user',
         email: 'example@example.com',
-        roles: ['apm_user'],
+        roles: ['viewer'],
       });
       await testSubjects.click('checkboxSelectRow-deleteA11y');
       await a11y.testAppSnapshot();

--- a/x-pack/test/functional/apps/security/users.ts
+++ b/x-pack/test/functional/apps/security/users.ts
@@ -18,6 +18,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const toasts = getService('toasts');
   const browser = getService('browser');
   const security = getService('security');
+  const esVersion = getService('esVersion');
 
   function isCloudEnvironment() {
     return config.get('servers.elasticsearch.hostname') !== 'localhost';
@@ -111,8 +112,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(roles.apm_system.reserved).to.be(true);
       expect(roles.apm_system.deprecated).to.be(false);
 
-      expect(roles.apm_user.reserved).to.be(true);
-      expect(roles.apm_user.deprecated).to.be(true);
+      log.debug(`Checking ES version: ${esVersion}`);
+
+      if (esVersion.matchRange('<9.0.0')) {
+        expect(roles.apm_user.reserved).to.be(true);
+        expect(roles.apm_user.deprecated).to.be(true);
+      } else {
+        log.debug('The `apm_user` role no longer exists in 9.0.0+.');
+      }
 
       expect(roles.beats_admin.reserved).to.be(true);
       expect(roles.beats_admin.deprecated).to.be(false);


### PR DESCRIPTION
## Summary

Adapt tests using `apm_user` to ensure they can run against Elasticsearch 9.0.0 either by checking ES version or switching to other roles when possible.

Closes: #200666
Closes: #200667