### PR TITLE
[Maps] Update @elastic/ems-client to 8.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@elastic/ebt": "^1.1.1",
     "@elastic/ecs": "^8.11.5",
     "@elastic/elasticsearch": "^8.16.0",
-    "@elastic/ems-client": "8.6.2",
+    "@elastic/ems-client": "8.6.3",
     "@elastic/eui": "99.0.0-borealis.1",
     "@elastic/eui-theme-borealis": "0.0.8",
     "@elastic/filesaver": "1.1.2",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -86,7 +86,7 @@ export const PER_PACKAGE_ALLOWED_LICENSES = {
 export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
-  '@elastic/ems-client@8.6.2': ['Elastic License 2.0'],
+  '@elastic/ems-client@8.6.3': ['Elastic License 2.0'],
   '@elastic/eui@99.0.0-borealis.1': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
   '@elastic/eui-theme-borealis@0.0.8': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry

--- a/yarn.lock
+++ b/yarn.lock
@@ -2313,10 +2313,10 @@
     apache-arrow "^18.0.0"
     tslib "^2.4.0"
 
-"@elastic/ems-client@8.6.2":
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-8.6.2.tgz#cdca0a063756391705492f1d301a33a314464d8e"
-  integrity sha512-bhbR6BmrA5pNEDI/ais9V3612KPimx6NLacViOc1QpRw9oNGfQPRQVSOwd7IXzCn2eJKgBJoTWBgJGu6sjvZ4g==
+"@elastic/ems-client@8.6.3":
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-8.6.3.tgz#9c5e29645516380c3550a33f2567456d38115b9f"
+  integrity sha512-ha8vsuT+AVsIThErXRNe3s8wwZCGI4EzJIbeXeFZoMcnD/x3t3DTOWwfSH1ov9RpDXKj5e8i4GkbvGDgPaLooQ==
   dependencies:
     "@types/geojson" "7946.0.15"
     "@types/topojson-client" "3.1.5"


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/ems-client/issues/543 and https://github.com/elastic/kibana/issues/198790

Updates `@elastic/ems-client@8.6.3` adding support for Node 22.x

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->