### PR TITLE
fix(codeql, 8.x): exclude `observability_solution` scripts and dev-only `kbn-spec-to-console` package from the CodeQL scans

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -74,6 +74,7 @@ paths-ignore:
   - packages/kbn-scout-*
   - packages/kbn-some-dev-log
   - packages/kbn-sort-package-json
+  - packages/kbn-spec-to-console
   - packages/kbn-stdio-dev-helpers
   - packages/kbn-storybook
   - packages/kbn-telemetry-tools
@@ -89,6 +90,7 @@ paths-ignore:
   - x-pack/examples
   - x-pack/performance
   - x-pack/platform/**/scripts
+  - x-pack/plugins/observability_solution/*/scripts
   - x-pack/scripts
   - x-pack/solutions/**/scripts
   - x-pack/test


### PR DESCRIPTION
## Summary

Exclude `observability_solution` scripts and dev-only `kbn-spec-to-console` package from the CodeQL scans.

__Follow-up for:__ https://github.com/elastic/kibana/pull/205197



