### PR TITLE
[8.17] [Obs AI Assistant] fix knowledge base installation state (#206130)

### DIFF
--- a/x-pack/packages/kbn-ai-assistant/src/chat/welcome_message.tsx
+++ b/x-pack/packages/kbn-ai-assistant/src/chat/welcome_message.tsx
@@ -85,7 +85,7 @@ export function WelcomeMessage({
             connectors={connectors}
             onSetupConnectorClick={handleConnectorClick}
           />
-          {knowledgeBase.status.value?.enabled ? (
+          {knowledgeBase.status.value?.enabled && connectors.connectors?.length ? (
             <WelcomeMessageKnowledgeBase connectors={connectors} knowledgeBase={knowledgeBase} />
           ) : null}
         </EuiFlexItem>

--- a/x-pack/packages/kbn-ai-assistant/src/chat/welcome_message_knowledge_base.test.tsx
+++ b/x-pack/packages/kbn-ai-assistant/src/chat/welcome_message_knowledge_base.test.tsx
@@ -1,0 +1,266 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+
+import { WelcomeMessageKnowledgeBase } from './welcome_message_knowledge_base';
+import type { UseGenAIConnectorsResult } from '../hooks/use_genai_connectors';
+import type { UseKnowledgeBaseResult } from '../hooks/use_knowledge_base';
+
+describe('WelcomeMessageKnowledgeBase', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  type StatusType = NonNullable<UseKnowledgeBaseResult['status']['value']>;
+  type EndpointType = StatusType['endpoint'];
+  const endpoint: EndpointType = {
+    inference_id: 'obs_ai_assistant_kb_inference',
+    task_type: 'sparse_embedding',
+    service: 'elasticsearch',
+    service_settings: {
+      num_threads: 1,
+      model_id: '.elser_model_2',
+      adaptive_allocations: {
+        enabled: true,
+        min_number_of_allocations: 1,
+      },
+    },
+  };
+  const initKnowledgeBase: UseKnowledgeBaseResult = {
+    isInstalling: false,
+    install: jest.fn(),
+    installError: undefined,
+    status: {
+      value: {
+        ready: false,
+        enabled: true,
+        errorMessage: 'error',
+      },
+      loading: false,
+      refresh: jest.fn(),
+    },
+  };
+  const defaultConnectors: UseGenAIConnectorsResult = {
+    connectors: [
+      {
+        id: 'default-connector-id',
+        actionTypeId: 'action-type-id',
+        name: 'Default Connector',
+        isPreconfigured: false,
+        isDeprecated: false,
+        isSystemAction: false,
+        referencedByCount: 0,
+      },
+    ],
+    selectedConnector: undefined,
+    loading: false,
+    error: undefined,
+    selectConnector: jest.fn(),
+    reloadConnectors: jest.fn(),
+  };
+  function renderComponent({
+    knowledgeBase,
+    connectors,
+  }: {
+    knowledgeBase: Partial<UseKnowledgeBaseResult>;
+    connectors: Partial<UseGenAIConnectorsResult>;
+  }) {
+    const mergedKnowledgeBase: UseKnowledgeBaseResult = {
+      ...initKnowledgeBase,
+      ...knowledgeBase,
+      status: {
+        ...initKnowledgeBase.status,
+        ...knowledgeBase.status,
+      },
+    };
+
+    return render(
+      <WelcomeMessageKnowledgeBase
+        knowledgeBase={mergedKnowledgeBase}
+        connectors={defaultConnectors}
+      />
+    );
+  }
+
+  it('renders "Setting up Knowledge base" message while inference endpoint is installing', () => {
+    renderComponent({
+      knowledgeBase: {
+        isInstalling: true,
+      },
+      connectors: defaultConnectors,
+    });
+
+    expect(
+      screen.getByText('We are setting up your knowledge base', { exact: false })
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Setting up Knowledge base', { exact: false })).toBeInTheDocument();
+  });
+  it('renders "Setting up Knowledge base" message while model is being deployed without deployment or allocation state yet being reported', () => {
+    renderComponent({
+      knowledgeBase: {
+        isInstalling: false,
+        status: {
+          value: {
+            endpoint,
+            ready: false,
+            enabled: true,
+            model_stats: { allocation_count: 0 },
+          },
+          loading: false,
+          refresh: jest.fn(),
+        },
+      },
+      connectors: defaultConnectors,
+    });
+    expect(
+      screen.getByText('We are setting up your knowledge base', { exact: false })
+    ).toBeInTheDocument();
+  });
+  it('renders "Setting up Knowledge base" message while model is being deployed and starting', () => {
+    renderComponent({
+      knowledgeBase: {
+        isInstalling: false,
+        status: {
+          value: {
+            endpoint,
+            ready: false,
+            enabled: true,
+            model_stats: {
+              deployment_state: 'starting',
+              allocation_state: 'starting',
+            },
+          },
+          loading: false,
+          refresh: jest.fn(),
+        },
+      },
+      connectors: defaultConnectors,
+    });
+
+    expect(
+      screen.getByText('We are setting up your knowledge base', { exact: false })
+    ).toBeInTheDocument();
+  });
+  it('displays success message after installation and hides it after timeout', async () => {
+    jest.useFakeTimers();
+
+    // Step 1: Initially not installed
+    const { rerender } = renderComponent({
+      knowledgeBase: {
+        isInstalling: true,
+      },
+      connectors: defaultConnectors,
+    });
+
+    // Step 2: Now it's ready
+    await act(async () => {
+      rerender(
+        <WelcomeMessageKnowledgeBase
+          knowledgeBase={{
+            ...initKnowledgeBase,
+            status: {
+              ...initKnowledgeBase.status,
+              value: {
+                ready: true,
+                enabled: true,
+                model_stats: { deployment_state: 'started', allocation_state: 'started' },
+              },
+            },
+          }}
+          connectors={defaultConnectors}
+        />
+      );
+    });
+
+    // the success message should appear
+    expect(screen.queryByText(/Knowledge base successfully installed/i)).toBeInTheDocument();
+
+    // fast-forward until the success message would disappear
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+
+    // now it should be gone
+    expect(screen.queryByText('Knowledge base successfully installed')).toBeNull();
+  });
+
+  it('renders no install messages when model has been installed and ready', () => {
+    // component should render nothing in this state (null)
+    renderComponent({
+      knowledgeBase: {
+        isInstalling: false,
+        status: {
+          ...initKnowledgeBase.status,
+          value: {
+            ready: true,
+            enabled: true,
+            model_stats: { deployment_state: 'started', allocation_state: 'started' },
+          },
+        },
+      },
+      connectors: defaultConnectors,
+    });
+    expect(screen.queryByText(/We are setting up your knowledge base/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Your Knowledge base hasn't been set up./i)).not.toBeInTheDocument();
+  });
+
+  it('renders knowledge base install and model state inspect when not installing and the inference endpoint installation has an error', () => {
+    renderComponent({
+      knowledgeBase: {
+        isInstalling: false,
+        installError: new Error('inference endpoint failed to install'),
+      },
+      connectors: defaultConnectors,
+    });
+    expect(
+      screen.getByText("Your Knowledge base hasn't been set up", { exact: false })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Install Knowledge base', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('Inspect issues', { exact: false })).toBeInTheDocument();
+  });
+
+  it('renders knowledge base install and model state inspect when not installing and no errors', () => {
+    // this can happen when you have a preconfigured connector,
+    // we don't automatically install in this case and just show the same UI as if there was an issue/error
+    renderComponent({
+      knowledgeBase: {
+        isInstalling: false,
+      },
+      connectors: defaultConnectors,
+    });
+    expect(
+      screen.getByText("Your Knowledge base hasn't been set up", { exact: false })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Install Knowledge base', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('Inspect issues', { exact: false })).toBeInTheDocument();
+  });
+
+  it('renders knowledge base install and model state inspect when not installing and model is not ready', () => {
+    // this state can occur if the model is having a deployment problem
+    renderComponent({
+      knowledgeBase: {
+        isInstalling: false,
+        status: {
+          ...initKnowledgeBase.status,
+          value: {
+            ready: false,
+            enabled: true,
+            model_stats: { deployment_state: 'failed', allocation_state: 'started' },
+          },
+        },
+      },
+      connectors: defaultConnectors,
+    });
+    expect(
+      screen.getByText("Your Knowledge base hasn't been set up", { exact: false })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Install Knowledge base', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('Inspect issues', { exact: false })).toBeInTheDocument();
+  });
+});

--- a/x-pack/packages/kbn-ai-assistant/src/chat/welcome_message_knowledge_base.tsx
+++ b/x-pack/packages/kbn-ai-assistant/src/chat/welcome_message_knowledge_base.tsx
@@ -40,44 +40,61 @@ export function WelcomeMessageKnowledgeBase({
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const handleClosePopover = () => setIsPopoverOpen(false);
 
-  const [checkForInstallStatus, setCheckForInstallStatus] = useState(false);
+  const [pollKnowledgeBaseStatus, setPollKnowledgeBaseStatus] = useState(false);
 
-  // When the knowledge base is installed, show a success message for 3 seconds
+  // Tracks whether the inference endpoint creation process has started
+  const inferenceEndpointIsInstalling = knowledgeBase.isInstalling;
+
+  // Tracks whether the model is fully ready
+  const modelIsReady = knowledgeBase.status.value?.ready === true;
+
+  // Determines if the model deployment is still in progress
+  // This happens when the model is not ready but the endpoint exists
+  const modelDeploymentInProgress = !modelIsReady && !!knowledgeBase.status.value?.endpoint;
+
+  // Determines if the overall installation process is ongoing
+  // Covers both the endpoint setup phase and the model deployment phase
+  const isInstalling = inferenceEndpointIsInstalling || modelDeploymentInProgress;
+  // start polling kb status if inference endpoint is being created or has been created but model isn't ready
   useEffect(() => {
-    if (previouslyNotInstalled && knowledgeBase.status.value?.ready) {
+    if (isInstalling) {
+      setPollKnowledgeBaseStatus(true);
+    }
+  }, [isInstalling]);
+
+  // When the knowledge base is installed and ready, show a success message for 3 seconds
+  useEffect(() => {
+    if (previouslyNotInstalled && modelIsReady) {
       setTimeoutTime(3000);
       reset();
       setShowHasBeenInstalled(true);
     }
-  }, [knowledgeBase.status.value?.ready, previouslyNotInstalled, reset]);
+  }, [modelIsReady, previouslyNotInstalled, reset]);
 
-  // When the knowledge base is installed, stop checking for install status
+  // When the knowledge base is ready, stop polling for status
   useEffect(() => {
-    if (!checkForInstallStatus && knowledgeBase.status.value?.ready) {
-      setCheckForInstallStatus(false);
+    if (modelIsReady) {
+      setPollKnowledgeBaseStatus(false);
     }
-  }, [checkForInstallStatus, knowledgeBase.status.value?.ready]);
+  }, [modelIsReady]);
 
-  // Check for install status every 5 seconds
+  // poll for knowledge base status every 5 seconds
   useInterval(
     () => {
       knowledgeBase.status.refresh();
     },
-    checkForInstallStatus ? 5000 : null
+    pollKnowledgeBaseStatus ? 5000 : null
   );
 
-  const handleRetryInstall = async () => {
-    setCheckForInstallStatus(true);
+  // gets called if there was an error previously during install or user has a preconfigured connector
+  // and is first time installing
+  const handleInstall = async () => {
     setIsPopoverOpen(false);
-
-    await knowledgeBase.install().then(() => {
-      setCheckForInstallStatus(false);
-    });
+    await knowledgeBase.install();
   };
-
-  return knowledgeBase.status.value?.ready !== undefined ? (
+  return modelIsReady !== undefined ? (
     <>
-      {knowledgeBase.isInstalling ? (
+      {isInstalling ? (
         <>
           <EuiText color="subdued" size="s">
             {i18n.translate('xpack.aiAssistant.welcomeMessage.weAreSettingUpTextLabel', {
@@ -100,69 +117,72 @@ export function WelcomeMessageKnowledgeBase({
         </>
       ) : null}
 
-      {connectors.connectors?.length ? (
-        (!knowledgeBase.isInstalling && knowledgeBase.installError) ||
-        (!knowledgeBase.isInstalling &&
-          knowledgeBase.status.loading === false &&
-          knowledgeBase.status.value.ready === false) ? (
-          <>
-            <EuiText color="subdued" size="s">
-              {i18n.translate(
-                'xpack.aiAssistant.welcomeMessageKnowledgeBase.yourKnowledgeBaseIsNotSetUpCorrectlyLabel',
-                { defaultMessage: `Your Knowledge base hasn't been set up.` }
-              )}
-            </EuiText>
+      {
+        // not currently installing
+        // and has an inference install error (timeout, etc) or model is not ready
+        // this state is when the user has a preconfigured connector and we prompt to install
+        // or there was a problem deploying the model
+        !isInstalling ? (
+          knowledgeBase.installError || !modelIsReady ? (
+            <>
+              <EuiText color="subdued" size="s">
+                {i18n.translate(
+                  'xpack.aiAssistant.welcomeMessageKnowledgeBase.yourKnowledgeBaseIsNotSetUpCorrectlyLabel',
+                  { defaultMessage: `Your Knowledge base hasn't been set up.` }
+                )}
+              </EuiText>
 
-            <EuiSpacer size="m" />
+              <EuiSpacer size="m" />
 
-            <EuiFlexGroup justifyContent="center">
-              <EuiFlexItem grow={false}>
-                <div>
-                  <EuiButton
-                    color="primary"
-                    data-test-subj="observabilityAiAssistantWelcomeMessageSetUpKnowledgeBaseButton"
-                    fill
-                    isLoading={checkForInstallStatus}
-                    iconType="importAction"
-                    onClick={handleRetryInstall}
-                  >
-                    {i18n.translate('xpack.aiAssistant.welcomeMessage.retryButtonLabel', {
-                      defaultMessage: 'Install Knowledge base',
-                    })}
-                  </EuiButton>
-                </div>
-              </EuiFlexItem>
-
-              <EuiFlexItem grow={false}>
-                <EuiPopover
-                  button={
-                    <EuiButtonEmpty
-                      data-test-subj="observabilityAiAssistantWelcomeMessageInspectErrorsButton"
-                      iconType="inspect"
-                      onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+              <EuiFlexGroup justifyContent="center">
+                <EuiFlexItem grow={false}>
+                  <div>
+                    <EuiButton
+                      color="primary"
+                      data-test-subj="observabilityAiAssistantWelcomeMessageSetUpKnowledgeBaseButton"
+                      fill
+                      isLoading={false}
+                      iconType="importAction"
+                      onClick={handleInstall}
                     >
-                      {i18n.translate(
-                        'xpack.aiAssistant.welcomeMessage.inspectErrorsButtonEmptyLabel',
-                        { defaultMessage: 'Inspect issues' }
-                      )}
-                    </EuiButtonEmpty>
-                  }
-                  isOpen={isPopoverOpen}
-                  panelPaddingSize="none"
-                  closePopover={handleClosePopover}
-                >
-                  <WelcomeMessageKnowledgeBaseSetupErrorPanel
-                    knowledgeBase={knowledgeBase}
-                    onRetryInstall={handleRetryInstall}
-                  />
-                </EuiPopover>
-              </EuiFlexItem>
-            </EuiFlexGroup>
+                      {i18n.translate('xpack.aiAssistant.welcomeMessage.retryButtonLabel', {
+                        defaultMessage: 'Install Knowledge base',
+                      })}
+                    </EuiButton>
+                  </div>
+                </EuiFlexItem>
 
-            <EuiSpacer size="m" />
-          </>
+                <EuiFlexItem grow={false}>
+                  <EuiPopover
+                    button={
+                      <EuiButtonEmpty
+                        data-test-subj="observabilityAiAssistantWelcomeMessageInspectErrorsButton"
+                        iconType="inspect"
+                        onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+                      >
+                        {i18n.translate(
+                          'xpack.aiAssistant.welcomeMessage.inspectErrorsButtonEmptyLabel',
+                          { defaultMessage: 'Inspect issues' }
+                        )}
+                      </EuiButtonEmpty>
+                    }
+                    isOpen={isPopoverOpen}
+                    panelPaddingSize="none"
+                    closePopover={handleClosePopover}
+                  >
+                    <WelcomeMessageKnowledgeBaseSetupErrorPanel
+                      knowledgeBase={knowledgeBase}
+                      onRetryInstall={handleInstall}
+                    />
+                  </EuiPopover>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+
+              <EuiSpacer size="m" />
+            </>
+          ) : null
         ) : null
-      ) : null}
+      }
 
       {showHasBeenInstalled ? (
         <div>

--- a/x-pack/packages/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
+++ b/x-pack/packages/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
@@ -62,8 +62,8 @@ export function useKnowledgeBase(): UseKnowledgeBaseResult {
           }
           setInstallError(error);
           notifications!.toasts.addError(error, {
-            title: i18n.translate('xpack.aiAssistant.errorSettingUpKnowledgeBase', {
-              defaultMessage: 'Could not set up Knowledge Base',
+            title: i18n.translate('xpack.aiAssistant.errorSettingUpInferenceEndpoint', {
+              defaultMessage: 'Could not create inference endpoint',
             }),
           });
         })

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/routes/knowledge_base/route.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/routes/knowledge_base/route.ts
@@ -12,7 +12,8 @@ import * as t from 'io-ts';
 import {
   InferenceInferenceEndpointInfo,
   MlDeploymentAllocationState,
-  MlDeploymentState,
+  MlDeploymentAssignmentState,
+  MlTrainedModelDeploymentAllocationStatus,
 } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import moment from 'moment';
 import { createObservabilityAIAssistantServerRoute } from '../create_observability_ai_assistant_server_route';
@@ -32,8 +33,9 @@ const getKnowledgeBaseStatus = createObservabilityAIAssistantServerRoute({
     enabled: boolean;
     endpoint?: Partial<InferenceInferenceEndpointInfo>;
     model_stats?: {
-      deployment_state: MlDeploymentState | undefined;
-      allocation_state: MlDeploymentAllocationState | undefined;
+      deployment_state?: MlDeploymentAssignmentState;
+      allocation_state?: MlDeploymentAllocationState;
+      allocation_count?: MlTrainedModelDeploymentAllocationStatus['allocation_count'];
     };
   }> => {
     const client = await service.getClient({ request });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Obs AI Assistant] fix knowledge base installation state (#206130)](https://github.com/elastic/kibana/pull/206130)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sandra G","email":"neptunian@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-15T14:38:07Z","message":"[Obs AI Assistant] fix knowledge base installation state (#206130)\n\nResolves https://github.com/elastic/kibana/issues/205970\r\n\r\nUpdates logic to account for knowledge base `/setup` no longer polling\r\nfor model readiness before returning.\r\n\r\n- Currently we only poll `/status` if user manually installs the\r\nknowledge base. In cases where we auto installed, such as after\r\nsuccessfully setting up a connector, we depended on `/setup` to poll\r\ninternally. Since the latter was removed, we need to always poll\r\n`/status`, otherwise user could potentially be in the state where\r\n`setup` has finished (considered installed) but `status` still reports\r\nnot ready and we show the install message again (see screenshots in\r\nhttps://github.com/elastic/kibana/issues/205970)\r\n- Currently if an install is in progress and user closes the flyout, the\r\nprogress state is lost. These changes should continue to reflect the\r\ninstallation progress in the UI.\r\n- Renames variables and adds comments for easier readability\r\n- adds unit test to component that handles the install UI state,\r\n`WelcomeMessageKnowledgeBase`\r\n\r\n---------\r\n\r\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>","sha":"06526fe928ac98580e6fe02768b3c403184694f1","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","ci:cloud-deploy","Team:Obs AI Assistant","ci:project-deploy-elasticsearch","ci:project-deploy-observability","backport:version","v8.18.0","v8.17.1"],"title":"[Obs AI Assistant] fix knowledge base installation state","number":206130,"url":"https://github.com/elastic/kibana/pull/206130","mergeCommit":{"message":"[Obs AI Assistant] fix knowledge base installation state (#206130)\n\nResolves https://github.com/elastic/kibana/issues/205970\r\n\r\nUpdates logic to account for knowledge base `/setup` no longer polling\r\nfor model readiness before returning.\r\n\r\n- Currently we only poll `/status` if user manually installs the\r\nknowledge base. In cases where we auto installed, such as after\r\nsuccessfully setting up a connector, we depended on `/setup` to poll\r\ninternally. Since the latter was removed, we need to always poll\r\n`/status`, otherwise user could potentially be in the state where\r\n`setup` has finished (considered installed) but `status` still reports\r\nnot ready and we show the install message again (see screenshots in\r\nhttps://github.com/elastic/kibana/issues/205970)\r\n- Currently if an install is in progress and user closes the flyout, the\r\nprogress state is lost. These changes should continue to reflect the\r\ninstallation progress in the UI.\r\n- Renames variables and adds comments for easier readability\r\n- adds unit test to component that handles the install UI state,\r\n`WelcomeMessageKnowledgeBase`\r\n\r\n---------\r\n\r\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>","sha":"06526fe928ac98580e6fe02768b3c403184694f1"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/206130","number":206130,"mergeCommit":{"message":"[Obs AI Assistant] fix knowledge base installation state (#206130)\n\nResolves https://github.com/elastic/kibana/issues/205970\r\n\r\nUpdates logic to account for knowledge base `/setup` no longer polling\r\nfor model readiness before returning.\r\n\r\n- Currently we only poll `/status` if user manually installs the\r\nknowledge base. In cases where we auto installed, such as after\r\nsuccessfully setting up a connector, we depended on `/setup` to poll\r\ninternally. Since the latter was removed, we need to always poll\r\n`/status`, otherwise user could potentially be in the state where\r\n`setup` has finished (considered installed) but `status` still reports\r\nnot ready and we show the install message again (see screenshots in\r\nhttps://github.com/elastic/kibana/issues/205970)\r\n- Currently if an install is in progress and user closes the flyout, the\r\nprogress state is lost. These changes should continue to reflect the\r\ninstallation progress in the UI.\r\n- Renames variables and adds comments for easier readability\r\n- adds unit test to component that handles the install UI state,\r\n`WelcomeMessageKnowledgeBase`\r\n\r\n---------\r\n\r\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>","sha":"06526fe928ac98580e6fe02768b3c403184694f1"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/206777","number":206777,"state":"OPEN"},{"branch":"8.17","label":"v8.17.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->