### PR TITLE
Remove usage of Kibana plugins build in performance test pipelines

### DIFF
--- a/.buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
+++ b/.buildkite/scripts/steps/functional/scalability_dataset_extraction.sh
@@ -36,7 +36,6 @@ buildkite-agent artifact upload "${OUTPUT_DIR}/scalability_traces.tar.gz"
 
 echo "--- Downloading Kibana artifacts used in tests"
 download_artifact kibana-default.tar.gz "${OUTPUT_DIR}/" --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
-download_artifact kibana-default-plugins.tar.gz "${OUTPUT_DIR}/" --build "${KIBANA_BUILD_ID:-$BUILDKITE_BUILD_ID}"
 
 echo "--- Adding commit info"
 echo "${BUILDKITE_COMMIT}" > "${OUTPUT_DIR}/KIBANA_COMMIT_HASH"

--- a/.buildkite/scripts/steps/scalability/benchmarking.sh
+++ b/.buildkite/scripts/steps/scalability/benchmarking.sh
@@ -36,7 +36,6 @@ download_artifacts() {
   tar -xzf "${LATEST_RUN_ARTIFACTS_DIR}/kibana-default.tar.gz" -C "$KIBANA_BUILD_LOCATION" --strip=1
 
   cd "$KIBANA_DIR"
-  tar -xzf "${LATEST_RUN_ARTIFACTS_DIR}/kibana-default-plugins.tar.gz"
   tar -xzf "${LATEST_RUN_ARTIFACTS_DIR}/scalability_traces.tar.gz"
 }
 


### PR DESCRIPTION
## Summary

This PR fixes the performance test pipelines by removing the bits that rely on the plugins build.

### Details

* The plugin build has been removed with #197125. Since the performance pipelines are running against a Kibana build (and not against sources), they should not need the plugin build.
* The `performance-data-set-extraction` pipeline started to fail immediately after the plugin build has been removed
* This failure went unnoticed since the `scalability-benchmarking` pipeline continued to work by using the last uploaded artifacts from the `performance-data-set-extraction` pipeline, which were available for another month. Once the old artifacts were no longer available, the `scalability-benchmarking` pipeline also started to fail.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->