### PR TITLE
[Docs] Backporting 8.17.1 Release Notes to 8.17

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -10,6 +10,7 @@
 
 Review important information about the {kib} 8.x releases.
 
+* <<release-notes-8.17.1>>
 * <<release-notes-8.17.0>>
 * <<release-notes-8.16.2>>
 * <<release-notes-8.16.1>>
@@ -83,6 +84,30 @@ Review important information about the {kib} 8.x releases.
 
 include::upgrade-notes.asciidoc[]
 
+[[release-notes-8.17.1]]
+== {kib} 8.17.1
+
+The 8.17.1 release includes the following enhancements and bug fixes.
+
+[float]
+[[enhancement-v8.17.1]]
+=== Enhancements
+Management::
+* Supports wildcards for transforms in the alerting rule flyout ({kibana-pull}204226[#204226]).
+
+[float]
+[[fixes-v8.17.1]]
+=== Bug fixes
+Discover::
+* Fixes a bug with adding comments in multiple lines ({kibana-pull}203966[#203966]).
+Elastic Observability solution::
+* Uses architecture-specific ELSER models ({kibana-pull}205851[#205851]).
+* Stringifies ignored values before rendering ({kibana-pull}203312[#203312]).
+* Fixes an issue with the `ViewInAppUrl` Custom Threshold Rule routing to the default space instead of the space where it was created ({kibana-pull}201793[#201793]).
+Elastic Search solution::
+* Align native box connector configs ({kibana-pull}203241[#203241]).
+Kibana platform::
+* Fixes an issue with short URLs not working for dashboards ({kibana-pull}197484[#197484]).
 
 [[release-notes-8.17.0]]
 == {kib} 8.17.0


### PR DESCRIPTION
## Summary

Adding https://github.com/elastic/kibana/pull/206157 to 8.17.