### PR TITLE
Adding fips docs to nav

### DIFF
--- a/dev_docs/nav-kibana-dev.docnav.json
+++ b/dev_docs/nav-kibana-dev.docnav.json
@@ -198,6 +198,9 @@
           "id": "kibDevTutorialDebugging"
         },
         {
+          "id": "kibDevTutorialDebuggingFipsTestFailures"
+        },
+        {
           "id": "kibDevTutorialBuildingDistributable",
           "label": "Building a Kibana distributable"
         },


### PR DESCRIPTION
## Summary

I recently added FIPS Test Failure Debugging docs, but forgot to add them to the nav bar

