### PR TITLE
[Profiling UI] Remove redundant page separator

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/public/components/profiling_app_page_template/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/profiling_app_page_template/index.tsx
@@ -12,7 +12,6 @@ import {
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiHorizontalRule,
   EuiPanel,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -116,7 +115,6 @@ export function ProfilingAppPageTemplate({
           <EuiFlexItem grow={false}>
             <EuiPanel hasShadow={false} color="subdued">
               <PrimaryProfilingSearchBar />
-              <EuiHorizontalRule />
             </EuiPanel>
           </EuiFlexItem>
         )}


### PR DESCRIPTION
Closes #206002

## Summary

This PR removes redundant page separator to save up some space.

Before:

<img width="1727" alt="Screenshot 2025-01-08 at 16 16 50" src="https://github.com/user-attachments/assets/9f69ebb2-d1a7-430e-9d9e-376712909ac1" />

After: 

<img width="1728" alt="Screenshot 2025-01-08 at 16 19 34" src="https://github.com/user-attachments/assets/9d738aa0-adba-46f3-ba79-5f20b7b90499" />




<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->