### PR TITLE
[8.16] [Custom threshold] Fix leading wildcard issue on the custom threshold alert details page (#206615)

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/helpers/log_rate_analysis_query.test.ts
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/helpers/log_rate_analysis_query.test.ts
@@ -118,6 +118,14 @@ describe('buildEsQuery', () => {
   ];
 
   test.each(testData)('should generate correct es query for $title', ({ alert, params }) => {
-    expect(getLogRateAnalysisEQQuery(alert, params)).toMatchSnapshot();
+    expect(getLogRateAnalysisEQQuery(
+      alert,
+      params,
+      {
+        allowLeadingWildcards: true,
+        queryStringOptions: {},
+        ignoreFilterIfFieldNotInIndex: false,
+      }
+    )).toMatchSnapshot();
   });
 });

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/helpers/log_rate_analysis_query.test.ts
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/helpers/log_rate_analysis_query.test.ts
@@ -118,14 +118,12 @@ describe('buildEsQuery', () => {
   ];
 
   test.each(testData)('should generate correct es query for $title', ({ alert, params }) => {
-    expect(getLogRateAnalysisEQQuery(
-      alert,
-      params,
-      {
+    expect(
+      getLogRateAnalysisEQQuery(alert, params, {
         allowLeadingWildcards: true,
         queryStringOptions: {},
         ignoreFilterIfFieldNotInIndex: false,
-      }
-    )).toMatchSnapshot();
+      })
+    ).toMatchSnapshot();
   });
 });

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/helpers/log_rate_analysis_query.ts
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/helpers/log_rate_analysis_query.ts
@@ -7,6 +7,7 @@
 
 import { get } from 'lodash';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { EsQueryConfig } from '@kbn/es-query';
 import { getGroupFilters } from '../../../../../../common/custom_threshold_rule/helpers/get_group';
 import { Aggregators } from '../../../../../../common/custom_threshold_rule/types';
 import { buildEsQuery } from '../../../../../utils/build_es_query';
