### PR TITLE
[Browser logger] Use `apm.captureError` if error is provided

### DIFF
--- a/src/core/packages/logging/browser-internal/src/logger.ts
+++ b/src/core/packages/logging/browser-internal/src/logger.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { LogLevel, LogRecord, LogMeta } from '@kbn/logging';
+import { apm } from '@elastic/apm-rum';
+import type { LogLevel, LogRecord, LogMeta } from '@kbn/logging';
 import { AbstractLogger } from '@kbn/core-logging-common-internal';
 
 function isError(x: any): x is Error {
@@ -24,6 +25,7 @@ export class BaseLogger extends AbstractLogger {
     meta?: Meta
   ): LogRecord {
     if (isError(errorOrMessage)) {
+      apm.captureError(Object.assign({}, errorOrMessage, { meta, context: this.context, level }));
       return {
         context: this.context,
         error: errorOrMessage,


### PR DESCRIPTION
## Summary

Attempt to address https://github.com/elastic/observability-dev/issues/4222

cc @maryam-saeidi @rudolf @kobelb @tsullivan @dgieselaar @Dosant 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Identify risks

- [ ] We may ship too many errors and become noisy (although the additional metadata should allow us to filter noise down).
- [ ] If logging a message and placing the error in the `meta`, we're not shipping it at the moment: We can discuss our preferred approach in such case and address it in follow-up PRs.



