### PR TITLE
[SharedUX] Don't use `kibana_user` role in functional tests

### DIFF
--- a/x-pack/test/accessibility/apps/group3/reporting.ts
+++ b/x-pack/test/accessibility/apps/group3/reporting.ts
@@ -20,7 +20,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     const createReportingUser = async () => {
       await security.user.create(reporting.REPORTING_USER_USERNAME, {
         password: reporting.REPORTING_USER_PASSWORD,
-        roles: ['data_analyst', 'kibana_user'],
+        roles: ['data_analyst', 'kibana_admin'],
         full_name: 'a reporting user',
       });
     };


### PR DESCRIPTION
In this PR I've moved a functional test to use the `kibana_admin` role, rather than `kibana_user`, to avoid usage of deprecated ES API.

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7660

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->