### PR TITLE
[Fleet] Fix getBulkAssets behavior with missing dashboard

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_bulk_assets.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get_bulk_assets.ts
@@ -53,7 +53,10 @@ export async function getBulkAssets(
 
   const res: SimpleSOAssetType[] = resolvedObjects
     .map(({ saved_object: savedObject }) => savedObject)
-    .filter((savedObject) => displayedAssetTypesLookup.has(savedObject.type))
+    .filter(
+      (savedObject) =>
+        savedObject?.error?.statusCode !== 404 && displayedAssetTypesLookup.has(savedObject.type)
+    )
     .map((obj) => {
       // Kibana SOs are registered with an app URL getter, so try to use that
       // for retrieving links to assets whenever possible


### PR DESCRIPTION
## Summary

Fix a breaking change introduce in https://github.com/elastic/kibana/pull/182180 

Resolve https://github.com/elastic/kibana/issues/190980

Bulk get assets used to filter not found dashboard, this was used for stack monitoring to display a button to add elasticsearch integration.

That PR fix that.

<img width="1492" alt="Screenshot 2025-01-06 at 10 33 38 AM" src="https://github.com/user-attachments/assets/1a4fd47f-38c2-49c1-b60c-258172b1b160" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->