### PR TITLE
Simplify and converge UnifiedDataTable usage

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -658,6 +658,7 @@ describe('UnifiedDataTable', () => {
             "allowRowHeight": false,
           },
           "showFullScreenSelector": true,
+          "showKeyboardShortcuts": true,
           "showSortSelector": true,
         }
       `);
@@ -696,6 +697,7 @@ describe('UnifiedDataTable', () => {
             "allowRowHeight": false,
           },
           "showFullScreenSelector": true,
+          "showKeyboardShortcuts": true,
           "showSortSelector": true,
         }
       `);
@@ -719,6 +721,7 @@ describe('UnifiedDataTable', () => {
           "showColumnSelector": false,
           "showDisplaySelector": undefined,
           "showFullScreenSelector": true,
+          "showKeyboardShortcuts": true,
           "showSortSelector": true,
         }
       `);

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
@@ -210,6 +210,10 @@ export interface UnifiedDataTableProps {
    */
   showFullScreenButton?: boolean;
   /**
+   * Determines whether the keyboard shortcuts button should be displayed
+   */
+  showKeyboardShortcuts?: boolean;
+  /**
    * Manage user sorting control
    */
   isSortEnabled?: boolean;
@@ -448,6 +452,7 @@ export const UnifiedDataTable = ({
   searchTitle,
   settings,
   showTimeCol,
+  showKeyboardShortcuts = true,
   showFullScreenButton = true,
   sort,
   isSortEnabled = true,
@@ -1056,6 +1061,7 @@ export const UnifiedDataTable = ({
             showSortSelector: isSortEnabled,
             additionalControls,
             showDisplaySelector,
+            showKeyboardShortcuts,
             showFullScreenSelector: showFullScreenButton,
           }
         : {
@@ -1063,9 +1069,17 @@ export const UnifiedDataTable = ({
             showSortSelector: isSortEnabled,
             additionalControls,
             showDisplaySelector,
+            showKeyboardShortcuts,
             showFullScreenSelector: showFullScreenButton,
           },
-    [defaultColumns, isSortEnabled, additionalControls, showDisplaySelector, showFullScreenButton]
+    [
+      defaultColumns,
+      isSortEnabled,
+      additionalControls,
+      showDisplaySelector,
+      showKeyboardShortcuts,
+      showFullScreenButton,
+    ]
   );
 
   const rowHeightsOptions = useRowHeightsOptions({

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_data_table/use_styles.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_data_table/use_styles.ts
@@ -47,23 +47,12 @@ export const useStyles = () => {
       flex-grow: 0;
       text-align: left;
     }
-    & .euiDataGrid__controls {
-      gap: ${euiTheme.size.s};
-    }
-    & .euiDataGrid__leftControls {
-      display: flex;
-      align-items: center;
-      width: 100%;
-    }
     & .cspDataTableTotal {
       font-size: ${euiTheme.size.m};
       font-weight: ${euiTheme.font.weight.bold};
       border-right: ${euiTheme.border.thin};
       margin-inline: ${euiTheme.size.s};
       padding-right: ${euiTheme.size.m};
-    }
-    & .euiDataGrid__rightControls {
-      display: none;
     }
 
     & [data-test-subj='docTableExpandToggleColumn'] svg {


### PR DESCRIPTION
## Summary

Simplify code and standardize visible data-grid controls on the right side by default.

### Motivation

`<CloudSecurityDataTable>` is used for rendering the Misconfigurations and Vulnerabilities tables in Security > Findings. As of now, we override via CSS the controls on the right side (the keyboard shortcuts button and the fullscreen toggle) even though these ones are a standard pattern in [EUIDataGrid](https://eui.elastic.co/#/tabular-content/data-grid) as well as in the new [Asset Inventory data grid](https://www.figma.com/design/9zUqAhhglT1EGYG4LOl1X6/Asset-Management?node-id=3068-34003&t=K0iVvrJzeWtlxwhh-0).

In addition, `<UnifiedDataTable>` is rendered by `<CloudSecurityDataTable` and currently accepts a `showFullScreenButton` prop that defaults to true, but misses an equivalent `showKeyboardShortcuts`. This PR adds the missing prop to provide the same level of control for both UI elements.

### Screenshots

| Before | After |
|--------|--------|
| <img width="1191" alt="Screenshot 2025-01-13 at 13 51 37" src="https://github.com/user-attachments/assets/9f88da2c-a753-4cbd-959a-ef8b61903047" /> | <img width="1194" alt="Screenshot 2025-01-13 at 13 51 44" src="https://github.com/user-attachments/assets/c6af90b9-86dd-43c0-b2e6-dda62f80d003" /> |

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Risks

No risks whatsoever