### PR TITLE
[8.x] [ML][UX]: Consistent Layout and UI Enhancements for ML Pages (#203813)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Kibana source code with Kibana X-Pack source code
-Copyright 2012-2024 Elasticsearch B.V.
+Copyright 2012-2025 Elasticsearch B.V.
 
 ---
 Adapted from remote-web-worker, which was available under a "MIT" license.

--- a/x-pack/platform/packages/private/ml/date_picker/src/components/date_picker_wrapper.tsx
+++ b/x-pack/platform/packages/private/ml/date_picker/src/components/date_picker_wrapper.tsx
@@ -88,10 +88,6 @@ interface DatePickerWrapperProps {
    */
   width?: EuiSuperDatePickerProps['width'];
   /**
-   * Boolean flag to set use of flex group wrapper
-   */
-  flexGroup?: boolean;
-  /**
    * Boolean flag to disable the date picker
    */
   isDisabled?: boolean;
@@ -123,7 +119,6 @@ export const DatePickerWrapper: FC<DatePickerWrapperProps> = (props) => {
     isLoading = false,
     showRefresh,
     width,
-    flexGroup = true,
     isDisabled = false,
     needsUpdate,
     onRefresh,
@@ -362,6 +357,8 @@ export const DatePickerWrapper: FC<DatePickerWrapperProps> = (props) => {
       ) : null}
     </>
   );
+
+  const flexGroup = !isTimeRangeSelectorEnabled || isAutoRefreshOnly === true;
 
   const wrapped = flexGroup ? (
     <EuiFlexGroup gutterSize="s" alignItems="center">

--- a/x-pack/platform/packages/private/ml/date_picker/src/components/full_time_range_selector.tsx
+++ b/x-pack/platform/packages/private/ml/date_picker/src/components/full_time_range_selector.tsx
@@ -220,7 +220,7 @@ export const FullTimeRangeSelector: FC<FullTimeRangeSelectorProps> = (props) => 
   }, [frozenDataPreference, showFrozenDataTierChoice]);
 
   return (
-    <EuiFlexGroup responsive={false} gutterSize="xs">
+    <EuiFlexGroup responsive={false} gutterSize="s">
       <EuiToolTip content={buttonTooltip}>
         <EuiButton
           isDisabled={disabled}

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/data_drift/data_drift_page.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/data_drift/data_drift_page.tsx
@@ -115,7 +115,6 @@ export const PageHeader: FC<PageHeaderProps> = ({ onRefresh, needsUpdate }) => {
           isAutoRefreshOnly={!hasValidTimeField}
           showRefresh={!hasValidTimeField}
           width="full"
-          flexGroup={!hasValidTimeField}
           onRefresh={onRefresh}
           needsUpdate={needsUpdate}
         />,

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_view.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_view.tsx
@@ -20,7 +20,6 @@ import {
   EuiPanel,
   EuiProgress,
   EuiSpacer,
-  EuiTitle,
 } from '@elastic/eui';
 
 import { type Filter, FilterStateStore, type Query, buildEsQuery } from '@kbn/es-query';
@@ -37,7 +36,6 @@ import { useStorage } from '@kbn/ml-local-storage';
 import type { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { SEARCH_QUERY_LANGUAGE, type SearchQueryLanguage } from '@kbn/ml-query-utils';
 import { kbnTypeToSupportedType } from '../../../common/util/field_types_utils';
-import { useCurrentEuiTheme } from '../../../common/hooks/use_current_eui_theme';
 import {
   DV_FROZEN_TIER_PREFERENCE,
   DV_RANDOM_SAMPLER_PREFERENCE,
@@ -108,8 +106,6 @@ export interface IndexDataVisualizerViewProps {
 }
 
 export const IndexDataVisualizerView: FC<IndexDataVisualizerViewProps> = (dataVisualizerProps) => {
-  const euiTheme = useCurrentEuiTheme();
-
   const [savedRandomSamplerPreference, saveRandomSamplerPreference] = useStorage<
     DVKey,
     DVStorageMapped<typeof DV_RANDOM_SAMPLER_PREFERENCE>
@@ -515,52 +511,40 @@ export const IndexDataVisualizerView: FC<IndexDataVisualizerViewProps> = (dataVi
       paddingSize="none"
     >
       <EuiPageTemplate.Section>
-        <EuiPageTemplate.Header data-test-subj="dataVisualizerPageHeader" css={dvPageHeader}>
-          <EuiFlexGroup
-            data-test-subj="dataViewTitleHeader"
-            direction="row"
-            alignItems="center"
-            css={{ padding: `${euiTheme.euiSizeS} 0`, marginRight: `${euiTheme.euiSize}` }}
-          >
-            <EuiTitle size={'s'}>
-              <h2>{currentDataView.getName()}</h2>
-            </EuiTitle>
-            <DataVisualizerDataViewManagement
-              currentDataView={currentDataView}
-              useNewFieldsApi={true}
-            />
-          </EuiFlexGroup>
-
-          {isWithinLargeBreakpoint ? <EuiSpacer size="m" /> : null}
-          <EuiFlexGroup
-            alignItems="center"
-            justifyContent="flexEnd"
-            gutterSize="s"
-            data-test-subj="dataVisualizerTimeRangeSelectorSection"
-          >
-            {hasValidTimeField ? (
-              <EuiFlexItem grow={false}>
-                <FullTimeRangeSelector
-                  frozenDataPreference={frozenDataPreference}
-                  setFrozenDataPreference={setFrozenDataPreference}
-                  dataView={currentDataView}
-                  query={undefined}
-                  disabled={false}
-                  timefilter={timefilter}
-                />
-              </EuiFlexItem>
-            ) : null}
-            <EuiFlexItem grow={false}>
-              <DatePickerWrapper
-                isAutoRefreshOnly={!hasValidTimeField}
-                showRefresh={!hasValidTimeField}
-                width="full"
-                needsUpdate={queryNeedsUpdate}
-                onRefresh={handleRefresh}
+        <EuiPageTemplate.Header
+          data-test-subj="dataVisualizerPageHeader"
+          css={dvPageHeader}
+          pageTitle={
+            <>
+              {currentDataView.getName()}
+              {/* TODO: This management section shouldn't live inside the header */}
+              <DataVisualizerDataViewManagement currentDataView={currentDataView} />
+            </>
+          }
+          rightSideGroupProps={{
+            gutterSize: 's',
+            'data-test-subj': 'dataVisualizerTimeRangeSelectorSection',
+          }}
+          rightSideItems={[
+            <DatePickerWrapper
+              isAutoRefreshOnly={!hasValidTimeField}
+              showRefresh={!hasValidTimeField}
+              width="full"
+              needsUpdate={queryNeedsUpdate}
+              onRefresh={handleRefresh}
+            />,
+            hasValidTimeField && (
+              <FullTimeRangeSelector
+                frozenDataPreference={frozenDataPreference}
+                setFrozenDataPreference={setFrozenDataPreference}
+                dataView={currentDataView}
+                query={undefined}
+                disabled={false}
+                timefilter={timefilter}
               />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiPageTemplate.Header>
+            ),
+          ]}
+        />
         <EuiSpacer size="m" />
 
         <EuiFlexGroup gutterSize="m" direction={isWithinLargeBreakpoint ? 'column' : 'row'}>

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_view.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/components/index_data_visualizer_view/index_data_visualizer_view.tsx
@@ -518,7 +518,10 @@ export const IndexDataVisualizerView: FC<IndexDataVisualizerViewProps> = (dataVi
             <>
               {currentDataView.getName()}
               {/* TODO: This management section shouldn't live inside the header */}
-              <DataVisualizerDataViewManagement currentDataView={currentDataView} />
+              <DataVisualizerDataViewManagement
+                currentDataView={currentDataView}
+                useNewFieldsApi={true}
+              />
             </>
           }
           rightSideGroupProps={{

--- a/x-pack/platform/plugins/shared/aiops/public/cases/constants.ts
+++ b/x-pack/platform/plugins/shared/aiops/public/cases/constants.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ChangePointDetectionViewType } from '@kbn/aiops-change-point-detection/constants';
+import { i18n } from '@kbn/i18n';
+
+/**
+ * Titles for the cases toast messages
+ */
+export const CASES_TOAST_MESSAGES_TITLES = {
+  CHANGE_POINT_DETECTION: (viewType: ChangePointDetectionViewType, chartsCount: number) =>
+    viewType === 'table'
+      ? i18n.translate('xpack.aiops.cases.changePointDetectionTableTitle', {
+          defaultMessage: 'Change point table',
+        })
+      : i18n.translate('xpack.aiops.cases.changePointDetectionChartsTitle', {
+          defaultMessage: 'Change point {chartsCount, plural, one {chart} other {charts}}',
+          values: {
+            chartsCount,
+          },
+        }),
+  LOG_RATE_ANALYSIS: i18n.translate('xpack.aiops.cases.logRateAnalysisTitle', {
+    defaultMessage: 'Log rate analysis',
+  }),
+  PATTERN_ANALYSIS: i18n.translate('xpack.aiops.cases.logPatternAnalysisTitle', {
+    defaultMessage: 'Log pattern analysis',
+  }),
+};

--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/fields_config.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/fields_config.tsx
@@ -56,6 +56,7 @@ import {
 import { useChangePointResults } from './use_change_point_agg_request';
 import { useSplitFieldCardinality } from './use_split_field_cardinality';
 import { ViewTypeSelector } from './view_type_selector';
+import { CASES_TOAST_MESSAGES_TITLES } from '../../cases/constants';
 
 const selectControlCss = { width: '350px' };
 
@@ -215,11 +216,17 @@ const FieldPanel: FC<FieldPanelProps> = ({
     progress,
   } = useChangePointResults(fieldConfig, requestParams, combinedQuery, splitFieldCardinality);
 
-  const openCasesModalCallback = useCasesModal(EMBEDDABLE_CHANGE_POINT_CHART_TYPE);
-
   const selectedPartitions = useMemo(() => {
     return (selectedChangePoints[panelIndex] ?? []).map((v) => v.group?.value as string);
   }, [selectedChangePoints, panelIndex]);
+
+  const openCasesModalCallback = useCasesModal(
+    EMBEDDABLE_CHANGE_POINT_CHART_TYPE,
+    CASES_TOAST_MESSAGES_TITLES.CHANGE_POINT_DETECTION(
+      caseAttachment.viewType,
+      selectedPartitions.length
+    )
+  );
 
   const caseAttachmentButtonDisabled =
     isDefined(fieldConfig.splitField) && selectedPartitions.length === 0;
@@ -283,6 +290,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
                     defaultMessage: 'To dashboard',
                   }),
                   panel: 'attachToDashboardPanel',
+                  icon: 'dashboardApp',
                   'data-test-subj': 'aiopsChangePointDetectionAttachToDashboardButton',
                 },
               ]
@@ -307,6 +315,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
                     : {}),
                   'data-test-subj': 'aiopsChangePointDetectionAttachToCaseButton',
                   panel: 'attachToCasePanel',
+                  icon: 'casesApp',
                 },
               ]
             : []),
@@ -513,42 +522,37 @@ const FieldPanel: FC<FieldPanelProps> = ({
 
   return (
     <EuiPanel paddingSize="s" hasBorder hasShadow={false} data-test-subj={dataTestSubj}>
-      <EuiFlexGroup alignItems={'center'} justifyContent={'spaceBetween'} gutterSize={'s'}>
+      <EuiFlexGroup alignItems={'flexStart'} justifyContent={'spaceBetween'} gutterSize={'s'}>
         <EuiFlexItem grow={false}>
-          <EuiFlexGroup alignItems={'center'} gutterSize={'s'}>
-            <EuiFlexItem grow={false}>
-              <EuiButtonIcon
-                data-test-subj="aiopsChangePointDetectionExpandConfigButton"
-                iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
-                onClick={setIsExpanded.bind(null, (prevState) => !prevState)}
-                aria-label={i18n.translate('xpack.aiops.changePointDetection.expandConfigLabel', {
-                  defaultMessage: 'Expand configuration',
-                })}
-              />
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <FieldsControls fieldConfig={fieldConfig} onChange={onChange}>
-                <EuiFlexItem
-                  css={{ visibility: progress === null ? 'hidden' : 'visible' }}
-                  grow={true}
-                >
-                  <EuiProgress
-                    label={
-                      <FormattedMessage
-                        id="xpack.aiops.changePointDetection.progressBarLabel"
-                        defaultMessage="Fetching change points"
-                      />
-                    }
-                    value={progress ?? 0}
-                    max={100}
-                    valueText
-                    size="m"
+          <EuiButtonIcon
+            data-test-subj="aiopsChangePointDetectionExpandConfigButton"
+            iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
+            onClick={setIsExpanded.bind(null, (prevState) => !prevState)}
+            aria-label={i18n.translate('xpack.aiops.changePointDetection.expandConfigLabel', {
+              defaultMessage: 'Expand configuration',
+            })}
+            size="s"
+          />
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          <FieldsControls fieldConfig={fieldConfig} onChange={onChange} data-test-subj="blablabla">
+            <EuiFlexItem {...(progress === null && { css: { display: 'none' } })} grow={true}>
+              <EuiProgress
+                label={
+                  <FormattedMessage
+                    id="xpack.aiops.changePointDetection.progressBarLabel"
+                    defaultMessage="Fetching change points"
                   />
-                  <EuiSpacer size="s" />
-                </EuiFlexItem>
-              </FieldsControls>
+                }
+                value={progress ?? 0}
+                max={100}
+                valueText
+                size="m"
+              />
+              <EuiSpacer size="s" />
             </EuiFlexItem>
-          </EuiFlexGroup>
+          </FieldsControls>
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
@@ -565,8 +569,11 @@ const FieldPanel: FC<FieldPanelProps> = ({
                         defaultMessage: 'Context menu',
                       }
                     )}
-                    iconType="boxesHorizontal"
                     color="text"
+                    display="base"
+                    size="s"
+                    isSelected={isActionMenuOpen}
+                    iconType="boxesHorizontal"
                     onClick={setIsActionMenuOpen.bind(null, !isActionMenuOpen)}
                   />
                 }
@@ -679,7 +686,7 @@ export const FieldsControls: FC<PropsWithChildren<FieldsControlsProps>> = ({
       }
       theme={theme}
     >
-      <EuiFlexGroup alignItems={'center'} responsive={true} wrap={true} gutterSize={'m'}>
+      <EuiFlexGroup alignItems={'center'} responsive={true} wrap={true} gutterSize={'s'}>
         <EuiFlexItem grow={false} css={{ width: '200px' }}>
           <FunctionPicker value={fieldConfig.fn} onChange={(v) => onChangeFn('fn', v)} />
         </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/attachments_menu.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/attachments_menu.tsx
@@ -34,6 +34,7 @@ import type { PatternAnalysisEmbeddableState } from '../../embeddables/pattern_a
 import type { RandomSamplerOption, RandomSamplerProbability } from './sampling_menu/random_sampler';
 import { useCasesModal } from '../../hooks/use_cases_modal';
 import { useAiopsAppContext } from '../../hooks/use_aiops_app_context';
+import { CASES_TOAST_MESSAGES_TITLES } from '../../cases/constants';
 
 const SavedObjectSaveModalDashboard = withSuspense(LazySavedObjectSaveModalDashboard);
 
@@ -66,7 +67,10 @@ export const AttachmentsMenu = ({
     update: false,
   };
 
-  const openCasesModalCallback = useCasesModal(EMBEDDABLE_PATTERN_ANALYSIS_TYPE);
+  const openCasesModalCallback = useCasesModal(
+    EMBEDDABLE_PATTERN_ANALYSIS_TYPE,
+    CASES_TOAST_MESSAGES_TITLES.PATTERN_ANALYSIS
+  );
 
   const timeRange = useTimeRangeUpdates();
 
@@ -123,6 +127,7 @@ export const AttachmentsMenu = ({
                     defaultMessage: 'Add to dashboard',
                   }),
                   panel: 'attachToDashboardPanel',
+                  icon: 'dashboardApp',
                   'data-test-subj': 'aiopsLogPatternAnalysisAttachToDashboardButton',
                 },
               ]
@@ -133,6 +138,7 @@ export const AttachmentsMenu = ({
                   name: i18n.translate('xpack.aiops.logCategorization.attachToCaseLabel', {
                     defaultMessage: 'Add to case',
                   }),
+                  icon: 'casesApp',
                   'data-test-subj': 'aiopsLogPatternAnalysisAttachToCaseButton',
                   onClick: () => {
                     setIsActionMenuOpen(false);
@@ -218,8 +224,11 @@ export const AttachmentsMenu = ({
                     defaultMessage: 'Attachments',
                   }
                 )}
-                iconType="boxesHorizontal"
+                size="m"
                 color="text"
+                display="base"
+                isSelected={isActionMenuOpen}
+                iconType="boxesHorizontal"
                 onClick={() => setIsActionMenuOpen(!isActionMenuOpen)}
               />
             }

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/log_categorization_page.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/log_categorization_page.tsx
@@ -357,48 +357,56 @@ export const LogCategorizationPage: FC = () => {
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="m" />
-      <EuiFlexGroup gutterSize="none">
-        <EuiFlexItem grow={false} css={{ minWidth: '410px' }}>
-          <EuiFormRow
-            label={i18n.translate('xpack.aiops.logCategorization.categoryFieldSelect', {
-              defaultMessage: 'Category field',
-            })}
-          >
-            <EuiComboBox
-              isDisabled={loading === true}
-              options={fields}
-              onChange={onFieldChange}
-              selectedOptions={selectedField === undefined ? undefined : [{ label: selectedField }]}
-              singleSelection={{ asPlainText: true }}
-              data-test-subj="aiopsLogPatternAnalysisCategoryField"
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false} css={{ marginTop: 'auto' }}>
-          {loading === false ? (
-            <EuiButton
-              disabled={selectedField === undefined}
-              onClick={() => {
-                loadCategories();
-              }}
-              data-test-subj="aiopsLogPatternAnalysisRunButton"
+      <EuiFlexGroup>
+        <EuiFlexGroup gutterSize="s">
+          <EuiFlexItem grow={false} css={{ minWidth: '400px' }}>
+            <EuiFormRow
+              label={i18n.translate('xpack.aiops.logCategorization.categoryFieldSelect', {
+                defaultMessage: 'Category field',
+              })}
             >
-              <FormattedMessage
-                id="xpack.aiops.logCategorization.runButton"
-                defaultMessage="Run pattern analysis"
+              <EuiComboBox
+                isDisabled={loading === true}
+                options={fields}
+                onChange={onFieldChange}
+                selectedOptions={
+                  selectedField === undefined ? undefined : [{ label: selectedField }]
+                }
+                singleSelection={{ asPlainText: true }}
+                data-test-subj="aiopsLogPatternAnalysisCategoryField"
               />
-            </EuiButton>
-          ) : (
-            <EuiButton
-              data-test-subj="aiopsLogCategorizationPageCancelButton"
-              onClick={() => cancelRequest()}
-            >
-              Cancel
-            </EuiButton>
-          )}
-        </EuiFlexItem>
-        <EuiFlexItem />
-        <EuiFlexGroup css={{ marginTop: 'auto' }} alignItems="center" justifyContent="flexEnd">
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false} css={{ marginTop: 'auto' }}>
+            {loading === false ? (
+              <EuiButton
+                disabled={selectedField === undefined}
+                onClick={() => {
+                  loadCategories();
+                }}
+                data-test-subj="aiopsLogPatternAnalysisRunButton"
+              >
+                <FormattedMessage
+                  id="xpack.aiops.logCategorization.runButton"
+                  defaultMessage="Run pattern analysis"
+                />
+              </EuiButton>
+            ) : (
+              <EuiButton
+                data-test-subj="aiopsLogCategorizationPageCancelButton"
+                onClick={() => cancelRequest()}
+              >
+                Cancel
+              </EuiButton>
+            )}
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiFlexGroup
+          css={{ marginTop: 'auto' }}
+          alignItems="center"
+          justifyContent="flexEnd"
+          gutterSize="s"
+        >
           <EuiFlexItem grow={false}>
             <SamplingMenu randomSampler={randomSampler} reload={() => loadCategories()} />
           </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/sampling_menu/sampling_menu.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/sampling_menu/sampling_menu.tsx
@@ -8,7 +8,7 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
 import React, { useState } from 'react';
-import { EuiPopover, EuiButtonEmpty, EuiPanel } from '@elastic/eui';
+import { EuiPopover, EuiPanel, EuiButton } from '@elastic/eui';
 
 import useObservable from 'react-use/lib/useObservable';
 import type { RandomSampler } from './random_sampler';
@@ -34,14 +34,16 @@ export const SamplingMenu: FC<Props> = ({ randomSampler, reload }) => {
       data-test-subj="aiopsRandomSamplerOptionsPopover"
       id="aiopsSamplingOptions"
       button={
-        <EuiButtonEmpty
+        <EuiButton
           data-test-subj="aiopsLogPatternAnalysisShowSamplingOptionsButton"
           onClick={() => setShowSamplingOptionsPopover(!showSamplingOptionsPopover)}
+          color="text"
           iconSide="right"
-          iconType="arrowDown"
+          isSelected={showSamplingOptionsPopover}
+          iconType={showSamplingOptionsPopover ? 'arrowUp' : 'arrowDown'}
         >
           {buttonText}
-        </EuiButtonEmpty>
+        </EuiButton>
       }
       isOpen={showSamplingOptionsPopover}
       closePopover={() => setShowSamplingOptionsPopover(false)}

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_attachments_menu.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_attachments_menu.tsx
@@ -28,6 +28,7 @@ import {
 } from '@elastic/eui';
 import type { WindowParameters } from '@kbn/aiops-log-rate-analysis/window_parameters';
 import type { SignificantItem } from '@kbn/ml-agg-utils';
+import { CASES_TOAST_MESSAGES_TITLES } from '../../../cases/constants';
 import { useCasesModal } from '../../../hooks/use_cases_modal';
 import { useDataSource } from '../../../hooks/use_data_source';
 import type { LogRateAnalysisEmbeddableState } from '../../../embeddables/log_rate_analysis/types';
@@ -60,7 +61,10 @@ export const LogRateAnalysisAttachmentsMenu = ({
   const timeRange = useTimeRangeUpdates();
   const absoluteTimeRange = useTimeRangeUpdates(true);
 
-  const openCasesModalCallback = useCasesModal(EMBEDDABLE_LOG_RATE_ANALYSIS_TYPE);
+  const openCasesModalCallback = useCasesModal(
+    EMBEDDABLE_LOG_RATE_ANALYSIS_TYPE,
+    CASES_TOAST_MESSAGES_TITLES.LOG_RATE_ANALYSIS
+  );
 
   const canEditDashboards = capabilities.dashboard.createNew;
 
@@ -120,6 +124,7 @@ export const LogRateAnalysisAttachmentsMenu = ({
                   name: i18n.translate('xpack.aiops.logRateAnalysis.addToDashboardTitle', {
                     defaultMessage: 'Add to dashboard',
                   }),
+                  icon: 'dashboardApp',
                   panel: 'attachToDashboardPanel',
                   'data-test-subj': 'aiopsLogRateAnalysisAttachToDashboardButton',
                 },
@@ -131,6 +136,7 @@ export const LogRateAnalysisAttachmentsMenu = ({
                   name: i18n.translate('xpack.aiops.logRateAnalysis.attachToCaseLabel', {
                     defaultMessage: 'Add to case',
                   }),
+                  icon: 'casesApp',
                   'data-test-subj': 'aiopsLogRateAnalysisAttachToCaseButton',
                   disabled: !isCasesAttachmentEnabled,
                   ...(!isCasesAttachmentEnabled
@@ -217,8 +223,11 @@ export const LogRateAnalysisAttachmentsMenu = ({
                 aria-label={i18n.translate('xpack.aiops.logRateAnalysis.attachmentsMenuAriaLabel', {
                   defaultMessage: 'Attachments',
                 })}
-                iconType="boxesHorizontal"
                 color="text"
+                display="base"
+                size="s"
+                isSelected={isActionMenuOpen}
+                iconType="boxesHorizontal"
                 onClick={() => setIsActionMenuOpen(!isActionMenuOpen)}
               />
             }

--- a/x-pack/platform/plugins/shared/aiops/public/components/page_header/page_header.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/page_header/page_header.tsx
@@ -80,7 +80,6 @@ export const PageHeader: FC = () => {
           isAutoRefreshOnly={!hasValidTimeField}
           showRefresh={!hasValidTimeField}
           width="full"
-          flexGroup={!hasValidTimeField}
         />,
         hasValidTimeField && (
           <FullTimeRangeSelector

--- a/x-pack/platform/plugins/shared/aiops/public/hooks/use_cases_modal.ts
+++ b/x-pack/platform/plugins/shared/aiops/public/hooks/use_cases_modal.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { stringHash } from '@kbn/ml-string-hash';
 import { AttachmentType } from '@kbn/cases-plugin/common';
+import { i18n } from '@kbn/i18n';
 import type { ChangePointEmbeddableRuntimeState } from '../embeddables/change_point_chart/types';
 import type { EmbeddableChangePointChartType } from '../embeddables/change_point_chart/embeddable_change_point_chart_factory';
 import { useAiopsAppContext } from './use_aiops_app_context';
@@ -34,11 +35,23 @@ type EmbeddableRuntimeState<T extends SupportedEmbeddableTypes> =
  * Returns a callback for opening the cases modal with provided attachment state.
  */
 export const useCasesModal = <EmbeddableType extends SupportedEmbeddableTypes>(
-  embeddableType: EmbeddableType
+  embeddableType: EmbeddableType,
+  title: string
 ) => {
   const { cases } = useAiopsAppContext();
 
-  const selectCaseModal = cases?.hooks.useCasesAddToExistingCaseModal();
+  const successMessage = useMemo(() => {
+    return i18n.translate('xpack.aiops.useCasesModal.successMessage', {
+      defaultMessage: '{title} added to case.',
+      values: { title },
+    });
+  }, [title]);
+
+  const selectCaseModal = cases?.hooks.useCasesAddToExistingCaseModal({
+    successToaster: {
+      content: successMessage,
+    },
+  });
 
   return useCallback(
     (persistableState: Partial<Omit<EmbeddableRuntimeState<EmbeddableType>, 'id'>>) => {
@@ -64,7 +77,6 @@ export const useCasesModal = <EmbeddableType extends SupportedEmbeddableTypes>(
         ],
       });
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [embeddableType]
+    [embeddableType, selectCaseModal]
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/common/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/translations.ts
@@ -319,7 +319,7 @@ export const LINK_APPROPRIATE_LICENSE = i18n.translate('xpack.cases.common.appro
 export const CASE_SUCCESS_TOAST = (title: string) =>
   i18n.translate('xpack.cases.actions.caseSuccessToast', {
     values: { title },
-    defaultMessage: '{title} has been updated',
+    defaultMessage: 'Case {title} updated',
   });
 
 export const CASE_ALERT_SUCCESS_TOAST = (title: string, quantity: number = 1) =>

--- a/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.test.tsx
@@ -144,7 +144,7 @@ describe('Use cases toast hook', () => {
           theCase: mockCase,
           attachments: [basicComment as SupportedCaseAttachment],
         });
-        validateTitle('Another horrible breach!! has been updated');
+        validateTitle('Case Another horrible breach!! updated');
       });
     });
 

--- a/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/common/use_cases_toast.tsx
@@ -6,7 +6,14 @@
  */
 
 import type { ErrorToastOptions } from '@kbn/core/public';
-import { EuiButtonEmpty, EuiText, logicalCSS, useEuiTheme } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  logicalCSS,
+  useEuiTheme,
+} from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import { toMountPoint } from '@kbn/react-kibana-mount';
@@ -203,14 +210,17 @@ export const CaseToastSuccessContent = ({
         </EuiText>
       ) : null}
       {onViewCaseClick !== undefined ? (
-        <EuiButtonEmpty
-          size="xs"
-          flush="left"
-          onClick={onViewCaseClick}
-          data-test-subj="toaster-content-case-view-link"
-        >
-          {VIEW_CASE}
-        </EuiButtonEmpty>
+        <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              onClick={onViewCaseClick}
+              data-test-subj="toaster-content-case-view-link"
+            >
+              {VIEW_CASE}
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       ) : null}
     </>
   );

--- a/x-pack/platform/plugins/shared/ml/public/application/contexts/kibana/use_cases_modal.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/contexts/kibana/use_cases_modal.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { stringHash } from '@kbn/ml-string-hash';
 import { AttachmentType } from '@kbn/cases-plugin/common';
+import { i18n } from '@kbn/i18n';
 import { useMlKibana } from './kibana_context';
 import type { MappedEmbeddableTypeOf, MlEmbeddableTypes } from '../../../embeddables';
 
@@ -15,13 +16,25 @@ import type { MappedEmbeddableTypeOf, MlEmbeddableTypes } from '../../../embedda
  * Returns a callback for opening the cases modal with provided attachment state.
  */
 export const useCasesModal = <EmbeddableType extends MlEmbeddableTypes>(
-  embeddableType: EmbeddableType
+  embeddableType: EmbeddableType,
+  title: string
 ) => {
   const {
     services: { cases },
   } = useMlKibana();
 
-  const selectCaseModal = cases?.hooks.useCasesAddToExistingCaseModal();
+  const successMessage = useMemo(() => {
+    return i18n.translate('xpack.ml.useCasesModal.successMessage', {
+      defaultMessage: '{title} added to case.',
+      values: { title },
+    });
+  }, [title]);
+
+  const selectCaseModal = cases?.hooks.useCasesAddToExistingCaseModal({
+    successToaster: {
+      content: successMessage,
+    },
+  });
 
   return useCallback(
     (persistableState: Partial<Omit<MappedEmbeddableTypeOf<EmbeddableType>, 'id'>>) => {
@@ -48,7 +61,7 @@ export const useCasesModal = <EmbeddableType extends MlEmbeddableTypes>(
         ],
       });
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [embeddableType]
+
+    [embeddableType, selectCaseModal]
   );
 };

--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_context_menu.tsx
@@ -52,6 +52,7 @@ import { useMlKibana } from '../contexts/kibana';
 import type { AppStateSelectedCells, ExplorerJob } from './explorer_utils';
 import { getSelectionInfluencers, getSelectionTimeRange } from './explorer_utils';
 import { getDefaultExplorerChartsPanelTitle } from '../../embeddables/anomaly_charts/utils';
+import { CASES_TOAST_MESSAGES_TITLES } from '../../cases/constants';
 
 interface AnomalyContextMenuProps {
   selectedJobs: ExplorerJob[];
@@ -99,7 +100,10 @@ export const AnomalyContextMenu: FC<AnomalyContextMenuProps> = ({
     [setIsMenuOpen]
   );
 
-  const openCasesModal = useCasesModal(ANOMALY_EXPLORER_CHARTS_EMBEDDABLE_TYPE);
+  const openCasesModal = useCasesModal(
+    ANOMALY_EXPLORER_CHARTS_EMBEDDABLE_TYPE,
+    CASES_TOAST_MESSAGES_TITLES.ANOMALY_CHARTS(maxSeriesToPlot)
+  );
 
   const canEditDashboards = capabilities.dashboard?.createNew ?? false;
   const casesPrivileges = cases?.helpers.canUseCases();
@@ -266,6 +270,7 @@ export const AnomalyContextMenu: FC<AnomalyContextMenuProps> = ({
           />
         ),
         panel: 'addToDashboardPanel',
+        icon: 'dashboardApp',
         'data-test-subj': 'mlAnomalyAddChartsToDashboardButton',
       });
 
@@ -286,6 +291,7 @@ export const AnomalyContextMenu: FC<AnomalyContextMenuProps> = ({
         name: (
           <FormattedMessage id="xpack.ml.explorer.attachToCaseLabel" defaultMessage="Add to case" />
         ),
+        icon: 'casesApp',
         panel: 'addToCasePanel',
         'data-test-subj': 'mlAnomalyAttachChartsToCasesButton',
       });
@@ -329,6 +335,7 @@ export const AnomalyContextMenu: FC<AnomalyContextMenuProps> = ({
                   defaultMessage: 'Actions',
                 })}
                 color="text"
+                display="base"
                 iconType="boxesHorizontal"
                 onClick={setIsMenuOpen.bind(null, !isMenuOpen)}
                 data-test-subj="mlExplorerAnomalyPanelMenu"

--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_timeline.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_timeline.tsx
@@ -66,6 +66,7 @@ import { useAnomalyExplorerContext } from './anomaly_explorer_context';
 import { getTimeBoundsFromSelection } from './hooks/use_selected_cells';
 import { SwimLaneWrapper } from './alerts';
 import { Y_AXIS_LABEL_WIDTH } from './constants';
+import { CASES_TOAST_MESSAGES_TITLES } from '../../cases/constants';
 import type { ExplorerState } from './explorer_data';
 import { useJobSelection } from './hooks/use_job_selection';
 
@@ -187,7 +188,10 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
       [severityUpdate, swimLaneSeverity]
     );
 
-    const openCasesModalCallback = useCasesModal(ANOMALY_SWIMLANE_EMBEDDABLE_TYPE);
+    const openCasesModalCallback = useCasesModal(
+      ANOMALY_SWIMLANE_EMBEDDABLE_TYPE,
+      CASES_TOAST_MESSAGES_TITLES.ANOMALY_TIMELINE
+    );
 
     const openCasesModal = useCallback(
       (swimLaneType: SwimlaneType) => {
@@ -235,6 +239,7 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
             />
           ),
           panel: 'addToDashboardPanel',
+          icon: 'dashboardApp',
           'data-test-subj': 'mlAnomalyTimelinePanelAddToDashboardButton',
         });
 
@@ -280,6 +285,7 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
               defaultMessage="Add to case"
             />
           ),
+          icon: 'casesApp',
           'data-test-subj': 'mlAnomalyTimelinePanelAttachToCaseButton',
         });
 
@@ -428,6 +434,8 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
                         defaultMessage: 'Actions',
                       })}
                       color="text"
