### PR TITLE
[8.x] [Synonyms UI] Synonyms UI base plugin (#203284)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -804,6 +804,7 @@ x-pack/solutions/search/plugins/search_notebooks @elastic/search-kibana
 x-pack/solutions/search/plugins/search_playground @elastic/search-kibana
 src/platform/packages/shared/kbn-search-response-warnings @elastic/kibana-data-discovery
 x-pack/solutions/search/packages/search/shared_ui @elastic/search-kibana
+x-pack/solutions/search/plugins/search_synonyms @elastic/search-kibana
 src/platform/packages/shared/kbn-search-types @elastic/kibana-data-discovery
 x-pack/platform/plugins/shared/searchprofiler @elastic/kibana-management
 x-pack/test/security_api_integration/packages/helpers @elastic/kibana-security

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -8,6 +8,7 @@ xpack.fleet.internal.activeAgentsSoftLimit: 25000
 xpack.fleet.internal.onlyAllowAgentUpgradeToKnownVersions: true
 xpack.fleet.internal.retrySetupOnBoot: true
 xpack.fleet.internal.useMeteringApi: true
+xpack.searchSynonyms.enabled: false
 
 ## Fine-tune the feature privileges.
 xpack.features.overrides:

--- a/docs/developer/plugin-list.asciidoc
+++ b/docs/developer/plugin-list.asciidoc
@@ -856,6 +856,10 @@ detailed information on how Elasticsearch executed the search request. People us
 to understand why a search request might be slow.
 
 
+|{kib-repo}blob/{branch}/x-pack/solutions/search/plugins/search_synonyms/README.md[searchSynonyms]
+|A plugin to manage synonyms in Elasticsearch through Synonyms APIs through Kibana.
+
+
 |{kib-repo}blob/{branch}/x-pack/platform/plugins/shared/security/README.md[security]
 |See Configuring security in
 Kibana.

--- a/package.json
+++ b/package.json
@@ -813,6 +813,7 @@
     "@kbn/search-playground": "link:x-pack/solutions/search/plugins/search_playground",
     "@kbn/search-response-warnings": "link:src/platform/packages/shared/kbn-search-response-warnings",
     "@kbn/search-shared-ui": "link:x-pack/solutions/search/packages/search/shared_ui",
+    "@kbn/search-synonyms": "link:x-pack/solutions/search/plugins/search_synonyms",
     "@kbn/search-types": "link:src/platform/packages/shared/kbn-search-types",
     "@kbn/searchprofiler-plugin": "link:x-pack/platform/plugins/shared/searchprofiler",
     "@kbn/security-api-key-management": "link:x-pack/platform/packages/shared/security/api_key_management",

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -148,6 +148,7 @@ pageLoadAssetSize:
   searchNotebooks: 18942
   searchPlayground: 19325
   searchprofiler: 67080
+  searchSynonyms: 20262
   security: 81771
   securitySolution: 98429
   securitySolutionEss: 31781

--- a/src/platform/packages/shared/deeplinks/search/constants.ts
+++ b/src/platform/packages/shared/deeplinks/search/constants.ts
@@ -17,6 +17,7 @@ export const SERVERLESS_ES_APP_ID = 'serverlessElasticsearch';
 export const SERVERLESS_ES_CONNECTORS_ID = 'serverlessConnectors';
 export const ES_SEARCH_PLAYGROUND_ID = 'searchPlayground';
 export const SERVERLESS_ES_SEARCH_INFERENCE_ENDPOINTS_ID = 'searchInferenceEndpoints';
+export const ES_SEARCH_SYNONYMS_ID = 'searchSynonyms';
 export const SEARCH_HOMEPAGE = 'searchHomepage';
 export const SEARCH_INDICES_START = 'elasticsearchStart';
 export const SEARCH_INDICES = 'elasticsearchIndices';

--- a/src/platform/packages/shared/deeplinks/search/deep_links.ts
+++ b/src/platform/packages/shared/deeplinks/search/deep_links.ts
@@ -26,6 +26,7 @@ import {
   SEARCH_VECTOR_SEARCH,
   SEARCH_SEMANTIC_SEARCH,
   SEARCH_AI_SEARCH,
+  ES_SEARCH_SYNONYMS_ID,
 } from './constants';
 
 export type EnterpriseSearchApp = typeof ENTERPRISE_SEARCH_APP_ID;
@@ -38,6 +39,7 @@ export type ServerlessSearchApp = typeof SERVERLESS_ES_APP_ID;
 export type ConnectorsId = typeof SERVERLESS_ES_CONNECTORS_ID;
 export type SearchPlaygroundId = typeof ES_SEARCH_PLAYGROUND_ID;
 export type SearchInferenceEndpointsId = typeof SERVERLESS_ES_SEARCH_INFERENCE_ENDPOINTS_ID;
+export type SearchSynonymsId = typeof ES_SEARCH_SYNONYMS_ID;
 export type SearchHomepage = typeof SEARCH_HOMEPAGE;
 export type SearchStart = typeof SEARCH_INDICES_START;
 export type SearchIndices = typeof SEARCH_INDICES;
@@ -54,6 +56,8 @@ export type AppsearchLinkId = 'engines';
 
 export type SearchInferenceEndpointsLinkId = 'inferenceEndpoints';
 
+export type SynonymsLinkId = 'synonyms';
+
 export type SearchIndicesLinkId = typeof SEARCH_INDICES_CREATE_INDEX;
 
 export type DeepLinkId =
@@ -67,11 +71,13 @@ export type DeepLinkId =
   | ConnectorsId
   | SearchPlaygroundId
   | SearchInferenceEndpointsId
+  | SearchSynonymsId
   | SearchHomepage
   | `${EnterpriseSearchContentApp}:${ContentLinkId}`
   | `${EnterpriseSearchApplicationsApp}:${ApplicationsLinkId}`
   | `${EnterpriseSearchAppsearchApp}:${AppsearchLinkId}`
   | `${SearchInferenceEndpointsId}:${SearchInferenceEndpointsLinkId}`
+  | `${SearchSynonymsId}:${SynonymsLinkId}`
   | SearchStart
   | SearchIndices
   | SearchElasticsearch

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1602,6 +1602,8 @@
       "@kbn/search-response-warnings/*": ["src/platform/packages/shared/kbn-search-response-warnings/*"],
       "@kbn/search-shared-ui": ["x-pack/solutions/search/packages/search/shared_ui"],
       "@kbn/search-shared-ui/*": ["x-pack/solutions/search/packages/search/shared_ui/*"],
+      "@kbn/search-synonyms": ["x-pack/solutions/search/plugins/search_synonyms"],
+      "@kbn/search-synonyms/*": ["x-pack/solutions/search/plugins/search_synonyms/*"],
       "@kbn/search-types": ["src/platform/packages/shared/kbn-search-types"],
       "@kbn/search-types/*": ["src/platform/packages/shared/kbn-search-types/*"],
       "@kbn/searchprofiler-plugin": ["x-pack/platform/plugins/shared/searchprofiler"],

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/base_nav.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/layout/base_nav.tsx
@@ -125,6 +125,14 @@ export const buildBaseClassicNavItems = ({
         },
         id: 'inference_endpoints',
       },
+      {
+        'data-test-subj': 'searchSideNav-Synonyms',
+        deepLink: {
+          link: 'searchSynonyms:synonyms',
+          shouldShowActiveForSubroutes: true,
+        },
+        id: 'synonyms',
+      },
     ],
     name: i18n.translate('xpack.enterpriseSearch.nav.relevanceTitle', {
       defaultMessage: 'Relevance',

--- a/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/navigation_tree.ts
@@ -209,7 +209,10 @@ export const getNavigationTreeDefinition = ({
                   }),
                 },
                 {
-                  children: [{ link: 'searchInferenceEndpoints:inferenceEndpoints' }],
+                  children: [
+                    { link: 'searchInferenceEndpoints:inferenceEndpoints' },
+                    { link: 'searchSynonyms:synonyms' },
+                  ],
                   id: 'relevance',
                   title: i18n.translate('xpack.enterpriseSearch.searchNav.relevance', {
                     defaultMessage: 'Relevance',

--- a/x-pack/solutions/search/plugins/search_synonyms/README.md
+++ b/x-pack/solutions/search/plugins/search_synonyms/README.md
@@ -1,0 +1,3 @@
+# Search Synonyms
+
+A plugin to manage synonyms in Elasticsearch through Synonyms APIs through Kibana.

--- a/x-pack/solutions/search/plugins/search_synonyms/common/index.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/common/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const PLUGIN_ID = 'searchSynonyms';
+export const PLUGIN_NAME = 'Synonyms';
+
+export const PLUGIN_TITLE = i18n.translate('xpack.searchSynonyms.pluginTitle', {
+  defaultMessage: 'Synonyms',
+});

--- a/x-pack/solutions/search/plugins/search_synonyms/common/types.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/common/types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SearchSynonymsPluginSetup {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SearchSynonymsPluginStart {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface AppPluginSetupDependencies {}
+
+export interface SearchSynonymsConfigType {
+  enabled: boolean;
+}

--- a/x-pack/solutions/search/plugins/search_synonyms/common/ui_flags.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/common/ui_flags.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const SYNONYMS_UI_FLAG = 'searchSynonyms:synonymsEnabled';

--- a/x-pack/solutions/search/plugins/search_synonyms/jest.config.js
+++ b/x-pack/solutions/search/plugins/search_synonyms/jest.config.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/x-pack/solutions/search/plugins/search_synonyms'],
+  coverageDirectory: '<rootDir>/target/kibana-coverage/jest/x-pack/plugins/search_synonyms',
+  coverageReporters: ['text', 'html'],
+  collectCoverageFrom: [
+    '<rootDir>/x-pack/solutions/search/plugins/search_synonyms/{public,server}/**/*.{ts,tsx}',
+  ],
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/search_synonyms/kibana.jsonc
@@ -1,0 +1,26 @@
+{
+  "type": "plugin",
+  "id": "@kbn/search-synonyms",
+  "owner": "@elastic/search-kibana",
+  "group": "search",
+  "visibility": "private",
+  "plugin": {
+    "id": "searchSynonyms",
+    "server": true,
+    "browser": true,
+    "configPath": [
+      "xpack",
+      "searchSynonyms"
+    ],
+    "requiredPlugins": [
+      "features",
+    ],
+    "optionalPlugins": [
+      "console",
+      "searchNavigation",
+    ],
+    "requiredBundles": [
+      "kibanaReact",
+    ]
+  }
+}

--- a/x-pack/solutions/search/plugins/search_synonyms/public/application.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/application.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { CoreStart } from '@kbn/core/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { I18nProvider } from '@kbn/i18n-react';
+import { Router } from '@kbn/shared-ux-router';
+import { AppPluginStartDependencies } from './types';
+
+export const renderApp = async (
+  core: CoreStart,
+  services: AppPluginStartDependencies,
+  element: HTMLElement
+) => {
+  ReactDOM.render(
+    <KibanaRenderContextProvider {...core}>
+      <KibanaContextProvider services={{ ...core, ...services }}>
+        <I18nProvider>
+          <Router history={services.history}>
+            <div>Synonyms</div>
+          </Router>
+        </I18nProvider>
+      </KibanaContextProvider>
+    </KibanaRenderContextProvider>,
+    element
+  );
+  return () => ReactDOM.unmountComponentAtNode(element);
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/public/index.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SearchSynonymsPlugin } from './plugin';
+
+export function plugin() {
+  return new SearchSynonymsPlugin();
+}

--- a/x-pack/solutions/search/plugins/search_synonyms/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/plugin.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, Plugin, AppMountParameters } from '@kbn/core/public';
+import { PLUGIN_ID, PLUGIN_NAME, PLUGIN_TITLE } from '../common';
+import {
+  AppPluginSetupDependencies,
+  AppPluginStartDependencies,
+  SearchSynonymsPluginSetup,
+  SearchSynonymsPluginStart,
+} from './types';
+import { SYNONYMS_UI_FLAG } from '../common/ui_flags';
+
+export class SearchSynonymsPlugin
+  implements Plugin<SearchSynonymsPluginSetup, SearchSynonymsPluginStart>
+{
+  constructor() {}
+
+  public setup(
+    core: CoreSetup<AppPluginStartDependencies, SearchSynonymsPluginStart>,
+    _: AppPluginSetupDependencies
+  ): SearchSynonymsPluginSetup {
+    if (!core.settings.client.get<boolean>(SYNONYMS_UI_FLAG, false)) {
+      return {};
+    }
+    core.application.register({
+      id: PLUGIN_ID,
+      appRoute: '/app/elasticsearch/synonyms',
+      title: PLUGIN_TITLE,
+      deepLinks: [
+        {
+          id: 'synonyms',
+          path: '/',
+          title: PLUGIN_TITLE,
+          visibleIn: ['globalSearch'],
+        },
+      ],
+      async mount({ element, history }: AppMountParameters) {
+        const { renderApp } = await import('./application');
+        const [coreStart, depsStart] = await core.getStartServices();
+
+        coreStart.chrome.docTitle.change(PLUGIN_NAME);
+
+        const startDeps: AppPluginStartDependencies = {
+          ...depsStart,
+          history,
+        };
+
+        depsStart.searchNavigation?.handleOnAppMount();
+
+        return renderApp(coreStart, startDeps, element);
+      },
+      visibleIn: [],
+    });
+
+    return {};
+  }
+
+  public start(): SearchSynonymsPluginStart {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/solutions/search/plugins/search_synonyms/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SearchNavigationPluginStart } from '@kbn/search-navigation/public';
+import { AppMountParameters } from '@kbn/core/public';
+import type { ConsolePluginStart } from '@kbn/console-plugin/public';
+
+export * from '../common/types';
+export interface AppPluginStartDependencies {
+  history: AppMountParameters['history'];
+  console?: ConsolePluginStart;
+  searchNavigation?: SearchNavigationPluginStart;
+}

--- a/x-pack/solutions/search/plugins/search_synonyms/server/config.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/config.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema, TypeOf } from '@kbn/config-schema';
+import { PluginConfigDescriptor } from '@kbn/core/server';
+
+const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: false }),
+});
+
+export type SearchPlaygroundConfig = TypeOf<typeof configSchema>;
+
+export const config: PluginConfigDescriptor<SearchPlaygroundConfig> = {
+  schema: configSchema,
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/server/index.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PluginInitializerContext } from '@kbn/core/server';
+
+export { config } from './config';
+
+export async function plugin(initializerContext: PluginInitializerContext) {
+  const { SearchSynonymsPlugin } = await import('./plugin');
+  return new SearchSynonymsPlugin(initializerContext);
+}
+
+export type { SearchSynonymsPluginSetup, SearchSynonymsPluginStart } from './types';

--- a/x-pack/solutions/search/plugins/search_synonyms/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/plugin.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  PluginInitializerContext,
+  CoreSetup,
+  CoreStart,
+  Plugin,
+  Logger,
+  DEFAULT_APP_CATEGORIES,
+} from '@kbn/core/server';
+
+import { KibanaFeatureScope } from '@kbn/features-plugin/common';
+import {
+  SearchSynonymsPluginSetup,
+  SearchSynonymsPluginSetupDependencies,
+  SearchSynonymsPluginStart,
+} from './types';
+
+import { defineRoutes } from './routes';
+import { PLUGIN_ID, PLUGIN_TITLE } from '../common';
+
+export class SearchSynonymsPlugin
+  implements Plugin<SearchSynonymsPluginSetup, SearchSynonymsPluginStart, {}, {}>
+{
+  private readonly logger: Logger;
+
+  constructor(initializerContext: PluginInitializerContext) {
+    this.logger = initializerContext.logger.get();
+  }
+
+  public setup(core: CoreSetup, plugins: SearchSynonymsPluginSetupDependencies) {
+    const router = core.http.createRouter();
+
+    defineRoutes({ router, logger: this.logger });
+
+    plugins.features.registerKibanaFeature({
+      id: PLUGIN_ID,
+      name: PLUGIN_TITLE,
+      order: 0,
+      category: DEFAULT_APP_CATEGORIES.enterpriseSearch,
+      app: ['kibana', PLUGIN_ID],
+      scope: [KibanaFeatureScope.Spaces, KibanaFeatureScope.Security],
+      catalogue: [PLUGIN_ID],
+      privileges: {
+        all: {
+          app: ['kibana', PLUGIN_ID],
+          api: ['synonyms:manage', 'synonyms:read'],
+          catalogue: [PLUGIN_ID],
+          savedObject: {
+            all: [],
+            read: [],
+          },
+          ui: ['read', 'save'],
+        },
+        read: {
+          app: ['kibana', PLUGIN_ID],
+          api: ['synonyms:read'],
+          savedObject: {
+            all: [],
+            read: [],
+          },
+          ui: ['read'],
+        },
+      },
+    });
+
+    return {};
+  }
+
+  public start(core: CoreStart) {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IRouter, Logger } from '@kbn/core/server';
+
+export function defineRoutes({ logger, router }: { logger: Logger; router: IRouter }) {}

--- a/x-pack/solutions/search/plugins/search_synonyms/server/types.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+export * from '../common/types';
+
+export interface SearchSynonymsPluginSetupDependencies {
+  features: FeaturesPluginSetup;
+}

--- a/x-pack/solutions/search/plugins/search_synonyms/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_synonyms/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+  },
+  "include": [
+    "__mocks__/**/*",
+    "common/**/*",
+    "public/**/*",
+    "server/**/*",
+  ],
+  "kbn_references": [
+    "@kbn/config-schema",
+    "@kbn/core",
+    "@kbn/i18n",
+    "@kbn/i18n-react",
+    "@kbn/kibana-react-plugin",
+    "@kbn/shared-ux-router",
+    "@kbn/react-kibana-context-render",
+    "@kbn/console-plugin",
+    "@kbn/features-plugin",
+    "@kbn/search-navigation",
+  ],
+  "exclude": [
+    "target/**/*",
+  ]
+}

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -99,6 +99,13 @@ export const navigationTree = ({ isAppRegistered }: ApplicationStart): Navigatio
                 ),
                 link: 'searchInferenceEndpoints',
               },
