### PR TITLE
🌊 Streams: Fix routing UI for no-condition routing

### DIFF
--- a/x-pack/solutions/observability/plugins/streams_app/public/components/condition_editor/index.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/condition_editor/index.tsx
@@ -7,6 +7,7 @@
 
 import {
   EuiBadge,
+  EuiButtonEmpty,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -14,6 +15,7 @@ import {
   EuiSelect,
   EuiSwitch,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import {
   AndCondition,
@@ -64,7 +66,7 @@ export function ConditionForm(props: {
   }, [syntaxEditor, props.condition]);
   return (
     <EuiFlexGroup direction="column" gutterSize="xs">
-      <EuiFlexGroup>
+      <EuiFlexGroup alignItems="center" gutterSize="xs">
         <EuiFlexItem grow>
           <EuiText
             className={css`
@@ -75,6 +77,22 @@ export function ConditionForm(props: {
             {i18n.translate('xpack.streams.conditionEditor.title', { defaultMessage: 'Condition' })}
           </EuiText>
         </EuiFlexItem>
+        <EuiToolTip
+          content={i18n.translate('xpack.streams.conditionEditor.disableTooltip', {
+            defaultMessage: 'Route no documents to this stream without deleting existing data',
+          })}
+        >
+          <EuiButtonEmpty
+            size="xs"
+            onClick={() => props.onConditionChange(undefined)}
+            disabled={props.condition === undefined}
+          >
+            {i18n.translate('xpack.streams.conditionEditor.disable', {
+              defaultMessage: 'Disable routing',
+            })}
+          </EuiButtonEmpty>
+        </EuiToolTip>
+
         <EuiSwitch
           label={i18n.translate('xpack.streams.conditionEditor.switch', {
             defaultMessage: 'Syntax editor',

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/condition_editor/index.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/condition_editor/index.tsx
@@ -7,7 +7,7 @@
 
 import {
   EuiBadge,
-  EuiButtonEmpty,
+  EuiButton,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -82,15 +82,15 @@ export function ConditionForm(props: {
             defaultMessage: 'Route no documents to this stream without deleting existing data',
           })}
         >
-          <EuiButtonEmpty
-            size="xs"
+          <EuiButton
+            size={'xs' as 's'} // TODO: remove this cast when EUI is updated - EuiButton takes xs, but the type is wrong
             onClick={() => props.onConditionChange(undefined)}
             disabled={props.condition === undefined}
           >
             {i18n.translate('xpack.streams.conditionEditor.disable', {
               defaultMessage: 'Disable routing',
             })}
-          </EuiButtonEmpty>
+          </EuiButton>
         </EuiToolTip>
 
         <EuiSwitch

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/condition_editor/index.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/condition_editor/index.tsx
@@ -32,9 +32,6 @@ export function ConditionEditor(props: {
   readonly?: boolean;
   onConditionChange?: (condition: Condition) => void;
 }) {
-  if (!props.condition) {
-    return null;
-  }
   if (props.readonly) {
     return (
       <EuiPanel color="subdued" borderRadius="none" hasShadow={false} paddingSize="xs">
@@ -102,16 +99,15 @@ export function ConditionForm(props: {
             }
           }}
         />
+      ) : !props.condition || 'operator' in props.condition ? (
+        <FilterForm
+          condition={
+            (props.condition as FilterCondition) || { field: '', operator: 'eq', value: '' }
+          }
+          onConditionChange={props.onConditionChange}
+        />
       ) : (
-        props.condition &&
-        ('operator' in props.condition ? (
-          <FilterForm
-            condition={props.condition as FilterCondition}
-            onConditionChange={props.onConditionChange}
-          />
-        ) : (
-          <pre>{JSON.stringify(props.condition, null, 2)}</pre>
-        ))
+        <pre>{JSON.stringify(props.condition, null, 2)}</pre>
       )}
     </EuiFlexGroup>
   );
@@ -213,7 +209,13 @@ function FilterForm(props: {
 
 export function ConditionDisplay(props: { condition: Condition }) {
   if (!props.condition) {
-    return null;
+    return (
+      <>
+        {i18n.translate('xpack.streams.streamDetailRouting.noCondition', {
+          defaultMessage: 'No condition, no documents will be routed',
+        })}
+      </>
+    );
   }
   return (
     <>

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_routing/index.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_routing/index.tsx
@@ -839,7 +839,10 @@ function RoutingStreamEntry({
                 color="transparent"
                 paddingSize="s"
                 {...draggableProvided.dragHandleProps}
-                aria-label="Drag Handle"
+                aria-label={i18n.translate(
+                  'xpack.streams.routingStreamEntry.euiPanel.dragHandleLabel',
+                  { defaultMessage: 'Drag Handle' }
+                )}
               >
                 <EuiIcon type="grab" />
               </EuiPanel>
@@ -875,25 +878,16 @@ function RoutingStreamEntry({
           })}
         />
       </EuiFlexGroup>
-      {child.condition && (
-        <ConditionEditor
-          readonly={!edit}
-          condition={child.condition}
-          onConditionChange={(condition) => {
-            onChildChange({
-              ...child,
-              condition,
-            });
-          }}
-        />
-      )}
-      {!child.condition && (
-        <EuiText>
-          {i18n.translate('xpack.streams.streamDetailRouting.noCondition', {
-            defaultMessage: 'No condition, no documents will be routed',
-          })}
-        </EuiText>
-      )}
+      <ConditionEditor
+        readonly={!edit}
+        condition={child.condition}
+        onConditionChange={(condition) => {
+          onChildChange({
+            ...child,
+            condition,
+          });
+        }}
+      />
     </EuiPanel>
   );
 }
@@ -927,25 +921,16 @@ function NewRoutingStreamEntry({
             }}
           />
         </EuiFormRow>
-        {child.condition && (
-          <ConditionEditor
-            readonly={false}
-            condition={child.condition}
-            onConditionChange={(condition) => {
-              onChildChange({
-                ...child,
-                condition,
-              });
-            }}
-          />
-        )}
-        {!child.condition && (
-          <EuiText>
-            {i18n.translate('xpack.streams.streamDetailRouting.noCondition', {
-              defaultMessage: 'No condition, no documents will be routed',
-            })}
-          </EuiText>
-        )}
+        <ConditionEditor
+          readonly={false}
+          condition={child.condition}
+          onConditionChange={(condition) => {
+            onChildChange({
+              ...child,
+              condition,
+            });
+          }}
+        />
       </EuiFlexGroup>
     </EuiPanel>
   );


### PR DESCRIPTION
It is possible for a stream to end up with no routing condition. This is useful to stop routing to a child, but keep the child stream around. Currently, this is not handled well by the UI - the font size is wrong and there is no way to change it:
<img width="671" alt="Screenshot 2025-01-15 at 13 25 12" src="https://github.com/user-attachments/assets/25d45969-eff8-449b-9f75-831aa6c46a25" />

This PR fixes this:
<img width="684" alt="Screenshot 2025-01-15 at 13 24 38" src="https://github.com/user-attachments/assets/dd9399e9-0841-4962-a8af-b15dc922cc6d" />

<img width="660" alt="Screenshot 2025-01-15 at 13 33 47" src="https://github.com/user-attachments/assets/c0a33aec-3c94-46c4-b440-2d582522f89e" />



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->