### PR TITLE
Add Criticality badge to Asset Inventory data grid

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
@@ -39,6 +39,7 @@ import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { type CriticalityLevelWithUnassigned } from '../../../common/entity_analytics/asset_criticality/types';
 import { useKibana } from '../../common/lib/kibana';
 
+import { AssetCriticalityBadge } from '../../entity_analytics/components/asset_criticality/asset_criticality_badge';
 import { EmptyState } from '../components/empty_state';
 import { AdditionalControls } from '../components/additional_controls';
 
@@ -96,7 +97,7 @@ const customCellRenderer = (rows: DataTableRecord[]) => ({
     const criticality = rows[rowIndex].flattened[
       'asset.criticality'
     ] as CriticalityLevelWithUnassigned;
-    return criticality;
+    return <AssetCriticalityBadge criticalityLevel={criticality} />;
   },
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/sample_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/sample_data.ts
@@ -68,7 +68,7 @@ export const mockData = [
     flattened: {
       'asset.risk': 65,
       'asset.name': 'kube-controller-cspm-monitor',
-      'asset.criticality': null,
+      'asset.criticality': 'unassigned_impact',
       'asset.source': 'cloud-sec-dev',
       '@timestamp': '2025-01-01T00:00:00.000Z',
     },
@@ -101,7 +101,7 @@ export const mockData = [
     flattened: {
       'asset.risk': 85,
       'asset.name': 'DNS-controller-azure-sec',
-      'asset.criticality': null,
+      'asset.criticality': 'unassigned_impact',
       'asset.source': 'cloud-sec-dev',
       '@timestamp': '2025-01-01T00:00:00.000Z',
     },


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/security-team/issues/11463.

Reuse AssetCriticalityBadge component from Entity Analytics to render the criticality status in the Asset Inventory data grid.

### Screenshots

| Before | After |
|--------|--------|
| <img width="168" alt="Screenshot 2025-01-16 at 17 16 21" src="https://github.com/user-attachments/assets/45d23ce9-a8dc-4f0c-8545-39afff824708" /> | <img width="169" alt="Screenshot 2025-01-16 at 17 16 09" src="https://github.com/user-attachments/assets/b3b6bedf-cdb9-49b5-9c1f-6dd3d24b3389" /> | 

### Definition of done

- [x] Add a **Criticality** circle badge to the **Criticality** column in the Asset Inventory DataGrid.
- [x] ~~Implement the badge styling:~~ Ended up reusing `AssetCriticalityBadge` component from Entity Analytics
  - Use the **Criticality Palette and mapping** defined in the [Asset Criticality Badge Utility](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/asset_criticality/asset_criticality_badge.tsx)] for color coding.
  - Ensure the badge's color accurately reflects the asset’s criticality level (e.g., Low, Medium, High, Critical, Extreme).
- [x] Ensure the badge includes:
  - A circular design with a color representing the criticality level.
- [ ] Add unit tests to verify:
  - Correct color mapping based on criticality levels.
  - Proper rendering of the badge in the DataGrid.
- [x] Update mock data for the DataGrid to include criticality levels for testing and development.

### Checklist

- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

No risks.