### PR TITLE
[dashboard] remove unused class dshDashboardViewportWrapper--isFullscreen

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
@@ -97,7 +97,6 @@ export const DashboardViewport = ({ dashboardContainer }: { dashboardContainer?:
     <div
       className={classNames('dshDashboardViewportWrapper', {
         'dshDashboardViewportWrapper--defaultBg': !useMargins,
-        'dshDashboardViewportWrapper--isFullscreen': fullScreenMode,
       })}
     >
       {viewMode !== 'print' ? (


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/205341 removed `dshDashboardViewportWrapper--isFullscreen` from "src/platform/plugins/shared/dashboard/public/dashboard_container/component/viewport/_dashboard_viewport.scss". The PR failed to remove the class from rendered DOM.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->