### PR TITLE
[Profiling UI, 9.0.0] Replace `aggregation_field` with `aggregation_fields` array

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/server/routes/apm.ts
+++ b/x-pack/solutions/observability/plugins/profiling/server/routes/apm.ts
@@ -85,7 +85,7 @@ export function registerTopNFunctionsAPMTransactionsRoute({
                   ],
                 },
               },
-              aggregationField: 'transaction.name',
+              aggregationFields: ['transaction.name'],
               indices: transactionIndices.split(','),
               stacktraceIdsField: 'transaction.profiler_stack_trace_ids',
               limit: 1000,

--- a/x-pack/solutions/observability/plugins/profiling/server/routes/functions.ts
+++ b/x-pack/solutions/observability/plugins/profiling/server/routes/functions.ts
@@ -89,7 +89,7 @@ export function registerTopNFunctionsSearchRoute({
               core,
               esClient,
               query,
-              aggregationField: 'service.name',
+              aggregationFields: ['service.name'],
               totalSeconds,
             });
 

--- a/x-pack/solutions/observability/plugins/profiling_data_access/common/profiling_es_client.ts
+++ b/x-pack/solutions/observability/plugins/profiling_data_access/common/profiling_es_client.ts
@@ -57,7 +57,7 @@ export interface ProfilingESClient {
     sampleSize?: number;
     indices?: string[];
     stacktraceIdsField?: string;
-    aggregationField?: AggregationField;
+    aggregationFields?: AggregationField[];
     co2PerKWH?: number;
     datacenterPUE?: number;
     pervCPUWattX86?: number;

--- a/x-pack/solutions/observability/plugins/profiling_data_access/server/services/functions/es_functions.ts
+++ b/x-pack/solutions/observability/plugins/profiling_data_access/server/services/functions/es_functions.ts
@@ -27,7 +27,7 @@ export interface FetchFunctionsParams {
   indices?: string[];
   stacktraceIdsField?: string;
   query: QueryDslQueryContainer;
-  aggregationField?: AggregationField;
+  aggregationFields?: AggregationField[];
   limit?: number;
   totalSeconds: number;
 }
@@ -41,7 +41,7 @@ export function createFetchESFunctions({ createProfilingEsClient }: RegisterServ
     indices,
     stacktraceIdsField,
     query,
-    aggregationField,
+    aggregationFields,
     limit,
     totalSeconds,
   }: FetchFunctionsParams) => {
@@ -72,7 +72,7 @@ export function createFetchESFunctions({ createProfilingEsClient }: RegisterServ
       query,
       indices,
       stacktraceIdsField,
-      aggregationField,
+      aggregationFields,
       co2PerKWH,
       datacenterPUE,
       pervCPUWattX86,

--- a/x-pack/solutions/observability/plugins/profiling_data_access/server/utils/create_profiling_es_client.ts
+++ b/x-pack/solutions/observability/plugins/profiling_data_access/server/utils/create_profiling_es_client.ts
@@ -153,7 +153,7 @@ export function createProfilingEsClient({
     },
     topNFunctions({
       query,
-      aggregationField,
+      aggregationFields,
       indices,
       stacktraceIdsField,
       co2PerKWH,
@@ -180,7 +180,7 @@ export function createProfilingEsClient({
               limit,
               indices,
               stacktrace_ids_field: stacktraceIdsField,
-              aggregation_field: aggregationField,
+              aggregation_fields: aggregationFields,
               co2_per_kwh: co2PerKWH,
               per_core_watt_x86: pervCPUWattX86,
               per_core_watt_arm64: pervCPUWattArm64,


### PR DESCRIPTION
### Summary

Replace `aggregation_field` with `aggregation_fields` to allow removal in ES v9.0.0

