### PR TITLE
reduce initial bundle size for console and index management

### DIFF
--- a/src/platform/plugins/shared/console/public/application/index.tsx
+++ b/src/platform/plugins/shared/console/public/application/index.tsx
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import '../index.scss';
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { HttpSetup, NotificationsSetup, DocLinksStart } from '@kbn/core/public';

--- a/src/platform/plugins/shared/console/public/index.ts
+++ b/src/platform/plugins/shared/console/public/index.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import './index.scss';
 import { PluginInitializerContext } from '@kbn/core/public';
 
 import { ConsoleUIPlugin } from './plugin';

--- a/x-pack/platform/plugins/shared/index_management/public/application/mount_management_section.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/application/mount_management_section.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import '../index.scss';
 import { i18n } from '@kbn/i18n';
 import SemVer from 'semver/classes/semver';
 import { CoreSetup, CoreStart, ScopedHistory } from '@kbn/core/public';

--- a/x-pack/platform/plugins/shared/index_management/public/index.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/index.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import './index.scss';
 import { PluginInitializerContext } from '@kbn/core/public';
 import { IndexMgmtUIPlugin } from './plugin';
 


### PR DESCRIPTION
## Summary

This moves the scss content from an initial bundle load to an async bundle load for the dev console and index management.

For testing - make sure the mapping editor and the dev console render correctly. It will be abundantly clear if they don't.



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->