### PR TITLE
[ES|QL] Allows the editor suggestions to be visible when inline docs flyout is open

### DIFF
--- a/src/platform/packages/private/kbn-language-documentation/src/components/as_flyout/index.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/components/as_flyout/index.tsx
@@ -81,6 +81,7 @@ function DocumentationFlyout({
           onClose={() => onHelpMenuVisibilityChange(false)}
           aria-labelledby="esqlInlineDocumentationFlyout"
           data-test-subj="esqlInlineDocumentationFlyout"
+          css={{ zIndex: 1 }}
           type="push"
           size={DEFAULT_WIDTH}
           paddingSize="m"


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/199299

Changes the flyout z-index in order the suggestions to be visible when the docs are open.


![image (75)](https://github.com/user-attachments/assets/e13595d0-e98c-4e7b-9673-a6e3d011fee7)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->