### PR TITLE
[docs] Update `kibana.yml` defaults

### DIFF
--- a/config/kibana.yml
+++ b/config/kibana.yml
@@ -63,7 +63,7 @@
 #elasticsearch.requestTimeout: 30000
 
 # The maximum number of sockets that can be used for communications with elasticsearch.
-# Defaults to `Infinity`.
+# Defaults to `800`.
 #elasticsearch.maxSockets: 1024
 
 # Specifies whether Kibana should use compression for communications with elasticsearch


### PR DESCRIPTION
## Summary

The default is now 800: https://github.com/elastic/kibana/blob/6049493e4a2372ea22986b231ad2bd59584fe9b8/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.ts#L44





<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->