### PR TITLE
Make dashboard listing initial render faster

### DIFF
--- a/src/platform/packages/shared/content-management/table_list_view_table/src/table_list_view_table.tsx
+++ b/src/platform/packages/shared/content-management/table_list_view_table/src/table_list_view_table.tsx
@@ -64,6 +64,13 @@ import type { RowActions, SearchQueryError, TableItemsRowActions } from './types
 import { sortByRecentlyAccessed } from './components/table_sort_select';
 import { ContentEditorActivityRow } from './components/content_editor_activity_row';
 
+const disabledEditAction = {
+  enabled: false,
+  reason: i18n.translate('contentManagement.tableList.managedItemNoEdit', {
+    defaultMessage: 'Elastic manages this item. Clone it to make changes.',
+  }),
+};
+
 interface ContentEditorConfig
   extends Pick<OpenContentEditorParams, 'isReadonly' | 'onSave' | 'customValidators'> {
   enabled?: boolean;
@@ -527,24 +534,17 @@ function TableListViewTableComp<T extends UserContentCommonSchema>({
 
   const tableItemsRowActions = useMemo(() => {
     return items.reduce<TableItemsRowActions>((acc, item) => {
-      const ret = {
-        ...acc,
-        [item.id]: rowItemActions ? rowItemActions(item) : undefined,
-      };
+      acc[item.id] = rowItemActions ? rowItemActions(item) : undefined;
 
       if (item.managed) {
-        ret[item.id] = {
-          edit: {
-            enabled: false,
-            reason: i18n.translate('contentManagement.tableList.managedItemNoEdit', {
-              defaultMessage: 'Elastic manages this item. Clone it to make changes.',
-            }),
-          },
-          ...ret[item.id],
-        };
+        if (acc[item.id]) {
+          acc[item.id]!.edit = disabledEditAction;
+        } else {
+          acc[item.id] = { edit: disabledEditAction };
+        }
       }
 
-      return ret;
+      return acc;
     }, {});
   }, [items, rowItemActions]);
 


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/201401

I opened perf profiler in overview cluster (1000 dashboards) and noticed a very slow function. The slowness was likely caused by two spread operators on each iteration, but there was likely something more to it from the engine perspective because it was very-very slow.


Before (318 ms, ~1000 dashboard)
 ![Screenshot 2025-01-14 at 16 49 17](https://github.com/user-attachments/assets/369bdbea-c17c-4b4c-a168-da6a9eda0f72)

After (<1ms, same data)
![Screenshot 2025-01-14 at 16 47 33](https://github.com/user-attachments/assets/4320b5c5-3da3-4f92-ad9a-eae2f35331d1)











<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->