### PR TITLE
fix(codeql, 7.17): fix path to `kbn-pm` package in CodeQL scan exclusion list

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -26,7 +26,6 @@ paths-ignore:
   - dev_docs
   - docs
   - examples
-  - kbn_pm
   - rfcs
   - packages/*/scripts
   - packages/core/test-helpers/core-test-helpers-kbn-server
@@ -65,6 +64,7 @@ paths-ignore:
   - packages/kbn-performance-testing-dataset-extractor
   - packages/kbn-plugin-generator
   - packages/kbn-plugin-helpers
+  - packages/kbn-pm
   - packages/kbn-repo-path
   - packages/kbn-repo-source-classifier
   - packages/kbn-repo-source-classifier-cli


### PR DESCRIPTION
## Summary

Fix path to `kbn-pm` package in CodeQL scan exclusion list (was broken by backport from `main` and `8.x` where `kbn-pm` package was moved to the repository root).

__Follow-up for:__ https://github.com/elastic/kibana/pull/205197


