### PR TITLE
[Lens][Visualize] Remove duplicate `data-render-complete` attribute

### DIFF
--- a/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
@@ -476,7 +476,6 @@ export const getVisualizeEmbeddableFactory: (deps: {
             ref={domNode}
             data-test-subj="visualizationLoader"
             data-rendering-count={renderCount /* Used for functional tests */}
-            data-render-complete={hasRendered}
             data-title={!api.hidePanelTitle?.getValue() ? api.panelTitle?.getValue() ?? '' : ''}
             data-description={api.panelDescription?.getValue() ?? ''}
             data-shared-item

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
@@ -71,7 +71,6 @@ export function LensEmbeddableComponent({
     <div
       style={{ width: '100%', height: '100%' }}
       data-rendering-count={renderCount + 1}
-      data-render-complete={hasRendered}
       {...title}
       {...description}
       data-shared-item


### PR DESCRIPTION
## Summary

Fixes #207063

Removes the attribute as it is a duplicate because the embeddable is already signalling the render complete event to the panel who's setting the attribute.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
