### PR TITLE
[SecuritySolution] Skip asset criticality integration test on MKI

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/asset_criticality_csv_upload.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/asset_criticality_csv_upload.ts
@@ -12,7 +12,7 @@ import {
 } from '../../utils';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 export default ({ getService }: FtrProviderContext) => {
-  describe('@ess @serverless @serverlessQA Entity Analytics - Asset Criticality CSV upload', () => {
+  describe('@ess @serverless Entity Analytics - Asset Criticality CSV upload', () => {
     const esClient = getService('es');
     const supertest = getService('supertest');
     const assetCriticalityRoutes = assetCriticalityRouteHelpersFactory(supertest);


### PR DESCRIPTION
## Summary

The test depends on an experimental flag and it is not supported by MKI tests.



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->