### PR TITLE
[Fleet] Fix verify test package test

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/scripts/verify_test_packages/verify_test_packages.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/scripts/verify_test_packages/verify_test_packages.test.ts
@@ -12,7 +12,12 @@ import type { Logger } from '@kbn/core/server';
 
 import { appContextService } from '../../server/services/app_context';
 
-import { verifyAllTestPackages } from './verify_test_packages';
+import {
+  getAllTestPackagesPaths,
+  getAllTestPackagesZip,
+  verifyTestPackage,
+  verifyTestPackageFromPath,
+} from './verify_test_packages';
 
 jest.mock('../../server/services/app_context');
 
@@ -23,15 +28,21 @@ mockedAppContextService.getSecuritySetup.mockImplementation(() => ({
 
 let mockedLogger: jest.Mocked<Logger>;
 
-// FLAKY: https://github.com/elastic/kibana/issues/200787
-describe.skip('Test packages', () => {
+describe('Test packages', () => {
   beforeEach(() => {
     mockedLogger = loggerMock.create();
     mockedAppContextService.getLogger.mockReturnValue(mockedLogger);
   });
 
-  test('All test packages should be valid (node scripts/verify_test_packages) ', async () => {
-    const { errors } = await verifyAllTestPackages();
-    expect(errors).toEqual([]);
-  });
+  for (const zip of getAllTestPackagesZip()) {
+    test(`${zip} should be a valid package`, async () => {
+      await verifyTestPackage(zip);
+    });
+  }
+
+  for (const { topLevelDir, paths } of getAllTestPackagesPaths()) {
+    test(`${topLevelDir} should be a valid package`, async () => {
+      await verifyTestPackageFromPath(paths, topLevelDir);
+    });
+  }
 });

--- a/x-pack/platform/plugins/shared/fleet/scripts/verify_test_packages/verify_test_packages.ts
+++ b/x-pack/platform/plugins/shared/fleet/scripts/verify_test_packages/verify_test_packages.ts
@@ -15,13 +15,13 @@ import type { Logger } from '@kbn/core/server';
 import { ToolingLog } from '@kbn/tooling-log';
 
 import {
-  _generatePackageInfoFromPaths,
   generatePackageInfoFromArchiveBuffer,
+  _generatePackageInfoFromPaths,
 } from '../../server/services/epm/archive/parse';
 
 const readFileAsync = promisify(readFile);
 
-const TEST_PACKAGE_DIRECTORIES = [
+export const TEST_PACKAGE_DIRECTORIES = [
   '../../../../../../test/fleet_api_integration/apis/fixtures/bundled_packages',
   '../../../../../../test/fleet_api_integration/apis/fixtures/test_packages',
   '../../../../../../test/fleet_api_integration/apis/fixtures/package_verification/packages',
@@ -62,43 +62,77 @@ export const run = async () => {
   }
 };
 
+export async function verifyTestPackage(zipPath: string, logger?: ToolingLog | Logger) {
+  const buffer = await readFileAsync(zipPath);
+  try {
+    const { packageInfo } = await generatePackageInfoFromArchiveBuffer(buffer, 'application/zip');
+    logger?.info(`Successfully parsed zip pkg ${packageInfo.name}-${packageInfo.version}`);
+  } catch (e) {
+    logger?.error(`Error parsing ${zipPath} : ${e}`);
+    throw e;
+  }
+}
+
+export async function verifyTestPackageFromPath(
+  packagePaths: string[],
+  topLevelDir: string,
+  logger?: ToolingLog | Logger
+) {
+  try {
+    const packageInfo = await _generatePackageInfoFromPaths(packagePaths, topLevelDir);
+    logger?.info(`Successfully parsed zip pkg ${packageInfo.name}-${packageInfo.version}`);
+  } catch (e) {
+    logger?.error(`Error parsing ${topLevelDir} : ${e}`);
+    throw e;
+  }
+}
+
+export function getAllTestPackagesZip() {
+  return TEST_PACKAGE_DIRECTORIES.reduce((acc, dir) => {
+    const packageVersionPaths = getAllPackagesFromDir(path.join(__dirname, dir));
+    const [zips] = partition(packageVersionPaths, (p) => p.endsWith('.zip'));
+
+    return [...acc, ...zips];
+  }, [] as string[]);
+}
+
+export function getAllTestPackagesPaths() {
+  return TEST_PACKAGE_DIRECTORIES.reduce((acc, dir) => {
+    const packageVersionPaths = getAllPackagesFromDir(path.join(__dirname, dir));
+    const [_, dirs] = partition(packageVersionPaths, (p) => p.endsWith('.zip'));
+
+    const allPackageDirPaths = dirs.map(getAllPathsFromDir);
+    return [
+      ...acc,
+      ...[...allPackageDirPaths.entries()].map(([i, paths]) => ({
+        topLevelDir: packageVersionPaths[i],
+        paths,
+      })),
+    ];
+  }, [] as Array<{ topLevelDir: string; paths: string[] }>);
+}
+
 export const verifyAllTestPackages = async (
   logger?: ToolingLog | Logger
 ): Promise<{ successCount: number; errors: Error[] }> => {
   const errors = [];
   let successCount = 0;
-  for (const dir of TEST_PACKAGE_DIRECTORIES) {
-    const packageVersionPaths = getAllPackagesFromDir(path.join(__dirname, dir));
 
-    const [zips, dirs] = partition(packageVersionPaths, (p) => p.endsWith('.zip'));
-
-    for (const zipPath of zips) {
-      const buffer = await readFileAsync(zipPath);
-
-      try {
-        const { packageInfo } = await generatePackageInfoFromArchiveBuffer(
-          buffer,
-          'application/zip'
-        );
-        logger?.info(`Successfully parsed zip pkg ${packageInfo.name}-${packageInfo.version}`);
-        successCount++;
-      } catch (e) {
-        logger?.error(`Error parsing ${zipPath} : ${e}`);
-        errors.push(e);
-      }
+  for (const zipPath of getAllTestPackagesZip()) {
+    try {
+      await verifyTestPackage(zipPath, logger);
+      successCount++;
+    } catch (e) {
+      errors.push(e);
     }
+  }
 
-    const allPackageDirPaths = dirs.map(getAllPathsFromDir);
-    for (const [i, packagePaths] of allPackageDirPaths.entries()) {
-      const topLevelDir = packageVersionPaths[i];
-      try {
-        const packageInfo = await _generatePackageInfoFromPaths(packagePaths, topLevelDir);
-        logger?.info(`Successfully parsed ${packageInfo.name}-${packageInfo.version}`);
-        successCount++;
-      } catch (e) {
-        logger?.error(`Error parsing ${topLevelDir} : ${e}`);
-        errors.push(e);
-      }
+  for (const { topLevelDir, paths } of getAllTestPackagesPaths()) {
+    try {
+      await verifyTestPackageFromPath(paths, topLevelDir, logger);
+      successCount++;
+    } catch (e) {
+      errors.push(e);
     }
   }
 


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/ingest-dev/issues/4683
Resolve https://github.com/elastic/kibana/issues/200787

We have a jest test that verify all of our test packages are corrects, as the number of test packages and version grow this test became flaky, that PR fix that by splitting the test to generate a test per package version, instead of one big test.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->