### PR TITLE
Logsdb snapshot functional tests

### DIFF
--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_indices_list.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/collapsible_lists/collapsible_indices_list.tsx
@@ -56,7 +56,10 @@ export const CollapsibleIndicesList: React.FunctionComponent<Props> = ({ indices
                 values={{ count: hiddenItemsCount }}
               />
             )}{' '}
-            <EuiIcon type={isShowingFullList ? 'arrowUp' : 'arrowDown'} />
+            <EuiIcon
+              type={isShowingFullList ? 'arrowUp' : 'arrowDown'}
+              data-test-subj="collapsibleIndicesArrow"
+            />
           </EuiLink>
         </>
       ) : null}

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/policy_form/steps/step_settings/fields/indices_and_data_streams_field/indices_and_data_streams_field.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/policy_form/steps/step_settings/fields/indices_and_data_streams_field/indices_and_data_streams_field.tsx
@@ -211,6 +211,7 @@ export const IndicesAndDataStreamsField: FunctionComponent<Props> = ({
                             setSelectIndicesMode('custom');
                             onUpdate({ indices: indexPatterns.join(',') });
                           }}
+                          data-test-subj="useIndexPatternsButton"
                         >
                           <FormattedMessage
                             id="xpack.snapshotRestore.policyForm.stepSettings.indicesToggleCustomLink"

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/restore_snapshot_form/steps/step_logistics/step_logistics.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/restore_snapshot_form/steps/step_logistics/step_logistics.tsx
@@ -260,6 +260,7 @@ export const RestoreSnapshotStepLogistics: React.FunctionComponent<StepProps> = 
                   });
                 }
               }}
+              data-test-subj="allDsAndIndicesToggle"
             />
             {isAllIndicesAndDataStreams ? null : (
               <Fragment>
@@ -281,6 +282,7 @@ export const RestoreSnapshotStepLogistics: React.FunctionComponent<StepProps> = 
                               setSelectIndicesMode('custom');
                               updateRestoreSettings({ indices: restoreIndexPatterns.join(',') });
                             }}
+                            data-test-subj="restoreIndexPatternsButton"
                           >
                             <FormattedMessage
                               id="xpack.snapshotRestore.restoreForm.stepLogistics.indicesToggleCustomLink"
@@ -476,6 +478,7 @@ export const RestoreSnapshotStepLogistics: React.FunctionComponent<StepProps> = 
                   });
                 }
               }}
+              data-test-subj="restoreRenameToggle"
             />
             {!isRenamingIndices ? null : (
               <Fragment>
@@ -510,6 +513,7 @@ export const RestoreSnapshotStepLogistics: React.FunctionComponent<StepProps> = 
                             renamePattern: e.target.value,
                           });
                         }}
+                        data-test-subj="capturePattern"
                       />
                     </EuiFormRow>
                   </EuiFlexItem>
@@ -536,6 +540,7 @@ export const RestoreSnapshotStepLogistics: React.FunctionComponent<StepProps> = 
                             renameReplacement: e.target.value,
                           });
                         }}
