### PR TITLE
[APM] Wrap Chart component in EuiErrorBoundary for improved error handling

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/metric_item.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/metric_item.tsx
@@ -9,6 +9,7 @@ import type { MetricDatum } from '@elastic/charts';
 import { Chart, Metric } from '@elastic/charts';
 import { EuiSkeletonText, EuiPanel } from '@elastic/eui';
 import { isEmpty } from 'lodash';
+import { EuiErrorBoundary } from '@elastic/eui';
 
 export function MetricItem({
   data,
@@ -37,9 +38,11 @@ export function MetricItem({
           <EuiSkeletonText lines={3} />
         </EuiPanel>
       ) : (
-        <Chart>
-          <Metric id={`metric_${id}`} data={[data]} />
-        </Chart>
+        <EuiErrorBoundary>
+          <Chart>
+            <Metric id={`metric_${id}`} data={[data]} />
+          </Chart>
+        </EuiErrorBoundary>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

In this PR we are wrapping the `Chart` component in `EuiErrorBoundary` to prevent getting a full screen error because some of the charts fail in the Service Overview screen.

This is now needed because of the [update of `@elastic/charts` from 68.0.4 to 68.1.0](https://github.com/elastic/kibana/pull/206497).

|Before|After|
|-|-|
|![Screenshot 2025-01-15 at 13 39 07](https://github.com/user-attachments/assets/4e10cb5c-eb9a-47ad-9acd-0d5a46818395)|![Screenshot 2025-01-15 at 12 17 05](https://github.com/user-attachments/assets/f8052b24-18bc-49e9-8776-e6932b54a527)|


>[!IMPORTANT]
>This PR will be followed by [another](https://github.com/elastic/kibana/pull/206762) to properly address the error triggered by the charts. For now, we need this one to silence the failing Cypress tests in some CI runs and ensure that at least the functioning charts are displayed on the screen.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->