### PR TITLE
[8.x] [Obs AI Assistant] Attempt to fix flaky KB migration test (#206324)

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_migration.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_migration.spec.ts
@@ -24,6 +24,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const esArchiver = getService('esArchiver');
   const es = getService('es');
   const ml = getService('ml');
+  const retry = getService('retry');
 
   const archive =
     'x-pack/test/functional/es_archives/observability/ai_assistant/knowledge_base_8_15';
@@ -91,32 +92,34 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       });
 
       it('the docs have semantic_text embeddings', async () => {
-        const hits = await getKnowledgeBaseEntries();
-        const hasSemanticTextEmbeddings = hits.every((hit) => hit._source?.semantic_text);
-        expect(hasSemanticTextEmbeddings).to.be(true);
+        await retry.try(async () => {
+          const hits = await getKnowledgeBaseEntries();
+          const hasSemanticTextEmbeddings = hits.every((hit) => hit._source?.semantic_text);
+          expect(hasSemanticTextEmbeddings).to.be(true);
 
-        expect(
-          orderBy(hits, '_source.title').map(({ _source }) => {
-            const { text, inference } = _source?.semantic_text!;
+          expect(
+            orderBy(hits, '_source.title').map(({ _source }) => {
+              const { text, inference } = _source?.semantic_text!;
 
-            return {
-              text,
-              inferenceId: inference.inference_id,
-              chunkCount: inference.chunks.length,
-            };
-          })
-        ).to.eql([
-          {
-            text: 'To infinity and beyond!',
-            inferenceId: AI_ASSISTANT_KB_INFERENCE_ID,
-            chunkCount: 1,
-          },
-          {
-            text: "The user's favourite color is blue.",
-            inferenceId: AI_ASSISTANT_KB_INFERENCE_ID,
-            chunkCount: 1,
-          },
-        ]);
+              return {
+                text,
+                inferenceId: inference.inference_id,
+                chunkCount: inference.chunks.length,
+              };
+            })
+          ).to.eql([
+            {
+              text: 'To infinity and beyond!',
+              inferenceId: AI_ASSISTANT_KB_INFERENCE_ID,
+              chunkCount: 1,
+            },
+            {
+              text: "The user's favourite color is blue.",
+              inferenceId: AI_ASSISTANT_KB_INFERENCE_ID,
+              chunkCount: 1,
+            },
+          ]);
+        });
       });
 
       it('returns entries correctly via API', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Obs AI Assistant] Attempt to fix flaky KB migration test (#206324)](https://github.com/elastic/kibana/pull/206324)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2025-01-13T20:12:58Z","message":"[Obs AI Assistant] Attempt to fix flaky KB migration test (#206324)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/202926\r\n\r\n### Problem\r\nThe KB migration test appears to be flaky sometimes, because the\r\nmigration takes a few seconds to run. Therefore, when the test expects\r\nto have semantic_text for all entries, it fails.\r\n\r\n### Solution\r\nAdding a retry statement to avoid the failure in cases where the\r\nmigration takes a little while to run.\r\n\r\n### Checklist\r\n\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"95b76dc12b11bc5e147bb6e6628cec471fbc02e3","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v8.18.0"],"number":206324,"url":"https://github.com/elastic/kibana/pull/206324","mergeCommit":{"message":"[Obs AI Assistant] Attempt to fix flaky KB migration test (#206324)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/202926\r\n\r\n### Problem\r\nThe KB migration test appears to be flaky sometimes, because the\r\nmigration takes a few seconds to run. Therefore, when the test expects\r\nto have semantic_text for all entries, it fails.\r\n\r\n### Solution\r\nAdding a retry statement to avoid the failure in cases where the\r\nmigration takes a little while to run.\r\n\r\n### Checklist\r\n\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"95b76dc12b11bc5e147bb6e6628cec471fbc02e3"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/206324","number":206324,"mergeCommit":{"message":"[Obs AI Assistant] Attempt to fix flaky KB migration test (#206324)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/202926\r\n\r\n### Problem\r\nThe KB migration test appears to be flaky sometimes, because the\r\nmigration takes a few seconds to run. Therefore, when the test expects\r\nto have semantic_text for all entries, it fails.\r\n\r\n### Solution\r\nAdding a retry statement to avoid the failure in cases where the\r\nmigration takes a little while to run.\r\n\r\n### Checklist\r\n\r\n- [x] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"95b76dc12b11bc5e147bb6e6628cec471fbc02e3"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->