### PR TITLE
[kbn-test] export fleet package registry image

### DIFF
--- a/packages/kbn-scout/src/config/serverless/serverless.base.config.ts
+++ b/packages/kbn-scout/src/config/serverless/serverless.base.config.ts
@@ -12,10 +12,12 @@ import { format as formatUrl } from 'url';
 import Fs from 'fs';
 
 import { CA_CERT_PATH, kibanaDevServiceAccount } from '@kbn/dev-utils';
-import { defineDockerServersConfig, getDockerFileMountPath } from '@kbn/test';
+import {
+  fleetPackageRegistryDockerImage,
+  defineDockerServersConfig,
+  getDockerFileMountPath,
+} from '@kbn/test';
 import { MOCK_IDP_REALM_NAME } from '@kbn/mock-idp-utils';
-
-import { dockerImage } from '@kbn/test-suites-xpack/fleet_api_integration/config.base';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { ScoutServerConfig } from '../../types';
 import { SAML_IDP_PLUGIN_PATH, SERVERLESS_IDP_METADATA_PATH, JWKS_PATH } from '../constants';
@@ -55,7 +57,7 @@ export const defaultConfig: ScoutServerConfig = {
   dockerServers: defineDockerServersConfig({
     registry: {
       enabled: !!dockerRegistryPort,
-      image: dockerImage,
+      image: fleetPackageRegistryDockerImage,
       portInContainer: 8080,
       port: dockerRegistryPort,
       args: dockerArgs,

--- a/packages/kbn-scout/src/config/stateful/base.config.ts
+++ b/packages/kbn-scout/src/config/stateful/base.config.ts
@@ -17,12 +17,9 @@ import {
   MOCK_IDP_ATTRIBUTE_EMAIL,
   MOCK_IDP_ATTRIBUTE_NAME,
 } from '@kbn/mock-idp-utils';
-import { defineDockerServersConfig } from '@kbn/test';
+import { fleetPackageRegistryDockerImage, defineDockerServersConfig } from '@kbn/test';
 import path from 'path';
-
 import { MOCK_IDP_REALM_NAME } from '@kbn/mock-idp-utils';
-
-import { dockerImage } from '@kbn/test-suites-xpack/fleet_api_integration/config.base';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { STATEFUL_ROLES_ROOT_PATH } from '@kbn/es';
 import type { ScoutServerConfig } from '../../types';
@@ -66,7 +63,7 @@ export const defaultConfig: ScoutServerConfig = {
   dockerServers: defineDockerServersConfig({
     registry: {
       enabled: !!dockerRegistryPort,
-      image: dockerImage,
+      image: fleetPackageRegistryDockerImage,
       portInContainer: 8080,
       port: dockerRegistryPort,
       args: dockerArgs,

--- a/packages/kbn-scout/tsconfig.json
+++ b/packages/kbn-scout/tsconfig.json
@@ -25,7 +25,6 @@
     "@kbn/es-archiver",
     "@kbn/dev-utils",
     "@kbn/mock-idp-utils",
-    "@kbn/test-suites-xpack",
     "@kbn/test-subj-selector",
     "@kbn/scout-info",
     "@kbn/scout-reporting"

--- a/packages/kbn-test/index.ts
+++ b/packages/kbn-test/index.ts
@@ -78,3 +78,10 @@ export * from './src/kbn_client';
 export * from './src/find_test_plugin_paths';
 
 export { getDockerFileMountPath } from '@kbn/es';
+
+// Docker image to use for Fleet API integration tests.
+// This image comes from the latest successful build of https://buildkite.com/elastic/kibana-package-registry-promote
+// which is promoted after acceptance tests succeed against docker.elastic.co/package-registry/distribution:lite
+export const fleetPackageRegistryDockerImage =
+  process.env.FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE ||
+  'docker.elastic.co/kibana-ci/package-registry-distribution:lite';

--- a/x-pack/test/api_integration/deployment_agnostic/default_configs/serverless.config.base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/default_configs/serverless.config.base.ts
@@ -4,11 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { FtrConfigProviderContext, Config, defineDockerServersConfig } from '@kbn/test';
+import {
+  fleetPackageRegistryDockerImage,
+  FtrConfigProviderContext,
+  Config,
+  defineDockerServersConfig,
+} from '@kbn/test';
 
 import { ServerlessProjectType } from '@kbn/es';
 import path from 'path';
-import { dockerImage } from '../../../fleet_api_integration/config.base';
 import { DeploymentAgnosticCommonServices, services } from '../services';
 
 interface CreateTestConfigOptions<T extends DeploymentAgnosticCommonServices> {
@@ -88,7 +92,7 @@ export function createServerlessTestConfig<T extends DeploymentAgnosticCommonSer
       dockerServers: defineDockerServersConfig({
         registry: {
           enabled: !!dockerRegistryPort,
-          image: dockerImage,
+          image: fleetPackageRegistryDockerImage,
           portInContainer: 8080,
           port: dockerRegistryPort,
           args: dockerArgs,

--- a/x-pack/test/api_integration/deployment_agnostic/default_configs/stateful.config.base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/default_configs/stateful.config.base.ts
@@ -13,6 +13,7 @@ import {
   MOCK_IDP_ATTRIBUTE_NAME,
 } from '@kbn/mock-idp-utils';
 import {
+  fleetPackageRegistryDockerImage,
   esTestConfig,
   kbnTestConfig,
   systemIndicesSuperuser,
@@ -22,7 +23,6 @@ import {
 import path from 'path';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { STATEFUL_ROLES_ROOT_PATH } from '@kbn/es';
-import { dockerImage } from '../../../fleet_api_integration/config.base';
 import { DeploymentAgnosticCommonServices, services } from '../services';
 
 interface CreateTestConfigOptions<T extends DeploymentAgnosticCommonServices> {
@@ -88,7 +88,7 @@ export function createStatefulTestConfig<T extends DeploymentAgnosticCommonServi
       dockerServers: defineDockerServersConfig({
         registry: {
           enabled: !!dockerRegistryPort,
-          image: dockerImage,
+          image: fleetPackageRegistryDockerImage,
           portInContainer: 8080,
           port: dockerRegistryPort,
           args: dockerArgs,

--- a/x-pack/test/common/services/security_solution/endpoint_registry_helpers.ts
+++ b/x-pack/test/common/services/security_solution/endpoint_registry_helpers.ts
@@ -7,8 +7,10 @@
 
 import path from 'path';
 
-import { defineDockerServersConfig } from '@kbn/test';
-import { dockerImage as ingestDockerImage } from '../../../fleet_api_integration/config.base';
+import {
+  fleetPackageRegistryDockerImage as ingestDockerImage,
+  defineDockerServersConfig,
+} from '@kbn/test';
 
 export function SecuritySolutionEndpointRegistryHelpers() {
   /**

--- a/x-pack/test/dataset_quality_api_integration/common/config.ts
+++ b/x-pack/test/dataset_quality_api_integration/common/config.ts
@@ -16,11 +16,14 @@ import {
   DATASET_QUALITY_TEST_PASSWORD,
   DatasetQualityUsername,
 } from '@kbn/dataset-quality-plugin/server/test_helpers/create_dataset_quality_users/authentication';
-import { FtrConfigProviderContext, defineDockerServersConfig } from '@kbn/test';
+import {
+  fleetPackageRegistryDockerImage,
+  FtrConfigProviderContext,
+  defineDockerServersConfig,
+} from '@kbn/test';
 import path from 'path';
 import supertest from 'supertest';
 import { UrlObject, format } from 'url';
-import { dockerImage } from '../../fleet_api_integration/config.base';
 import { DatasetQualityFtrConfigName } from '../configs';
 import { createDatasetQualityApiClient } from './dataset_quality_api_supertest';
 import {
@@ -119,7 +122,7 @@ export function createTestConfig(
       dockerServers: defineDockerServersConfig({
         registry: {
           enabled: !!dockerRegistryPort,
-          image: dockerImage,
+          image: fleetPackageRegistryDockerImage,
           portInContainer: 8080,
           port: dockerRegistryPort,
           args: dockerArgs,

--- a/x-pack/test/fleet_api_integration/config.base.ts
+++ b/x-pack/test/fleet_api_integration/config.base.ts
@@ -8,18 +8,13 @@
 import path from 'path';
 
 import {
+  fleetPackageRegistryDockerImage,
   FtrConfigProviderContext,
   defineDockerServersConfig,
   getKibanaCliLoggers,
 } from '@kbn/test';
 
 const getFullPath = (relativePath: string) => path.join(path.dirname(__filename), relativePath);
-// Docker image to use for Fleet API integration tests.
-// This image comes from the latest successful build of https://buildkite.com/elastic/kibana-package-registry-promote
-// which is promoted after acceptance tests succeed against docker.elastic.co/package-registry/distribution:lite
-export const dockerImage =
-  process.env.FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE ||
-  'docker.elastic.co/kibana-ci/package-registry-distribution:lite';
 
 export const BUNDLED_PACKAGE_DIR = '/tmp/fleet_bundled_packages';
 
@@ -47,7 +42,7 @@ export default async function ({ readConfigFile, log }: FtrConfigProviderContext
     ? defineDockerServersConfig({
         registry: {
           enabled: !!registryPort,
-          image: dockerImage,
+          image: fleetPackageRegistryDockerImage,
           portInContainer: 8080,
           port: registryPort,
           args: dockerArgs,
@@ -58,7 +53,9 @@ export default async function ({ readConfigFile, log }: FtrConfigProviderContext
     : undefined;
 
   if (skipRunningDockerRegistry) {
-    const cmd = `docker run ${dockerArgs.join(' ')} -p ${registryPort}:8080 ${dockerImage}`;
+    const cmd = `docker run ${dockerArgs.join(
+      ' '
+    )} -p ${registryPort}:8080 ${fleetPackageRegistryDockerImage}`;
     log.warning(`Not running docker registry, you can run it with the following command: ${cmd}`);
   }
 

--- a/x-pack/test/functional/config.base.js
+++ b/x-pack/test/functional/config.base.js
@@ -6,16 +6,8 @@
  */
 
 import { resolve } from 'path';
-
 import { services } from './services';
 import { pageObjects } from './page_objects';
-
-// Docker image to use for Fleet API integration tests.
-// This image comes from the latest successful build of https://buildkite.com/elastic/kibana-package-registry-promote
-// which is promoted after acceptance tests succeed against docker.elastic.co/package-registry/distribution:lite
-export const dockerImage =
-  process.env.FLEET_PACKAGE_REGISTRY_DOCKER_IMAGE ||
-  'docker.elastic.co/kibana-ci/package-registry-distribution:lite';
 
 // the default export of config files must be a config provider
 // that returns an object with the projects config values

--- a/x-pack/test_serverless/shared/config.base.ts
+++ b/x-pack/test_serverless/shared/config.base.ts
@@ -20,8 +20,7 @@ import { CA_CERT_PATH, kibanaDevServiceAccount } from '@kbn/dev-utils';
 import { commonFunctionalServices } from '@kbn/ftr-common-functional-services';
 import { MOCK_IDP_REALM_NAME } from '@kbn/mock-idp-utils';
 import path from 'path';
-import { defineDockerServersConfig } from '@kbn/test';
-import { dockerImage } from '@kbn/test-suites-xpack/fleet_api_integration/config.base';
+import { fleetPackageRegistryDockerImage, defineDockerServersConfig } from '@kbn/test';
 import { services } from './services';
 
 export default async () => {
@@ -66,7 +65,7 @@ export default async () => {
     dockerServers: defineDockerServersConfig({
       registry: {
         enabled: !!dockerRegistryPort,
-        image: dockerImage,
+        image: fleetPackageRegistryDockerImage,
         portInContainer: 8080,
         port: dockerRegistryPort,
         args: dockerArgs,


### PR DESCRIPTION
## Summary

Should fix TS check error `Project references may not form a circular graph` by removing `@kbn/test-suites-xpack` from `kbn-scout` dependency list.

Since dockerImage for Fleet package registry is just a constant, that is used across different FTR and Scout configurations, it makes sense to export it from `kbn-test`

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->