### PR TITLE
[8.17] [ResponseOps][Rules] Allow to set notify when and throttle at rule level (#203235)

### DIFF
--- a/packages/kbn-alerts-ui-shared/src/rule_form/constants.ts
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/constants.ts
@@ -37,7 +37,7 @@ export const getDefaultFormData = ({
   ruleTypeId: RuleFormData['ruleTypeId'];
   name: RuleFormData['name'];
   consumer: RuleFormData['consumer'];
-  actions: RuleFormData['actions'];
+  actions?: RuleFormData['actions'];
   schedule?: RuleFormData['schedule'];
 }) => {
   return {
@@ -49,7 +49,7 @@ export const getDefaultFormData = ({
     consumer,
     ruleTypeId,
     name,
-    actions,
+    actions: actions ?? [],
     alertDelay: { active: 1 },
   };
 };

--- a/packages/kbn-alerts-ui-shared/src/rule_form/create_rule_form.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/create_rule_form.tsx
@@ -124,7 +124,6 @@ export const CreateRuleForm = (props: CreateRuleFormProps) => {
           params: newFormData.params,
           schedule: newFormData.schedule,
           actions: newFormData.actions,
-          notifyWhen: newFormData.notifyWhen,
           alertDelay: newFormData.alertDelay,
           flapping: newFormData.flapping,
         },

--- a/packages/kbn-alerts-ui-shared/src/rule_form/edit_rule_form.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/edit_rule_form.tsx
@@ -101,7 +101,6 @@ export const EditRuleForm = (props: EditRuleFormProps) => {
           schedule: newFormData.schedule,
           params: newFormData.params,
           actions: newFormData.actions,
-          notifyWhen: newFormData.notifyWhen,
           alertDelay: newFormData.alertDelay,
           flapping: newFormData.flapping,
         },
@@ -162,6 +161,24 @@ export const EditRuleForm = (props: EditRuleFormProps) => {
     );
   }
 
+  const actionsWithFrequency = fetchedFormData.actions.map((action) => {
+    const isSystemAction = connectorTypes.some((connectorType) => {
+      return connectorType.id === action.actionTypeId && connectorType.isSystemActionType;
+    });
+
+    if (!isSystemAction && fetchedFormData.notifyWhen) {
+      return {
+        ...action,
+        frequency: {
+          notifyWhen: fetchedFormData.notifyWhen ?? 'onActionGroupChange',
+          throttle: fetchedFormData.throttle ?? null,
+          summary: false,
+        },
+      };
+    }
+    return action;
+  });
+
   return (
     <div data-test-subj="editRuleForm">
       <RuleFormStateProvider
@@ -177,6 +194,7 @@ export const EditRuleForm = (props: EditRuleFormProps) => {
               actions: fetchedFormData.actions,
             }),
             ...fetchedFormData,
+            actions: actionsWithFrequency,
           },
           id,
           plugins,

--- a/packages/kbn-alerts-ui-shared/src/rule_form/rule_actions/rule_actions_settings.test.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/rule_actions/rule_actions_settings.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { RuleActionsSettings } from './rule_actions_settings';
 import { getAction } from '../../common/test_utils/actions_test_utils';
-import type { RuleTypeModel } from '@kbn/alerts-ui-shared';
+import type { RuleTypeModel } from '../../common';
 import { RuleType } from '@kbn/alerting-types';
 import userEvent from '@testing-library/user-event';
 import type { RuleActionsNotifyWhenProps } from './rule_actions_notify_when';

--- a/packages/kbn-alerts-ui-shared/src/rule_form/rule_actions/rule_actions_settings.test.tsx
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/rule_actions/rule_actions_settings.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { RuleActionsSettings } from './rule_actions_settings';
 import { getAction } from '../../common/test_utils/actions_test_utils';
-import { RuleTypeModel } from '../../common';
+import type { RuleTypeModel } from '@kbn/alerts-ui-shared';
 import { RuleType } from '@kbn/alerting-types';
 import userEvent from '@testing-library/user-event';
 import type { RuleActionsNotifyWhenProps } from './rule_actions_notify_when';

--- a/packages/kbn-alerts-ui-shared/src/rule_form/types.ts
+++ b/packages/kbn-alerts-ui-shared/src/rule_form/types.ts
@@ -45,6 +45,7 @@ export interface RuleFormData<Params extends RuleTypeParams = RuleTypeParams> {
   actions: RuleUiAction[];
   alertDelay?: Rule<Params>['alertDelay'];
   notifyWhen?: Rule<Params>['notifyWhen'];
+  throttle?: Rule<Params>['throttle'];
   ruleTypeId?: Rule<Params>['ruleTypeId'];
   flapping?: Rule<Params>['flapping'];
 }

--- a/packages/kbn-alerts-ui-shared/tsconfig.json
+++ b/packages/kbn-alerts-ui-shared/tsconfig.json
@@ -51,6 +51,5 @@
     "@kbn/core-notifications-browser-mocks",
     "@kbn/kibana-react-plugin",
     "@kbn/shared-ux-table-persist",
-    "@kbn/alerts-ui-shared"
   ]
 }

