### PR TITLE
[Filters] Improves relative time check

### DIFF
--- a/src/platform/packages/shared/kbn-es-query/src/filters/helpers/convert_range_filter.test.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/filters/helpers/convert_range_filter.test.ts
@@ -35,4 +35,17 @@ describe('convertRangeFilterToTimeRange', () => {
 
     expect(convertedRangeFilter).toEqual(filterAfterConvertedRangeFilter);
   });
+
+  it('should return converted range for relative dates without now', () => {
+    const filter: any = {
+      query: { range: { '@timestamp': { gte: '2024.02.01', lte: '2024.02.01||+1M/d' } } },
+    };
+    const filterAfterConvertedRangeFilter = {
+      from: moment('2024.02.01'),
+      to: '2024.02.01||+1M/d',
+    };
+    const convertedRangeFilter = convertRangeFilterToTimeRange(filter);
+
+    expect(convertedRangeFilter).toEqual(filterAfterConvertedRangeFilter);
+  });
 });

--- a/src/platform/packages/shared/kbn-es-query/src/filters/helpers/convert_range_filter.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/filters/helpers/convert_range_filter.ts
@@ -13,7 +13,7 @@ import type { RangeFilter } from '../build_filters';
 import type { TimeRange } from './types';
 
 const isRelativeTime = (value: string | number | undefined): boolean => {
-  return typeof value === 'string' && value.includes('now');
+  return typeof value === 'string' && !moment(value).isValid();
 };
 
 export function convertRangeFilterToTimeRange(filter: RangeFilter) {


### PR DESCRIPTION
## Summary

Improves relative time check for the range time filter (as a follow up of https://github.com/elastic/kibana/pull/206914)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->