### PR TITLE
fix: [Security:Rules:Detection Rules]Notify Bell button on installed rules table on Detection rules(siem) page is missing accessible discernible text

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
@@ -854,7 +854,7 @@ describe('Detections Rules API', () => {
       expect(fetchMock).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          body: '{"filter":"alert.id:\\"alert:id1\\" or alert.id:\\"alert:id2\\"","fields":"[\\"muteAll\\",\\"activeSnoozes\\",\\"isSnoozedUntil\\",\\"snoozeSchedule\\"]","per_page":2}',
+          body: '{"filter":"alert.id:\\"alert:id1\\" or alert.id:\\"alert:id2\\"","fields":"[\\"name\\",\\"muteAll\\",\\"activeSnoozes\\",\\"isSnoozedUntil\\",\\"snoozeSchedule\\"]","per_page":2}',
         })
       );
     });
@@ -865,7 +865,7 @@ describe('Detections Rules API', () => {
       expect(fetchMock).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          body: '{"filter":"alert.id:\\"alert:id1\\" or alert.id:\\"alert:id2\\"","fields":"[\\"muteAll\\",\\"activeSnoozes\\",\\"isSnoozedUntil\\",\\"snoozeSchedule\\"]","per_page":2}',
+          body: '{"filter":"alert.id:\\"alert:id1\\" or alert.id:\\"alert:id2\\"","fields":"[\\"name\\",\\"muteAll\\",\\"activeSnoozes\\",\\"isSnoozedUntil\\",\\"snoozeSchedule\\"]","per_page":2}',
         })
       );
     });
@@ -876,7 +876,7 @@ describe('Detections Rules API', () => {
       expect(fetchMock).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          body: '{"filter":"alert.id:\\"alert:id1\\" or alert.id:\\"alert:id2\\"","fields":"[\\"muteAll\\",\\"activeSnoozes\\",\\"isSnoozedUntil\\",\\"snoozeSchedule\\"]","per_page":2}',
+          body: '{"filter":"alert.id:\\"alert:id1\\" or alert.id:\\"alert:id2\\"","fields":"[\\"name\\",\\"muteAll\\",\\"activeSnoozes\\",\\"isSnoozedUntil\\",\\"snoozeSchedule\\"]","per_page":2}',
         })
       );
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
@@ -245,7 +245,13 @@ export const fetchRulesSnoozeSettings = async ({
       method: 'POST',
       body: JSON.stringify({
         filter: ids.map((x) => `alert.id:"alert:${x}"`).join(' or '),
-        fields: JSON.stringify(['muteAll', 'activeSnoozes', 'isSnoozedUntil', 'snoozeSchedule']),
+        fields: JSON.stringify([
+          'name',
+          'muteAll',
+          'activeSnoozes',
+          'isSnoozedUntil',
+          'snoozeSchedule',
+        ]),
         per_page: ids.length,
       }),
       signal,


### PR DESCRIPTION
Closes: #204483

Related to: https://github.com/elastic/kibana/pull/188075

## Description 

A similar issue was already fixed in https://github.com/elastic/kibana/pull/188075. To address #204483, we just need to restore the name from the fetchRulesSnoozeSettings request.

## Screen

<img width="1652" alt="image" src="https://github.com/user-attachments/assets/c3f6fcf6-6448-49cb-8e46-e840656417a6" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->