### PR TITLE
[AI Assistant] Icon render fix

### DIFF
--- a/x-pack/platform/packages/shared/ai-assistant/icon/icon.tsx
+++ b/x-pack/platform/packages/shared/ai-assistant/icon/icon.tsx
@@ -7,7 +7,8 @@
 
 import React from 'react';
 import { EuiIcon, EuiIconProps } from '@elastic/eui';
-import { dynamic } from '@kbn/shared-ux-utility';
+// TODO: can be removed once added to EUI.
+import assistantIcon from './svg/assistant';
 
 /**
  * Props for the AI Assistant icon.
@@ -18,7 +19,5 @@ export type AssistantIconProps = Omit<EuiIconProps, 'type'>;
  * Default Elastic AI Assistant icon.
  */
 export const AssistantIcon = ({ size = 'm', ...rest }: AssistantIconProps) => {
-  // TODO: can be removed once added to EUI.
-  const type = dynamic(() => import('./svg/assistant'));
-  return <EuiIcon {...{ type, size, ...rest }} />;
+  return <EuiIcon {...{ type: assistantIcon, size, ...rest }} />;
 };

--- a/x-pack/platform/packages/shared/ai-assistant/icon/tsconfig.json
+++ b/x-pack/platform/packages/shared/ai-assistant/icon/tsconfig.json
@@ -18,6 +18,5 @@
     "target/**/*"
   ],
   "kbn_references": [
-    "@kbn/shared-ux-utility",
   ]
 }


### PR DESCRIPTION
## Summary

We found that when the ai assistant icon component re-renders, there was a flash of empty icon. Moving the import outside of the component fixes the issue.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->