### PR TITLE
Remove build hash from Storybook upload

### DIFF
--- a/.buildkite/scripts/steps/storybooks/build_and_upload.ts
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.ts
@@ -21,7 +21,7 @@ const STORYBOOK_DIRECTORY =
     : (process.env.BUILDKITE_BRANCH ?? '').replace('/', '__');
 const STORYBOOK_BUCKET = 'ci-artifacts.kibana.dev/storybooks';
 const STORYBOOK_BUCKET_URL = `https://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}`;
-const STORYBOOK_BASE_URL = `${STORYBOOK_BUCKET_URL}/${process.env.BUILDKITE_COMMIT}`;
+const STORYBOOK_BASE_URL = `${STORYBOOK_BUCKET_URL}`;
 
 const exec = (...args: string[]) => execSync(args.join(' '), { stdio: 'inherit' });
 
@@ -80,7 +80,7 @@ const upload = () => {
     );
     exec(`
       ${activateScript} gs://ci-artifacts.kibana.dev
-      gsutil -q -m cp -r -z js,css,html,json,map,txt,svg '*' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/${process.env.BUILDKITE_COMMIT}/'
+      gsutil -q -m cp -r -z js,css,html,json,map,txt,svg '*' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/'
       gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" cp -z html 'index.html' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/latest/'
     `);
 

--- a/.buildkite/scripts/steps/storybooks/build_and_upload.ts
+++ b/.buildkite/scripts/steps/storybooks/build_and_upload.ts
@@ -80,7 +80,7 @@ const upload = () => {
     );
     exec(`
       ${activateScript} gs://ci-artifacts.kibana.dev
-      gsutil -q -m cp -r -z js,css,html,json,map,txt,svg '*' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/'
+      gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" -q -m cp -r -z js,css,html,json,map,txt,svg '*' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/'
       gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" cp -z html 'index.html' 'gs://${STORYBOOK_BUCKET}/${STORYBOOK_DIRECTORY}/latest/'
     `);
 


### PR DESCRIPTION
## Summary

After a CI run, Storybooks are built.  Each commit is built and uploaded separately, which makes sense: 

https://github.com/elastic/kibana/blob/main/.buildkite/scripts/steps/storybooks/build_and_upload.ts#L24

Unfortunately, we don't have a way to consistently point to main, or to a PR.

## PRs

Using https://github.com/elastic/kibana/pull/206540 as an example, the Storybook is currently hosted at:

https://ci-artifacts.kibana.dev/storybooks/pr-206540/803ec26fb200e1fd23c33ead174dcc5356262cfc

This means that, if I push another commit, the URL will change... so all of the links I've posted in Slack are now invalid.  This PR changes the URL so it will remain:

https://ci-artifacts.kibana.dev/storybooks/pr-206540

regardless of how many commits I push.

## `main`

Furthermore, being able to visit https://ci-artifacts.kibana.dev/storybooks/main/latest/index.html to see the most recent Storybook build is awesome.  The issue is each Storybook is hosted with that same hash:

https://ci-artifacts.kibana.dev/storybooks/main/5ad3ef7b0a76968a31b0824bd08f9132c374c841/shared_ux/index.html

So this PR alters the URL so you can consistently point to the latest Storybook build:

https://ci-artifacts.kibana.dev/storybooks/main/shared_ux/index.html

