### PR TITLE
[8.x] remove outstanding testing-library/react-hooks usages (#205307)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -271,6 +271,10 @@ const RESTRICTED_IMPORTS = [
     message:
       'Please, use rxjs instead: rxjs/operators is just a subset, unnecessarily duplicating the package import.',
   },
+  {
+    name: '@testing-library/react-hooks',
+    message: 'Please use @testing-library/react instead',
+  },
 ];
 
 module.exports = {

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_find_alerts_query.test.tsx
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_find_alerts_query.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { testQueryClientConfig } from '../test_utils/test_query_client_config';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
@@ -32,7 +32,7 @@ describe('useFindAlertsQuery', () => {
   });
 
   it('calls the api correctly', async () => {
-    const { result, waitForValueToChange } = renderHook(
+    const { result } = renderHook(
       () =>
         useFindAlertsQuery({
           ...mockServices,
@@ -43,7 +43,7 @@ describe('useFindAlertsQuery', () => {
       }
     );
 
-    await waitForValueToChange(() => result.current.isLoading, { timeout: 5000 });
+    await waitFor(() => expect(result.current.isLoading).toBe(true), { timeout: 5000 });
 
     expect(mockServices.http.post).toHaveBeenCalledTimes(1);
     expect(mockServices.http.post).toBeCalledWith('/internal/rac/alerts/find', {

--- a/src/platform/plugins/shared/share/public/components/context/index.test.tsx
+++ b/src/platform/plugins/shared/share/public/components/context/index.test.tsx
@@ -7,18 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useShareTabsContext } from '.';
 
 describe('share menu context', () => {
   describe('useShareTabsContext', () => {
     it('throws an error if used outside of ShareMenuProvider tree', () => {
-      const { result } = renderHook(() => useShareTabsContext());
-
-      expect(result.error?.message).toEqual(
-        expect.stringContaining(
-          'Failed to call `useShareTabsContext` because the context from ShareMenuProvider is missing.'
-        )
+      expect(() => renderHook(() => useShareTabsContext())).toThrow(
+        /^Failed to call `useShareTabsContext` because the context from ShareMenuProvider is missing./
       );
     });
   });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/knowledge_base/entries/use_create_knowledge_base_entry.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/knowledge_base/entries/use_create_knowledge_base_entry.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { act, renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import {
   useCreateKnowledgeBaseEntry,
   UseCreateKnowledgeBaseEntryParams,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/knowledge_base/entries/use_delete_knowledge_base_entries.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/knowledge_base/entries/use_delete_knowledge_base_entries.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { act, renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import {
   useDeleteKnowledgeBaseEntries,
   UseDeleteKnowledgeEntriesParams,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/knowledge_base/entries/use_knowledge_base_entries.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/knowledge_base/entries/use_knowledge_base_entries.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useKnowledgeBaseEntries } from './use_knowledge_base_entries';
 import { HttpSetup } from '@kbn/core/public';
 import { IToasts } from '@kbn/core-notifications-browser';
@@ -27,7 +27,7 @@ describe('useKnowledgeBaseEntries', () => {
       data: [{ id: '1', title: 'Entry 1' }],
     });
 
-    const { result, waitForNextUpdate } = renderHook(
+    const { result } = renderHook(
       () => useKnowledgeBaseEntries({ http: httpMock, enabled: true }),
       {
         wrapper: TestProviders,
@@ -35,32 +35,32 @@ describe('useKnowledgeBaseEntries', () => {
     );
     expect(result.current.fetchStatus).toEqual('fetching');
 
-    await waitForNextUpdate();
-
-    expect(result.current.data).toEqual({
-      page: 1,
-      perPage: 100,
-      total: 1,
-      data: [{ id: '1', title: 'Entry 1' }],
-    });
+    await waitFor(() =>
+      expect(result.current.data).toEqual({
+        page: 1,
+        perPage: 100,
+        total: 1,
+        data: [{ id: '1', title: 'Entry 1' }],
+      })
+    );
   });
 
   it('handles fetch error', async () => {
     const error = new Error('Fetch error');
     (httpMock.fetch as jest.Mock).mockRejectedValue(error);
 
-    const { waitForNextUpdate } = renderHook(
+    renderHook(
       () => useKnowledgeBaseEntries({ http: httpMock, toasts: toastsMock, enabled: true }),
       {
         wrapper: TestProviders,
       }
     );
 
-    await waitForNextUpdate();
-
-    expect(toastsMock.addError).toHaveBeenCalledWith(error, {
-      title: 'Error fetching Knowledge Base entries',
-    });
+    await waitFor(() =>
+      expect(toastsMock.addError).toHaveBeenCalledWith(error, {
+        title: 'Error fetching Knowledge Base entries',
+      })
+    );
   });
 
   it('does not fetch when disabled', async () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/knowledge_base/entries/use_update_knowledge_base_entries.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/knowledge_base/entries/use_update_knowledge_base_entries.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { act, renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import {
   useUpdateKnowledgeBaseEntries,
   UseUpdateKnowledgeBaseEntriesParams,

--- a/x-pack/platform/plugins/shared/cases/public/components/actions/status/use_should_disable_status.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/actions/status/use_should_disable_status.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { CaseStatuses } from '../../../../common/types/domain';
 import { useUserPermissions } from '../../user_actions/use_user_permissions';
 import { useShouldDisableStatus } from './use_should_disable_status';

--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_observables.test.ts
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/use_case_observables.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useCaseObservables } from './use_case_observables';
 import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
 import { OBSERVABLE_TYPES_BUILTIN_KEYS } from '../../../common/constants';

--- a/x-pack/platform/plugins/shared/cases/public/components/user_actions/use_user_permissions.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_actions/use_user_permissions.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useCasesContext } from '../cases_context/use_cases_context';
 import { useUserPermissions } from './use_user_permissions';
 import type { UserActivityParams } from '../user_actions_activity_bar/types';

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_delete_observables.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_delete_observables.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useDeleteObservable } from './use_delete_observables';
 import { deleteObservable } from './api';
 import { useCasesToast } from '../common/use_cases_toast';
@@ -35,7 +35,7 @@ describe('useDeleteObservable', () => {
   it('should call deleteObservable and show success toast on success', async () => {
     (deleteObservable as jest.Mock).mockResolvedValue({});
 
-    const { result, waitFor } = renderHook(() => useDeleteObservable(caseId, observableId), {
+    const { result } = renderHook(() => useDeleteObservable(caseId, observableId), {
       wrapper: appMockRender.AppWrapper,
     });
 
@@ -52,7 +52,7 @@ describe('useDeleteObservable', () => {
     const error = new Error('Failed to delete observable');
     (deleteObservable as jest.Mock).mockRejectedValue(error);
 
-    const { result, waitFor } = renderHook(() => useDeleteObservable(caseId, observableId), {
+    const { result } = renderHook(() => useDeleteObservable(caseId, observableId), {
       wrapper: appMockRender.AppWrapper,
     });
 

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_get_similar_cases.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_get_similar_cases.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, waitFor } from '@testing-library/react';
 import * as api from './api';
 import type { AppMockRenderer } from '../common/mock';
 import { createAppMockRenderer } from '../common/mock';
@@ -30,12 +30,9 @@ describe('useGetSimilarCases', () => {
 
   it('calls getSimilarCases with correct arguments', async () => {
     const spyOnGetCases = jest.spyOn(api, 'getSimilarCases');
-    const { waitFor } = renderHook(
-      () => useGetSimilarCases({ caseId: mockCase.id, perPage: 10, page: 0 }),
-      {
-        wrapper: appMockRender.AppWrapper,
-      }
-    );
+    renderHook(() => useGetSimilarCases({ caseId: mockCase.id, perPage: 10, page: 0 }), {
+      wrapper: appMockRender.AppWrapper,
+    });
 
     await waitFor(() => {
       expect(spyOnGetCases).toBeCalled();
@@ -58,12 +55,9 @@ describe('useGetSimilarCases', () => {
     const addError = jest.fn();
     (useToasts as jest.Mock).mockReturnValue({ addSuccess, addError });
 
-    const { waitFor } = renderHook(
-      () => useGetSimilarCases({ caseId: mockCase.id, perPage: 10, page: 0 }),
-      {
-        wrapper: appMockRender.AppWrapper,
-      }
-    );
+    renderHook(() => useGetSimilarCases({ caseId: mockCase.id, perPage: 10, page: 0 }), {
+      wrapper: appMockRender.AppWrapper,
+    });
 
     await waitFor(() => {
       expect(addError).toHaveBeenCalled();

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_patch_observables.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_patch_observables.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { usePatchObservable } from './use_patch_observables';
 import { patchObservable } from './api';
 import { useCasesToast } from '../common/use_cases_toast';
@@ -41,7 +41,7 @@ describe('usePatchObservable', () => {
   it('should call patchObservable and show success toast on success', async () => {
     (patchObservable as jest.Mock).mockResolvedValue({});
 
-    const { result, waitFor } = renderHook(() => usePatchObservable(caseId, observableId), {
+    const { result } = renderHook(() => usePatchObservable(caseId, observableId), {
       wrapper: appMockRender.AppWrapper,
     });
 
@@ -60,7 +60,7 @@ describe('usePatchObservable', () => {
     const error = new Error('Failed to patch observable');
     (patchObservable as jest.Mock).mockRejectedValue(error);
 
-    const { result, waitFor } = renderHook(() => usePatchObservable(caseId, observableId), {
+    const { result } = renderHook(() => usePatchObservable(caseId, observableId), {
       wrapper: appMockRender.AppWrapper,
     });
 

--- a/x-pack/platform/plugins/shared/cases/public/containers/use_post_observables.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/use_post_observables.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import * as api from './api';
 import { useToasts } from '../common/lib/kibana';
 import type { AppMockRenderer } from '../common/mock';
@@ -41,7 +41,7 @@ describe('usePostObservables', () => {
 
   it('calls the api when invoked with the correct parameters', async () => {
     const spy = jest.spyOn(api, 'postObservable');
-    const { waitForNextUpdate, result } = renderHook(() => usePostObservable(mockCase.id), {
+    const { result } = renderHook(() => usePostObservable(mockCase.id), {
       wrapper: appMockRender.AppWrapper,
     });
 
@@ -49,14 +49,14 @@ describe('usePostObservables', () => {
       result.current.mutate(observableMock);
     });
 
-    await waitForNextUpdate();
-
-    expect(spy).toHaveBeenCalledWith({ observable: observableMock.observable }, mockCase.id);
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith({ observable: observableMock.observable }, mockCase.id)
+    );
   });
 
   it('invalidates the queries correctly', async () => {
     const queryClientSpy = jest.spyOn(appMockRender.queryClient, 'invalidateQueries');
-    const { waitForNextUpdate, result } = renderHook(() => usePostObservable(mockCase.id), {
+    const { result } = renderHook(() => usePostObservable(mockCase.id), {
       wrapper: appMockRender.AppWrapper,
     });
 
@@ -64,13 +64,11 @@ describe('usePostObservables', () => {
       result.current.mutate(observableMock);
     });
 
-    await waitForNextUpdate();
-
-    expect(queryClientSpy).toHaveBeenCalledWith(casesQueriesKeys.caseView());
+    await waitFor(() => expect(queryClientSpy).toHaveBeenCalledWith(casesQueriesKeys.caseView()));
   });
 
   it('does shows a success toaster', async () => {
-    const { waitForNextUpdate, result } = renderHook(() => usePostObservable(mockCase.id), {
+    const { result } = renderHook(() => usePostObservable(mockCase.id), {
       wrapper: appMockRender.AppWrapper,
     });
 
@@ -78,9 +76,7 @@ describe('usePostObservables', () => {
       result.current.mutate(observableMock);
     });
 
-    await waitForNextUpdate();
-
-    expect(addSuccess).toHaveBeenCalled();
+    await waitFor(() => expect(addSuccess).toHaveBeenCalled());
   });
 
   it('shows a toast error when the api return an error', async () => {
@@ -88,7 +84,7 @@ describe('usePostObservables', () => {
       .spyOn(api, 'postObservable')
       .mockRejectedValue(new Error('usePostObservables: Test error'));
 
-    const { waitForNextUpdate, result } = renderHook(() => usePostObservable(mockCase.id), {
+    const { result } = renderHook(() => usePostObservable(mockCase.id), {
       wrapper: appMockRender.AppWrapper,
     });
 
@@ -96,8 +92,6 @@ describe('usePostObservables', () => {
       result.current.mutate(observableMock);
     });
 
-    await waitForNextUpdate();
-
-    expect(addError).toHaveBeenCalled();
+    await waitFor(() => expect(addError).toHaveBeenCalled());
   });
 });

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_untrack_alerts_by_query.test.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_untrack_alerts_by_query.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { act, renderHook } from '@testing-library/react-hooks';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { AppMockRenderer, createAppMockRenderer } from '../../test_utils';
 import { AlertsQueryContext } from '@kbn/alerts-ui-shared/src/common/contexts/alerts_query_context';
 import { useBulkUntrackAlertsByQuery } from './use_bulk_untrack_alerts_by_query';
@@ -35,7 +35,7 @@ describe('useBulkUntrackAlertsByQuery', () => {
   it('calls the api when invoked with the correct parameters', async () => {
     httpMock.mockResolvedValue(response);
 
-    const { result, waitFor } = renderHook(() => useBulkUntrackAlertsByQuery(), {
+    const { result } = renderHook(() => useBulkUntrackAlertsByQuery(), {
       wrapper: appMockRender.AppWrapper,
     });
 

--- a/x-pack/plugins/lens/public/app_plugin/app_helpers.test.ts
+++ b/x-pack/plugins/lens/public/app_plugin/app_helpers.test.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { renderHook, act } from '@testing-library/react-hooks';
-import faker from 'faker';
+import { renderHook, act } from '@testing-library/react';
+import { faker } from '@faker-js/faker';
 import { UseNavigateBackToAppProps, useNavigateBackToApp } from './app_helpers';
 import { defaultDoc, makeDefaultServices } from '../mocks/services_mock';
 import { cloneDeep } from 'lodash';

--- a/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/hooks/use_time_range.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useTimeRange } from './use_time_range';
 import * as datemath from '../utils/datemath';
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_filters.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_filters.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import * as spaceHook from '../../../../../hooks/use_kibana_space';
 import * as paramHook from '../../../hooks/use_url_params';
 import * as redux from 'react-redux';

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/hooks/use_fetch_graph_data.test.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/hooks/use_fetch_graph_data.test.tsx
@@ -5,10 +5,15 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useFetchGraphData } from './use_fetch_graph_data';
 
-const mockUseQuery = jest.fn();
+const mockUseQuery = jest.fn((...args: unknown[]) => ({
+  isLoading: true,
+  data: null,
+  isError: false,
+  isFetching: true,
+}));
 
 jest.mock('@tanstack/react-query', () => {
   return {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_graph_visualization.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_graph_visualization.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { mockFlyoutApi } from '../mocks/mock_flyout_context';
 import { useWhichFlyout } from './use_which_flyout';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_navigate_to_left_panel.test.tsx
@@ -8,7 +8,7 @@
 import { useNavigateToLeftPanel } from './use_navigate_to_left_panel';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useDocumentDetailsContext } from '../context';
 import { mockFlyoutApi } from '../mocks/mock_flyout_context';
 import { DocumentDetailsRightPanelKey, DocumentDetailsLeftPanelKey } from '../constants/panel_keys';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/hooks/use_navigate_to_host_details.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useNavigateToHostDetails } from './use_navigate_to_host_details';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_navigate_to_user_details.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useNavigateToUserDetails } from './use_navigate_to_user_details';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [remove outstanding testing-library/react-hooks usages (#205307)](https://github.com/elastic/kibana/pull/205307)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-07T13:43:37Z","message":"remove outstanding testing-library/react-hooks usages (#205307)\n\n## Summary\r\n\r\nThis PR removes usages of `@testing-library/react-hooks` from the\r\ncodebase, as we've transitioned to using `@testing-library/react`\r\nespecially that it provides the same utils we need and the later package\r\nis not supported for react 18. alongside this ~other instance of the\r\nusages for `@testing-library/react-hooks` have been removed~ an eslint\r\nrule has been enabled to prevent further usages of the mentioned\r\npackage.\r\n\r\n<!--\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...\r\n\r\n\r\n-->\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1c3f7a6215be2c3459325145a9e4677b2ff4b836","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:SharedUX","backport:prev-minor","Team:obs-ux-infra_services","Team:obs-ux-management","React@18"],"number":205307,"url":"https://github.com/elastic/kibana/pull/205307","mergeCommit":{"message":"remove outstanding testing-library/react-hooks usages (#205307)\n\n## Summary\r\n\r\nThis PR removes usages of `@testing-library/react-hooks` from the\r\ncodebase, as we've transitioned to using `@testing-library/react`\r\nespecially that it provides the same utils we need and the later package\r\nis not supported for react 18. alongside this ~other instance of the\r\nusages for `@testing-library/react-hooks` have been removed~ an eslint\r\nrule has been enabled to prevent further usages of the mentioned\r\npackage.\r\n\r\n<!--\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...\r\n\r\n\r\n-->\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1c3f7a6215be2c3459325145a9e4677b2ff4b836"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205307","number":205307,"mergeCommit":{"message":"remove outstanding testing-library/react-hooks usages (#205307)\n\n## Summary\r\n\r\nThis PR removes usages of `@testing-library/react-hooks` from the\r\ncodebase, as we've transitioned to using `@testing-library/react`\r\nespecially that it provides the same utils we need and the later package\r\nis not supported for react 18. alongside this ~other instance of the\r\nusages for `@testing-library/react-hooks` have been removed~ an eslint\r\nrule has been enabled to prevent further usages of the mentioned\r\npackage.\r\n\r\n<!--\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...\r\n\r\n\r\n-->\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1c3f7a6215be2c3459325145a9e4677b2ff4b836"}}]}] BACKPORT-->