### PR TITLE
[Fleet] Fix required validation for multi text input field

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
@@ -872,6 +872,46 @@ describe('Fleet - validationHasErrors()', () => {
 });
 
 describe('Fleet - validatePackagePolicyConfig', () => {
+  describe('Multi Text', () => {
+    it('should return required error message for empty string', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          type: 'text',
+          value: [''],
+        },
+        {
+          name: 'myvariable',
+          type: 'text',
+          multi: true,
+          required: true,
+        },
+        'myvariable',
+        load
+      );
+
+      expect(res).toEqual(['myvariable is required']);
+    });
+
+    it('should return required error message for blank spaces', () => {
+      const res = validatePackagePolicyConfig(
+        {
+          type: 'text',
+          value: ['value1', '  '],
+        },
+        {
+          name: 'myvariable',
+          type: 'text',
+          multi: true,
+          required: true,
+        },
+        'myvariable',
+        load
+      );
+
+      expect(res).toEqual(['myvariable is required']);
+    });
+  });
+
   describe('Integer', () => {
     it('should return an error message for invalid integer', () => {
       const res = validatePackagePolicyConfig(

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
@@ -291,15 +291,20 @@ export const validatePackagePolicyConfig = (
       );
       return errors;
     }
-    if (varDef.required && Array.isArray(parsedValue) && parsedValue.length === 0) {
-      errors.push(
-        i18n.translate('xpack.fleet.packagePolicyValidation.requiredErrorMessage', {
-          defaultMessage: '{fieldName} is required',
-          values: {
-            fieldName: varDef.title || varDef.name,
-          },
-        })
-      );
+    if (varDef.required && Array.isArray(parsedValue)) {
+      const hasEmptyString =
+        varDef.type === 'text' && parsedValue.some((item) => item.trim() === '');
+
+      if (hasEmptyString || parsedValue.length === 0) {
+        errors.push(
+          i18n.translate('xpack.fleet.packagePolicyValidation.requiredErrorMessage', {
+            defaultMessage: '{fieldName} is required',
+            values: {
+              fieldName: varDef.title || varDef.name,
+            },
+          })
+        );
+      }
     }
     if (varDef.type === 'text' && parsedValue) {
       const invalidStrings = parsedValue.filter((cand: any) => /^[*&]/.test(cand));


### PR DESCRIPTION
## Summary

Fixes #196648 

- ✅  add required validation to blank spaces value
- ❓  when adding additional rows for path. It seems that the updated value is specially processed. 

**And this is why the required validation is not triggered when clicking to add a row.**

![image](https://github.com/user-attachments/assets/f2f0d813-3762-47c5-bf31-1171c82c3b07)

## After fixup

![image](https://github.com/user-attachments/assets/857bef47-38c1-4951-8ea9-15b5ef5d143d)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->