### PR TITLE
[8.x] [inference] handle toolCall indices not starting at 0 (#205954)

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/chunks_into_message.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/chunks_into_message.test.ts
@@ -141,6 +141,92 @@ describe('chunksIntoMessage', () => {
     });
   });
 
+  it('parses tool calls even when the index does not start at 0', async () => {
+    const message = await lastValueFrom(
+      chunksIntoMessage({
+        toolOptions: {
+          toolChoice: ToolChoiceType.auto,
+          tools: {
+            myFunction: {
+              description: 'myFunction',
+              schema: {
+                type: 'object',
+                properties: {
+                  foo: {
+                    type: 'string',
+                    const: 'bar',
+                  },
+                },
+              },
+            },
+          },
+        },
+        logger,
+      })(
+        fromEvents(
+          {
+            content: '',
+            type: ChatCompletionEventType.ChatCompletionChunk,
+            tool_calls: [
+              {
+                function: {
+                  name: 'myFunction',
+                  arguments: '',
+                },
+                index: 1,
+                toolCallId: '0',
+              },
+            ],
+          },
+          {
+            content: '',
+            type: ChatCompletionEventType.ChatCompletionChunk,
+            tool_calls: [
+              {
+                function: {
+                  name: '',
+                  arguments: '{',
+                },
+                index: 1,
+                toolCallId: '0',
+              },
+            ],
+          },
+          {
+            content: '',
+            type: ChatCompletionEventType.ChatCompletionChunk,
+            tool_calls: [
+              {
+                function: {
+                  name: '',
+                  arguments: '"foo": "bar" }',
+                },
+                index: 1,
+                toolCallId: '1',
+              },
+            ],
+          }
+        )
+      )
+    );
+
+    expect(message).toEqual({
+      content: '',
+      toolCalls: [
+        {
+          function: {
+            name: 'myFunction',
+            arguments: {
+              foo: 'bar',
+            },
+          },
+          toolCallId: '001',
+        },
+      ],
+      type: ChatCompletionEventType.ChatCompletionMessage,
+    });
+  });
+
   it('validates tool calls', async () => {
     async function getMessage() {
       return await lastValueFrom(

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/chunks_into_message.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/chunks_into_message.ts
@@ -67,6 +67,9 @@ export function chunksIntoMessage<TToolOptions extends ToolOptions>({
             { content: '', tool_calls: [] as UnvalidatedToolCall[] }
           );
 
+          // some models (Claude not to name it) can have their toolCall index not start at 0, so we remove the null elements
+          concatenatedChunk.tool_calls = concatenatedChunk.tool_calls.filter((call) => !!call);
+
           logger.debug(() => `Received completed message: ${JSON.stringify(concatenatedChunk)}`);
 
           const validatedToolCalls = validateToolCalls<TToolOptions>({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[inference] handle toolCall indices not starting at 0 (#205954)](https://github.com/elastic/kibana/pull/205954)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pierre Gayvallet","email":"pierre.gayvallet@elastic.co"},"sourceCommit":{"committedDate":"2025-01-09T07:00:31Z","message":"[inference] handle toolCall indices not starting at 0 (#205954)\n\n## Summary\r\n\r\nTurns out, claude can in some situations (when returning both text and\r\ntoolcall in a single message) starts their toolcall index at `1` instead\r\nof `0`, which introducing null values in the concatenated messages.\r\n\r\nThis fixes it, by removing null values from the tool calls when merging\r\nthe chunks.\r\n\r\nAlso remove the SKA codeowner override for the inference plugin to get\r\nback the shared ownership","sha":"8eec8065bde1f9d46b74f261f96bc8d8d54d67d2","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","v9.0.0","backport:version","v8.18.0"],"number":205954,"url":"https://github.com/elastic/kibana/pull/205954","mergeCommit":{"message":"[inference] handle toolCall indices not starting at 0 (#205954)\n\n## Summary\r\n\r\nTurns out, claude can in some situations (when returning both text and\r\ntoolcall in a single message) starts their toolcall index at `1` instead\r\nof `0`, which introducing null values in the concatenated messages.\r\n\r\nThis fixes it, by removing null values from the tool calls when merging\r\nthe chunks.\r\n\r\nAlso remove the SKA codeowner override for the inference plugin to get\r\nback the shared ownership","sha":"8eec8065bde1f9d46b74f261f96bc8d8d54d67d2"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205954","number":205954,"mergeCommit":{"message":"[inference] handle toolCall indices not starting at 0 (#205954)\n\n## Summary\r\n\r\nTurns out, claude can in some situations (when returning both text and\r\ntoolcall in a single message) starts their toolcall index at `1` instead\r\nof `0`, which introducing null values in the concatenated messages.\r\n\r\nThis fixes it, by removing null values from the tool calls when merging\r\nthe chunks.\r\n\r\nAlso remove the SKA codeowner override for the inference plugin to get\r\nback the shared ownership","sha":"8eec8065bde1f9d46b74f261f96bc8d8d54d67d2"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->