### PR TITLE
Adds notification settings for unsupported ftr tests (synthetics, inventory)

### DIFF
--- a/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
+++ b/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
@@ -75,6 +75,8 @@ steps:
       machineType: n2-standard-4
       preemptible: true
     depends_on: build
+    env:
+      PING_SLACK_TEAM: "@obs-ux-management-team"
     timeout_in_minutes: 120
     artifact_paths:
       - 'x-pack/solutions/observability/plugins/synthetics/e2e/.journeys/**/*'
@@ -94,6 +96,8 @@ steps:
       machineType: n2-standard-4
       preemptible: true
     depends_on: build
+    env:
+      PING_SLACK_TEAM: "@obs-ux-infra_services-team"
     timeout_in_minutes: 120
     retry:
       automatic:


### PR DESCRIPTION
## Summary

Based on [work by @v1v to notify Slack teams when there are unsupported FTR failures](https://github.com/elastic/kibana/pull/205260), I've added the remaining ones for synthetics and inventory tests here.


<!--ONMERGE {"backportTargets":["7.17","8.16","8.17","8.x"]} ONMERGE-->