### PR TITLE
use info notice for color mode change notification toast

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/handle_system_colormode_change.test.ts
+++ b/packages/core/chrome/core-chrome-browser-internal/src/handle_system_colormode_change.test.ts
@@ -206,7 +206,7 @@ describe('handleSystemColorModeChange', () => {
           expect(notifications.toasts.addSuccess).not.toHaveBeenCalled();
           expect(type).toBe('change');
           cb({ matches: true } as any); // The system changed to dark mode
-          expect(notifications.toasts.addSuccess).toHaveBeenCalledWith(
+          expect(notifications.toasts.addInfo).toHaveBeenCalledWith(
             expect.objectContaining({
               text: expect.any(Function),
               title: 'System color mode updated',

--- a/packages/core/chrome/core-chrome-browser-internal/src/handle_system_colormode_change.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/handle_system_colormode_change.tsx
@@ -103,7 +103,7 @@ export async function handleSystemColorModeChange({
       // we actually apply set the dark/light color mode of the page.
       currentDarkModeValue = isDarkMode;
     } else if (currentDarkModeValue !== isDarkMode) {
-      notifications.toasts.addSuccess(
+      notifications.toasts.addInfo(
         {
           title: i18n.translate('core.ui.chrome.appearanceChange.successNotificationTitle', {
             defaultMessage: 'System color mode updated',


### PR DESCRIPTION
## Summary

This PR changes the toast notification for instances when the color mode changes from a toast that signifies a success operation to one that denotes the presentation of an information.

### Before
<img width="383" alt="Screenshot 2025-01-02 at 11 28 40" src="https://github.com/user-attachments/assets/ff1df992-4f9c-4454-8dca-5a816c5ddf55" />


### After
<img width="353" alt="Screenshot 2025-01-02 at 11 20 11" src="https://github.com/user-attachments/assets/f673edcc-ac07-4fdf-ba70-8491d75ffbe8" />



<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


-->


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->