### PR TITLE
[Case Observables] use isLoading instead of isFetching on similar cases table

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_similar_cases.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_view/components/case_view_similar_cases.tsx
@@ -24,7 +24,7 @@ export const CaseViewSimilarCases = ({ caseData }: CaseViewSimilarCasesProps) =>
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(CASES_TABLE_PER_PAGE_VALUES[0]);
 
-  const { data = initialData, isFetching: isLoadingCases } = useGetSimilarCases({
+  const { data = initialData, isLoading: isLoadingCases } = useGetSimilarCases({
     caseId: caseData.id,
     page: pageIndex + 1,
     perPage: pageSize,


### PR DESCRIPTION
## Summary

This improves the behavior described in https://github.com/elastic/kibana/issues/206274 , where the loading skeleton is shown even when the similar cases data is already in the cache.




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->