### PR TITLE
Rename AssetInventory feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -271,7 +271,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables the Asset Inventory feature
    */
-  assetInventoryStoreEnabled: false,
+  assetInventoryUXEnabled: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/links.ts
@@ -19,7 +19,7 @@ export const links: LinkItem = {
       defaultMessage: 'Inventory',
     }),
   ],
-  experimentalKey: 'assetInventoryStoreEnabled',
+  experimentalKey: 'assetInventoryUXEnabled',
   id: SecurityPageName.assetInventory,
   path: ASSET_INVENTORY_PATH,
   title: INVENTORY,

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/routes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/routes.tsx
@@ -11,7 +11,6 @@ import { SecurityPageName } from '../app/types';
 import { ASSET_INVENTORY_PATH } from '../../common/constants';
 import { PluginTemplateWrapper } from '../common/components/plugin_template_wrapper';
 import { SecurityRoutePageWrapper } from '../common/components/security_route_page_wrapper';
-import { ExperimentalFeaturesService } from '../common/experimental_features_service';
 import { AssetInventoryContainer } from './pages';
 
 export const AssetInventoryRoutes = () => (
@@ -24,7 +23,7 @@ export const AssetInventoryRoutes = () => (
 
 export const routes: SecuritySubPluginRoutes = [
   {
-    path: ExperimentalFeaturesService.get().assetInventoryStoreEnabled ? ASSET_INVENTORY_PATH : [],
+    path: ASSET_INVENTORY_PATH,
     component: AssetInventoryRoutes,
   },
 ];


### PR DESCRIPTION
## Summary

Renames `assetInventoryStoreEnabled` -> `assetInventoryUXEnabled`

Follow-up of this PR:
- https://github.com/elastic/kibana/issues/201705

### Motivation

Deviate from `assetInventoryStoreEnabled` which is also used for backend changes. This gives us more fine-grained control about changes and the new `assetInventoryUXEnabled` will only be responsible of showing/hiding the interface.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Risks

No risk whatsoever