### PR TITLE
[renovate] Fix match for all base branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -67,7 +67,7 @@
         "team:kibana-operations"
       ],
       "matchBaseBranches": [
-        "*"
+        "/.*/"
       ],
       "labels": [
         "Team:Operations",
@@ -94,7 +94,7 @@
         "team:kibana-operations"
       ],
       "matchBaseBranches": [
-        "*"
+        "/.*/"
       ],
       "labels": [
         "Team:Operations",
@@ -2442,7 +2442,7 @@
         "team:kibana-operations"
       ],
       "matchBaseBranches": [
-        "*"
+        "/.*/"
       ],
       "labels": [
         "Team:Operations",

--- a/renovate.json
+++ b/renovate.json
@@ -67,7 +67,7 @@
         "team:kibana-operations"
       ],
       "matchBaseBranches": [
-        "/.*/"
+        "/^[8-9].*/"
       ],
       "labels": [
         "Team:Operations",


### PR DESCRIPTION
https://docs.renovatebot.com/string-pattern-matching/ doesn't appear to be working for this setting.

The documentation [mentions regular expression support](https://docs.renovatebot.com/configuration-options/#matchbasebranches), this moves the expression over.