### PR TITLE
[inference] handle toolCall indices not starting at 0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3260,7 +3260,6 @@ x-pack/platform/plugins/shared/fields_metadata @elastic/obs-ux-logs-team
 x-pack/platform/plugins/shared/fleet @elastic/fleet
 x-pack/platform/plugins/shared/global_search @elastic/appex-sharedux
 x-pack/platform/plugins/shared/index_management @elastic/kibana-management
-x-pack/platform/plugins/shared/inference @elastic/appex-ai-infra
 x-pack/platform/plugins/shared/ingest_pipelines @elastic/kibana-management
 x-pack/platform/plugins/shared/integration_assistant @elastic/security-scalability
 x-pack/platform/plugins/shared/lens @elastic/kibana-visualizations

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/chunks_into_message.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/chunks_into_message.test.ts
@@ -141,6 +141,92 @@ describe('chunksIntoMessage', () => {
     });
   });
 
+  it('parses tool calls even when the index does not start at 0', async () => {
+    const message = await lastValueFrom(
+      chunksIntoMessage({
+        toolOptions: {
+          toolChoice: ToolChoiceType.auto,
+          tools: {
+            myFunction: {
+              description: 'myFunction',
+              schema: {
+                type: 'object',
+                properties: {
+                  foo: {
+                    type: 'string',
+                    const: 'bar',
+                  },
+                },
+              },
+            },
+          },
+        },
+        logger,
+      })(
+        fromEvents(
+          {
+            content: '',
+            type: ChatCompletionEventType.ChatCompletionChunk,
+            tool_calls: [
+              {
+                function: {
+                  name: 'myFunction',
+                  arguments: '',
+                },
+                index: 1,
+                toolCallId: '0',
+              },
+            ],
+          },
+          {
+            content: '',
+            type: ChatCompletionEventType.ChatCompletionChunk,
+            tool_calls: [
+              {
+                function: {
+                  name: '',
+                  arguments: '{',
+                },
+                index: 1,
+                toolCallId: '0',
+              },
+            ],
+          },
+          {
+            content: '',
+            type: ChatCompletionEventType.ChatCompletionChunk,
+            tool_calls: [
+              {
+                function: {
+                  name: '',
+                  arguments: '"foo": "bar" }',
+                },
+                index: 1,
+                toolCallId: '1',
+              },
+            ],
+          }
+        )
+      )
+    );
+
+    expect(message).toEqual({
+      content: '',
+      toolCalls: [
+        {
+          function: {
+            name: 'myFunction',
+            arguments: {
+              foo: 'bar',
+            },
+          },
+          toolCallId: '001',
+        },
+      ],
+      type: ChatCompletionEventType.ChatCompletionMessage,
+    });
+  });
+
   it('validates tool calls', async () => {
     async function getMessage() {
       return await lastValueFrom(

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/chunks_into_message.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/chunks_into_message.ts
@@ -67,6 +67,9 @@ export function chunksIntoMessage<TToolOptions extends ToolOptions>({
             { content: '', tool_calls: [] as UnvalidatedToolCall[] }
           );
 
+          // some models (Claude not to name it) can have their toolCall index not start at 0, so we remove the null elements
+          concatenatedChunk.tool_calls = concatenatedChunk.tool_calls.filter((call) => !!call);
+
           logger.debug(() => `Received completed message: ${JSON.stringify(concatenatedChunk)}`);
 
           const validatedToolCalls = validateToolCalls<TToolOptions>({


### PR DESCRIPTION
## Summary

Turns out, claude can in some situations (when returning both text and toolcall in a single message) starts their toolcall index at `1` instead of `0`, which introducing null values in the concatenated messages. 

This fixes it, by removing null values from the tool calls when merging the chunks.

Also remove the SKA codeowner override for the inference plugin to get back the shared ownership


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->