### PR TITLE
[Docs] 7.17.27 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -13,6 +13,7 @@ Review important information about the {kib} 7.17.x releases.
 // Best practices:
 // * When there are changes to kibana.yml settings, include the links to the new settings.
 
+* <<release-notes-7.17.27>>
 * <<release-notes-7.17.26>>
 * <<release-notes-7.17.25>>
 * <<release-notes-7.17.24>>
@@ -96,6 +97,11 @@ Review important information about the {kib} 7.17.x releases.
 //* <<release-notes-7.0.0-alpha1>>
 
 --
+
+[[release-notes-7.17.27]]
+== {kib} 7.17.27
+
+There are no user-facing changes in the 7.17.27 release.
 
 [[release-notes-7.17.26]]
 == {kib} 7.17.26


### PR DESCRIPTION
## Summary

Adding 7.17.27 release notes. There were no user-facing changes.

Rel: [2955](https://github.com/elastic/dev/issues/2955)
Closes: [605](https://github.com/elastic/platform-docs-team/issues/605)

[Preview here](https://kibana_bk_206347.docs-preview.app.elstc.co/guide/en/kibana/7.17/release-notes-7.17.27.html)

![Screenshot 2025-01-10 at 5 05 48 PM](https://github.com/user-attachments/assets/ec028ad3-372c-40be-955b-22f267b65405)
