### PR TITLE
[Reporting/CSV/Docs] Specify maximum value for scroll.duration setting

### DIFF
--- a/docs/settings/reporting-settings.asciidoc
+++ b/docs/settings/reporting-settings.asciidoc
@@ -250,7 +250,7 @@ The maximum {byte-units}[byte size] of a CSV file before being truncated. This s
 exports from causing performance and storage issues. Can be specified as a number of bytes. Defaults to `250mb`.
 
 `xpack.reporting.csv.scroll.size`::
-Number of documents retrieved from {es} for each scroll iteration during a CSV export. Defaults to `500`.
+Number of documents retrieved from {es} for each scroll iteration during a CSV export. The maximum value is `10000`. Defaults to `500`.
 [NOTE]
 ============
 You may need to lower this setting if the default number of documents creates a strain on network resources.


### PR DESCRIPTION
## Summary

Updates Reporting CSV export documentation to specify there is a maximum value for `xpack.reporting.csv.scroll.size`, which is 10000.

<!--ONMERGE {"backportTargets":["8.13","8.14","8.15","8.16","8.17","8.x"]} ONMERGE-->