### PR TITLE
SKA: Relocate Script v7.1

### DIFF
--- a/packages/kbn-relocate/list.ts
+++ b/packages/kbn-relocate/list.ts
@@ -11,6 +11,7 @@ import { sortBy } from 'lodash';
 import type { ToolingLog } from '@kbn/tooling-log';
 import { getPackages } from '@kbn/repo-packages';
 import { REPO_ROOT } from '@kbn/repo-info';
+import { join } from 'path';
 import type { Package } from './types';
 import { BASE_FOLDER, EXCLUDED_MODULES, KIBANA_FOLDER } from './constants';
 import { calculateModuleTargetFolder, isInTargetFolder } from './utils/relocate';
@@ -31,42 +32,29 @@ export const listModules = async (listFlag: string, log: ToolingLog) => {
     // explicit exclusions
     .filter(({ id }) => !EXCLUDED_MODULES.includes(id))
     .forEach((module) => {
+      const directory = module.directory.startsWith(BASE_FOLDER)
+        ? module.directory
+        : join(BASE_FOLDER, module.directory);
+
       if (module.isDevOnly()) {
         devOnly.push(module);
-        return;
-      }
-
-      if (
-        module.directory.includes(`/${KIBANA_FOLDER}/test/`) ||
-        module.directory.includes(`/${KIBANA_FOLDER}/x-pack/test/`)
+      } else if (
+        directory.includes(`/${KIBANA_FOLDER}/test/`) ||
+        directory.includes(`/${KIBANA_FOLDER}/x-pack/test/`)
       ) {
         test.push(module);
-        return;
-      }
-
-      if (
-        module.directory.includes(`/${KIBANA_FOLDER}/examples/`) ||
-        module.directory.includes(`/${KIBANA_FOLDER}/x-pack/examples/`)
+      } else if (
+        directory.includes(`/${KIBANA_FOLDER}/examples/`) ||
+        directory.includes(`/${KIBANA_FOLDER}/x-pack/examples/`)
       ) {
         examples.push(module);
-        return;
-      }
-
-      if (!module.group || module.group === 'common' || !module.visibility) {
-        // log.warning(`The module ${module.id} does not specify 'group' or 'visibility'. Skipping`);
+      } else if (!module.group || module.group === 'common' || !module.visibility) {
         uncategorised.push(module);
-        return;
-      }
-
-      if (!isInTargetFolder(module)) {
+      } else if (!isInTargetFolder(module)) {
         incorrect.push(module);
-        // log.warning(dedent`The module ${module.id} is not in the correct folder:
-        //   - ${module.directory}
-        //   - ${calculateModuleTargetFolder(module)}`);
-
-        return;
+      } else {
+        correct.push(module);
       }
-      correct.push(module);
     });
 
   if (listFlag === 'all') {

--- a/packages/kbn-relocate/list.ts
+++ b/packages/kbn-relocate/list.ts
@@ -16,16 +16,19 @@ import type { Package } from './types';
 import { BASE_FOLDER, EXCLUDED_MODULES, KIBANA_FOLDER } from './constants';
 import { calculateModuleTargetFolder, isInTargetFolder } from './utils/relocate';
 import { createModuleTable } from './utils/logging';
+import { safeExec } from './utils/exec';
 
 export const listModules = async (listFlag: string, log: ToolingLog) => {
-  // get all modules
-  const modules = getPackages(REPO_ROOT);
   const devOnly: Package[] = [];
   const test: Package[] = [];
   const examples: Package[] = [];
   const uncategorised: Package[] = [];
   const incorrect: Package[] = [];
   const correct: Package[] = [];
+
+  // get all modules
+  await safeExec('yarn kbn bootstrap');
+  const modules = getPackages(REPO_ROOT);
 
   // find modules selected by user filters
   sortBy(modules, 'directory')

--- a/packages/kbn-relocate/relocate.ts
+++ b/packages/kbn-relocate/relocate.ts
@@ -102,6 +102,7 @@ export interface RelocateModulesParams {
 const findModules = ({ teams, paths, included, excluded }: FindModulesParams, log: ToolingLog) => {
   // get all modules
   const modules = getPackages(REPO_ROOT);
+  const moduleFilters = teams.length > 0 || paths.length > 0 || included.length > 0;
 
   // find modules selected by user filters
   return (
@@ -121,6 +122,7 @@ const findModules = ({ teams, paths, included, excluded }: FindModulesParams, lo
       // the module is under the umbrella specified by the user
       .filter(
         (module) =>
+          !moduleFilters ||
           included.includes(module.id) ||
           teams.some((team) => belongsTo(module, team)) ||
           paths.some((path) => module.directory.includes(path))


### PR DESCRIPTION
## Summary

* Fix an issue with the `--list` command failing the 1st run.
* Allow passing in no filters, and relocate "incorrect" modules (aka modules that are not in the correct folder) in that case.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->