### PR TITLE
[7.17] [webdriver/chrome] Use headless=new

### DIFF
--- a/test/examples/expressions_explorer/expressions.ts
+++ b/test/examples/expressions_explorer/expressions.ts
@@ -53,7 +53,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
       await find.clickByCssSelector(selector);
       await retry.try(async () => {
         const text = await browser.getCurrentUrl();
-        expect(text).to.be('https://www.google.com/?gws_rd=ssl');
+        expect(text).to.be('https://www.google.com/');
       });
     });
   });

--- a/test/functional/apps/dashboard/dashboard_snapshots.ts
+++ b/test/functional/apps/dashboard/dashboard_snapshots.ts
@@ -84,7 +84,7 @@ export default function ({
       );
 
       await PageObjects.dashboard.clickExitFullScreenLogoButton();
-      expect(percentDifference).to.be.lessThan(0.02);
+      expect(percentDifference).to.be.lessThan(0.03);
     });
   });
 }

--- a/test/functional/apps/visualize/_timelion.ts
+++ b/test/functional/apps/visualize/_timelion.ts
@@ -171,7 +171,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       expect(firstAxesLabels).to.eql(['12.2GB', '12.21GB']);
       expect(secondAxesLabels).to.eql(['5.59KB', '5.6KB']);
       expect(thirdAxesLabels.toString()).to.be(
-        'BYTES_5721,BYTES_5722,BYTES_5723,BYTES_5724,BYTES_5725,BYTES_5726,BYTES_5727,BYTES_5728,BYTES_5729,BYTES_5730,BYTES_5731,BYTES_5732,BYTES_5733'
+        'BYTES_5721,BYTES_5722,BYTES_5723,BYTES_5724,BYTES_5725,BYTES_5726,BYTES_5727,BYTES_5728,BYTES_5729,BYTES_5730,BYTES_5731,BYTES_5732,BYTES_5733,BYTES_5734'
       );
     });
 

--- a/test/functional/services/remote/webdriver.ts
+++ b/test/functional/services/remote/webdriver.ts
@@ -99,7 +99,7 @@ function initChromiumOptions(browserType: Browsers, acceptInsecureCerts: boolean
   if (headlessBrowser === '1') {
     // Use --disable-gpu to avoid an error from a missing Mesa library, as per
     // See: https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md
-    options.addArguments('headless=old');
+    options.addArguments('headless=new');
     options.addArguments('disable-gpu');
   }
 
@@ -109,7 +109,7 @@ function initChromiumOptions(browserType: Browsers, acceptInsecureCerts: boolean
 
   if (remoteDebug === '1') {
     // Visit chrome://inspect in chrome to remotely view/debug
-    options.addArguments('headless=old');
+    options.addArguments('headless=new');
     options.addArguments('disable-gpu', 'remote-debugging-port=9222');
   }
 

--- a/x-pack/test/functional/apps/maps/blended_vector_layer.js
+++ b/x-pack/test/functional/apps/maps/blended_vector_layer.js
@@ -35,7 +35,7 @@ export default function ({ getPageObjects, getService }) {
     it('should request clusters when zoomed to larger regions showing lots of data', async () => {
       await PageObjects.maps.setView(20, -90, 2);
       const { rawResponse: response } = await PageObjects.maps.getResponse();
-      expect(response.aggregations.gridSplit.buckets.length).to.equal(17);
+      expect(response.aggregations.gridSplit.buckets.length).to.equal(15);
     });
 
     it('should request documents when query narrows data', async () => {

--- a/x-pack/test/functional/apps/maps/sample_data.js
+++ b/x-pack/test/functional/apps/maps/sample_data.js
@@ -178,7 +178,7 @@ export default function ({ getPageObjects, getService, updateBaselines }) {
           'web_logs_map',
           updateBaselines
         );
-        expect(percentDifference).to.be.lessThan(0.02);
+        expect(percentDifference).to.be.lessThan(0.03);
       });
     });
   });

--- a/x-pack/test/functional/apps/maps/sample_data.js
+++ b/x-pack/test/functional/apps/maps/sample_data.js
@@ -153,7 +153,7 @@ export default function ({ getPageObjects, getService, updateBaselines }) {
           'flights_map',
           updateBaselines
         );
-        expect(percentDifference).to.be.lessThan(0.02);
+        expect(percentDifference).to.be.lessThan(0.03);
       });
     });
 


### PR DESCRIPTION
headless=old is no longer available as of Chrome 132