### PR TITLE
Remove wrong test

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/components/alerts_flyout/alerts_flyout.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alerts_flyout/alerts_flyout.test.tsx
@@ -52,17 +52,6 @@ describe('AlertsFlyout', () => {
 
     expect(flyout.getByText('Recovered')).toBeInTheDocument();
   });
-
-  it('should NOT show the Alert details button as the feature flag is disabled', async () => {
-    const flyout = render(
-      <AlertsFlyout
-        alert={recoveredAlert}
-        observabilityRuleTypeRegistry={observabilityRuleTypeRegistryMock}
-        onClose={jest.fn()}
-      />
-    );
-    expect(flyout.queryByTestId('alertsFlyoutAlertDetailsButton')).not.toBeInTheDocument();
-  });
 });
 
 const activeAlert: TopAlert = {


### PR DESCRIPTION
## Summary

This test is not useful and has a bug, so we decided to remove it.



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->