--- a/packages/kbn-alerts-ui-shared/tsconfig.json
+++ b/packages/kbn-alerts-ui-shared/tsconfig.json
@@ -50,6 +50,7 @@
     "@kbn/core-http-browser-mocks",
     "@kbn/core-notifications-browser-mocks",
     "@kbn/kibana-react-plugin",
-    "@kbn/shared-ux-table-persist"
+    "@kbn/shared-ux-table-persist",
+    "@kbn/alerts-ui-shared"
   ]
 }

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/details.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/details.ts
@@ -656,7 +656,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await find.clickByCssSelector('[data-test-subj="saveEditedRuleButton"]:not(disabled)');
 
         const toastTitle = await toasts.getTitleAndDismiss();
-        expect(toastTitle).to.eql(`Updated '${updatedRuleName}'`);
+        expect(toastTitle).to.eql(`Updated "${updatedRuleName}"`);
       });
     });
 

--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/details.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/details.ts
@@ -656,7 +656,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await find.clickByCssSelector('[data-test-subj="saveEditedRuleButton"]:not(disabled)');
 
         const toastTitle = await toasts.getTitleAndDismiss();
-        expect(toastTitle).to.eql(`Updated "${updatedRuleName}"`);
+        expect(toastTitle).to.eql(`Updated '${updatedRuleName}'`);
       });
     });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[ResponseOps][Rules] Allow to set notify when and throttle at rule level (#203235)](https://github.com/elastic/kibana/pull/203235)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Janki Salvi","email":"117571355+js-jankisalvi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-09T16:18:28Z","message":"[ResponseOps][Rules] Allow to set notify when and throttle at rule level (#203235)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/199494\r\n\r\nThis PR allows to create and update rule with `notify_when` and\r\n`throttle` attributes at rule level instead of `action.frequency` level.\r\n\r\n### How to test\r\n- create a rule via api where `notify_when` and `throttle` attributes\r\nare at rule level\r\n  <details><summary>Example</summary>\r\n  Note: use your existing connector for action\r\n  \r\n  ```typescript\r\n  POST kbn:/api/alerting/rule\r\n  {\r\n    \"tags\": [],\r\n    \"params\": {\r\n      \"searchConfiguration\": {\r\n        \"query\": {\r\n          \"query\": \"\",\r\n          \"language\": \"kuery\"\r\n        },\r\n        \"index\": \"ff959d40-b880-11e8-a6d9-e546fe2bba5f\"\r\n      },\r\n      \"timeField\": \"order_date\",\r\n      \"searchType\": \"searchSource\",\r\n      \"timeWindowSize\": 5,\r\n      \"timeWindowUnit\": \"d\",\r\n      \"threshold\": [\r\n        10\r\n      ],\r\n      \"thresholdComparator\": \">\",\r\n      \"size\": 100,\r\n      \"aggType\": \"count\",\r\n      \"groupBy\": \"all\",\r\n      \"termSize\": 5,\r\n      \"excludeHitsFromPreviousRun\": false,\r\n      \"sourceFields\": []\r\n    },\r\n    \"schedule\": {\r\n      \"interval\": \"1m\"\r\n    },\r\n    \"consumer\": \"stackAlerts\",\r\n    \"name\": \"ES query rule from devtools\",\r\n    \"rule_type_id\": \".es-query\",\r\n    \"notify_when\": \"onThrottleInterval\",\r\n    \"throttle\": \"1h\",\r\n    \"actions\": [\r\n      {\r\n        \"group\": \"query matched\",\r\n        \"id\": \"ad923c8a-d27d-41a9-8c71-d33d94db4abb\",\r\n        \"params\": {\r\n          \"documents\": [\r\n            {\r\n              \"name\": \"{{rule.name}}\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"alert_delay\": {\r\n      \"active\": 1\r\n    }\r\n  }\r\n  ``` \r\n  </details> \r\n\r\n- open the created rule\r\n- go to `settings` tab \r\n- verify that dropdowns reflect notify_when and throttle value correctly\r\n- update the rule via UI and verify the same\r\n- update the rule via API and verify the same\r\n\r\n### Flaky test runner: \r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7684\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"a56227bf37108da0604d731f304e0dcb81e03a4f","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","v9.0.0","backport:prev-major","v8.18.0","v8.16.3","v8.17.1"],"number":203235,"url":"https://github.com/elastic/kibana/pull/203235","mergeCommit":{"message":"[ResponseOps][Rules] Allow to set notify when and throttle at rule level (#203235)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/199494\r\n\r\nThis PR allows to create and update rule with `notify_when` and\r\n`throttle` attributes at rule level instead of `action.frequency` level.\r\n\r\n### How to test\r\n- create a rule via api where `notify_when` and `throttle` attributes\r\nare at rule level\r\n  <details><summary>Example</summary>\r\n  Note: use your existing connector for action\r\n  \r\n  ```typescript\r\n  POST kbn:/api/alerting/rule\r\n  {\r\n    \"tags\": [],\r\n    \"params\": {\r\n      \"searchConfiguration\": {\r\n        \"query\": {\r\n          \"query\": \"\",\r\n          \"language\": \"kuery\"\r\n        },\r\n        \"index\": \"ff959d40-b880-11e8-a6d9-e546fe2bba5f\"\r\n      },\r\n      \"timeField\": \"order_date\",\r\n      \"searchType\": \"searchSource\",\r\n      \"timeWindowSize\": 5,\r\n      \"timeWindowUnit\": \"d\",\r\n      \"threshold\": [\r\n        10\r\n      ],\r\n      \"thresholdComparator\": \">\",\r\n      \"size\": 100,\r\n      \"aggType\": \"count\",\r\n      \"groupBy\": \"all\",\r\n      \"termSize\": 5,\r\n      \"excludeHitsFromPreviousRun\": false,\r\n      \"sourceFields\": []\r\n    },\r\n    \"schedule\": {\r\n      \"interval\": \"1m\"\r\n    },\r\n    \"consumer\": \"stackAlerts\",\r\n    \"name\": \"ES query rule from devtools\",\r\n    \"rule_type_id\": \".es-query\",\r\n    \"notify_when\": \"onThrottleInterval\",\r\n    \"throttle\": \"1h\",\r\n    \"actions\": [\r\n      {\r\n        \"group\": \"query matched\",\r\n        \"id\": \"ad923c8a-d27d-41a9-8c71-d33d94db4abb\",\r\n        \"params\": {\r\n          \"documents\": [\r\n            {\r\n              \"name\": \"{{rule.name}}\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"alert_delay\": {\r\n      \"active\": 1\r\n    }\r\n  }\r\n  ``` \r\n  </details> \r\n\r\n- open the created rule\r\n- go to `settings` tab \r\n- verify that dropdowns reflect notify_when and throttle value correctly\r\n- update the rule via UI and verify the same\r\n- update the rule via API and verify the same\r\n\r\n### Flaky test runner: \r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7684\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"a56227bf37108da0604d731f304e0dcb81e03a4f"}},"sourceBranch":"main","suggestedTargetBranches":["8.16","8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203235","number":203235,"mergeCommit":{"message":"[ResponseOps][Rules] Allow to set notify when and throttle at rule level (#203235)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/199494\r\n\r\nThis PR allows to create and update rule with `notify_when` and\r\n`throttle` attributes at rule level instead of `action.frequency` level.\r\n\r\n### How to test\r\n- create a rule via api where `notify_when` and `throttle` attributes\r\nare at rule level\r\n  <details><summary>Example</summary>\r\n  Note: use your existing connector for action\r\n  \r\n  ```typescript\r\n  POST kbn:/api/alerting/rule\r\n  {\r\n    \"tags\": [],\r\n    \"params\": {\r\n      \"searchConfiguration\": {\r\n        \"query\": {\r\n          \"query\": \"\",\r\n          \"language\": \"kuery\"\r\n        },\r\n        \"index\": \"ff959d40-b880-11e8-a6d9-e546fe2bba5f\"\r\n      },\r\n      \"timeField\": \"order_date\",\r\n      \"searchType\": \"searchSource\",\r\n      \"timeWindowSize\": 5,\r\n      \"timeWindowUnit\": \"d\",\r\n      \"threshold\": [\r\n        10\r\n      ],\r\n      \"thresholdComparator\": \">\",\r\n      \"size\": 100,\r\n      \"aggType\": \"count\",\r\n      \"groupBy\": \"all\",\r\n      \"termSize\": 5,\r\n      \"excludeHitsFromPreviousRun\": false,\r\n      \"sourceFields\": []\r\n    },\r\n    \"schedule\": {\r\n      \"interval\": \"1m\"\r\n    },\r\n    \"consumer\": \"stackAlerts\",\r\n    \"name\": \"ES query rule from devtools\",\r\n    \"rule_type_id\": \".es-query\",\r\n    \"notify_when\": \"onThrottleInterval\",\r\n    \"throttle\": \"1h\",\r\n    \"actions\": [\r\n      {\r\n        \"group\": \"query matched\",\r\n        \"id\": \"ad923c8a-d27d-41a9-8c71-d33d94db4abb\",\r\n        \"params\": {\r\n          \"documents\": [\r\n            {\r\n              \"name\": \"{{rule.name}}\"\r\n            }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"alert_delay\": {\r\n      \"active\": 1\r\n    }\r\n  }\r\n  ``` \r\n  </details> \r\n\r\n- open the created rule\r\n- go to `settings` tab \r\n- verify that dropdowns reflect notify_when and throttle value correctly\r\n- update the rule via UI and verify the same\r\n- update the rule via API and verify the same\r\n\r\n### Flaky test runner: \r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7684\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"a56227bf37108da0604d731f304e0dcb81e03a4f"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/206099","number":206099,"state":"OPEN"},{"branch":"8.16","label":"v8.16.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->