### PR TITLE
[Search serverless / Connectors FTRs] Update test role to developer

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/connectors.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/connectors.ts
@@ -19,7 +19,7 @@ export default function ({ getService }: FtrProviderContext) {
     describe('GET connectors', function () {
       before(async () => {
         supertestViewerWithCookieCredentials = await roleScopedSupertest.getSupertestWithRoleScope(
-          'viewer',
+          'developer',
           {
             useCookieHeader: true,
             withInternalHeaders: true,

--- a/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/connectors.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/connectors.ts
@@ -13,22 +13,20 @@ const API_BASE_PATH = '/internal/serverless_search';
 
 export default function ({ getService }: FtrProviderContext) {
   const roleScopedSupertest = getService('roleScopedSupertest');
-  let supertestViewerWithCookieCredentials: SupertestWithRoleScope;
+  let supertestDeveloperWithCookieCredentials: SupertestWithRoleScope;
 
   describe('Connectors routes', function () {
     describe('GET connectors', function () {
       before(async () => {
-        supertestViewerWithCookieCredentials = await roleScopedSupertest.getSupertestWithRoleScope(
-          'developer',
-          {
+        supertestDeveloperWithCookieCredentials =
+          await roleScopedSupertest.getSupertestWithRoleScope('developer', {
             useCookieHeader: true,
             withInternalHeaders: true,
-          }
-        );
+          });
       });
 
       it('returns list of connectors', async () => {
-        const { body } = await supertestViewerWithCookieCredentials
+        const { body } = await supertestDeveloperWithCookieCredentials
           .get(`${API_BASE_PATH}/connectors`)
           .expect(200);
 


### PR DESCRIPTION
## Summary

`viewer` role is not sufficient to call Connector APIs with new change https://github.com/elastic/elasticsearch/pull/119863

Update the FTR tests to use developer role for testing


