### PR TITLE
[Automatic Import ] Enable inference connector for Auto Import

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/use_assistant_overlay/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/use_assistant_overlay/index.tsx
@@ -82,9 +82,10 @@ export const useAssistantOverlay = (
    */
   replacements?: Replacements | null
 ): UseAssistantOverlay => {
-  const { http } = useAssistantContext();
+  const { http, inferenceEnabled } = useAssistantContext();
   const { data: connectors } = useLoadConnectors({
     http,
+    inferenceEnabled,
   });
 
   const defaultConnector = useMemo(() => getDefaultConnector(connectors), [connectors]);

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
@@ -57,14 +57,18 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
     setIsOpen,
     stats = null,
   }) => {
-    const { actionTypeRegistry, http, assistantAvailability } = useAssistantContext();
+    const { actionTypeRegistry, http, assistantAvailability, inferenceEnabled } =
+      useAssistantContext();
     // Connector Modal State
     const [isConnectorModalVisible, setIsConnectorModalVisible] = useState<boolean>(false);
     const { data: actionTypes } = useLoadActionTypes({ http });
 
     const [selectedActionType, setSelectedActionType] = useState<ActionType | null>(null);
 
-    const { data: aiConnectors, refetch: refetchConnectors } = useLoadConnectors({ http });
+    const { data: aiConnectors, refetch: refetchConnectors } = useLoadConnectors({
+      http,
+      inferenceEnabled,
+    });
 
     const localIsDisabled = isDisabled || !assistantAvailability.hasConnectorsReadPrivilege;
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_setup/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_setup/index.tsx
@@ -35,9 +35,9 @@ export const ConnectorSetup = ({
   );
   const { setApiConfig } = useConversation();
   // Access all conversations so we can add connector to all on initial setup
-  const { actionTypeRegistry, http } = useAssistantContext();
+  const { actionTypeRegistry, http, inferenceEnabled } = useAssistantContext();
 
-  const { refetch: refetchConnectors } = useLoadConnectors({ http });
+  const { refetch: refetchConnectors } = useLoadConnectors({ http, inferenceEnabled });
 
   const { data: actionTypes } = useLoadActionTypes({ http });
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/use_load_connectors/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/use_load_connectors/index.test.tsx
@@ -9,7 +9,6 @@ import { waitFor, renderHook } from '@testing-library/react';
 import { useLoadConnectors, Props } from '.';
 import { mockConnectors } from '../../mock/connectors';
 import { TestProviders } from '../../mock/test_providers/test_providers';
-import React, { ReactNode } from 'react';
 
 const mockConnectorsAndExtras = [
   ...mockConnectors,
@@ -55,13 +54,6 @@ const toasts = {
 };
 const defaultProps = { http, toasts } as unknown as Props;
 
-const createWrapper = (inferenceEnabled = false) => {
-  // eslint-disable-next-line react/display-name
-  return ({ children }: { children: ReactNode }) => (
-    <TestProviders providerContext={{ inferenceEnabled }}>{children}</TestProviders>
-  );
-};
-
 describe('useLoadConnectors', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -91,9 +83,12 @@ describe('useLoadConnectors', () => {
   });
 
   it('includes preconfigured .inference results when inferenceEnabled is true', async () => {
-    const { result } = renderHook(() => useLoadConnectors(defaultProps), {
-      wrapper: createWrapper(true),
-    });
+    const { result } = renderHook(
+      () => useLoadConnectors({ ...defaultProps, inferenceEnabled: true }),
+      {
+        wrapper: TestProviders,
+      }
+    );
     await waitFor(() => {
       expect(result.current.data).toStrictEqual(
         mockConnectors

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/use_load_connectors/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/use_load_connectors/index.tsx
@@ -13,7 +13,6 @@ import type { IHttpFetchError } from '@kbn/core-http-browser';
 import { HttpSetup } from '@kbn/core-http-browser';
 import { IToasts } from '@kbn/core-notifications-browser';
 import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/common/openai/constants';
-import { useAssistantContext } from '../../assistant_context';
 import { AIConnector } from '../connector_selector';
 import * as i18n from '../translations';
 
@@ -26,6 +25,7 @@ const QUERY_KEY = ['elastic-assistant, load-connectors'];
 export interface Props {
   http: HttpSetup;
   toasts?: IToasts;
+  inferenceEnabled: boolean;
 }
 
 const actionTypes = ['.bedrock', '.gen-ai', '.gemini'];
@@ -33,8 +33,8 @@ const actionTypes = ['.bedrock', '.gen-ai', '.gemini'];
 export const useLoadConnectors = ({
   http,
   toasts,
+  inferenceEnabled,
 }: Props): UseQueryResult<AIConnector[], IHttpFetchError> => {
-  const { inferenceEnabled } = useAssistantContext();
   if (inferenceEnabled) {
     actionTypes.push('.inference');
   }

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/use_load_connectors/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/use_load_connectors/index.tsx
@@ -25,7 +25,7 @@ const QUERY_KEY = ['elastic-assistant, load-connectors'];
 export interface Props {
   http: HttpSetup;
   toasts?: IToasts;
-  inferenceEnabled: boolean;
+  inferenceEnabled?: boolean;
 }
 
 const actionTypes = ['.bedrock', '.gen-ai', '.gemini'];
@@ -33,7 +33,7 @@ const actionTypes = ['.bedrock', '.gen-ai', '.gemini'];
 export const useLoadConnectors = ({
   http,
   toasts,
-  inferenceEnabled,
+  inferenceEnabled = false,
 }: Props): UseQueryResult<AIConnector[], IHttpFetchError> => {
   if (inferenceEnabled) {
     actionTypes.push('.inference');

--- a/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.test.tsx
+++ b/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.test.tsx
@@ -34,6 +34,12 @@ const actionType = { id: '.bedrock', name: 'Bedrock', iconClass: 'logoBedrock' }
 mockServices.triggersActionsUi.actionTypeRegistry.register(
   actionType as unknown as ActionTypeModel
 );
+
+const inferenceActionType = { id: '.inference', name: 'Inference', iconClass: 'logoInference' };
+mockServices.triggersActionsUi.actionTypeRegistry.register(
+  inferenceActionType as unknown as ActionTypeModel
+);
+
 jest.mock('@kbn/elastic-assistant/impl/connectorland/use_load_action_types', () => ({
   useLoadActionTypes: jest.fn(() => ({ data: [actionType] })),
 }));

--- a/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
+++ b/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
@@ -46,9 +46,11 @@ export const ConnectorStep = React.memo<ConnectorStepProps>(({ connector }) => {
   const { setConnector, completeStep } = useActions();
 
   const [connectors, setConnectors] = useState<AIConnector[]>();
-  const inferenceEnabled = triggersActionsUi.actionTypeRegistry.get(
-    '.inference'
-  ) as unknown as boolean;
+  let inferenceEnabled: boolean = false;
+
+  if (triggersActionsUi.actionTypeRegistry.has('.inference')) {
+    inferenceEnabled = triggersActionsUi.actionTypeRegistry.get('.inference') as unknown as boolean;
+  }
   if (inferenceEnabled) {
     AllowedActionTypeIds.push('.inference');
   }

--- a/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
+++ b/x-pack/platform/plugins/shared/integration_assistant/public/components/create_integration/create_integration_assistant/steps/connector_step/connector_step.tsx
@@ -42,15 +42,21 @@ interface ConnectorStepProps {
 }
 export const ConnectorStep = React.memo<ConnectorStepProps>(({ connector }) => {
   const { euiTheme } = useEuiTheme();
-  const { http, notifications } = useKibana().services;
+  const { http, notifications, triggersActionsUi } = useKibana().services;
   const { setConnector, completeStep } = useActions();
 
   const [connectors, setConnectors] = useState<AIConnector[]>();
+  const inferenceEnabled = triggersActionsUi.actionTypeRegistry.get(
+    '.inference'
+  ) as unknown as boolean;
+  if (inferenceEnabled) {
+    AllowedActionTypeIds.push('.inference');
+  }
   const {
     isLoading,
     data: aiConnectors,
     refetch: refetchConnectors,
-  } = useLoadConnectors({ http, toasts: notifications.toasts });
+  } = useLoadConnectors({ http, toasts: notifications.toasts, inferenceEnabled });
 
   useEffect(() => {
     if (aiConnectors != null) {

--- a/x-pack/platform/plugins/shared/integration_assistant/server/util/llm.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/util/llm.ts
@@ -16,12 +16,13 @@ export const getLLMType = (actionTypeId: string): string | undefined => {
     [`.gen-ai`]: `openai`,
     [`.bedrock`]: `bedrock`,
     [`.gemini`]: `gemini`,
+    [`.inference`]: `inference`,
   };
   return llmTypeDictionary[actionTypeId];
 };
 
 export const getLLMClass = (llmType?: string) =>
-  llmType === 'openai'
+  llmType === 'openai' || llmType === 'inference'
     ? ActionsClientChatOpenAI
     : llmType === 'bedrock'
     ? ActionsClientBedrockChatModel

--- a/x-pack/platform/plugins/shared/stack_connectors/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/experimental_features.ts
@@ -15,7 +15,7 @@ export const allowedExperimentalValues = Object.freeze({
   isMustacheAutocompleteOn: false,
   sentinelOneConnectorOn: true,
   crowdstrikeConnectorOn: true,
-  inferenceConnectorOn: false,
+  inferenceConnectorOn: true,
   crowdstrikeConnectorRTROn: false,
   microsoftDefenderEndpointOn: false,
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/experimental_features.ts
@@ -15,7 +15,7 @@ export const allowedExperimentalValues = Object.freeze({
   isMustacheAutocompleteOn: false,
   sentinelOneConnectorOn: true,
   crowdstrikeConnectorOn: true,
-  inferenceConnectorOn: true,
+  inferenceConnectorOn: false,
   crowdstrikeConnectorRTROn: false,
   microsoftDefenderEndpointOn: false,
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.test.tsx
@@ -12,15 +12,10 @@ import { render } from '@testing-library/react';
 import type { RuleExecutionStatus } from '../../../../../common/api/detection_engine/rule_monitoring';
 import { RuleExecutionStatusEnum } from '../../../../../common/api/detection_engine/rule_monitoring';
 import { RuleStatusFailedCallOut } from './rule_status_failed_callout';
-import { AssistantProvider } from '@kbn/elastic-assistant';
-import type { AssistantAvailability } from '@kbn/elastic-assistant';
-import { httpServiceMock } from '@kbn/core-http-browser-mocks';
-import { actionTypeRegistryMock } from '@kbn/triggers-actions-ui-plugin/public/application/action_type_registry.mock';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BASE_SECURITY_CONVERSATIONS } from '../../../../assistant/content/conversations';
-import type { UserProfileService } from '@kbn/core-user-profile-browser';
 import { chromeServiceMock } from '@kbn/core/public/mocks';
 import { of } from 'rxjs';
+import { MockAssistantProviderComponent } from '../../../../common/mock/mock_assistant_provider';
 
 jest.mock('../../../../common/lib/kibana');
 
@@ -28,18 +23,6 @@ const TEST_ID = 'ruleStatusFailedCallOut';
 const DATE = '2022-01-27T15:03:31.176Z';
 const MESSAGE = 'This rule is attempting to query data but...';
 
-const actionTypeRegistry = actionTypeRegistryMock.create();
-const mockGetComments = jest.fn(() => []);
-const mockHttp = httpServiceMock.createStartContract({ basePath: '/test' });
-const mockNavigationToApp = jest.fn();
-const mockAssistantAvailability: AssistantAvailability = {
-  hasAssistantPrivilege: false,
-  hasConnectorsAllPrivilege: true,
-  hasConnectorsReadPrivilege: true,
-  hasUpdateAIAssistantAnonymization: true,
-  hasManageGlobalKnowledgeBase: true,
-  isAssistantEnabled: true,
-};
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -58,25 +41,7 @@ const ContextWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   chrome.getChromeStyle$.mockReturnValue(of('classic'));
   return (
     <QueryClientProvider client={queryClient}>
-      <AssistantProvider
-        actionTypeRegistry={actionTypeRegistry}
-        assistantAvailability={mockAssistantAvailability}
-        augmentMessageCodeBlocks={jest.fn()}
-        basePath={'https://localhost:5601/kbn'}
-        docLinks={{
-          ELASTIC_WEBSITE_URL: 'https://www.elastic.co/',
-          DOC_LINK_VERSION: 'current',
-        }}
-        getComments={mockGetComments}
-        http={mockHttp}
-        navigateToApp={mockNavigationToApp}
-        baseConversations={BASE_SECURITY_CONVERSATIONS}
-        currentAppId={'security'}
-        userProfileService={jest.fn() as unknown as UserProfileService}
-        chrome={chrome}
-      >
-        {children}
-      </AssistantProvider>
+      <MockAssistantProviderComponent>{children}</MockAssistantProviderComponent>
     </QueryClientProvider>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/rules/rule_execution_status/rule_status_failed_callout.test.tsx
@@ -12,10 +12,15 @@ import { render } from '@testing-library/react';
 import type { RuleExecutionStatus } from '../../../../../common/api/detection_engine/rule_monitoring';
 import { RuleExecutionStatusEnum } from '../../../../../common/api/detection_engine/rule_monitoring';
 import { RuleStatusFailedCallOut } from './rule_status_failed_callout';
+import { AssistantProvider } from '@kbn/elastic-assistant';
+import type { AssistantAvailability } from '@kbn/elastic-assistant';
+import { httpServiceMock } from '@kbn/core-http-browser-mocks';
+import { actionTypeRegistryMock } from '@kbn/triggers-actions-ui-plugin/public/application/action_type_registry.mock';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BASE_SECURITY_CONVERSATIONS } from '../../../../assistant/content/conversations';
+import type { UserProfileService } from '@kbn/core-user-profile-browser';
 import { chromeServiceMock } from '@kbn/core/public/mocks';
 import { of } from 'rxjs';
-import { MockAssistantProviderComponent } from '../../../../common/mock/mock_assistant_provider';
 
 jest.mock('../../../../common/lib/kibana');
 
@@ -23,6 +28,18 @@ const TEST_ID = 'ruleStatusFailedCallOut';
 const DATE = '2022-01-27T15:03:31.176Z';
 const MESSAGE = 'This rule is attempting to query data but...';
 
+const actionTypeRegistry = actionTypeRegistryMock.create();
+const mockGetComments = jest.fn(() => []);
+const mockHttp = httpServiceMock.createStartContract({ basePath: '/test' });
+const mockNavigationToApp = jest.fn();
+const mockAssistantAvailability: AssistantAvailability = {
+  hasAssistantPrivilege: false,
+  hasConnectorsAllPrivilege: true,
+  hasConnectorsReadPrivilege: true,
+  hasUpdateAIAssistantAnonymization: true,
+  hasManageGlobalKnowledgeBase: true,
+  isAssistantEnabled: true,
+};
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -41,7 +58,25 @@ const ContextWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   chrome.getChromeStyle$.mockReturnValue(of('classic'));
   return (
     <QueryClientProvider client={queryClient}>
-      <MockAssistantProviderComponent>{children}</MockAssistantProviderComponent>
+      <AssistantProvider
+        actionTypeRegistry={actionTypeRegistry}
+        assistantAvailability={mockAssistantAvailability}
+        augmentMessageCodeBlocks={jest.fn()}
+        basePath={'https://localhost:5601/kbn'}
+        docLinks={{
+          ELASTIC_WEBSITE_URL: 'https://www.elastic.co/',
+          DOC_LINK_VERSION: 'current',
+        }}
+        getComments={mockGetComments}
+        http={mockHttp}
+        navigateToApp={mockNavigationToApp}
+        baseConversations={BASE_SECURITY_CONVERSATIONS}
+        currentAppId={'security'}
+        userProfileService={jest.fn() as unknown as UserProfileService}
+        chrome={chrome}
+      >
+        {children}
+      </AssistantProvider>
     </QueryClientProvider>
   );
 };


### PR DESCRIPTION
## Summary

Enables new inference connector in the Automatic Import.

This PR also fixes the use of `inferenceEnabled` from `useAssistantContext` since it is not available in AutoImport.

## To test

1. Update the value for `inferenceConnectorOn` to `true` in `x-pack/platform/plugins/shared/stack_connectors/common/experimental_features.ts`
2. Create an inference connector using OpenAI creds Configure the inference endpoint for completion and name the endpoint `openai-completion-preconfig`
3. Now that the inference endpoint is created, add a preconfigured connector with the same credentials.
4. Select the preconfigured selector in Automatic Import.
5. Test the Auto Import flow works.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->