### PR TITLE
[Security Solution] Show deprecated bulk endpoints in Upgrade Assistant

### DIFF
--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -49,7 +49,7 @@ For Elastic Security solution release information, refer to {security-guide}/rel
 === Breaking changes
 
 [discrete]
-[[REPO-PR]]
+[[breaking-207091]]
 .Removed legacy security rules bulk endpoints (9.0.0)
 [%collapsible]
 ====

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -71,7 +71,7 @@ Deprecated endpoints will fail with a 404 status code starting from version 9.0.
 Update your implementations to use the new endpoints:
 
 * **For bulk creation of rules:**
-   - Use `POST /api/detection_engine/rules/_import` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-importrules[API documentation]) to create multiple rules along with their associated entities (e.g., exceptions and action connectors).
+   - Use `POST /api/detection_engine/rules/_import` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-importrules[API documentation]) to create multiple rules along with their associated entities (for example, exceptions and action connectors).
    - Alternatively, create rules individually using `POST /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-createrule[API documentation]).
 
 * **For bulk updates of rules:**

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -75,12 +75,12 @@ Update your implementations to use the new endpoints:
    - Alternatively, create rules individually using `POST /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-createrule[API documentation]).
 
 2. **For bulk updates of rules:**
-   - Use `POST /api/detection_engine/rules/_bulk_action` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-bulkaction[API documentation]) to update fields in multiple rules simultaneously.
+   - Use `POST /api/detection_engine/rules/_bulk_action` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-performrulesbulkaction[API documentation]) to update fields in multiple rules simultaneously.
    - Alternatively, update rules individually using `PUT /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-updaterule[API documentation]).
 
 3. **For bulk deletion of rules:**
    - Use `POST /api/detection_engine/rules/_bulk_action` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-performrulesbulkaction[API documentation]) to delete multiple rules by IDs or query.
-   - Alternatively, delete rules individually using `DELETE /api/detection_engine/rules/{id}` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-deleterule[API documentation]).
+   - Alternatively, delete rules individually using `DELETE /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-deleterule[API documentation]).
 --
 ====
 

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -49,6 +49,21 @@ For Elastic Security solution release information, refer to {security-guide}/rel
 === Breaking changes
 
 [discrete]
+[[REPO-PR]]
+.Removed legacy security rules bulk endpoints (9.0.0)
+[%collapsible]
+====
+*Details* +
+ADD MORE DETAILS ON WHAT IS CHANGING AND A LINK TO THE PR INTRODUCING THE CHANGE
+
+*Impact* +
+ADD INFORMATION ABOUT WHAT THIS CHANGE WILL BREAK FOR USERS
+
+*Action* +
+ADD INSTRUCTIONS FOR USERS LOOKING TO UPGRADE. HOW CAN THEY WORK AROUND THIS?
+====
+
+[discrete]
 [[breaking-199598]]
 .Remove deprecated endpoint management endpoints (9.0.0)
 [%collapsible]

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -54,13 +54,34 @@ For Elastic Security solution release information, refer to {security-guide}/rel
 [%collapsible]
 ====
 *Details* +
-ADD MORE DETAILS ON WHAT IS CHANGING AND A LINK TO THE PR INTRODUCING THE CHANGE
+--
+* `POST /api/detection_engine/rules/_bulk_create` has been replaced by `POST /api/detection_engine/rules/_import`
+* `PUT /api/detection_engine/rules/_bulk_update` has been replaced by `POST /api/detection_engine/rules/_bulk_action`
+* `PATCH /api/detection_engine/rules/_bulk_update has been replaced by `POST /api/detection_engine/rules/_bulk_action`
+* `DELETE /api/detection_engine/rules/_bulk_delete` has been replaced by `POST /api/detection_engine/rules/_bulk_action`
+* `POST api/detection_engine/rules/_bulk_delete` has been replaced by `POST /api/detection_engine/rules/_bulk_action`
+--
+These changes were introduced in PR {kibana-pull}#197422[#197422].
 
 *Impact* +
-ADD INFORMATION ABOUT WHAT THIS CHANGE WILL BREAK FOR USERS
+Deprecated endpoints will fail with a 404 status code starting from version 9.0.0
 
 *Action* +
-ADD INSTRUCTIONS FOR USERS LOOKING TO UPGRADE. HOW CAN THEY WORK AROUND THIS?
+--
+Update your implementations to use the new endpoints:
+
+1. **For bulk creation of rules:**
+   - Use `POST /api/detection_engine/rules/_import` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-importrules[API documentation]) to create multiple rules along with their associated entities (e.g., exceptions and action connectors).
+   - Alternatively, create rules individually using `POST /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-createrule[API documentation]).
+
+2. **For bulk updates of rules:**
+   - Use `POST /api/detection_engine/rules/_bulk_action` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-bulkaction[API documentation]) to update fields in multiple rules simultaneously.
+   - Alternatively, update rules individually using `PUT /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-updaterule[API documentation]).
+
+3. **For bulk deletion of rules:**
+   - Use `POST /api/detection_engine/rules/_bulk_action` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-performrulesbulkaction[API documentation]) to delete multiple rules by IDs or query.
+   - Alternatively, delete rules individually using `DELETE /api/detection_engine/rules/{id}` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-deleterule[API documentation]).
+--
 ====
 
 [discrete]

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -71,16 +71,16 @@ Deprecated endpoints will fail with a 404 status code starting from version 9.0.
 Update your implementations to use the new endpoints:
 
 * **For bulk creation of rules:**
-   - Use `POST /api/detection_engine/rules/_import` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-importrules[API documentation]) to create multiple rules along with their associated entities (for example, exceptions and action connectors).
-   - Alternatively, create rules individually using `POST /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-createrule[API documentation]).
+   - Use `POST /api/detection_engine/rules/_import` (link:{api-kibana}/operation/operation-importrules[API documentation]) to create multiple rules along with their associated entities (for example, exceptions and action connectors).
+   - Alternatively, create rules individually using `POST /api/detection_engine/rules` (link:{api-kibana}/operation/operation-createrule[API documentation]).
 
 * **For bulk updates of rules:**
