### PR TITLE
[ESQL] Remove filtering out of dot prefixed index patterns

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -37,8 +37,8 @@ describe('helpers', function () {
       expect(
         parseErrors(
           errors,
-          `SELECT * 
-      FROM "kibana_sample_data_ecommerce" 
+          `SELECT *
+      FROM "kibana_sample_data_ecommerce"
       WHERE category`
         )
       ).toEqual([
@@ -213,6 +213,7 @@ describe('helpers', function () {
           {
             name: '.system1',
             title: 'system1',
+            tags: [{ name: 'system', type: 'system', key: 'alias' }],
           },
           {
             name: 'logs',
@@ -222,7 +223,7 @@ describe('helpers', function () {
       };
       const indices = await getIndicesList(updatedDataViewsMock);
       expect(indices).toStrictEqual([
-        { name: '.system1', hidden: true, type: 'Index' },
+        { name: '.system1', hidden: true, type: 'system' },
         { name: 'logs', hidden: false, type: 'Index' },
       ]);
     });
@@ -273,6 +274,7 @@ describe('helpers', function () {
             item: {
               name: 'system',
             },
+            tags: [{ name: 'system', type: 'system', key: 'alias' }],
           },
           {
             name: 'remote:logs',

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -177,8 +177,10 @@ export const getIndicesList = async (dataViews: DataViewsPublicPluginStart) => {
   });
 
   return indices.map((index) => {
+    const hidden =
+      index.name.startsWith('.') && Boolean(index.tags.find((tag) => tag.key === 'alias'));
     const [tag] = index?.tags ?? [];
-    return { name: index.name, hidden: false, type: tag?.name ?? 'Index' };
+    return { name: index.name, hidden, type: tag?.name ?? 'Index' };
   });
 };
 
@@ -189,7 +191,10 @@ export const getRemoteIndicesList = async (dataViews: DataViewsPublicPluginStart
     isRollupIndex: () => false,
   });
   const finalIndicesList = indices.filter((source) => {
-    return !Boolean(source.item.indices);
+    const [_, indexName] = source.name.split(':');
+    const hidden =
+      indexName.startsWith('.') && Boolean(source.tags.find((tag) => tag.key === 'alias'));
+    return !hidden && !Boolean(source.item.indices);
   });
 
   return finalIndicesList.map((source) => {

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -178,7 +178,7 @@ export const getIndicesList = async (dataViews: DataViewsPublicPluginStart) => {
 
   return indices.map((index) => {
     const [tag] = index?.tags ?? [];
-    return { name: index.name, hidden: index.name.startsWith('.'), type: tag?.name ?? 'Index' };
+    return { name: index.name, hidden: false, type: tag?.name ?? 'Index' };
   });
 };
 
@@ -189,8 +189,7 @@ export const getRemoteIndicesList = async (dataViews: DataViewsPublicPluginStart
     isRollupIndex: () => false,
   });
   const finalIndicesList = indices.filter((source) => {
-    const [_, index] = source.name.split(':');
-    return !index.startsWith('.') && !Boolean(source.item.indices);
+    return !Boolean(source.item.indices);
   });
 
   return finalIndicesList.map((source) => {

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_adhoc_dataview.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_adhoc_dataview.ts
@@ -67,9 +67,7 @@ export async function getIndexForESQLQuery(deps: {
       pattern: '*',
       isRollupIndex: () => false,
     })
-  )
-    .filter((index) => !index.name.startsWith('.'))
-    .map((index) => index.name);
+  ).map((index) => index.name);
 
   let indexName = indices[0];
   if (indices.length > 0) {

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_adhoc_dataview.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/get_esql_adhoc_dataview.ts
@@ -67,7 +67,12 @@ export async function getIndexForESQLQuery(deps: {
       pattern: '*',
       isRollupIndex: () => false,
     })
-  ).map((index) => index.name);
+  )
+    .filter(
+      (index) =>
+        !index.name.startsWith('.') && !Boolean(index.tags.find((tag) => tag.key === 'alias'))
+    )
+    .map((index) => index.name);
 
   let indexName = indices[0];
   if (indices.length > 0) {


### PR DESCRIPTION
## Summary

A quick POC to filter out dot prefixed alias indices like in the following screenshot by @stratoula 

![image](https://github.com/user-attachments/assets/c884a57d-c662-470c-91c1-9a635d75436f)

Note that it would be better to fix those indices to be hidden, if this is intended. 

With the simple change of this PR, non-hidden but `.` prefixed indices are suggested by the autocomplete of the ES|QL editor:

![CleanShot 2024-12-30 at 18 19 41](https://github.com/user-attachments/assets/f730d8f6-252d-4131-85a1-d424f0bf80b2)

This can be tested here:
https://kertal-pr-205276-discover-esql-make-use-of-dot-prefixed-ind.kbndev.co/app/r/s/vFXr6



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



