### PR TITLE
Preparation for High Contrast Mode, Observability domains

### DIFF
--- a/src/platform/plugins/shared/ai_assistant_management/selection/public/management_section/mount_section.tsx
+++ b/src/platform/plugins/shared/ai_assistant_management/selection/public/management_section/mount_section.tsx
@@ -64,7 +64,8 @@ export const mountManagementSection = async ({
           </AppContextProvider>
         </I18nProvider>
       </RedirectToHomeIfUnauthorized>,
-      theme$
+      theme$,
+      coreStart.userProfile
     ),
     element
   );

--- a/x-pack/platform/plugins/shared/logs_shared/public/test_utils/use_global_storybook_theme.tsx
+++ b/x-pack/platform/plugins/shared/logs_shared/public/test_utils/use_global_storybook_theme.tsx
@@ -7,7 +7,7 @@
 
 import type { DecoratorFn } from '@storybook/react';
 import React, { useEffect, useMemo, useState, FC, PropsWithChildren } from 'react';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import type { CoreTheme } from '@kbn/core/public';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
@@ -17,6 +17,7 @@ type StoryContext = Parameters<DecoratorFn>[1];
 export const useGlobalStorybookTheme = ({ globals: { euiTheme } }: StoryContext) => {
   const theme = useMemo(() => euiThemeFromId(euiTheme), [euiTheme]);
   const [theme$] = useState(() => new BehaviorSubject(theme));
+  const userProfile = { getUserProfile$: () => of(null) };
 
   useEffect(() => {
     theme$.next(theme);
@@ -25,6 +26,7 @@ export const useGlobalStorybookTheme = ({ globals: { euiTheme } }: StoryContext)
   return {
     theme,
     theme$,
+    userProfile,
   };
 };
 
@@ -33,9 +35,9 @@ export const GlobalStorybookThemeProviders: FC<
     storyContext: StoryContext;
   }>
 > = ({ children, storyContext }) => {
-  const { theme, theme$ } = useGlobalStorybookTheme(storyContext);
+  const { theme, theme$, userProfile } = useGlobalStorybookTheme(storyContext);
   return (
-    <KibanaThemeProvider theme={{ theme$ }}>
+    <KibanaThemeProvider theme={{ theme$ }} userProfile={userProfile}>
       <EuiThemeProvider darkMode={theme.darkMode}>{children}</EuiThemeProvider>
     </KibanaThemeProvider>
   );

--- a/x-pack/solutions/observability/plugins/apm/public/application/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/application/index.tsx
@@ -42,7 +42,7 @@ export const renderApp = ({
   apmServices: ApmServices;
   kibanaEnvironment: KibanaEnvContext;
 }) => {
-  const { element, theme$ } = appMountParameters;
+  const { element } = appMountParameters;
   const apmPluginContextValue = {
     appMountParameters,
     config,
@@ -74,7 +74,7 @@ export const renderApp = ({
   ReactDOM.render(
     <KibanaRenderContextProvider {...coreStart}>
       <KibanaThemeProvider
-        theme={{ theme$ }}
+        {...coreStart}
         modify={{
           breakpoint: {
             xxl: 1600,

--- a/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/routing/app_root/index.tsx
@@ -109,11 +109,12 @@ export function ApmAppRoot({
 
 function MountApmHeaderActionMenu() {
   const {
-    appMountParameters: { setHeaderActionMenu, theme$ },
+    appMountParameters: { setHeaderActionMenu },
+    core,
   } = useApmPluginContext();
 
   return (
-    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} {...core}>
       <EuiFlexGroup responsive={false} gutterSize="s">
         <EuiFlexItem>
           <ApmHeaderActionMenu />

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/embeddable_context.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/embeddable_context.tsx
@@ -53,7 +53,7 @@ export function ApmEmbeddableContext({
   return (
     <I18nContext>
       <ApmPluginContext.Provider value={services}>
-        <KibanaThemeProvider theme={deps.coreStart.theme}>
+        <KibanaThemeProvider {...deps.coreStart}>
           <KibanaContextProvider services={deps.coreStart}>
             <TimeRangeMetadataContextProvider
               uiSettings={deps.coreStart.uiSettings}

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/application/index.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/application/index.tsx
@@ -20,7 +20,7 @@ import { PluginContext } from '../context/plugin_context';
 import { routes } from '../routes';
 import { ExploratoryViewPublicPluginsStart } from '../plugin';
 
-export type StartServices = Pick<CoreStart, 'analytics' | 'i18n' | 'theme'>;
+export type StartServices = Pick<CoreStart, 'analytics' | 'i18n' | 'theme' | 'userProfile'>;
 
 function App(props: { startServices: StartServices }) {
   return (

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/application/types.ts
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/application/types.ts
@@ -17,6 +17,7 @@ import type {
   OverlayStart,
   SavedObjectsStart,
   ThemeServiceStart,
+  UserProfileService,
 } from '@kbn/core/public';
 import { EmbeddableStateTransfer } from '@kbn/embeddable-plugin/public';
 import { NavigationPublicPluginStart } from '@kbn/navigation-plugin/public';
@@ -53,6 +54,7 @@ export interface ObservabilityAppServices {
   analytics: AnalyticsServiceStart;
   i18n: I18nStart;
   theme: ThemeServiceStart;
+  userProfile: UserProfileService;
   triggersActionsUi: TriggersAndActionsUIPublicPluginStart;
   uiSettings: IUiSettingsClient;
   isDev?: boolean;

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/components/action_menu/index.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/components/action_menu/index.tsx
@@ -17,10 +17,10 @@ interface Props {
   lensAttributes: TypedLensByValueInput['attributes'] | null;
 }
 export function ExpViewActionMenu(props: Props) {
-  const { setHeaderActionMenu, theme$ } = useExploratoryView();
+  const { setHeaderActionMenu, ...startServices } = useExploratoryView();
 
   return (
-    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} {...startServices}>
       <EuiFlexGroup responsive={false} gutterSize="s">
         <EuiFlexItem>
           <ExpViewActionMenuContent {...props} />

--- a/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/contexts/exploratory_view_config.tsx
+++ b/x-pack/solutions/observability/plugins/exploratory_view/public/components/shared/exploratory_view/contexts/exploratory_view_config.tsx
@@ -12,7 +12,7 @@ import type { AppDataType, ConfigProps, ReportViewType, SeriesConfig } from '../
 
 export type ReportConfigMap = Record<string, Array<(config: ConfigProps) => SeriesConfig>>;
 
-type StartServices = Pick<CoreStart, 'analytics' | 'i18n' | 'theme'>;
+type StartServices = Pick<CoreStart, 'analytics' | 'i18n' | 'theme' | 'userProfile'>;
 
 interface ExploratoryViewContextValue extends StartServices {
   dataTypes: Array<{ id: AppDataType; label: string }>;

--- a/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/log_rate_analysis.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/log_rate_analysis.tsx
@@ -232,6 +232,7 @@ export const LogRateAnalysis: FC<AlertDetailsLogRateAnalysisSectionProps> = ({ r
                 'storage',
                 'uiSettings',
                 'unifiedSearch',
+                'userProfile',
                 'theme',
                 'lens',
                 'i18n',

--- a/x-pack/solutions/observability/plugins/infra/public/apps/common_providers.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/apps/common_providers.tsx
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import type { AppMountParameters, CoreStart } from '@kbn/core/public';
+import type {
+  AppMountParameters,
+  CoreStart,
+  ThemeServiceStart,
+  UserProfileService,
+} from '@kbn/core/public';
 import type { FC, PropsWithChildren } from 'react';
 import React from 'react';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
@@ -31,16 +36,17 @@ export const CommonInfraProviders: FC<
     storage: Storage;
     triggersActionsUI: TriggersAndActionsUIPublicPluginStart;
     setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
-    theme$: AppMountParameters['theme$'];
+    theme: ThemeServiceStart;
+    userProfile: UserProfileService;
   }>
-> = ({ children, triggersActionsUI, setHeaderActionMenu, appName, storage, theme$ }) => {
+> = ({ children, triggersActionsUI, setHeaderActionMenu, appName, storage, ...startServices }) => {
   const darkMode = useIsDarkMode();
 
   return (
     <TriggersActionsProvider triggersActionsUI={triggersActionsUI}>
       <EuiThemeProvider darkMode={darkMode}>
         <DataUIProviders appName={appName} storage={storage}>
-          <HeaderActionMenuProvider setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+          <HeaderActionMenuProvider setHeaderActionMenu={setHeaderActionMenu} {...startServices}>
             <NavigationWarningPromptProvider>{children}</NavigationWarningPromptProvider>
           </HeaderActionMenuProvider>
         </DataUIProviders>

--- a/x-pack/solutions/observability/plugins/infra/public/apps/logs_app.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/apps/logs_app.tsx
@@ -77,8 +77,8 @@ const LogsApp: React.FC<{
         appName="Logs UI"
         setHeaderActionMenu={setHeaderActionMenu}
         storage={storage}
-        theme$={theme$}
         triggersActionsUI={plugins.triggersActionsUi}
+        {...core}
       >
         <Router history={history}>
           <KbnUrlStateStorageFromRouterProvider

--- a/x-pack/solutions/observability/plugins/infra/public/apps/metrics_app.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/apps/metrics_app.tsx
@@ -93,8 +93,8 @@ const MetricsApp: React.FC<{
         appName="Metrics UI"
         setHeaderActionMenu={setHeaderActionMenu}
         storage={storage}
-        theme$={theme$}
         triggersActionsUI={plugins.triggersActionsUi}
+        {...core}
       >
         <SourceProvider sourceId="default">
           <MetricsDataViewProvider>

--- a/x-pack/solutions/observability/plugins/infra/public/containers/header_action_menu_provider.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/containers/header_action_menu_provider.tsx
@@ -6,24 +6,31 @@
  */
 
 import type { PropsWithChildren } from 'react';
-import React from 'react';
-import type { AppMountParameters } from '@kbn/core/public';
+import React, { useContext } from 'react';
+import type { AppMountParameters, ThemeServiceStart, UserProfileService } from '@kbn/core/public';
 
 interface ContextProps {
-  setHeaderActionMenu?: AppMountParameters['setHeaderActionMenu'];
-  theme$?: AppMountParameters['theme$'];
+  setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
+  userProfile: UserProfileService;
+  theme: ThemeServiceStart;
 }
 
-export const HeaderActionMenuContext = React.createContext<ContextProps>({});
+export const HeaderActionMenuContext = React.createContext<ContextProps | null>(null);
 
 export const HeaderActionMenuProvider: React.FC<PropsWithChildren<Required<ContextProps>>> = ({
   setHeaderActionMenu,
-  theme$,
+  theme,
+  userProfile,
   children,
 }) => {
   return (
-    <HeaderActionMenuContext.Provider value={{ setHeaderActionMenu, theme$ }}>
+    <HeaderActionMenuContext.Provider value={{ setHeaderActionMenu, theme, userProfile }}>
       {children}
     </HeaderActionMenuContext.Provider>
   );
+};
+
+export const useHeaderActionMenu = () => {
+  // TODO: throw error if context is null?
+  return useContext(HeaderActionMenuContext);
 };

--- a/x-pack/solutions/observability/plugins/infra/public/pages/logs/page_content.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/logs/page_content.tsx
@@ -7,7 +7,7 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiHeaderLink, EuiHeaderLinks } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useContext } from 'react';
+import React from 'react';
 import { Routes, Route } from '@kbn/shared-ux-router';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { HeaderMenuPortal, useLinkProps } from '@kbn/observability-shared-plugin/public';
@@ -22,7 +22,7 @@ import { type LogsLocatorParams, LOGS_LOCATOR_ID } from '@kbn/logs-shared-plugin
 import { LazyAlertDropdownWrapper } from '../../alerting/log_threshold';
 import { HelpCenterContent } from '../../components/help_center_content';
 import { useReadOnlyBadge } from '../../hooks/use_readonly_badge';
-import { HeaderActionMenuContext } from '../../containers/header_action_menu_provider';
+import { useHeaderActionMenu } from '../../containers/header_action_menu_provider';
 import { RedirectWithQueryParams } from '../../utils/redirect_with_query_params';
 import { NotFoundPage } from '../404';
 import { getLogsAppRoutes } from './routes';
@@ -47,7 +47,7 @@ export const LogsPageContent: React.FunctionComponent = () => {
   const onboardingLocator = share?.url.locators.get<ObservabilityOnboardingLocatorParams>(
     OBSERVABILITY_ONBOARDING_LOCATOR
   );
-  const { setHeaderActionMenu, theme$ } = useContext(HeaderActionMenuContext);
+  const headerActionMenuContext = useHeaderActionMenu();
 
   const enableDeveloperRoutes = isDevMode();
 
@@ -64,8 +64,8 @@ export const LogsPageContent: React.FunctionComponent = () => {
     <>
       <HelpCenterContent feedbackLink={feedbackLinkUrl} appName={pageTitle} />
 
-      {setHeaderActionMenu && theme$ && (
-        <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+      {headerActionMenuContext && (
+        <HeaderMenuPortal {...headerActionMenuContext}>
           <EuiFlexGroup responsive={false} gutterSize="s">
             <EuiFlexItem>
               <EuiHeaderLinks gutterSize="xs">

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/index.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/index.tsx
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 
-import React, { useContext } from 'react';
+import React from 'react';
 import { Routes, Route } from '@kbn/shared-ux-router';
 
 import {
@@ -30,7 +30,7 @@ import { MetricsAlertDropdown } from '../../alerting/common/components/metrics_a
 import { AlertPrefillProvider } from '../../alerting/use_alert_prefill';
 import { InfraMLCapabilitiesProvider } from '../../containers/ml/infra_ml_capabilities';
 import { AnomalyDetectionFlyout } from '../../components/ml/anomaly_detection/anomaly_detection_flyout';
-import { HeaderActionMenuContext } from '../../containers/header_action_menu_provider';
+import { useHeaderActionMenu } from '../../containers/header_action_menu_provider';
 import { NotFoundPage } from '../404';
 import { ReactQueryProvider } from '../../containers/react_query_provider';
 import { usePluginConfig } from '../../containers/plugin_config_context';
@@ -56,7 +56,7 @@ const HostsPage = dynamic(() => import('./hosts').then((mod) => ({ default: mod.
 export const InfrastructurePage = () => {
   const config = usePluginConfig();
   const { application } = useKibana<{ share: SharePublicStart }>().services;
-  const { setHeaderActionMenu, theme$ } = useContext(HeaderActionMenuContext);
+  const headerActionMenuContext = useHeaderActionMenu();
 
   const uiCapabilities = application?.capabilities;
 
@@ -83,8 +83,8 @@ export const InfrastructurePage = () => {
                   defaultMessage: 'Metrics',
                 })}
               />
-              {setHeaderActionMenu && theme$ && (
-                <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+              {headerActionMenuContext && (
+                <HeaderMenuPortal {...headerActionMenuContext}>
                   <EuiFlexGroup responsive={false} gutterSize="s">
                     <EuiFlexItem>
                       <EuiHeaderLinks gutterSize="xs">

--- a/x-pack/solutions/observability/plugins/infra/public/test_utils/use_global_storybook_theme.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/test_utils/use_global_storybook_theme.tsx
@@ -8,7 +8,7 @@
 import type { DecoratorFn } from '@storybook/react';
 import type { FC, PropsWithChildren } from 'react';
 import React, { useEffect, useMemo, useState } from 'react';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import type { CoreTheme } from '@kbn/core/public';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
@@ -18,6 +18,7 @@ type StoryContext = Parameters<DecoratorFn>[1];
 export const useGlobalStorybookTheme = ({ globals: { euiTheme } }: StoryContext) => {
   const theme = useMemo(() => euiThemeFromId(euiTheme), [euiTheme]);
   const [theme$] = useState(() => new BehaviorSubject(theme));
+  const userProfile = { getUserProfile$: () => of(null) };
 
   useEffect(() => {
     theme$.next(theme);
@@ -26,6 +27,7 @@ export const useGlobalStorybookTheme = ({ globals: { euiTheme } }: StoryContext)
   return {
     theme,
     theme$,
+    userProfile,
   };
 };
 
@@ -34,9 +36,9 @@ export const GlobalStorybookThemeProviders: FC<
     storyContext: StoryContext;
   }>
 > = ({ children, storyContext }) => {
-  const { theme, theme$ } = useGlobalStorybookTheme(storyContext);
+  const { theme, theme$, userProfile } = useGlobalStorybookTheme(storyContext);
   return (
-    <KibanaThemeProvider theme={{ theme$ }}>
+    <KibanaThemeProvider theme={{ theme$ }} userProfile={userProfile}>
       <EuiThemeProvider darkMode={theme.darkMode}>{children}</EuiThemeProvider>
     </KibanaThemeProvider>
   );

--- a/x-pack/solutions/observability/plugins/inventory/public/components/app_root/index.tsx
+++ b/x-pack/solutions/observability/plugins/inventory/public/components/app_root/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import type { ThemeServiceStart, UserProfileService } from '@kbn/core/public';
 import { type AppMountParameters, type CoreStart } from '@kbn/core/public';
 import { HeaderMenuPortal } from '@kbn/observability-shared-plugin/public';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
@@ -46,7 +47,10 @@ export function AppRoot({
         <RouterProvider history={history} router={inventoryRouter as any}>
           <UnifiedSearchProvider>
             <RouteRenderer />
-            <InventoryHeaderActionMenu appMountParameters={appMountParameters} />
+            <InventoryHeaderActionMenu
+              setHeaderActionMenu={appMountParameters.setHeaderActionMenu}
+              {...coreStart}
+            />
           </UnifiedSearchProvider>
         </RouterProvider>
       </RedirectAppLinks>
@@ -54,15 +58,18 @@ export function AppRoot({
   );
 }
 
-export function InventoryHeaderActionMenu({
-  appMountParameters,
-}: {
-  appMountParameters: AppMountParameters;
-}) {
-  const { setHeaderActionMenu, theme$ } = appMountParameters;
+interface InventoryHeaderActionMenuProps {
+  setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
+  theme: ThemeServiceStart;
+  userProfile: UserProfileService;
+}
 
+export function InventoryHeaderActionMenu({
+  setHeaderActionMenu,
+  ...startServices
+}: InventoryHeaderActionMenuProps) {
   return (
-    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} {...startServices}>
       <EuiFlexGroup responsive={false} gutterSize="s">
         <EuiFlexItem>
           <HeaderActionMenuItems />

--- a/x-pack/solutions/observability/plugins/investigate_app/public/application.tsx
+++ b/x-pack/solutions/observability/plugins/investigate_app/public/application.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { CoreStart, CoreTheme } from '@kbn/core/public';
+import type { CoreStart } from '@kbn/core/public';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import { Route, Router, Routes } from '@kbn/shared-ux-router';
@@ -12,7 +12,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { History } from 'history';
 import React, { useMemo } from 'react';
-import type { Observable } from 'rxjs';
 import { InvestigateAppContextProvider } from './components/investigate_app_context_provider';
 import { InvestigateAppKibanaContext } from './hooks/use_kibana';
 import { getRoutes } from './routes/config';
@@ -25,19 +24,13 @@ function Application({
   coreStart,
   history,
   pluginsStart,
-  theme$,
   services,
 }: {
   coreStart: CoreStart;
   history: History;
   pluginsStart: InvestigateAppStartDependencies;
-  theme$: Observable<CoreTheme>;
   services: InvestigateAppServices;
 }) {
-  const theme = useMemo(() => {
-    return { theme$ };
-  }, [theme$]);
-
   const context: InvestigateAppKibanaContext = useMemo(
     () => ({
       core: coreStart,
@@ -65,7 +58,7 @@ function Application({
   };
 
   return (
-    <KibanaThemeProvider theme={theme}>
+    <KibanaThemeProvider {...coreStart}>
       <InvestigateAppContextProvider context={context}>
         <RedirectAppLinks coreStart={coreStart}>
           <coreStart.i18n.Context>

--- a/x-pack/solutions/observability/plugins/investigate_app/public/plugin.tsx
+++ b/x-pack/solutions/observability/plugins/investigate_app/public/plugin.tsx
@@ -105,7 +105,6 @@ export class InvestigateAppPlugin
             coreStart={coreStart}
             history={appMountParameters.history}
             pluginsStart={pluginsStart}
-            theme$={appMountParameters.theme$}
             services={services}
           />,
           appMountParameters.element

--- a/x-pack/solutions/observability/plugins/metrics_data_access/public/test_utils/use_global_storybook_theme.tsx
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/public/test_utils/use_global_storybook_theme.tsx
@@ -7,7 +7,7 @@
 
 import type { DecoratorFn } from '@storybook/react';
 import React, { useEffect, useMemo, useState } from 'react';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import type { CoreTheme } from '@kbn/core/public';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
@@ -17,6 +17,7 @@ type StoryContext = Parameters<DecoratorFn>[1];
 export const useGlobalStorybookTheme = ({ globals: { euiTheme } }: StoryContext) => {
   const theme = useMemo(() => euiThemeFromId(euiTheme), [euiTheme]);
   const [theme$] = useState(() => new BehaviorSubject(theme));
+  const userProfile = { getUserProfile$: () => of(null) };
 
   useEffect(() => {
     theme$.next(theme);
@@ -25,6 +26,7 @@ export const useGlobalStorybookTheme = ({ globals: { euiTheme } }: StoryContext)
   return {
     theme,
     theme$,
+    userProfile,
   };
 };
 
@@ -32,9 +34,9 @@ export const GlobalStorybookThemeProviders: React.FC<{
   children: React.ReactNode;
   storyContext: StoryContext;
 }> = ({ children, storyContext }) => {
-  const { theme, theme$ } = useGlobalStorybookTheme(storyContext);
+  const { theme, theme$, userProfile } = useGlobalStorybookTheme(storyContext);
   return (
-    <KibanaThemeProvider theme={{ theme$ }}>
+    <KibanaThemeProvider theme={{ theme$ }} userProfile={userProfile}>
       <EuiThemeProvider darkMode={theme.darkMode}>{children}</EuiThemeProvider>
     </KibanaThemeProvider>
   );

--- a/x-pack/solutions/observability/plugins/observability/public/application/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/application/index.tsx
@@ -65,7 +65,7 @@ export const renderApp = ({
   kibanaVersion: string;
   isServerless?: boolean;
 }) => {
-  const { element, history, theme$ } = appMountParameters;
+  const { element, history } = appMountParameters;
   const isDarkMode = core.theme.getTheme().darkMode;
 
   core.chrome.setHelpExtension({
@@ -87,7 +87,7 @@ export const renderApp = ({
   ReactDOM.render(
     <KibanaRenderContextProvider {...core}>
       <ApplicationUsageTrackingProvider>
-        <KibanaThemeProvider {...{ theme: { theme$ } }}>
+        <KibanaThemeProvider {...core}>
           <CloudProvider>
             <KibanaContextProvider
               services={{

--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/hooks/use_create_annotation.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/hooks/use_create_annotation.tsx
@@ -26,10 +26,9 @@ export interface CreateAnnotationResponse {
 
 export function useCreateAnnotation() {
   const {
-    i18n: i18nStart,
-    theme,
     http,
     notifications: { toasts },
+    ...startServices
   } = useKibana().services;
   const services = useKibana().services;
 
@@ -60,10 +59,7 @@ export function useCreateAnnotation() {
                 }}
               />
             </RedirectAppLinks>,
-            {
-              i18n: i18nStart,
-              theme,
-            }
+            startServices
           ),
         });
       },

--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/hooks/use_delete_annotation.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/hooks/use_delete_annotation.tsx
@@ -19,10 +19,9 @@ type ServerError = IHttpFetchError<ResponseErrorBody>;
 
 export function useDeleteAnnotation() {
   const {
-    i18n: i18nStart,
-    theme,
     http,
     notifications: { toasts },
+    ...startServices
   } = useKibana().services;
   const services = useKibana().services;
 
@@ -47,10 +46,7 @@ export function useDeleteAnnotation() {
                 }}
               />
             </RedirectAppLinks>,
-            {
-              i18n: i18nStart,
-              theme,
-            }
+            startServices
           ),
         });
       },

--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/hooks/use_update_annotation.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/hooks/use_update_annotation.tsx
@@ -26,10 +26,9 @@ export interface CreateAnnotationResponse {
 
 export function useUpdateAnnotation() {
   const {
-    i18n: i18nStart,
-    theme,
     http,
     notifications: { toasts },
+    ...startServices
   } = useKibana().services;
   const services = useKibana().services;
 
@@ -65,10 +64,7 @@ export function useUpdateAnnotation() {
                 }}
               />
             </RedirectAppLinks>,
-            {
-              i18n: i18nStart,
-              theme,
-            }
+            startServices
           ),
         });
       },

--- a/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/components/alert_details_app_section/log_rate_analysis.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/components/alert_details_app_section/log_rate_analysis.tsx
@@ -200,6 +200,7 @@ export function LogRateAnalysis({ alert, dataView, services }: AlertDetailsLogRa
                 'storage',
                 'uiSettings',
                 'unifiedSearch',
+                'userProfile',
                 'theme',
                 'lens',
                 'i18n',

--- a/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/header_menu/header_menu.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/header_menu/header_menu.tsx
@@ -18,7 +18,7 @@ import { useKibana } from '../../../../utils/kibana_react';
 import HeaderMenuPortal from './header_menu_portal';
 
 export function HeaderMenu(): React.ReactElement | null {
-  const { share, theme, http } = useKibana().services;
+  const { share, http, ...startServices } = useKibana().services;
 
   const onboardingLocator = share?.url.locators.get<ObservabilityOnboardingLocatorParams>(
     OBSERVABILITY_ONBOARDING_LOCATOR
@@ -30,7 +30,7 @@ export function HeaderMenu(): React.ReactElement | null {
   return (
     <HeaderMenuPortal
       setHeaderActionMenu={appMountParameters?.setHeaderActionMenu!}
-      theme$={theme.theme$}
+      {...startServices}
     >
       <EuiFlexGroup responsive={false} gutterSize="s">
         <EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/header_menu/header_menu_portal.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/header_menu/header_menu_portal.test.tsx
@@ -7,17 +7,17 @@
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import { coreMock } from '@kbn/core/public/mocks';
 import HeaderMenuPortal from './header_menu_portal';
-import { themeServiceMock } from '@kbn/core/public/mocks';
 
 describe('HeaderMenuPortal', () => {
   describe('when unmounted', () => {
     it('calls setHeaderActionMenu with undefined', () => {
       const setHeaderActionMenu = jest.fn();
-      const theme$ = themeServiceMock.createTheme$();
+      const coreStart = coreMock.createStart();
 
       const { unmount } = render(
-        <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+        <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} {...coreStart}>
           test
         </HeaderMenuPortal>
       );

--- a/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/header_menu/header_menu_portal.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/header_menu/header_menu_portal.tsx
@@ -8,27 +8,35 @@
 import React, { ReactNode, useEffect, useMemo } from 'react';
 import { createHtmlPortalNode, InPortal, OutPortal } from 'react-reverse-portal';
 import { toMountPoint } from '@kbn/react-kibana-mount';
-import { AppMountParameters } from '@kbn/core/public';
-import { useKibana } from '../../../../utils/kibana_react';
+import {
+  AppMountParameters,
+  I18nStart,
+  ThemeServiceStart,
+  UserProfileService,
+} from '@kbn/core/public';
+
 export interface HeaderMenuPortalProps {
   children: ReactNode;
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
-  theme$: AppMountParameters['theme$'];
+  i18n: I18nStart;
+  theme: ThemeServiceStart;
+  userProfile: UserProfileService;
 }
 
 // eslint-disable-next-line import/no-default-export
 export default function HeaderMenuPortal({
   children,
   setHeaderActionMenu,
-  theme$,
+  i18n,
+  theme,
+  userProfile,
 }: HeaderMenuPortalProps) {
-  const { i18n } = useKibana().services;
   const portalNode = useMemo(() => createHtmlPortalNode(), []);
 
   useEffect(() => {
     setHeaderActionMenu((element) => {
       const mount = toMountPoint(<OutPortal node={portalNode} />, {
-        ...{ theme: { theme$ }, i18n },
+        ...{ theme, i18n, userProfile },
       });
       return mount(element);
     });
@@ -37,7 +45,7 @@ export default function HeaderMenuPortal({
       portalNode.unmount();
       setHeaderActionMenu(undefined);
     };
-  }, [portalNode, setHeaderActionMenu, i18n, theme$]);
+  }, [portalNode, setHeaderActionMenu, i18n, theme, userProfile]);
 
   return <InPortal node={portalNode}>{children}</InPortal>;
 }

--- a/x-pack/solutions/observability/plugins/observability/public/test_utils/use_global_storybook_theme.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/test_utils/use_global_storybook_theme.tsx
@@ -7,7 +7,7 @@
 
 import type { DecoratorFn } from '@storybook/react';
 import React, { useEffect, useMemo, useState } from 'react';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import type { CoreTheme } from '@kbn/core/public';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
@@ -17,6 +17,7 @@ type StoryContext = Parameters<DecoratorFn>[1];
 export const useGlobalStorybookTheme = ({ globals: { euiTheme } }: StoryContext) => {
   const theme = useMemo(() => euiThemeFromId(euiTheme), [euiTheme]);
   const [theme$] = useState(() => new BehaviorSubject(theme));
+  const userProfile = { getUserProfile$: () => of(null) };
 
   useEffect(() => {
     theme$.next(theme);
@@ -25,6 +26,7 @@ export const useGlobalStorybookTheme = ({ globals: { euiTheme } }: StoryContext)
   return {
     theme,
     theme$,
+    userProfile,
   };
 };
 
@@ -35,9 +37,9 @@ export function GlobalStorybookThemeProviders({
   storyContext: StoryContext;
   children: React.ReactChild;
 }) {
-  const { theme, theme$ } = useGlobalStorybookTheme(storyContext);
+  const { theme, theme$, userProfile } = useGlobalStorybookTheme(storyContext);
   return (
-    <KibanaThemeProvider theme={{ theme$ }}>
+    <KibanaThemeProvider theme={{ theme$ }} userProfile={userProfile}>
       <EuiThemeProvider darkMode={theme.darkMode}>{children}</EuiThemeProvider>
     </KibanaThemeProvider>
   );

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/application.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/application.tsx
@@ -4,12 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { CoreStart, CoreTheme } from '@kbn/core/public';
+import type { CoreStart } from '@kbn/core/public';
 import { RouteRenderer, RouterProvider } from '@kbn/typed-react-router-config';
 import type { History } from 'history';
 import React from 'react';
-import type { Observable } from 'rxjs';
-import type { AIAssistantAppService } from '@kbn/ai-assistant';
 import type { ObservabilityAIAssistantAppPluginStartDependencies } from './types';
 import { SharedProviders } from './utils/shared_providers';
 import { observabilityAIAssistantRouter } from './routes/config';
@@ -20,22 +18,13 @@ export function Application({
   coreStart,
   history,
   pluginsStart,
-  service,
-  theme$,
 }: {
   coreStart: CoreStart;
   history: History;
   pluginsStart: ObservabilityAIAssistantAppPluginStartDependencies;
-  service: AIAssistantAppService;
-  theme$: Observable<CoreTheme>;
 }) {
   return (
-    <SharedProviders
-      coreStart={coreStart}
-      pluginsStart={pluginsStart}
-      service={service}
-      theme$={theme$}
-    >
+    <SharedProviders coreStart={coreStart} pluginsStart={pluginsStart}>
       <RouterProvider history={history} router={observabilityAIAssistantRouter}>
         <RouteRenderer />
       </RouterProvider>

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
@@ -41,12 +41,7 @@ export const NavControlWithProvider = ({
   isServerless,
 }: NavControlWithProviderDeps) => {
   return (
-    <SharedProviders
-      coreStart={coreStart}
-      pluginsStart={pluginsStart}
-      service={appService}
-      theme$={coreStart.theme.theme$}
-    >
+    <SharedProviders coreStart={coreStart} pluginsStart={pluginsStart}>
       <NavControl isServerless={isServerless} />
     </SharedProviders>
   );

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/plugin.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/plugin.tsx
@@ -84,7 +84,6 @@ export class ObservabilityAIAssistantAppPlugin
         ReactDOM.render(
           <Application
             {...appMountParameters}
-            service={this.appService!}
             coreStart={coreStart}
             pluginsStart={pluginsStart as ObservabilityAIAssistantAppPluginStartDependencies}
           />,
@@ -139,12 +138,7 @@ export class ObservabilityAIAssistantAppPlugin
 
     const withProviders = <P extends {}, R = {}>(Component: React.ComponentType<P>) =>
       React.forwardRef((props: P, ref: React.Ref<R>) => (
-        <SharedProviders
-          coreStart={coreStart}
-          pluginsStart={pluginsStart}
-          service={service}
-          theme$={coreStart.theme.theme$}
-        >
+        <SharedProviders coreStart={coreStart} pluginsStart={pluginsStart}>
           <Component {...props} ref={ref} />
         </SharedProviders>
       ));

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/utils/shared_providers.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/utils/shared_providers.tsx
@@ -5,35 +5,25 @@
  * 2.0.
  */
 import { EuiErrorBoundary } from '@elastic/eui';
-import type { CoreStart, CoreTheme } from '@kbn/core/public';
+import type { CoreStart } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
-import React, { useMemo } from 'react';
-import type { Observable } from 'rxjs';
-import { AIAssistantAppService } from '@kbn/ai-assistant';
+import React from 'react';
 import type { ObservabilityAIAssistantAppPluginStartDependencies } from '../types';
 
 export function SharedProviders({
   children,
   coreStart,
   pluginsStart,
-  service,
-  theme$,
 }: {
   children: React.ReactElement;
   coreStart: CoreStart;
   pluginsStart: ObservabilityAIAssistantAppPluginStartDependencies;
-  service: AIAssistantAppService;
-  theme$: Observable<CoreTheme>;
 }) {
-  const theme = useMemo(() => {
-    return { theme$ };
-  }, [theme$]);
-
   return (
     <EuiErrorBoundary>
-      <KibanaThemeProvider theme={theme}>
+      <KibanaThemeProvider {...coreStart}>
         <KibanaContextProvider
           services={{
             ...coreStart,

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_management/public/app.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_management/public/app.tsx
@@ -64,7 +64,8 @@ export const mountManagementSection = async ({ core, mountParams, config }: Moun
           </KibanaContextProvider>
         </I18nProvider>
       </RedirectToHomeIfUnauthorized>,
-      theme$
+      theme$,
+      coreStart.userProfile
     ),
     element
   );

--- a/x-pack/solutions/observability/plugins/observability_logs_explorer/public/applications/observability_logs_explorer.tsx
+++ b/x-pack/solutions/observability/plugins/observability_logs_explorer/public/applications/observability_logs_explorer.tsx
@@ -68,7 +68,7 @@ export const ObservabilityLogsExplorerApp = ({
   );
 
   return (
-    <KibanaRenderContextProvider i18n={core.i18n} theme={core.theme}>
+    <KibanaRenderContextProvider {...core}>
       <KibanaContextProviderForPlugin>
         <KbnUrlStateStorageFromRouterProvider>
           <Router history={appParams.history}>

--- a/x-pack/solutions/observability/plugins/observability_logs_explorer/public/components/logs_explorer_top_nav_menu.tsx
+++ b/x-pack/solutions/observability/plugins/observability_logs_explorer/public/components/logs_explorer_top_nav_menu.tsx
@@ -86,6 +86,7 @@ const ClassicTopNav = () => {
       chrome,
       i18n: i18nStart,
       theme,
+      userProfile,
     },
   } = useKibanaContextForPlugin();
   /**
@@ -112,7 +113,7 @@ const ClassicTopNav = () => {
               <FeedbackLink />
             </EuiHeaderSectionItem>
           </EuiHeaderSection>,
-          { theme, i18n: i18nStart }
+          { theme, i18n: i18nStart, userProfile }
         ),
       });
     }
@@ -122,10 +123,14 @@ const ClassicTopNav = () => {
         chrome.setBreadcrumbsAppendExtension(previousAppendExtension);
       }
     };
-  }, [chrome, i18nStart, previousAppendExtension, theme, euiTheme]);
+  }, [chrome, i18nStart, previousAppendExtension, theme, euiTheme, userProfile]);
 
   return (
-    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme.theme$}>
+    <HeaderMenuPortal
+      setHeaderActionMenu={setHeaderActionMenu}
+      theme={theme}
+      userProfile={userProfile}
+    >
       <EuiHeaderSection data-test-subj="logsExplorerHeaderMenu">
         <EuiHeaderSectionItem>
           <EuiHeaderLinks gutterSize="xs">

--- a/x-pack/solutions/observability/plugins/observability_logs_explorer/public/routes/main/main_route.tsx
+++ b/x-pack/solutions/observability/plugins/observability_logs_explorer/public/routes/main/main_route.tsx
@@ -27,8 +27,7 @@ import { useKibanaContextForPlugin } from '../../utils/use_kibana';
 
 export const ObservabilityLogsExplorerMainRoute = () => {
   const { services } = useKibanaContextForPlugin();
-  const { logsExplorer, notifications, appParams, analytics, i18n, theme, logsDataAccess } =
-    services;
+  const { logsExplorer, notifications, appParams, logsDataAccess, ...startServices } = services;
   const { history } = appParams;
 
   useBreadcrumbs();
@@ -54,13 +53,7 @@ export const ObservabilityLogsExplorerMainRoute = () => {
       logSourcesService={logsDataAccess.services.logSourcesService}
     >
       <LogsExplorerTopNavMenu />
-      <LazyOriginInterpreter
-        history={history}
-        toasts={notifications.toasts}
-        analytics={analytics}
-        i18n={i18n}
-        theme={theme}
-      />
+      <LazyOriginInterpreter history={history} toasts={notifications.toasts} {...startServices} />
       <ConnectedContent />
     </ObservabilityLogsExplorerPageStateProvider>
   );

--- a/x-pack/solutions/observability/plugins/observability_logs_explorer/public/types.ts
+++ b/x-pack/solutions/observability/plugins/observability_logs_explorer/public/types.ts
@@ -17,6 +17,7 @@ import type {
   AnalyticsServiceStart,
   I18nStart,
   ThemeServiceStart,
+  UserProfileService,
 } from '@kbn/core/public';
 import { LogsSharedClientStartExports } from '@kbn/logs-shared-plugin/public';
 import { ObservabilityAIAssistantPublicStart } from '@kbn/observability-ai-assistant-plugin/public';
@@ -68,4 +69,5 @@ export interface ObservabilityLogsExplorerStartServices {
   analytics: AnalyticsServiceStart;
   i18n: I18nStart;
   theme: ThemeServiceStart;
+  userProfile: UserProfileService;
 }

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/app.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/app.tsx
@@ -45,7 +45,7 @@ export function ObservabilityOnboardingAppRoot({
 }: {
   appMountParameters: AppMountParameters;
 } & RenderAppProps) {
-  const { history, setHeaderActionMenu, theme$ } = appMountParameters;
+  const { history, setHeaderActionMenu } = appMountParameters;
   const services: ObservabilityOnboardingAppServices = {
     ...core,
     ...corePlugins,
@@ -67,19 +67,19 @@ export function ObservabilityOnboardingAppRoot({
         >
           <KibanaContextProvider services={services}>
             <KibanaThemeProvider
-              theme={{ theme$ }}
               modify={{
                 breakpoint: {
                   xxl: 1600,
                   xxxl: 2000,
                 },
               }}
+              {...core}
             >
               <Router history={history}>
                 <EuiErrorBoundary>
                   <ObservabilityOnboardingHeaderActionMenu
                     setHeaderActionMenu={setHeaderActionMenu}
-                    theme$={theme$}
+                    {...core}
                   />
                   <ObservabilityOnboardingFlow />
                 </EuiErrorBoundary>

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/shared/header_action_menu.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/shared/header_action_menu.tsx
@@ -13,14 +13,20 @@ import { LOGS_ONBOARDING_FEEDBACK_LINK } from '@kbn/observability-shared-plugin/
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { type AppMountParameters } from '@kbn/core-application-browser';
+import { ThemeServiceStart } from '@kbn/core-theme-browser';
+import { UserProfileService } from '@kbn/core-user-profile-browser';
 import { type ObservabilityOnboardingAppServices } from '../..';
 
 interface Props {
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
-  theme$: AppMountParameters['theme$'];
+  theme: ThemeServiceStart;
+  userProfile: UserProfileService;
 }
 
-export function ObservabilityOnboardingHeaderActionMenu({ setHeaderActionMenu, theme$ }: Props) {
+export function ObservabilityOnboardingHeaderActionMenu({
+  setHeaderActionMenu,
+  ...startServices
+}: Props) {
   const {
     services: { context },
   } = useKibana<ObservabilityOnboardingAppServices>();
@@ -31,7 +37,7 @@ export function ObservabilityOnboardingHeaderActionMenu({ setHeaderActionMenu, t
 
   if (!context.isServerless && !isRootPage) {
     return (
-      <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+      <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} {...startServices}>
         <EuiButton
           data-test-subj="observabilityOnboardingPageGiveFeedback"
           href={LOGS_ONBOARDING_FEEDBACK_LINK}

--- a/x-pack/solutions/observability/plugins/observability_onboarding/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/tsconfig.json
@@ -43,6 +43,8 @@
     "@kbn/server-route-repository-utils",
     "@kbn/core-application-browser",
     "@kbn/core-plugins-server",
+    "@kbn/core-theme-browser",
+    "@kbn/core-user-profile-browser",
     "@kbn/logs-shared-plugin"
   ],
   "exclude": [

--- a/x-pack/solutions/observability/plugins/observability_shared/public/components/header_menu/header_menu_portal.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability_shared/public/components/header_menu/header_menu_portal.test.tsx
@@ -8,16 +8,16 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import HeaderMenuPortal from './header_menu_portal';
-import { themeServiceMock } from '@kbn/core/public/mocks';
+import { coreMock } from '@kbn/core/public/mocks';
 
 describe('HeaderMenuPortal', () => {
   describe('when unmounted', () => {
     it('calls setHeaderActionMenu with undefined', () => {
       const setHeaderActionMenu = jest.fn();
-      const theme$ = themeServiceMock.createTheme$();
+      const core = coreMock.createStart();
 
       const { unmount } = render(
-        <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+        <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} {...core}>
           test
         </HeaderMenuPortal>
       );

--- a/x-pack/solutions/observability/plugins/observability_shared/public/components/header_menu/header_menu_portal.tsx
+++ b/x-pack/solutions/observability/plugins/observability_shared/public/components/header_menu/header_menu_portal.tsx
@@ -15,13 +15,17 @@ import type { HeaderMenuPortalProps } from '../../types';
 export default function HeaderMenuPortal({
   children,
   setHeaderActionMenu,
-  theme$,
+  theme,
+  userProfile,
 }: HeaderMenuPortalProps) {
   const portalNode = useMemo(() => createHtmlPortalNode(), []);
 
   useEffect(() => {
     setHeaderActionMenu((element) => {
-      const mount = toMountPoint(<OutPortal node={portalNode} />, { theme$ });
+      const mount = toMountPoint(<OutPortal node={portalNode} />, {
+        theme$: theme.theme$,
+        userProfile,
+      });
       return mount(element);
     });
 
@@ -29,7 +33,7 @@ export default function HeaderMenuPortal({
       portalNode.unmount();
       setHeaderActionMenu(undefined);
     };
-  }, [portalNode, setHeaderActionMenu, theme$]);
+  }, [portalNode, setHeaderActionMenu, theme, userProfile]);
 
   return <InPortal node={portalNode}>{children}</InPortal>;
 }

--- a/x-pack/solutions/observability/plugins/observability_shared/public/components/header_menu/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_shared/public/components/header_menu/index.tsx
@@ -12,9 +12,10 @@ import { HeaderMenuPortalProps } from '../../types';
 const HeaderMenuPortalLazy = lazy(() => import('./header_menu_portal'));
 
 export function HeaderMenuPortal(props: HeaderMenuPortalProps) {
+  const { setHeaderActionMenu, theme, userProfile, children } = props;
   return (
     <Suspense fallback={<EuiLoadingSpinner />}>
-      <HeaderMenuPortalLazy {...props} />
+      <HeaderMenuPortalLazy {...{ setHeaderActionMenu, theme, userProfile, children }} />
     </Suspense>
   );
 }

--- a/x-pack/solutions/observability/plugins/observability_shared/public/types.ts
+++ b/x-pack/solutions/observability/plugins/observability_shared/public/types.ts
@@ -7,6 +7,8 @@
 
 import { ReactNode } from 'react';
 import { AppMountParameters } from '@kbn/core-application-browser';
+import type { UserProfileService } from '@kbn/core-user-profile-browser';
+import { ThemeServiceStart } from '@kbn/core-theme-browser';
 
 export interface ApmIndicesConfig {
   error: string;
@@ -32,7 +34,8 @@ export interface UXMetrics {
 export interface HeaderMenuPortalProps {
   children: ReactNode;
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
-  theme$: AppMountParameters['theme$'];
+  theme: ThemeServiceStart;
+  userProfile: UserProfileService;
 }
 
 export interface TimePickerTimeDefaults {

--- a/x-pack/solutions/observability/plugins/observability_shared/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability_shared/tsconfig.json
@@ -48,6 +48,8 @@
     "@kbn/data-views-plugin",
     "@kbn/charts-theme",
     "@kbn/deeplinks-observability",
+    "@kbn/core-user-profile-browser",
+    "@kbn/core-theme-browser",
   ],
   "exclude": ["target/**/*", ".storybook/**/*.js"]
 }

--- a/x-pack/solutions/observability/plugins/observability_solution/entity_manager_app/public/application.tsx
+++ b/x-pack/solutions/observability/plugins/observability_solution/entity_manager_app/public/application.tsx
@@ -43,7 +43,7 @@ export function renderApp({
   isServerless?: boolean;
   entityClient: EntityClient;
 }) {
-  const { element, history, theme$ } = appMountParameters;
+  const { element, history } = appMountParameters;
 
   // ensure all divs are .kbnAppWrappers
   element.classList.add(APP_WRAPPER_CLASS);
@@ -56,7 +56,7 @@ export function renderApp({
   ReactDOM.render(
     <KibanaRenderContextProvider {...core}>
       <ApplicationUsageTrackingProvider>
-        <KibanaThemeProvider {...{ theme: { theme$ } }}>
+        <KibanaThemeProvider {...core}>
           <CloudProvider>
             <KibanaContextProvider
               services={{

--- a/x-pack/solutions/observability/plugins/profiling/public/app.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/app.tsx
@@ -34,7 +34,6 @@ interface Props {
   coreSetup: CoreSetup;
   pluginsStart: ProfilingPluginPublicStartDeps;
   pluginsSetup: ProfilingPluginPublicSetupDeps;
-  theme$: AppMountParameters['theme$'];
   history: AppMountParameters['history'];
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
 }
@@ -42,14 +41,14 @@ interface Props {
 const storage = new Storage(localStorage);
 
 function MountProfilingActionMenu({
-  theme$,
+  core,
   setHeaderActionMenu,
 }: {
-  theme$: AppMountParameters['theme$'];
+  core: CoreStart;
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
 }) {
   return (
-    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} {...core}>
       <EuiFlexGroup responsive={false} gutterSize="s">
         <EuiFlexItem>
           <ProfilingHeaderActionMenu />
@@ -65,7 +64,6 @@ function App({
   pluginsStart,
   pluginsSetup,
   profilingFetchServices,
-  theme$,
   history,
   setHeaderActionMenu,
 }: Props) {
@@ -105,8 +103,8 @@ function App({
                             </RedirectWithDefaultDateRange>
                           </CheckSetup>
                           <MountProfilingActionMenu
+                            core={coreStart}
                             setHeaderActionMenu={setHeaderActionMenu}
-                            theme$={theme$}
                           />
                         </>
                       </LicenseProvider>

--- a/x-pack/solutions/observability/plugins/profiling/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/profiling/public/plugin.ts
@@ -123,7 +123,7 @@ export class ProfilingPlugin
       category: DEFAULT_APP_CATEGORIES.observability,
       deepLinks: links,
       updater$: appUpdater$,
-      async mount({ element, history, theme$, setHeaderActionMenu }: AppMountParameters) {
+      async mount({ element, history, setHeaderActionMenu }: AppMountParameters) {
         const [coreStart, pluginsStart] = await coreSetup.getStartServices();
 
         const { renderApp } = await import('./app');
@@ -145,7 +145,6 @@ export class ProfilingPlugin
             pluginsStart,
             pluginsSetup,
             history,
-            theme$,
             setHeaderActionMenu,
           },
           element

--- a/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/custom_kql/log_rate_analysis_panel.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/custom_kql/log_rate_analysis_panel.tsx
@@ -301,6 +301,7 @@ export function LogRateAnalysisPanel({ slo, alert, rule }: Props) {
                 'storage',
                 'uiSettings',
                 'unifiedSearch',
+                'userProfile',
                 'theme',
                 'lens',
                 'i18n',

--- a/x-pack/solutions/observability/plugins/slo/public/components/header_menu/header_menu.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/header_menu/header_menu.tsx
@@ -14,13 +14,13 @@ import { usePluginContext } from '../../hooks/use_plugin_context';
 import { SLOS_BASE_PATH, SLO_SETTINGS_PATH } from '../../../common/locators/paths';
 
 export function HeaderMenu(): React.ReactElement | null {
-  const { http, theme } = useKibana().services;
+  const { http, ...startServices } = useKibana().services;
 
   const { appMountParameters, isServerless } = usePluginContext();
   return (
     <HeaderMenuPortal
       setHeaderActionMenu={appMountParameters?.setHeaderActionMenu!}
-      theme$={theme.theme$}
+      {...startServices}
     >
       <EuiFlexGroup responsive={false} gutterSize="s">
         <EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_create_burn_rate_rule.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_create_burn_rate_rule.tsx
@@ -21,9 +21,8 @@ import { useKibana } from './use_kibana';
 export function useCreateRule<Params extends RuleTypeParams = never>() {
   const {
     http,
-    i18n: i18nStart,
     notifications: { toasts },
-    theme,
+    ...startServices
   } = useKibana().services;
 
   return useMutation<
@@ -58,7 +57,7 @@ export function useCreateRule<Params extends RuleTypeParams = never>() {
                 <EuiLoadingSpinner size="s" />
               </EuiFlexItem>
             </EuiFlexGroup>,
-            { i18n: i18nStart, theme }
+            startServices
           ),
         });
         return { loadingToastId: loadingToast.id };

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_create_slo.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_create_slo.tsx
@@ -24,11 +24,10 @@ type ServerError = IHttpFetchError<ResponseErrorBody>;
 
 export function useCreateSlo() {
   const {
-    i18n: i18nStart,
-    theme,
     application: { navigateToUrl },
     http,
     notifications: { toasts },
+    ...startServices
   } = useKibana().services;
   const { sloClient } = usePluginContext();
   const services = useKibana().services;
@@ -69,10 +68,7 @@ export function useCreateSlo() {
                   }}
                 />
               </RedirectAppLinks>,
-              {
-                i18n: i18nStart,
-                theme,
-              }
+              startServices
             ),
           },
           {

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/app_root/index.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/app_root/index.tsx
@@ -7,7 +7,12 @@
 
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import React from 'react';
-import { type AppMountParameters, type CoreStart } from '@kbn/core/public';
+import {
+  ThemeServiceStart,
+  type AppMountParameters,
+  type CoreStart,
+  type UserProfileService,
+} from '@kbn/core/public';
 import {
   BreadcrumbsContextProvider,
   RouteRenderer,
@@ -47,22 +52,27 @@ export function AppRoot({
           <BreadcrumbsContextProvider>
             <RouteRenderer />
           </BreadcrumbsContextProvider>
-          <StreamsAppHeaderActionMenu appMountParameters={appMountParameters} />
+          <StreamsAppHeaderActionMenu appMountParameters={appMountParameters} {...coreStart} />
         </RouterProvider>
       </RedirectAppLinks>
     </StreamsAppContextProvider>
   );
 }
 
+interface StreamsAppHeaderActionMenuProps {
+  appMountParameters: AppMountParameters;
+  theme: ThemeServiceStart;
+  userProfile: UserProfileService;
+}
+
 export function StreamsAppHeaderActionMenu({
   appMountParameters,
-}: {
-  appMountParameters: AppMountParameters;
-}) {
-  const { setHeaderActionMenu, theme$ } = appMountParameters;
+  ...startServices
+}: StreamsAppHeaderActionMenuProps) {
+  const { setHeaderActionMenu } = appMountParameters;
 
   return (
-    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} theme$={theme$}>
+    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} {...startServices}>
       <EuiFlexGroup responsive={false} gutterSize="s">
         <EuiFlexItem>
           <></>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/header/action_menu.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/header/action_menu.tsx
@@ -7,16 +7,19 @@
 
 import React from 'react';
 import { HeaderMenuPortal } from '@kbn/observability-shared-plugin/public';
-import { AppMountParameters } from '@kbn/core/public';
+import { AppMountParameters, ThemeServiceStart, UserProfileService } from '@kbn/core/public';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { ActionMenuContent } from './action_menu_content';
 
-export const ActionMenu = ({ appMountParameters }: { appMountParameters: AppMountParameters }) => {
+interface ActionMenuProps {
+  setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
+  theme: ThemeServiceStart;
+  userProfile: UserProfileService;
+}
+
+export const ActionMenu = ({ setHeaderActionMenu, ...startServices }: ActionMenuProps) => {
   return (
-    <HeaderMenuPortal
-      setHeaderActionMenu={appMountParameters.setHeaderActionMenu}
-      theme$={appMountParameters.theme$}
-    >
+    <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} {...startServices}>
       <EuiFlexGroup responsive={false} gutterSize="s">
         <EuiFlexItem>
           <ActionMenuContent />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/synthetics_app.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/synthetics_app.tsx
@@ -51,7 +51,7 @@ const Application = (props: SyntheticsAppProps) => {
   return (
     <KibanaRenderContextProvider {...coreStart}>
       <KibanaThemeProvider
-        theme={coreStart.theme}
+        {...coreStart}
         modify={{
           breakpoint: {
             xxl: 1600,
@@ -66,7 +66,10 @@ const Application = (props: SyntheticsAppProps) => {
                 <div className={APP_WRAPPER_CLASS} data-test-subj="syntheticsApp">
                   <InspectorContextProvider>
                     <PageRouter />
-                    <ActionMenu appMountParameters={appMountParameters} />
+                    <ActionMenu
+                      setHeaderActionMenu={appMountParameters.setHeaderActionMenu}
+                      {...coreStart}
+                    />
                     <TestNowModeFlyoutContainer />
                   </InspectorContextProvider>
                 </div>

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/app/uptime_app.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/app/uptime_app.tsx
@@ -90,13 +90,13 @@ const Application = (props: UptimeAppProps) => {
   return (
     <KibanaRenderContextProvider {...core}>
       <KibanaThemeProvider
-        theme={core.theme}
         modify={{
           breakpoint: {
             xxl: 1600,
             xxxl: 2000,
           },
         }}
+        {...core}
       >
         <ReduxProvider store={store}>
           <KibanaContextProvider
@@ -131,7 +131,10 @@ const Application = (props: UptimeAppProps) => {
                               <InspectorContextProvider>
                                 <UptimeAlertsFlyoutWrapper />
                                 <PageRouter />
-                                <ActionMenu appMountParameters={appMountParameters} />
+                                <ActionMenu
+                                  setHeaderActionMenu={appMountParameters.setHeaderActionMenu}
+                                  {...core}
+                                />
                               </InspectorContextProvider>
                             </RedirectAppLinks>
                           </div>

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/header/action_menu.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/header/action_menu.tsx
@@ -7,15 +7,18 @@
 
 import React from 'react';
 import { HeaderMenuPortal } from '@kbn/observability-shared-plugin/public';
-import { AppMountParameters } from '@kbn/core/public';
+import { AppMountParameters, ThemeServiceStart, UserProfileService } from '@kbn/core/public';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { ActionMenuContent } from './action_menu_content';
 
-export const ActionMenu = ({ appMountParameters }: { appMountParameters: AppMountParameters }) => (
-  <HeaderMenuPortal
-    setHeaderActionMenu={appMountParameters.setHeaderActionMenu}
-    theme$={appMountParameters.theme$}
-  >
+interface ActionMenuProps {
+  setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
+  theme: ThemeServiceStart;
+  userProfile: UserProfileService;
+}
+
+export const ActionMenu = ({ setHeaderActionMenu, ...startServices }: ActionMenuProps) => (
+  <HeaderMenuPortal setHeaderActionMenu={setHeaderActionMenu} {...startServices}>
     <EuiFlexGroup responsive={false} gutterSize="s">
       <EuiFlexItem>
         <ActionMenuContent />

--- a/x-pack/solutions/observability/plugins/ux/public/application/ux_app.tsx
+++ b/x-pack/solutions/observability/plugins/ux/public/application/ux_app.tsx
@@ -145,13 +145,13 @@ export function UXAppRoot({
             }}
           >
             <KibanaThemeProvider
-              theme={core.theme}
               modify={{
                 breakpoint: {
                   xxl: 1600,
                   xxxl: 2000,
                 },
               }}
+              {...core}
             >
               <PluginContext.Provider
                 value={{

--- a/x-pack/solutions/observability/plugins/ux/public/components/app/rum_dashboard/action_menu/index.tsx
+++ b/x-pack/solutions/observability/plugins/ux/public/components/app/rum_dashboard/action_menu/index.tsx
@@ -32,7 +32,7 @@ export function UXActionMenu({
   appMountParameters: AppMountParameters;
   isDev: boolean;
 }) {
-  const { http, application } = useKibanaServices();
+  const { http, application, ...startServices } = useKibanaServices();
 
   const { urlParams } = useLegacyUrlParams();
   const { rangeTo, rangeFrom, serviceName } = urlParams;
@@ -58,7 +58,7 @@ export function UXActionMenu({
   return (
     <HeaderMenuPortal
       setHeaderActionMenu={appMountParameters.setHeaderActionMenu}
-      theme$={appMountParameters.theme$}
+      {...startServices}
     >
       <EuiFlexGroup responsive={false} gutterSize="s">
         <EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/ux/public/hooks/use_kibana_services.tsx
+++ b/x-pack/solutions/observability/plugins/ux/public/hooks/use_kibana_services.tsx
@@ -5,7 +5,14 @@
  * 2.0.
  */
 
-import { HttpStart, DocLinksStart, IUiSettingsClient, ApplicationStart } from '@kbn/core/public';
+import {
+  HttpStart,
+  DocLinksStart,
+  IUiSettingsClient,
+  ApplicationStart,
+  ThemeServiceStart,
+  UserProfileService,
+} from '@kbn/core/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { ApmPluginStartDeps } from '../plugin';
 
@@ -14,6 +21,8 @@ interface UxKibanaServices extends ApmPluginStartDeps {
   docLinks: DocLinksStart;
   uiSettings: IUiSettingsClient;
   application: ApplicationStart;
+  theme: ThemeServiceStart;
+  userProfile: UserProfileService;
 }
 
 export function useKibanaServices() {


### PR DESCRIPTION
## Summary

**Reviewers: Please test the code paths affected by this PR. See the "Risks" section below.**

Part of work for enabling "high contrast mode" in Kibana. See https://github.com/elastic/kibana/issues/205411

**Background:**
Kibana will soon have a user profile setting to allow users to enable "high contrast mode." This setting will activate a flag with `<EuiProvider>` that causes EUI components to render with higher contrast visual elements. Consumer plugins and packages need to be updated selected places where `<EuiProvider>` is wrapped, to pass the `UserProfileService` service dependency from the CoreStart contract.

**NOTE:** **EUI currently does not yet support the high-contrast mode flag**, but support for that is expected to come soon. These first PRs are simply preparing the code by wiring up the `UserProvideService`.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [X] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [medium/high] The implementor of this change did not manually test the affected code paths and relied on type-checking and functional tests to drive the changes. Code owners for this PR need to manually test the affected code paths.
- [ ] [medium] The `UserProfileService` dependency comes from the CoreStart contract. If acquiring the service causes synchronous code to become asynchronous, check for race conditions or errors in rendering React components. Code owners for this PR need to manually test the affected code paths.