### PR TITLE
[8.x] [SharedUX] Don't use `kibana_user` role in functional tests (#205654)

### DIFF
--- a/x-pack/test/accessibility/apps/group3/reporting.ts
+++ b/x-pack/test/accessibility/apps/group3/reporting.ts
@@ -20,7 +20,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     const createReportingUser = async () => {
       await security.user.create(reporting.REPORTING_USER_USERNAME, {
         password: reporting.REPORTING_USER_PASSWORD,
-        roles: ['reporting_user', 'data_analyst', 'kibana_user'], // Deprecated: using built-in `reporting_user` role grants all Reporting privileges
+        roles: ['reporting_user', 'data_analyst', 'kibana_admin'], // Deprecated: using built-in `reporting_user` role grants all Reporting privileges
         full_name: 'a reporting user',
       });
     };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[SharedUX] Don't use `kibana_user` role in functional tests (#205654)](https://github.com/elastic/kibana/pull/205654)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tim Sullivan","email":"tsullivan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-08T15:26:15Z","message":"[SharedUX] Don't use `kibana_user` role in functional tests (#205654)\n\nIn this PR I've moved a functional test to use the `kibana_admin` role,\r\nrather than `kibana_user`, to avoid usage of deprecated ES API.\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7660","sha":"5a3c914e7beebe3b635488b28d78a377a4760cc5","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:SharedUX","backport:prev-minor"],"number":205654,"url":"https://github.com/elastic/kibana/pull/205654","mergeCommit":{"message":"[SharedUX] Don't use `kibana_user` role in functional tests (#205654)\n\nIn this PR I've moved a functional test to use the `kibana_admin` role,\r\nrather than `kibana_user`, to avoid usage of deprecated ES API.\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7660","sha":"5a3c914e7beebe3b635488b28d78a377a4760cc5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205654","number":205654,"mergeCommit":{"message":"[SharedUX] Don't use `kibana_user` role in functional tests (#205654)\n\nIn this PR I've moved a functional test to use the `kibana_admin` role,\r\nrather than `kibana_user`, to avoid usage of deprecated ES API.\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7660","sha":"5a3c914e7beebe3b635488b28d78a377a4760cc5"}}]}] BACKPORT-->