### PR TITLE
chore(slo): use CCS Remote index name util function

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_search_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_search_client.ts
@@ -6,11 +6,12 @@
  */
 
 import { SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ElasticsearchClient, Logger, SavedObjectsClientContract } from '@kbn/core/server';
+import { isCCSRemoteIndexName } from '@kbn/es-query';
 import { ALL_VALUE, Paginated, Pagination } from '@kbn/slo-schema';
 import { assertNever } from '@kbn/std';
 import { partition } from 'lodash';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { SLO_SUMMARY_DESTINATION_INDEX_PATTERN } from '../../common/constants';
 import { Groupings, SLODefinition, SLOId, StoredSLOSettings, Summary } from '../domain/models';
 import { toHighPrecision } from '../utils/number';
@@ -225,8 +226,8 @@ function excludeStaleSummaryFilter(
 }
 
 function getRemoteClusterName(index: string) {
-  if (index.includes(':')) {
-    return index.split(':')[0];
+  if (isCCSRemoteIndexName(index)) {
+    return index.substring(0, index.indexOf(':'));
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/194141

## Summary

This PR uses the new util function for parsing CCS remote index name instead of relying on `.includes(":")`

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->