### PR TITLE
[APM] Set metric trend to an empty array if undefined in MobileLocationStats

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/location_stats.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/location_stats.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { MetricDatum } from '@elastic/charts';
+import type { MetricWTrend } from '@elastic/charts';
 import { MetricTrendShape } from '@elastic/charts';
 import { i18n } from '@kbn/i18n';
 import { EuiIcon, EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, useEuiTheme } from '@elastic/eui';
@@ -105,7 +105,7 @@ export function MobileLocationStats({
     [comparisonEnabled, previousPeriodLabel]
   );
 
-  const metrics: MetricDatum[] = [
+  const metrics: MetricWTrend[] = [
     {
       color: euiTheme.colors.lightestShade,
       title: i18n.translate('xpack.apm.mobile.location.metrics.http.requests.title', {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/location_stats.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/location_stats.tsx
@@ -117,7 +117,7 @@ export function MobileLocationStats({
       }),
       icon: getIcon('visBarHorizontal'),
       value: currentPeriod?.mostRequests.location ?? NOT_AVAILABLE_LABEL,
-      trend: currentPeriod?.mostRequests.timeseries,
+      trend: currentPeriod?.mostRequests.timeseries || [],
       trendShape: MetricTrendShape.Area,
     },
     {
@@ -131,7 +131,7 @@ export function MobileLocationStats({
       }),
       icon: getIcon('bug'),
       value: currentPeriod?.mostCrashes.location ?? NOT_AVAILABLE_LABEL,
-      trend: currentPeriod?.mostCrashes.timeseries,
+      trend: currentPeriod?.mostCrashes.timeseries || [],
       trendShape: MetricTrendShape.Area,
     },
     {
@@ -145,7 +145,7 @@ export function MobileLocationStats({
       }),
       icon: getIcon('timeslider'),
       value: currentPeriod?.mostSessions.location ?? NOT_AVAILABLE_LABEL,
-      trend: currentPeriod?.mostSessions.timeseries,
+      trend: currentPeriod?.mostSessions.timeseries || [],
       trendShape: MetricTrendShape.Area,
     },
     {
@@ -159,7 +159,7 @@ export function MobileLocationStats({
       }),
       icon: getIcon('launch'),
       value: currentPeriod?.mostLaunches.location ?? NOT_AVAILABLE_LABEL,
-      trend: currentPeriod?.mostLaunches.timeseries,
+      trend: currentPeriod?.mostLaunches.timeseries || [],
       trendShape: MetricTrendShape.Area,
     },
   ];

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/location_stats.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/mobile/service_overview/stats/location_stats.tsx
@@ -117,7 +117,7 @@ export function MobileLocationStats({
       }),
       icon: getIcon('visBarHorizontal'),
       value: currentPeriod?.mostRequests.location ?? NOT_AVAILABLE_LABEL,
-      trend: currentPeriod?.mostRequests.timeseries || [],
+      trend: currentPeriod?.mostRequests.timeseries ?? [],
       trendShape: MetricTrendShape.Area,
     },
     {
@@ -131,7 +131,7 @@ export function MobileLocationStats({
       }),
       icon: getIcon('bug'),
       value: currentPeriod?.mostCrashes.location ?? NOT_AVAILABLE_LABEL,
-      trend: currentPeriod?.mostCrashes.timeseries || [],
+      trend: currentPeriod?.mostCrashes.timeseries ?? [],
       trendShape: MetricTrendShape.Area,
     },
     {
@@ -145,7 +145,7 @@ export function MobileLocationStats({
       }),
       icon: getIcon('timeslider'),
       value: currentPeriod?.mostSessions.location ?? NOT_AVAILABLE_LABEL,
-      trend: currentPeriod?.mostSessions.timeseries || [],
+      trend: currentPeriod?.mostSessions.timeseries ?? [],
       trendShape: MetricTrendShape.Area,
     },
     {
@@ -159,7 +159,7 @@ export function MobileLocationStats({
       }),
       icon: getIcon('launch'),
       value: currentPeriod?.mostLaunches.location ?? NOT_AVAILABLE_LABEL,
-      trend: currentPeriod?.mostLaunches.timeseries || [],
+      trend: currentPeriod?.mostLaunches.timeseries ?? [],
       trendShape: MetricTrendShape.Area,
     },
   ];


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/206712

This PR addresses an issue with the `MobileLocationStats` component in the Service Overview.

In one of our charts, we were passing data to a `Metric` component where the `trend` property was set to `undefined`. By definition, it should be an empty array if there's no value. Initially, this wasn’t an issue because no error appeared visually. However, after an update to the `@elastic/charts` library, a full-screen error was triggered.

Additionally, a conversation has been initiated with the maintainers of `@elastic/charts` to explore making the typings stricter, as we didn’t receive any TypeScript warnings, even though the `trend` property should not be `undefined`.

|Before|After|
|-|-|
|![Screenshot 2025-01-15 at 13 56 56](https://github.com/user-attachments/assets/19e2ae8e-73ca-4c65-ae6f-1d4d5bce5c1e)|![Screenshot 2025-01-15 at 13 57 44](https://github.com/user-attachments/assets/89ee9eff-17d2-47f7-b38b-c95423e76d78)|




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->