### PR TITLE
[EDR Workflows] Hardcode virtual box url

### DIFF
--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -4,7 +4,6 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 100
     depends_on:
       - build
       - quick_checks
@@ -25,7 +24,6 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
-      diskSizeGb: 100
     depends_on:
       - build
       - quick_checks

--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -4,6 +4,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
+      diskSizeGb: 100
     depends_on:
       - build
       - quick_checks
@@ -24,6 +25,7 @@ steps:
     agents:
       enableNestedVirtualization: true
       machineType: n2-standard-4
+      diskSizeGb: 100
     depends_on:
       - build
       - quick_checks

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vagrant/Vagrantfile
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vagrant/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :vmware_desktop do |v, override|
     config.vm.box = "ubuntu/jammy64"
-    config.vm.box_version = "20241002.0.0"
+    config.vm.box_version = "20221104.0.0"
     config.vm.provider "virtualbox"
     override.vm.box_download_insecure = true
     override.vm.network "private_network", type: "dhcp"

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vagrant/Vagrantfile
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vagrant/Vagrantfile
@@ -19,8 +19,9 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provider :vmware_desktop do |v, override|
-    override.vm.box = "starboard/ubuntu-arm64-20.04.5"
-    override.vm.box_version = "20221120.20.40.0"
+    config.vm.box = "ubuntu/jammy64"
+    config.vm.box_version = "20241002.0.0"
+    config.vm.provider "virtualbox"
     override.vm.box_download_insecure = true
     override.vm.network "private_network", type: "dhcp"
 

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vagrant/Vagrantfile
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vagrant/Vagrantfile
@@ -19,9 +19,9 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provider :vmware_desktop do |v, override|
-    config.vm.box = "ubuntu/jammy64"
-    config.vm.box_version = "20221104.0.0"
-    config.vm.provider "virtualbox"
+    override.vm.box = "starboard/ubuntu-arm64-20.04.5"
+    override.vm.box_version = "20221120.20.40.0"
+    config.vm.box_url = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64-vagrant.box"
     override.vm.box_download_insecure = true
     override.vm.network "private_network", type: "dhcp"
 

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vm_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vm_services.ts
@@ -273,7 +273,7 @@ const createVagrantVm = async ({
 
   try {
     const vagrantUpResponse = (
-      await execa.command(`vagrant up`, {
+      await execa.command(`sudo vagrant up`, {
         env: {
           VAGRANT_DISABLE_VBOXSYMLINKCREATE: '1',
           VAGRANT_CWD,
@@ -359,7 +359,7 @@ export const createVagrantHostVmClient = (
   };
 
   const start = async () => {
-    const response = await execa.command(`vagrant up`, execaOptions);
+    const response = await execa.command(`sudo vagrant up`, execaOptions);
     log.verbose('vagrant up response:\n', response);
   };
 

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vm_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vm_services.ts
@@ -273,7 +273,7 @@ const createVagrantVm = async ({
 
   try {
     const vagrantUpResponse = (
-      await execa.command(`vagrant init hashicorp/precise32 && vagrant up`, {
+      await execa.command(`vagrant up`, {
         env: {
           VAGRANT_DISABLE_VBOXSYMLINKCREATE: '1',
           VAGRANT_CWD,
@@ -359,10 +359,7 @@ export const createVagrantHostVmClient = (
   };
 
   const start = async () => {
-    const response = await execa.command(
-      `vagrant init hashicorp/precise32 && vagrant up`,
-      execaOptions
-    );
+    const response = await execa.command(`vagrant up`, execaOptions);
     log.verbose('vagrant up response:\n', response);
   };
 

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vm_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vm_services.ts
@@ -273,7 +273,7 @@ const createVagrantVm = async ({
 
   try {
     const vagrantUpResponse = (
-      await execa.command(`sudo vagrant up`, {
+      await execa.command(`vagrant init hashicorp/precise32 && vagrant up`, {
         env: {
           VAGRANT_DISABLE_VBOXSYMLINKCREATE: '1',
           VAGRANT_CWD,
@@ -359,7 +359,10 @@ export const createVagrantHostVmClient = (
   };
 
   const start = async () => {
-    const response = await execa.command(`sudo vagrant up`, execaOptions);
+    const response = await execa.command(
+      `vagrant init hashicorp/precise32 && vagrant up`,
+      execaOptions
+    );
     log.verbose('vagrant up response:\n', response);
   };
 


### PR DESCRIPTION
10th January we started seeing DW workflows e2e tests failing on CI - the environment that uses Vagrant to setup VMs.
```
https://vagrantcloud.com/api/v2/vagrant/almalinux/9", "==> box: Loading metadata for box 'ubuntu/jammy64'", "    box: URL: https://vagrantcloud.com/api/v2/vagrant/ubuntu/jammy64", "==> box: Adding box 'ubuntu/jammy64' (v20241002.0.0) for provider: virtualbox", "    box: Downloading: https://vagrantcloud.com/ubuntu/boxes/jammy64/versions/20241002.0.0/providers/virtualbox/unknown/vagrant.box"]}
```

Apparently there is some issue with the vagrant.box image url, so we temporarily hardcode the external link to unblock other PRs, while we investigate further where the issue lies.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->