### PR TITLE
[Security assistant] Update custom tool name regex

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.test.tsx
@@ -221,4 +221,18 @@ describe('getStructuredToolForIndexEntry', () => {
     );
     expect(result).toContain(`I'm sorry, but I was unable to find any information`);
   });
+
+  it('should match the name regex correctly', () => {
+    const tool = getStructuredToolForIndexEntry({
+      indexEntry: getCreateKnowledgeBaseEntrySchemaMock({
+        type: 'index',
+        name: `1bad-name?`,
+      }) as IndexEntry,
+      esClient: mockEsClient,
+      logger: mockLogger,
+    });
+
+    const nameRegex = /^[a-zA-Z0-9_-]+$/;
+    expect(tool.lc_kwargs.name).toMatch(nameRegex);
+  });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.test.tsx
@@ -235,4 +235,17 @@ describe('getStructuredToolForIndexEntry', () => {
     const nameRegex = /^[a-zA-Z0-9_-]+$/;
     expect(tool.lc_kwargs.name).toMatch(nameRegex);
   });
+
+  it('dashes get removed before `a` is prepended', () => {
+    const tool = getStructuredToolForIndexEntry({
+      indexEntry: getCreateKnowledgeBaseEntrySchemaMock({
+        type: 'index',
+        name: `-testing`,
+      }) as IndexEntry,
+      esClient: mockEsClient,
+      logger: mockLogger,
+    });
+
+    expect(tool.lc_kwargs.name).toMatch('testing');
+  });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.ts
@@ -157,7 +157,11 @@ export const getStructuredToolForIndexEntry = ({
   }, {});
 
   return new DynamicStructuredTool({
-    name: indexEntry.name.replace(/[^a-zA-Z0-9-]/g, ''), // // Tool names expects a string that matches the pattern '^[a-zA-Z0-9-]+$'
+    name: indexEntry.name
+      // Ensure it starts with a letter. If not, prepend 'a'
+      .replace(/^[^a-zA-Z]/, 'a')
+      // Replace invalid characters with an empty string
+      .replace(/[^a-zA-Z0-9_]/g, ''),
     description: indexEntry.description,
     schema: z.object({
       query: z.string().describe(indexEntry.queryDescription),

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.ts
@@ -158,10 +158,10 @@ export const getStructuredToolForIndexEntry = ({
 
   return new DynamicStructuredTool({
     name: indexEntry.name
-      // Ensure it starts with a letter. If not, prepend 'a'
-      .replace(/^[^a-zA-Z]/, 'a')
       // Replace invalid characters with an empty string
-      .replace(/[^a-zA-Z0-9_]/g, ''),
+      .replace(/[^a-zA-Z0-9_]/g, '')
+      // Ensure it starts with a letter. If not, prepend 'a'
+      .replace(/^[^a-zA-Z]/, 'a'),
     description: indexEntry.description,
     schema: z.object({
       query: z.string().describe(indexEntry.queryDescription),


### PR DESCRIPTION
## Summary

Updates the tool name regex replace to comply with Bedrock's regex: ` [a-zA-Z][a-zA-Z0-9_]`

Resolves the error:
```
ActionsClient BedrockRuntimeClient: action result status is error: an error occurred while running the action - 1 validation error detected: Value 'gtr-cool' at 'toolConfig.tools.8.member.toolSpec.name' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z][a-zA-Z0-9_]*
```




<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->