### PR TITLE
[8.17] [Obs AI Assistant] Use architecture-specific elser model (#205851)

### DIFF
--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/client/index.ts
@@ -86,6 +86,7 @@ import {
 } from '../task_manager_definitions/register_migrate_knowledge_base_entries_task';
 import { ObservabilityAIAssistantPluginStartDependencies } from '../../types';
 import { ObservabilityAIAssistantConfig } from '../../config';
+import { getElserModelId } from '../knowledge_base_service/get_elser_model_id';
 
 const MAX_FUNCTION_CALLS = 8;
 
@@ -734,6 +735,10 @@ export class ObservabilityAIAssistantClient {
 
   setupKnowledgeBase = async (modelId: string | undefined) => {
     const { esClient, core, logger, knowledgeBaseService } = this.dependencies;
+
+    if (!modelId) {
+      modelId = await getElserModelId({ core, logger });
+    }
 
     // setup the knowledge base
     const res = await knowledgeBaseService.setup(esClient, modelId);

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/inference_endpoint.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/inference_endpoint.ts
@@ -16,13 +16,13 @@ export const AI_ASSISTANT_KB_INFERENCE_ID = 'obs_ai_assistant_kb_inference';
 export async function createInferenceEndpoint({
   esClient,
   logger,
-  modelId = '.elser_model_2',
+  modelId,
 }: {
   esClient: {
     asCurrentUser: ElasticsearchClient;
   };
   logger: Logger;
-  modelId: string | undefined;
+  modelId: string;
 }) {
   try {
     logger.debug(`Creating inference endpoint "${AI_ASSISTANT_KB_INFERENCE_ID}"`);

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/get_elser_model_id.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/get_elser_model_id.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import { CoreSetup } from '@kbn/core-lifecycle-server';
+import { firstValueFrom } from 'rxjs';
+import { ObservabilityAIAssistantPluginStartDependencies } from '../../types';
+
+export async function getElserModelId({
+  core,
+  logger,
+}: {
+  core: CoreSetup<ObservabilityAIAssistantPluginStartDependencies>;
+  logger: Logger;
+}) {
+  const defaultModelId = '.elser_model_2';
+  const [_, pluginsStart] = await core.getStartServices();
+
+  // Wait for the license to be available so the ML plugin's guards pass once we ask for ELSER stats
+  const license = await firstValueFrom(pluginsStart.licensing.license$);
+  if (!license.hasAtLeast('enterprise')) {
+    return defaultModelId;
+  }
+
+  try {
+    // Wait for the ML plugin's dependency on the internal saved objects client to be ready
+    const { ml } = await core.plugins.onSetup<{
+      ml: {
+        trainedModelsProvider: (
+          request: {},
+          soClient: {}
+        ) => { getELSER: () => Promise<{ model_id: string }> };
+      };
+    }>('ml');
+
+    if (!ml.found) {
+      throw new Error('Could not find ML plugin');
+    }
+
+    const elserModelDefinition = await ml.contract
+      .trainedModelsProvider({} as any, {} as any) // request, savedObjectsClient (but we fake it to use the internal user)
+      .getELSER();
+
+    return elserModelDefinition.model_id;
+  } catch (error) {
+    logger.error(`Failed to resolve ELSER model definition: ${error}`);
+    return defaultModelId;
+  }
+}

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/index.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/index.ts
@@ -58,7 +58,7 @@ export class KnowledgeBaseService {
       asCurrentUser: ElasticsearchClient;
       asInternalUser: ElasticsearchClient;
     },
-    modelId: string | undefined
+    modelId: string
   ) {
     await deleteInferenceEndpoint({ esClient }).catch((e) => {}); // ensure existing inference endpoint is deleted
     return createInferenceEndpoint({ esClient, logger: this.dependencies.logger, modelId });

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/recall_from_search_connectors.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/recall_from_search_connectors.ts
@@ -10,10 +10,10 @@ import { IUiSettingsClient } from '@kbn/core-ui-settings-server';
 import { isEmpty, orderBy, compact } from 'lodash';
 import type { Logger } from '@kbn/logging';
 import { CoreSetup } from '@kbn/core-lifecycle-server';
-import { firstValueFrom } from 'rxjs';
 import { RecalledEntry } from '.';
 import { aiAssistantSearchConnectorIndexPattern } from '../../../common';
 import { ObservabilityAIAssistantPluginStartDependencies } from '../../types';
+import { getElserModelId } from './get_elser_model_id';
 
 export async function recallFromSearchConnectors({
   queries,
@@ -128,7 +128,7 @@ async function recallFromLegacyConnectors({
 }): Promise<RecalledEntry[]> {
   const ML_INFERENCE_PREFIX = 'ml.inference.';
 
-  const modelIdPromise = getElserModelId(core, logger); // pre-fetch modelId in parallel with fieldCaps
+  const modelIdPromise = getElserModelId({ core, logger }); // pre-fetch modelId in parallel with fieldCaps
   const fieldCaps = await esClient.asCurrentUser.fieldCaps({
     index: connectorIndices,
     fields: `${ML_INFERENCE_PREFIX}*`,
@@ -230,43 +230,4 @@ async function getConnectorIndices(
   }
 
   return connectorIndices;
-}
-
-async function getElserModelId(
-  core: CoreSetup<ObservabilityAIAssistantPluginStartDependencies>,
-  logger: Logger
-) {
-  const defaultModelId = '.elser_model_2';
-  const [_, pluginsStart] = await core.getStartServices();
-
-  // Wait for the license to be available so the ML plugin's guards pass once we ask for ELSER stats
-  const license = await firstValueFrom(pluginsStart.licensing.license$);
-  if (!license.hasAtLeast('enterprise')) {
-    return defaultModelId;
-  }
-
-  try {
-    // Wait for the ML plugin's dependency on the internal saved objects client to be ready
-    const { ml } = await core.plugins.onSetup('ml');
-
-    if (!ml.found) {
-      throw new Error('Could not find ML plugin');
-    }
-
-    const elserModelDefinition = await (
-      ml.contract as {
-        trainedModelsProvider: (
-          request: {},
-          soClient: {}
-        ) => { getELSER: () => Promise<{ model_id: string }> };
-      }
-    )
-      .trainedModelsProvider({} as any, {} as any) // request, savedObjectsClient (but we fake it to use the internal user)
-      .getELSER();
-
-    return elserModelDefinition.model_id;
-  } catch (error) {
-    logger.error(`Failed to resolve ELSER model definition: ${error}`);
-    return defaultModelId;
-  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Obs AI Assistant] Use architecture-specific elser model (#205851)](https://github.com/elastic/kibana/pull/205851)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Søren Louv-Jansen","email":"soren.louv@elastic.co"},"sourceCommit":{"committedDate":"2025-01-08T18:59:20Z","message":"[Obs AI Assistant] Use architecture-specific elser model (#205851)\n\nCloses https://github.com/elastic/kibana/issues/205852\n\nWhen installing the Obs knowledge base it will always install the model\n`.elser_model_2`.\nFor Linux with an x86-64 CPU an optimised version of Elser exists\n(`elser_model_2_linux-x86_64`). We should use that when possible.\n\nAfter this change the inference endpoint will use\n`.elser_model_2_linux-x86_64` on supported hardware:\n\n![image](https://github.com/user-attachments/assets/fedc6700-877a-47ab-a3b8-055db53407d0)","sha":"ad3b9880c792833e7590a60d57b65e08ecbd9b25","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:Obs AI Assistant","backport:version","v8.18.0","v8.17.1"],"title":"[Obs AI Assistant] Use architecture-specific elser model","number":205851,"url":"https://github.com/elastic/kibana/pull/205851","mergeCommit":{"message":"[Obs AI Assistant] Use architecture-specific elser model (#205851)\n\nCloses https://github.com/elastic/kibana/issues/205852\n\nWhen installing the Obs knowledge base it will always install the model\n`.elser_model_2`.\nFor Linux with an x86-64 CPU an optimised version of Elser exists\n(`elser_model_2_linux-x86_64`). We should use that when possible.\n\nAfter this change the inference endpoint will use\n`.elser_model_2_linux-x86_64` on supported hardware:\n\n![image](https://github.com/user-attachments/assets/fedc6700-877a-47ab-a3b8-055db53407d0)","sha":"ad3b9880c792833e7590a60d57b65e08ecbd9b25"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205851","number":205851,"mergeCommit":{"message":"[Obs AI Assistant] Use architecture-specific elser model (#205851)\n\nCloses https://github.com/elastic/kibana/issues/205852\n\nWhen installing the Obs knowledge base it will always install the model\n`.elser_model_2`.\nFor Linux with an x86-64 CPU an optimised version of Elser exists\n(`elser_model_2_linux-x86_64`). We should use that when possible.\n\nAfter this change the inference endpoint will use\n`.elser_model_2_linux-x86_64` on supported hardware:\n\n![image](https://github.com/user-attachments/assets/fedc6700-877a-47ab-a3b8-055db53407d0)","sha":"ad3b9880c792833e7590a60d57b65e08ecbd9b25"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/205951","number":205951,"state":"OPEN"},{"branch":"8.17","label":"v8.17.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->