### PR TITLE
fix(codeql): exclude `observability_solution` scripts from the CodeQL scans

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -89,6 +89,7 @@ paths-ignore:
   - x-pack/examples
   - x-pack/performance
   - x-pack/platform/**/scripts
+  - x-pack/plugins/observability_solution/*/scripts
   - x-pack/scripts
   - x-pack/solutions/**/scripts
   - x-pack/test


### PR DESCRIPTION
## Summary

Exclude `observability_solution` scripts from the CodeQL scans.

__Follow-up for:__ https://github.com/elastic/kibana/pull/205197

