### PR TITLE
[ObsUX] Use styled from @emotion in log-stream component

### DIFF
--- a/x-pack/platform/plugins/shared/logs_shared/public/components/log_stream/log_stream.tsx
+++ b/x-pack/platform/plugins/shared/logs_shared/public/components/log_stream/log_stream.tsx
@@ -8,7 +8,7 @@
 import type { HttpStart } from '@kbn/core-http-browser';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { buildEsQuery, Filter, Query } from '@kbn/es-query';
-import { euiStyled } from '@kbn/kibana-react-plugin/common';
+import styled from '@emotion/styled';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import type { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
@@ -297,9 +297,9 @@ Read more at https://github.com/elastic/kibana/blob/main/src/plugins/kibana_reac
   );
 };
 
-const LogStreamContainer = euiStyled.div`
+const LogStreamContainer = styled.div`
   display: flex;
-  background-color: ${(props) => props.theme.eui.euiColorEmptyShade};
+  background-color: ${(props) => props.theme.euiTheme.colors.emptyShade};
 `;
 
 function convertLogColumnDefinitionToLogSourceColumnDefinition(


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/205683

LogStream embeddable loads correctly

<img width="1486" alt="Screenshot 2025-01-08 at 15 08 46" src="https://github.com/user-attachments/assets/7e53e7ba-2b86-471d-9fb0-39ae54b7f919" />
