### PR TITLE
[Infra] Fix dateRange handling when set to `now`

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/hooks/use_page_header.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/hooks/use_page_header.tsx
@@ -149,8 +149,8 @@ const useMetricsTabs = () => {
   const { dataStreams } = useEntitySummary({
     entityType: asset.type,
     entityId: asset.id,
-    from: new Date(dateRange.from).toISOString(),
-    to: new Date(dateRange.to).toISOString(),
+    from: dateRange.from,
+    to: dateRange.to,
   });
 
   const isMetrics = isMetricsSignal(dataStreams);

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/metrics/metrics_template.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/metrics/metrics_template.tsx
@@ -42,8 +42,8 @@ export const MetricsTemplate = React.forwardRef<HTMLDivElement, { children: Reac
     const { dataStreams, status: dataStreamsStatus } = useEntitySummary({
       entityType: asset.type,
       entityId: asset.id,
-      from: new Date(dateRange.from).toISOString(),
-      to: new Date(dateRange.to).toISOString(),
+      from: dateRange.from,
+      to: dateRange.to,
     });
 
     const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/overview/overview.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/overview/overview.tsx
@@ -42,8 +42,8 @@ export const Overview = () => {
   const { dataStreams, status: dataStreamsStatus } = useEntitySummary({
     entityType: asset.type,
     entityId: asset.id,
-    from: new Date(dateRange.from).toISOString(),
-    to: new Date(dateRange.to).toISOString(),
+    from: dateRange.from,
+    to: dateRange.to,
   });
   const addMetricsCalloutId: AddMetricsCalloutKey =
     asset.type === 'host' ? 'hostOverview' : 'containerOverview';


### PR DESCRIPTION
## Summary

Quick fix to allow the datepicker on Infra pages to not break when setting the `to` date to `"now"`. `use_date_picker()` hook already does date parsing, so whatever it provides as the `dateRange` result is going to be correct and not need further `Date` handling.

## How to test

* Go to Infra inventory page. Click on a host to open the flyout.
* Set the date for `to` to "now" on the Overview.
* It should update the page instead of crashing
* Any permutation of date ranges, from absolute, absolute + now, and relative, should not crash the page and should load the correct data.
* Test against all tabs for the flyout/page to ensure no date configuration causes crashes.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->