+              {
+                id: 'searchSynonyms',
+                title: i18n.translate('xpack.serverlessSearch.nav.relevance.searchSynonyms', {
+                  defaultMessage: 'Synonyms',
+                }),
+                link: 'searchSynonyms',
+              },
             ],
           },
           {

--- a/x-pack/test/api_integration/apis/features/features/features.ts
+++ b/x-pack/test/api_integration/apis/features/features/features.ts
@@ -185,6 +185,7 @@ export default function ({ getService }: FtrProviderContext) {
           'rulesSettings',
           'uptime',
           'searchInferenceEndpoints',
+          'searchSynonyms',
           'searchPlayground',
           'siem',
           'slo',

--- a/x-pack/test/ui_capabilities/security_and_spaces/tests/catalogue.ts
+++ b/x-pack/test/ui_capabilities/security_and_spaces/tests/catalogue.ts
@@ -95,6 +95,7 @@ export default function catalogueTests({ getService }: FtrProviderContext) {
               'enterpriseSearchElasticsearch',
               'searchPlayground',
               'searchInferenceEndpoints',
+              'searchSynonyms',
               'appSearch',
               'observabilityAIAssistant',
               'workplaceSearch',

--- a/x-pack/test/ui_capabilities/security_and_spaces/tests/nav_links.ts
+++ b/x-pack/test/ui_capabilities/security_and_spaces/tests/nav_links.ts
@@ -68,6 +68,7 @@ export default function navLinksTests({ getService }: FtrProviderContext) {
                 'enterpriseSearchAnalytics',
                 'searchPlayground',
                 'searchInferenceEndpoints',
+                'searchSynonyms',
                 'guidedOnboardingFeature',
                 'securitySolutionAssistant',
                 'securitySolutionAttackDiscovery',

--- a/x-pack/test_serverless/functional/test_suites/search/config.feature_flags.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/config.feature_flags.ts
@@ -43,6 +43,9 @@ export default createTestConfig({
     searchPlayground: {
       pathname: '/app/search_playground',
     },
+    searchSynonyms: {
+      pathname: '/app/elasticsearch/search_synonyms',
+    },
     elasticsearchStart: {
       pathname: '/app/elasticsearch/start',
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7047,6 +7047,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/search-synonyms@link:x-pack/solutions/search/plugins/search_synonyms":
+  version "0.0.0"
+  uid ""
+
 "@kbn/search-types@link:src/platform/packages/shared/kbn-search-types":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Synonyms UI] Synonyms UI base plugin (#203284)](https://github.com/elastic/kibana/pull/203284)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Efe Gürkan YALAMAN","email":"efeguerkan.yalaman@elastic.co"},"sourceCommit":{"committedDate":"2025-01-06T19:15:19Z","message":"[Synonyms UI] Synonyms UI base plugin (#203284)\n\n## Summary\r\n\r\nCreates a plugin for Synonyms UI implementation. It is hidden under the\r\nUI flag and config option which is off by default.\r\n```\r\nPOST kbn:/internal/kibana/settings/searchSynonyms:synonymsEnabled\r\n{\"value\": true}\r\n```\r\n\r\nServerless Search:\r\n<img width=\"379\" alt=\"Screenshot 2024-12-17 at 13 18 02\"\r\nsrc=\"https://github.com/user-attachments/assets/8c2cb6f0-ce2a-4be6-8605-4f994adeefd7\"\r\n/>\r\n\r\nStack Search\r\n<img width=\"293\" alt=\"Screenshot 2024-12-17 at 13 21 43\"\r\nsrc=\"https://github.com/user-attachments/assets/0d61de0e-2cd3-46a6-990f-1f1a70843324\"\r\n/>\r\n\r\n\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e542fd2370c8b247beb938f337602f60bb6c0573","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:EnterpriseSearch","backport:version","v8.18.0"],"number":203284,"url":"https://github.com/elastic/kibana/pull/203284","mergeCommit":{"message":"[Synonyms UI] Synonyms UI base plugin (#203284)\n\n## Summary\r\n\r\nCreates a plugin for Synonyms UI implementation. It is hidden under the\r\nUI flag and config option which is off by default.\r\n```\r\nPOST kbn:/internal/kibana/settings/searchSynonyms:synonymsEnabled\r\n{\"value\": true}\r\n```\r\n\r\nServerless Search:\r\n<img width=\"379\" alt=\"Screenshot 2024-12-17 at 13 18 02\"\r\nsrc=\"https://github.com/user-attachments/assets/8c2cb6f0-ce2a-4be6-8605-4f994adeefd7\"\r\n/>\r\n\r\nStack Search\r\n<img width=\"293\" alt=\"Screenshot 2024-12-17 at 13 21 43\"\r\nsrc=\"https://github.com/user-attachments/assets/0d61de0e-2cd3-46a6-990f-1f1a70843324\"\r\n/>\r\n\r\n\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e542fd2370c8b247beb938f337602f60bb6c0573"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203284","number":203284,"mergeCommit":{"message":"[Synonyms UI] Synonyms UI base plugin (#203284)\n\n## Summary\r\n\r\nCreates a plugin for Synonyms UI implementation. It is hidden under the\r\nUI flag and config option which is off by default.\r\n```\r\nPOST kbn:/internal/kibana/settings/searchSynonyms:synonymsEnabled\r\n{\"value\": true}\r\n```\r\n\r\nServerless Search:\r\n<img width=\"379\" alt=\"Screenshot 2024-12-17 at 13 18 02\"\r\nsrc=\"https://github.com/user-attachments/assets/8c2cb6f0-ce2a-4be6-8605-4f994adeefd7\"\r\n/>\r\n\r\nStack Search\r\n<img width=\"293\" alt=\"Screenshot 2024-12-17 at 13 21 43\"\r\nsrc=\"https://github.com/user-attachments/assets/0d61de0e-2cd3-46a6-990f-1f1a70843324\"\r\n/>\r\n\r\n\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e542fd2370c8b247beb938f337602f60bb6c0573"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->