### PR TITLE
[Search Connectors] Handle insufficient permissions in Serverless UI correctly

### DIFF
--- a/x-pack/solutions/search/plugins/serverless_search/server/routes/connectors_routes.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/routes/connectors_routes.ts
@@ -34,10 +34,12 @@ export const registerConnectorsRoutes = ({ logger, http, router }: RouteDependen
     errorHandler(logger)(async (context, request, response) => {
       const { client } = (await context.core).elasticsearch;
       const privileges = await client.asCurrentUser.security.hasPrivileges({
-        index: [{ names: ['.elastic-connectors'], privileges: ['read', 'write'] }],
+        body: {
+          cluster: ['manage_connector', 'monitor_connector'],
+        },
       });
-      const canManageConnectors = privileges.index['.elastic-connectors'].write;
-      const canReadConnectors = privileges.index['.elastic-connectors'].read;
+      const canManageConnectors = privileges.cluster['manage_connector'];
+      const canReadConnectors = privileges.cluster['monitor_connector'];
 
       const connectors = canReadConnectors ? await fetchConnectors(client.asCurrentUser) : [];
 

--- a/x-pack/solutions/search/plugins/serverless_search/server/routes/connectors_routes.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/routes/connectors_routes.ts
@@ -38,8 +38,8 @@ export const registerConnectorsRoutes = ({ logger, http, router }: RouteDependen
           cluster: ['manage_connector', 'monitor_connector'],
         },
       });
-      const canManageConnectors = privileges.cluster['manage_connector'];
-      const canReadConnectors = privileges.cluster['monitor_connector'];
+      const canManageConnectors = privileges.cluster.manage_connector;
+      const canReadConnectors = privileges.cluster.monitor_connector;
 
       const connectors = canReadConnectors ? await fetchConnectors(client.asCurrentUser) : [];
 


### PR DESCRIPTION
## Summary

Adapt serverless logic that checks permissions to monitor/manage connector. 

### Validation
- Switching between viewer/developer/admin works as expected

Setup es and kibana:
```
yarn es serverless --projectType es --ssl --kibanaUrl=https://0.0.0.0:5601/

yarn start --serverless=es --ssl   
```

### Screenshots 

#### Case 1 - Viewer
<img width="800" alt="Screenshot 2025-01-14 at 13 47 12" src="https://github.com/user-attachments/assets/6e9c52b9-601f-476b-b1ce-29400246e789" />

This is what we get from the endpoint for `viewer` role (as expected)

<img width="400" alt="Screenshot 2025-01-14 at 13 47 17" src="https://github.com/user-attachments/assets/7acd0bd3-ac2e-4bfe-9ec4-1090821d7716" />

#### Case 2 - Developer / Admin

<img width="800" alt="Screenshot 2025-01-14 at 13 46 27" src="https://github.com/user-attachments/assets/441a6aed-785f-4347-8af4-e5dd88382a1b" />
<img width="800" alt="Screenshot 2025-01-14 at 13 46 45" src="https://github.com/user-attachments/assets/5721ce92-519c-461b-9c48-ab057c916364" />

This is what we get from the endpoint for `developer` role (as expected)

<img width="490" alt="Screenshot 2025-01-14 at 13 46 54" src="https://github.com/user-attachments/assets/20c8940d-7390-4423-ac85-59156d7293ab" />




### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