-   - Use `POST /api/detection_engine/rules/_bulk_action` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-performrulesbulkaction[API documentation]) to update fields in multiple rules simultaneously.
-   - Alternatively, update rules individually using `PUT /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-updaterule[API documentation]).
+   - Use `POST /api/detection_engine/rules/_bulk_action` (link:{api-kibana}/operation/operation-performrulesbulkaction[API documentation]) to update fields in multiple rules simultaneously.
+   - Alternatively, update rules individually using `PUT /api/detection_engine/rules` (link:{api-kibana}/operation/operation-updaterule[API documentation]).
 
 * **For bulk deletion of rules:**
-   - Use `POST /api/detection_engine/rules/_bulk_action` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-performrulesbulkaction[API documentation]) to delete multiple rules by IDs or query.
-   - Alternatively, delete rules individually using `DELETE /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-deleterule[API documentation]).
+   - Use `POST /api/detection_engine/rules/_bulk_action` (link:{api-kibana}/operation/operation-performrulesbulkaction[API documentation]) to delete multiple rules by IDs or query.
+   - Alternatively, delete rules individually using `DELETE /api/detection_engine/rules` (link:{api-kibana}/operation/operation-deleterule[API documentation]).
 --
 ====
 

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -61,7 +61,7 @@ For Elastic Security solution release information, refer to {security-guide}/rel
 * `DELETE /api/detection_engine/rules/_bulk_delete` has been replaced by `POST /api/detection_engine/rules/_bulk_action`
 * `POST api/detection_engine/rules/_bulk_delete` has been replaced by `POST /api/detection_engine/rules/_bulk_action`
 --
-These changes were introduced in PR {kibana-pull}#197422[#197422]
+These changes were introduced in {kibana-pull}197422[#197422].
 
 *Impact* +
 Deprecated endpoints will fail with a 404 status code starting from version 9.0.0
@@ -70,15 +70,15 @@ Deprecated endpoints will fail with a 404 status code starting from version 9.0.
 --
 Update your implementations to use the new endpoints:
 
-1. **For bulk creation of rules:**
+* **For bulk creation of rules:**
    - Use `POST /api/detection_engine/rules/_import` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-importrules[API documentation]) to create multiple rules along with their associated entities (e.g., exceptions and action connectors).
    - Alternatively, create rules individually using `POST /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-createrule[API documentation]).
 
-2. **For bulk updates of rules:**
+* **For bulk updates of rules:**
    - Use `POST /api/detection_engine/rules/_bulk_action` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-performrulesbulkaction[API documentation]) to update fields in multiple rules simultaneously.
    - Alternatively, update rules individually using `PUT /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-updaterule[API documentation]).
 
