### PR TITLE
[renovate] matchBaseBranches for a few more groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -67,11 +67,12 @@
         "team:kibana-operations"
       ],
       "matchBaseBranches": [
-        "main"
+        "*"
       ],
       "labels": [
         "Team:Operations",
-        "release_note:skip"
+        "release_note:skip",
+        "backport:skip"
       ],
       "enabled": true
     },
@@ -93,11 +94,11 @@
         "team:kibana-operations"
       ],
       "matchBaseBranches": [
-        "main"
+        "*"
       ],
       "labels": [
         "Team:Operations",
-        "backport:all-open",
+        "backport:skip",
         "release_note:skip"
       ],
       "enabled": true


### PR DESCRIPTION
Follow up to https://github.com/elastic/kibana/pull/205285

This uses renovate instead of backport tooling on a few more of operation's groups.  These were selected because they have not required any code changes to date. 