### PR TITLE
Use EuiIconTip for lock icon in privileges table action

### DIFF
--- a/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assigned_roles_table.test.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assigned_roles_table.test.tsx
@@ -120,8 +120,6 @@ describe('SpaceAssignedRolesTable', () => {
     expect(screen.getByTestId('checkboxSelectAll')).toBeInTheDocument();
   });
 
-  // it('will not render the bulk actions context menu when the table is in readOnly mode', () => {})
-
   it('prevents modification of reserved roles', () => {
     renderTestComponent({
       assignedRoles: spaceAssignedRoles,
@@ -134,8 +132,7 @@ describe('SpaceAssignedRolesTable', () => {
 
     expect(trisolarisRow).toBeInTheDocument();
 
-    // We expect a length of 2 because EUI also adds a second node for screen readers
-    expect(within(trisolarisRow).getAllByText('Reserved')).toHaveLength(2);
+    expect(within(trisolarisRow).getAllByText('Reserved')).toHaveLength(1);
     expect(within(trisolarisRow).getByTestId('spaceRoleCellActionLocked')).toBeInTheDocument();
     expect(within(trisolarisRow).getByTestId('spaceRoleCellActionLocked')).toBeDisabled();
     expect(

--- a/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assigned_roles_table.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assigned_roles_table.tsx
@@ -149,14 +149,13 @@ const getTableColumns = ({
                   isRoleReserved(role)
                     ? i18n.translate(
                         'xpack.spaces.management.spaceDetails.rolesTable.column.actions.notEditableDescription.isReserved',
-                        {
-                          defaultMessage: `You can’t edit the access of reserved roles to this space.`,
-                        }
+                        { defaultMessage: 'This role is reserved.' }
                       )
                     : i18n.translate(
                         'xpack.spaces.management.spaceDetails.rolesTable.column.actions.notEditableDescription.isAssignedToAll',
                         {
-                          defaultMessage: `You can't edit the access of a role that is assigned to all spaces.`,
+                          defaultMessage:
+                            'This role is assigned to all spaces. To change this, go to Roles.',
                         }
                       )
                 }

--- a/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assigned_roles_table.tsx
+++ b/x-pack/plugins/spaces/public/management/edit_space/roles/component/space_assigned_roles_table.tsx
@@ -9,6 +9,7 @@ import {
   EuiBadge,
   EuiButton,
   EuiButtonEmpty,
+  EuiButtonIcon,
   EuiContextMenu,
   EuiFlexGroup,
   EuiFlexItem,
@@ -18,6 +19,7 @@ import {
   EuiPopover,
   EuiText,
   EuiTextColor,
+  EuiToolTip,
 } from '@elastic/eui';
 import type {
   CriteriaWithPagination,
@@ -140,33 +142,44 @@ const getTableColumns = ({
       ),
       actions: [
         {
-          type: 'icon',
-          icon: 'lock',
-          href: '#',
-          target: '_self',
-          'data-test-subj': 'spaceRoleCellActionLocked',
-          name: (role) =>
-            isRoleReserved(role)
-              ? i18n.translate(
-                  'xpack.spaces.management.spaceDetails.rolesTable.column.actions.notEditableTitle.isReserved',
-                  { defaultMessage: 'Reserved' }
-                )
-              : i18n.translate(
-                  'xpack.spaces.management.spaceDetails.rolesTable.column.actions.notEditableTitle.isAssignedToAll',
-                  { defaultMessage: 'Assigned to all spaces' }
-                ),
-          description: (role) =>
-            isRoleReserved(role)
-              ? i18n.translate(
-                  'xpack.spaces.management.spaceDetails.rolesTable.column.actions.notEditableDescription.isReserved',
-                  { defaultMessage: `You can’t edit the access of reserved roles to this space.` }
-                )
-              : i18n.translate(
-                  'xpack.spaces.management.spaceDetails.rolesTable.column.actions.notEditableDescription.isAssignedToAll',
-                  {
-                    defaultMessage: `You can't edit the access of a role that is assigned to all spaces.`,
+          render: (role) => {
+            return (
+              <EuiToolTip
+                content={
+                  isRoleReserved(role)
+                    ? i18n.translate(
+                        'xpack.spaces.management.spaceDetails.rolesTable.column.actions.notEditableDescription.isReserved',
+                        {
+                          defaultMessage: `You can’t edit the access of reserved roles to this space.`,
+                        }
+                      )
+                    : i18n.translate(
+                        'xpack.spaces.management.spaceDetails.rolesTable.column.actions.notEditableDescription.isAssignedToAll',
+                        {
+                          defaultMessage: `You can't edit the access of a role that is assigned to all spaces.`,
+                        }
+                      )
+                }
+              >
+                <EuiButtonIcon
+                  iconType="lock"
+                  disabled={true}
+                  data-test-subj="spaceRoleCellActionLocked"
+                  aria-label={
+                    isRoleReserved(role)
+                      ? i18n.translate(
+                          'xpack.spaces.management.spaceDetails.rolesTable.column.actions.notEditableTitle.isReserved',
+                          { defaultMessage: 'Reserved' }
+                        )
+                      : i18n.translate(
+                          'xpack.spaces.management.spaceDetails.rolesTable.column.actions.notEditableTitle.isAssignedToAll',
+                          { defaultMessage: 'Assigned to all spaces' }
+                        )
                   }
-                ),
+                />
+              </EuiToolTip>
+            );
+          },
           showOnHover: true,
           enabled: () => false,
           available: (rowRecord) => !isEditableRole(rowRecord),


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana-team/issues/1323

## Screenshots

**Before**

https://github.com/user-attachments/assets/a7eed859-7e81-44b2-86ec-6fa542983960

**After**

https://github.com/user-attachments/assets/58c2b576-4d4a-4869-8252-edd327ae7062

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->