### PR TITLE
support "field" AST node for `WHERE` clause in `STATS` command

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/src/builder/builder.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/builder/builder.ts
@@ -38,6 +38,7 @@ import {
   ESQLTimeInterval,
   ESQLBooleanLiteral,
   ESQLNullLiteral,
+  ESQLField,
 } from '../types';
 import { AstNodeParserFields, AstNodeTemplate, PartialFields } from './types';
 
@@ -56,10 +57,10 @@ export namespace Builder {
     incomplete,
   });
 
-  export const command = (
-    template: PartialFields<AstNodeTemplate<ESQLCommand>, 'args'>,
+  export const command = <Name extends string>(
+    template: PartialFields<AstNodeTemplate<ESQLCommand<Name>>, 'args'>,
     fromParser?: Partial<AstNodeParserFields>
-  ): ESQLCommand => {
+  ): ESQLCommand<Name> => {
     return {
       ...template,
       ...Builder.parserFields(fromParser),
@@ -171,6 +172,20 @@ export namespace Builder {
       };
 
       node.name = LeafPrinter.column(node);
+
+      return node;
+    };
+
+    export const field = (
+      template: Omit<AstNodeTemplate<ESQLField>, 'name' | 'args'>,
+      fromParser?: Partial<AstNodeParserFields>
+    ): ESQLField => {
+      const node: ESQLField = {
+        ...template,
+        ...Builder.parserFields(fromParser),
+        name: '',
+        type: 'field',
+      };
 
       return node;
     };

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/stats.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/__tests__/stats.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EsqlQuery } from '../../query';
+
+describe('STATS', () => {
+  describe('correctly formatted', () => {
+    it('a simple single aggregate expression', () => {
+      const src = `
+        FROM employees
+          | STATS 123
+          | WHERE still_hired == true
+          `;
+      const query = EsqlQuery.fromSrc(src);
+
+      expect(query.errors.length).toBe(0);
+      expect(query.ast.commands).toMatchObject([
+        {},
+        {
+          type: 'command',
+          name: 'stats',
+          args: [
+            {
+              type: 'field',
+              column: {
+                type: 'column',
+                args: [
+                  {
+                    type: 'identifier',
+                    name: '123',
+                  },
+                ],
+              },
+              value: {
+                type: 'literal',
+                value: 123,
+              },
+            },
+          ],
+        },
+        {},
+      ]);
+    });
+
+    it('aggregation function with escaped values', () => {
+      const src = `
+        FROM employees
+          | STATS 123, agg("salary")
+          | WHERE still_hired == true
+          `;
+      const query = EsqlQuery.fromSrc(src);
+
+      expect(query.errors.length).toBe(0);
+      expect(query.ast.commands).toMatchObject([
+        {},
+        {
+          type: 'command',
+          name: 'stats',
+          args: [
+            {
+              type: 'field',
+              column: {
+                type: 'column',
+                args: [
+                  {
+                    type: 'identifier',
+                    name: '123',
+                  },
+                ],
+              },
+              value: {
+                type: 'literal',
+                value: 123,
+              },
+            },
+            {
+              type: 'field',
+              column: {
+                type: 'column',
+                args: [
+                  {
+                    type: 'identifier',
+                    name: 'agg("salary")',
+                  },
+                ],
+              },
+              value: {
+                type: 'function',
+                name: 'agg',
+              },
+            },
+          ],
+        },
+        {},
+      ]);
+    });
+
+    it('field column name defined', () => {
+      const src = `
+        FROM employees
+          | STATS my_field = agg("salary")
+          | WHERE still_hired == true
+          `;
+      const query = EsqlQuery.fromSrc(src);
+
+      expect(query.errors.length).toBe(0);
+      expect(query.ast.commands).toMatchObject([
+        {},
+        {
+          type: 'command',
+          name: 'stats',
+          args: [
+            {
+              type: 'field',
+              column: {
+                type: 'column',
+                args: [
+                  {
+                    type: 'identifier',
+                    name: 'my_field',
+                  },
+                ],
+              },
+              value: {
+                type: 'function',
+                name: 'agg',
+              },
+            },
+          ],
+        },
+        {},
+      ]);
+    });
+
+    it('parses BY clause', () => {
+      const src = `
+        FROM employees
+          | STATS my_field = agg("salary") BY department
+          | WHERE still_hired == true
+          `;
+      const query = EsqlQuery.fromSrc(src);
+
+      expect(query.errors.length).toBe(0);
+      expect(query.ast.commands).toMatchObject([
+        {},
+        {
+          type: 'command',
+          name: 'stats',
+          args: [
+            {},
+            {
+              type: 'option',
+              name: 'by',
+            },
+          ],
+        },
+        {},
+      ]);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/esql_ast_builder_listener.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/esql_ast_builder_listener.ts
@@ -60,9 +60,12 @@ import type { ESQLAst, ESQLAstMetricsCommand } from '../types';
 import { createJoinCommand } from './factories/join';
 import { createDissectCommand } from './factories/dissect';
 import { createGrokCommand } from './factories/grok';
+import { createStatsCommand } from './factories/stats';
 
 export class ESQLAstBuilderListener implements ESQLParserListener {
   private ast: ESQLAst = [];
+
+  constructor(public src: string) {}
 
   public getAst() {
     return { ast: this.ast };
@@ -173,16 +176,9 @@ export class ESQLAstBuilderListener implements ESQLParserListener {
    * @param ctx the parse tree
    */
   exitStatsCommand(ctx: StatsCommandContext) {
-    const command = createCommand('stats', ctx);
-    this.ast.push(command);
+    const command = createStatsCommand(ctx, this.src);
 
-    // STATS expression is optional
-    if (ctx._stats) {
-      command.args.push(...collectAllAggFields(ctx.aggFields()));
-    }
-    if (ctx._grouping) {
-      command.args.push(...visitByOption(ctx, ctx.fields()));
-    }
+    this.ast.push(command);
   }
 
   /**

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/factories.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/factories.ts
@@ -84,7 +84,7 @@ const createParserFields = (ctx: ParserRuleContext): AstNodeParserFields => ({
   incomplete: Boolean(ctx.exception),
 });
 
-export const createCommand = (name: string, ctx: ParserRuleContext) =>
+export const createCommand = <Name extends string>(name: Name, ctx: ParserRuleContext) =>
   Builder.command({ name, args: [] }, createParserFields(ctx));
 
 export const createInlineCast = (ctx: InlineCastContext, value: ESQLInlineCast['value']) =>

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/factories/stats.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/factories/stats.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { AggFieldContext, StatsCommandContext } from '../../antlr/esql_parser';
+import { ESQLCommand, ESQLField } from '../../types';
+import { createCommand } from '../factories';
+import { createField, visitByOption } from '../walkers';
+
+const createAggField = (ctx: AggFieldContext, src: string): ESQLField => {
+  const fieldCtx = ctx.field();
+  const field = createField(fieldCtx, src);
+
+  return field;
+};
+
+export const createStatsCommand = (ctx: StatsCommandContext, src: string): ESQLCommand<'stats'> => {
+  const command = createCommand('stats', ctx);
+
+  if (ctx._stats) {
+    const fields = ctx.aggFields();
+
+    for (const fieldCtx of fields.aggField_list()) {
+      const node = createAggField(fieldCtx, src);
+
+      command.args.push(node);
+    }
+  }
+
+  if (ctx._grouping) {
+    const options = visitByOption(ctx, ctx.fields());
+
+    command.args.push(...options);
+  }
+
+  return command;
+};

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/parser.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/parser.ts
@@ -55,11 +55,11 @@ export const getParser = (
   };
 };
 
-export const createParser = (text: string) => {
+export const createParser = (src: string) => {
   const errorListener = new ESQLErrorListener();
-  const parseListener = new ESQLAstBuilderListener();
+  const parseListener = new ESQLAstBuilderListener(src);
 
-  return getParser(CharStreams.fromString(text), errorListener, parseListener);
+  return getParser(CharStreams.fromString(src), errorListener, parseListener);
 };
 
 // These will need to be manually updated whenever the relevant grammar changes.
@@ -106,7 +106,7 @@ export const parse = (text: string | undefined, options: ParseOptions = {}): Par
       return { ast: commands, root: Builder.expression.query(commands), errors: [], tokens: [] };
     }
     const errorListener = new ESQLErrorListener();
-    const parseListener = new ESQLAstBuilderListener();
+    const parseListener = new ESQLAstBuilderListener(text);
     const { tokens, parser } = getParser(
       CharStreams.fromString(text),
       errorListener,

--- a/src/platform/packages/shared/kbn-esql-ast/src/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/types.ts
@@ -30,6 +30,7 @@ export type ESQLSingleAstItem =
   | ESQLCommandMode
   | ESQLInlineCast
   | ESQLOrderExpression
+  | ESQLField
   | ESQLUnknownItem;
 
 export type ESQLAstField = ESQLFunction | ESQLColumn;
@@ -315,6 +316,29 @@ export interface ESQLColumn extends ESQLAstBaseItem {
    * property is not enough to represent the identifier. Use `parts` instead.
    */
   quoted: boolean;
+}
+
+/**
+ * An ES|QL field definition.
+ */
+export interface ESQLField extends ESQLAstBaseItem {
+  type: 'field';
+
+  /**
+   * The column name of the field. If not specified, the raw text of the
+   * expression is used. Hence, this property is always present.
+   */
+  column: ESQLColumn;
+
+  /**
+   * The expression which defines the value of the field.
+   */
+  value: ESQLAstExpression;
+
+  /**
+   * The WHERE clause of the field, used in STATS command aggregation fields.
+   */
+  where?: ESQLAstExpression;
 }
 
 export interface ESQLList extends ESQLAstBaseItem {

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/__tests__/scenarios.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/__tests__/scenarios.test.ts
@@ -126,6 +126,9 @@ export const prettyPrint = (ast: ESQLAstQueryExpression | ESQLAstQueryExpression
     .on('visitColumnExpression', (ctx) => {
       return ctx.node.name;
     })
+    .on('visitFieldExpression', (ctx) => {
+      return `${ctx.visitArgument(1)}`;
+    })
     .on('visitFunctionCallExpression', (ctx) => {
       let args = '';
       for (const arg of ctx.visitArguments()) {
@@ -189,6 +192,6 @@ test('can print a query to text', () => {
   const text = prettyPrint(ast);
 
   expect(text).toBe(
-    'FROM index METADATA _id, asdf, 123 | STATS FN(<LIST>, <TIME_INTERVAL>, <CAST>, IN(x, 1, 2)), =(a, b) | LIMIT 1000'
+    'FROM index METADATA _id, asdf, 123 | STATS FN(<LIST>, <TIME_INTERVAL>, <CAST>, IN(x, 1, 2)), b | LIMIT 1000'
   );
 });

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/contexts.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/contexts.ts
@@ -24,6 +24,7 @@ import type {
   ESQLColumn,
   ESQLCommandOption,
   ESQLDecimalLiteral,
+  ESQLField,
   ESQLFunction,
   ESQLIdentifier,
   ESQLInlineCast,
@@ -46,6 +47,7 @@ import type {
   VisitorOutput,
 } from './types';
 import { Builder } from '../builder';
+import { isProperNode } from '../ast/helpers';
 
 const isNodeWithArgs = (x: unknown): x is ESQLAstNodeWithArgs =>
   !!x && typeof x === 'object' && Array.isArray((x as any).args);
@@ -85,13 +87,7 @@ export class VisitorContext<
   ): Iterable<VisitorOutput<Methods, 'visitExpression'>> {
     this.ctx.assertMethodExists('visitExpression');
 
-    const node = this.node;
-
-    if (!isNodeWithArgs(node)) {
-      return;
-    }
-
-    for (const arg of singleItems(node.args)) {
+    for (const arg of this.arguments()) {
       if (arg.type === 'option' && arg.name !== 'as') {
         continue;
       }
@@ -107,7 +103,7 @@ export class VisitorContext<
   public arguments(): ESQLAstExpressionNode[] {
     const node = this.node;
 
-    if (!isNodeWithChildren(node)) {
+    if (!isProperNode(node)) {
       return [];
     }
 
@@ -128,12 +124,12 @@ export class VisitorContext<
 
     const node = this.node;
 
-    if (!isNodeWithArgs(node)) {
+    if (!isProperNode(node)) {
       throw new Error('Node does not have arguments');
     }
 
     let i = 0;
-    for (const arg of singleItems(node.args)) {
+    for (const arg of this.arguments()) {
       if (i === index) {
         return this.visitExpression(arg, input as any);
       }
@@ -580,3 +576,8 @@ export class IdentifierExpressionVisitorContext<
   Methods extends VisitorMethods = VisitorMethods,
   Data extends SharedData = SharedData
 > extends VisitorContext<Methods, Data, ESQLIdentifier> {}
+
+export class FieldExpressionVisitorContext<
+  Methods extends VisitorMethods = VisitorMethods,
+  Data extends SharedData = SharedData
+> extends VisitorContext<Methods, Data, ESQLField> {}

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/global_visitor_context.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/global_visitor_context.ts
@@ -13,6 +13,7 @@ import type {
   ESQLAstJoinCommand,
   ESQLAstRenameExpression,
   ESQLColumn,
+  ESQLField,
   ESQLFunction,
   ESQLIdentifier,
   ESQLInlineCast,
@@ -424,6 +425,10 @@ export class GlobalVisitorContext<
         if (!this.methods.visitIdentifierExpression) break;
         return this.visitIdentifierExpression(parent, expressionNode, input as any);
       }
+      case 'field': {
+        if (!this.methods.visitFieldExpression) break;
+        return this.visitFieldExpression(parent, expressionNode, input as any);
+      }
       case 'option': {
         switch (expressionNode.name) {
           case 'as': {
@@ -528,5 +533,14 @@ export class GlobalVisitorContext<
   ): types.VisitorOutput<Methods, 'visitIdentifierExpression'> {
     const context = new contexts.IdentifierExpressionVisitorContext(this, node, parent);
     return this.visitWithSpecificContext('visitIdentifierExpression', context, input);
+  }
+
+  public visitFieldExpression(
+    parent: contexts.VisitorContext | null,
+    node: ESQLField,
+    input: types.VisitorInput<Methods, 'visitFieldExpression'>
+  ): types.VisitorOutput<Methods, 'visitFieldExpression'> {
+    const context = new contexts.FieldExpressionVisitorContext(this, node, parent);
+    return this.visitWithSpecificContext('visitFieldExpression', context, input);
   }
 }

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/types.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/types.ts
@@ -62,7 +62,8 @@ export type ExpressionVisitorInput<Methods extends VisitorMethods> = AnyToVoid<
       VisitorInput<Methods, 'visitInlineCastExpression'> &
       VisitorInput<Methods, 'visitRenameExpression'> &
       VisitorInput<Methods, 'visitOrderExpression'> &
-      VisitorInput<Methods, 'visitIdentifierExpression'>
+      VisitorInput<Methods, 'visitIdentifierExpression'> &
+      VisitorInput<Methods, 'visitFieldExpression'>
 >;
 
 /**
@@ -79,7 +80,8 @@ export type ExpressionVisitorOutput<Methods extends VisitorMethods> =
   | VisitorOutput<Methods, 'visitInlineCastExpression'>
   | VisitorOutput<Methods, 'visitRenameExpression'>
   | VisitorOutput<Methods, 'visitOrderExpression'>
-  | VisitorOutput<Methods, 'visitIdentifierExpression'>;
+  | VisitorOutput<Methods, 'visitIdentifierExpression'>
+  | VisitorOutput<Methods, 'visitFieldExpression'>;
 
 /**
  * Input that satisfies any command visitor input constraints.
@@ -215,6 +217,7 @@ export interface VisitorMethods<
     any,
     any
   >;
+  visitFieldExpression?: Visitor<contexts.FieldExpressionVisitorContext<Visitors, Data>, any, any>;
 }
 
 /**
@@ -242,6 +245,8 @@ export type AstNodeToVisitorName<Node extends VisitorAstNode> = Node extends ESQ
   ? 'visitInlineCastExpression'
   : Node extends ast.ESQLIdentifier
   ? 'visitIdentifierExpression'
+  : Node extends ast.ESQLField
+  ? 'visitFieldExpression'
   : never;
 
 /**

--- a/src/platform/packages/shared/kbn-esql-ast/src/visitor/utils.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/visitor/utils.ts
@@ -81,5 +81,14 @@ export function* children(node: ESQLProperNode): Iterable<ESQLAstExpression> {
       }
       break;
     }
+    case 'field': {
+      yield node.column;
+      yield node.value;
+
+      if (node.where) {
+        yield node.where;
+      }
+      break;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



