### PR TITLE
[Search] [Playground] fix semantic_text issue

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/__mocks__/fetch_query_source_fields.mock.ts
+++ b/x-pack/solutions/search/plugins/search_playground/__mocks__/fetch_query_source_fields.mock.ts
@@ -11,10 +11,10 @@ export const SPARSE_SEMANTIC_FIELD_FIELD_CAPS = {
   indices: ['test-index2'],
   fields: {
     infer_field: {
-      semantic_text: {
-        type: 'semantic_text',
+      text: {
+        type: 'text',
         metadata_field: false,
-        searchable: false,
+        searchable: true,
         aggregatable: false,
       },
     },
@@ -127,10 +127,10 @@ export const DENSE_SEMANTIC_FIELD_FIELD_CAPS = {
   indices: ['test-index2'],
   fields: {
     infer_field: {
-      semantic_text: {
-        type: 'semantic_text',
+      text: {
+        type: 'text',
         metadata_field: false,
-        searchable: false,
+        searchable: true,
         aggregatable: false,
       },
     },

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/fetch_query_source_fields.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/fetch_query_source_fields.ts
@@ -244,9 +244,9 @@ export const parseFieldsCapabilities = (
           (indexModelIdField) => indexModelIdField.index === index
         )!;
         const nestedField = isFieldNested(fieldKey, fieldCapsResponse);
-
-        if (isFieldInIndex(field, 'semantic_text', index)) {
-          const semanticFieldMapping = getSemanticField(fieldKey, semanticTextFields);
+        const semanticFieldMapping = getSemanticField(fieldKey, semanticTextFields);
+        
+        if (isFieldInIndex(field, 'text', index) && semanticFieldMapping) {
 
           // only use this when embeddingType and inferenceId is defined
           // this requires semantic_text field to be set up correctly and ingested
@@ -260,7 +260,7 @@ export const parseFieldsCapabilities = (
               field: fieldKey,
               inferenceId: semanticFieldMapping.inferenceId,
               embeddingType: semanticFieldMapping.embeddingType,
-              indices: (field.semantic_text.indices as string[]) || indicesPresentIn,
+              indices: (field.text.indices as string[]) || indicesPresentIn,
             };
 
             acc[index].semantic_fields.push(semanticField);

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/fetch_query_source_fields.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/fetch_query_source_fields.ts
@@ -245,9 +245,8 @@ export const parseFieldsCapabilities = (
         )!;
         const nestedField = isFieldNested(fieldKey, fieldCapsResponse);
         const semanticFieldMapping = getSemanticField(fieldKey, semanticTextFields);
-        
-        if (isFieldInIndex(field, 'text', index) && semanticFieldMapping) {
 
+        if (isFieldInIndex(field, 'text', index) && semanticFieldMapping) {
           // only use this when embeddingType and inferenceId is defined
           // this requires semantic_text field to be set up correctly and ingested
           if (

--- a/x-pack/solutions/search/plugins/search_playground/server/utils/stream_factory.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/utils/stream_factory.ts
@@ -107,7 +107,7 @@ export function streamFactory(logger: Logger, isCloud: boolean = false): StreamF
     );
 
     if (line === undefined) {
-      logger.error('Stream chunk must not be undefined.');
+      logDebugMessage('Stream chunk must not be undefined.');
       return;
     }
 


### PR DESCRIPTION
## Summary

This fixes an issue in playground where the generated query is using a multi_match. This is because the field is now defined as a text field and Playground was treating the field as a text field and using it in a multi-match.

This fix detects if the field is declared in the mappings API as semantic_text and what the model_id is. 





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->