### PR TITLE
[8.16] Upgrading APM Node (#205440)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1107,7 +1107,7 @@
     "del": "^6.1.0",
     "diff": "^5.1.0",
     "dotenv": "^16.4.5",
-    "elastic-apm-node": "^4.7.3",
+    "elastic-apm-node": "^4.10.0",
     "email-addresses": "^5.0.0",
     "eventsource-parser": "^1.1.1",
     "execa": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16748,10 +16748,10 @@ elastic-apm-node@3.46.0:
     traverse "^0.6.6"
     unicode-byte-truncate "^1.0.0"
 
-elastic-apm-node@^4.7.3:
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/elastic-apm-node/-/elastic-apm-node-4.7.3.tgz#d819a9030f7321cc858c788f60b383de85461f24"
-  integrity sha512-x+cQKrXSCz6JgoTFAiBpLlC85ruqZ7sAl+jAS3+DeSmc6ZXLRTwTa2ay2PCGv3DxGLZjVZ+ItzGdHTj5B7PYKg==
+elastic-apm-node@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/elastic-apm-node/-/elastic-apm-node-4.10.0.tgz#b0560f1f49ac4f7633a810d4d7f727e45f8ebe20"
+  integrity sha512-QmnKLArA84lJ4mNoUTi9qMUfLE1nUeFLB+VO/7iG6UOTiAdR5Wxk0nu3SpcgFe+tr+4GkyXM2xXdmL2XYfQ1Qg==
   dependencies:
     "@elastic/ecs-pino-format" "^1.5.0"
     "@opentelemetry/api" "^1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14961,10 +14961,10 @@ cookie@^0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
-cookie@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
-  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
+cookie@^0.7.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 cookiejar@^2.1.4:
   version "2.1.4"
@@ -16762,7 +16762,7 @@ elastic-apm-node@^4.10.0:
     async-value-promise "^1.1.1"
     basic-auth "^2.0.1"
     breadth-filter "^2.0.0"
-    cookie "^0.6.0"
+    cookie "^0.7.1"
     core-util-is "^1.0.2"
     end-of-stream "^1.4.4"
     error-callsites "^2.0.4"
@@ -16771,7 +16771,7 @@ elastic-apm-node@^4.10.0:
     fast-safe-stringify "^2.0.7"
     fast-stream-to-buffer "^1.0.0"
     http-headers "^3.0.2"
-    import-in-the-middle "1.11.0"
+    import-in-the-middle "1.11.3"
     json-bigint "^1.0.0"
     lru-cache "10.2.0"
     measured-reporting "^1.51.1"
@@ -20063,10 +20063,10 @@ import-fresh@^3.1.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.11.0.tgz#a94c4925b8da18256cde3b3b7b38253e6ca5e708"
-  integrity sha512-5DimNQGoe0pLUHbR9qK84iWaWjjbsxiqXnw6Qz64+azRgleqv9k2kTt5fw7QsOpmaGYtuxxursnPPsnTKEx10Q==
+import-in-the-middle@1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.11.3.tgz#08559f2c05fd65ba7062e747af056ed18a80120c"
+  integrity sha512-tNpKEb4AjZrCyrxi+Eyu43h5ig0O8ZRFSXPHh/00/o+4P4pKzVEW/m5lsVtsAT7fCIgmQOAPjdqecGDsBXRxsw==
   dependencies:
     acorn "^8.8.2"
     acorn-import-attributes "^1.9.5"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Upgrading APM Node (#205440)](https://github.com/elastic/kibana/pull/205440)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kurt","email":"kc13greiner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-03T20:39:25Z","message":"Upgrading APM Node (#205440)\n\n## Summary\r\n\r\nUpgrade `elastic-apm-node` from 4.9.0 to 4.10.0\r\n\r\n\r\n[CHANGELOG](https://github.com/elastic/apm-agent-nodejs/blob/main/CHANGELOG.asciidoc)","sha":"283bcf5a155ae14c4217a02d6850da43eb8eea15","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","v9.0.0","backport:all-open"],"number":205440,"url":"https://github.com/elastic/kibana/pull/205440","mergeCommit":{"message":"Upgrading APM Node (#205440)\n\n## Summary\r\n\r\nUpgrade `elastic-apm-node` from 4.9.0 to 4.10.0\r\n\r\n\r\n[CHANGELOG](https://github.com/elastic/apm-agent-nodejs/blob/main/CHANGELOG.asciidoc)","sha":"283bcf5a155ae14c4217a02d6850da43eb8eea15"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205440","number":205440,"mergeCommit":{"message":"Upgrading APM Node (#205440)\n\n## Summary\r\n\r\nUpgrade `elastic-apm-node` from 4.9.0 to 4.10.0\r\n\r\n\r\n[CHANGELOG](https://github.com/elastic/apm-agent-nodejs/blob/main/CHANGELOG.asciidoc)","sha":"283bcf5a155ae14c4217a02d6850da43eb8eea15"}},{"url":"https://github.com/elastic/kibana/pull/205541","number":205541,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->