### PR TITLE
[renovate] Match all branches instead of backporting for FTR group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,9 @@
   ],
   "baseBranches": [
     "main",
+    "8.x",
+    "8.17",
+    "8.16",
     "7.17"
   ],
   "prConcurrentLimit": 0,
@@ -2345,12 +2348,12 @@
         "team:kibana-operations"
       ],
       "matchBaseBranches": [
-        "main"
+        "*"
       ],
       "labels": [
         "Team:Operations",
         "release_note:skip",
-        "backport:all-open"
+        "backport:skip"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true


### PR DESCRIPTION
FTR dependencies needs to be kept up to date across all branches, but using the backport automation ends up requiring manual intervention due to merge conflicts.

This configures renovate to open separate pull requests per branch for the `ftr` group.  If this works as expected I'll do another pass and see if there's other groups that this makes sense for.