+                      display="base"
+                      isSelected={isMenuOpen}
                       iconType="boxesHorizontal"
                       onClick={setIsMenuOpen.bind(null, !isMenuOpen)}
                       data-test-subj="mlAnomalyTimelinePanelMenu"

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/forecasting_modal/forecast_button.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/forecasting_modal/forecast_button.tsx
@@ -20,6 +20,8 @@ export const ForecastButton: FC<Props> = ({ isDisabled, onClick, mode = 'full' }
   const Button = mode === 'full' ? EuiButton : EuiButtonEmpty;
   return (
     <Button
+      // Keep primary color for EmptyButton
+      color={mode === 'full' ? 'text' : 'primary'}
       onClick={onClick}
       isDisabled={isDisabled}
       data-test-subj="mlSingleMetricViewerButtonForecast"

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/series_controls/series_controls.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/series_controls/series_controls.tsx
@@ -321,8 +321,8 @@ export const SeriesControls: FC<PropsWithChildren<SeriesControlsProps>> = ({
 
   return (
     <div data-test-subj="mlSingleMetricViewerSeriesControls">
-      <EuiFlexGroup direction={direction}>
-        <EuiFlexItem grow={false}>
+      <EuiFlexGroup direction={direction} gutterSize="s" wrap={true}>
+        <EuiFlexItem grow={false} css={{ minWidth: '200px' }}>
           <EuiFormRow
             label={
               <FormattedMessage

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/timeseriesexplorer_controls/timeseriesexplorer_controls.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/timeseriesexplorer_controls/timeseriesexplorer_controls.tsx
@@ -14,6 +14,7 @@ import {
   EuiContextMenu,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiFormRow,
   EuiPopover,
   htmlIdGenerator,
 } from '@elastic/eui';
@@ -25,6 +26,9 @@ import {
   withSuspense,
 } from '@kbn/presentation-util-plugin/public';
 import { useTimeRangeUpdates } from '@kbn/ml-date-picker';
+import type { MlJobState } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { CASES_TOAST_MESSAGES_TITLES } from '../../../../cases/constants';
+import type { CombinedJobWithStats } from '../../../../../server/shared';
 import type { JobId } from '../../../../../common/types/anomaly_detection_jobs/job';
 import { useMlKibana } from '../../../contexts/kibana';
 import { useCasesModal } from '../../../contexts/kibana/use_cases_modal';
@@ -32,12 +36,13 @@ import { getDefaultSingleMetricViewerPanelTitle } from '../../../../embeddables/
 import type { MlEntity } from '../../../../embeddables';
 import { ANOMALY_SINGLE_METRIC_VIEWER_EMBEDDABLE_TYPE } from '../../../../embeddables/constants';
 import type { SingleMetricViewerEmbeddableState } from '../../../../embeddables/types';
+import { ForecastingModal } from '../forecasting_modal/forecasting_modal';
+import type { Entity } from '../entity_control/entity_control';
 
 interface Props {
   forecastId?: string;
   selectedDetectorIndex: number;
   selectedEntities?: MlEntity;
-  selectedJobId: JobId;
   showAnnotationsCheckbox: boolean;
   showAnnotations: boolean;
   showForecastCheckbox: boolean;
@@ -47,6 +52,17 @@ interface Props {
   onShowModelBoundsChange: () => void;
   onShowAnnotationsChange: () => void;
   onShowForecastChange: () => void;
+  fullRefresh: boolean;
+  loading: boolean;
+  hasResults: boolean;
+  selectedJob: CombinedJobWithStats;
+  selectedJobId: string;
+  jobs: CombinedJobWithStats[];
+  setForecastId: (forecastId: string) => void;
+  entities: Entity[];
+  jobState: MlJobState;
+  earliestRecordTimestamp: number;
+  latestRecordTimestamp: number;
 }
 
 const SavedObjectSaveModalDashboard = withSuspense(LazySavedObjectSaveModalDashboard);
@@ -74,6 +90,16 @@ export const TimeSeriesExplorerControls: FC<Props> = ({
   onShowAnnotationsChange,
   onShowModelBoundsChange,
   onShowForecastChange,
+  fullRefresh,
+  loading,
+  hasResults,
+  setForecastId,
+  selectedJob,
+  entities,
+  jobs,
+  jobState,
+  earliestRecordTimestamp,
+  latestRecordTimestamp,
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const [createInDashboard, setCreateInDashboard] = useState<boolean>(false);
@@ -100,7 +126,13 @@ export const TimeSeriesExplorerControls: FC<Props> = ({
     [setIsMenuOpen]
   );
 
-  const openCasesModalCallback = useCasesModal(ANOMALY_SINGLE_METRIC_VIEWER_EMBEDDABLE_TYPE);
+  const openCasesModalCallback = useCasesModal(
+    ANOMALY_SINGLE_METRIC_VIEWER_EMBEDDABLE_TYPE,
+    CASES_TOAST_MESSAGES_TITLES.SINGLE_METRIC_VIEWER
+  );
+
+  const showControls =
+    (fullRefresh === false || loading === false) && hasResults === true && jobs.length > 0;
 
   const menuPanels: EuiContextMenuPanelDescriptor[] = [
     {
@@ -113,6 +145,7 @@ export const TimeSeriesExplorerControls: FC<Props> = ({
               defaultMessage="Add to dashboard"
             />
           ),
+          icon: 'dashboardApp',
           onClick: closePopoverOnAction(() => {
             setCreateInDashboard(true);
           }),
@@ -131,6 +164,7 @@ export const TimeSeriesExplorerControls: FC<Props> = ({
           defaultMessage="Add to case"
         />
       ),
+      icon: 'casesApp',
       onClick: closePopoverOnAction(() => {
         openCasesModalCallback({
           forecastId,
@@ -175,72 +209,101 @@ export const TimeSeriesExplorerControls: FC<Props> = ({
 
   return (
     <>
-      <EuiFlexGroup style={{ float: 'right' }} alignItems="center">
-        {showModelBoundsCheckbox && (
-          <EuiFlexItem grow={false}>
-            <EuiCheckbox
-              id="toggleModelBoundsCheckbox"
-              label={i18n.translate('xpack.ml.timeSeriesExplorer.showModelBoundsLabel', {
-                defaultMessage: 'show model bounds',
-              })}
-              checked={showModelBounds}
-              onChange={onShowModelBoundsChange}
-            />
+      <EuiFlexGroup
+        style={{ float: 'right' }}
+        alignItems="center"
+        justifyContent="flexEnd"
+        gutterSize="s"
+      >
+        {showModelBoundsCheckbox && showControls && (
+          <EuiFlexItem grow={false} css={{ minWidth: '170px' }}>
+            <EuiFormRow hasEmptyLabelSpace>
+              <EuiCheckbox
+                id="toggleModelBoundsCheckbox"
+                label={i18n.translate('xpack.ml.timeSeriesExplorer.showModelBoundsLabel', {
+                  defaultMessage: 'show model bounds',
+                })}
+                checked={showModelBounds}
+                onChange={onShowModelBoundsChange}
+              />
+            </EuiFormRow>
           </EuiFlexItem>
         )}
 
-        {showAnnotationsCheckbox && (
+        {showAnnotationsCheckbox && showControls && (
           <EuiFlexItem grow={false}>
-            <EuiCheckbox
-              id="toggleAnnotationsCheckbox"
-              label={i18n.translate('xpack.ml.timeSeriesExplorer.annotationsLabel', {
-                defaultMessage: 'annotations',
-              })}
-              checked={showAnnotations}
-              onChange={onShowAnnotationsChange}
-            />
+            <EuiFormRow hasEmptyLabelSpace>
+              <EuiCheckbox
+                id="toggleAnnotationsCheckbox"
+                label={i18n.translate('xpack.ml.timeSeriesExplorer.annotationsLabel', {
+                  defaultMessage: 'annotations',
+                })}
+                checked={showAnnotations}
+                onChange={onShowAnnotationsChange}
+              />
+            </EuiFormRow>
           </EuiFlexItem>
         )}
 
-        {showForecastCheckbox && (
-          <EuiFlexItem grow={false}>
-            <EuiCheckbox
-              id="toggleShowForecastCheckbox"
-              label={
-                <span data-test-subj={'mlForecastCheckbox'}>
-                  {i18n.translate('xpack.ml.timeSeriesExplorer.showForecastLabel', {
-                    defaultMessage: 'show forecast',
-                  })}
-                </span>
-              }
-              checked={showForecast}
-              onChange={onShowForecastChange}
-            />
+        {showForecastCheckbox && showControls && (
+          <EuiFlexItem grow={false} css={{ minWidth: '120px' }}>
+            <EuiFormRow hasEmptyLabelSpace>
+              <EuiCheckbox
+                id="toggleShowForecastCheckbox"
+                label={
+                  <span data-test-subj={'mlForecastCheckbox'}>
+                    {i18n.translate('xpack.ml.timeSeriesExplorer.showForecastLabel', {
+                      defaultMessage: 'show forecast',
+                    })}
+                  </span>
+                }
+                checked={showForecast}
+                onChange={onShowForecastChange}
+              />
+            </EuiFormRow>
           </EuiFlexItem>
         )}
 
-        {canEditDashboards ? (
-          <EuiFlexItem grow={false} css={{ marginLeft: 'auto !important', alignSelf: 'baseline' }}>
-            <EuiPopover
-              button={
-                <EuiButtonIcon
-                  size="s"
-                  aria-label={i18n.translate('xpack.ml.explorer.swimlaneActions', {
-                    defaultMessage: 'Actions',
-                  })}
-                  color="text"
-                  iconType="boxesHorizontal"
-                  onClick={setIsMenuOpen.bind(null, !isMenuOpen)}
-                  data-test-subj="mlAnomalyTimelinePanelMenu"
-                />
-              }
-              isOpen={isMenuOpen}
-              closePopover={setIsMenuOpen.bind(null, false)}
-              panelPaddingSize="none"
-              anchorPosition="downLeft"
-            >
-              <EuiContextMenu initialPanelId={0} panels={menuPanels} />
-            </EuiPopover>
+        <EuiFormRow hasEmptyLabelSpace>
+          <ForecastingModal
+            job={selectedJob}
+            jobState={jobState}
+            detectorIndex={selectedDetectorIndex}
+            entities={entities}
+            earliestRecordTimestamp={earliestRecordTimestamp}
+            latestRecordTimestamp={latestRecordTimestamp}
+            setForecastId={setForecastId}
+            className="forecast-controls"
+            selectedForecastId={forecastId}
+          />
+        </EuiFormRow>
+
+        {canEditDashboards && showControls ? (
+          <EuiFlexItem grow={false}>
+            <EuiFormRow hasEmptyLabelSpace>
+              <EuiPopover
+                button={
+                  <EuiButtonIcon
+                    aria-label={i18n.translate('xpack.ml.explorer.swimlaneActions', {
+                      defaultMessage: 'Actions',
+                    })}
+                    color="text"
+                    display="base"
+                    isSelected={isMenuOpen}
+                    iconType="boxesHorizontal"
+                    onClick={setIsMenuOpen.bind(null, !isMenuOpen)}
+                    data-test-subj="mlAnomalyTimelinePanelMenu"
+                    size="m"
+                  />
+                }
+                isOpen={isMenuOpen}
+                closePopover={setIsMenuOpen.bind(null, false)}
+                panelPaddingSize="none"
+                anchorPosition="downLeft"
+              >
+                <EuiContextMenu initialPanelId={0} panels={menuPanels} />
+              </EuiPopover>
+            </EuiFormRow>
           </EuiFlexItem>
         ) : null}
       </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer.js
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/timeseriesexplorer.js
@@ -28,7 +28,6 @@ import {
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
   EuiSpacer,
   EuiPanel,
   EuiTitle,
@@ -64,7 +63,6 @@ import { mlJobServiceFactory } from '../services/job_service';
 import { mlResultsServiceProvider } from '../services/results_service';
 import { toastNotificationServiceProvider } from '../services/toast_notification_service';
 
-import { ForecastingModal } from './components/forecasting_modal/forecasting_modal';
 import { TimeseriesexplorerNoChartData } from './components/timeseriesexplorer_no_chart_data';
 import { TimeSeriesExplorerPage } from './timeseriesexplorer_page';
 import { TimeSeriesExplorerHelpPopover } from './timeseriesexplorer_help_popover';
@@ -1080,20 +1078,34 @@ export class TimeSeriesExplorer extends React.Component {
           setFunctionDescription={this.setFunctionDescription}
         >
           {arePartitioningFieldsProvided && (
-            <EuiFlexItem style={{ textAlign: 'right' }}>
-              <EuiFormRow hasEmptyLabelSpace style={{ maxWidth: '100%' }}>
-                <ForecastingModal
-                  job={selectedJob}
-                  jobState={selectedJob.state}
-                  detectorIndex={selectedDetectorIndex}
-                  entities={entityControls}
-                  earliestRecordTimestamp={selectedJob.data_counts.earliest_record_timestamp}
-                  latestRecordTimestamp={selectedJob.data_counts.latest_record_timestamp}
-                  setForecastId={this.setForecastId}
-                  className="forecast-controls"
-                  selectedForecastId={this.props.selectedForecastId}
-                />
-              </EuiFormRow>
+            <EuiFlexItem>
+              <TimeSeriesExplorerControls
+                forecastId={this.props.selectedForecastId}
+                selectedDetectorIndex={selectedDetectorIndex}
+                selectedEntities={selectedEntities}
+                selectedJob={selectedJob}
+                showAnnotationsCheckbox={showAnnotationsCheckbox}
+                showAnnotations={showAnnotations}
+                showForecastCheckbox={showForecastCheckbox}
+                showForecast={showForecast}
+                showModelBoundsCheckbox={showModelBoundsCheckbox}
+                showModelBounds={showModelBounds}
+                onShowModelBoundsChange={this.toggleShowModelBoundsHandler}
+                onShowAnnotationsChange={this.toggleShowAnnotationsHandler}
+                onShowForecastChange={this.toggleShowForecastHandler}
+                fullRefresh={fullRefresh}
+                loading={loading}
+                hasResults={hasResults}
+                setForecastId={this.setForecastId}
+                entities={entityControls}
+                jobs={jobs}
+                selectedJobId={selectedJobId}
+                // It seems like props below can be easily extracted from the selectedJob
+                // However, it seems like we are losing sync at some point and they need to be passed directly
+                jobState={selectedJob.state}
+                earliestRecordTimestamp={selectedJob.data_counts.earliest_record_timestamp}
+                latestRecordTimestamp={selectedJob.data_counts.latest_record_timestamp}
+              />
             </EuiFlexItem>
           )}
         </SeriesControls>
@@ -1190,22 +1202,6 @@ export class TimeSeriesExplorer extends React.Component {
                   <TimeSeriesExplorerHelpPopover />
                 </EuiFlexItem>
               </EuiFlexGroup>
-
-              <TimeSeriesExplorerControls
-                forecastId={this.props.selectedForecastId}
-                selectedDetectorIndex={selectedDetectorIndex}
-                selectedEntities={selectedEntities}
-                selectedJobId={selectedJobId}
-                showAnnotationsCheckbox={showAnnotationsCheckbox}
-                showAnnotations={showAnnotations}
-                showForecastCheckbox={showForecastCheckbox}
-                showForecast={showForecast}
-                showModelBoundsCheckbox={showModelBoundsCheckbox}
-                showModelBounds={showModelBounds}
-                onShowModelBoundsChange={this.toggleShowModelBoundsHandler}
-                onShowAnnotationsChange={this.toggleShowAnnotationsHandler}
-                onShowForecastChange={this.toggleShowForecastHandler}
-              />
 
               <TimeSeriesChartWithTooltips
                 chartProps={chartProps}

--- a/x-pack/platform/plugins/shared/ml/public/cases/constants.ts
+++ b/x-pack/platform/plugins/shared/ml/public/cases/constants.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+/**
+ * Titles for the cases toast messages
+ */
+export const CASES_TOAST_MESSAGES_TITLES = {
+  ANOMALY_TIMELINE: i18n.translate('xpack.ml.cases.anomalyTimelineTitle', {
+    defaultMessage: 'Anomaly timeline',
+  }),
+  ANOMALY_CHARTS: (chartsCount: number) =>
+    i18n.translate('xpack.ml.cases.anomalyChartsTitle', {
+      defaultMessage: 'Anomaly {chartsCount, plural, one {chart} other {charts}}',
+      values: {
+        chartsCount,
+      },
+    }),
+  SINGLE_METRIC_VIEWER: i18n.translate('xpack.ml.cases.singleMetricViewerTitle', {
+    defaultMessage: 'Single metric viewer',
+  }),
+};

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/attachment_framework.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/attachment_framework.ts
@@ -255,7 +255,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
              * The flyout close automatically after submitting a case
              */
             await cases.create.createCase({ owner });
-            await cases.common.expectToasterToContain('has been updated');
+            await cases.common.expectToasterToContain('updated');
             await toasts.dismissAllWithChecks();
           }
 
@@ -352,7 +352,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
             await cases.casesTable.getCaseById(currentCaseId);
             await testSubjects.click(`cases-table-row-select-${currentCaseId}`);
 
-            await cases.common.expectToasterToContain('has been updated');
+            await cases.common.expectToasterToContain('updated');
             await toasts.dismissAllWithChecks();
             await ensureFirstCommentOwner(currentCaseId, owner);
           }
@@ -412,7 +412,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         });
         await testSubjects.click('create-case-submit');
 
-        await cases.common.expectToasterToContain(`${caseTitle} has been updated`);
+        await cases.common.expectToasterToContain(`Case ${caseTitle} updated`);
         await testSubjects.click('toaster-content-case-view-link');
         await toasts.dismissAllWithChecks();
 
@@ -438,7 +438,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         await testSubjects.click(`cases-table-row-select-${theCase.id}`);
 
-        await cases.common.expectToasterToContain(`${theCaseTitle} has been updated`);
+        await cases.common.expectToasterToContain(`Case ${theCaseTitle} updated`);
         await testSubjects.click('toaster-content-case-view-link');
         await toasts.dismissAllWithChecks();
 

--- a/x-pack/test_serverless/functional/test_suites/observability/cases/attachment_framework.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/cases/attachment_framework.ts
@@ -82,7 +82,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await testSubjects.missingOrFail('caseOwnerSelector');
         await testSubjects.click('create-case-submit');
 
-        await cases.common.expectToasterToContain(`${caseTitle} has been updated`);
+        await cases.common.expectToasterToContain(`Case ${caseTitle} updated`);
         await testSubjects.click('toaster-content-case-view-link');
         await toasts.dismissAllWithChecks();
 
@@ -115,7 +115,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         await testSubjects.click(`cases-table-row-select-${theCase.id}`);
 
-        await cases.common.expectToasterToContain(`${theCaseTitle} has been updated`);
+        await cases.common.expectToasterToContain(`Case ${theCaseTitle} updated`);
         await testSubjects.click('toaster-content-case-view-link');
         await toasts.dismissAllWithChecks();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ML][UX]: Consistent Layout and UI Enhancements for ML Pages (#203813)](https://github.com/elastic/kibana/pull/203813)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Robert Jaszczurek","email":"92210485+rbrtj@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-12-23T10:56:12Z","message":"[ML][UX]: Consistent Layout and UI Enhancements for ML Pages (#203813)\n\n## Summary\n\n* Updated alignment for `Add to` action buttons across various ML pages\n- see: #184109\n* Fixed the overflowing date picker on `Anomaly Detection` pages - see:\n[#204394](https://github.com/elastic/kibana/issues/204394)\n* Standardized gaps around items on pages to maintain consistent values\nof `8px` (`gutterSize = 's'`)\n* Fixed the header on the Data Visualizer page - see:\n[#204393](https://github.com/elastic/kibana/issues/204393)\n* Adjusted the layout for Change Point Detection\n* Updated toast messages & toast action button - see: #184109\n* Added icons for attachments actions\n\nExploration around new `Add to` actions buttons - the right column is\nthe most recent one, see: #184109 :\n\n| Before  | After (add_to button) | After (icon button) - current |\n| ------------- | ------------- | ------------- |\n| ![Screenshot 2024-12-12 at 11 45\n14](https://github.com/user-attachments/assets/08dc0be5-0b98-481d-9906-d3434f03f634)\n| ![Screenshot 2024-12-12 at 11 37\n38](https://github.com/user-attachments/assets/0b2cbdcd-cad0-49aa-842f-123eebec1716)\n| ![Screenshot 2024-12-12 at 12 42\n58](https://github.com/user-attachments/assets/c0a0c732-bbc0-4007-998e-df413fae612b)\n|\n| ![Screenshot 2024-12-12 at 11 45\n49](https://github.com/user-attachments/assets/9ff45cf8-1c24-4ef4-ab59-2b54f1569c6e)\n| ![Screenshot 2024-12-12 at 11 39\n34](https://github.com/user-attachments/assets/293255eb-eba5-4d90-a10b-0f41de0cc195)\n| ![Screenshot 2024-12-12 at 12 44\n58](https://github.com/user-attachments/assets/740da2fb-ceed-4e6a-add6-9a8d695776a6)\n|\n| ![Screenshot 2024-12-12 at 11 46\n30](https://github.com/user-attachments/assets/71cea9f4-7658-4776-865d-0f7c5682e67a)\n| ![Screenshot 2024-12-12 at 11 40\n18](https://github.com/user-attachments/assets/b03e8a75-68d3-4c26-942c-1d41072a62ee)\n|\n![image](https://github.com/user-attachments/assets/6a259924-7081-426c-8bd2-346e4f0ae152)\n|\n| ![Screenshot 2024-12-12 at 11 48\n07](https://github.com/user-attachments/assets/2b340d38-26a5-45bc-851e-8b1956503500)\n| ![Screenshot 2024-12-12 at 11 42\n03](https://github.com/user-attachments/assets/ecef0b37-a43c-42a3-911f-31d4acf9ac7b)\n| ![Screenshot 2024-12-12 at 12 46\n14](https://github.com/user-attachments/assets/f9dddfe0-7296-4394-bb2f-94d702361f49)\n|\n| ![Screenshot 2024-12-12 at 11 49\n05](https://github.com/user-attachments/assets/d670ad40-58d4-40fb-a88d-7ac5e6c1fbbd)\n| ![Screenshot 2024-12-12 at 11 43\n40](https://github.com/user-attachments/assets/856f9476-c6ff-4405-8865-fb8784f3d818)\n|\n![image](https://github.com/user-attachments/assets/b18f624b-e648-403f-9595-442b2723bdde)\n|\n\nToasts:\n| Before | After |\n| ------ | ------ | \n| <img width=\"376\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c58000c2-30d4-4312-be53-0e3e9a6e3ae6\"\n/> |\n![image](https://github.com/user-attachments/assets/36955456-026a-4abe-b872-c72c115a2dbe)\n|\n\n\n\nOther changes:\n\n| Before | After |\n| ------ | ------ | \n| ![Screenshot 2024-12-13 at 17 57\n36](https://github.com/user-attachments/assets/263940ea-9396-4f82-b14e-c9086c6d36e8)\n| ![Screenshot 2024-12-13 at 18 00\n26](https://github.com/user-attachments/assets/49430be4-356b-4902-b855-7fc1b252fbdb)\n|\n| ![Screenshot 2024-12-13 at 18 06\n59](https://github.com/user-attachments/assets/67ad0faf-42f7-44e1-9290-857e28a9d5e4)\n| ![Screenshot 2024-12-13 at 18 02\n04](https://github.com/user-attachments/assets/357d7296-7b5f-4df5-b664-8bd99c93205b)\n|\n| ![Screenshot 2024-12-13 at 18 08\n20](https://github.com/user-attachments/assets/819a7c33-9c7a-4423-be1b-cbec30dd8a97)\n| ![Screenshot 2024-12-13 at 18 09\n30](https://github.com/user-attachments/assets/c4b3cb40-f572-4828-888b-4cfff6b565b9)\n|\n| ![Screenshot 2024-12-13 at 18 11\n52](https://github.com/user-attachments/assets/c63ccdf3-aeaa-4047-a3b5-f67c11690020)\n| ![Screenshot 2024-12-13 at 18 10\n34](https://github.com/user-attachments/assets/6a6343d5-a7f7-45da-bf40-46b14b257e41)\n|\n| ![Screenshot 2024-12-13 at 18 30\n32](https://github.com/user-attachments/assets/7aa13ad8-ba6f-4801-b0fe-ff90dd9038c1)\n| ![Screenshot 2024-12-13 at 18 32\n59](https://github.com/user-attachments/assets/17774c78-003d-46fd-b7bb-d21cdee7df47)\n|\n| ![Screenshot 2024-12-13 at 18 35\n56](https://github.com/user-attachments/assets/b7b003c6-11a6-4a1d-97c2-c1b920c0fd1a)\n| ![Screenshot 2024-12-13 at 18 34\n25](https://github.com/user-attachments/assets/5af49323-cb9c-433d-aa6f-91af21dfa5bf)\n|\n| <img width=\"342\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6529eebe-510e-4688-81e6-4cf3e880c610\"\n/> | <img width=\"323\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6dada83e-252f-45d5-95d2-a03fa856d70a\"\n/> |\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0cc887be92df434671ad37fe89cb4ebcc0d5af3d","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement",":ml","backport missing","v9.0.0","Team:ML","backport:version","v8.18.0"],"number":203813,"url":"https://github.com/elastic/kibana/pull/203813","mergeCommit":{"message":"[ML][UX]: Consistent Layout and UI Enhancements for ML Pages (#203813)\n\n## Summary\n\n* Updated alignment for `Add to` action buttons across various ML pages\n- see: #184109\n* Fixed the overflowing date picker on `Anomaly Detection` pages - see:\n[#204394](https://github.com/elastic/kibana/issues/204394)\n* Standardized gaps around items on pages to maintain consistent values\nof `8px` (`gutterSize = 's'`)\n* Fixed the header on the Data Visualizer page - see:\n[#204393](https://github.com/elastic/kibana/issues/204393)\n* Adjusted the layout for Change Point Detection\n* Updated toast messages & toast action button - see: #184109\n* Added icons for attachments actions\n\nExploration around new `Add to` actions buttons - the right column is\nthe most recent one, see: #184109 :\n\n| Before  | After (add_to button) | After (icon button) - current |\n| ------------- | ------------- | ------------- |\n| ![Screenshot 2024-12-12 at 11 45\n14](https://github.com/user-attachments/assets/08dc0be5-0b98-481d-9906-d3434f03f634)\n| ![Screenshot 2024-12-12 at 11 37\n38](https://github.com/user-attachments/assets/0b2cbdcd-cad0-49aa-842f-123eebec1716)\n| ![Screenshot 2024-12-12 at 12 42\n58](https://github.com/user-attachments/assets/c0a0c732-bbc0-4007-998e-df413fae612b)\n|\n| ![Screenshot 2024-12-12 at 11 45\n49](https://github.com/user-attachments/assets/9ff45cf8-1c24-4ef4-ab59-2b54f1569c6e)\n| ![Screenshot 2024-12-12 at 11 39\n34](https://github.com/user-attachments/assets/293255eb-eba5-4d90-a10b-0f41de0cc195)\n| ![Screenshot 2024-12-12 at 12 44\n58](https://github.com/user-attachments/assets/740da2fb-ceed-4e6a-add6-9a8d695776a6)\n|\n| ![Screenshot 2024-12-12 at 11 46\n30](https://github.com/user-attachments/assets/71cea9f4-7658-4776-865d-0f7c5682e67a)\n| ![Screenshot 2024-12-12 at 11 40\n18](https://github.com/user-attachments/assets/b03e8a75-68d3-4c26-942c-1d41072a62ee)\n|\n![image](https://github.com/user-attachments/assets/6a259924-7081-426c-8bd2-346e4f0ae152)\n|\n| ![Screenshot 2024-12-12 at 11 48\n07](https://github.com/user-attachments/assets/2b340d38-26a5-45bc-851e-8b1956503500)\n| ![Screenshot 2024-12-12 at 11 42\n03](https://github.com/user-attachments/assets/ecef0b37-a43c-42a3-911f-31d4acf9ac7b)\n| ![Screenshot 2024-12-12 at 12 46\n14](https://github.com/user-attachments/assets/f9dddfe0-7296-4394-bb2f-94d702361f49)\n|\n| ![Screenshot 2024-12-12 at 11 49\n05](https://github.com/user-attachments/assets/d670ad40-58d4-40fb-a88d-7ac5e6c1fbbd)\n| ![Screenshot 2024-12-12 at 11 43\n40](https://github.com/user-attachments/assets/856f9476-c6ff-4405-8865-fb8784f3d818)\n|\n![image](https://github.com/user-attachments/assets/b18f624b-e648-403f-9595-442b2723bdde)\n|\n\nToasts:\n| Before | After |\n| ------ | ------ | \n| <img width=\"376\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c58000c2-30d4-4312-be53-0e3e9a6e3ae6\"\n/> |\n![image](https://github.com/user-attachments/assets/36955456-026a-4abe-b872-c72c115a2dbe)\n|\n\n\n\nOther changes:\n\n| Before | After |\n| ------ | ------ | \n| ![Screenshot 2024-12-13 at 17 57\n36](https://github.com/user-attachments/assets/263940ea-9396-4f82-b14e-c9086c6d36e8)\n| ![Screenshot 2024-12-13 at 18 00\n26](https://github.com/user-attachments/assets/49430be4-356b-4902-b855-7fc1b252fbdb)\n|\n| ![Screenshot 2024-12-13 at 18 06\n59](https://github.com/user-attachments/assets/67ad0faf-42f7-44e1-9290-857e28a9d5e4)\n| ![Screenshot 2024-12-13 at 18 02\n04](https://github.com/user-attachments/assets/357d7296-7b5f-4df5-b664-8bd99c93205b)\n|\n| ![Screenshot 2024-12-13 at 18 08\n20](https://github.com/user-attachments/assets/819a7c33-9c7a-4423-be1b-cbec30dd8a97)\n| ![Screenshot 2024-12-13 at 18 09\n30](https://github.com/user-attachments/assets/c4b3cb40-f572-4828-888b-4cfff6b565b9)\n|\n| ![Screenshot 2024-12-13 at 18 11\n52](https://github.com/user-attachments/assets/c63ccdf3-aeaa-4047-a3b5-f67c11690020)\n| ![Screenshot 2024-12-13 at 18 10\n34](https://github.com/user-attachments/assets/6a6343d5-a7f7-45da-bf40-46b14b257e41)\n|\n| ![Screenshot 2024-12-13 at 18 30\n32](https://github.com/user-attachments/assets/7aa13ad8-ba6f-4801-b0fe-ff90dd9038c1)\n| ![Screenshot 2024-12-13 at 18 32\n59](https://github.com/user-attachments/assets/17774c78-003d-46fd-b7bb-d21cdee7df47)\n|\n| ![Screenshot 2024-12-13 at 18 35\n56](https://github.com/user-attachments/assets/b7b003c6-11a6-4a1d-97c2-c1b920c0fd1a)\n| ![Screenshot 2024-12-13 at 18 34\n25](https://github.com/user-attachments/assets/5af49323-cb9c-433d-aa6f-91af21dfa5bf)\n|\n| <img width=\"342\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6529eebe-510e-4688-81e6-4cf3e880c610\"\n/> | <img width=\"323\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6dada83e-252f-45d5-95d2-a03fa856d70a\"\n/> |\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0cc887be92df434671ad37fe89cb4ebcc0d5af3d"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203813","number":203813,"mergeCommit":{"message":"[ML][UX]: Consistent Layout and UI Enhancements for ML Pages (#203813)\n\n## Summary\n\n* Updated alignment for `Add to` action buttons across various ML pages\n- see: #184109\n* Fixed the overflowing date picker on `Anomaly Detection` pages - see:\n[#204394](https://github.com/elastic/kibana/issues/204394)\n* Standardized gaps around items on pages to maintain consistent values\nof `8px` (`gutterSize = 's'`)\n* Fixed the header on the Data Visualizer page - see:\n[#204393](https://github.com/elastic/kibana/issues/204393)\n* Adjusted the layout for Change Point Detection\n* Updated toast messages & toast action button - see: #184109\n* Added icons for attachments actions\n\nExploration around new `Add to` actions buttons - the right column is\nthe most recent one, see: #184109 :\n\n| Before  | After (add_to button) | After (icon button) - current |\n| ------------- | ------------- | ------------- |\n| ![Screenshot 2024-12-12 at 11 45\n14](https://github.com/user-attachments/assets/08dc0be5-0b98-481d-9906-d3434f03f634)\n| ![Screenshot 2024-12-12 at 11 37\n38](https://github.com/user-attachments/assets/0b2cbdcd-cad0-49aa-842f-123eebec1716)\n| ![Screenshot 2024-12-12 at 12 42\n58](https://github.com/user-attachments/assets/c0a0c732-bbc0-4007-998e-df413fae612b)\n|\n| ![Screenshot 2024-12-12 at 11 45\n49](https://github.com/user-attachments/assets/9ff45cf8-1c24-4ef4-ab59-2b54f1569c6e)\n| ![Screenshot 2024-12-12 at 11 39\n34](https://github.com/user-attachments/assets/293255eb-eba5-4d90-a10b-0f41de0cc195)\n| ![Screenshot 2024-12-12 at 12 44\n58](https://github.com/user-attachments/assets/740da2fb-ceed-4e6a-add6-9a8d695776a6)\n|\n| ![Screenshot 2024-12-12 at 11 46\n30](https://github.com/user-attachments/assets/71cea9f4-7658-4776-865d-0f7c5682e67a)\n| ![Screenshot 2024-12-12 at 11 40\n18](https://github.com/user-attachments/assets/b03e8a75-68d3-4c26-942c-1d41072a62ee)\n|\n![image](https://github.com/user-attachments/assets/6a259924-7081-426c-8bd2-346e4f0ae152)\n|\n| ![Screenshot 2024-12-12 at 11 48\n07](https://github.com/user-attachments/assets/2b340d38-26a5-45bc-851e-8b1956503500)\n| ![Screenshot 2024-12-12 at 11 42\n03](https://github.com/user-attachments/assets/ecef0b37-a43c-42a3-911f-31d4acf9ac7b)\n| ![Screenshot 2024-12-12 at 12 46\n14](https://github.com/user-attachments/assets/f9dddfe0-7296-4394-bb2f-94d702361f49)\n|\n| ![Screenshot 2024-12-12 at 11 49\n05](https://github.com/user-attachments/assets/d670ad40-58d4-40fb-a88d-7ac5e6c1fbbd)\n| ![Screenshot 2024-12-12 at 11 43\n40](https://github.com/user-attachments/assets/856f9476-c6ff-4405-8865-fb8784f3d818)\n|\n![image](https://github.com/user-attachments/assets/b18f624b-e648-403f-9595-442b2723bdde)\n|\n\nToasts:\n| Before | After |\n| ------ | ------ | \n| <img width=\"376\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c58000c2-30d4-4312-be53-0e3e9a6e3ae6\"\n/> |\n![image](https://github.com/user-attachments/assets/36955456-026a-4abe-b872-c72c115a2dbe)\n|\n\n\n\nOther changes:\n\n| Before | After |\n| ------ | ------ | \n| ![Screenshot 2024-12-13 at 17 57\n36](https://github.com/user-attachments/assets/263940ea-9396-4f82-b14e-c9086c6d36e8)\n| ![Screenshot 2024-12-13 at 18 00\n26](https://github.com/user-attachments/assets/49430be4-356b-4902-b855-7fc1b252fbdb)\n|\n| ![Screenshot 2024-12-13 at 18 06\n59](https://github.com/user-attachments/assets/67ad0faf-42f7-44e1-9290-857e28a9d5e4)\n| ![Screenshot 2024-12-13 at 18 02\n04](https://github.com/user-attachments/assets/357d7296-7b5f-4df5-b664-8bd99c93205b)\n|\n| ![Screenshot 2024-12-13 at 18 08\n20](https://github.com/user-attachments/assets/819a7c33-9c7a-4423-be1b-cbec30dd8a97)\n| ![Screenshot 2024-12-13 at 18 09\n30](https://github.com/user-attachments/assets/c4b3cb40-f572-4828-888b-4cfff6b565b9)\n|\n| ![Screenshot 2024-12-13 at 18 11\n52](https://github.com/user-attachments/assets/c63ccdf3-aeaa-4047-a3b5-f67c11690020)\n| ![Screenshot 2024-12-13 at 18 10\n34](https://github.com/user-attachments/assets/6a6343d5-a7f7-45da-bf40-46b14b257e41)\n|\n| ![Screenshot 2024-12-13 at 18 30\n32](https://github.com/user-attachments/assets/7aa13ad8-ba6f-4801-b0fe-ff90dd9038c1)\n| ![Screenshot 2024-12-13 at 18 32\n59](https://github.com/user-attachments/assets/17774c78-003d-46fd-b7bb-d21cdee7df47)\n|\n| ![Screenshot 2024-12-13 at 18 35\n56](https://github.com/user-attachments/assets/b7b003c6-11a6-4a1d-97c2-c1b920c0fd1a)\n| ![Screenshot 2024-12-13 at 18 34\n25](https://github.com/user-attachments/assets/5af49323-cb9c-433d-aa6f-91af21dfa5bf)\n|\n| <img width=\"342\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6529eebe-510e-4688-81e6-4cf3e880c610\"\n/> | <img width=\"323\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/6dada83e-252f-45d5-95d2-a03fa856d70a\"\n/> |\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0cc887be92df434671ad37fe89cb4ebcc0d5af3d"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->