### PR TITLE
[APM] Attempt to fix Cypress flaky test in Mobile Transactions

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/mobile/mobile_transactions.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/mobile/mobile_transactions.cy.ts
@@ -42,19 +42,22 @@ describe('Mobile transactions page', () => {
     describe('when click on tab shows correct table', () => {
       it('shows version tab', () => {
         cy.visitKibana(mobileTransactionsPageHref);
-        cy.getByTestSubj('apmAppVersionTab').click().should('have.attr', 'aria-selected', 'true');
+        cy.getByTestSubj('apmAppVersionTab').click();
+        cy.getByTestSubj('apmAppVersionTab').should('have.attr', 'aria-selected', 'true');
         cy.url().should('include', 'mobileSelectedTab=app_version_tab');
       });
 
       it('shows OS version tab', () => {
         cy.visitKibana(mobileTransactionsPageHref);
-        cy.getByTestSubj('apmOsVersionTab').click().should('have.attr', 'aria-selected', 'true');
+        cy.getByTestSubj('apmOsVersionTab').click();
+        cy.getByTestSubj('apmOsVersionTab').should('have.attr', 'aria-selected', 'true');
         cy.url().should('include', 'mobileSelectedTab=os_version_tab');
       });
 
       it('shows devices tab', () => {
         cy.visitKibana(mobileTransactionsPageHref);
-        cy.getByTestSubj('apmDevicesTab').click().should('have.attr', 'aria-selected', 'true');
+        cy.getByTestSubj('apmDevicesTab').click();
+        cy.getByTestSubj('apmDevicesTab').should('have.attr', 'aria-selected', 'true');
         cy.url().should('include', 'mobileSelectedTab=devices_tab');
       });
     });


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/206599

This PR aims to fix a flaky test that waits for `aria-selected` attribute to be `true` after click, but it resolved to `false`.

The test was written like this:

````
cy.getByTestSubj('apmAppVersionTab').click().should('have.attr', 'aria-selected', 'true');
````

After some research, I found that having it like that makes Cypress skip waiting for any visual or state changes after the click. This can lead to scenarios where the attribute hasn't been updated yet by the time the expectation is evaluated.

By separating the click and the assertion, we effectively allow more time for the state to update, and Cypress will automatically retry it within the configured timeout.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->