### PR TITLE
[8.x] [Security Assistant] Migrate semantic_text to use highlighter instead of inner_hits (#204962)

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.test.tsx
@@ -159,7 +159,6 @@ describe('getStructuredToolForIndexEntry', () => {
       indexEntry: mockIndexEntry,
       esClient: mockEsClient,
       logger: mockLogger,
-      elserId: 'elser123',
     });
 
     expect(tool).toBeInstanceOf(DynamicStructuredTool);
@@ -181,15 +180,8 @@ describe('getStructuredToolForIndexEntry', () => {
               field1: 'value1',
               field2: 2,
             },
-            inner_hits: {
-              'test.test': {
-                hits: {
-                  hits: [
-                    { _source: { text: 'Inner text 1' } },
-                    { _source: { text: 'Inner text 2' } },
-                  ],
-                },
-              },
+            highlight: {
+              test: ['Inner text 1', 'Inner text 2'],
             },
           },
         ],
@@ -202,7 +194,6 @@ describe('getStructuredToolForIndexEntry', () => {
       indexEntry: mockIndexEntry,
       esClient: mockEsClient,
       logger: mockLogger,
-      elserId: 'elser123',
     });
 
     const input = { query: 'testQuery', field1: 'value1', field2: 2 };
@@ -220,7 +211,6 @@ describe('getStructuredToolForIndexEntry', () => {
       indexEntry: mockIndexEntry,
       esClient: mockEsClient,
       logger: mockLogger,
-      elserId: 'elser123',
     });
 
     const input = { query: 'testQuery', field1: 'value1', field2: 2 };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
@@ -652,7 +652,6 @@ export class AIAssistantKnowledgeBaseDataClient extends AIAssistantDataClient {
     }
 
     try {
-      const elserId = ASSISTANT_ELSER_INFERENCE_ID;
       const userFilter = getKBUserFilter(user);
       const results = await this.findDocuments<EsIndexEntry>({
         // Note: This is a magic number to set some upward bound as to not blow the context with too
@@ -682,7 +681,6 @@ export class AIAssistantKnowledgeBaseDataClient extends AIAssistantDataClient {
                 indexEntry,
                 esClient,
                 logger: this.options.logger,
-                elserId,
               });
             })
         );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Assistant] Migrate semantic_text to use highlighter instead of inner_hits (#204962)](https://github.com/elastic/kibana/pull/204962)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Patryk Kopyciński","email":"contact@patrykkopycinski.com"},"sourceCommit":{"committedDate":"2025-01-10T15:51:38Z","message":"[Security Assistant] Migrate semantic_text to use highlighter instead of inner_hits (#204962)\n\n## Summary\r\n\r\nSwitch to use https://github.com/elastic/elasticsearch/pull/118064 when\r\nretrieving Knowledge base Index entry docs\r\n\r\nFollowed testing instructions from\r\nhttps://github.com/elastic/kibana/pull/198020\r\n\r\nResults:\r\n<img width=\"1498\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 28\"\r\nsrc=\"https://github.com/user-attachments/assets/a16bf729-ac30-4ea7-9b11-6e9ecca842dc\"\r\n/>\r\n\r\n<img width=\"1495\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 38\"\r\nsrc=\"https://github.com/user-attachments/assets/016c08c3-9865-4461-86a5-638e9559b202\"\r\n/>\r\n\r\n<img width=\"1502\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 43\"\r\nsrc=\"https://github.com/user-attachments/assets/37a14a2d-191d-420c-940d-1de649e082fd\"\r\n/>\r\n\r\n<img width=\"1491\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 47\"\r\nsrc=\"https://github.com/user-attachments/assets/e2be1e95-6fc8-4149-b1ff-2e8b8a9a0a8d\"\r\n/>\r\n\r\n<img width=\"1494\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 50\"\r\nsrc=\"https://github.com/user-attachments/assets/38b17f44-e349-46ab-8069-80d1a3fd42ae\"\r\n/>","sha":"55390001adf8ea1eb1f50d46a4a8bb925a8a33d4","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Feature:Security Assistant","Team:Security Generative AI","backport:version","v8.18.0"],"number":204962,"url":"https://github.com/elastic/kibana/pull/204962","mergeCommit":{"message":"[Security Assistant] Migrate semantic_text to use highlighter instead of inner_hits (#204962)\n\n## Summary\r\n\r\nSwitch to use https://github.com/elastic/elasticsearch/pull/118064 when\r\nretrieving Knowledge base Index entry docs\r\n\r\nFollowed testing instructions from\r\nhttps://github.com/elastic/kibana/pull/198020\r\n\r\nResults:\r\n<img width=\"1498\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 28\"\r\nsrc=\"https://github.com/user-attachments/assets/a16bf729-ac30-4ea7-9b11-6e9ecca842dc\"\r\n/>\r\n\r\n<img width=\"1495\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 38\"\r\nsrc=\"https://github.com/user-attachments/assets/016c08c3-9865-4461-86a5-638e9559b202\"\r\n/>\r\n\r\n<img width=\"1502\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 43\"\r\nsrc=\"https://github.com/user-attachments/assets/37a14a2d-191d-420c-940d-1de649e082fd\"\r\n/>\r\n\r\n<img width=\"1491\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 47\"\r\nsrc=\"https://github.com/user-attachments/assets/e2be1e95-6fc8-4149-b1ff-2e8b8a9a0a8d\"\r\n/>\r\n\r\n<img width=\"1494\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 50\"\r\nsrc=\"https://github.com/user-attachments/assets/38b17f44-e349-46ab-8069-80d1a3fd42ae\"\r\n/>","sha":"55390001adf8ea1eb1f50d46a4a8bb925a8a33d4"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/204962","number":204962,"mergeCommit":{"message":"[Security Assistant] Migrate semantic_text to use highlighter instead of inner_hits (#204962)\n\n## Summary\r\n\r\nSwitch to use https://github.com/elastic/elasticsearch/pull/118064 when\r\nretrieving Knowledge base Index entry docs\r\n\r\nFollowed testing instructions from\r\nhttps://github.com/elastic/kibana/pull/198020\r\n\r\nResults:\r\n<img width=\"1498\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 28\"\r\nsrc=\"https://github.com/user-attachments/assets/a16bf729-ac30-4ea7-9b11-6e9ecca842dc\"\r\n/>\r\n\r\n<img width=\"1495\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 38\"\r\nsrc=\"https://github.com/user-attachments/assets/016c08c3-9865-4461-86a5-638e9559b202\"\r\n/>\r\n\r\n<img width=\"1502\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 43\"\r\nsrc=\"https://github.com/user-attachments/assets/37a14a2d-191d-420c-940d-1de649e082fd\"\r\n/>\r\n\r\n<img width=\"1491\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 47\"\r\nsrc=\"https://github.com/user-attachments/assets/e2be1e95-6fc8-4149-b1ff-2e8b8a9a0a8d\"\r\n/>\r\n\r\n<img width=\"1494\" alt=\"Zrzut ekranu 2024-12-19 o 16 32 50\"\r\nsrc=\"https://github.com/user-attachments/assets/38b17f44-e349-46ab-8069-80d1a3fd42ae\"\r\n/>","sha":"55390001adf8ea1eb1f50d46a4a8bb925a8a33d4"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->