### PR TITLE
[Security solution] Do not send model if connector is inference

### DIFF
--- a/x-pack/platform/packages/shared/kbn-langchain/server/language_models/chat_openai.test.ts
+++ b/x-pack/platform/packages/shared/kbn-langchain/server/language_models/chat_openai.test.ts
@@ -198,7 +198,6 @@ describe('ActionsClientChatOpenAI', () => {
       const defaultStreamingArgs: OpenAI.ChatCompletionCreateParamsStreaming = {
         messages: [{ content: prompt, role: 'user' }],
         stream: true,
-        model: 'gpt-4o',
         n: 99,
         stop: ['a stop sequence'],
         tools: [{ function: jest.fn(), type: 'function' }],
@@ -220,7 +219,6 @@ describe('ActionsClientChatOpenAI', () => {
             subAction: 'unified_completion_async_iterator',
             subActionParams: {
               body: {
-                model: 'gpt-4o',
                 messages: [{ role: 'user', content: 'Do you know my name?' }],
 
                 n: defaultStreamingArgs.n,
@@ -241,7 +239,6 @@ describe('ActionsClientChatOpenAI', () => {
       const defaultNonStreamingArgs: OpenAI.ChatCompletionCreateParamsNonStreaming = {
         messages: [{ content: prompt, role: 'user' }],
         stream: false,
-        model: 'gpt-4o',
         n: 99,
         stop: ['a stop sequence'],
         tools: [{ function: jest.fn(), type: 'function' }],
@@ -264,7 +261,6 @@ describe('ActionsClientChatOpenAI', () => {
               subActionParams: {
                 body: {
                   temperature: 0.2,
-                  model: 'gpt-4o',
                   n: 99,
                   stop: ['a stop sequence'],
                   tools: [{ function: jest.fn(), type: 'function' }],

--- a/x-pack/platform/packages/shared/kbn-langchain/server/language_models/chat_openai.test.ts
+++ b/x-pack/platform/packages/shared/kbn-langchain/server/language_models/chat_openai.test.ts
@@ -198,6 +198,7 @@ describe('ActionsClientChatOpenAI', () => {
       const defaultStreamingArgs: OpenAI.ChatCompletionCreateParamsStreaming = {
         messages: [{ content: prompt, role: 'user' }],
         stream: true,
+        model: 'gpt-4o',
         n: 99,
         stop: ['a stop sequence'],
         tools: [{ function: jest.fn(), type: 'function' }],
@@ -239,6 +240,7 @@ describe('ActionsClientChatOpenAI', () => {
       const defaultNonStreamingArgs: OpenAI.ChatCompletionCreateParamsNonStreaming = {
         messages: [{ content: prompt, role: 'user' }],
         stream: false,
+        model: 'gpt-4o',
         n: 99,
         stop: ['a stop sequence'],
         tools: [{ function: jest.fn(), type: 'function' }],

--- a/x-pack/platform/packages/shared/kbn-langchain/server/language_models/chat_openai.ts
+++ b/x-pack/platform/packages/shared/kbn-langchain/server/language_models/chat_openai.ts
@@ -201,7 +201,7 @@ export class ActionsClientChatOpenAI extends ChatOpenAI {
       // possible client model override
       // security sends this from connectors, it is only missing from preconfigured connectors
       // this should be undefined otherwise so the connector handles the model (stack_connector has access to preconfigured connector model values)
-      model: this.model,
+      ...(llmType === 'inference' ? {} : { model: this.model }),
       n: completionRequest.n,
       stop: completionRequest.stop,
       tools: completionRequest.tools,


### PR DESCRIPTION
## Summary

Removes the model argument from the `ActionsClientChatOpenAI` chat model if `llmType === 'inference`.

Prevents this error:
 
![image (13)](https://github.com/user-attachments/assets/e13d3c57-5b94-4dbc-a903-be9b28ba0f72)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->