### PR TITLE
Implement Asset Inventory filters

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/filters/filters.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/filters/filters.tsx
@@ -1,0 +1,207 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { EuiSpacer, EuiFlexItem } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FilterGroup } from '@kbn/alerts-ui-shared/src/alert_filter_controls/filter_group';
+import type { FilterControlConfig } from '@kbn/alerts-ui-shared';
+import type { FieldSpec } from '@kbn/data-views-plugin/common';
+import type { DataViewBase, Filter } from '@kbn/es-query';
+import { createKbnUrlStateStorage, Storage } from '@kbn/kibana-utils-plugin/public';
+import { ControlGroupRenderer } from '@kbn/controls-plugin/public';
+import type { DataViewSpec } from '@kbn/data-plugin/common';
+import { useHistory } from 'react-router-dom';
+import { useKibana } from '../../../common/lib/kibana';
+import { useSpaceId } from '../../../common/hooks/use_space_id';
+import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
+import { useGlobalTime } from '../../../common/containers/use_global_time';
+import { FilterGroupLoading } from './filters_loading';
+
+const SECURITY_ASSET_INVENTORY_DATA_VIEW = {
+  id: 'asset-inventory-logs-default',
+  name: 'asset-inventory-logs',
+};
+
+const DEFAULT_ASSET_INVENTORY_FILTERS: FilterControlConfig[] = [
+  {
+    title: i18n.translate('xpack.securitySolution.assetInventory.filters.type', {
+      defaultMessage: 'Type',
+    }),
+    fieldName: 'entity.category',
+  },
+  {
+    title: i18n.translate('xpack.securitySolution.assetInventory.filters.criticality', {
+      defaultMessage: 'Criticality',
+    }),
+    fieldName: 'asset.criticality',
+  },
+  {
+    title: i18n.translate('xpack.securitySolution.assetInventory.filters.tags', {
+      defaultMessage: 'Tags',
+    }),
+    fieldName: 'asset.tags.name',
+  },
+  {
+    title: i18n.translate('xpack.securitySolution.assetInventory.filters.name', {
+      defaultMessage: 'Name',
+    }),
+    fieldName: 'asset.name',
+  },
+];
+
+type DataView = Omit<DataViewBase, 'fields'> & { fields: FieldSpec[] };
+
+export interface FiltersProps {
+  // TODO Remove dataView prop when integrating with backend (fetched from hook)
+  dataView: DataView;
+  dataViewSpec: DataViewSpec;
+  onFiltersChange: (newFilters: Filter[]) => void;
+}
+
+export const Filters = ({
+  dataView,
+  dataViewSpec: indexPattern,
+  onFiltersChange,
+  ...props
+}: FiltersProps) => {
+  const {
+    // http,
+    // notifications: { toasts },
+    dataViews,
+  } = useKibana().services;
+  const { to, from } = useGlobalTime();
+  const spaceId = useSpaceId();
+  const history = useHistory();
+  const urlStorage = useMemo(
+    () =>
+      createKbnUrlStateStorage({
+        history,
+        useHash: false,
+        useHashQuery: false,
+      }),
+    [history]
+  );
+  const filterControlsUrlState = useMemo(
+    () =>
+      urlStorage.get<FilterControlConfig[] | undefined>(URL_PARAM_KEY.assetInventory) ?? undefined,
+    [urlStorage]
+  );
+
+  const setFilterControlsUrlState = useCallback(
+    (newFilterControls: FilterControlConfig[]) => {
+      urlStorage.set(URL_PARAM_KEY.assetInventory, newFilterControls);
+    },
+    [urlStorage]
+  );
+
+  const dataViewSpec = useMemo(
+    () =>
+      indexPattern
+        ? {
+            id: SECURITY_ASSET_INVENTORY_DATA_VIEW.id,
+            name: SECURITY_ASSET_INVENTORY_DATA_VIEW.name,
+            allowNoIndex: true,
+            title: indexPattern.title,
+            timeFieldName: '@timestamp',
+          }
+        : null,
+    [indexPattern]
+  );
+
+  const [loadingPageFilters, setLoadingPageFilters] = useState(true);
+
+  // TODO Resolve when integrating with backend
+  // const { dataView, isLoading: isLoadingDataView } = useAlertsDataView({
+  //   ruleTypeIds,
+  //   dataViewsService: dataViews,
+  //   http,
+  //   toasts,
+  // });
+  const isLoadingDataView = false;
+
+  useEffect(() => {
+    if (!isLoadingDataView) {
+      // If a data view spec is provided, create a new data view
+      if (dataViewSpec?.id) {
+        (async () => {
+          // Creates an adhoc data view starting from the alert data view
+          // and applying the overrides specified in the dataViewSpec
+          const spec = {
+            ...(dataView ?? {}),
+            ...(dataViewSpec ?? {}),
+            // } as DataViewSpec;
+          } as unknown as DataViewSpec;
+          await dataViews.create(spec);
+          setLoadingPageFilters(false);
+        })();
+      } else {
+        setLoadingPageFilters(false);
+      }
+    }
+
+    return () => dataViews.clearInstanceCache();
+  }, [dataView, dataViewSpec, dataViews, isLoadingDataView]);
+
+  const handleFilterChanges = useCallback(
+    (newFilters: Filter[]) => {
+      if (!onFiltersChange) {
+        return;
+      }
+      const updatedFilters = newFilters.map((filter) => {
+        return {
+          ...filter,
+          meta: {
+            ...filter.meta,
+            disabled: false,
+          },
+        };
+      });
+
+      onFiltersChange(updatedFilters);
+    },
+    [onFiltersChange]
+  );
+
+  if (!spaceId || !dataViewSpec) {
+    return null;
+  }
+
+  if (loadingPageFilters) {
+    return (
+      <EuiFlexItem grow={true}>
+        <FilterGroupLoading />
+      </EuiFlexItem>
+    );
+  }
+
+  return (
+    <>
+      <EuiSpacer size="l" />
+      <FilterGroup
+        dataViewId={dataViewSpec?.id || null}
+        onFiltersChange={handleFilterChanges}
+        ruleTypeIds={[]}
+        storageKey={'assetInventory'}
+        Storage={Storage}
+        defaultControls={DEFAULT_ASSET_INVENTORY_FILTERS}
+        chainingSystem="HIERARCHICAL"
+        spaceId={spaceId}
+        controlsUrlState={filterControlsUrlState}
+        setControlsUrlState={setFilterControlsUrlState}
+        ControlGroupRenderer={ControlGroupRenderer}
+        maxControls={4}
+        timeRange={{
+          from,
+          to,
+          mode: 'absolute',
+        }}
+        {...props}
+      />
+      <EuiSpacer size="l" />
+    </>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/filters/filters.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/filters/filters.tsx
@@ -4,22 +4,21 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { EuiSpacer, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FilterGroup } from '@kbn/alerts-ui-shared/src/alert_filter_controls/filter_group';
 import type { FilterControlConfig } from '@kbn/alerts-ui-shared';
-import type { FieldSpec } from '@kbn/data-views-plugin/common';
-import type { DataViewBase, Filter } from '@kbn/es-query';
+import type { Filter } from '@kbn/es-query';
 import { createKbnUrlStateStorage, Storage } from '@kbn/kibana-utils-plugin/public';
 import { ControlGroupRenderer } from '@kbn/controls-plugin/public';
-import type { DataViewSpec } from '@kbn/data-plugin/common';
 import { useHistory } from 'react-router-dom';
-import { useKibana } from '../../../common/lib/kibana';
+import { useDataViewContext } from '../../hooks/data_view_context';
 import { useSpaceId } from '../../../common/hooks/use_space_id';
 import { URL_PARAM_KEY } from '../../../common/hooks/use_url_state';
 import { useGlobalTime } from '../../../common/containers/use_global_time';
 import { FilterGroupLoading } from './filters_loading';
+import { ASSET_INVENTORY_RULE_TYPE_IDS } from './rule_type_ids';
 
 const SECURITY_ASSET_INVENTORY_DATA_VIEW = {
   id: 'asset-inventory-logs-default',
@@ -53,27 +52,13 @@ const DEFAULT_ASSET_INVENTORY_FILTERS: FilterControlConfig[] = [
   },
 ];
 
-type DataView = Omit<DataViewBase, 'fields'> & { fields: FieldSpec[] };
-
 export interface FiltersProps {
-  // TODO Remove dataView prop when integrating with backend (fetched from hook)
-  dataView: DataView;
-  dataViewSpec: DataViewSpec;
   onFiltersChange: (newFilters: Filter[]) => void;
 }
 
-export const Filters = ({
-  dataView,
-  dataViewSpec: indexPattern,
-  onFiltersChange,
-  ...props
-}: FiltersProps) => {
-  const {
-    // http,
-    // notifications: { toasts },
-    dataViews,
-  } = useKibana().services;
-  const { to, from } = useGlobalTime();
+export const Filters = ({ onFiltersChange }: FiltersProps) => {
+  const { dataView: indexPattern, dataViewIsLoading, dataViewIsRefetching } = useDataViewContext();
+  const { from, to } = useGlobalTime();
   const spaceId = useSpaceId();
   const history = useHistory();
   const urlStorage = useMemo(
@@ -112,40 +97,6 @@ export const Filters = ({
     [indexPattern]
   );
 
-  const [loadingPageFilters, setLoadingPageFilters] = useState(true);
-
-  // TODO Resolve when integrating with backend
-  // const { dataView, isLoading: isLoadingDataView } = useAlertsDataView({
-  //   ruleTypeIds,
-  //   dataViewsService: dataViews,
-  //   http,
-  //   toasts,
-  // });
-  const isLoadingDataView = false;
-
-  useEffect(() => {
-    if (!isLoadingDataView) {
-      // If a data view spec is provided, create a new data view
-      if (dataViewSpec?.id) {
-        (async () => {
-          // Creates an adhoc data view starting from the alert data view
-          // and applying the overrides specified in the dataViewSpec
-          const spec = {
-            ...(dataView ?? {}),
-            ...(dataViewSpec ?? {}),
-            // } as DataViewSpec;
-          } as unknown as DataViewSpec;
-          await dataViews.create(spec);
-          setLoadingPageFilters(false);
-        })();
-      } else {
-        setLoadingPageFilters(false);
-      }
-    }
-
-    return () => dataViews.clearInstanceCache();
-  }, [dataView, dataViewSpec, dataViews, isLoadingDataView]);
-
   const handleFilterChanges = useCallback(
     (newFilters: Filter[]) => {
       if (!onFiltersChange) {
@@ -170,7 +121,7 @@ export const Filters = ({
     return null;
   }
 
-  if (loadingPageFilters) {
+  if (dataViewIsLoading || dataViewIsRefetching) {
     return (
       <EuiFlexItem grow={true}>
         <FilterGroupLoading />
@@ -184,8 +135,7 @@ export const Filters = ({
       <FilterGroup
         dataViewId={dataViewSpec?.id || null}
         onFiltersChange={handleFilterChanges}
-        ruleTypeIds={[]}
-        storageKey={'assetInventory'}
+        ruleTypeIds={ASSET_INVENTORY_RULE_TYPE_IDS}
         Storage={Storage}
         defaultControls={DEFAULT_ASSET_INVENTORY_FILTERS}
         chainingSystem="HIERARCHICAL"
@@ -199,7 +149,6 @@ export const Filters = ({
           to,
           mode: 'absolute',
         }}
-        {...props}
       />
       <EuiSpacer size="l" />
     </>

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/filters/filters_loading.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/filters/filters_loading.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiButton, EuiLoadingChart } from '@elastic/eui';
+
+export const FilterGroupLoading = () => {
+  return (
+    <EuiButton color="text" size="s">
+      <EuiLoadingChart className="filter-group__loading" data-test-subj="filter-group__loading" />
+    </EuiButton>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/filters/rule_type_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/filters/rule_type_ids.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+const RULE_TYPE_PREFIX = `assetInventorySiem` as const;
+export const EQL_RULE_TYPE_ID = `${RULE_TYPE_PREFIX}.eqlRule` as const;
+export const ESQL_RULE_TYPE_ID = `${RULE_TYPE_PREFIX}.esqlRule` as const;
+export const INDICATOR_RULE_TYPE_ID = `${RULE_TYPE_PREFIX}.indicatorRule` as const;
+export const ML_RULE_TYPE_ID = `${RULE_TYPE_PREFIX}.mlRule` as const;
+export const QUERY_RULE_TYPE_ID = `${RULE_TYPE_PREFIX}.queryRule` as const;
+export const SAVED_QUERY_RULE_TYPE_ID = `${RULE_TYPE_PREFIX}.savedQueryRule` as const;
+export const THRESHOLD_RULE_TYPE_ID = `${RULE_TYPE_PREFIX}.thresholdRule` as const;
+export const NEW_TERMS_RULE_TYPE_ID = `${RULE_TYPE_PREFIX}.newTermsRule` as const;
+
+export const ASSET_INVENTORY_RULE_TYPE_IDS = [
+  EQL_RULE_TYPE_ID,
+  ESQL_RULE_TYPE_ID,
+  INDICATOR_RULE_TYPE_ID,
+  ML_RULE_TYPE_ID,
+  QUERY_RULE_TYPE_ID,
+  SAVED_QUERY_RULE_TYPE_ID,
+  THRESHOLD_RULE_TYPE_ID,
+  NEW_TERMS_RULE_TYPE_ID,
+];

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
@@ -399,13 +399,7 @@ const AllAssets = ({
             />
           </h1>
         </EuiTitle>
-        {dataView ? (
-          <Filters
-            dataView={dataView}
-            dataViewSpec={dataView.toSpec()}
-            onFiltersChange={() => {}}
-          />
-        ) : null}
+        <Filters onFiltersChange={() => {}} />
         <CellActionsProvider getTriggerCompatibleActions={uiActions.getTriggerCompatibleActions}>
           <div
             data-test-subj={rest['data-test-subj']}

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
@@ -46,6 +46,7 @@ import { AssetCriticalityBadge } from '../../entity_analytics/components/asset_c
 import { AdditionalControls } from '../components/additional_controls';
 import { AssetInventorySearchBar } from '../components/search_bar';
 import { RiskBadge } from '../components/risk_badge';
+import { Filters } from '../components/filters/filters';
 
 import { useDataViewContext } from '../hooks/data_view_context';
 import { useStyles } from '../hooks/use_styles';
@@ -398,6 +399,13 @@ const AllAssets = ({
             />
           </h1>
         </EuiTitle>
+        {dataView ? (
+          <Filters
+            dataView={dataView}
+            dataViewSpec={dataView.toSpec()}
+            onFiltersChange={() => {}}
+          />
+        ) : null}
         <CellActionsProvider getTriggerCompatibleActions={uiActions.getTriggerCompatibleActions}>
           <div
             data-test-subj={rest['data-test-subj']}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_url_state.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/hooks/use_url_state.ts
@@ -36,4 +36,5 @@ export const URL_PARAM_KEY = {
   timerange: 'timerange',
   pageFilter: 'pageFilters',
   rulesTable: 'rulesTable',
+  assetInventory: 'assetInventory',
 } as const;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/201710.

Implements filters section for Asset Inventory reusing `FilterGroup` component from `@kbn/alerts-ui-shared` package.

### Screenshot

<img width="1740" alt="Screenshot 2025-01-17 at 16 21 55" src="https://github.com/user-attachments/assets/bf83d9e8-4919-498d-a0ab-fdc3df711d4e" />

### Definition of done

- [x] Add multiple dropdown filters labelled:
  - Type - filter by `asset.category`
  - Criticality - filter by `asset.criticality`
  - Tags -  filter by `asset.tags.name`
  - Name - filter TBD
- [x] Ensure each dropdown allows users to select multiple options to filter the inventory data.
- [x] Add a button or dropdown labeled "More filters" that exposes advanced filtering options, including "Reset control" and "Edit control".
- [x] Verify if the `FilterGroup` component from `packages/kbn-alerts-ui-shared` can be reused to wrap the required functionalities.
  - It can be reused, but the detection engine uses `AlertFilterControls` instead, which is a higher-level alternative. And that's what I did in Asset Inventory too  
- [x] Ensure the filters are functional on the front-end and can interact with placeholder data.

### Out of scope

- Backend data filtering logic
- Implementation of the actual data fetching based on filters

### How to test

Follow the "how to test" instructions written on this PR:
- https://github.com/elastic/kibana/pull/206115

### Checklist

- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Risks

No risks at all.