### PR TITLE
[8.x] [Obs AI Assistant] Ensure compatibility with the new semantic_text format (#206510)

### DIFF
--- a/x-pack/platform/plugins/shared/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/recall_from_search_connectors.ts
+++ b/x-pack/platform/plugins/shared/observability_solution/observability_ai_assistant/server/service/knowledge_base_service/recall_from_search_connectors.ts
@@ -85,9 +85,6 @@ async function recallFromSemanticTextConnectors({
   const params = {
     index: connectorIndices,
     size: 20,
-    _source: {
-      excludes: semanticTextFields.map((field) => `${field}.inference`),
-    },
     query: {
       bool: {
         should: semanticTextFields.flatMap((field) => {

--- a/x-pack/platform/plugins/shared/observability_solution/observability_ai_assistant/server/service/setup_conversation_and_kb_index_assets.ts
+++ b/x-pack/platform/plugins/shared/observability_solution/observability_ai_assistant/server/service/setup_conversation_and_kb_index_assets.ts
@@ -80,6 +80,7 @@ export async function setupConversationAndKbIndexAssets({
           number_of_shards: 1,
           auto_expand_replicas: '0-1',
           hidden: true,
+          'index.mapping.semantic_text.use_legacy_format': false,
         },
       },
     });

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/elasticsearch/index.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/elasticsearch/index.spec.ts
@@ -45,6 +45,9 @@ describe('elasticsearch functions', () => {
               },
             },
           },
+          settings: {
+            'index.mapping.semantic_text.use_legacy_format': false,
+          },
         });
 
         await esClient.index({

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/esql/index.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/scenarios/esql/index.spec.ts
@@ -72,6 +72,9 @@ describe('ES|QL query generation', () => {
               },
             },
           },
+          settings: {
+            'index.mapping.semantic_text.use_legacy_format': false,
+          },
         });
         await esClient.index({
           index: 'packetbeat-8.11.3',
@@ -123,6 +126,9 @@ describe('ES|QL query generation', () => {
                 type: 'integer',
               },
             },
+          },
+          settings: {
+            'index.mapping.semantic_text.use_legacy_format': false,
           },
         });
 

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_migration.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_migration.spec.ts
@@ -19,6 +19,27 @@ import {
   TINY_ELSER,
 } from './helpers';
 
+interface InferenceChunk {
+  text: string;
+  embeddings: any;
+}
+
+interface InferenceData {
+  inference_id: string;
+  chunks: {
+    semantic_text: InferenceChunk[];
+  };
+}
+
+interface SemanticTextField {
+  semantic_text: string;
+  _inference_fields?: {
+    semantic_text?: {
+      inference: InferenceData;
+    };
+  };
+}
+
 export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
   const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
   const esArchiver = getService('esArchiver');
@@ -32,23 +53,20 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   async function getKnowledgeBaseEntries() {
     const res = (await es.search({
       index: '.kibana-observability-ai-assistant-kb*',
+      // Add fields parameter to include inference metadata
+      fields: ['_inference_fields'],
       body: {
         query: {
           match_all: {},
         },
       },
-    })) as SearchResponse<
-      KnowledgeBaseEntry & {
-        semantic_text: {
-          text: string;
-          inference: { inference_id: string; chunks: Array<{ text: string; embeddings: any }> };
-        };
-      }
-    >;
+    })) as SearchResponse<KnowledgeBaseEntry & SemanticTextField>;
 
     return res.hits.hits;
   }
