### PR TITLE
fix(slo): non-breaking changes of an SLO running with older resources is a breaking change

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
@@ -26,6 +26,7 @@ const createTransformManagerMock = (): jest.Mocked<TransformManager> => {
     start: jest.fn(),
     stop: jest.fn(),
     inspect: jest.fn(),
+    getVersion: jest.fn(),
   };
 };
 
@@ -37,6 +38,7 @@ const createSummaryTransformManagerMock = (): jest.Mocked<TransformManager> => {
     start: jest.fn(),
     stop: jest.fn(),
     inspect: jest.fn(),
+    getVersion: jest.fn(),
   };
 };
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/summay_transform_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summay_transform_manager.ts
@@ -111,4 +111,21 @@ export class DefaultSummaryTransformManager implements TransformManager {
       throw err;
     }
   }
+
+  async getVersion(transformId: TransformId): Promise<number | undefined> {
+    try {
+      const response = await retryTransientEsErrors(
+        () =>
+          this.scopedClusterClient.asSecondaryAuthUser.transform.getTransform(
+            { transform_id: transformId },
+            { ignore: [404] }
+          ),
+        { logger: this.logger }
+      );
+      return response?.transforms[0]?._meta?.version;
+    } catch (err) {
+      this.logger.error(`Cannot retrieve SLO transform version [${transformId}]. ${err}`);
+      throw err;
+    }
+  }
 }

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
@@ -21,6 +21,7 @@ export interface TransformManager {
   start(transformId: TransformId): Promise<void>;
   stop(transformId: TransformId): Promise<void>;
   uninstall(transformId: TransformId): Promise<void>;
+  getVersion(transformId: TransformId): Promise<number | undefined>;
 }
 
 export class DefaultTransformManager implements TransformManager {
@@ -129,6 +130,23 @@ export class DefaultTransformManager implements TransformManager {
       );
     } catch (err) {
       this.logger.error(`Cannot delete SLO transform [${transformId}]. ${err}`);
+      throw err;
+    }
+  }
+
+  async getVersion(transformId: TransformId): Promise<number | undefined> {
+    try {
+      const response = await retryTransientEsErrors(
+        () =>
+          this.scopedClusterClient.asSecondaryAuthUser.transform.getTransform(
+            { transform_id: transformId },
+            { ignore: [404] }
+          ),
+        { logger: this.logger }
+      );
+      return response?.transforms[0]?._meta?.version;
+    } catch (err) {
+      this.logger.error(`Cannot retrieve SLO transform version [${transformId}]. ${err}`);
       throw err;
     }
   }

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
@@ -11,6 +11,7 @@ import { asyncForEach } from '@kbn/std';
 import { isEqual, pick } from 'lodash';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
+  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_PATTERN,
   SLO_SUMMARY_TEMP_INDEX_NAME,
   getSLOPipelineId,
@@ -53,15 +54,7 @@ export class UpdateSLO {
       return this.toResponse(originalSlo);
     }
 
-    const fields = [
-      'indicator',
-      'groupBy',
-      'timeWindow',
-      'objective',
-      'budgetingMethod',
-      'settings',
-    ];
-    const requireRevisionBump = !isEqual(pick(originalSlo, fields), pick(updatedSlo, fields));
+    const requireRevisionBump = await this.isRevisionBumpRequired(originalSlo, updatedSlo);
 
     updatedSlo = Object.assign(updatedSlo, {
       updatedAt: new Date(),
@@ -77,23 +70,8 @@ export class UpdateSLO {
     rollbackOperations.push(() => this.repository.update(originalSlo));
 
     if (!requireRevisionBump) {
-      // At this point, we still need to update the sli and summary pipeline to include the changes (id and revision in the rollup index) and (name, desc, tags, ...) in the summary index
-
+      // we only have to update the summary pipeline to include the non-breaking changes (name, desc, tags, ...) in the summary index
       try {
-        await retryTransientEsErrors(
-          () =>
-            this.scopedClusterClient.asSecondaryAuthUser.ingest.putPipeline(
-              getSLOPipelineTemplate(updatedSlo)
-            ),
-          { logger: this.logger }
-        );
-        rollbackOperations.push(() =>
-          this.scopedClusterClient.asSecondaryAuthUser.ingest.deletePipeline(
-            { id: getSLOPipelineId(updatedSlo.id, updatedSlo.revision) },
-            { ignore: [404] }
-          )
-        );
-
         await retryTransientEsErrors(
           () =>
             this.scopedClusterClient.asSecondaryAuthUser.ingest.putPipeline(
@@ -203,6 +181,26 @@ export class UpdateSLO {
     await this.deleteOriginalSLO(originalSlo);
 
     return this.toResponse(updatedSlo);
+  }
+
+  private async isRevisionBumpRequired(originalSlo: SLODefinition, updatedSlo: SLODefinition) {
+    const fields = [
+      'indicator',
+      'groupBy',
+      'timeWindow',
+      'objective',
+      'budgetingMethod',
+      'settings',
+    ];
+    const hasBreakingChanges = !isEqual(pick(originalSlo, fields), pick(updatedSlo, fields));
+    const currentResourcesVersion = await this.summaryTransformManager.getVersion(
+      getSLOSummaryTransformId(originalSlo.id, originalSlo.revision)
+    );
+
+    const hasOutdatedVersion =
+      currentResourcesVersion === undefined || currentResourcesVersion < SLO_RESOURCES_VERSION;
+
+    return hasBreakingChanges || hasOutdatedVersion;
   }
 
   private async deleteOriginalSLO(originalSlo: SLODefinition) {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/206320

## Summary

This PR fixes a bug when updating an SLO with a non-breaking change, e.g. name, tags, description, ... but with older resources running, e.g. transforms from previous version.

Before this change, we would only reinstall the _latest_ summary pipeline, and this new pipeline could reference fields that are not provided by the _old_ summary transform. Thus breaking the SLO entirely.

After this change, we also compare the summary transform `_meta.version` of the existing SLO with the latest SLO resources version. If the current transform is running on an older version, even if the change is non-breaking (name, description, ...) we consider the change as breaking and do a full reinstallation.

I've added tests to cover this scenario, and remove the need for reinstalling the sli rollup pipeline with non-breaking change.

## Release note

Updating an SLO with non-breaking changes is considered a breaking change when the SLO is running on outdated resources



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->