### PR TITLE
[Cloud Security] changed findings group by name to group by id

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
@@ -171,6 +171,7 @@ export const DEFAULT_GROUPING_TABLE_HEIGHT = 512;
 
 export const FINDINGS_GROUPING_OPTIONS = {
   NONE: 'none',
+  RESOURCE_ID: 'resource.id',
   RESOURCE_NAME: 'resource.name',
   RULE_NAME: 'rule.name',
   RULE_SECTION: 'rule.section',

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
@@ -131,7 +131,7 @@ export const SummarySection = ({
             data-test-subj="dashboard-view-all-resources"
             onClick={() => {
               navToFindings(getPolicyTemplateQuery(dashboardType), [
-                FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME,
+                FINDINGS_GROUPING_OPTIONS.RESOURCE_ID,
               ]);
             }}
           >

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
@@ -25,7 +25,7 @@ export const MISCONFIGURATIONS_GROUPS_UNIT = (
   const groupCount = hasNullGroup ? totalCount - 1 : totalCount;
 
   switch (selectedGroup) {
-    case FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME:
+    case FINDINGS_GROUPING_OPTIONS.RESOURCE_ID:
       return i18n.translate('xpack.csp.findings.groupUnit.resource', {
         values: { groupCount },
         defaultMessage: `{groupCount} {groupCount, plural, =1 {resource} other {resources}}`,
@@ -78,10 +78,10 @@ export const NULL_GROUPING_MESSAGES = {
 
 export const defaultGroupingOptions: GroupOption[] = [
   {
-    label: i18n.translate('xpack.csp.findings.latestFindings.groupByResource', {
-      defaultMessage: 'Resource',
+    label: i18n.translate('xpack.csp.findings.latestFindings.groupByResourceId', {
+      defaultMessage: 'Resource ID',
     }),
-    key: FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME,
+    key: FINDINGS_GROUPING_OPTIONS.RESOURCE_ID,
   },
   {
     label: i18n.translate('xpack.csp.findings.latestFindings.groupByRuleName', {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
@@ -78,7 +78,7 @@ export const NULL_GROUPING_MESSAGES = {
 
 export const defaultGroupingOptions: GroupOption[] = [
   {
-    label: i18n.translate('xpack.csp.findings.latestFindings.groupByResourceId', {
+    label: i18n.translate('xpack.csp.findings.latestFindings.groupByResource', {
       defaultMessage: 'Resource ID',
     }),
     key: FINDINGS_GROUPING_OPTIONS.RESOURCE_ID,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
@@ -46,10 +46,12 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
   );
 
   const getGroupPanelTitle = () => {
-    if (bucket.resourceName?.buckets) {
+    const resourceId = bucket.resourceName?.buckets?.[0]?.key;
+
+    if (resourceId) {
       return (
         <>
-          <strong>{bucket.resourceName.buckets[0]?.key}</strong> - {bucket.key_as_string}
+          <strong>{resourceId}</strong> - {bucket.key_as_string}
         </>
       );
     }

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
@@ -31,10 +31,10 @@ import { NULL_GROUPING_MESSAGES, NULL_GROUPING_UNIT } from './constants';
 import { FINDINGS_GROUPING_COUNTER } from '../test_subjects';
 
 export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation> = (
-  selectedGroup,
-  bucket,
-  nullGroupMessage,
-  isLoading
+  selectedGroup: string,
+  bucket: RawBucket<FindingsGroupingAggregation>,
+  nullGroupMessage: string | undefined,
+  isLoading: boolean | undefined
 ) => {
   if (isLoading) {
     return <LoadingGroup />;
@@ -45,8 +45,20 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
     <NullGroup title={title} field={selectedGroup} unit={NULL_GROUPING_UNIT} />
   );
 
+  const getGroupPanelTitle = () => {
+    if (bucket.resourceName?.buckets) {
+      return (
+        <>
+          <strong>{bucket.resourceName.buckets[0]?.key}</strong> - {bucket.key_as_string}
+        </>
+      );
+    }
+
+    return <strong>{bucket.key_as_string}</strong>;
+  };
+
   switch (selectedGroup) {
-    case FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME:
+    case FINDINGS_GROUPING_OPTIONS.RESOURCE_ID:
       return nullGroupMessage ? (
         renderNullGroup(NULL_GROUPING_MESSAGES.RESOURCE_NAME)
       ) : (
@@ -66,7 +78,7 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
                     `}
                     title={bucket.resourceName?.buckets?.[0]?.key as string}
                   >
-                    <strong>{bucket.key_as_string}</strong> {bucket.resourceName?.buckets?.[0]?.key}
+                    {getGroupPanelTitle()}
                   </EuiTextBlockTruncate>
                 </EuiText>
               </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
@@ -86,10 +86,10 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
   ];
 
   switch (field) {
-    case FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME:
+    case FINDINGS_GROUPING_OPTIONS.RESOURCE_ID:
       return [
         ...aggMetrics,
-        getTermAggregation('resourceName', 'resource.id'),
+        getTermAggregation('resourceName', 'resource.name'),
         getTermAggregation('resourceSubType', 'resource.sub_type'),
       ];
     case FINDINGS_GROUPING_OPTIONS.RULE_NAME:

--- a/x-pack/test/cloud_security_posture_functional/pages/findings_grouping.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings_grouping.ts
@@ -182,7 +182,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('groups findings by resource and sort by compliance score desc', async () => {
         const groupSelector = await findings.groupSelector();
         await groupSelector.openDropDown();
-        await groupSelector.setValue('Resource');
+        await groupSelector.setValue('Resource ID');
 
         const grouping = await findings.findingsGrouping();
 
@@ -414,7 +414,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await groupSelector.openDropDown();
         await groupSelector.setValue('None');
         await groupSelector.openDropDown();
-        await groupSelector.setValue('Resource');
+        await groupSelector.setValue('Resource ID');
 
         // Filter bar uses the field's customLabel in the DataView
         await filterBar.addFilter({ field: 'rule.name', operation: 'is', value: ruleName1 });
@@ -515,12 +515,12 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         const groupSelector = await findings.groupSelector();
         await groupSelector.openDropDown();
-        await groupSelector.setValue('Resource');
+        await groupSelector.setValue('Resource ID');
 
         const grouping = await findings.findingsGrouping();
 
         const groupCount = await grouping.getGroupCount();
-        expect(groupCount).to.be(`${resourceGroupCount + 1} resources`);
+        expect(groupCount).to.be(`${resourceGroupCount} resources`);
 
         const unitCount = await grouping.getUnitCount();
         expect(unitCount).to.be(`${findingsCount + 1} findings`);


### PR DESCRIPTION
## Summary
This PR fixes group by logic in the findings table to be based on resource.id instead of resource.name.

### Screenshots
![image](https://github.com/user-attachments/assets/5d480501-9f44-4395-82bd-e069b4a3c3f7)



### Closes
- https://github.com/elastic/security-team/issues/9782

### Definition of done
- [x] When grouping findings by Resource, the findings are grouped by resource.id
- [x] The group title should still contain resource.name for better UX in combination with the id
- [x] The label in the grouping properties should be Resource ID, not just Resource

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct release_note:* label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



