### PR TITLE
[Canvas] Fix colors for Borealis

### DIFF
--- a/x-pack/platform/plugins/private/canvas/public/components/datasource/datasource_component.js
+++ b/x-pack/platform/plugins/private/canvas/public/components/datasource/datasource_component.js
@@ -191,7 +191,6 @@ export class DatasourceComponent extends PureComponent {
                     size="s"
                     onClick={this.save}
                     fill
-                    color="success"
                     data-test-subj="canvasSaveDatasourceButton"
                   >
                     {strings.getSaveButtonLabel()}

--- a/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/workpad_table_tools.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/workpad_table_tools.component.tsx
@@ -47,7 +47,6 @@ export const WorkpadTableTools = ({
 
   const downloadButton = (
     <EuiButton
-      color="success"
       onClick={() => onExportWorkpads(selectedWorkpadIds)}
       iconType="exportAction"
       aria-label={strings.getExportButtonAriaLabel(selectedWorkpadIds.length)}

--- a/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/workpad_table_tools.component.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/home/my_workpads/workpad_table_tools.component.tsx
@@ -47,6 +47,7 @@ export const WorkpadTableTools = ({
 
   const downloadButton = (
     <EuiButton
+      color="success"
       onClick={() => onExportWorkpads(selectedWorkpadIds)}
       iconType="exportAction"
       aria-label={strings.getExportButtonAriaLabel(selectedWorkpadIds.length)}

--- a/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.scss
@@ -33,7 +33,7 @@
 
   .canvasPageManager__addPage {
     width: $euiSizeXXL + $euiSize;
-    background: $euiColorSuccess;
+    background: $euiColorPrimary;
     color: $euiColorGhost;
     opacity: 0;
     animation: buttonPop $euiAnimSpeedNormal $euiAnimSlightResistance;

--- a/x-pack/platform/plugins/private/canvas/public/components/var_config/edit_var.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/var_config/edit_var.tsx
@@ -209,7 +209,6 @@ export const EditVar: FC<Props> = ({ variables, selectedVar, onCancel, onSave })
           <EuiFlexGroup alignItems="center">
             <EuiFlexItem grow={false}>
               <EuiButton
-                color="success"
                 size="s"
                 fill
                 onClick={() =>


### PR DESCRIPTION
## Summary

Closes #204597.

This changes the `success` colored buttons into `primary` colored buttons in Canvas. There are no other necessary color/style changes for Borealis in Canvas.

<img width="1859" alt="Screenshot 2025-01-16 at 3 44 05 PM" src="https://github.com/user-attachments/assets/03febdfa-6f9f-4017-99f2-f6eaf82ad07f" />

### Variable save button
#### Before
<img width="348" alt="Screenshot 2025-01-16 at 3 33 54 PM" src="https://github.com/user-attachments/assets/20cdb998-617e-4a96-9e9f-c497be1682c7" />

#### After
<img width="350" alt="Screenshot 2025-01-16 at 3 34 20 PM" src="https://github.com/user-attachments/assets/b7bf6962-ccd2-4e32-8003-73d7245395f2" />


### Add page button
#### Before
<img width="952" alt="Screenshot 2025-01-16 at 3 33 06 PM" src="https://github.com/user-attachments/assets/6c9db0c4-46db-47c5-bfe6-44307928bd0b" />

#### After
<img width="804" alt="Screenshot 2025-01-16 at 3 47 20 PM" src="https://github.com/user-attachments/assets/b45f0977-fcad-44a1-be6f-ffb587851e12" />

### Datasource save button
#### Before
<img width="345" alt="Screenshot 2025-01-16 at 3 32 23 PM" src="https://github.com/user-attachments/assets/5f926b8c-057e-4925-a932-1a69b6077980" />

#### After
<img width="181" alt="Screenshot 2025-01-16 at 3 30 58 PM" src="https://github.com/user-attachments/assets/d38bf8c7-6971-4840-8866-9303f963ed3f" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



