### PR TITLE
[Authc] Security authentication config

### DIFF
--- a/src/core/packages/http/router-server-internal/src/request.test.ts
+++ b/src/core/packages/http/router-server-internal/src/request.test.ts
@@ -397,35 +397,6 @@ describe('CoreKibanaRequest', () => {
 
         expect(kibanaRequest.route.options.authRequired).toBe(true);
       });
-      it('handles required authc: { enabled: false }', () => {
-        const request = hapiMocks.createRequest({
-          route: {
-            settings: {
-              app: {
-                security: { authc: { enabled: false } },
-              },
-            },
-          },
-        });
-        const kibanaRequest = CoreKibanaRequest.from(request);
-
-        expect(kibanaRequest.route.options.authRequired).toBe(false);
-      });
-
-      it(`handles required authc: { enabled: 'optional' }`, () => {
-        const request = hapiMocks.createRequest({
-          route: {
-            settings: {
-              app: {
-                security: { authc: { enabled: 'optional' } },
-              },
-            },
-          },
-        });
-        const kibanaRequest = CoreKibanaRequest.from(request);
-
-        expect(kibanaRequest.route.options.authRequired).toBe('optional');
-      });
 
       it('handles required authz simple config', () => {
         const security: RouteSecurity = {

--- a/src/core/packages/http/router-server-internal/src/request.ts
+++ b/src/core/packages/http/router-server-internal/src/request.ts
@@ -328,12 +328,6 @@ export class CoreKibanaRequest<
       return true;
     }
 
-    const security = this.getSecurity(request);
-
-    if (security?.authc !== undefined) {
-      return security.authc?.enabled ?? true;
-    }
-
     const authOptions = request.route.settings.auth;
     if (typeof authOptions === 'object') {
       // 'try' is used in the legacy platform

--- a/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.test.ts
+++ b/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.test.ts
@@ -542,22 +542,19 @@ describe('Versioned route', () => {
       authz: {
         requiredPrivileges: ['foo', 'bar', 'baz'],
       },
+      authc: undefined,
     };
     const securityConfig1: RouteSecurity = {
       authz: {
         requiredPrivileges: ['foo'],
       },
-      authc: {
-        enabled: 'optional',
-      },
+      authc: undefined,
     };
     const securityConfig2: RouteSecurity = {
       authz: {
         requiredPrivileges: ['foo', 'bar'],
       },
-      authc: {
-        enabled: true,
-      },
+      authc: undefined,
     };
     const versionedRoute = versionedRouter
       .get({ path: '/test/{id}', access: 'internal', security: securityConfigDefault })

--- a/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.ts
+++ b/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.ts
@@ -302,9 +302,12 @@ export class CoreVersionedRoute implements VersionedRoute {
     return [...this.handlers.values()];
   }
 
-  public getSecurity: RouteSecurityGetter = (req: RequestLike) => {
-    const version = this.getVersion(req)!;
+  public getSecurity: RouteSecurityGetter = (req?: RequestLike) => {
+    if (!req) {
+      return this.defaultSecurityConfig;
+    }
 
+    const version = this.getVersion(req)!;
     const security = this.handlers.get(version)?.options.security ?? this.defaultSecurityConfig;
 
     // authc can be defined only on the top route level,

--- a/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.ts
+++ b/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.ts
@@ -305,6 +305,12 @@ export class CoreVersionedRoute implements VersionedRoute {
   public getSecurity: RouteSecurityGetter = (req: RequestLike) => {
     const version = this.getVersion(req)!;
 
-    return this.handlers.get(version)?.options.security ?? this.defaultSecurityConfig;
+    const security = this.handlers.get(version)?.options.security ?? this.defaultSecurityConfig;
+
+    // authc can be defined only on the top route level,
+    // so we need to merge it with the versioned one which can have different authz per version
+    return security
+      ? { authz: security.authz, authc: this.defaultSecurityConfig?.authc }
+      : undefined;
   };
 }

--- a/src/core/packages/http/server-internal/src/http_server.ts
+++ b/src/core/packages/http/server-internal/src/http_server.ts
@@ -742,13 +742,22 @@ export class HttpServer {
     });
   }
 
+  private getSecurity(route: RouterRoute) {
+    const securityConfig = route?.security;
+
+    // for versioned routes, we need to check if the security config is a function
+    return typeof securityConfig === 'function' ? securityConfig({ headers: {} }) : securityConfig;
+  }
+
   private configureRoute(route: RouterRoute) {
     const optionsLogger = this.log.get('options');
     this.log.debug(`registering route handler for [${route.path}]`);
     // Hapi does not allow payload validation to be specified for 'head' or 'get' requests
     const validate = isSafeMethod(route.method) ? undefined : { payload: true };
-    const { authRequired, tags, body = {}, timeout, deprecated } = route.options;
+    const { tags, body = {}, timeout, deprecated } = route.options;
     const { accepts: allow, override, maxBytes, output, parse } = body;
+
+    const authRequired = this.getSecurity(route)?.authc?.enabled ?? route.options.authRequired;
 
     const kibanaRouteOptions: KibanaRouteOptions = {
       xsrfRequired: route.options.xsrfRequired ?? !isSafeMethod(route.method),

--- a/src/core/packages/http/server-internal/src/http_server.ts
+++ b/src/core/packages/http/server-internal/src/http_server.ts
@@ -746,7 +746,7 @@ export class HttpServer {
     const securityConfig = route?.security;
 
     // for versioned routes, we need to check if the security config is a function
-    return typeof securityConfig === 'function' ? securityConfig({ headers: {} }) : securityConfig;
+    return typeof securityConfig === 'function' ? securityConfig() : securityConfig;
   }
 
   private configureRoute(route: RouterRoute) {

--- a/src/core/packages/http/server/src/router/request.ts
+++ b/src/core/packages/http/server/src/router/request.ts
@@ -16,7 +16,7 @@ import type { IKibanaSocket } from './socket';
 import type { RouteMethod, RouteConfigOptions, RouteSecurity, RouteDeprecationInfo } from './route';
 import type { Headers } from './headers';
 
-export type RouteSecurityGetter = (request: {
+export type RouteSecurityGetter = (request?: {
   headers: KibanaRequest['headers'];
   query?: KibanaRequest['query'];
 }) => RouteSecurity | undefined;

--- a/src/core/packages/http/server/src/versioning/types.ts
+++ b/src/core/packages/http/server/src/versioning/types.ts
@@ -338,7 +338,7 @@ export interface AddVersionOpts<P, Q, B> {
    */
   validate: false | VersionedRouteValidation<P, Q, B> | (() => VersionedRouteValidation<P, Q, B>); // Provide a way to lazily load validation schemas
 
-  security?: RouteSecurity;
+  security?: Pick<RouteSecurity, 'authz'>;
 
   options?: {
     deprecated?: RouteDeprecationInfo;

--- a/x-pack/platform/plugins/shared/security/server/routes/authentication/common.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/authentication/common.test.ts
@@ -6,8 +6,8 @@
  */
 
 import { Type } from '@kbn/config-schema';
-import type { RequestHandler, RouteConfig } from '@kbn/core/server';
 import { kibanaResponseFactory } from '@kbn/core/server';
+import type { AuthzDisabled, RequestHandler, RouteConfig } from '@kbn/core/server';
 import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
 import type { DeeplyMockedKeys } from '@kbn/utility-types-jest';
 
@@ -65,9 +65,11 @@ describe('Common authentication routes', () => {
     });
 
     it('correctly defines route.', async () => {
+      expect(routeConfig.security?.authc?.enabled).toEqual(false);
+      expect((routeConfig.security?.authz as AuthzDisabled).enabled).toEqual(false);
+
       expect(routeConfig.options).toEqual({
         access: 'public',
-        authRequired: false,
         tags: [ROUTE_TAG_CAN_REDIRECT, ROUTE_TAG_AUTH_FLOW],
         excludeFromOAS: true,
       });
@@ -201,7 +203,9 @@ describe('Common authentication routes', () => {
     });
 
     it('correctly defines route.', () => {
-      expect(routeConfig.options).toEqual({ authRequired: false });
+      expect(routeConfig.security?.authc?.enabled).toEqual(false);
+      expect((routeConfig.security?.authz as AuthzDisabled).enabled).toEqual(false);
+
       expect(routeConfig.validate).toEqual({
         body: expect.any(Type),
         query: undefined,

--- a/x-pack/platform/plugins/shared/security/server/routes/authentication/common.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/authentication/common.ts
@@ -51,6 +51,11 @@ export function defineCommonRoutes({
             enabled: false,
             reason: 'This route must remain accessible to 3rd-party IdPs',
           },
+          authc: {
+            enabled: false,
+            reason:
+              'This route is used for authentication - it does not require existing authentication',
+          },
         },
         // Allow unknown query parameters as this endpoint can be hit by the 3rd-party with any
         // set of query string parameters (e.g. SAML/OIDC logout request/response parameters).
@@ -58,7 +63,6 @@ export function defineCommonRoutes({
         options: {
           access: 'public',
           excludeFromOAS: true,
-          authRequired: false,
           tags: [ROUTE_TAG_CAN_REDIRECT, ROUTE_TAG_AUTH_FLOW],
           ...(isDeprecated && {
             deprecated: {
@@ -191,7 +195,12 @@ export function defineCommonRoutes({
       security: {
         authz: {
           enabled: false,
-          reason: `This route provides basic and token login capbility, which is delegated to the internal authentication service`,
+          reason: `This route provides basic and token login capability, which is delegated to the internal authentication service`,
+        },
+        authc: {
+          enabled: false,
+          reason:
+            'This route is used for authentication - it does not require existing authentication',
         },
       },
       validate: {
@@ -210,7 +219,6 @@ export function defineCommonRoutes({
           ),
         }),
       },
-      options: { authRequired: false },
     },
     createLicensedRouteHandler(async (context, request, response) => {
       const { providerType, providerName, currentURL, params } = request.body;


### PR DESCRIPTION
## Summary

We cannot support `security.authc` evolvement for versioned routes, since authentication is passed down to hapi during route registration and it is tight up with the authentication strategy defined. Adjusted the code to pass `auth` option correctly.

https://github.com/elastic/kibana/blob/e5cf28bc27b6ca80c92c44a4fc805adce857b518/packages/core/http/core-http-server-internal/src/http_server.ts#L378-L393


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

__Fixes: https://github.com/elastic/kibana/issues/205360__

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->