### PR TITLE
[EDR Workflows] Fix wrong paths for junit reported in Osquery

### DIFF
--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_multiple_agents.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_multiple_agents.cy.ts
@@ -42,7 +42,8 @@ describe(
 
     it('should substitute parameters in investigation guide', () => {
       cy.getBySel('expand-event').first().click();
-      cy.getBySel('securitySolutionFlyoutInvestigationGuideButton').click();
+      // TODO changed for testing purposes - to be reverted
+      cy.getBySel('securitySossssssslutionFlyoutInvestigationGuideButton').click();
       // Flakes at times if the button is only clicked once
       cy.contains('Get processes').should('be.visible').dblclick({ force: true });
       // Cypress can properly reads the fields when the codeEditor is interacted with first

--- a/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_multiple_agents.cy.ts
+++ b/x-pack/platform/plugins/shared/osquery/cypress/e2e/all/alerts_multiple_agents.cy.ts
@@ -42,8 +42,7 @@ describe(
 
     it('should substitute parameters in investigation guide', () => {
       cy.getBySel('expand-event').first().click();
-      // TODO changed for testing purposes - to be reverted
-      cy.getBySel('securitySossssssslutionFlyoutInvestigationGuideButton').click();
+      cy.getBySel('securitySolutionFlyoutInvestigationGuideButton').click();
       // Flakes at times if the button is only clicked once
       cy.contains('Get processes').should('be.visible').dblclick({ force: true });
       // Cypress can properly reads the fields when the codeEditor is interacted with first

--- a/x-pack/platform/plugins/shared/osquery/package.json
+++ b/x-pack/platform/plugins/shared/osquery/package.json
@@ -17,7 +17,7 @@
     "cypress:qa:serverless:run": "yarn cypress:qa:serverless run",
     "nyc": "../../../../../node_modules/.bin/nyc report --reporter=text-summary",
     "junit:merge": "../../../../../node_modules/.bin/mochawesome-merge ../../../../../target/kibana-osquery/cypress/results/mochawesome*.json > ../../../../../target/kibana-osquery/cypress/results/output.json && ../../../../../node_modules/.bin/marge ../../../../../target/kibana-osquery/cypress/results/output.json --reportDir ../../../../../target/kibana-osquery/cypress/results && yarn junit:transform && mkdir -p ../../../../../target/junit && cp ../../../../../target/kibana-osquery/cypress/results/*.xml ../../../../../target/junit/",
-    "junit:transform": "node ../../../../solutions/security/plugins/security_solution/scripts/junit_transformer --pathPattern '../../../../../target/cypress/results/*.xml' --rootDirectory ../../../../../ --reportName 'Osquery Cypress' --writeInPlace",
+    "junit:transform": "node ../../../../solutions/security/plugins/security_solution/scripts/junit_transformer --pathPattern '../../../../../target/kibana-osquery/results/*.xml' --rootDirectory ../../../../../ --reportName 'Osquery Cypress' --writeInPlace",
     "openapi:generate": "node scripts/openapi/generate",
     "openapi:bundle": "node scripts/openapi/bundle"
   }

--- a/x-pack/platform/plugins/shared/osquery/package.json
+++ b/x-pack/platform/plugins/shared/osquery/package.json
@@ -16,8 +16,8 @@
     "cypress:qa:serverless": "NODE_OPTIONS=--openssl-legacy-provider node ../../../../solutions/security/plugins/security_solution/scripts/start_cypress_parallel_serverless --config-file ../../platform/plugins/shared/osquery/cypress/serverless_cypress_qa.config.ts --onBeforeHook ../../../../test/osquery_cypress/runner_qa.ts",
     "cypress:qa:serverless:run": "yarn cypress:qa:serverless run",
     "nyc": "../../../../../node_modules/.bin/nyc report --reporter=text-summary",
-    "junit:merge": "../../../../../node_modules/.bin/mochawesome-merge ../../../target/kibana-osquery/cypress/results/mochawesome*.json > ../../../target/kibana-osquery/cypress/results/output.json && ../../../node_modules/.bin/marge ../../../target/kibana-osquery/cypress/results/output.json --reportDir ../../../target/kibana-osquery/cypress/results && yarn junit:transform && mkdir -p ../../../target/junit && cp ../../../target/kibana-osquery/cypress/results/*.xml ../../../target/junit/",
-    "junit:transform": "node ../security_solution/scripts/junit_transformer --pathPattern '../../../../../target/kibana-osquery/cypress/results/*.xml' --rootDirectory ../../../ --reportName 'Osquery Cypress' --writeInPlace",
+    "junit:merge": "../../../../../node_modules/.bin/mochawesome-merge ../../../../../target/kibana-osquery/cypress/results/mochawesome*.json > ../../../../../target/kibana-osquery/cypress/results/output.json && ../../../../../node_modules/.bin/marge ../../../../../target/kibana-osquery/cypress/results/output.json --reportDir ../../../../../target/kibana-osquery/cypress/results && yarn junit:transform && mkdir -p ../../../../../target/junit && cp ../../../../../target/kibana-osquery/cypress/results/*.xml ../../../../../target/junit/",
+    "junit:transform": "node ../../../../solutions/security/plugins/security_solution/scripts/junit_transformer --pathPattern '../../../../../target/cypress/results/*.xml' --rootDirectory ../../../../../ --reportName 'Osquery Cypress' --writeInPlace",
     "openapi:generate": "node scripts/openapi/generate",
     "openapi:bundle": "node scripts/openapi/bundle"
   }


### PR DESCRIPTION
It was brought to our attention that the junit reporter doesn't work for Osquery. This Pr fixes this 👍 

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->