### PR TITLE
Set relative date for host details link in onboarding flow

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
@@ -183,6 +183,12 @@ export const AutoDetectPanel: FunctionComponent = () => {
                                       href: assetDetailsLocator.getRedirectUrl({
                                         assetType: 'host',
                                         assetId: integration.metadata?.hostname,
+                                        assetDetails: {
+                                          dateRange: {
+                                            from: 'now-15m',
+                                            to: 'now',
+                                          },
+                                        },
                                       }),
                                     },
                                   ]


### PR DESCRIPTION
This change sets a relative date range to the host details link from the auto-detect onboarding flow. This prevents a situation when host details page would open saying there is no data and it would be stuck on a fixed date range unable to load data even if user refreshes the page.

Somehow, even when onboarding flow can detect that the data was already ingested, the host details page might not see it for some reason. This requires a further investigation, but relative data range is a fix for the time being.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->