-  describe('When there are knowledge base entries (from 8.15 or earlier) that does not contain semantic_text embeddings', function () {
+
+  // Failing: See https://github.com/elastic/kibana/issues/206474
+  describe.skip('When there are knowledge base entries (from 8.15 or earlier) that does not contain semantic_text embeddings', function () {
     // security_exception: action [indices:admin/settings/update] is unauthorized for user [testing-internal] with effective roles [superuser] on restricted indices [.kibana_security_solution_1,.kibana_task_manager_1,.kibana_alerting_cases_1,.kibana_usage_counters_1,.kibana_1,.kibana_ingest_1,.kibana_analytics_1], this action is granted by the index privileges [manage,all]
     this.tags(['failsOnMKI']);
 
@@ -99,12 +117,13 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
 
           expect(
             orderBy(hits, '_source.title').map(({ _source }) => {
-              const { text, inference } = _source?.semantic_text!;
+              const text = _source?.semantic_text;
+              const inference = _source?._inference_fields?.semantic_text?.inference;
 
               return {
-                text,
-                inferenceId: inference.inference_id,
-                chunkCount: inference.chunks.length,
+                text: text ?? '',
+                inferenceId: inference?.inference_id,
+                chunkCount: inference?.chunks?.semantic_text?.length,
               };
             })
           ).to.eql([


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Obs AI Assistant] Ensure compatibility with the new semantic_text format (#206510)](https://github.com/elastic/kibana/pull/206510)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2025-01-14T18:19:18Z","message":"[Obs AI Assistant] Ensure compatibility with the new semantic_text format (#206510)\n\n## Summary\r\n\r\nElasticsearch is introducing a breaking change in `8.18` and `9.0.0` to\r\n`semantic_text` fields.\r\nThis PR ensures compatibility with this new `semantic_text` format.\r\n\r\nRelates to https://github.com/elastic/dev/issues/2936\r\n\r\n### Changes made\r\n- Remove the `inference` meta field exclusions in recalling from\r\nsemantic search connectors (the `inference` subfield won't be returned\r\nanymore with the new `semantic_text` format)\r\n- Set the `index.mapping.semantic_text.use_legacy_format` index setting\r\nto false to force the new format for KB indices and evaluation framework\r\nindices.\r\n\r\nThe following does not impact Obs AI Assistant as a part of this\r\nbreaking change:\r\n\r\n| Breaking change | Do we use it? | Is there an impact? |\r\n|--------|--------|--------|\r\n| `inner_hits` is removed and `highlight is introduced | We don't use\r\n`inner_hits` at the moment | No |\r\n| The shape of semantic text field return type is updated to a string\r\n(previously it was an object with a `text` property) | Even though we\r\nquery via the `semantic_text` field in KB entries, we don't use the\r\nresult of the `semantic_text` field in `_source` | No |\r\n| pre-computed embeddings using a new `_inference_fields` metafield |\r\nNot used | No |\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"b8cda36aa8c573a43fc47300103db6ad2b57938f","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Obs AI Assistant","backport:version","v8.18.0"],"title":"[Obs AI Assistant] Ensure compatibility with the new semantic_text format","number":206510,"url":"https://github.com/elastic/kibana/pull/206510","mergeCommit":{"message":"[Obs AI Assistant] Ensure compatibility with the new semantic_text format (#206510)\n\n## Summary\r\n\r\nElasticsearch is introducing a breaking change in `8.18` and `9.0.0` to\r\n`semantic_text` fields.\r\nThis PR ensures compatibility with this new `semantic_text` format.\r\n\r\nRelates to https://github.com/elastic/dev/issues/2936\r\n\r\n### Changes made\r\n- Remove the `inference` meta field exclusions in recalling from\r\nsemantic search connectors (the `inference` subfield won't be returned\r\nanymore with the new `semantic_text` format)\r\n- Set the `index.mapping.semantic_text.use_legacy_format` index setting\r\nto false to force the new format for KB indices and evaluation framework\r\nindices.\r\n\r\nThe following does not impact Obs AI Assistant as a part of this\r\nbreaking change:\r\n\r\n| Breaking change | Do we use it? | Is there an impact? |\r\n|--------|--------|--------|\r\n| `inner_hits` is removed and `highlight is introduced | We don't use\r\n`inner_hits` at the moment | No |\r\n| The shape of semantic text field return type is updated to a string\r\n(previously it was an object with a `text` property) | Even though we\r\nquery via the `semantic_text` field in KB entries, we don't use the\r\nresult of the `semantic_text` field in `_source` | No |\r\n| pre-computed embeddings using a new `_inference_fields` metafield |\r\nNot used | No |\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"b8cda36aa8c573a43fc47300103db6ad2b57938f"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/206510","number":206510,"mergeCommit":{"message":"[Obs AI Assistant] Ensure compatibility with the new semantic_text format (#206510)\n\n## Summary\r\n\r\nElasticsearch is introducing a breaking change in `8.18` and `9.0.0` to\r\n`semantic_text` fields.\r\nThis PR ensures compatibility with this new `semantic_text` format.\r\n\r\nRelates to https://github.com/elastic/dev/issues/2936\r\n\r\n### Changes made\r\n- Remove the `inference` meta field exclusions in recalling from\r\nsemantic search connectors (the `inference` subfield won't be returned\r\nanymore with the new `semantic_text` format)\r\n- Set the `index.mapping.semantic_text.use_legacy_format` index setting\r\nto false to force the new format for KB indices and evaluation framework\r\nindices.\r\n\r\nThe following does not impact Obs AI Assistant as a part of this\r\nbreaking change:\r\n\r\n| Breaking change | Do we use it? | Is there an impact? |\r\n|--------|--------|--------|\r\n| `inner_hits` is removed and `highlight is introduced | We don't use\r\n`inner_hits` at the moment | No |\r\n| The shape of semantic text field return type is updated to a string\r\n(previously it was an object with a `text` property) | Even though we\r\nquery via the `semantic_text` field in KB entries, we don't use the\r\nresult of the `semantic_text` field in `_source` | No |\r\n| pre-computed embeddings using a new `_inference_fields` metafield |\r\nNot used | No |\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"b8cda36aa8c573a43fc47300103db6ad2b57938f"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->