### PR TITLE
[CodeQL] Added env var to skip types for 8.x branch 

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,10 +45,9 @@ jobs:
       run: |
         echo "CHECKOUT_REF=$(git symbolic-ref HEAD)" >> "$GITHUB_ENV"
         echo "CHECKOUT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
-        echo "CHECKOUT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD) >> "$GITHUB_ENV"
 
     - name: Set experimental environment variable for 8.x branch
-        if: env.CHECKOUT_BRANCH_NAME == '8.x'
+        if: env.CHECKOUT_REF == 'refs/heads/8.x'
         run: echo "CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES=true" >> "$GITHUB_ENV"
 
     - name: Set experimental environment variable for 8.x branch

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,8 +51,8 @@ jobs:
         run: echo "CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES=true" >> "$GITHUB_ENV"
 
     - name: Set experimental environment variable for 8.x branch
-        if: env.CHECKOUT_REF == 'refs/heads/8.x'
-        run: echo "CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES=true" >> "$GITHUB_ENV"
+      if: env.CHECKOUT_REF == 'refs/heads/8.x'
+      run: echo "CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES=true" >> "$GITHUB_ENV"
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@883d8588e56d1753a8a58c1c86e88976f0c23449 # v3.26.3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,11 @@ jobs:
       run: |
         echo "CHECKOUT_REF=$(git symbolic-ref HEAD)" >> "$GITHUB_ENV"
         echo "CHECKOUT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+        echo "CHECKOUT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD) >> "$GITHUB_ENV"
+
+    - name: Set experimental environment variable for 8.x branch
+        if: env.CHECKOUT_BRANCH_NAME == '8.x'
+        run: echo "CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES=true" >> "$GITHUB_ENV"
 
     - name: Set experimental environment variable for 8.x branch
         if: env.CHECKOUT_REF == 'refs/heads/8.x'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,10 +47,6 @@ jobs:
         echo "CHECKOUT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
     - name: Set experimental environment variable for 8.x branch
-        if: env.CHECKOUT_REF == 'refs/heads/8.x'
-        run: echo "CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES=true" >> "$GITHUB_ENV"
-
-    - name: Set experimental environment variable for 8.x branch
       if: env.CHECKOUT_REF == 'refs/heads/8.x'
       run: echo "CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES=true" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary

Added `CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES` env var for `8.x` branch to check if that speeds up the CodeQL run, refer to [documentation](https://codeql.github.com/docs/codeql-overview/codeql-changelog/codeql-cli-2.15.5/) for details.




