### PR TITLE
Sustainable Kibana Architecture: Fix after-relocation issues

### DIFF
--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -236,7 +236,7 @@ const getPipeline = (filename: string, removeSteps = true) => {
     if (
       (await doAnyChangesMatch([
         /^packages\/kbn-securitysolution-.*/,
-        /^x-pack\/solutions\/security\/platform\/plugins\/shared\/security_solution/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution/,
         /^x-pack\/test\/defend_workflows_cypress/,
         /^x-pack\/test\/security_solution_cypress/,
         /^fleet_packages\.json/,
@@ -256,9 +256,9 @@ const getPipeline = (filename: string, removeSteps = true) => {
         /^x-pack\/platform\/plugins\/shared\/data_views\/common/,
         /^x-pack\/solutions\/security\/plugins\/lists/,
         /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
-        /^x-pack\/solutions\/security\/platform\/plugins\/shared\/security_solution/,
-        /^x-pack\/solutions\/security\/platform\/plugins\/shared\/security_solution_ess/,
-        /^x-pack\/solutions\/security\/platform\/plugins\/shared\/security_solution_serverless/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
         /^x-pack\/platform\/plugins\/shared\/task_manager/,
         /^x-pack\/solutions\/security\/plugins\/timelines/,
         /^x-pack\/platform\/plugins\/shared\/triggers_actions_ui\/public\/application\/sections\/action_connector_form/,
@@ -341,9 +341,9 @@ const getPipeline = (filename: string, removeSteps = true) => {
         /^x-pack\/solutions\/security\/plugins\/elastic_assistant/,
         /^x-pack\/solutions\/security\/plugins\/lists/,
         /^x-pack\/platform\/plugins\/shared\/rule_registry\/common/,
-        /^x-pack\/solutions\/security\/platform\/plugins\/shared\/security_solution/,
-        /^x-pack\/solutions\/security\/platform\/plugins\/shared\/security_solution_ess/,
-        /^x-pack\/solutions\/security\/platform\/plugins\/shared\/security_solution_serverless/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution_ess/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution_serverless/,
         /^x-pack\/platform\/plugins\/shared\/task_manager/,
         /^x-pack\/solutions\/security\/plugins\/threat_intelligence/,
         /^x-pack\/solutions\/security\/plugins\/timelines/,
@@ -363,7 +363,7 @@ const getPipeline = (filename: string, removeSteps = true) => {
       ((await doAnyChangesMatch([
         /^x-pack\/platform\/plugins\/shared\/osquery/,
         /^x-pack\/test\/osquery_cypress/,
-        /^x-pack\/solutions\/security\/platform\/plugins\/shared\/security_solution/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution/,
       ])) ||
         GITHUB_PR_LABELS.includes('ci:all-cypress-suites')) &&
       !GITHUB_PR_LABELS.includes('ci:skip-cypress-osquery')
@@ -376,8 +376,8 @@ const getPipeline = (filename: string, removeSteps = true) => {
     if (
       (await doAnyChangesMatch([
         /^x-pack\/packages\/kbn-cloud-security-posture/,
-        /^x-pack\/solutions\/security\/platform\/plugins\/shared\/cloud_security_posture/,
-        /^x-pack\/solutions\/security\/platform\/plugins\/shared\/security_solution/,
+        /^x-pack\/solutions\/security\/plugins\/cloud_security_posture/,
+        /^x-pack\/solutions\/security\/plugins\/security_solution/,
         /^x-pack\/test\/security_solution_cypress/,
       ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites')

--- a/packages/kbn-telemetry-tools/src/tools/tasks/generate_schemas_task.ts
+++ b/packages/kbn-telemetry-tools/src/tools/tasks/generate_schemas_task.ts
@@ -13,7 +13,7 @@ import { generateMapping } from '../manage_schema';
 export function generateSchemasTask({ roots }: TaskContext) {
   return roots.map((root) => ({
     task: () => {
-      if (!root.parsedCollections || !root.parsedCollections.length) {
+      if (!root.parsedCollections) {
         return;
       }
       const mapping = generateMapping(root.parsedCollections);


### PR DESCRIPTION
## Summary

After merging #202748, #204959, and #201653, all of the properties in some telemetry schemas were moved completely, but `node scripts/telemetry_check --fix` didn't update the `properties` object correctly.

Also, in #202748 and #201653, the relocation script changed some paths, confusing them with `@kbn/security-plugin` and `@kbn/cloud-plugin`.



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->