### PR TITLE
Upgrade cypress to 13.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1718,7 +1718,7 @@
     "cssnano-preset-default": "^5.2.12",
     "cssstyle": "^4.1.0",
     "csstype": "^3.0.2",
-    "cypress": "13.15.2",
+    "cypress": "13.17.0",
     "cypress-axe": "^1.5.0",
     "cypress-file-upload": "^5.0.8",
     "cypress-multi-reporters": "^1.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16430,10 +16430,10 @@ cypress-recurse@^1.35.2:
   dependencies:
     humanize-duration "^3.27.3"
 
-cypress@13.15.2:
-  version "13.15.2"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.15.2.tgz#ef19554c274bc4ff23802aeb5c52951677fa67f1"
-  integrity sha512-ARbnUorjcCM3XiPwgHKuqsyr5W9Qn+pIIBPaoilnoBkLdSC2oLQjV1BUpnmc7KR+b7Avah3Ly2RMFnfxr96E/A==
+cypress@13.17.0:
+  version "13.17.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.17.0.tgz#34c3d68080c4497eace0f353bd1629587a5f600d"
+  integrity sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==
   dependencies:
     "@cypress/request" "^3.0.6"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
Starting with an upgrade before backporting to make sure we're running the same version on 8.x (which is on 13.6.3).  

We want to make sure this dependency is cached due to the download size, and that browser testing is aligned on all branches.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->