### PR TITLE
[Security Solution ] Increase test timeouts for EQL Tests to reduce the flakyness.

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
@@ -137,47 +137,59 @@ describe('EQL Tab', () => {
 
   describe('rendering', () => {
     const fetchNotesMock = jest.spyOn(notesApi, 'fetchNotesByDocumentIds');
-    test('should render the timeline table', async () => {
-      fetchNotesMock.mockImplementation(jest.fn());
-      render(
-        <TestProviders store={createMockStore(mockState)}>
-          <TestComponent />
-        </TestProviders>
-      );
+    test(
+      'should render the timeline table',
+      async () => {
+        fetchNotesMock.mockImplementation(jest.fn());
+        render(
+          <TestProviders store={createMockStore(mockState)}>
+            <TestComponent />
+          </TestProviders>
+        );
 
-      expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
-    });
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
 
-    test('it renders the timeline column headers', async () => {
-      render(
-        <TestProviders store={createMockStore(mockState)}>
-          <TestComponent />
-        </TestProviders>
-      );
+    test(
+      'it renders the timeline column headers',
+      async () => {
+        render(
+          <TestProviders store={createMockStore(mockState)}>
+            <TestComponent />
+          </TestProviders>
+        );
 
-      expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
-    });
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
 
-    test('should render correct placeholder when there are not results', async () => {
-      (useTimelineEvents as jest.Mock).mockReturnValue([
-        false,
-        {
-          events: [],
-          pageInfo: {
-            activePage: 0,
-            totalPages: 10,
+    test(
+      'should render correct placeholder when there are not results',
+      async () => {
+        (useTimelineEvents as jest.Mock).mockReturnValue([
+          false,
+          {
+            events: [],
+            pageInfo: {
+              activePage: 0,
+              totalPages: 10,
+            },
           },
-        },
-      ]);
+        ]);
 
-      render(
-        <TestProviders store={createMockStore(mockState)}>
-          <TestComponent />
-        </TestProviders>
-      );
+        render(
+          <TestProviders store={createMockStore(mockState)}>
+            <TestComponent />
+          </TestProviders>
+        );
 
-      expect(await screen.findByText('No results found')).toBeVisible();
-    });
+        expect(await screen.findByText('No results found')).toBeVisible();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
 
     describe('pagination', () => {
       beforeEach(() => {


### PR DESCRIPTION
## Summary

Failures in build like [this](https://buildkite.com/elastic/kibana-on-merge/builds/58925#019451ad-90f1-421d-b09a-0f7893340686) are happening for EQL tests because for high rendering content and low test timeout.

This tests extends that timeout so that tests can run on CI without any issues.