+                        data-test-subj="replacementPattern"
                       />
                     </EuiFormRow>
                   </EuiFlexItem>

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/restore_snapshot_form/steps/step_review.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/restore_snapshot_form/steps/step_review.tsx
@@ -301,7 +301,7 @@ export const RestoreSnapshotStepReview: React.FunctionComponent<StepProps> = ({
 
   return (
     <Fragment>
-      <EuiTitle>
+      <EuiTitle data-test-subj="reviewSnapshotTitle">
         <h2>
           <FormattedMessage
             id="xpack.snapshotRestore.restoreForm.stepReviewTitle"

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/components/restore_snapshot_form/steps/step_settings.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/components/restore_snapshot_form/steps/step_settings.tsx
@@ -76,7 +76,7 @@ export const RestoreSnapshotStepSettings: React.FunctionComponent<StepProps> = (
       {/* Step title and doc link */}
       <EuiFlexGroup justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>
-          <EuiTitle>
+          <EuiTitle data-test-subj="indexSettingsTitle">
             <h2>
               <FormattedMessage
                 id="xpack.snapshotRestore.restoreForm.stepSettingsTitle"

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/policy_list/policy_details/policy_details.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/policy_list/policy_details/policy_details.tsx
@@ -253,6 +253,7 @@ export const PolicyDetails: React.FunctionComponent<Props> = ({
                                       );
                                     },
                                     disabled: Boolean(policyDetails.policy.inProgress),
+                                    'data-test-subj': 'policyActionMenuRunPolicy',
                                   },
                                   {
                                     name: i18n.translate(

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/restore_list/restore_table/restore_table.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/restore_list/restore_table/restore_table.tsx
@@ -107,6 +107,7 @@ export const RestoreTable: React.FunctionComponent<Props> = React.memo(({ restor
       }),
       truncateText: true,
       sortable: true,
+      'data-test-subj': 'restoreTableIndex',
     },
     {
       field: 'isComplete',
@@ -115,6 +116,7 @@ export const RestoreTable: React.FunctionComponent<Props> = React.memo(({ restor
       }),
       truncateText: true,
       sortable: true,
+      'data-test-subj': 'restoreTableIsComplete',
       render: (isComplete: SnapshotRestore['isComplete']) =>
         isComplete ? (
           <EuiHealth color="success">

--- a/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/snapshot_list/snapshot_details/snapshot_details.tsx
+++ b/x-pack/platform/plugins/private/snapshot_restore/public/application/sections/home/snapshot_list/snapshot_details/snapshot_details.tsx
@@ -233,6 +233,7 @@ export const SnapshotDetails: React.FunctionComponent<Props> = ({
                     snapshotDetails.state !== SNAPSHOT_STATE.SUCCESS &&
                     snapshotDetails.state !== SNAPSHOT_STATE.PARTIAL
                   }
+                  data-test-subj="restoreSnapshotButton"
                 >
                   <FormattedMessage
                     id="xpack.snapshotRestore.snapshotDetails.restoreButtonLabel"

--- a/x-pack/test/functional/apps/snapshot_restore/snapshot_restore.ts
+++ b/x-pack/test/functional/apps/snapshot_restore/snapshot_restore.ts
@@ -16,13 +16,14 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const security = getService('security');
 
   describe('Snapshot restore', function () {
+    const REPOSITORY = 'my-repository';
     before(async () => {
       await security.testUser.setRoles(['snapshot_restore_user'], { skipBrowserRefresh: true });
       await pageObjects.common.navigateToApp('snapshotRestore');
 
       // Create a repository
       await es.snapshot.createRepository({
-        name: 'my-repository',
+        name: REPOSITORY,
         verify: true,
         repository: {
           type: 'fs',
@@ -32,50 +33,169 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           },
         },
       });
-
-      // Create a snapshot
-      await es.snapshot.create({
-        snapshot: 'my-snapshot',
-        repository: 'my-repository',
-      });
-
-      // Wait for snapshot to be ready
-      await pageObjects.common.sleep(2000);
-
-      // Refresh page so that the snapshot shows up in the snapshots table
-      await browser.refresh();
     });
 
-    it('Renders the Snapshot restore form', async () => {
-      const snapshots = await pageObjects.snapshotRestore.getSnapshotList();
-      const snapshotRestoreButton = await snapshots[0].snapshotRestore;
-      // Open the Snapshot restore form
-      await snapshotRestoreButton.click();
+    describe('Snapshot', () => {
+      before(async () => {
+        // Create a snapshot
+        await es.snapshot.create({
+          snapshot: 'my-snapshot',
+          repository: REPOSITORY,
+        });
 
-      // Go to second step (Index settings)
-      await testSubjects.click('nextButton');
+        // Wait for snapshot to be ready
+        await pageObjects.common.sleep(2000);
 
-      // Verify that the Index Settings editor is rendered (uses CodeEditor)
-      await testSubjects.click('modifyIndexSettingsSwitch');
-      expect(await testSubjects.exists('indexSettingsEditor')).to.be(true);
+        // Refresh page so that the snapshot shows up in the snapshots table
+        await browser.refresh();
+      });
 
-      // Close Index Settings editor
-      await testSubjects.click('modifyIndexSettingsSwitch');
+      after(async () => {
+        await es.snapshot.delete({
+          snapshot: 'my-snapshot',
+          repository: REPOSITORY,
+        });
+      });
 
-      // Go to final step (Review)
-      await testSubjects.click('nextButton');
+      it('Renders the Snapshot restore form', async () => {
+        const snapshots = await pageObjects.snapshotRestore.getSnapshotList();
+        const snapshotRestoreButton = await snapshots[0].snapshotRestore;
+        // Open the Snapshot restore form
+        await snapshotRestoreButton.click();
 
-      // Verify that Restore button exists
-      expect(await testSubjects.exists('restoreButton')).to.be(true);
+        // Go to second step (Index settings)
+        await testSubjects.click('nextButton');
+
+        // Verify that the Index Settings editor is rendered (uses CodeEditor)
+        await testSubjects.click('modifyIndexSettingsSwitch');
+        expect(await testSubjects.exists('indexSettingsEditor')).to.be(true);
+
+        // Close Index Settings editor
+        await testSubjects.click('modifyIndexSettingsSwitch');
+
+        // Go to final step (Review)
+        await testSubjects.click('nextButton');
+
+        // Verify that Restore button exists
+        expect(await testSubjects.exists('restoreButton')).to.be(true);
+      });
+    });
+
+    describe('Allows to create and restore a snapshot from a Logsdb index', () => {
+      const logsDbIndex = 'logsdb-index';
+      const policyId = 'testPolicy';
+      const snapshotPrefx = 'logsdb-snap';
+
+      before(async () => {
+        await es.indices.create({
+          index: logsDbIndex,
+          settings: {
+            mode: 'logsdb',
+          },
+        });
+        await pageObjects.common.navigateToApp('snapshotRestore');
+        // Create a policy
+        await pageObjects.snapshotRestore.navToPolicies();
+        await pageObjects.snapshotRestore.fillCreateNewPolicyPageOne(
+          policyId,
+          `<${snapshotPrefx}-{now/d}>`
+        );
+        await pageObjects.snapshotRestore.fillCreateNewPolicyPageTwo();
+        await pageObjects.snapshotRestore.fillCreateNewPolicyPageThree();
+        await pageObjects.snapshotRestore.submitNewPolicy();
+        await pageObjects.snapshotRestore.closeFlyout();
+      });
+
+      after(async () => {
+        // Delete the logdb index
+        await es.indices.delete({
+          index: logsDbIndex,
+        });
+        // Delete policy
+        await es.slm.deleteLifecycle({
+          policy_id: policyId,
+        });
+        await es.snapshot.delete({
+          snapshot: `${snapshotPrefx}-*`,
+          repository: REPOSITORY,
+        });
+        await es.indices.delete({
+          index: `restored_${logsDbIndex}`,
+        });
+      });
+
+      it('create snapshot', async () => {
+        // Verify there are no snapshots
+        await pageObjects.snapshotRestore.navToSnapshots();
+        expect(await testSubjects.exists('emptyPrompt')).to.be(true);
+
+        // Run policy snapshot
+        await pageObjects.snapshotRestore.navToPolicies();
+
+        await pageObjects.snapshotRestore.clickPolicyNameLink(policyId);
+        await pageObjects.snapshotRestore.clickPolicyActionButton();
+        await pageObjects.snapshotRestore.clickRunPolicy();
+        await pageObjects.snapshotRestore.clickConfirmationModal();
+        await pageObjects.snapshotRestore.closeFlyout();
+
+        // Wait for snapshot to be ready
+        await pageObjects.common.sleep(2000);
+
+        // Open snapshot info flyout
+        await pageObjects.snapshotRestore.navToSnapshots(false);
+        await pageObjects.header.waitUntilLoadingHasFinished();
+        expect(await testSubjects.exists('snapshotList')).to.be(true);
+
+        // Reload page to make sure snapshot is complete
+        await testSubjects.click('reloadButton');
+        await pageObjects.header.waitUntilLoadingHasFinished();
+
+        // Verify that one snapshot has been created
+        const snapshots = await pageObjects.snapshotRestore.getSnapshotList();
+        expect(snapshots.length).to.be(1);
+
+        // Verify that snaphot has been created
+        const snapshotLink = snapshots[0].snapshotLink;
+        await snapshotLink.click();
+
+        // Verify snapshot exists, is complete and contains the logsdb index
+        expect(await testSubjects.exists('detailTitle')).to.be(true);
+        expect(await testSubjects.getVisibleText('detailTitle')).to.contain(snapshotPrefx);
+        expect(await testSubjects.exists('state')).to.be(true);
+        expect(await testSubjects.getVisibleText('state')).to.contain('Complete');
+        await pageObjects.snapshotRestore.clickShowCollapsedIndicesIfPresent();
+        expect(await testSubjects.getVisibleText('indices')).to.contain(logsDbIndex);
+        await pageObjects.snapshotRestore.closeSnaphsotFlyout();
+      });
+
+      it('restore snapshot', async () => {
+        // Verify there are not restore snapshots
+        await pageObjects.snapshotRestore.navToRestoreStatus();
+        await pageObjects.header.waitUntilLoadingHasFinished();
+        expect(await testSubjects.exists('noRestoredSnapshotsHeader')).to.be(true);
+
+        // restore snapshot
+        await pageObjects.snapshotRestore.navToSnapshots(false);
+        await pageObjects.header.waitUntilLoadingHasFinished();
+
+        const snapshots = await pageObjects.snapshotRestore.getSnapshotList();
+        const snapshotLink = snapshots[0].snapshotLink;
+        await snapshotLink.click();
+        await pageObjects.snapshotRestore.restoreSnapshot(logsDbIndex, true);
+
+        // Verify snapshot has been restored and is complete
+        await pageObjects.snapshotRestore.navToRestoreStatus(false);
+        const status = await pageObjects.snapshotRestore.getRestoreStatusList();
+        const statusIndex = status[0].index;
+        const statusIsComplete = status[0].isComplete;
+        expect(await statusIndex.getVisibleText()).to.be(`restored_${logsDbIndex}`);
+        expect(await statusIsComplete.getVisibleText()).to.contain('Complete');
+      });
     });
 
     after(async () => {
-      await es.snapshot.delete({
-        snapshot: 'my-snapshot',
-        repository: 'my-repository',
-      });
       await es.snapshot.deleteRepository({
-        name: 'my-repository',
+        name: REPOSITORY,
       });
       await security.testUser.restoreDefaults();
     });

--- a/x-pack/test/functional/config.base.js
+++ b/x-pack/test/functional/config.base.js
@@ -625,6 +625,13 @@ export default async function ({ readConfigFile }) {
               'manage_slm',
               'cluster:admin/snapshot',
               'cluster:admin/repository',
+              'manage_index_templates',
+            ],
+            indices: [
+              {
+                names: ['*'],
+                privileges: ['all'],
+              },
             ],
           },
           kibana: [

--- a/x-pack/test/functional/page_objects/snapshot_restore_page.ts
+++ b/x-pack/test/functional/page_objects/snapshot_restore_page.ts
@@ -10,6 +10,7 @@ import { FtrProviderContext } from '../ftr_provider_context';
 export function SnapshotRestorePageProvider({ getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
+  const find = getService('find');
 
   return {
     async appTitleText() {
@@ -44,28 +45,43 @@ export function SnapshotRestorePageProvider({ getService }: FtrProviderContext) 
         'Wait for register repository button to be on page',
         10000,
         async () => {
-          return await testSubjects.isDisplayed('noRestoredSnapshotsHeader');
+          return await testSubjects.isDisplayed(
+            emptyList ? 'noRestoredSnapshotsHeader' : 'restoreList'
+          );
         }
       );
     },
     async navToSnapshots(emptyList: boolean = true) {
       await testSubjects.click('snapshots_tab');
       await retry.waitForWithTimeout('Wait for snapshot list to be on page', 10000, async () => {
-        return await testSubjects.isDisplayed(emptyList ? 'snapshotListEmpty' : 'snapshotList');
+        return await testSubjects.isDisplayed(emptyList ? 'emptyPrompt' : 'snapshotList');
       });
     },
 
-    async fillCreateNewPolicyPageOne(policyName: string, snapshotName: string) {
+    async fillCreateNewPolicyPageOne(
+      policyName: string,
+      snapshotName: string,
+      repositoryName?: string
+    ) {
       await testSubjects.click('createPolicyButton');
       await testSubjects.setValue('nameInput', policyName);
       await testSubjects.setValue('snapshotNameInput', snapshotName);
+      if (repositoryName) {
+        await testSubjects.selectValue('repositorySelect', repositoryName);
+      }
       await testSubjects.click('nextButton');
       await retry.waitFor('all indices to be visible', async () => {
         return await testSubjects.isDisplayed('allIndicesToggle');
       });
     },
 
-    async fillCreateNewPolicyPageTwo() {
+    async fillCreateNewPolicyPageTwo(singleIndexToSelect?: string) {
+      if (singleIndexToSelect) {
+        await testSubjects.click('allIndicesToggle');
+        await testSubjects.click('useIndexPatternsButton');
+        await testSubjects.setValue('comboBoxSearchInput', singleIndexToSelect);
+        await testSubjects.pressEnter('comboBoxSearchInput');
+      }
       await testSubjects.click('nextButton');
       await retry.waitFor('expire after value input to be visible', async () => {
         return await testSubjects.isDisplayed('expireAfterValueInput');
@@ -90,6 +106,18 @@ export function SnapshotRestorePageProvider({ getService }: FtrProviderContext) 
       await testSubjects.click('srPolicyDetailsFlyoutCloseButton');
       await retry.waitFor('policy table to be visible', async () => {
         return await testSubjects.isDisplayed('policyLink');
+      });
+    },
+    async closeSnaphsotFlyout() {
+      await testSubjects.click('euiFlyoutCloseButton');
+      await retry.waitFor('snapshot table to be visible', async () => {
+        return await testSubjects.isDisplayed('snapshotLink');
+      });
+    },
+    async closeRepositoriesFlyout() {
+      await testSubjects.click('srRepositoryDetailsFlyoutCloseButton');
+      await retry.waitFor('repositories table to be visible', async () => {
+        return await testSubjects.isDisplayed('repositoryLink');
       });
     },
     async getSnapshotList() {
@@ -120,6 +148,18 @@ export function SnapshotRestorePageProvider({ getService }: FtrProviderContext) 
         })
       );
     },
+    async getRestoreStatusList() {
+      const table = await testSubjects.find('restoreList');
+      const rows = await table.findAllByTestSubject('row');
+      return await Promise.all(
+        rows.map(async (row) => {
+          return {
+            index: await row.findByTestSubject('restoreTableIndex'),
+            isComplete: await row.findByTestSubject('restoreTableIsComplete'),
+          };
+        })
+      );
+    },
     async viewRepositoryDetails(name: string) {
       const repos = await this.getRepoList();
       if (repos.length === 1) {
@@ -136,6 +176,65 @@ export function SnapshotRestorePageProvider({ getService }: FtrProviderContext) 
         return await testSubjects.isDisplayed('cleanupCodeBlock');
       });
       return await testSubjects.getVisibleText('cleanupCodeBlock');
+    },
+
+    async clickPolicyNameLink(name: string): Promise<void> {
+      await find.clickByLinkText(name);
+    },
+
+    async clickRestoredStatusNameLink(name: string): Promise<void> {
+      await find.clickByLinkText(name);
+    },
+
+    async clickPolicyActionButton() {
+      await testSubjects.click('policyActionMenuButton');
+      await retry.waitFor('run button to be visible', async () => {
+        return await testSubjects.isDisplayed('policyActionMenuRunPolicy');
+      });
+    },
+
+    async clickRunPolicy() {
+      await testSubjects.click('policyActionMenuRunPolicy');
+      await retry.waitFor('confirm modal to be visible', async () => {
+        return await testSubjects.isDisplayed('confirmModalConfirmButton');
+      });
+    },
+
+    async clickConfirmationModal() {
+      await testSubjects.click('confirmModalConfirmButton');
+    },
+
+    async clickShowCollapsedIndicesIfPresent() {
+      if (await testSubjects.exists('collapsibleIndicesArrow')) {
+        await testSubjects.click('collapsibleIndicesArrow');
+      }
+    },
+
+    async restoreSnapshot(indexName: string, rename: boolean = false) {
+      await testSubjects.click('restoreSnapshotButton');
+      await retry.waitFor('restore form to be visible', async () => {
+        return await testSubjects.isDisplayed('snapshotRestoreApp');
+      });
+
+      await testSubjects.click('allDsAndIndicesToggle');
+      await testSubjects.click('restoreIndexPatternsButton');
+      await testSubjects.setValue('comboBoxSearchInput', indexName);
+      await testSubjects.pressEnter('comboBoxSearchInput');
+
+      if (rename) {
+        await testSubjects.click('restoreRenameToggle');
+        await testSubjects.setValue('capturePattern', `${indexName}(.*)`);
+        await testSubjects.setValue('replacementPattern', `restored_${indexName}$1`);
+      }
+      await testSubjects.click('nextButton');
+      await retry.waitFor('index settings to be visible', async () => {
+        return await testSubjects.isDisplayed('indexSettingsTitle');
+      });
+      await testSubjects.click('nextButton');
+      await retry.waitFor('review step to be visible', async () => {
+        return await testSubjects.isDisplayed('reviewSnapshotTitle');
+      });
+      await testSubjects.click('restoreButton');
     },
   };
 }


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