@@ -33,7 +34,8 @@ const getKuery = (metrics: CustomThresholdExpressionMetric[], filter?: string) =
 
 export const getLogRateAnalysisEQQuery = (
   alert: TopAlert<Record<string, any>>,
-  params: CustomThresholdRuleTypeParams
+  params: CustomThresholdRuleTypeParams,
+  config: EsQueryConfig
 ): QueryDslQueryContainer | undefined => {
   // We only show log rate analysis for one condition with one count aggregation
   if (
@@ -50,6 +52,7 @@ export const getLogRateAnalysisEQQuery = (
   const boolQuery = buildEsQuery({
     kuery: getKuery(params.criteria[0].metrics, optionalFilter),
     filters: groupByFilters,
+    config,
   });
 
   return boolQuery;

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/log_rate_analysis.test.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/log_rate_analysis.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { COMPARATORS } from '@kbn/alerting-comparators';
+import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { ALERT_RULE_PARAMETERS } from '@kbn/rule-data-utils';
+import { Aggregators } from '../../../../../common/custom_threshold_rule/types';
+import {
+  buildCustomThresholdAlert,
+  buildCustomThresholdRule,
+} from '../../mocks/custom_threshold_rule';
+import { kibanaStartMock } from '../../../../utils/kibana_react.mock';
+import { CustomThresholdAlert } from '../types';
+import { LogRateAnalysis } from './log_rate_analysis';
+
+describe('AlertDetailsAppSection', () => {
+  const renderComponent = (alert: Partial<CustomThresholdAlert> = {}) => {
+    return render(
+      <IntlProvider locale="en">
+        <LogRateAnalysis
+          alert={buildCustomThresholdAlert(alert, {
+            [ALERT_RULE_PARAMETERS]: {
+              ...buildCustomThresholdRule().params,
+              criteria: [
+                {
+                  comparator: COMPARATORS.GREATER_THAN,
+                  metrics: [
+                    {
+                      name: 'A',
+                      aggType: Aggregators.COUNT,
+                      filter: 'host.name: *host',
+                    },
+                  ],
+                  threshold: [2000],
+                  timeSize: 15,
+                  timeUnit: 'm',
+                },
+              ],
+            },
+          })}
+          dataView={{}}
+          services={{
+            ...kibanaStartMock.startContract().services,
+            uiSettings: {
+              ...uiSettingsServiceMock.createStartContract(),
+              get: jest.fn().mockReturnValue(true),
+            },
+          }}
+        />
+      </IntlProvider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // To avoid https://github.com/elastic/kibana/issues/206588
+  it('should render LogRateAnalysis without throwing error', async () => {
+    expect(renderComponent).not.toThrowError();
+  });
+});

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/log_rate_analysis.test.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/log_rate_analysis.test.tsx
@@ -10,7 +10,6 @@ import { render } from '@testing-library/react';
 import { COMPARATORS } from '@kbn/alerting-comparators';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
-import { ALERT_RULE_PARAMETERS } from '@kbn/rule-data-utils';
 import { Aggregators } from '../../../../../common/custom_threshold_rule/types';
 import {
   buildCustomThresholdAlert,
@@ -25,8 +24,10 @@ describe('AlertDetailsAppSection', () => {
     return render(
       <IntlProvider locale="en">
         <LogRateAnalysis
-          alert={buildCustomThresholdAlert(alert, {
-            [ALERT_RULE_PARAMETERS]: {
+          alert={buildCustomThresholdAlert(alert)}
+          rule={{
+            ...buildCustomThresholdRule(),
+            params: {
               ...buildCustomThresholdRule().params,
               criteria: [
                 {
@@ -44,7 +45,7 @@ describe('AlertDetailsAppSection', () => {
                 },
               ],
             },
-          })}
+          }}
           dataView={{}}
           services={{
             ...kibanaStartMock.startContract().services,

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/log_rate_analysis.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/log_rate_analysis.tsx
@@ -61,7 +61,11 @@ export function LogRateAnalysis({
   >();
 
   useEffect(() => {
-    const esSearchRequest = getLogRateAnalysisEQQuery(alert, rule.params, getEsQueryConfig(uiSettings));
+    const esSearchRequest = getLogRateAnalysisEQQuery(
+      alert,
+      rule.params,
+      getEsQueryConfig(uiSettings)
+    );
 
     if (esSearchRequest) {
       setEsSearchQuery(esSearchRequest);

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/log_rate_analysis.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/alert_details_app_section/log_rate_analysis.tsx
@@ -15,6 +15,7 @@ import {
 } from '@kbn/aiops-log-rate-analysis/log_rate_analysis_type';
 import { getLogRateAnalysisParametersFromAlert } from '@kbn/aiops-log-rate-analysis/get_log_rate_analysis_parameters_from_alert';
 import { LogRateAnalysisContent, type LogRateAnalysisResultsData } from '@kbn/aiops-plugin/public';
+import { getEsQueryConfig } from '@kbn/data-service';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -51,6 +52,7 @@ export function LogRateAnalysis({
       ObservabilityAIAssistantContextualInsight,
       getContextualInsightMessages,
     },
+    uiSettings,
   } = services;
   const [esSearchQuery, setEsSearchQuery] = useState<QueryDslQueryContainer | undefined>();
   const [logRateAnalysisParams, setLogRateAnalysisParams] = useState<
@@ -59,12 +61,12 @@ export function LogRateAnalysis({
   >();
 
   useEffect(() => {
-    const esSearchRequest = getLogRateAnalysisEQQuery(alert, rule.params);
+    const esSearchRequest = getLogRateAnalysisEQQuery(alert, rule.params, getEsQueryConfig(uiSettings));
 
     if (esSearchRequest) {
       setEsSearchQuery(esSearchRequest);
     }
-  }, [alert, rule.params]);
+  }, [alert, rule.params, uiSettings]);
 
   const { timeRange, windowParameters } = useMemo(() => {
     const alertStartedAt = moment(alert.start).toISOString();

--- a/x-pack/plugins/observability_solution/observability/public/plugin.mock.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/plugin.mock.tsx
@@ -10,6 +10,7 @@ import { mockCasesContract } from '@kbn/cases-plugin/public/mocks';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { contentManagementMock } from '@kbn/content-management-plugin/public/mocks';
+import { observabilityAIAssistantPluginMock } from '@kbn/observability-ai-assistant-plugin/public/mock';
 import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import type { AlertActionsProps } from '@kbn/triggers-actions-ui-plugin/public/types';
@@ -128,6 +129,7 @@ export const observabilityPublicPluginsStartMock = {
       dataViews: dataViews.createStart(),
       discover: null,
       lens: lensPluginMock.createStartContract(),
+      observabilityAIAssistant: observabilityAIAssistantPluginMock.createStartContract(),
       share: sharePluginMock.createStartContract(),
       triggersActionsUi: triggersActionsUiStartMock.createStart(),
       unifiedSearch: unifiedSearchPluginMock.createStartContract(),

--- a/x-pack/plugins/observability_solution/observability/tsconfig.json
+++ b/x-pack/plugins/observability_solution/observability/tsconfig.json
@@ -114,6 +114,7 @@
     "@kbn/core-ui-settings-server-mocks",
     "@kbn/es-types",
     "@kbn/logging-mocks",
+    "@kbn/data-service"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Custom threshold] Fix leading wildcard issue on the custom threshold alert details page (#206615)](https://github.com/elastic/kibana/pull/206615)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2025-01-16T08:01:31Z","message":"[Custom threshold] Fix leading wildcard issue on the custom threshold alert details page (#206615)\n\nFixes #206588\r\n\r\n## Summary\r\n\r\nThis PR fixes the `Unable to load page` error on the alert details page\r\nwhen the query has a leading wildcard by passing the uiSetting config to\r\nthe buildEsQuery helper in the LogRateAnalysis component.\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/baef8a1e-9c63-4f63-9300-b85618f18f57)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"362f2dd9b06cbbd10f0746e5138509bd0e595b8d","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","v9.0.0","backport:prev-major","Team:obs-ux-management","v8.18.0"],"title":"[Custom threshold] Fix leading wildcard issue on the custom threshold alert details page","number":206615,"url":"https://github.com/elastic/kibana/pull/206615","mergeCommit":{"message":"[Custom threshold] Fix leading wildcard issue on the custom threshold alert details page (#206615)\n\nFixes #206588\r\n\r\n## Summary\r\n\r\nThis PR fixes the `Unable to load page` error on the alert details page\r\nwhen the query has a leading wildcard by passing the uiSetting config to\r\nthe buildEsQuery helper in the LogRateAnalysis component.\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/baef8a1e-9c63-4f63-9300-b85618f18f57)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"362f2dd9b06cbbd10f0746e5138509bd0e595b8d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/206615","number":206615,"mergeCommit":{"message":"[Custom threshold] Fix leading wildcard issue on the custom threshold alert details page (#206615)\n\nFixes #206588\r\n\r\n## Summary\r\n\r\nThis PR fixes the `Unable to load page` error on the alert details page\r\nwhen the query has a leading wildcard by passing the uiSetting config to\r\nthe buildEsQuery helper in the LogRateAnalysis component.\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/baef8a1e-9c63-4f63-9300-b85618f18f57)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"362f2dd9b06cbbd10f0746e5138509bd0e595b8d"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/206892","number":206892,"state":"MERGED","mergeCommit":{"sha":"58b4af3cd1194c3ea809533c081b5dc8553825c9","message":"[8.x] [Custom threshold] Fix leading wildcard issue on the custom threshold alert details page (#206615) (#206892)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Custom threshold] Fix leading wildcard issue on the custom threshold\nalert details page\n(#206615)](https://github.com/elastic/kibana/pull/206615)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Maryam\nSaeidi\",\"email\":\"maryam.saeidi@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-01-16T08:01:31Z\",\"message\":\"[Custom\nthreshold] Fix leading wildcard issue on the custom threshold alert\ndetails page (#206615)\\n\\nFixes #206588\\r\\n\\r\\n## Summary\\r\\n\\r\\nThis PR\nfixes the `Unable to load page` error on the alert details page\\r\\nwhen\nthe query has a leading wildcard by passing the uiSetting config\nto\\r\\nthe buildEsQuery helper in the LogRateAnalysis\ncomponent.\\r\\n\\r\\n\\r\\n![image](https://github.com/user-attachments/assets/baef8a1e-9c63-4f63-9300-b85618f18f57)\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"362f2dd9b06cbbd10f0746e5138509bd0e595b8d\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"release_note:fix\",\"v9.0.0\",\"backport:prev-major\",\"Team:obs-ux-management\"],\"title\":\"[Custom\nthreshold] Fix leading wildcard issue on the custom threshold alert\ndetails\npage\",\"number\":206615,\"url\":\"https://github.com/elastic/kibana/pull/206615\",\"mergeCommit\":{\"message\":\"[Custom\nthreshold] Fix leading wildcard issue on the custom threshold alert\ndetails page (#206615)\\n\\nFixes #206588\\r\\n\\r\\n## Summary\\r\\n\\r\\nThis PR\nfixes the `Unable to load page` error on the alert details page\\r\\nwhen\nthe query has a leading wildcard by passing the uiSetting config\nto\\r\\nthe buildEsQuery helper in the LogRateAnalysis\ncomponent.\\r\\n\\r\\n\\r\\n![image](https://github.com/user-attachments/assets/baef8a1e-9c63-4f63-9300-b85618f18f57)\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"362f2dd9b06cbbd10f0746e5138509bd0e595b8d\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/206615\",\"number\":206615,\"mergeCommit\":{\"message\":\"[Custom\nthreshold] Fix leading wildcard issue on the custom threshold alert\ndetails page (#206615)\\n\\nFixes #206588\\r\\n\\r\\n## Summary\\r\\n\\r\\nThis PR\nfixes the `Unable to load page` error on the alert details page\\r\\nwhen\nthe query has a leading wildcard by passing the uiSetting config\nto\\r\\nthe buildEsQuery helper in the LogRateAnalysis\ncomponent.\\r\\n\\r\\n\\r\\n![image](https://github.com/user-attachments/assets/baef8a1e-9c63-4f63-9300-b85618f18f57)\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"362f2dd9b06cbbd10f0746e5138509bd0e595b8d\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Maryam Saeidi <maryam.saeidi@elastic.co>"}},{"url":"https://github.com/elastic/kibana/pull/206966","number":206966,"branch":"8.17","state":"OPEN"}]}] BACKPORT-->