### PR TITLE
[8.17] [Fleet] Use index.mapping.source.mode instead of _source.mode (#202729)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.test.ts
@@ -124,12 +124,13 @@ describe('EPM index template install', () => {
 
     const packageTemplate = componentTemplates['metrics-package.dataset@package'].template;
 
-    if (!('mappings' in packageTemplate)) {
+    if (!('settings' in packageTemplate)) {
       throw new Error('no mappings on package template');
     }
 
-    expect(packageTemplate.mappings).toHaveProperty('_source');
-    expect(packageTemplate.mappings._source).toEqual({ mode: 'synthetic' });
+    expect(packageTemplate.settings?.index?.mapping).toHaveProperty('source');
+    // @ts-expect-error esclient mapping out-of-date
+    expect(packageTemplate.settings?.index?.mapping?.source).toEqual({ mode: 'synthetic' });
   });
 
   it('tests prepareTemplate to set source mode to synthetics if index_mode:time_series', async () => {
@@ -154,12 +155,13 @@ describe('EPM index template install', () => {
 
     const packageTemplate = componentTemplates['metrics-package.dataset@package'].template;
 
-    if (!('mappings' in packageTemplate)) {
-      throw new Error('no mappings on package template');
+    if (!('settings' in packageTemplate)) {
+      throw new Error('no settings on package template');
     }
 
-    expect(packageTemplate.mappings).toHaveProperty('_source');
-    expect(packageTemplate.mappings._source).toEqual({ mode: 'synthetic' });
+    expect(packageTemplate.settings?.index?.mapping).toHaveProperty('source');
+    // @ts-expect-error esclient mapping out-of-date
+    expect(packageTemplate.settings?.index?.mapping?.source).toEqual({ mode: 'synthetic' });
   });
 
   it('tests prepareTemplate to not set source mode to synthetics if index_mode:time_series and user disabled synthetic', async () => {
@@ -193,11 +195,11 @@ describe('EPM index template install', () => {
 
     const packageTemplate = componentTemplates['metrics-package.dataset@package'].template;
 
-    if (!('mappings' in packageTemplate)) {
-      throw new Error('no mappings on package template');
+    if (!('settings' in packageTemplate)) {
+      throw new Error('no settings on package template');
     }
 
-    expect(packageTemplate.mappings).not.toHaveProperty('_source');
+    expect(packageTemplate.settings?.index?.mapping).not.toHaveProperty('source');
   });
 
   it('tests prepareTemplate to not set source mode to synthetics if specified but user disabled it', async () => {
@@ -231,11 +233,11 @@ describe('EPM index template install', () => {
 
     const packageTemplate = componentTemplates['metrics-package.dataset@package'].template;
 
-    if (!('mappings' in packageTemplate)) {
-      throw new Error('no mappings on package template');
+    if (!('settings' in packageTemplate)) {
+      throw new Error('no settings on package template');
     }
 
-    expect(packageTemplate.mappings).not.toHaveProperty('_source');
+    expect(packageTemplate.settings?.index?.mapping).not.toHaveProperty('source');
   });
 
   it('tests prepareTemplate to set index_mode time series if index_mode:time_series', async () => {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/install.ts
@@ -395,6 +395,14 @@ export function buildComponentTemplates(params: {
                 templateSettings.index?.mapping?.total_fields?.limit
               ),
             },
+            ...(templateSettings.index?.mapping?.source || sourceModeSynthetic
+              ? {
+                  source: {
+                    ...templateSettings.index?.mapping?.source,
+                    ...(sourceModeSynthetic ? { mode: 'synthetic' } : {}),
+                  },
+                }
+              : {}),
           },
         },
       },
@@ -404,15 +412,7 @@ export function buildComponentTemplates(params: {
           ? { runtime: mappingsRuntimeFields }
           : {}),
         dynamic_templates: mappingsDynamicTemplates.length ? mappingsDynamicTemplates : undefined,
-        ...omit(indexTemplateMappings, 'properties', 'dynamic_templates', '_source', 'runtime'),
-        ...(indexTemplateMappings?._source || sourceModeSynthetic
-          ? {
-              _source: {
-                ...indexTemplateMappings?._source,
-                ...(sourceModeSynthetic ? { mode: 'synthetic' } : {}),
-              },
-            }
-          : {}),
+        ...omit(indexTemplateMappings, 'properties', 'dynamic_templates', 'runtime'),
       },
       ...(lifecycle ? { lifecycle } : {}),
     },

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -1040,8 +1040,8 @@ const updateExistingDataStream = async ({
   const existingDsConfig = Object.values(existingDs);
   const currentBackingIndexConfig = existingDsConfig.at(-1);
   const currentIndexMode = currentBackingIndexConfig?.settings?.index?.mode;
-  // @ts-expect-error Property 'mode' does not exist on type 'MappingSourceField'
-  const currentSourceType = currentBackingIndexConfig.mappings?._source?.mode;
+  // @ts-expect-error Property 'source.mode' does not exist on type 'IndicesMappingLimitSettings'
+  const currentSourceType = currentBackingIndexConfig?.settings?.index?.mapping?.source?.mode;
 
   let settings: IndicesIndexSettings;
   let mappings: MappingTypeMapping = {};
@@ -1140,7 +1140,7 @@ const updateExistingDataStream = async ({
   // Trigger a rollover if the index mode or source type has changed
   if (
     currentIndexMode !== settings?.index?.mode ||
-    currentSourceType !== mappings?._source?.mode ||
+    currentSourceType !== settings?.index?.source?.mode ||
     dynamicDimensionMappingsChanged
   ) {
     if (options?.skipDataStreamRollover === true) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Fleet] Use index.mapping.source.mode instead of _source.mode (#202729)](https://github.com/elastic/kibana/pull/202729)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2024-12-03T17:49:49Z","message":"[Fleet] Use index.mapping.source.mode instead of _source.mode (#202729)","sha":"6e5fc696a6f940d21af4ec5e4fd46d73a1007b71","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","backport:prev-minor","v8.18.0","v8.17.1","backport:8.17"],"number":202729,"url":"https://github.com/elastic/kibana/pull/202729","mergeCommit":{"message":"[Fleet] Use index.mapping.source.mode instead of _source.mode (#202729)","sha":"6e5fc696a6f940d21af4ec5e4fd46d73a1007b71"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/202729","number":202729,"mergeCommit":{"message":"[Fleet] Use index.mapping.source.mode instead of _source.mode (#202729)","sha":"6e5fc696a6f940d21af4ec5e4fd46d73a1007b71"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/204406","number":204406,"state":"MERGED","mergeCommit":{"sha":"d3fcf47725332af0ec6a04465f495c5ef0a93b2e","message":"[8.x] [Fleet] Use index.mapping.source.mode instead of _source.mode (#202729) (#204406)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Fleet] Use index.mapping.source.mode instead of _source.mode\n(#202729)](https://github.com/elastic/kibana/pull/202729)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Nicolas\nChaulet\",\"email\":\"nicolas.chaulet@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2024-12-03T17:49:49Z\",\"message\":\"[Fleet]\nUse index.mapping.source.mode instead of _source.mode\n(#202729)\",\"sha\":\"6e5fc696a6f940d21af4ec5e4fd46d73a1007b71\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"Team:Fleet\",\"v9.0.0\",\"backport:prev-minor\",\"v8.18.0\"],\"title\":\"[Fleet]\nUse index.mapping.source.mode instead of\n_source.mode\",\"number\":202729,\"url\":\"https://github.com/elastic/kibana/pull/202729\",\"mergeCommit\":{\"message\":\"[Fleet]\nUse index.mapping.source.mode instead of _source.mode\n(#202729)\",\"sha\":\"6e5fc696a6f940d21af4ec5e4fd46d73a1007b71\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.x\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/202729\",\"number\":202729,\"mergeCommit\":{\"message\":\"[Fleet]\nUse index.mapping.source.mode instead of _source.mode\n(#202729)\",\"sha\":\"6e5fc696a6f940d21af4ec5e4fd46d73a1007b71\"}},{\"branch\":\"8.x\",\"label\":\"v8.18.0\",\"branchLabelMappingKey\":\"^v8.18.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>"}},{"branch":"8.17","label":"v8.17.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->