### PR TITLE
Remove experimental tag from docs for FIPS

### DIFF
--- a/docs/user/security/fips-140-2.asciidoc
+++ b/docs/user/security/fips-140-2.asciidoc
@@ -1,8 +1,6 @@
 [[xpack-security-fips-140-2]]
 === FIPS 140-2
 
-experimental::[]
-
 The Federal Information Processing Standard (FIPS) Publication 140-2, (FIPS PUB 140-2), 
 titled "Security Requirements for Cryptographic Modules" is a U.S. government computer security standard
 used to approve cryptographic modules.


### PR DESCRIPTION
## Summary

Remove the Tech Preview tag from the docs for 8.17+
<img width="882" alt="Screenshot 2025-01-13 at 9 47 39 AM" src="https://github.com/user-attachments/assets/571718e2-5e80-4bc9-941e-25164d05a911" />





<!--ONMERGE {"backportTargets":["8.17","8.x"]} ONMERGE-->