### PR TITLE
[fix] remove `elserId` in `helpers.test.tsx`

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.test.tsx
@@ -230,7 +230,6 @@ describe('getStructuredToolForIndexEntry', () => {
       }) as IndexEntry,
       esClient: mockEsClient,
       logger: mockLogger,
-      elserId: 'hi',
     });
 
     const nameRegex = /^[a-zA-Z0-9_-]+$/;
@@ -245,7 +244,6 @@ describe('getStructuredToolForIndexEntry', () => {
       }) as IndexEntry,
       esClient: mockEsClient,
       logger: mockLogger,
-      elserId: 'hi',
     });
 
     expect(tool.lc_kwargs.name).toMatch('testing');


### PR DESCRIPTION
## Summary
Backport for https://github.com/elastic/kibana/pull/206514 added tests that filled `elserId` with a dummy value. Concurrently, that field was removed in https://github.com/elastic/kibana/pull/206509.

This is now causing type errors in the on-merge for 8.x.

This PR removes that dummy field.