### PR TITLE
[ci] Fix cache trigger for package registry

### DIFF
--- a/.buildkite/scripts/steps/fleet/promote_package_registry.sh
+++ b/.buildkite/scripts/steps/fleet/promote_package_registry.sh
@@ -14,8 +14,8 @@ steps:
     async: true
     build:
       env:
-        IMAGES_CONFIG="kibana/images.yml"
-        RETRY="1"
+        IMAGES_CONFIG: "kibana/images.yml"
+        RETRY: "1"
 EOF
 else
   echo "Skipping promotion for untracked branch $BUILDKITE_BRANCH"


### PR DESCRIPTION
Same bug as https://github.com/elastic/kibana/pull/199644.  This implementation PR was stale and I didn't bring the fix over.