### PR TITLE
[ci] Work around docosaurus errors

### DIFF
--- a/packages/kbn-validate-next-docs-cli/validate_next_docs_cli.ts
+++ b/packages/kbn-validate-next-docs-cli/validate_next_docs_cli.ts
@@ -36,8 +36,7 @@ run(
 
         // TODO: Remove this, once https://github.com/elastic/kibana/issues/206077 is resolved
         if (source.location === 'elastic/kibana-team') {
-          // eslint-disable-next-line no-console
-          console.warn(
+          log.info(
             'Removing internal.kibana.dev from elastic/kibana-team - see https://github.com/elastic/kibana/issues/206077 for more details.'
           );
           await repo.run('rm', ['-rf', 'internal.kibana.dev'], { desc: 'rm internal.kibana.dev' });

--- a/packages/kbn-validate-next-docs-cli/validate_next_docs_cli.ts
+++ b/packages/kbn-validate-next-docs-cli/validate_next_docs_cli.ts
@@ -34,6 +34,15 @@ run(
       sources.map(async (source): Promise<Source> => {
         const repo = await repos.init(source.location);
 
+        // TODO: Remove this, once https://github.com/elastic/kibana/issues/206077 is resolved
+        if (source.location === 'elastic/kibana-team') {
+          // eslint-disable-next-line no-console
+          console.warn(
+            'Removing internal.kibana.dev from elastic/kibana-team - see https://github.com/elastic/kibana/issues/206077 for more details.'
+          );
+          await repo.run('rm', ['-rf', 'internal.kibana.dev'], { desc: 'rm internal.kibana.dev' });
+        }
+
         return {
           type: 'file',
           location: repo.resolve(),


### PR DESCRIPTION
## Summary
This workaround removes the folder that needs to be built differently after cloning the repos.

See: https://github.com/elastic/kibana/issues/206077

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->