-3. **For bulk deletion of rules:**
+* **For bulk deletion of rules:**
    - Use `POST /api/detection_engine/rules/_bulk_action` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-performrulesbulkaction[API documentation]) to delete multiple rules by IDs or query.
    - Alternatively, delete rules individually using `DELETE /api/detection_engine/rules` (link:https://www.elastic.co/docs/api/doc/kibana/v8/operation/operation-deleterule[API documentation]).
 --

--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -61,7 +61,7 @@ For Elastic Security solution release information, refer to {security-guide}/rel
 * `DELETE /api/detection_engine/rules/_bulk_delete` has been replaced by `POST /api/detection_engine/rules/_bulk_action`
 * `POST api/detection_engine/rules/_bulk_delete` has been replaced by `POST /api/detection_engine/rules/_bulk_action`
 --
-These changes were introduced in PR {kibana-pull}#197422[#197422].
+These changes were introduced in PR {kibana-pull}#197422[#197422]
 
 *Impact* +
 Deprecated endpoints will fail with a 404 status code starting from version 9.0.0

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -449,6 +449,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       aiAssistant: `${SECURITY_SOLUTION_DOCS}security-assistant.html`,
       signalsMigrationApi: `${SECURITY_SOLUTION_DOCS}signals-migration-api.html`,
       legacyEndpointManagementApiDeprecations: `${KIBANA_DOCS}breaking-changes-summary.html#breaking-199598`,
+      legacyBulkApiDeprecations: `${KIBANA_DOCS}breaking-changes-summary.html#breaking-207091`,
     },
     query: {
       eql: `${ELASTICSEARCH_DOCS}eql.html`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -315,6 +315,7 @@ export interface DocLinks {
     readonly detectionEngineOverview: string;
     readonly signalsMigrationApi: string;
     readonly legacyEndpointManagementApiDeprecations: string;
+    readonly legacyBulkApiDeprecations: string;
   };
   readonly query: {
     readonly eql: string;

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -248,6 +248,7 @@ export const DETECTION_ENGINE_RULES_BULK_CREATE =
   `${DETECTION_ENGINE_RULES_URL}/_bulk_create` as const;
 export const DETECTION_ENGINE_RULES_BULK_UPDATE =
   `${DETECTION_ENGINE_RULES_URL}/_bulk_update` as const;
+export const DETECTION_ENGINE_RULES_IMPORT_URL = `${DETECTION_ENGINE_RULES_URL}/_import` as const;
 
 export * from './entity_analytics/constants';
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
@@ -40,6 +40,7 @@ import {
 import type { BulkActionsDryRunErrCode } from '../../../../common/constants';
 import {
   DETECTION_ENGINE_RULES_BULK_ACTION,
+  DETECTION_ENGINE_RULES_IMPORT_URL,
   DETECTION_ENGINE_RULES_PREVIEW,
   DETECTION_ENGINE_RULES_URL,
   DETECTION_ENGINE_RULES_URL_FIND,
@@ -455,21 +456,18 @@ export const importRules = async ({
   const formData = new FormData();
   formData.append('file', fileToImport);
 
-  return KibanaServices.get().http.fetch<ImportDataResponse>(
-    `${DETECTION_ENGINE_RULES_URL}/_import`,
-    {
-      method: 'POST',
-      version: '2023-10-31',
-      headers: { 'Content-Type': undefined },
-      query: {
-        overwrite,
-        overwrite_exceptions: overwriteExceptions,
-        overwrite_action_connectors: overwriteActionConnectors,
-      },
-      body: formData,
-      signal,
-    }
-  );
+  return KibanaServices.get().http.fetch<ImportDataResponse>(DETECTION_ENGINE_RULES_IMPORT_URL, {
+    method: 'POST',
+    version: '2023-10-31',
+    headers: { 'Content-Type': undefined },
+    query: {
+      overwrite,
+      overwrite_exceptions: overwriteExceptions,
+      overwrite_action_connectors: overwriteActionConnectors,
+    },
+    body: formData,
+    signal,
+  });
 };
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_responses.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_responses.ts
@@ -29,6 +29,7 @@ import {
   DETECTION_ENGINE_RULES_BULK_DELETE,
   DETECTION_ENGINE_RULES_BULK_CREATE,
   DETECTION_ENGINE_RULES_URL_FIND,
+  DETECTION_ENGINE_RULES_IMPORT_URL,
 } from '../../../../../common/constants';
 import { RULE_MANAGEMENT_FILTERS_URL } from '../../../../../common/api/detection_engine/rule_management/urls';
 
@@ -260,14 +261,14 @@ export const getFindResultWithMultiHits = ({
 export const getImportRulesRequest = (hapiStream?: HapiReadableStream) =>
   requestMock.create({
     method: 'post',
-    path: `${DETECTION_ENGINE_RULES_URL}/_import`,
+    path: DETECTION_ENGINE_RULES_IMPORT_URL,
     body: { file: hapiStream },
   });
 
 export const getImportRulesRequestOverwriteTrue = (hapiStream?: HapiReadableStream) =>
   requestMock.create({
     method: 'post',
-    path: `${DETECTION_ENGINE_RULES_URL}/_import`,
+    path: DETECTION_ENGINE_RULES_IMPORT_URL,
     body: { file: hapiStream },
     query: { overwrite: true },
   });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
@@ -41,12 +41,11 @@ export const registerRuleManagementRoutes = (
   patchRuleRoute(router);
   deleteRuleRoute(router);
 
-  // DEPRECATED. NIKITA, REMOVE THESE
+  // These four bulk endpoints are deprecated and will be removed in 9.0
   bulkCreateRulesRoute(router, logger, docLinks);
   bulkUpdateRulesRoute(router, logger, docLinks);
   bulkPatchRulesRoute(router, logger, docLinks);
   bulkDeleteRulesRoute(router, logger, docLinks);
-  // ALONG WITH THEIR IMPORTS
 
   // Rules bulk actions
   performBulkActionRoute(router, config, ml, logger);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
@@ -45,7 +45,7 @@ export const registerRuleManagementRoutes = (
   bulkCreateRulesRoute(router, logger, docLinks);
   bulkUpdateRulesRoute(router, logger, docLinks);
   bulkPatchRulesRoute(router, logger, docLinks);
-  bulkDeleteRulesRoute(router, logger);
+  bulkDeleteRulesRoute(router, logger, docLinks);
   // ALONG WITH THEIR IMPORTS
 
   // Rules bulk actions

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
@@ -43,7 +43,7 @@ export const registerRuleManagementRoutes = (
 
   // DEPRECATED. NIKITA, REMOVE THESE
   bulkCreateRulesRoute(router, logger, docLinks);
-  bulkUpdateRulesRoute(router, logger);
+  bulkUpdateRulesRoute(router, logger, docLinks);
   bulkPatchRulesRoute(router, logger, docLinks);
   bulkDeleteRulesRoute(router, logger);
   // ALONG WITH THEIR IMPORTS

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { Logger } from '@kbn/core/server';
+import type { DocLinksServiceSetup, Logger } from '@kbn/core/server';
 import type { ConfigType } from '../../../../config';
 import type { SetupPlugins } from '../../../../plugin_contract';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
@@ -22,12 +22,17 @@ import { readRuleRoute } from './rules/read_rule/route';
 import { updateRuleRoute } from './rules/update_rule/route';
 import { readTagsRoute } from './tags/read_tags/route';
 import { getCoverageOverviewRoute } from './rules/coverage_overview/route';
+import { bulkCreateRulesRoute } from './rules/bulk_create_rules/route';
+import { bulkUpdateRulesRoute } from './rules/bulk_update_rules/route';
+import { bulkPatchRulesRoute } from './rules/bulk_patch_rules/route';
+import { bulkDeleteRulesRoute } from './rules/bulk_delete_rules/route';
 
 export const registerRuleManagementRoutes = (
   router: SecuritySolutionPluginRouter,
   config: ConfigType,
   ml: SetupPlugins['ml'],
-  logger: Logger
+  logger: Logger,
+  docLinks: DocLinksServiceSetup
 ) => {
   // Rules CRUD
   createRuleRoute(router);
@@ -35,6 +40,13 @@ export const registerRuleManagementRoutes = (
   updateRuleRoute(router);
   patchRuleRoute(router);
   deleteRuleRoute(router);
+
+  // DEPRECATED. NIKITA, REMOVE THESE
+  bulkCreateRulesRoute(router, logger);
+  bulkUpdateRulesRoute(router, logger);
+  bulkPatchRulesRoute(router, logger, docLinks);
+  bulkDeleteRulesRoute(router, logger);
+  // ALONG WITH THEIR IMPORTS
 
   // Rules bulk actions
   performBulkActionRoute(router, config, ml, logger);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
@@ -42,7 +42,7 @@ export const registerRuleManagementRoutes = (
   deleteRuleRoute(router);
 
   // DEPRECATED. NIKITA, REMOVE THESE
-  bulkCreateRulesRoute(router, logger);
+  bulkCreateRulesRoute(router, logger, docLinks);
   bulkUpdateRulesRoute(router, logger);
   bulkPatchRulesRoute(router, logger, docLinks);
   bulkDeleteRulesRoute(router, logger);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.test.ts
@@ -20,7 +20,7 @@ import { bulkCreateRulesRoute } from './route';
 import { getCreateRulesSchemaMock } from '../../../../../../../common/api/detection_engine/model/rule_schema/mocks';
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
 import { getQueryRuleParams } from '../../../../rule_schema/mocks';
-import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { loggingSystemMock, docLinksServiceMock } from '@kbn/core/server/mocks';
 import { HttpAuthzError } from '../../../../../machine_learning/validation';
 import { getRulesSchemaMock } from '../../../../../../../common/api/detection_engine/model/rule_schema/rule_response_schema.mock';
 
@@ -32,6 +32,7 @@ describe('Bulk create rules route', () => {
     server = serverMock.create();
     ({ clients, context } = requestContextMock.createTools());
     const logger = loggingSystemMock.createLogger();
+    const docLinks = docLinksServiceMock.createSetupContract();
 
     clients.rulesClient.find.mockResolvedValue(getEmptyFindResult()); // no existing rules
     clients.rulesClient.create.mockResolvedValue(getRuleMock(getQueryRuleParams())); // successful creation
@@ -39,7 +40,7 @@ describe('Bulk create rules route', () => {
     context.core.elasticsearch.client.asCurrentUser.search.mockResolvedValue(
       elasticsearchClientMock.createSuccessTransportRequestPromise(getBasicEmptySearchResponse())
     );
-    bulkCreateRulesRoute(server.router, logger);
+    bulkCreateRulesRoute(server.router, logger, docLinks);
   });
 
   describe('status codes', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
@@ -5,11 +5,14 @@
  * 2.0.
  */
 
-import type { IKibanaResponse, Logger } from '@kbn/core/server';
+import type { DocLinksServiceSetup, IKibanaResponse, Logger } from '@kbn/core/server';
 
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
-import { DETECTION_ENGINE_RULES_BULK_CREATE } from '../../../../../../../common/constants';
+import {
+  DETECTION_ENGINE_RULES_BULK_CREATE,
+  DETECTION_ENGINE_RULES_IMPORT_URL,
+} from '../../../../../../../common/constants';
 import {
   BulkCreateRulesRequestBody,
   validateCreateRuleProps,
@@ -34,7 +37,11 @@ import { getDeprecatedBulkEndpointHeader, logDeprecatedBulkEndpoint } from '../.
  *
  * TODO: https://github.com/elastic/kibana/issues/193184 Delete this route and clean up the code
  */
-export const bulkCreateRulesRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
+export const bulkCreateRulesRoute = (
+  router: SecuritySolutionPluginRouter,
+  logger: Logger,
+  docLinks: DocLinksServiceSetup
+) => {
   router.versioned
     .post({
       access: 'public',
@@ -56,6 +63,17 @@ export const bulkCreateRulesRoute = (router: SecuritySolutionPluginRouter, logge
         validate: {
           request: {
             body: buildRouteValidationWithZod(BulkCreateRulesRequestBody),
+          },
+        },
+        options: {
+          deprecated: {
+            documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
+            severity: 'warning',
+            reason: {
+              type: 'migrate',
+              newApiMethod: 'POST',
+              newApiPath: DETECTION_ENGINE_RULES_IMPORT_URL,
+            },
           },
         },
       },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
@@ -68,7 +68,7 @@ export const bulkCreateRulesRoute = (
         options: {
           deprecated: {
             documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
-            severity: 'warning',
+            severity: 'critical',
             reason: {
               type: 'migrate',
               newApiMethod: 'POST',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.test.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../../routes/__mocks__/request_responses';
 import { requestContextMock, serverMock, requestMock } from '../../../../routes/__mocks__';
 import { bulkDeleteRulesRoute } from './route';
-import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { loggingSystemMock, docLinksServiceMock } from '@kbn/core/server/mocks';
 
 describe('Bulk delete rules route', () => {
   let server: ReturnType<typeof serverMock.create>;
@@ -27,12 +27,13 @@ describe('Bulk delete rules route', () => {
     server = serverMock.create();
     ({ clients, context } = requestContextMock.createTools());
     const logger = loggingSystemMock.createLogger();
+    const docLinks = docLinksServiceMock.createSetupContract();
 
     clients.rulesClient.find.mockResolvedValue(getFindResultWithSingleHit()); // rule exists
     clients.rulesClient.delete.mockResolvedValue({}); // successful deletion
     clients.savedObjectsClient.find.mockResolvedValue(getEmptySavedObjectsResponse()); // rule status request
 
-    bulkDeleteRulesRoute(server.router, logger);
+    bulkDeleteRulesRoute(server.router, logger, docLinks);
   });
 
   describe('status codes with actionClient and alertClient', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
@@ -141,7 +141,7 @@ export const bulkDeleteRulesRoute = (
       options: {
         deprecated: {
           documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
-          severity: 'warning',
+          severity: 'critical',
           reason: {
             type: 'migrate',
             newApiMethod: 'POST',
@@ -163,7 +163,7 @@ export const bulkDeleteRulesRoute = (
       options: {
         deprecated: {
           documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
-          severity: 'warning',
+          severity: 'critical',
           reason: {
             type: 'migrate',
             newApiMethod: 'POST',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
@@ -6,7 +6,12 @@
  */
 
 import type { VersionedRouteConfig } from '@kbn/core-http-server';
-import type { IKibanaResponse, Logger, RequestHandler } from '@kbn/core/server';
+import type {
+  DocLinksServiceSetup,
+  IKibanaResponse,
+  Logger,
+  RequestHandler,
+} from '@kbn/core/server';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
 import type {
@@ -19,7 +24,10 @@ import {
   BulkDeleteRulesRequestBody,
   validateQueryRuleByIds,
 } from '../../../../../../../common/api/detection_engine/rule_management';
-import { DETECTION_ENGINE_RULES_BULK_DELETE } from '../../../../../../../common/constants';
+import {
+  DETECTION_ENGINE_RULES_BULK_ACTION,
+  DETECTION_ENGINE_RULES_BULK_DELETE,
+} from '../../../../../../../common/constants';
 import type {
   SecuritySolutionPluginRouter,
   SecuritySolutionRequestHandlerContext,
@@ -48,7 +56,11 @@ type Handler = RequestHandler<
  *
  * TODO: https://github.com/elastic/kibana/issues/193184 Delete this route and clean up the code
  */
-export const bulkDeleteRulesRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
+export const bulkDeleteRulesRoute = (
+  router: SecuritySolutionPluginRouter,
+  logger: Logger,
+  docLinks: DocLinksServiceSetup
+) => {
   const handler: Handler = async (
     context,
     request,
@@ -126,6 +138,17 @@ export const bulkDeleteRulesRoute = (router: SecuritySolutionPluginRouter, logge
           body: buildRouteValidationWithZod(BulkDeleteRulesRequestBody),
         },
       },
+      options: {
+        deprecated: {
+          documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
+          severity: 'warning',
+          reason: {
+            type: 'migrate',
+            newApiMethod: 'POST',
+            newApiPath: DETECTION_ENGINE_RULES_BULK_ACTION,
+          },
+        },
+      },
     },
     handler
   );
@@ -135,6 +158,17 @@ export const bulkDeleteRulesRoute = (router: SecuritySolutionPluginRouter, logge
       validate: {
         request: {
           body: buildRouteValidationWithZod(BulkDeleteRulesPostRequestBody),
+        },
+      },
+      options: {
+        deprecated: {
+          documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
+          severity: 'warning',
+          reason: {
+            type: 'migrate',
+            newApiMethod: 'POST',
+            newApiPath: DETECTION_ENGINE_RULES_BULK_ACTION,
+          },
         },
       },
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.test.ts
@@ -24,7 +24,7 @@ import {
 import { bulkPatchRulesRoute } from './route';
 import { getCreateRulesSchemaMock } from '../../../../../../../common/api/detection_engine/model/rule_schema/mocks';
 import { getMlRuleParams, getQueryRuleParams } from '../../../../rule_schema/mocks';
-import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { loggingSystemMock, docLinksServiceMock } from '@kbn/core/server/mocks';
 import { HttpAuthzError } from '../../../../../machine_learning/validation';
 
 describe('Bulk patch rules route', () => {
@@ -35,12 +35,13 @@ describe('Bulk patch rules route', () => {
     server = serverMock.create();
     ({ clients, context } = requestContextMock.createTools());
     const logger = loggingSystemMock.createLogger();
+    const docLinks = docLinksServiceMock.createSetupContract();
 
     clients.rulesClient.find.mockResolvedValue(getFindResultWithSingleHit()); // rule exists
     clients.rulesClient.update.mockResolvedValue(getRuleMock(getQueryRuleParams())); // update succeeds
     clients.detectionRulesClient.patchRule.mockResolvedValue(getRulesSchemaMock());
 
-    bulkPatchRulesRoute(server.router, logger);
+    bulkPatchRulesRoute(server.router, logger, docLinks);
   });
 
   describe('status codes', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
@@ -5,11 +5,14 @@
  * 2.0.
  */
 
-import type { IKibanaResponse, Logger } from '@kbn/core/server';
+import type { DocLinksServiceSetup, IKibanaResponse, Logger } from '@kbn/core/server';
 
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
-import { DETECTION_ENGINE_RULES_BULK_UPDATE } from '../../../../../../../common/constants';
+import {
+  DETECTION_ENGINE_RULES_BULK_ACTION,
+  DETECTION_ENGINE_RULES_BULK_UPDATE,
+} from '../../../../../../../common/constants';
 import {
   BulkPatchRulesRequestBody,
   BulkCrudRulesResponse,
@@ -28,7 +31,11 @@ import { RULE_MANAGEMENT_BULK_ACTION_SOCKET_TIMEOUT_MS } from '../../timeouts';
  *
  * TODO: https://github.com/elastic/kibana/issues/193184 Delete this route and clean up the code
  */
-export const bulkPatchRulesRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
+export const bulkPatchRulesRoute = (
+  router: SecuritySolutionPluginRouter,
+  logger: Logger,
+  docLinks: DocLinksServiceSetup
+) => {
   router.versioned
     .patch({
       access: 'public',
@@ -50,6 +57,17 @@ export const bulkPatchRulesRoute = (router: SecuritySolutionPluginRouter, logger
         validate: {
           request: {
             body: buildRouteValidationWithZod(BulkPatchRulesRequestBody),
+          },
+        },
+        options: {
+          deprecated: {
+            documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
+            severity: 'warning',
+            reason: {
+              type: 'migrate',
+              newApiMethod: 'POST',
+              newApiPath: DETECTION_ENGINE_RULES_BULK_ACTION,
+            },
           },
         },
       },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
@@ -62,7 +62,7 @@ export const bulkPatchRulesRoute = (
         options: {
           deprecated: {
             documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
-            severity: 'warning',
+            severity: 'critical',
             reason: {
               type: 'migrate',
               newApiMethod: 'POST',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.test.ts
@@ -19,7 +19,7 @@ import { bulkUpdateRulesRoute } from './route';
 import type { BulkError } from '../../../../routes/utils';
 import { getCreateRulesSchemaMock } from '../../../../../../../common/api/detection_engine/model/rule_schema/mocks';
 import { getQueryRuleParams } from '../../../../rule_schema/mocks';
-import { loggingSystemMock } from '@kbn/core/server/mocks';
+import { loggingSystemMock, docLinksServiceMock } from '@kbn/core/server/mocks';
 import { HttpAuthzError } from '../../../../../machine_learning/validation';
 
 describe('Bulk update rules route', () => {
@@ -30,13 +30,14 @@ describe('Bulk update rules route', () => {
     server = serverMock.create();
     ({ clients, context } = requestContextMock.createTools());
     const logger = loggingSystemMock.createLogger();
+    const docLinks = docLinksServiceMock.createSetupContract();
 
     clients.rulesClient.find.mockResolvedValue(getFindResultWithSingleHit());
     clients.rulesClient.update.mockResolvedValue(getRuleMock(getQueryRuleParams()));
     clients.detectionRulesClient.updateRule.mockResolvedValue(getRulesSchemaMock());
     clients.appClient.getSignalsIndex.mockReturnValue('.siem-signals-test-index');
 
-    bulkUpdateRulesRoute(server.router, logger);
+    bulkUpdateRulesRoute(server.router, logger, docLinks);
   });
 
   describe('status codes', () => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
@@ -66,7 +66,7 @@ export const bulkUpdateRulesRoute = (
         options: {
           deprecated: {
             documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
-            severity: 'warning',
+            severity: 'critical',
             reason: {
               type: 'migrate',
               newApiMethod: 'POST',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { IKibanaResponse, Logger } from '@kbn/core/server';
+import type { DocLinksServiceSetup, IKibanaResponse, Logger } from '@kbn/core/server';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import {
@@ -14,7 +14,10 @@ import {
   BulkCrudRulesResponse,
 } from '../../../../../../../common/api/detection_engine/rule_management';
 import type { SecuritySolutionPluginRouter } from '../../../../../../types';
-import { DETECTION_ENGINE_RULES_BULK_UPDATE } from '../../../../../../../common/constants';
+import {
+  DETECTION_ENGINE_RULES_BULK_ACTION,
+  DETECTION_ENGINE_RULES_BULK_UPDATE,
+} from '../../../../../../../common/constants';
 import { getIdBulkError } from '../../../utils/utils';
 import {
   transformBulkError,
@@ -32,7 +35,11 @@ import { RULE_MANAGEMENT_BULK_ACTION_SOCKET_TIMEOUT_MS } from '../../timeouts';
  *
  * TODO: https://github.com/elastic/kibana/issues/193184 Delete this route and clean up the code
  */
-export const bulkUpdateRulesRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
+export const bulkUpdateRulesRoute = (
+  router: SecuritySolutionPluginRouter,
+  logger: Logger,
+  docLinks: DocLinksServiceSetup
+) => {
   router.versioned
     .put({
       access: 'public',
@@ -54,6 +61,17 @@ export const bulkUpdateRulesRoute = (router: SecuritySolutionPluginRouter, logge
         validate: {
           request: {
             body: buildRouteValidationWithZod(BulkUpdateRulesRequestBody),
+          },
+        },
+        options: {
+          deprecated: {
+            documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
+            severity: 'warning',
+            reason: {
+              type: 'migrate',
+              newApiMethod: 'POST',
+              newApiPath: DETECTION_ENGINE_RULES_BULK_ACTION,
+            },
           },
         },
       },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
@@ -15,7 +15,7 @@ import {
   ImportRulesRequestQuery,
   ImportRulesResponse,
 } from '../../../../../../../common/api/detection_engine/rule_management';
-import { DETECTION_ENGINE_RULES_URL } from '../../../../../../../common/constants';
+import { DETECTION_ENGINE_RULES_IMPORT_URL } from '../../../../../../../common/constants';
 import type { ConfigType } from '../../../../../../config';
 import type { HapiReadableStream, SecuritySolutionPluginRouter } from '../../../../../../types';
 import type { ImportRuleResponse } from '../../../../routes/utils';
@@ -46,7 +46,7 @@ export const importRulesRoute = (router: SecuritySolutionPluginRouter, config: C
   router.versioned
     .post({
       access: 'public',
-      path: `${DETECTION_ENGINE_RULES_URL}/_import`,
+      path: DETECTION_ENGINE_RULES_IMPORT_URL,
       security: {
         authz: {
           requiredPrivileges: ['securitySolution'],

--- a/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
@@ -79,7 +79,7 @@ export const initRoutes = (
   registerPrebuiltRulesRoutes(router, config);
   registerRuleExceptionsRoutes(router);
   registerManageExceptionsRoutes(router);
-  registerRuleManagementRoutes(router, config, ml, logger);
+  registerRuleManagementRoutes(router, config, ml, logger, docLinks);
   registerRuleMonitoringRoutes(router);
   registerRulePreviewRoutes(
     router,

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/basic_license_essentials_tier/import_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/basic_license_essentials_tier/import_rules.ts
@@ -213,7 +213,7 @@ export default ({ getService }: FtrProviderContext): void => {
       // it('should be able to import 10000 rules', async () => {
       //   const ruleIds = new Array(10000).fill(undefined).map((_, index) => `rule-${index}`);
       //   const { body } = await supertest
-      //     .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+      //     .post(DETECTION_ENGINE_RULES_IMPORT_URL)
       //     .set('kbn-xsrf', 'true')
       //     .attach('file', getSimpleRuleAsNdjson(ruleIds, false), 'rules.ndjson')
       //     .expect(200);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/basic_license_essentials_tier/import_rules_with_overwrite.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/basic_license_essentials_tier/import_rules_with_overwrite.ts
@@ -7,7 +7,7 @@
 
 import expect from 'expect';
 
-import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
+import { DETECTION_ENGINE_RULES_IMPORT_URL } from '@kbn/security-solution-plugin/common/constants';
 import { createRule, deleteAllRules } from '../../../../../../common/utils/security_solution';
 import { combineToNdJson, getCustomQueryRuleParams, fetchRule } from '../../../utils';
 import { FtrProviderContext } from '../../../../../ftr_provider_context';
@@ -28,7 +28,7 @@ export default ({ getService }: FtrProviderContext): void => {
       );
 
       const { body } = await supertest
-        .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+        .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
         .set('kbn-xsrf', 'true')
         .set('elastic-api-version', '2023-10-31')
         .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -55,14 +55,14 @@ export default ({ getService }: FtrProviderContext): void => {
       );
 
       await supertest
-        .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+        .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
         .set('kbn-xsrf', 'true')
         .set('elastic-api-version', '2023-10-31')
         .attach('file', Buffer.from(ndjson), 'rules.ndjson')
         .expect(200);
 
       const { body } = await supertest
-        .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+        .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
         .set('kbn-xsrf', 'true')
         .set('elastic-api-version', '2023-10-31')
         .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -94,7 +94,7 @@ export default ({ getService }: FtrProviderContext): void => {
       );
 
       const { body } = await supertest
-        .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+        .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
         .set('kbn-xsrf', 'true')
         .set('elastic-api-version', '2023-10-31')
         .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -150,7 +150,7 @@ export default ({ getService }: FtrProviderContext): void => {
       );
 
       const { body } = await supertest
-        .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+        .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
         .set('kbn-xsrf', 'true')
         .set('elastic-api-version', '2023-10-31')
         .attach('file', Buffer.from(ndjson), 'rules.ndjson')

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/import_connectors.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/import_connectors.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from 'expect';
-import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
+import { DETECTION_ENGINE_RULES_IMPORT_URL } from '@kbn/security-solution-plugin/common/constants';
 import { deleteAllRules } from '../../../../../../common/utils/security_solution';
 import { combineToNdJson, getCustomQueryRuleParams } from '../../../utils';
 import { createConnector, deleteConnector, getConnector } from '../../../utils/connectors';
@@ -79,7 +79,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -106,7 +106,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(CUSTOM_ACTION_CONNECTOR);
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -154,7 +154,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -200,7 +200,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -262,7 +262,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -308,7 +308,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -389,7 +389,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite_action_connectors=true`)
+          .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite_action_connectors=true`)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -435,7 +435,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite_action_connectors=true`)
+          .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite_action_connectors=true`)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -494,7 +494,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite_action_connectors=true`)
+          .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite_action_connectors=true`)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/import_export_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/import_export_rules.ts
@@ -16,7 +16,10 @@ import {
   getCreateExceptionListDetectionSchemaMock,
   getCreateExceptionListMinimalSchemaMock,
 } from '@kbn/lists-plugin/common/schemas/request/create_exception_list_schema.mock';
-import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
+import {
+  DETECTION_ENGINE_RULES_IMPORT_URL,
+  DETECTION_ENGINE_RULES_URL,
+} from '@kbn/security-solution-plugin/common/constants';
 import { ROLES } from '@kbn/security-solution-plugin/common/test';
 import { binaryToString, getCustomQueryRuleParams } from '../../../utils';
 import {
@@ -121,7 +124,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .parse(binaryToString);
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true&overwrite_exceptions=true`)
+          .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true&overwrite_exceptions=true`)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(body), 'rules.ndjson')
@@ -203,7 +206,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .parse(binaryToString);
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true&overwrite_exceptions=true`)
+          .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true&overwrite_exceptions=true`)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(body), 'rules.ndjson')
@@ -294,7 +297,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .parse(binaryToString);
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true&overwrite_exceptions=true`)
+          .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true&overwrite_exceptions=true`)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(body), 'rules.ndjson')
@@ -376,7 +379,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .parse(binaryToString);
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true&overwrite_exceptions=true`)
+          .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true&overwrite_exceptions=true`)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(body), 'rules.ndjson')

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/import_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/import_rules.ts
@@ -10,7 +10,7 @@ import { range } from 'lodash';
 
 import { EXCEPTION_LIST_ITEM_URL, EXCEPTION_LIST_URL } from '@kbn/securitysolution-list-constants';
 import { getCreateExceptionListMinimalSchemaMock } from '@kbn/lists-plugin/common/schemas/request/create_exception_list_schema.mock';
-import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
+import { DETECTION_ENGINE_RULES_IMPORT_URL } from '@kbn/security-solution-plugin/common/constants';
 import {
   getImportExceptionsListItemSchemaMock,
   getImportExceptionsListSchemaMock,
@@ -184,7 +184,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(rule);
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -208,7 +208,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(rule);
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -235,7 +235,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(rule);
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -267,7 +267,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(rule);
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -331,7 +331,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(rule);
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -353,7 +353,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(getCustomQueryRuleParams());
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -363,7 +363,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
       it('should reject with an error if the file type is not that of a ndjson', async () => {
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(''), 'rules.txt')
@@ -379,7 +379,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(getCustomQueryRuleParams());
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -398,7 +398,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(ruleToImport);
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -416,7 +416,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -437,7 +437,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -467,7 +467,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(existingRule);
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -511,7 +511,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -562,7 +562,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -608,7 +608,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(existingRule1, existingRule2, ruleToImportSuccessfully);
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -638,7 +638,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -706,7 +706,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -748,7 +748,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -823,7 +823,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+          .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -885,7 +885,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -946,7 +946,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const buffer = getImportRuleBuffer(space714ActionConnectorId);
 
             const { body } = await supertest
-              .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
+              .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_IMPORT_URL}`)
               .set('kbn-xsrf', 'true')
               .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
@@ -965,7 +965,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
             const buffer = getImportRuleWithConnectorsBuffer(differentSpaceConnectorId);
             const { body } = await supertest
-              .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
+              .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_IMPORT_URL}`)
               .set('kbn-xsrf', 'true')
               .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
@@ -989,7 +989,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const buffer = getImportRuleWithConnectorsBuffer(differentSpaceConnectorId);
 
             const { body } = await supertest
-              .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+              .post(DETECTION_ENGINE_RULES_IMPORT_URL)
               .set('kbn-xsrf', 'true')
               .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
@@ -1013,7 +1013,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const buffer = getImportRuleBuffer(space714ActionConnectorId);
 
             const { body } = await supertest
-              .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+              .post(DETECTION_ENGINE_RULES_IMPORT_URL)
               .set('kbn-xsrf', 'true')
               .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
@@ -1040,7 +1040,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const buffer = getImportRuleBuffer(space714ActionConnectorId);
 
             const { body } = await supertest
-              .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
+              .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_IMPORT_URL}`)
               .set('kbn-xsrf', 'true')
               .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
@@ -1074,7 +1074,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const buffer = getImportRuleWithConnectorsBuffer(defaultSpaceConnectorId);
 
             const { body } = await supertest
-              .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
+              .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_IMPORT_URL}`)
               .set('kbn-xsrf', 'true')
               .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
@@ -1100,7 +1100,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const buffer = getImportRuleBuffer(defaultSpaceActionConnectorId);
 
             const { body } = await supertest
-              .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+              .post(DETECTION_ENGINE_RULES_IMPORT_URL)
               .set('kbn-xsrf', 'true')
               .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
@@ -1124,7 +1124,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const buffer = getImportRuleBuffer(defaultSpaceActionConnectorId);
 
             const { body } = await supertest
-              .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
+              .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_IMPORT_URL}`)
               .set('kbn-xsrf', 'true')
               .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
@@ -1166,7 +1166,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
           // import old exception version
           const { body } = await supertest
-            .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+            .post(DETECTION_ENGINE_RULES_IMPORT_URL)
             .set('kbn-xsrf', 'true')
             .set('elastic-api-version', '2023-10-31')
             .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -1198,7 +1198,7 @@ export default ({ getService }: FtrProviderContext): void => {
           );
 
           const { body } = await supertest
-            .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+            .post(DETECTION_ENGINE_RULES_IMPORT_URL)
             .set('kbn-xsrf', 'true')
             .set('elastic-api-version', '2023-10-31')
             .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -1250,7 +1250,7 @@ export default ({ getService }: FtrProviderContext): void => {
           );
 
           const { body } = await supertest
-            .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+            .post(DETECTION_ENGINE_RULES_IMPORT_URL)
             .set('kbn-xsrf', 'true')
             .set('elastic-api-version', '2023-10-31')
             .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -1301,7 +1301,7 @@ export default ({ getService }: FtrProviderContext): void => {
           );
 
           const { body } = await supertest
-            .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+            .post(DETECTION_ENGINE_RULES_IMPORT_URL)
             .set('kbn-xsrf', 'true')
             .set('elastic-api-version', '2023-10-31')
             .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -1393,7 +1393,7 @@ export default ({ getService }: FtrProviderContext): void => {
           // Importing the "simpleRule", along with the exception list
           // it's referencing and the list's item
           const { body } = await supertest
-            .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+            .post(DETECTION_ENGINE_RULES_IMPORT_URL)
             .set('kbn-xsrf', 'true')
             .set('elastic-api-version', '2023-10-31')
             .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -1468,7 +1468,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const importPayload = combineArraysToNdJson(rules, exceptionLists, exceptionItems);
 
           const { body } = await supertest
-            .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+            .post(DETECTION_ENGINE_RULES_IMPORT_URL)
             .set('kbn-xsrf', 'true')
             .set('elastic-api-version', '2023-10-31')
             .attach('file', Buffer.from(importPayload), 'rules.ndjson')
@@ -1549,7 +1549,7 @@ export default ({ getService }: FtrProviderContext): void => {
           // Importing the "simpleRule", along with the exception list
           // it's referencing and the list's item
           const { body } = await supertest
-            .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+            .post(DETECTION_ENGINE_RULES_IMPORT_URL)
             .set('kbn-xsrf', 'true')
             .set('elastic-api-version', '2023-10-31')
             .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -1615,7 +1615,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
           .expect('Content-Type', 'application/json; charset=utf-8')
@@ -1634,7 +1634,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const ndjson = combineToNdJson(rule);
 
           const { body } = await supertest
-            .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+            .post(DETECTION_ENGINE_RULES_IMPORT_URL)
             .set('kbn-xsrf', 'true')
             .set('elastic-api-version', '2023-10-31')
             .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -1667,7 +1667,7 @@ export default ({ getService }: FtrProviderContext): void => {
           );
 
           const { body } = await supertest
-            .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+            .post(DETECTION_ENGINE_RULES_IMPORT_URL)
             .set('kbn-xsrf', 'true')
             .set('elastic-api-version', '2023-10-31')
             .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -1700,7 +1700,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const ndjson = combineToNdJson(rule);
 
           const { body } = await supertest
-            .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+            .post(DETECTION_ENGINE_RULES_IMPORT_URL)
             .set('kbn-xsrf', 'true')
             .set('elastic-api-version', '2023-10-31')
             .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -1722,7 +1722,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const ndjson = combineToNdJson(rule);
 
           const { body } = await supertest
-            .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+            .post(DETECTION_ENGINE_RULES_IMPORT_URL)
             .set('kbn-xsrf', 'true')
             .set('elastic-api-version', '2023-10-31')
             .attach('file', Buffer.from(ndjson), 'rules.ndjson')

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/import_rules_ess.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/import_rules_ess.ts
@@ -7,7 +7,7 @@
 
 import expect from 'expect';
 
-import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
+import { DETECTION_ENGINE_RULES_IMPORT_URL } from '@kbn/security-solution-plugin/common/constants';
 import { ROLES } from '@kbn/security-solution-plugin/common/test';
 import {
   createLegacyRuleAction,
@@ -67,7 +67,7 @@ export default ({ getService }: FtrProviderContext): void => {
       );
 
       await supertest
-        .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+        .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
         .set('kbn-xsrf', 'true')
         .set('elastic-api-version', '2023-10-31')
         .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -93,7 +93,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const ndjson = combineToNdJson(getCustomQueryRuleParams());
 
         const { body } = await supertestWithoutAuth
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .auth(ROLES.hunter_no_actions, 'changeme')
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
@@ -146,7 +146,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertestWithoutAuth
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .auth(ROLES.hunter, 'changeme')
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
@@ -217,7 +217,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         const { body } = await supertestWithoutAuth
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .auth(ROLES.hunter_no_actions, 'changeme')
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
@@ -269,7 +269,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -308,7 +308,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -345,7 +345,7 @@ export default ({ getService }: FtrProviderContext): void => {
         );
 
         await supertest
-          .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
+          .post(DETECTION_ENGINE_RULES_IMPORT_URL)
           .set('kbn-xsrf', 'true')
           .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(ndjson), 'rules.ndjson')

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/import_rules_with_overwrite.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_import_export/trial_license_complete_tier/import_rules_with_overwrite.ts
@@ -7,7 +7,7 @@
 
 import expect from 'expect';
 
-import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
+import { DETECTION_ENGINE_RULES_IMPORT_URL } from '@kbn/security-solution-plugin/common/constants';
 import { createRule, deleteAllRules } from '../../../../../../common/utils/security_solution';
 import { combineToNdJson, getCustomQueryRuleParams, fetchRule } from '../../../utils';
 import { FtrProviderContext } from '../../../../../ftr_provider_context';
@@ -28,7 +28,7 @@ export default ({ getService }: FtrProviderContext): void => {
       );
 
       const { body } = await supertest
-        .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+        .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
         .set('kbn-xsrf', 'true')
         .set('elastic-api-version', '2023-10-31')
         .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -55,14 +55,14 @@ export default ({ getService }: FtrProviderContext): void => {
       );
 
       await supertest
-        .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+        .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
         .set('kbn-xsrf', 'true')
         .set('elastic-api-version', '2023-10-31')
         .attach('file', Buffer.from(ndjson), 'rules.ndjson')
         .expect(200);
 
       const { body } = await supertest
-        .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+        .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
         .set('kbn-xsrf', 'true')
         .set('elastic-api-version', '2023-10-31')
         .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -94,7 +94,7 @@ export default ({ getService }: FtrProviderContext): void => {
       );
 
       const { body } = await supertest
-        .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+        .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
         .set('kbn-xsrf', 'true')
         .set('elastic-api-version', '2023-10-31')
         .attach('file', Buffer.from(ndjson), 'rules.ndjson')
@@ -150,7 +150,7 @@ export default ({ getService }: FtrProviderContext): void => {
       );
 
       const { body } = await supertest
-        .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
+        .post(`${DETECTION_ENGINE_RULES_IMPORT_URL}?overwrite=true`)
         .set('kbn-xsrf', 'true')
         .set('elastic-api-version', '2023-10-31')
         .attach('file', Buffer.from(ndjson), 'rules.ndjson')


### PR DESCRIPTION
**Partially addresses: https://github.com/elastic/kibana/issues/193184**

## Summary
We are going to remove our deprecated [bulk action endpoints](https://github.com/elastic/kibana/issues/193184) in v9.0.0. They are already unavailable in `main`.

This PR makes deprecated bulk endpoints visible in Upgrade Assistant. Also, it adds an upgrade guide to the documentation to help users transition to supported endpoints.

⚠️ This PR temporarily adds the deprecated endpoints back to `register_routes.ts`. This is needed to make merging changes easier. I'll open up a follow up PR for `main` that will delete these endpoints from `9.0`. Will do it once this PR is merged.

## Screenshots
**Deprecated endpoints visible in Upgrade Assistant table**
<img width="1276" alt="Scherm­afbeelding 2025-01-21 om 11 27 53" src="https://github.com/user-attachments/assets/909c7a20-31d9-46bb-89ec-b409550074e4" />

**Clicking on a table item opens a flyout with more info**
<table>
  <tr>
    <td>
<img width="1270" alt="patch_update" src="https://github.com/user-attachments/assets/8e99459d-1ea1-40c4-936c-23074c02cd6f" />
    </td>
    <td>
<img width="1270" alt="post_create" src="https://github.com/user-attachments/assets/6e734e97-4cf4-4d96-9f8d-51efeb3977ad" />
    </td>
  </tr>
  <tr>
    <td>
<img width="1270" alt="put_update" src="https://github.com/user-attachments/assets/d5b08e16-bf49-475d-81a9-fe5654483e1d" />
    </td>
    <td>
<img width="1271" alt="post_delete" src="https://github.com/user-attachments/assets/ccb74552-50a4-4bdb-b04e-06857caa8f38" />
    </td>
  </tr>
</table>

**Clicking on "Learn more" in the flyout takes you to the [upgrade guide](https://kibana_bk_207091.docs-preview.app.elstc.co/guide/en/kibana/master/breaking-changes-summary.html#breaking-207091)**
<img width="731" alt="upgrade_notes" src="https://github.com/user-attachments/assets/b8b471ea-98c7-4b07-91db-b1630c382554" />


## Testing
Once you send a request to one of the deprecated endpoints it should show up in Upgrade Assistant at `<basePath>/app/management/stack/upgrade_assistant/kibana_deprecations`.
Please refer to [this ticket](https://github.com/elastic/kibana/issues/193184) for the list of deprecated endpoints.

Work started on: 16-Jan-2025

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->