### PR TITLE
SKA: Relocate script V6.2

### DIFF
--- a/packages/kbn-relocate/utils/relocate.ts
+++ b/packages/kbn-relocate/utils/relocate.ts
@@ -39,7 +39,12 @@ export const calculateModuleTargetFolder = (module: Package): string => {
   const group = module.manifest.group!;
   const isPlugin = module.manifest.type === 'plugin';
   const fullPath = join(BASE_FOLDER, module.directory);
-  let moduleDelimiter = isPlugin ? '/plugins/' : '/packages/';
+  if (!fullPath.includes('/plugins/') && !fullPath.includes('/packages/')) {
+    throw new Error(
+      `The module ${module.id} is not located under a '*/plugins/*' or '*/packages/*' folder`
+    );
+  }
+  let moduleDelimiter = fullPath.includes('/plugins/') ? '/plugins/' : '/packages/';
 
   // for platform modules that are in a sustainable folder, strip the /private/ or /shared/ part too
   if (module.directory.includes(`${moduleDelimiter}private/`)) {

--- a/packages/kbn-relocate/utils/transforms.ts
+++ b/packages/kbn-relocate/utils/transforms.ts
@@ -11,6 +11,8 @@ import type { Package } from '../types';
 
 type TransformFunction = (param: string) => string;
 const TRANSFORMS: Record<string, string | TransformFunction> = {
+  'src/platform/packages/shared/chart_expressions/common':
+    'src/platform/packages/shared/chart-expressions-common',
   'x-pack/solutions/security/packages/security-solution/': 'x-pack/solutions/security/packages/',
   'x-pack/solutions/observability/plugins/observability_solution/':
     'x-pack/solutions/observability/plugins/',


### PR DESCRIPTION
## Summary

* Support packages that are currently placed under a `*/plugins/*` folder (and viceversa).
* Transform (simplify) the following path:

```
src/platform/packages/shared/chart_expressions/common
# becomes
src/platform/packages/shared/chart-expressions-common
```

cc @markov00 






<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->