### PR TITLE
Fix telemetry CLI to write empty properties collection

### DIFF
--- a/packages/kbn-telemetry-tools/src/tools/tasks/write_to_file_task.ts
+++ b/packages/kbn-telemetry-tools/src/tools/tasks/write_to_file_task.ts
@@ -15,7 +15,7 @@ export function writeToFileTask({ roots }: TaskContext) {
   return roots.map((root) => ({
     task: async () => {
       const fullPath = path.resolve(process.cwd(), root.config.output);
-      if (root.mapping && Object.keys(root.mapping.properties).length > 0) {
+      if (root.mapping) {
         // Sort first-level properties alphabetically
         root.mapping.properties = Object.fromEntries(
           Object.entries(root.mapping.properties).sort(([a], [b]) => {

--- a/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -1,4 +1,3 @@
 {
-  "properties": {
-  }
+  "properties": {}
 }


### PR DESCRIPTION
## Summary

Follow-up of #205613. Remove check blocking empty properties from writing.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->