### PR TITLE
[Fleet] Fix parsing policy_templates_behavior from archive

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/parse.ts
@@ -125,6 +125,7 @@ const optionalArchivePackageProps: readonly OptionalPackageProp[] = [
   'screenshots',
   'icons',
   'policy_templates',
+  'policy_templates_behavior',
   'release',
   'agent',
   'elasticsearch',


### PR DESCRIPTION
## Summary

Fix parsing `policy_templates_behavior` from archive to not show installed packages with `policy_templates_behavior: individual_policies` in the integrations list page.


## Test

Install elastic_connector:0.0.5 and verify it's not displayed in the integration list

<img width="1510" alt="Screenshot 2025-01-07 at 10 24 00 AM" src="https://github.com/user-attachments/assets/b04ec093-3071-4567-9178-f6ce94d8380d" />


## Todo 

 - [ ] add tests

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->