### PR TITLE
[SLOs] Allows adding drop condition for events !!

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/slo.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/slo.ts
@@ -33,7 +33,7 @@ const settingsSchema = t.intersection([
     frequency: durationType,
     preventInitialBackfill: t.boolean,
   }),
-  t.partial({ syncField: t.union([t.string, t.null]) }),
+  t.partial({ syncField: t.union([t.string, t.null]), dropCondition: t.string }),
 ]);
 
 const groupBySchema = allOrAnyStringOrArray;
@@ -43,6 +43,7 @@ const optionalSettingsSchema = t.partial({
   frequency: durationType,
   preventInitialBackfill: t.boolean,
   syncField: t.union([t.string, t.null]),
+  dropCondition: t.string,
 });
 
 const tagsSchema = t.array(t.string);

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/advanced_settings/advanced_settings.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/advanced_settings/advanced_settings.tsx
@@ -15,12 +15,14 @@ import {
   EuiFormRow,
   EuiIcon,
   EuiIconTip,
+  EuiLink,
   EuiTitle,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
+import { CodeEditor } from './condition_editor';
 import { CreateSLOForm } from '../../../types';
 import { SyncFieldSelector } from './sync_field_selector';
 
@@ -165,6 +167,34 @@ export function AdvancedSettings() {
                 checked={Boolean(field.value)}
                 onChange={(event: any) => onChange(event.target.checked)}
               />
+            )}
+          />
+        </EuiFormRow>
+        <EuiFormRow
+          label={'Drop condition'}
+          helpText={i18n.translate('xpack.slo.sloEdit.settings.dropCondition.helpText', {
+            defaultMessage:
+              'The condition that determines whether data points are dropped from the SLO calculation. For example, you can use this to exclude certain data points from the SLO calculation.',
+          })}
+          labelAppend={
+            <EuiLink
+              external={true}
+              target="_blank"
+              href="https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest.html#conditionally-run-processor"
+            >
+              {i18n.translate('xpack.slo.sloEdit.settings.dropCondition.docs', {
+                defaultMessage: 'Learn more',
+              })}
+            </EuiLink>
+          }
+          isInvalid={getFieldState('settings.dropCondition').invalid}
+          fullWidth
+        >
+          <Controller
+            name="settings.dropCondition"
+            control={control}
+            render={({ field: { ref, onChange, ...field } }) => (
+              <CodeEditor value={field.value ?? ''} onChange={(val: string) => onChange(val)} />
             )}
           />
         </EuiFormRow>

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/advanced_settings/condition_editor.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/advanced_settings/condition_editor.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+
+import { CodeEditor as MonacoCodeEditor } from '@kbn/code-editor';
+import { PainlessLang } from '@kbn/monaco';
+import { EuiPanel } from '@elastic/eui';
+
+export interface CodeEditorProps {
+  onChange: (value: string) => void;
+  value: string;
+}
+
+export function CodeEditor({ onChange, value }: CodeEditorProps) {
+  const suggestionProvider = PainlessLang.getSuggestionProvider('processor_conditional');
+
+  return (
+    <EuiPanel borderRadius="none" hasShadow={false} hasBorder={true} paddingSize="none">
+      <MonacoCodeEditor
+        signatureProvider={suggestionProvider}
+        languageId={PainlessLang.ID}
+        width={'100%'}
+        height={'120px'}
+        value={value}
+        onChange={onChange}
+        options={{
+          renderValidationDecorations: value ? 'on' : 'off',
+          lineNumbers: 'off',
+          minimap: { enabled: false },
+        }}
+        isCopyable={true}
+        placeholder={
+          "def hour = ZonedDateTime.parse(ctx['@timestamp']).getHour(); \n" +
+          'return hour < 9 || hour >= 17'
+        }
+      />
+    </EuiPanel>
+  );
+}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/helpers/process_slo_form_values.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/helpers/process_slo_form_values.ts
@@ -60,6 +60,7 @@ export function transformSloResponseToCreateSloForm(
         ? toMinutes(toDuration(values.settings.frequency))
         : SETTINGS_DEFAULT_VALUES.frequency,
       syncField: values.settings?.syncField ?? null,
+      ...(values.settings?.dropCondition && { dropCondition: values.settings.dropCondition }),
     },
   };
 }
@@ -92,6 +93,7 @@ export function transformCreateSLOFormToCreateSLOInput(values: CreateSLOForm): C
       syncDelay: `${values.settings.syncDelay ?? SETTINGS_DEFAULT_VALUES.syncDelay}m`,
       frequency: `${values.settings.frequency ?? SETTINGS_DEFAULT_VALUES.frequency}m`,
       syncField: values.settings.syncField,
+      dropCondition: values.settings.dropCondition,
     },
   };
 }
@@ -124,6 +126,7 @@ export function transformValuesToUpdateSLOInput(values: CreateSLOForm): UpdateSL
       syncDelay: `${values.settings.syncDelay ?? SETTINGS_DEFAULT_VALUES.syncDelay}m`,
       frequency: `${values.settings.frequency ?? SETTINGS_DEFAULT_VALUES.frequency}m`,
       syncField: values.settings.syncField,
+      dropCondition: values.settings.dropCondition,
     },
   };
 }

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/types.ts
@@ -28,5 +28,6 @@ export interface CreateSLOForm<IndicatorType = Indicator> {
     syncDelay: number; // in minutes
     frequency: number; // in minutes
     syncField: string | null;
+    dropCondition?: string;
   };
 }

--- a/x-pack/solutions/observability/plugins/slo/server/assets/ingest_templates/slo_pipeline_template.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/assets/ingest_templates/slo_pipeline_template.ts
@@ -77,6 +77,9 @@ export const getSLOPipelineTemplate = (slo: SLODefinition) => ({
         name: `slo-${slo.id}@custom`,
       },
     },
+    ...(slo.settings.dropCondition
+      ? [{ drop: { if: slo.settings.dropCondition, ignore_failure: true } }]
+      : []),
   ],
   _meta: {
     description: 'Ingest pipeline for SLO rollup data',


### PR DESCRIPTION
## Summary

Simplifies process to specify drop condition for events , which needs to omitted from SLO calculation !!

This is a follow up to https://github.com/elastic/kibana/pull/193628 !!

This simplifies the process a bit, user can just specify a drop condition in slo settings to drop events from SLO calculation !!

Drop condition is a simple painless script from Drop processor https://www.elastic.co/guide/en/elasticsearch/reference/master/ingest.html#conditionally-run-processor
https://www.elastic.co/guide/en/elasticsearch/reference/master/drop-processor.html

User can either specify it via API as part of slo settings via field `dropCondition`

or they can do it via ui text box under advanced settings !!


<img width="1728" alt="image" src="https://github.com/user-attachments/assets/5cf2fa8d-4162-41eb-9c93-f6e1802e226b" />


### Working 
If drop condition exists, this just add another drop processor as part of roll up pipeline 

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b3cb3de3-64d0-40f8-8952-8442f6c4aa2e" />

