### PR TITLE
[8.16] Add `consistent-type-imports` eslint rule in `obs-ux-infra_services-team` owned plugins (#204549)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1018,6 +1018,20 @@ module.exports = {
         ],
       },
     },
+    {
+      files: [
+        'x-pack/solutions/observability/plugins/apm/**/*.{js,mjs,ts,tsx}',
+        'x-pack/solutions/observability/plugins/apm_data_access/**/*.{js,mjs,ts,tsx}',
+        'x-pack/solutions/observability/plugins/infra/**/*.{js,mjs,ts,tsx}',
+        'x-pack/solutions/observability/plugins/inventory/**/*.{js,mjs,ts,tsx}',
+        'x-pack/solutions/observability/plugins/metrics_data_access/**/*.{js,mjs,ts,tsx}',
+        'x-pack/solutions/observability/plugins/profiling/**/*.{js,mjs,ts,tsx}',
+        'x-pack/solutions/observability/plugins/profiling_data_access/**/*.{js,mjs,ts,tsx}',
+      ],
+      rules: {
+        '@typescript-eslint/consistent-type-imports': 'error',
+      },
+    },
 
     /**
      * Fleet overrides


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Add `consistent-type-imports` eslint rule in `obs-ux-infra_services-team` owned plugins (#204549)](https://github.com/elastic/kibana/pull/204549)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Milosz Marcinkowski","email":"38698566+miloszmarcinkowski@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-02T13:30:47Z","message":"Add `consistent-type-imports` eslint rule in `obs-ux-infra_services-team` owned plugins (#204549)\n\nCloses #204412\r\n\r\n## Summary\r\n\r\nThis PR enforces `consistent-type-imports` eslint rule in\r\n`x-pack/solutions/observability/plugins/*` plugins owned by\r\n`obs-ux-infra_services-team`.\r\n\r\nDetailed list of plugins:\r\n- `x-pack/solutions/observability/plugins/apm`,\r\n- `x-pack/solutions/observability/plugins/apm_data_access`,\r\n- `x-pack/solutions/observability/plugins/infra`,\r\n- `x-pack/solutions/observability/plugins/inventory`,\r\n- `x-pack/solutions/observability/plugins/metrics_data_access`,\r\n- `x-pack/solutions/observability/plugins/profiling`,\r\n- `x-pack/solutions/observability/plugins/profiling_data_access`\r\n\r\nScript for fixing eslint rules in above plugins:\r\n```bash\r\nyarn eslint --no-error-on-unmatched-pattern --quiet --fix \"x-pack/solutions/observability/plugins/apm/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/apm_data_access/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/infra/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/inventory/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/metrics_data_access/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/profiling/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/profiling_data_access/**/*.{js,mjs,ts,tsx}\"\r\n```\r\n\r\n## Results\r\n\r\nThe affected plugins have been profiled using `node\r\nscripts/build_kibana_platform_plugins.js --dist --profile --focus=apm\r\n--no-cache` command and bundle size checked manually (`du -s` command).\r\n\r\n#### APM plugin\r\nZero benefits in terms of size.\r\n<img width=\"1728\" alt=\"Screenshot 2024-12-19 at 12 18 36\"\r\nsrc=\"https://github.com/user-attachments/assets/d86be5d8-a4ad-4d9c-bac1-110a0c6bba81\"\r\n/>\r\n\r\n#### Infra plugin\r\nZero benefits in terms of size.\r\n<img width=\"1728\" alt=\"Screenshot 2024-12-19 at 12 56 08\"\r\nsrc=\"https://github.com/user-attachments/assets/410bc068-1f20-4de8-ac4e-89c74478ec59\"\r\n/>\r\n\r\n#### Profiling plugin\r\nZero benefits in terms of size.\r\n<img width=\"1725\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/bf47c319-0716-4a5b-9858-94ce7d2a3251\"\r\n/>\r\n\r\n## Conclusions\r\n\r\n- Using [type-only\r\nimports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)\r\nin Kibana doesn't provide any benefits in terms of bundle size,\r\n- Possible safeguarding against edge-case TS errors\r\n- avoiding unintentional side effects\r\n([source](https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/#avoiding-unintentional-side-effects))\r\n- circular dependency reference error\r\n[(source)](https://stackoverflow.com/questions/40982927/using-import-type-statement-to-fix-circular-dependency-reference-error)\r\n- Better ground for incoming tooling (improving performance, reliability\r\nwith type definition analysis),\r\n- Clearer code intent.","sha":"6461b7e26a9afb2710353c0a84a67e4935504da4","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","ci:project-deploy-observability","Team:obs-ux-infra_services"],"number":204549,"url":"https://github.com/elastic/kibana/pull/204549","mergeCommit":{"message":"Add `consistent-type-imports` eslint rule in `obs-ux-infra_services-team` owned plugins (#204549)\n\nCloses #204412\r\n\r\n## Summary\r\n\r\nThis PR enforces `consistent-type-imports` eslint rule in\r\n`x-pack/solutions/observability/plugins/*` plugins owned by\r\n`obs-ux-infra_services-team`.\r\n\r\nDetailed list of plugins:\r\n- `x-pack/solutions/observability/plugins/apm`,\r\n- `x-pack/solutions/observability/plugins/apm_data_access`,\r\n- `x-pack/solutions/observability/plugins/infra`,\r\n- `x-pack/solutions/observability/plugins/inventory`,\r\n- `x-pack/solutions/observability/plugins/metrics_data_access`,\r\n- `x-pack/solutions/observability/plugins/profiling`,\r\n- `x-pack/solutions/observability/plugins/profiling_data_access`\r\n\r\nScript for fixing eslint rules in above plugins:\r\n```bash\r\nyarn eslint --no-error-on-unmatched-pattern --quiet --fix \"x-pack/solutions/observability/plugins/apm/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/apm_data_access/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/infra/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/inventory/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/metrics_data_access/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/profiling/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/profiling_data_access/**/*.{js,mjs,ts,tsx}\"\r\n```\r\n\r\n## Results\r\n\r\nThe affected plugins have been profiled using `node\r\nscripts/build_kibana_platform_plugins.js --dist --profile --focus=apm\r\n--no-cache` command and bundle size checked manually (`du -s` command).\r\n\r\n#### APM plugin\r\nZero benefits in terms of size.\r\n<img width=\"1728\" alt=\"Screenshot 2024-12-19 at 12 18 36\"\r\nsrc=\"https://github.com/user-attachments/assets/d86be5d8-a4ad-4d9c-bac1-110a0c6bba81\"\r\n/>\r\n\r\n#### Infra plugin\r\nZero benefits in terms of size.\r\n<img width=\"1728\" alt=\"Screenshot 2024-12-19 at 12 56 08\"\r\nsrc=\"https://github.com/user-attachments/assets/410bc068-1f20-4de8-ac4e-89c74478ec59\"\r\n/>\r\n\r\n#### Profiling plugin\r\nZero benefits in terms of size.\r\n<img width=\"1725\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/bf47c319-0716-4a5b-9858-94ce7d2a3251\"\r\n/>\r\n\r\n## Conclusions\r\n\r\n- Using [type-only\r\nimports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)\r\nin Kibana doesn't provide any benefits in terms of bundle size,\r\n- Possible safeguarding against edge-case TS errors\r\n- avoiding unintentional side effects\r\n([source](https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/#avoiding-unintentional-side-effects))\r\n- circular dependency reference error\r\n[(source)](https://stackoverflow.com/questions/40982927/using-import-type-statement-to-fix-circular-dependency-reference-error)\r\n- Better ground for incoming tooling (improving performance, reliability\r\nwith type definition analysis),\r\n- Clearer code intent.","sha":"6461b7e26a9afb2710353c0a84a67e4935504da4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/204549","number":204549,"mergeCommit":{"message":"Add `consistent-type-imports` eslint rule in `obs-ux-infra_services-team` owned plugins (#204549)\n\nCloses #204412\r\n\r\n## Summary\r\n\r\nThis PR enforces `consistent-type-imports` eslint rule in\r\n`x-pack/solutions/observability/plugins/*` plugins owned by\r\n`obs-ux-infra_services-team`.\r\n\r\nDetailed list of plugins:\r\n- `x-pack/solutions/observability/plugins/apm`,\r\n- `x-pack/solutions/observability/plugins/apm_data_access`,\r\n- `x-pack/solutions/observability/plugins/infra`,\r\n- `x-pack/solutions/observability/plugins/inventory`,\r\n- `x-pack/solutions/observability/plugins/metrics_data_access`,\r\n- `x-pack/solutions/observability/plugins/profiling`,\r\n- `x-pack/solutions/observability/plugins/profiling_data_access`\r\n\r\nScript for fixing eslint rules in above plugins:\r\n```bash\r\nyarn eslint --no-error-on-unmatched-pattern --quiet --fix \"x-pack/solutions/observability/plugins/apm/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/apm_data_access/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/infra/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/inventory/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/metrics_data_access/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/profiling/**/*.{js,mjs,ts,tsx}\" \"x-pack/solutions/observability/plugins/profiling_data_access/**/*.{js,mjs,ts,tsx}\"\r\n```\r\n\r\n## Results\r\n\r\nThe affected plugins have been profiled using `node\r\nscripts/build_kibana_platform_plugins.js --dist --profile --focus=apm\r\n--no-cache` command and bundle size checked manually (`du -s` command).\r\n\r\n#### APM plugin\r\nZero benefits in terms of size.\r\n<img width=\"1728\" alt=\"Screenshot 2024-12-19 at 12 18 36\"\r\nsrc=\"https://github.com/user-attachments/assets/d86be5d8-a4ad-4d9c-bac1-110a0c6bba81\"\r\n/>\r\n\r\n#### Infra plugin\r\nZero benefits in terms of size.\r\n<img width=\"1728\" alt=\"Screenshot 2024-12-19 at 12 56 08\"\r\nsrc=\"https://github.com/user-attachments/assets/410bc068-1f20-4de8-ac4e-89c74478ec59\"\r\n/>\r\n\r\n#### Profiling plugin\r\nZero benefits in terms of size.\r\n<img width=\"1725\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/bf47c319-0716-4a5b-9858-94ce7d2a3251\"\r\n/>\r\n\r\n## Conclusions\r\n\r\n- Using [type-only\r\nimports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)\r\nin Kibana doesn't provide any benefits in terms of bundle size,\r\n- Possible safeguarding against edge-case TS errors\r\n- avoiding unintentional side effects\r\n([source](https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/#avoiding-unintentional-side-effects))\r\n- circular dependency reference error\r\n[(source)](https://stackoverflow.com/questions/40982927/using-import-type-statement-to-fix-circular-dependency-reference-error)\r\n- Better ground for incoming tooling (improving performance, reliability\r\nwith type definition analysis),\r\n- Clearer code intent.","sha":"6461b7e26a9afb2710353c0a84a67e4935504da4"}},{"url":"https://github.com/elastic/kibana/pull/206047","number":206047,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->