### PR TITLE
[kbn-scout-reporting] escape html characters in html report

### DIFF
--- a/packages/kbn-scout-reporting/src/helpers/index.ts
+++ b/packages/kbn-scout-reporting/src/helpers/index.ts
@@ -8,6 +8,6 @@
  */
 
 export { getPluginManifestData, type PluginManifest } from './plugin_manifest';
-export { stripFilePath, parseStdout } from './text_processing';
+export { excapeHtmlCharacters, stripFilePath, parseStdout } from './text_processing';
 export { getRunTarget, stripRunCommand } from './cli_processing';
 export { getTestIDForTitle, generateTestRunId } from './test_id_generator';

--- a/packages/kbn-scout-reporting/src/helpers/text_processing.ts
+++ b/packages/kbn-scout-reporting/src/helpers/text_processing.ts
@@ -21,3 +21,6 @@ export function parseStdout(stdout: Array<string | Buffer>): string {
   // Escape special HTML characters
   return stripANSI(stdoutContent);
 }
+
+export const excapeHtmlCharacters = (htmlText: string): string =>
+  htmlText.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');

--- a/packages/kbn-scout-reporting/src/reporting/playwright/failed_test/failed_test_reporter.ts
+++ b/packages/kbn-scout-reporting/src/reporting/playwright/failed_test/failed_test_reporter.ts
@@ -36,6 +36,7 @@ import {
   getTestIDForTitle,
   stripRunCommand,
   stripFilePath,
+  excapeHtmlCharacters,
 } from '../../../helpers';
 
 /**
@@ -105,7 +106,9 @@ export class ScoutFailedTestReporter implements Reporter {
         duration: result.duration,
         error: {
           message: result.error?.message ? stripFilePath(result.error.message) : undefined,
-          stack_trace: result.error?.stack ? stripFilePath(result.error.stack) : undefined,
+          stack_trace: result.error?.stack
+            ? excapeHtmlCharacters(stripFilePath(result.error.stack))
+            : undefined,
         },
         stdout: result.stdout ? parseStdout(result.stdout) : undefined,
         attachments: result.attachments.map((attachment) => ({


### PR DESCRIPTION
## Summary

Fixing `Error details` section not properly displaying html characters in error stacktrace.

Before:

<img width="1347" alt="image" src="https://github.com/user-attachments/assets/1821751f-3a89-46a6-bf55-ed2fe845a196" />

After: 

<img width="1347" alt="image" src="https://github.com/user-attachments/assets/83526d8a-ca3c-4b62-a01e-69029f0e8e7e" />



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->