### PR TITLE
[8.x] [Performance] Report scale dimensions for service-map and hosts (#205607)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/index.tsx
@@ -111,7 +111,7 @@ export function ServiceMap({
   const { onPageReady } = usePerformanceContext();
 
   const {
-    data = { elements: [] },
+    data = { elements: [], nodesCount: 0, tracesCount: 0 },
     status,
     error,
   } = useFetcher(
@@ -188,6 +188,12 @@ export function ServiceMap({
 
   if (status === FETCH_STATUS.SUCCESS) {
     onPageReady({
+      customMetrics: {
+        key1: 'num_of_nodes',
+        value1: data.nodesCount,
+        key2: 'num_of_traces',
+        value2: data.tracesCount,
+      },
       meta: { rangeFrom: start, rangeTo: end },
     });
   }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/service_map/group_resource_nodes.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/service_map/group_resource_nodes.ts
@@ -39,6 +39,7 @@ interface GroupedEdge {
 
 export interface GroupResourceNodesResponse {
   elements: Array<GroupedNode | GroupedEdge | ConnectionElement>;
+  nodesCount: number;
 }
 
 export function groupResourceNodes(responseData: {
@@ -151,5 +152,6 @@ export function groupResourceNodes(responseData: {
 
   return {
     elements: [...ungroupedNodes, ...groupedNodes, ...ungroupedEdges, ...groupedEdges],
+    nodesCount: ungroupedNodes.length,
   };
 }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/service_map/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/service_map/route.ts
@@ -23,7 +23,7 @@ import { environmentRt, rangeRt, kueryRt } from '../default_api_types';
 import { getServiceGroup } from '../service_groups/get_service_group';
 import { offsetRt } from '../../../common/comparison_rt';
 import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
-import type { TransformServiceMapResponse } from './transform_service_map_responses';
+import type { ServiceMapResponse } from './get_service_map';
 
 const serviceMapRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/service-map',
@@ -39,7 +39,7 @@ const serviceMapRoute = createApmServerRoute({
     ]),
   }),
   security: { authz: { requiredPrivileges: ['apm'] } },
-  handler: async (resources): Promise<TransformServiceMapResponse> => {
+  handler: async (resources): Promise<ServiceMapResponse> => {
     const { config, context, params, logger } = resources;
     if (!config.serviceMapEnabled) {
       throw Boom.notFound();

--- a/x-pack/solutions/observability/plugins/apm/server/routes/service_map/transform_service_map_responses.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/service_map/transform_service_map_responses.test.ts
@@ -73,6 +73,7 @@ describe('transformServiceMapResponses', () => {
         },
       ],
       anomalies,
+      tracesCount: 10,
     };
 
     const { elements } = transformServiceMapResponses({ response });
@@ -106,6 +107,7 @@ describe('transformServiceMapResponses', () => {
         },
       ],
       anomalies,
+      tracesCount: 10,
     };
 
     const { elements } = transformServiceMapResponses({ response });
@@ -165,6 +167,7 @@ describe('transformServiceMapResponses', () => {
         },
       ],
       anomalies,
+      tracesCount: 10,
     };
 
     const { elements } = transformServiceMapResponses({ response });
@@ -203,6 +206,7 @@ describe('transformServiceMapResponses', () => {
         },
       ],
       anomalies,
+      tracesCount: 10,
     };
 
     const { elements } = transformServiceMapResponses({ response });
@@ -228,6 +232,7 @@ describe('transformServiceMapResponses', () => {
         },
       ],
       anomalies,
+      tracesCount: 10,
     };
 
     const { elements } = transformServiceMapResponses({ response });

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
@@ -17,10 +17,13 @@ import { useHostCountContext } from '../hooks/use_host_count';
 import { FlyoutWrapper } from './host_details_flyout/flyout_wrapper';
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from '../constants';
 import { FilterAction } from './table/filter_action';
+import { useUnifiedSearchContext } from '../hooks/use_unified_search';
 
 export const HostsTable = () => {
   const { loading } = useHostsViewContext();
-  const { loading: hostCountLoading } = useHostCountContext();
+  const { loading: hostCountLoading, count } = useHostCountContext();
+  const { searchCriteria } = useUnifiedSearchContext();
+
   const { onPageReady } = usePerformanceContext();
 
   const {
@@ -40,9 +43,16 @@ export const HostsTable = () => {
 
   useEffect(() => {
     if (!loading && !hostCountLoading) {
-      onPageReady();
+      onPageReady({
+        customMetrics: {
+          key1: 'num_of_hosts',
+          value1: count,
+          key2: `max_hosts_per_page`,
+          value2: searchCriteria.limit,
+        },
+      });
     }
-  }, [loading, hostCountLoading, onPageReady]);
+  }, [loading, hostCountLoading, onPageReady, count, searchCriteria]);
 
   return (
     <>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Performance] Report scale dimensions for service-map and hosts (#205607)](https://github.com/elastic/kibana/pull/205607)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Katerina","email":"aikaterini.patticha@elastic.co"},"sourceCommit":{"committedDate":"2025-01-08T14:16:24Z","message":"[Performance] Report scale dimensions for service-map and hosts (#205607)\n\ncloses https://github.com/elastic/observability-dev/issues/3777 \r\n\r\n## Summary\r\n\r\nThis PR provides scale dimensions for the service map and infra host\r\npages without introducing any additional requests.\r\n\r\n### Global Service Map and Per-service APM Service Map \r\n\r\n\r\n| Metric         | Description                        |\r\n|----------------|------------------------------------|\r\n| `num_of_nodes` | Total number of discovered nodes (services +\r\ndependenies |\r\n| `num_of_traces`   | Total number of traces             |\r\n\r\n### Infra\r\n\r\n\r\n| Metric        | Description                     | default\r\n|---------------|---------------------------------| -----------------\r\n| `num_of_hosts`  | Total number of hosts          |\r\n| `max_hosts_per_page` | Maximum number of host returne `50/100/500` |\r\n100\r\n\r\n\r\n| Page | Screenshot |\r\n\r\n|-------------------------------|-------------------------------------------------------------------------------------------|\r\n| Global Service Map | ![Screenshot 2025-01-08 at 12 54\r\n43](https://github.com/user-attachments/assets/478b1f7b-bbd7-4ed5-8a7f-b041e6dab3b5)\r\n|\r\n| Per-service APM Service Map | ![Screenshot 2025-01-08 at 12 53\r\n07](https://github.com/user-attachments/assets/62ee7852-6410-4dfc-9da2-5fc849ec18bc)\r\n|\r\n| Infra | !![Screenshot 2025-01-08 at 12 56\r\n00](https://github.com/user-attachments/assets/e8b28a9c-14f7-4296-83cb-ddc25047f508)\r\n|\r\n\r\n \r\n\r\n\r\n\r\n\r\n\r\n### How to test\r\n- Open any of the above pages\r\n- In the network tab, look for `kibana:plugin_render_time`","sha":"24f8888aaed266ad02f17913c795362fbd4448f8","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","backport:prev-minor","Team:obs-ux-infra_services"],"number":205607,"url":"https://github.com/elastic/kibana/pull/205607","mergeCommit":{"message":"[Performance] Report scale dimensions for service-map and hosts (#205607)\n\ncloses https://github.com/elastic/observability-dev/issues/3777 \r\n\r\n## Summary\r\n\r\nThis PR provides scale dimensions for the service map and infra host\r\npages without introducing any additional requests.\r\n\r\n### Global Service Map and Per-service APM Service Map \r\n\r\n\r\n| Metric         | Description                        |\r\n|----------------|------------------------------------|\r\n| `num_of_nodes` | Total number of discovered nodes (services +\r\ndependenies |\r\n| `num_of_traces`   | Total number of traces             |\r\n\r\n### Infra\r\n\r\n\r\n| Metric        | Description                     | default\r\n|---------------|---------------------------------| -----------------\r\n| `num_of_hosts`  | Total number of hosts          |\r\n| `max_hosts_per_page` | Maximum number of host returne `50/100/500` |\r\n100\r\n\r\n\r\n| Page | Screenshot |\r\n\r\n|-------------------------------|-------------------------------------------------------------------------------------------|\r\n| Global Service Map | ![Screenshot 2025-01-08 at 12 54\r\n43](https://github.com/user-attachments/assets/478b1f7b-bbd7-4ed5-8a7f-b041e6dab3b5)\r\n|\r\n| Per-service APM Service Map | ![Screenshot 2025-01-08 at 12 53\r\n07](https://github.com/user-attachments/assets/62ee7852-6410-4dfc-9da2-5fc849ec18bc)\r\n|\r\n| Infra | !![Screenshot 2025-01-08 at 12 56\r\n00](https://github.com/user-attachments/assets/e8b28a9c-14f7-4296-83cb-ddc25047f508)\r\n|\r\n\r\n \r\n\r\n\r\n\r\n\r\n\r\n### How to test\r\n- Open any of the above pages\r\n- In the network tab, look for `kibana:plugin_render_time`","sha":"24f8888aaed266ad02f17913c795362fbd4448f8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205607","number":205607,"mergeCommit":{"message":"[Performance] Report scale dimensions for service-map and hosts (#205607)\n\ncloses https://github.com/elastic/observability-dev/issues/3777 \r\n\r\n## Summary\r\n\r\nThis PR provides scale dimensions for the service map and infra host\r\npages without introducing any additional requests.\r\n\r\n### Global Service Map and Per-service APM Service Map \r\n\r\n\r\n| Metric         | Description                        |\r\n|----------------|------------------------------------|\r\n| `num_of_nodes` | Total number of discovered nodes (services +\r\ndependenies |\r\n| `num_of_traces`   | Total number of traces             |\r\n\r\n### Infra\r\n\r\n\r\n| Metric        | Description                     | default\r\n|---------------|---------------------------------| -----------------\r\n| `num_of_hosts`  | Total number of hosts          |\r\n| `max_hosts_per_page` | Maximum number of host returne `50/100/500` |\r\n100\r\n\r\n\r\n| Page | Screenshot |\r\n\r\n|-------------------------------|-------------------------------------------------------------------------------------------|\r\n| Global Service Map | ![Screenshot 2025-01-08 at 12 54\r\n43](https://github.com/user-attachments/assets/478b1f7b-bbd7-4ed5-8a7f-b041e6dab3b5)\r\n|\r\n| Per-service APM Service Map | ![Screenshot 2025-01-08 at 12 53\r\n07](https://github.com/user-attachments/assets/62ee7852-6410-4dfc-9da2-5fc849ec18bc)\r\n|\r\n| Infra | !![Screenshot 2025-01-08 at 12 56\r\n00](https://github.com/user-attachments/assets/e8b28a9c-14f7-4296-83cb-ddc25047f508)\r\n|\r\n\r\n \r\n\r\n\r\n\r\n\r\n\r\n### How to test\r\n- Open any of the above pages\r\n- In the network tab, look for `kibana:plugin_render_time`","sha":"24f8888aaed266ad02f17913c795362fbd4448f8"}}]}] BACKPORT-->