### PR TITLE
[8.x] Add `x-elastic-product-origin` to header (#203447)

### DIFF
--- a/x-pack/platform/plugins/shared/observability_solution/observability_ai_assistant/server/functions/kibana.ts
+++ b/x-pack/platform/plugins/shared/observability_solution/observability_ai_assistant/server/functions/kibana.ts
@@ -77,6 +77,7 @@ export function registerKibanaFunction({
         'referer',
         'user-agent',
         'x-elastic-internal-origin',
+        'x-elastic-product-origin',
         'x-kbn-context',
       ];
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add &#x60;x-elastic-product-origin&#x60; to header (#203447)](https://github.com/elastic/kibana/pull/203447)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Søren Louv-Jansen","email":"soren.louv@elastic.co"},"sourceCommit":{"committedDate":"2024-12-11T08:19:49Z","message":"Add `x-elastic-product-origin` to header (#203447)\n\nRelated to: https://github.com/elastic/observability-dev/issues/4147\n\nAdds the `x-elastic-product-origin` when invoking the kibana function","sha":"a48725ad6de3f4217ec7539d39b1477184810493","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","backport:prev-minor","Team:Obs AI Assistant","ci:project-deploy-observability"],"title":"Add `x-elastic-product-origin` to header","number":203447,"url":"https://github.com/elastic/kibana/pull/203447","mergeCommit":{"message":"Add `x-elastic-product-origin` to header (#203447)\n\nRelated to: https://github.com/elastic/observability-dev/issues/4147\n\nAdds the `x-elastic-product-origin` when invoking the kibana function","sha":"a48725ad6de3f4217ec7539d39b1477184810493"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203447","number":203447,"mergeCommit":{"message":"Add `x-elastic-product-origin` to header (#203447)\n\nRelated to: https://github.com/elastic/observability-dev/issues/4147\n\nAdds the `x-elastic-product-origin` when invoking the kibana function","sha":"a48725ad6de3f4217ec7539d39b1477184810493"}}]}] BACKPORT-->