### PR TITLE
[kbn-test] Jest run script should use `testPathPattern` to lookup config

### DIFF
--- a/packages/kbn-test/src/jest/run.ts
+++ b/packages/kbn-test/src/jest/run.ts
@@ -79,6 +79,11 @@ export function runJest(configName = 'jest.config.js') {
 
   if (!argv.config) {
     testFiles = argv._.map((p) => resolve(cwd, p.toString()));
+
+    if (argv.testPathPattern) {
+      testFiles.push(argv.testPathPattern);
+    }
+
     const commonTestFiles = commonBasePath(testFiles);
     const testFilesProvided = testFiles.length > 0;
 

--- a/packages/kbn-test/src/jest/run.ts
+++ b/packages/kbn-test/src/jest/run.ts
@@ -128,7 +128,7 @@ export function runJest(configName = 'jest.config.js') {
         );
       } else {
         log.error(
-          `we no longer ship a root config file so you either need to pass a path to a test file, a folder where tests can be found, or a --config argument pointing to one of the many ${configName} files in the repository`
+          `we no longer ship a root config file so you either need to pass a path to a test file, a folder where tests can be found, a --testPathPattern argument pointing to a file/directory or a --config argument pointing to one of the many ${configName} files in the repository`
         );
       }
 


### PR DESCRIPTION
## Summary

TLDR; Adds logic to support the jest vscode extension by reading the `--testPathPattern` arg for the purpose of config lookup. This enables running tests easily in the vscode jest extension.

Currently the `yarn test:jest` command, requires one of the following:

- A path to a test file
- A folder where tests can be found
- A `--config` argument pointing to one of the many `jest.config.js` files

The [jest vscode extension ](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest) does not easily support this behavior as it expects a static command to run all tests.

One option people have used is [`virtualfolders`](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest#virtualfolders) but this requires enumerating all possible configs. See [doc](https://docs.google.com/document/d/1s8eju9p_Aj75LmFnF2PB7UeEEvJfl-M_VEHh-MZ16do/edit?tab=t.0).

```json
{
  "jest.virtualFolders": [
    {
      "name": "@kbn/maps-plugin",
      "jestCommandLine": "yarn test:jest --config x-pack/platform/plugins/shared/maps/jest.config.js"
    },
    {
      "name": "@kbn/embeddable-enhanced-plugin",
      "jestCommandLine": "yarn test:jest --config x-pack/platform/plugins/shared/embeddable_enhanced/jest.config.js"
    }
  ]
}
```

This could be autogenerate and `@managed` options in `.vscode/setting` but this is more complicated to achieve at the moment.

Without using `virtualFolders` the best option is to use the `jestcommandline`. But this option does not allow parameterizing the command like we can with the debug `launch.json` config (e.g. `"${jest.testNamePattern}"`). 

The `jestcommandline` does however pass a few additional argument as shown below...

```
node scripts/jest --testLocationInResults --json --useStderr --outputFile '/var/folders/yx/ykmyj9616fn746d191gqc50m0000gn/T/jest_runner_kibana_501_2.json' --testNamePattern 'IndexPattern Data Source #getUserMessages warning messages should show different types of warning messages$' --no-coverage --reporters 'default' --reporters '/Users/nickpartridge/.vscode/extensions/orta.vscode-jest-6.4.0/out/reporter.js' --colors --watchAll=false --testPathPattern '/Users/nickpartridge/Documents/repos/kibana/x-pack/platform/plugins/shared/lens/public/datasources/form_based/form_based.test.ts
```

Most importantly the [`--testPathPattern`](https://jestjs.io/docs/cli#--testpathpatternregex) argument. This is passed whenever the extension is ran against a directory, file or specific test. The file name is passed as unnamed argument when run on save of a file. But the current `yarn test:jest` command expects this as an additional unnamed argument. This PR now treats the `testPathPattern` as a file or directory to find the config.

> [!WARNING]  
> This works for most cases with the most notable exception being if you were to run a directory that contained multiple `jest.config.ts` files. This would error just the same as calling something like...
> ```
> yarn test:jest x-pack/platform/plugins/shared
> ```
>  
> Or running this from the vscode jest extension like this...
> ![node scriptsjest --testLocationInResult • Untitled-1 — kibana 2025-01-10 at 1 36 46 PM](https://github.com/user-attachments/assets/4ec968a1-a726-48b7-83c0-6a0b515b36b4)
> This would result in multiple configs which will not work. I think this is not a very common use case.
> 
> If we did want to address this case I think it could be solved with `virtualFolders` to run files grouped by their respective configs.


<!--ONMERGE {"backportTargets":["7.17","8.16","8.17","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->