### PR TITLE
[8.x] Conditionally add agentless index permissions (#203810)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -41,16 +41,6 @@ export const UNIVERSAL_PROFILING_PERMISSIONS = [
   'view_index_metadata',
 ];
 
-export const ELASTIC_CONNECTORS_INDEX_PERMISSIONS = [
-  'read',
-  'write',
-  'monitor',
-  'create_index',
-  'auto_configure',
-  'maintenance',
-  'view_index_metadata',
-];
-
 export const AGENTLESS_INDEX_PERMISSIONS = [
   'read',
   'write',

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -41,6 +41,26 @@ export const UNIVERSAL_PROFILING_PERMISSIONS = [
   'view_index_metadata',
 ];
 
+export const ELASTIC_CONNECTORS_INDEX_PERMISSIONS = [
+  'read',
+  'write',
+  'monitor',
+  'create_index',
+  'auto_configure',
+  'maintenance',
+  'view_index_metadata',
+];
+
+export const AGENTLESS_INDEX_PERMISSIONS = [
+  'read',
+  'write',
+  'monitor',
+  'create_index',
+  'auto_configure',
+  'maintenance',
+  'view_index_metadata',
+];
+
 export function storedPackagePoliciesToAgentPermissions(
   packageInfoCache: Map<string, PackageInfo>,
   agentPolicyNamespace: string,
@@ -158,13 +178,10 @@ export function storedPackagePoliciesToAgentPermissions(
     }
     // namespace is either the package policy's or the agent policy one
     const namespace = packagePolicy?.namespace || agentPolicyNamespace;
-    return [
-      packagePolicy.id,
-      {
-        indices: dataStreamsForPermissions.map((ds) => getDataStreamPrivileges(ds, namespace)),
-        ...clusterRoleDescriptor,
-      },
-    ];
+    return maybeAddAgentlessPermissions(packagePolicy, {
+      indices: dataStreamsForPermissions.map((ds) => getDataStreamPrivileges(ds, namespace)),
+      ...clusterRoleDescriptor,
+    });
   });
 
   return Object.fromEntries(permissionEntries);
@@ -227,6 +244,20 @@ function universalProfilingPermissions(packagePolicyId: string): [string, Securi
       ],
     },
   ];
+}
+
+function maybeAddAgentlessPermissions(
+  packagePolicy: PackagePolicy,
+  existing: SecurityRoleDescriptor
+): [string, SecurityRoleDescriptor] {
+  if (!packagePolicy.supports_agentless) {
+    return [packagePolicy.id, existing];
+  }
+  existing.indices!.push({
+    names: ['agentless-*'],
+    privileges: AGENTLESS_INDEX_PERMISSIONS,
+  });
+  return [packagePolicy.id, existing];
 }
 
 function apmPermissions(packagePolicyId: string): [string, SecurityRoleDescriptor] {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Conditionally add agentless index permissions (#203810)](https://github.com/elastic/kibana/pull/203810)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Orestis Floros","email":"orestis.floros@elastic.co"},"sourceCommit":{"committedDate":"2025-01-07T12:34:54Z","message":"Conditionally add agentless index permissions (#203810)\n\n## Summary\n\nAdds necessary permissions to write to the `agentless-*` index. See:\n- Elasticsearch PR: https://github.com/elastic/elasticsearch/pull/118644\n- Context: https://github.com/elastic/security-team/issues/11104\n\nAs part of https://github.com/elastic/security-team/issues/11104, we\nneed to write integration data that needs to be persistent. The\nimplementation we are working on, uses Elasticsearch as the storage\nmechanism for this data.\n\nNormally, integrations write to data streams instead of normal ES\nindices. However, data streams cannot provide a generic implementation\nfor our use case and thus we need a normal ES index.\n\nThis PR grants permissions from the fleet service account to the\nagentless integrations to write to `agentless-*` ES indices.\n\nIn\n`x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts`\nthere are other examples of other integrations that need ES index\npermissions so there is prior art in doing this. The difference with\nthis PR however, is that we need to conditionally merge the extra\n`agentless-*` permissions with any potential existing data stream\npermissions since we are dealing with arbitrary agentless integrations.","sha":"d0166b6730e8cf712aa0f7fc3a38f00fa7693396","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","Team:Cloud Security","backport:prev-minor","ci:build-serverless-image","v8.18.0"],"number":203810,"url":"https://github.com/elastic/kibana/pull/203810","mergeCommit":{"message":"Conditionally add agentless index permissions (#203810)\n\n## Summary\n\nAdds necessary permissions to write to the `agentless-*` index. See:\n- Elasticsearch PR: https://github.com/elastic/elasticsearch/pull/118644\n- Context: https://github.com/elastic/security-team/issues/11104\n\nAs part of https://github.com/elastic/security-team/issues/11104, we\nneed to write integration data that needs to be persistent. The\nimplementation we are working on, uses Elasticsearch as the storage\nmechanism for this data.\n\nNormally, integrations write to data streams instead of normal ES\nindices. However, data streams cannot provide a generic implementation\nfor our use case and thus we need a normal ES index.\n\nThis PR grants permissions from the fleet service account to the\nagentless integrations to write to `agentless-*` ES indices.\n\nIn\n`x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts`\nthere are other examples of other integrations that need ES index\npermissions so there is prior art in doing this. The difference with\nthis PR however, is that we need to conditionally merge the extra\n`agentless-*` permissions with any potential existing data stream\npermissions since we are dealing with arbitrary agentless integrations.","sha":"d0166b6730e8cf712aa0f7fc3a38f00fa7693396"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203810","number":203810,"mergeCommit":{"message":"Conditionally add agentless index permissions (#203810)\n\n## Summary\n\nAdds necessary permissions to write to the `agentless-*` index. See:\n- Elasticsearch PR: https://github.com/elastic/elasticsearch/pull/118644\n- Context: https://github.com/elastic/security-team/issues/11104\n\nAs part of https://github.com/elastic/security-team/issues/11104, we\nneed to write integration data that needs to be persistent. The\nimplementation we are working on, uses Elasticsearch as the storage\nmechanism for this data.\n\nNormally, integrations write to data streams instead of normal ES\nindices. However, data streams cannot provide a generic implementation\nfor our use case and thus we need a normal ES index.\n\nThis PR grants permissions from the fleet service account to the\nagentless integrations to write to `agentless-*` ES indices.\n\nIn\n`x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts`\nthere are other examples of other integrations that need ES index\npermissions so there is prior art in doing this. The difference with\nthis PR however, is that we need to conditionally merge the extra\n`agentless-*` permissions with any potential existing data stream\npermissions since we are dealing with arbitrary agentless integrations.","sha":"d0166b6730e8cf712aa0f7fc3a38f00fa7693396"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->