### PR TITLE
[Fleet] limit concurrency in bumpRevision actions

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -102,7 +102,6 @@ import type { ExternalCallback } from '..';
 
 import {
   MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS,
-  MAX_CONCURRENT_EPM_PACKAGES_INSTALLATIONS,
   MAX_CONCURRENT_PACKAGE_ASSETS,
 } from '../constants';
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -102,6 +102,7 @@ import type { ExternalCallback } from '..';
 
 import {
   MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS,
+  MAX_CONCURRENT_EPM_PACKAGES_INSTALLATIONS,
   MAX_CONCURRENT_PACKAGE_ASSETS,
 } from '../constants';
 
@@ -1117,24 +1118,25 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     // Bump revision of all associated agent policies (old and new)
     const associatedPolicyIds = new Set([...oldPackagePolicy.policy_ids, ...newPolicy.policy_ids]);
     logger.debug(`Bumping revision of associated agent policies ${associatedPolicyIds}`);
-    const bumpPromises = [];
-    for (const policyId of associatedPolicyIds) {
-      // Check if the agent policy is in both old and updated package policies
-      const assignedInOldPolicy = oldPackagePolicy.policy_ids.includes(policyId);
-      const assignedInNewPolicy = newPolicy.policy_ids.includes(policyId);
+    const bumpPromise = pMap(
+      associatedPolicyIds,
+      (policyId) => {
+        // Check if the agent policy is in both old and updated package policies
+        const assignedInOldPolicy = oldPackagePolicy.policy_ids.includes(policyId);
+        const assignedInNewPolicy = newPolicy.policy_ids.includes(policyId);
 
-      // Remove protection if policy is unassigned (in old but not in updated) or policy is assigned (in updated but not in old)
-      const removeProtection =
-        (assignedInOldPolicy && !assignedInNewPolicy) ||
-        (!assignedInOldPolicy && assignedInNewPolicy);
+        // Remove protection if policy is unassigned (in old but not in updated) or policy is assigned (in updated but not in old)
+        const removeProtection =
+          (assignedInOldPolicy && !assignedInNewPolicy) ||
+          (!assignedInOldPolicy && assignedInNewPolicy);
 
-      bumpPromises.push(
-        agentPolicyService.bumpRevision(soClient, esClient, policyId, {
+        return agentPolicyService.bumpRevision(soClient, esClient, policyId, {
           user: options?.user,
           removeProtection,
-        })
-      );
-    }
+        });
+      },
+      { concurrency: MAX_CONCURRENT_EPM_PACKAGES_INSTALLATIONS }
+    );
 
     const assetRemovePromise = removeOldAssets({
       soClient,
@@ -1145,7 +1147,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       ? deleteSecrets({ esClient, soClient, ids: secretsToDelete.map((s) => s.id) })
       : Promise.resolve();
 
-    await Promise.all([...bumpPromises, assetRemovePromise, deleteSecretsPromise]);
+    await Promise.all([bumpPromise, assetRemovePromise, deleteSecretsPromise]);
 
     sendUpdatePackagePolicyTelemetryEvent(soClient, [packagePolicyUpdate], [oldPackagePolicy]);
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -1135,7 +1135,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
           removeProtection,
         });
       },
-      { concurrency: MAX_CONCURRENT_EPM_PACKAGES_INSTALLATIONS }
+      { concurrency: MAX_CONCURRENT_AGENT_POLICIES_OPERATIONS }
     );
 
     const assetRemovePromise = removeOldAssets({


### PR DESCRIPTION
## Summary

In Serverless, we've noticed some OOMKilled events caused by Fleet upgrading too many packages in one go.

This PR attempts to apply some concurrency to those actions to limit their impact on large projects.

### Identify risks

- [ ] The upgrade action might take longer now.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->