### PR TITLE
[Cloud Security] Fleet validation using the RequiredVars and CSPM showing validation errors

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
@@ -49,6 +49,7 @@ describe('Fleet - validatePackagePolicy()', () => {
           dataset: 'foo',
           streams: [
             {
+              input: 'foo',
               title: 'Foo',
               vars: [{ name: 'var-name', type: 'yaml' }],
             },

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
@@ -8,7 +8,12 @@
 import { load } from 'js-yaml';
 
 import { installationStatuses } from '../constants';
-import type { PackageInfo, NewPackagePolicy, RegistryPolicyTemplate } from '../types';
+import type {
+  PackageInfo,
+  NewPackagePolicy,
+  RegistryPolicyTemplate,
+  NewPackagePolicyInputStream,
+} from '../types';
 
 import {
   validatePackagePolicy,
@@ -44,7 +49,6 @@ describe('Fleet - validatePackagePolicy()', () => {
           dataset: 'foo',
           streams: [
             {
-              input: 'foo',
               title: 'Foo',
               vars: [{ name: 'var-name', type: 'yaml' }],
             },
@@ -768,6 +772,280 @@ describe('Fleet - validatePackagePolicy()', () => {
         )
       ).toBe(false);
     });
+  });
+});
+
+describe('Fleet - validateConditionalRequiredVars()', () => {
+  const createMockRequiredVarPackageInfo = (streams: unknown) => {
+    return {
+      name: 'mock-package',
+      title: 'Mock package',
+      version: '0.0.0',
+      description: 'description',
+      type: 'mock',
+      categories: [],
+      requirement: { kibana: { versions: '' }, elasticsearch: { versions: '' } },
+      format_version: '',
+      download: '',
+      path: '',
+      assets: {
+        kibana: {
+          dashboard: [],
+          visualization: [],
+          search: [],
+          'index-pattern': [],
+        },
+      },
+      status: installationStatuses.NotInstalled,
+      data_streams: [
+        {
+          dataset: 'foo',
+          streams,
+        },
+        {
+          dataset: 'bar',
+          streams: [
+            {
+              input: 'bar',
+              title: 'Bar',
+              vars: [
+                { name: 'bar-name', type: 'text', required: true },
+                { name: 'bar-age', type: 'text' },
+              ],
+            },
+            {
+              input: 'with-no-stream-vars',
+              title: 'Bar stream no vars',
+              enabled: true,
+            },
+          ],
+        },
+      ],
+      policy_templates: [
+        {
+          name: 'pkgPolicy1',
+          title: 'Package policy 1',
+          description: 'test package policy',
+          inputs: [
+            {
+              type: 'foo',
+              title: 'Foo',
+              vars: [
+                { default: 'foo-input-var-value', name: 'foo-input-var-name', type: 'text' },
+                {
+                  default: 'foo-input2-var-value',
+                  name: 'foo-input2-var-name',
+                  required: true,
+                  type: 'text',
+                },
+                { name: 'foo-input3-var-name', type: 'text', required: true, multi: true },
+              ],
+            },
+            {
+              type: 'bar',
+              title: 'Bar',
+              vars: [
+                {
+                  default: ['value1', 'value2'],
+                  name: 'bar-input-var-name',
+                  type: 'text',
+                  multi: true,
+                },
+                { name: 'bar-input2-var-name', required: true, type: 'text' },
+              ],
+            },
+            {
+              type: 'with-no-config-or-streams',
+              title: 'With no config or streams',
+            },
+            {
+              type: 'with-disabled-streams',
+              title: 'With disabled streams',
+            },
+            {
+              type: 'with-no-stream-vars',
+              enabled: true,
+              vars: [{ required: true, name: 'var-name', type: 'text' }],
+            },
+          ],
+        },
+      ],
+    } as unknown as PackageInfo;
+  };
+
+  const createPackagePolicyForRequiredVars = (streams: NewPackagePolicyInputStream[]) => {
+    return {
+      name: 'pkgPolicy1-1',
+      namespace: 'default',
+      policy_id: 'test-policy',
+      policy_ids: ['test-policy'],
+      enabled: true,
+      inputs: [
+        {
+          type: 'foo-input',
+          policy_template: 'pkgPolicy1',
+          enabled: true,
+          streams,
+        },
+      ],
+      vars: {},
+    };
+  };
+
+  it('should return package policy validation error if invalid required_vars exist', () => {
+    const mockPackageInfoRequireVars = createMockRequiredVarPackageInfo([
+      {
+        title: 'Foo',
+        input: 'foo-input',
+        vars: [
+          { name: 'foo-name', type: 'text' },
+          { name: 'foo-age', type: 'text' },
+        ],
+        required_vars: {
+          'foo-required-var-name': [{ name: 'foo-name' }, { name: 'foo-age', value: '1' }],
+        },
+      },
+    ]);
+    const invalidPackagePolicyWithRequiredVars = createPackagePolicyForRequiredVars([
+      {
+        data_stream: { dataset: 'foo', type: 'logs' },
+        enabled: true,
+        vars: { 'foo-name': { type: 'text' }, 'foo-age': { type: 'text' } },
+      },
+    ]);
+
+    const validationResults = validatePackagePolicy(
+      invalidPackagePolicyWithRequiredVars,
+      mockPackageInfoRequireVars,
+      load
+    );
+
+    expect(validationResults).toEqual(
+      expect.objectContaining({
+        inputs: {
+          'foo-input': {
+            streams: {
+              foo: {
+                required_vars: {
+                  'foo-required-var-name': [
+                    { name: 'foo-name', invalid: true },
+                    { name: 'foo-age', invalid: true },
+                  ],
+                },
+                vars: {
+                  'foo-name': null,
+                  'foo-age': null,
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    expect(validationHasErrors(validationResults)).toBe(true);
+  });
+
+  it('should return package policy validation error if partial invalid required_vars exist', () => {
+    const mockPackageInfoRequireVars = createMockRequiredVarPackageInfo([
+      {
+        title: 'Foo',
+        input: 'foo-input',
+        vars: [
+          { name: 'foo-name', type: 'text' },
+          { name: 'foo-age', type: 'text' },
+        ],
+        required_vars: {
+          'foo-required-var-name': [{ name: 'foo-name' }, { name: 'foo-age', value: '1' }],
+        },
+      },
+    ]);
+    const invalidPackagePolicyWithRequiredVars = createPackagePolicyForRequiredVars([
+      {
+        data_stream: { dataset: 'foo', type: 'logs' },
+        enabled: true,
+        vars: { 'foo-name': { type: 'text' }, 'foo-age': { type: 'text', value: '1' } },
+      },
+    ]);
+
+    const validationResults = validatePackagePolicy(
+      invalidPackagePolicyWithRequiredVars,
+      mockPackageInfoRequireVars,
+      load
+    );
+
+    expect(validationResults).toEqual(
+      expect.objectContaining({
+        inputs: {
+          'foo-input': {
+            streams: {
+              foo: {
+                required_vars: {
+                  'foo-required-var-name': [{ name: 'foo-name', invalid: true }],
+                },
+                vars: {
+                  'foo-name': null,
+                  'foo-age': null,
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    expect(validationHasErrors(validationResults)).toBe(true);
+  });
+
+  it('should not return package policy validation errors if required_vars have values', () => {
+    const mockPackageInfoRequireVars = createMockRequiredVarPackageInfo([
+      {
+        title: 'Foo',
+        input: 'foo-input',
+        vars: [
+          { name: 'foo-name', type: 'text' },
+          { name: 'foo-age', type: 'text' },
+        ],
+        required_vars: {
+          'foo-required-var-name': [{ name: 'foo-name' }, { name: 'foo-age', value: '1' }],
+        },
+      },
+    ]);
+    const invalidPackagePolicyWithRequiredVars = createPackagePolicyForRequiredVars([
+      {
+        data_stream: { dataset: 'foo', type: 'logs' },
+        enabled: true,
+        vars: {
+          'foo-name': { type: 'text', value: 'Some name' },
+          'foo-age': { type: 'text', value: '1' },
+        },
+      },
+    ]);
+
+    const validationResults = validatePackagePolicy(
+      invalidPackagePolicyWithRequiredVars,
+      mockPackageInfoRequireVars,
+      load
+    );
+
+    expect(validationResults).toEqual(
+      expect.objectContaining({
+        inputs: {
+          'foo-input': {
+            streams: {
+              foo: {
+                vars: {
+                  'foo-name': null,
+                  'foo-age': null,
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    expect(validationHasErrors(validationResults)).toBe(false);
   });
 });
 

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.test.ts
@@ -998,7 +998,7 @@ describe('Fleet - validateConditionalRequiredVars()', () => {
     expect(validationHasErrors(validationResults)).toBe(true);
   });
 
-  it('should not return package policy validation errors if required_vars have values', () => {
+  it('should not return package policy validation errors if required_vars have existence and a value', () => {
     const mockPackageInfoRequireVars = createMockRequiredVarPackageInfo([
       {
         title: 'Foo',
@@ -1009,6 +1009,60 @@ describe('Fleet - validateConditionalRequiredVars()', () => {
         ],
         required_vars: {
           'foo-required-var-name': [{ name: 'foo-name' }, { name: 'foo-age', value: '1' }],
+        },
+      },
+    ]);
+    const invalidPackagePolicyWithRequiredVars = createPackagePolicyForRequiredVars([
+      {
+        data_stream: { dataset: 'foo', type: 'logs' },
+        enabled: true,
+        vars: {
+          'foo-name': { type: 'text', value: 'Some name' },
+          'foo-age': { type: 'text', value: '1' },
+        },
+      },
+    ]);
+
+    const validationResults = validatePackagePolicy(
+      invalidPackagePolicyWithRequiredVars,
+      mockPackageInfoRequireVars,
+      load
+    );
+
+    expect(validationResults).toEqual(
+      expect.objectContaining({
+        inputs: {
+          'foo-input': {
+            streams: {
+              foo: {
+                vars: {
+                  'foo-name': null,
+                  'foo-age': null,
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    expect(validationHasErrors(validationResults)).toBe(false);
+  });
+
+  it('should not return package policy validation errors if required_vars all have values', () => {
+    const mockPackageInfoRequireVars = createMockRequiredVarPackageInfo([
+      {
+        title: 'Foo',
+        input: 'foo-input',
+        vars: [
+          { name: 'foo-name', type: 'text' },
+          { name: 'foo-age', type: 'text' },
+        ],
+        required_vars: {
+          'foo-required-var-name': [
+            { name: 'foo-name', value: 'Some name' },
+            { name: 'foo-age', value: '1' },
+          ],
         },
       },
     ]);

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
@@ -57,7 +57,7 @@ export type PackagePolicyValidationResults = {
   inputs: Record<PackagePolicyInput['type'], PackagePolicyInputValidationResults> | null;
 } & PackagePolicyConfigValidationResults;
 
-const validateConditionalRequiredVars = (
+const validatePackageRequiredVars = (
   stream: NewPackagePolicyInputStream,
   requiredVars?: RegistryRequiredVars
 ) => {
@@ -262,7 +262,7 @@ export const validatePackagePolicy = (
         }
 
         if (stream.vars && stream.enabled) {
-          const requiredVars = validateConditionalRequiredVars(
+          const requiredVars = validatePackageRequiredVars(
             stream,
             streamRequiredVarsDefsByDataAndInput[`${stream.data_stream.dataset}-${input.type}`]
           );

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
@@ -261,15 +261,17 @@ export const validatePackagePolicy = (
           }, {} as ValidationEntry);
         }
 
-        inputValidationResults.streams![stream.data_stream.dataset] = streamValidationResults;
-
         if (stream.vars && stream.enabled) {
-          inputValidationResults.streams![stream.data_stream.dataset].required_vars =
-            validateConditionalRequiredVars(
-              stream,
-              streamRequiredVarsDefsByDataAndInput[`${stream.data_stream.dataset}-${input.type}`]
-            );
+          const requiredVars = validateConditionalRequiredVars(
+            stream,
+            streamRequiredVarsDefsByDataAndInput[`${stream.data_stream.dataset}-${input.type}`]
+          );
+          if (requiredVars) {
+            streamValidationResults.required_vars = requiredVars;
+          }
         }
+
+        inputValidationResults.streams![stream.data_stream.dataset] = streamValidationResults;
       });
     } else {
       delete inputValidationResults.streams;

--- a/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/services/validate_package_policy.ts
@@ -277,11 +277,7 @@ export const validatePackagePolicy = (
       delete inputValidationResults.streams;
     }
 
-    if (
-      inputValidationResults.vars ||
-      inputValidationResults.streams ||
-      inputValidationResults.required_vars
-    ) {
+    if (inputValidationResults.vars || inputValidationResults.streams) {
       validationResults.inputs![inputKey] = inputValidationResults;
     }
   });

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/epm.ts
@@ -229,6 +229,7 @@ export enum RegistryPolicyTemplateKeys {
   readme = 'readme',
   multiple = 'multiple',
   type = 'type',
+  required_vars = 'required_vars',
   vars = 'vars',
   input = 'input',
   template_path = 'template_path',
@@ -261,6 +262,7 @@ export interface RegistryPolicyInputOnlyTemplate extends BaseTemplate {
   [RegistryPolicyTemplateKeys.type]: string;
   [RegistryPolicyTemplateKeys.input]: string;
   [RegistryPolicyTemplateKeys.template_path]: string;
+  [RegistryPolicyTemplateKeys.required_vars]?: RegistryRequiredVars;
   [RegistryPolicyTemplateKeys.vars]?: RegistryVarsEntry[];
 }
 
@@ -275,6 +277,7 @@ export enum RegistryInputKeys {
   template_path = 'template_path',
   condition = 'condition',
   input_group = 'input_group',
+  required_vars = 'required_vars',
   vars = 'vars',
 }
 
@@ -287,6 +290,7 @@ export interface RegistryInput {
   [RegistryInputKeys.template_path]?: string;
   [RegistryInputKeys.condition]?: string;
   [RegistryInputKeys.input_group]?: RegistryInputGroup;
+  [RegistryInputKeys.required_vars]?: RegistryRequiredVars;
   [RegistryInputKeys.vars]?: RegistryVarsEntry[];
 }
 
@@ -295,6 +299,7 @@ export enum RegistryStreamKeys {
   title = 'title',
   description = 'description',
   enabled = 'enabled',
+  required_vars = 'required_vars',
   vars = 'vars',
   template_path = 'template_path',
 }
@@ -304,6 +309,7 @@ export interface RegistryStream {
   [RegistryStreamKeys.title]: string;
   [RegistryStreamKeys.description]?: string;
   [RegistryStreamKeys.enabled]?: boolean;
+  [RegistryStreamKeys.required_vars]?: RegistryRequiredVars;
   [RegistryStreamKeys.vars]?: RegistryVarsEntry[];
   [RegistryStreamKeys.template_path]: string;
 }
@@ -450,6 +456,15 @@ export interface RegistryDataStreamRoutingRules {
 
 export interface RegistryDataStreamLifecycle {
   data_retention: string;
+}
+
+export interface RegistryRequireVarConstraint {
+  name: string;
+  value?: string;
+}
+
+export interface RegistryRequiredVars {
+  [key: string]: RegistryRequireVarConstraint[];
 }
 
 export type RegistryVarType =

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -141,12 +141,6 @@ const DEFAULT_PACKAGE_POLICY = {
   inputs: [],
 };
 
-interface RequiredVarsValidation {
-  name: string;
-  requiredVars?: RegistryRequiredVars;
-  vars: PackagePolicyConfigRecord;
-}
-
 export function useOnSubmit({
   agentCount,
   selectedPolicyTab,
@@ -202,91 +196,7 @@ export function useOnSubmit({
 
   const { isAgentlessIntegration, isAgentlessAgentPolicy } = useAgentless();
 
-  const conditionallyInvalid = () => {
-    const requiredVars: { [key: string]: RequiredVarsValidation } = {};
-    const validatedVars: {
-      [key: string]: boolean;
-    } = {};
-
-    if (packageInfo?.data_streams && packagePolicy.inputs) {
-      packagePolicy.inputs.forEach((input) => {
-        if (input.enabled && input.streams) {
-          input.streams.forEach((stream) => {
-            if (stream.enabled && stream.vars) {
-              requiredVars[input.type] = {
-                name: input.type,
-                vars: stream.vars,
-              };
-            }
-          });
-        }
-      });
-
-      packageInfo.data_streams.forEach((dataStream) => {
-        if (dataStream.streams) {
-          dataStream.streams.forEach((stream) => {
-            if (
-              stream.required_vars &&
-              stream.vars &&
-              requiredVars[stream.input] &&
-              !requiredVars[stream.input].requiredVars
-            ) {
-              requiredVars[stream.input].requiredVars = stream.required_vars;
-            }
-          });
-        }
-      });
-
-      for (const [streamName, validator] of Object.entries(requiredVars)) {
-        if (validator.requiredVars && validator.vars) {
-          // TODO refactor below
-          for (const [requiredVarName, requiredVarDefinition] of Object.entries(
-            validator.requiredVars
-          )) {
-            const validations = Array<boolean>();
-            // loop through the reqruiredVar's item
-            requiredVarDefinition.forEach((requiredVar) => {
-              const varItem = validator.vars[requiredVar.name];
-
-              if (varItem) {
-                if (!requiredVar.value && varItem.value) {
-                  validations.push(true);
-                  return;
-                }
-
-                if (requiredVar.value && varItem.value && requiredVar.value === varItem.value) {
-                  validations.push(true);
-                  return;
-                }
-
-                validations.push(false);
-              }
-            });
-
-            validatedVars[streamName] = {
-              ...validatedVars[streamName],
-              [requiredVarName]: !validations.some((v) => v === false),
-            };
-          }
-        }
-      }
-    }
-
-    // console.log('validatedVars', validatedVars);
-    const allStreamsValid = Object.values(validatedVars).every((stream) => {
-      return Object.values(stream).some((valid) => {
-        return valid;
-      });
-    });
-
-    console.log('allStreamsValid', allStreamsValid);
-
-    return !allStreamsValid;
-  };
-
-  const hasErrors = validationResults
-    ? validationHasErrors(validationResults) || conditionallyInvalid()
-    : false;
+  const hasErrors = validationResults ? validationHasErrors(validationResults) : false;
 
   // Update agent policy method
   const updateAgentPolicies = useCallback(

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/form.tsx
@@ -52,11 +52,6 @@ import {
 
 import { AGENTLESS_DISABLED_INPUTS } from '../../../../../../../../common/constants';
 
-import type {
-  PackagePolicyConfigRecord,
-  RegistryRequiredVars,
-} from '../../../../../../../../common/types';
-
 import { useAgentless, useSetupTechnology } from './setup_technology';
 
 export async function createAgentPolicy({

--- a/x-pack/solutions/security/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/common/constants.ts
@@ -174,4 +174,4 @@ export const SINGLE_ACCOUNT = 'single-account';
 
 export const CLOUD_SECURITY_PLUGIN_VERSION = '1.9.0';
 // Cloud Credentials Template url was implemented in 1.10.0-preview01. See PR - https://github.com/elastic/integrations/pull/9828
-export const CLOUD_CREDENTIALS_PACKAGE_VERSION = '1.13.0-preview02';
+export const CLOUD_CREDENTIALS_PACKAGE_VERSION = '1.11.0-preview13';

--- a/x-pack/solutions/security/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/common/constants.ts
@@ -174,4 +174,4 @@ export const SINGLE_ACCOUNT = 'single-account';
 
 export const CLOUD_SECURITY_PLUGIN_VERSION = '1.9.0';
 // Cloud Credentials Template url was implemented in 1.10.0-preview01. See PR - https://github.com/elastic/integrations/pull/9828
-export const CLOUD_CREDENTIALS_PACKAGE_VERSION = '1.11.0-preview13';
+export const CLOUD_CREDENTIALS_PACKAGE_VERSION = '1.13.0-preview02';

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form.tsx
@@ -97,7 +97,7 @@ export interface AwsFormProps {
   onChange: any;
   setIsValid: (isValid: boolean) => void;
   disabled: boolean;
-  isConditionallyRequired: boolean;
+  hasInvalidRequiredVars: boolean;
 }
 
 const CloudFormationSetup = ({
@@ -211,7 +211,7 @@ export const AwsCredentialsForm = ({
   onChange,
   setIsValid,
   disabled,
-  isConditionallyRequired,
+  hasInvalidRequiredVars,
 }: AwsFormProps) => {
   const {
     awsCredentialsType,
@@ -291,7 +291,7 @@ export const AwsCredentialsForm = ({
             onChange={(key, value) => {
               updatePolicy(getPosturePolicy(newPolicy, input.type, { [key]: { value } }));
             }}
-            isConditionallyRequired={isConditionallyRequired}
+            hasInvalidRequiredVars={hasInvalidRequiredVars}
           />
         </>
       )}

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form.tsx
@@ -97,6 +97,7 @@ export interface AwsFormProps {
   onChange: any;
   setIsValid: (isValid: boolean) => void;
   disabled: boolean;
+  isConditionallyRequired: boolean;
 }
 
 const CloudFormationSetup = ({
@@ -210,6 +211,7 @@ export const AwsCredentialsForm = ({
   onChange,
   setIsValid,
   disabled,
+  isConditionallyRequired,
 }: AwsFormProps) => {
   const {
     awsCredentialsType,
@@ -289,6 +291,7 @@ export const AwsCredentialsForm = ({
             onChange={(key, value) => {
               updatePolicy(getPosturePolicy(newPolicy, input.type, { [key]: { value } }));
             }}
+            isConditionallyRequired={isConditionallyRequired}
           />
         </>
       )}

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form_agentless.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form_agentless.tsx
@@ -187,6 +187,18 @@ export const AwsCredentialsFormAgentless = ({
   const documentationLink = cspIntegrationDocsNavigation.cspm.awsGetStartedPath;
   const accountType = input?.streams?.[0].vars?.['aws.account_type']?.value ?? SINGLE_ACCOUNT;
 
+  // This should ony set the credentials after the initial render
+  if (!getAwsCredentialsType(input)) {
+    updatePolicy({
+      ...getPosturePolicy(newPolicy, input.type, {
+        'aws.credentials.type': {
+          value: awsCredentialsType,
+          type: 'text',
+        },
+      }),
+    });
+  }
+
   const isValidSemantic = semverValid(packageInfo.version);
   const showCloudCredentialsButton = isValidSemantic
     ? semverCompare(packageInfo.version, CLOUD_CREDENTIALS_PACKAGE_VERSION) >= 0

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form_agentless.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form_agentless.tsx
@@ -37,7 +37,6 @@ import {
   AwsCredentialTypeSelector,
   ReadDocumentation,
 } from './aws_credentials_form';
-
 const CLOUD_FORMATION_EXTERNAL_DOC_URL =
   'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-whatis-howdoesitwork.html';
 
@@ -179,6 +178,7 @@ export const AwsCredentialsFormAgentless = ({
   newPolicy,
   packageInfo,
   updatePolicy,
+  hasInvalidRequiredVars,
 }: AwsFormProps) => {
   const awsCredentialsType = getAwsCredentialsType(input) || DEFAULT_AGENTLESS_AWS_CREDENTIALS_TYPE;
   const options = getAwsCredentialsFormOptions();
@@ -282,6 +282,7 @@ export const AwsCredentialsFormAgentless = ({
         onChange={(key, value) => {
           updatePolicy(getPosturePolicy(newPolicy, input.type, { [key]: { value } }));
         }}
+        hasInvalidRequiredVars={hasInvalidRequiredVars}
       />
       <ReadDocumentation url={documentationLink} />
     </>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
@@ -11,13 +11,13 @@ import { PackageInfo } from '@kbn/fleet-plugin/common';
 import { css } from '@emotion/react';
 import { LazyPackagePolicyInputVarField } from '@kbn/fleet-plugin/public';
 import { AwsOptions } from './get_aws_credentials_form_options';
-import { findVariableDef } from '../utils';
+import { findVariableDef, fieldIsInvalid } from '../utils';
 
 export const AwsInputVarFields = ({
   fields,
   onChange,
   packageInfo,
-  isConditionallyRequired,
+  hasInvalidRequiredVars,
 }: {
   fields: Array<
     AwsOptions[keyof AwsOptions]['fields'][number] & {
@@ -28,74 +28,74 @@ export const AwsInputVarFields = ({
   >;
   onChange: (key: string, value: string) => void;
   packageInfo: PackageInfo;
-  isConditionallyRequired: boolean;
+  hasInvalidRequiredVars: boolean;
 }) => {
   return (
     <div>
-      {fields.map((field, index) => (
-        <div key={index}>
-          {field.type === 'password' && field.isSecret === true && (
-            <>
-              <EuiSpacer size="m" />
-              <div
-                css={css`
-                  width: 100%;
-                  .euiFormControlLayout,
-                  .euiFormControlLayout__childrenWrapper,
-                  .euiFormRow,
-                  input {
-                    max-width: 100%;
+      {fields.map((field, index) => {
+        const invalid = fieldIsInvalid(field.value, hasInvalidRequiredVars);
+        const invalidError = `${field.label} is required`;
+        return (
+          <div key={index}>
+            {field.type === 'password' && field.isSecret === true && (
+              <>
+                <EuiSpacer size="m" />
+                <div
+                  css={css`
                     width: 100%;
-                  }
-                `}
-              >
-                <Suspense fallback={<EuiLoadingSpinner size="l" />}>
-                  <LazyPackagePolicyInputVarField
-                    varDef={{
-                      ...findVariableDef(packageInfo, field.id)!,
-                      required: true,
-                      type: 'password',
-                    }}
-                    value={field.value || ''}
-                    onChange={(value) => {
-                      onChange(field.id, value);
-                    }}
-                    errors={
-                      isConditionallyRequired && !field.value ? [`${field.label} is required`] : []
+                    .euiFormControlLayout,
+                    .euiFormControlLayout__childrenWrapper,
+                    .euiFormRow,
+                    input {
+                      max-width: 100%;
+                      width: 100%;
                     }
-                    forceShowErrors={isConditionallyRequired && !field.value}
-                    isEditPage={true}
-                    data-test-subj={field.dataTestSubj}
-                  />
-                </Suspense>
-              </div>
-              <EuiSpacer size="m" />
-            </>
-          )}
-          {field.type === 'text' && (
-            <EuiFormRow
-              key={field.id}
-              label={field.label}
-              isInvalid={isConditionallyRequired && !field.value}
-              error={
-                isConditionallyRequired && !field.value ? `${field.label} is required` : undefined
-              }
-              fullWidth
-              hasChildLabel={true}
-              id={field.id}
-            >
-              <EuiFieldText
-                id={field.id}
+                  `}
+                >
+                  <Suspense fallback={<EuiLoadingSpinner size="l" />}>
+                    <LazyPackagePolicyInputVarField
+                      varDef={{
+                        ...findVariableDef(packageInfo, field.id)!,
+                        required: true,
+                        type: 'password',
+                      }}
+                      value={field.value || ''}
+                      onChange={(value) => {
+                        onChange(field.id, value);
+                      }}
+                      errors={invalid ? [invalidError] : []}
+                      forceShowErrors={invalid}
+                      isEditPage={true}
+                      data-test-subj={field.dataTestSubj}
+                    />
+                  </Suspense>
+                </div>
+                <EuiSpacer size="m" />
+              </>
+            )}
+            {field.type === 'text' && (
+              <EuiFormRow
+                key={field.id}
+                label={field.label}
+                isInvalid={invalid}
+                error={invalid ? invalidError : undefined}
                 fullWidth
-                value={field.value || ''}
-                isInvalid={isConditionallyRequired && !field.value}
-                onChange={(event) => onChange(field.id, event.target.value)}
-                data-test-subj={field.dataTestSubj}
-              />
-            </EuiFormRow>
-          )}
-        </div>
-      ))}
+                hasChildLabel={true}
+                id={field.id}
+              >
+                <EuiFieldText
+                  id={field.id}
+                  fullWidth
+                  value={field.value || ''}
+                  isInvalid={invalid}
+                  onChange={(event) => onChange(field.id, event.target.value)}
+                  data-test-subj={field.dataTestSubj}
+                />
+              </EuiFormRow>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
@@ -36,7 +36,10 @@ export const AwsInputVarFields = ({
       {fields.map((field, index) => {
         const invalid = fieldIsInvalid(field.value, hasInvalidRequiredVars);
         const invalidError = i18n.translate('xpack.csp.cspmIntegration.integration.fieldRequired', {
-          defaultMessage: `${field.label} is required`,
+          defaultMessage: '{field} is required',
+          values: {
+            field: field.label,
+          },
         });
         return (
           <div key={index}>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
@@ -17,7 +17,7 @@ export const AwsInputVarFields = ({
   fields,
   onChange,
   packageInfo,
-  hasInvalidRequiredVars,
+  hasInvalidRequiredVars = false,
 }: {
   fields: Array<
     AwsOptions[keyof AwsOptions]['fields'][number] & {
@@ -28,7 +28,7 @@ export const AwsInputVarFields = ({
   >;
   onChange: (key: string, value: string) => void;
   packageInfo: PackageInfo;
-  hasInvalidRequiredVars: boolean;
+  hasInvalidRequiredVars?: boolean;
 }) => {
   return (
     <div>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
@@ -10,6 +10,7 @@ import { EuiFieldText, EuiFormRow, EuiSpacer, EuiLoadingSpinner } from '@elastic
 import { PackageInfo } from '@kbn/fleet-plugin/common';
 import { css } from '@emotion/react';
 import { LazyPackagePolicyInputVarField } from '@kbn/fleet-plugin/public';
+import { i18n } from '@kbn/i18n';
 import { AwsOptions } from './get_aws_credentials_form_options';
 import { findVariableDef, fieldIsInvalid } from '../utils';
 
@@ -34,7 +35,9 @@ export const AwsInputVarFields = ({
     <div>
       {fields.map((field, index) => {
         const invalid = fieldIsInvalid(field.value, hasInvalidRequiredVars);
-        const invalidError = `${field.label} is required`;
+        const invalidError = i18n.translate('xpack.csp.cspmIntegration.integration.fieldRequired', {
+          defaultMessage: `${field.label} is required`,
+        });
         return (
           <div key={index}>
             {field.type === 'password' && field.isSecret === true && (

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_input_var_fields.tsx
@@ -17,6 +17,7 @@ export const AwsInputVarFields = ({
   fields,
   onChange,
   packageInfo,
+  isConditionallyRequired,
 }: {
   fields: Array<
     AwsOptions[keyof AwsOptions]['fields'][number] & {
@@ -27,6 +28,7 @@ export const AwsInputVarFields = ({
   >;
   onChange: (key: string, value: string) => void;
   packageInfo: PackageInfo;
+  isConditionallyRequired: boolean;
 }) => {
   return (
     <div>
@@ -58,8 +60,10 @@ export const AwsInputVarFields = ({
                     onChange={(value) => {
                       onChange(field.id, value);
                     }}
-                    errors={[]}
-                    forceShowErrors={false}
+                    errors={
+                      isConditionallyRequired && !field.value ? [`${field.label} is required`] : []
+                    }
+                    forceShowErrors={isConditionallyRequired && !field.value}
                     isEditPage={true}
                     data-test-subj={field.dataTestSubj}
                   />
@@ -72,6 +76,10 @@ export const AwsInputVarFields = ({
             <EuiFormRow
               key={field.id}
               label={field.label}
+              isInvalid={isConditionallyRequired && !field.value}
+              error={
+                isConditionallyRequired && !field.value ? `${field.label} is required` : undefined
+              }
               fullWidth
               hasChildLabel={true}
               id={field.id}
@@ -80,6 +88,7 @@ export const AwsInputVarFields = ({
                 id={field.id}
                 fullWidth
                 value={field.value || ''}
+                isInvalid={isConditionallyRequired && !field.value}
                 onChange={(event) => onChange(field.id, event.target.value)}
                 data-test-subj={field.dataTestSubj}
               />

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/hooks.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/hooks.ts
@@ -60,19 +60,33 @@ export const useAwsCredentialsForm = ({
 }) => {
   // We only have a value for 'aws.credentials.type' once the form has mounted.
   // On initial render we don't have that value, so we fall back to the default option.
-  const awsCredentialsType: AwsCredentialsType =
-    getAwsCredentialsType(input) || DEFAULT_MANUAL_AWS_CREDENTIALS_TYPE;
 
   const options = getAwsCredentialsFormOptions();
 
   const hasCloudFormationTemplate = !!getCspmCloudFormationDefaultValue(packageInfo);
 
   const setupFormat = getSetupFormatFromInput(input, hasCloudFormationTemplate);
+  const lastManualCredentialsType = useRef<string | undefined>(undefined);
+
+  // Assumes if the credentials type is not set, the default is CloudFormation
+  const awsCredentialsType: AwsCredentialsType =
+    getAwsCredentialsType(input) || AWS_SETUP_FORMAT.CLOUD_FORMATION;
 
   const group = options[awsCredentialsType];
   const fields = getInputVarsFields(input, group.fields);
   const fieldsSnapshot = useRef({});
-  const lastManualCredentialsType = useRef<string | undefined>(undefined);
+
+  // This should ony set the credentials after the initial render
+  if (!getAwsCredentialsType(input) && !lastManualCredentialsType.current) {
+    onChange({
+      updatedPolicy: getPosturePolicy(newPolicy, input.type, {
+        'aws.credentials.type': {
+          value: awsCredentialsType,
+          type: 'text',
+        },
+      }),
+    });
+  }
 
   useEffect(() => {
     const isInvalid =

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/hooks.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/hooks.ts
@@ -76,17 +76,19 @@ export const useAwsCredentialsForm = ({
   const fields = getInputVarsFields(input, group.fields);
   const fieldsSnapshot = useRef({});
 
-  // This should ony set the credentials after the initial render
-  if (!getAwsCredentialsType(input) && !lastManualCredentialsType.current) {
-    onChange({
-      updatedPolicy: getPosturePolicy(newPolicy, input.type, {
-        'aws.credentials.type': {
-          value: awsCredentialsType,
-          type: 'text',
-        },
-      }),
-    });
-  }
+  useEffect(() => {
+    // This should ony set the credentials after the initial render
+    if (!getAwsCredentialsType(input) && !lastManualCredentialsType.current) {
+      onChange({
+        updatedPolicy: getPosturePolicy(newPolicy, input.type, {
+          'aws.credentials.type': {
+            value: awsCredentialsType,
+            type: 'text',
+          },
+        }),
+      });
+    }
+  }, [awsCredentialsType, input, newPolicy, onChange]);
 
   useEffect(() => {
     const isInvalid =

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
@@ -289,7 +289,9 @@ export const AzureInputVarFields = ({
     <div>
       {fields.map((field, index) => {
         const invalid = fieldIsInvalid(field.value, hasInvalidRequiredVars);
-        const invalidError = `${field.label} is required`;
+        const invalidError = i18n.translate('xpack.csp.cspmIntegration.integration.fieldRequired', {
+          defaultMessage: `${field.label} is required`,
+        });
         return (
           <div key={index}>
             {field.type === 'password' && field.isSecret === true && (

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
@@ -290,7 +290,10 @@ export const AzureInputVarFields = ({
       {fields.map((field, index) => {
         const invalid = fieldIsInvalid(field.value, hasInvalidRequiredVars);
         const invalidError = i18n.translate('xpack.csp.cspmIntegration.integration.fieldRequired', {
-          defaultMessage: `${field.label} is required`,
+          defaultMessage: '{field} is required',
+          values: {
+            field: field.label,
+          },
         });
         return (
           <div key={index}>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form.tsx
@@ -32,7 +32,12 @@ import {
 } from './get_azure_credentials_form_options';
 import { AzureCredentialsType } from '../../../../common/types_old';
 import { useAzureCredentialsForm } from './hooks';
-import { findVariableDef, getPosturePolicy, NewPackagePolicyPostureInput } from '../utils';
+import {
+  fieldIsInvalid,
+  findVariableDef,
+  getPosturePolicy,
+  NewPackagePolicyPostureInput,
+} from '../utils';
 import { CspRadioOption, RadioGroup } from '../csp_boxed_radio_group';
 import { CIS_AZURE_SETUP_FORMAT_TEST_SUBJECTS } from '../../test_subjects';
 import { AZURE_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ } from '../../test_subjects';
@@ -114,6 +119,7 @@ export interface AzureCredentialsFormProps {
   onChange: any;
   setIsValid: (isValid: boolean) => void;
   disabled: boolean;
+  hasInvalidRequiredVars: boolean;
 }
 
 export const ARM_TEMPLATE_EXTERNAL_DOC_URL =
@@ -272,71 +278,80 @@ export const AzureInputVarFields = ({
   fields,
   packageInfo,
   onChange,
+  hasInvalidRequiredVars,
 }: {
   fields: Array<AzureOptions[keyof AzureOptions]['fields'][number] & { value: string; id: string }>;
   packageInfo: PackageInfo;
   onChange: (key: string, value: string) => void;
+  hasInvalidRequiredVars: boolean;
 }) => {
   return (
     <div>
-      {fields.map((field, index) => (
-        <div key={index}>
-          {field.type === 'password' && field.isSecret === true && (
-            <>
-              <EuiSpacer size="m" />
-              <div
-                css={css`
-                  width: 100%;
-                  .euiFormControlLayout,
-                  .euiFormControlLayout__childrenWrapper,
-                  .euiFormRow,
-                  input {
-                    max-width: 100%;
+      {fields.map((field, index) => {
+        const invalid = fieldIsInvalid(field.value, hasInvalidRequiredVars);
+        const invalidError = `${field.label} is required`;
+        return (
+          <div key={index}>
+            {field.type === 'password' && field.isSecret === true && (
+              <>
+                <EuiSpacer size="m" />
+                <div
+                  css={css`
                     width: 100%;
-                  }
-                `}
-              >
-                <Suspense fallback={<EuiLoadingSpinner size="l" />}>
-                  <LazyPackagePolicyInputVarField
-                    varDef={{
-                      ...findVariableDef(packageInfo, field.id)!,
-                      required: true,
-                      type: 'password',
-                    }}
-                    value={field.value || ''}
-                    onChange={(value) => {
-                      onChange(field.id, value);
-                    }}
-                    errors={[]}
-                    forceShowErrors={false}
-                    isEditPage={true}
-                  />
-                </Suspense>
-              </div>
-            </>
-          )}
-          {field.type === 'text' && (
-            <>
-              <EuiFormRow
-                key={field.id}
-                label={field.label}
-                fullWidth
-                hasChildLabel={true}
-                id={field.id}
-              >
-                <EuiFieldText
-                  id={field.id}
+                    .euiFormControlLayout,
+                    .euiFormControlLayout__childrenWrapper,
+                    .euiFormRow,
+                    input {
+                      max-width: 100%;
+                      width: 100%;
+                    }
+                  `}
+                >
+                  <Suspense fallback={<EuiLoadingSpinner size="l" />}>
+                    <LazyPackagePolicyInputVarField
+                      varDef={{
+                        ...findVariableDef(packageInfo, field.id)!,
+                        required: true,
+                        type: 'password',
+                      }}
+                      value={field.value || ''}
+                      onChange={(value) => {
+                        onChange(field.id, value);
+                      }}
+                      errors={invalid ? [invalidError] : []}
+                      forceShowErrors={invalid}
+                      isEditPage={true}
+                    />
+                  </Suspense>
+                </div>
+              </>
+            )}
+            {field.type === 'text' && (
+              <>
+                <EuiFormRow
+                  key={field.id}
+                  label={field.label}
                   fullWidth
-                  value={field.value || ''}
-                  onChange={(event) => onChange(field.id, event.target.value)}
-                  data-test-subj={field.testSubj}
-                />
-              </EuiFormRow>
-              <EuiSpacer size="s" />
-            </>
-          )}
-        </div>
-      ))}
+                  hasChildLabel={true}
+                  id={field.id}
+                  isInvalid={invalid}
+                  error={invalid ? invalidError : undefined}
+                >
+                  <EuiFieldText
+                    id={field.id}
+                    fullWidth
+                    value={field.value || ''}
+                    onChange={(event) => onChange(field.id, event.target.value)}
+                    data-test-subj={field.testSubj}
+                    isInvalid={invalid}
+                  />
+                </EuiFormRow>
+                <EuiSpacer size="s" />
+              </>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 };
@@ -349,6 +364,7 @@ export const AzureCredentialsForm = ({
   onChange,
   setIsValid,
   disabled,
+  hasInvalidRequiredVars,
 }: AzureCredentialsFormProps) => {
   const {
     group,
@@ -447,6 +463,7 @@ export const AzureCredentialsForm = ({
             onChange={(key, value) => {
               updatePolicy(getPosturePolicy(newPolicy, input.type, { [key]: { value } }));
             }}
+            hasInvalidRequiredVars={hasInvalidRequiredVars}
           />
           <EuiSpacer size="m" />
           {group.info}

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form_agentless.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/azure_credentials_form/azure_credentials_form_agentless.tsx
@@ -30,6 +30,7 @@ export const AzureCredentialsFormAgentless = ({
   newPolicy,
   updatePolicy,
   packageInfo,
+  hasInvalidRequiredVars,
 }: AzureCredentialsFormProps) => {
   const documentationLink = cspIntegrationDocsNavigation.cspm.azureGetStartedPath;
   const options = getAzureCredentialsFormOptions();
@@ -46,6 +47,7 @@ export const AzureCredentialsFormAgentless = ({
         onChange={(key, value) => {
           updatePolicy(getPosturePolicy(newPolicy, input.type, { [key]: { value } }));
         }}
+        hasInvalidRequiredVars={hasInvalidRequiredVars}
       />
       <EuiSpacer size="m" />
       <EuiText color="subdued" size="s">

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
@@ -31,6 +31,7 @@ import { GcpCredentialsType } from '../../../../common/types_old';
 import { CLOUDBEAT_GCP } from '../../../../common/constants';
 import { CspRadioOption, RadioGroup } from '../csp_boxed_radio_group';
 import {
+  fieldIsInvalid,
   findVariableDef,
   getCspmCloudShellDefaultValue,
   getPosturePolicy,
@@ -114,18 +115,28 @@ const GoogleCloudShellSetup = ({
   onChange,
   input,
   disabled,
+  hasInvalidRequiredVars,
 }: {
   fields: Array<GcpFields[keyof GcpFields] & { value: string; id: string }>;
   onChange: (key: string, value: string) => void;
   input: NewPackagePolicyInput;
   disabled: boolean;
+  hasInvalidRequiredVars: boolean;
 }) => {
   const accountType = input.streams?.[0]?.vars?.['gcp.account_type']?.value;
   const getFieldById = (id: keyof GcpInputFields['fields']) => {
     return fields.find((element) => element.id === id);
   };
   const projectIdFields = getFieldById('gcp.project_id');
+  const projectIdValueInvalid = fieldIsInvalid(projectIdFields?.value, hasInvalidRequiredVars);
+  const projectIdError = `${projectIdFields?.label} is required`;
+
   const organizationIdFields = getFieldById('gcp.organization_id');
+  const organizationIdValueInvalid = fieldIsInvalid(
+    organizationIdFields?.value,
+    hasInvalidRequiredVars
+  );
+  const organizationIdError = `${organizationIdFields?.label} is required`;
   return (
     <>
       <EuiText
@@ -177,7 +188,12 @@ const GoogleCloudShellSetup = ({
       <EuiSpacer size="l" />
       <EuiForm component="form">
         {organizationIdFields && accountType === GCP_ORGANIZATION_ACCOUNT && (
-          <EuiFormRow fullWidth label={gcpField.fields['gcp.organization_id'].label}>
+          <EuiFormRow
+            fullWidth
+            label={gcpField.fields['gcp.organization_id'].label}
+            isInvalid={organizationIdValueInvalid}
+            error={organizationIdValueInvalid ? organizationIdError : undefined}
+          >
             <EuiFieldText
               disabled={disabled}
               data-test-subj={CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.ORGANIZATION_ID}
@@ -185,11 +201,17 @@ const GoogleCloudShellSetup = ({
               fullWidth
               value={organizationIdFields.value || ''}
               onChange={(event) => onChange(organizationIdFields.id, event.target.value)}
+              isInvalid={organizationIdValueInvalid}
             />
           </EuiFormRow>
         )}
         {projectIdFields && (
-          <EuiFormRow fullWidth label={gcpField.fields['gcp.project_id'].label}>
+          <EuiFormRow
+            fullWidth
+            label={gcpField.fields['gcp.project_id'].label}
+            isInvalid={projectIdValueInvalid}
+            error={projectIdValueInvalid ? projectIdError : undefined}
+          >
             <EuiFieldText
               disabled={disabled}
               data-test-subj={CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.PROJECT_ID}
@@ -197,6 +219,7 @@ const GoogleCloudShellSetup = ({
               fullWidth
               value={projectIdFields.value || ''}
               onChange={(event) => onChange(projectIdFields.id, event.target.value)}
+              isInvalid={projectIdValueInvalid}
             />
           </EuiFormRow>
         )}
@@ -298,6 +321,7 @@ export interface GcpFormProps {
   onChange: any;
   disabled: boolean;
   isEditPage?: boolean;
+  hasInvalidRequiredVars: boolean;
 }
 
 export const getInputVarsFields = (input: NewPackagePolicyInput, fields: GcpFields) =>
@@ -403,6 +427,7 @@ export const GcpCredentialsForm = ({
   onChange,
   disabled,
   isEditPage,
+  hasInvalidRequiredVars,
 }: GcpFormProps) => {
   /* Create a subset of properties from GcpField to use for hiding value of credentials json and credentials file when user switch from Manual to Cloud Shell, we wanna keep Project and Organization ID */
   const subsetOfGcpField = (({ ['gcp.credentials.file']: a, ['gcp.credentials.json']: b }) => ({
@@ -516,6 +541,7 @@ export const GcpCredentialsForm = ({
             updatePolicy(getPosturePolicy(newPolicy, input.type, { [key]: { value } }))
           }
           input={input}
+          hasInvalidRequiredVars={hasInvalidRequiredVars}
         />
       ) : (
         <GcpInputVarFields
@@ -527,6 +553,7 @@ export const GcpCredentialsForm = ({
           isOrganization={isOrganization}
           packageInfo={packageInfo}
           isEditPage={isEditPage}
+          hasInvalidRequiredVars={hasInvalidRequiredVars}
         />
       )}
 
@@ -544,6 +571,7 @@ export const GcpInputVarFields = ({
   disabled,
   packageInfo,
   isEditPage,
+  hasInvalidRequiredVars,
 }: {
   fields: Array<GcpFields[keyof GcpFields] & { value: string; id: string }>;
   onChange: (key: string, value: string) => void;
@@ -551,17 +579,38 @@ export const GcpInputVarFields = ({
   disabled: boolean;
   packageInfo: PackageInfo;
   isEditPage?: boolean;
+  hasInvalidRequiredVars: boolean;
 }) => {
   const getFieldById = (id: keyof GcpInputFields['fields']) => {
     return fields.find((element) => element.id === id);
   };
 
   const organizationIdFields = getFieldById('gcp.organization_id');
+  const organizationIdValueInvalid = fieldIsInvalid(
+    organizationIdFields?.value,
+    hasInvalidRequiredVars
+  );
+  const organizationIdError = `${organizationIdFields?.label} is required`;
 
   const projectIdFields = getFieldById('gcp.project_id');
+  const projectIdValueInvalid = fieldIsInvalid(projectIdFields?.value, hasInvalidRequiredVars);
+  const projectIdError = `${projectIdFields?.label} is required`;
+
   const credentialsTypeFields = getFieldById('gcp.credentials.type');
+
   const credentialFilesFields = getFieldById('gcp.credentials.file');
+  const credentialFilesFieldsInvalid = fieldIsInvalid(
+    credentialFilesFields?.value,
+    hasInvalidRequiredVars
+  );
+  const credentialFilesError = `${credentialFilesFields?.label} is required`;
+
   const credentialJSONFields = getFieldById('gcp.credentials.json');
+  const credentialJSONFieldsInvalid = fieldIsInvalid(
+    credentialJSONFields?.value,
+    hasInvalidRequiredVars
+  );
+  const credentialJSONError = `${credentialJSONFields?.label} is required`;
 
   const credentialFieldValue = credentialOptionsList[0].value;
   const credentialJSONValue = credentialOptionsList[1].value;
@@ -575,7 +624,12 @@ export const GcpInputVarFields = ({
     <div>
       <EuiForm component="form">
         {organizationIdFields && isOrganization && (
-          <EuiFormRow fullWidth label={gcpField.fields['gcp.organization_id'].label}>
+          <EuiFormRow
+            fullWidth
+            label={gcpField.fields['gcp.organization_id'].label}
+            isInvalid={organizationIdValueInvalid}
+            error={organizationIdValueInvalid ? organizationIdError : undefined}
+          >
             <EuiFieldText
               disabled={disabled}
               data-test-subj={CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.ORGANIZATION_ID}
@@ -583,11 +637,17 @@ export const GcpInputVarFields = ({
               fullWidth
               value={organizationIdFields.value || ''}
               onChange={(event) => onChange(organizationIdFields.id, event.target.value)}
+              isInvalid={organizationIdValueInvalid}
             />
           </EuiFormRow>
         )}
         {projectIdFields && (
-          <EuiFormRow fullWidth label={gcpField.fields['gcp.project_id'].label}>
+          <EuiFormRow
+            fullWidth
+            label={gcpField.fields['gcp.project_id'].label}
+            isInvalid={projectIdValueInvalid}
+            error={projectIdValueInvalid ? projectIdError : undefined}
+          >
             <EuiFieldText
               disabled={disabled}
               data-test-subj={CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.PROJECT_ID}
@@ -595,6 +655,7 @@ export const GcpInputVarFields = ({
               fullWidth
               value={projectIdFields.value || ''}
               onChange={(event) => onChange(projectIdFields.id, event.target.value)}
+              isInvalid={projectIdValueInvalid}
             />
           </EuiFormRow>
         )}
@@ -612,13 +673,19 @@ export const GcpInputVarFields = ({
           </EuiFormRow>
         )}
         {credentialsTypeValue === credentialFieldValue && credentialFilesFields && (
-          <EuiFormRow fullWidth label={gcpField.fields['gcp.credentials.file'].label}>
+          <EuiFormRow
+            fullWidth
+            label={gcpField.fields['gcp.credentials.file'].label}
+            isInvalid={credentialFilesFieldsInvalid}
+            error={credentialFilesFieldsInvalid ? credentialFilesError : undefined}
+          >
             <EuiFieldText
               data-test-subj={CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.CREDENTIALS_FILE}
               id={credentialFilesFields.id}
               fullWidth
               value={credentialFilesFields.value || ''}
               onChange={(event) => onChange(credentialFilesFields.id, event.target.value)}
+              isInvalid={credentialFilesFieldsInvalid}
             />
           </EuiFormRow>
         )}
@@ -636,7 +703,12 @@ export const GcpInputVarFields = ({
             `}
           >
             <EuiSpacer size="m" />
-            <EuiFormRow fullWidth label={gcpField.fields['gcp.credentials.json'].label}>
+            <EuiFormRow
+              fullWidth
+              label={gcpField.fields['gcp.credentials.json'].label}
+              isInvalid={credentialJSONFieldsInvalid}
+              error={credentialJSONFieldsInvalid ? credentialJSONError : undefined}
+            >
               <Suspense fallback={<EuiLoadingSpinner size="l" />}>
                 <LazyPackagePolicyInputVarField
                   data-test-subj={CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.CREDENTIALS_JSON}
@@ -651,7 +723,7 @@ export const GcpInputVarFields = ({
                   onChange={(value) => {
                     onChange(credentialJSONFields.id, value);
                   }}
-                  errors={[]}
+                  errors={credentialJSONFieldsInvalid ? [credentialJSONError] : []}
                   forceShowErrors={false}
                   isEditPage={isEditPage}
                 />

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
@@ -593,14 +593,20 @@ export const GcpInputVarFields = ({
   const organizationIdError = i18n.translate(
     'xpack.csp.cspmIntegration.integration.fieldRequired',
     {
-      defaultMessage: `${organizationIdFields?.label} is required`,
+      defaultMessage: '{field} is required',
+      values: {
+        field: organizationIdFields?.label,
+      },
     }
   );
 
   const projectIdFields = getFieldById('gcp.project_id');
   const projectIdValueInvalid = fieldIsInvalid(projectIdFields?.value, hasInvalidRequiredVars);
   const projectIdError = i18n.translate('xpack.csp.cspmIntegration.integration.fieldRequired', {
-    defaultMessage: `${projectIdFields?.label} is required`,
+    defaultMessage: '{field} is required',
+    values: {
+      field: projectIdFields?.label,
+    },
   });
 
   const credentialsTypeFields = getFieldById('gcp.credentials.type');
@@ -613,7 +619,10 @@ export const GcpInputVarFields = ({
   const credentialFilesError = i18n.translate(
     'xpack.csp.cspmIntegration.integration.fieldRequired',
     {
-      defaultMessage: `${credentialFilesFields?.label} is required`,
+      defaultMessage: '{field} is required',
+      values: {
+        field: credentialFilesFields?.label,
+      },
     }
   );
 
@@ -625,7 +634,10 @@ export const GcpInputVarFields = ({
   const credentialJSONError = i18n.translate(
     'xpack.csp.cspmIntegration.integration.fieldRequired',
     {
-      defaultMessage: `${credentialJSONFields?.label} is required`,
+      defaultMessage: '{field} is required',
+      values: {
+        field: credentialJSONFields?.label,
+      },
     }
   );
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
@@ -590,11 +590,18 @@ export const GcpInputVarFields = ({
     organizationIdFields?.value,
     hasInvalidRequiredVars
   );
-  const organizationIdError = `${organizationIdFields?.label} is required`;
+  const organizationIdError = i18n.translate(
+    'xpack.csp.cspmIntegration.integration.fieldRequired',
+    {
+      defaultMessage: `${organizationIdFields?.label} is required`,
+    }
+  );
 
   const projectIdFields = getFieldById('gcp.project_id');
   const projectIdValueInvalid = fieldIsInvalid(projectIdFields?.value, hasInvalidRequiredVars);
-  const projectIdError = `${projectIdFields?.label} is required`;
+  const projectIdError = i18n.translate('xpack.csp.cspmIntegration.integration.fieldRequired', {
+    defaultMessage: `${projectIdFields?.label} is required`,
+  });
 
   const credentialsTypeFields = getFieldById('gcp.credentials.type');
 
@@ -603,14 +610,24 @@ export const GcpInputVarFields = ({
     credentialFilesFields?.value,
     hasInvalidRequiredVars
   );
-  const credentialFilesError = `${credentialFilesFields?.label} is required`;
+  const credentialFilesError = i18n.translate(
+    'xpack.csp.cspmIntegration.integration.fieldRequired',
+    {
+      defaultMessage: `${credentialFilesFields?.label} is required`,
+    }
+  );
 
   const credentialJSONFields = getFieldById('gcp.credentials.json');
   const credentialJSONFieldsInvalid = fieldIsInvalid(
     credentialJSONFields?.value,
     hasInvalidRequiredVars
   );
-  const credentialJSONError = `${credentialJSONFields?.label} is required`;
+  const credentialJSONError = i18n.translate(
+    'xpack.csp.cspmIntegration.integration.fieldRequired',
+    {
+      defaultMessage: `${credentialJSONFields?.label} is required`,
+    }
+  );
 
   const credentialFieldValue = credentialOptionsList[0].value;
   const credentialJSONValue = credentialOptionsList[1].value;

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credentials_form_agentless.tsx
@@ -164,6 +164,7 @@ export const GcpCredentialsFormAgentless = ({
   updatePolicy,
   disabled,
   packageInfo,
+  hasInvalidRequiredVars,
 }: GcpFormProps) => {
   const accountType = input.streams?.[0]?.vars?.['gcp.account_type']?.value;
   const isOrganization = accountType === ORGANIZATION_ACCOUNT;
@@ -250,6 +251,7 @@ export const GcpCredentialsFormAgentless = ({
         }
         isOrganization={isOrganization}
         packageInfo={packageInfo}
+        hasInvalidRequiredVars={hasInvalidRequiredVars}
       />
       <EuiSpacer size="s" />
       <ReadDocumentation url={cspIntegrationDocsNavigation.cspm.gcpGetStartedPath} />

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -764,9 +764,12 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
       (key) => (validationResults?.vars || {})[key] !== null
     );
 
+    const inputName = `${input.policy_template}-${input.type}`;
     const isConditionallyRequired =
-      validationResults?.conditionalRequired &&
-      Object.entries(validationResults.conditionalRequired).length > 0;
+      validationResults?.inputs &&
+      // validationResults.inputs[inputName] &&
+      // validationResults.inputs[inputName].required_vars &&
+      Object.entries(validationResults.inputs[inputName].required_vars ?? {}).length > 0;
 
     const [isLoading, setIsLoading] = useState(validationResultsNonNullFields.length > 0);
     const [canFetchIntegration, setCanFetchIntegration] = useState(true);

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -764,7 +764,7 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
     const validationResultsNonNullFields = Object.keys(validationResults?.vars || {}).filter(
       (key) => (validationResults?.vars || {})[key] !== null
     );
-    const hasInvalidRequiredVars = hasErrors(validationResults);
+    const hasInvalidRequiredVars = !!hasErrors(validationResults);
 
     const [isLoading, setIsLoading] = useState(validationResultsNonNullFields.length > 0);
     const [canFetchIntegration, setCanFetchIntegration] = useState(true);

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -52,6 +52,7 @@ import {
   type NewPackagePolicyPostureInput,
   POSTURE_NAMESPACE,
   POLICY_TEMPLATE_FORM_DTS,
+  hasErrors,
 } from './utils';
 import {
   PolicyTemplateInfo,
@@ -763,9 +764,7 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
     const validationResultsNonNullFields = Object.keys(validationResults?.vars || {}).filter(
       (key) => (validationResults?.vars || {})[key] !== null
     );
-
-    const inputName = `${input.policy_template}-${input.type}`;
-    const hasInvalidRequiredVars = !!validationResults?.inputs?.[inputName]?.required_vars;
+    const hasInvalidRequiredVars = hasErrors(validationResults);
 
     const [isLoading, setIsLoading] = useState(validationResultsNonNullFields.length > 0);
     const [canFetchIntegration, setCanFetchIntegration] = useState(true);

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -765,11 +765,7 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
     );
 
     const inputName = `${input.policy_template}-${input.type}`;
-    const isConditionallyRequired =
-      validationResults?.inputs &&
-      // validationResults.inputs[inputName] &&
-      // validationResults.inputs[inputName].required_vars &&
-      Object.entries(validationResults.inputs[inputName].required_vars ?? {}).length > 0;
+    const hasInvalidRequiredVars = !!validationResults?.inputs?.[inputName]?.required_vars;
 
     const [isLoading, setIsLoading] = useState(validationResultsNonNullFields.length > 0);
     const [canFetchIntegration, setCanFetchIntegration] = useState(true);
@@ -1017,7 +1013,7 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
           disabled={isEditPage}
           setupTechnology={setupTechnology}
           isEditPage={isEditPage}
-          isConditionallyRequired={isConditionallyRequired}
+          hasInvalidRequiredVars={hasInvalidRequiredVars}
         />
         <EuiSpacer />
       </>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -764,6 +764,10 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
       (key) => (validationResults?.vars || {})[key] !== null
     );
 
+    const isConditionallyRequired =
+      validationResults?.conditionalRequired &&
+      Object.entries(validationResults.conditionalRequired).length > 0;
+
     const [isLoading, setIsLoading] = useState(validationResultsNonNullFields.length > 0);
     const [canFetchIntegration, setCanFetchIntegration] = useState(true);
 
@@ -1010,6 +1014,7 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
           disabled={isEditPage}
           setupTechnology={setupTechnology}
           isEditPage={isEditPage}
+          isConditionallyRequired={isConditionallyRequired}
         />
         <EuiSpacer />
       </>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_selectors.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_selectors.tsx
@@ -80,6 +80,7 @@ interface PolicyTemplateVarsFormProps {
   disabled: boolean;
   setupTechnology: SetupTechnology;
   isEditPage?: boolean;
+  isConditionallyRequired?: boolean;
 }
 
 export const PolicyTemplateVarsForm = ({

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_selectors.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_selectors.tsx
@@ -80,7 +80,7 @@ interface PolicyTemplateVarsFormProps {
   disabled: boolean;
   setupTechnology: SetupTechnology;
   isEditPage?: boolean;
-  isConditionallyRequired?: boolean;
+  hasInvalidRequiredVars: boolean;
 }
 
 export const PolicyTemplateVarsForm = ({

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
@@ -395,6 +395,9 @@ export const findVariableDef = (packageInfo: PackageInfo, key: string) => {
     .find((vars) => vars?.name === key);
 };
 
+export const fieldIsInvalid = (value: string | undefined, hasInvalidRequiredVars: boolean) =>
+  hasInvalidRequiredVars && !value;
+
 export const POLICY_TEMPLATE_FORM_DTS = {
   LOADER: 'policy-template-form-loader',
 };

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
@@ -18,6 +18,8 @@ import merge from 'lodash/merge';
 import semverValid from 'semver/functions/valid';
 import semverCoerce from 'semver/functions/coerce';
 import semverLt from 'semver/functions/lt';
+import { PackagePolicyValidationResults } from '@kbn/fleet-plugin/common/services';
+import { getFlattenedObject } from '@kbn/std';
 import {
   CLOUDBEAT_AWS,
   CLOUDBEAT_AZURE,
@@ -43,8 +45,6 @@ import {
 } from './aws_credentials_form/get_aws_credentials_form_options';
 import { GCP_CREDENTIALS_TYPE, GCP_SETUP_ACCESS } from './gcp_credentials_form/gcp_credential_form';
 import { AZURE_CREDENTIALS_TYPE } from './azure_credentials_form/azure_credentials_form';
-import { PackagePolicyValidationResults } from '@kbn/fleet-plugin/common/services';
-import { getFlattenedObject } from '@kbn/std';
 
 // Posture policies only support the default namespace
 export const POSTURE_NAMESPACE = 'default';

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
@@ -43,6 +43,8 @@ import {
 } from './aws_credentials_form/get_aws_credentials_form_options';
 import { GCP_CREDENTIALS_TYPE, GCP_SETUP_ACCESS } from './gcp_credentials_form/gcp_credential_form';
 import { AZURE_CREDENTIALS_TYPE } from './azure_credentials_form/azure_credentials_form';
+import { PackagePolicyValidationResults } from '@kbn/fleet-plugin/common/services';
+import { getFlattenedObject } from '@kbn/std';
 
 // Posture policies only support the default namespace
 export const POSTURE_NAMESPACE = 'default';
@@ -400,4 +402,12 @@ export const fieldIsInvalid = (value: string | undefined, hasInvalidRequiredVars
 
 export const POLICY_TEMPLATE_FORM_DTS = {
   LOADER: 'policy-template-form-loader',
+};
+
+export const hasErrors = (validationResults: PackagePolicyValidationResults | undefined) => {
+  if (!validationResults) return 0;
+
+  const flattenedValidation = getFlattenedObject(validationResults);
+  const errors = Object.values(flattenedValidation).filter((value) => Boolean(value)) || [];
+  return errors.length;
 };

--- a/x-pack/test/cloud_security_posture_functional/agentless/create_agent.ts
+++ b/x-pack/test/cloud_security_posture_functional/agentless/create_agent.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { CLOUD_CREDENTIALS_PACKAGE_VERSION } from '@kbn/cloud-security-posture-plugin/common/constants';
 import * as http from 'http';
 import expect from '@kbn/expect';
 import equals from 'fast-deep-equal';
+import { AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION } from '../constants';
 import type { FtrProviderContext } from '../ftr_provider_context';
 import { setupMockServer } from './mock_agentless_api';
 // eslint-disable-next-line import/no-default-export
@@ -47,7 +47,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     it(`should create agentless-agent`, async () => {
       const integrationPolicyName = `cloud_security_posture-${new Date().toISOString()}`;
       await cisIntegration.navigateToAddIntegrationCspmWithVersionPage(
-        CLOUD_CREDENTIALS_PACKAGE_VERSION
+        AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION
       );
 
       await cisIntegration.clickOptionButton(CIS_AWS_OPTION_TEST_ID);
@@ -59,6 +59,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await cisIntegration.selectAwsCredentials('direct');
 
       await pageObjects.header.waitUntilLoadingHasFinished();
+
+      await cisIntegration.fillInTextField('awsDirectAccessKeyId', 'access_key_id');
+      await cisIntegration.fillInTextField('passwordInput-secret-access-key', 'secret_access_key');
 
       await cisIntegration.clickSaveButton();
       await pageObjects.header.waitUntilLoadingHasFinished();
@@ -84,7 +87,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     it(`should show setup technology selector in edit mode`, async () => {
       const integrationPolicyName = `cloud_security_posture-${new Date().toISOString()}`;
       await cisIntegration.navigateToAddIntegrationCspmWithVersionPage(
-        CLOUD_CREDENTIALS_PACKAGE_VERSION
+        AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION
       );
 
       await cisIntegration.clickOptionButton(CIS_AWS_OPTION_TEST_ID);
@@ -96,6 +99,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await cisIntegration.selectAwsCredentials('direct');
 
       await pageObjects.header.waitUntilLoadingHasFinished();
+
+      await cisIntegration.fillInTextField('awsDirectAccessKeyId', 'access_key_id');
+      await cisIntegration.fillInTextField('passwordInput-secret-access-key', 'secret_access_key');
 
       await cisIntegration.clickSaveButton();
       await pageObjects.header.waitUntilLoadingHasFinished();
@@ -114,7 +120,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     it(`should hide setup technology selector in edit mode`, async () => {
       const integrationPolicyName = `cloud_security_posture1-${new Date().toISOString()}`;
       await cisIntegration.navigateToAddIntegrationCspmWithVersionPage(
-        CLOUD_CREDENTIALS_PACKAGE_VERSION
+        AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION
       );
 
       await cisIntegration.clickOptionButton(CIS_AWS_OPTION_TEST_ID);
@@ -141,7 +147,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       const integrationPolicyName = `cloud_security_posture-${new Date().toISOString()}`;
 
       await cisIntegration.navigateToAddIntegrationCspmWithVersionPage(
-        CLOUD_CREDENTIALS_PACKAGE_VERSION
+        AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION
       );
 
       await cisIntegration.clickOptionButton(CIS_AWS_OPTION_TEST_ID);

--- a/x-pack/test/cloud_security_posture_functional/agentless/security_posture.ts
+++ b/x-pack/test/cloud_security_posture_functional/agentless/security_posture.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { CLOUD_CREDENTIALS_PACKAGE_VERSION } from '@kbn/cloud-security-posture-plugin/common/constants';
 import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../ftr_provider_context';
+import { AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION } from '../constants';
 // eslint-disable-next-line import/no-default-export
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
@@ -39,7 +39,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
     it(`should show kspm without agentless option`, async () => {
       await cisIntegration.navigateToAddIntegrationWithVersionPage(
-        CLOUD_CREDENTIALS_PACKAGE_VERSION
+        AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION
       );
 
       await cisIntegration.clickOptionButton(KSPM_RADIO_OPTION);
@@ -55,7 +55,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     it(`should show cnvm without agentless option`, async () => {
       //   const integrationPolicyName = `cloud_security_posture-${new Date().toISOString()}`;
       await cisIntegration.navigateToAddIntegrationWithVersionPage(
-        CLOUD_CREDENTIALS_PACKAGE_VERSION
+        AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION
       );
 
       await cisIntegration.clickOptionButton(CNVM_RADIO_OPTION);
@@ -71,7 +71,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     it(`should show cspm with agentless option`, async () => {
       //   const integrationPolicyName = `cloud_security_posture-${new Date().toISOString()}`;
       await cisIntegration.navigateToAddIntegrationWithVersionPage(
-        CLOUD_CREDENTIALS_PACKAGE_VERSION
+        AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION
       );
 
       await cisIntegration.clickOptionButton(CSPM_RADIO_OPTION);

--- a/x-pack/test/cloud_security_posture_functional/constants.ts
+++ b/x-pack/test/cloud_security_posture_functional/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION = '1.13.0-preview02';

--- a/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/cis_integration_azure.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/cis_integration_azure.ts
@@ -117,7 +117,7 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     describe('Azure Organization Manual Service Principle with Client Certificate', () => {
-      it('Azure Organization Manual Service Principle with Client Certificate Workflow', async () => {
+      it.only('Azure Organization Manual Service Principle with Client Certificate Workflow', async () => {
         await cisIntegration.clickOptionButton(CIS_AZURE_OPTION_TEST_ID);
         await cisIntegration.clickOptionButton(CIS_AZURE_SETUP_FORMAT_TEST_SUBJECTS.MANUAL);
         await cisIntegration.selectValue(
@@ -162,11 +162,6 @@ export default function (providerContext: FtrProviderContext) {
           (await cisIntegration.getValueInEditPage(
             CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS.CLIENT_CERTIFICATE_PATH
           )) === clientCertificatePath
-        ).to.be(true);
-        expect(
-          (await cisIntegration.getValueInEditPage(
-            CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS.CLIENT_CERTIFICATE_PASSWORD
-          )) === clientCertificatePassword
         ).to.be(true);
       });
     });

--- a/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/cis_integration_azure.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/cis_integration_azure.ts
@@ -16,13 +16,14 @@ const clientId = 'clientIdTest';
 const tenantId = 'tenantIdTest';
 const clientCertificatePath = 'clientCertificatePathTest';
 const clientSecret = 'clientSecretTest';
+const clientCertificatePassword = 'clientCertificatePasswordTest';
 
 export const CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS = {
   TENANT_ID: 'cisAzureTenantId',
   CLIENT_ID: 'cisAzureClientId',
   CLIENT_SECRET: 'passwordInput-client-secret',
   CLIENT_CERTIFICATE_PATH: 'cisAzureClientCertificatePath',
-  CLIENT_CERTIFICATE_PASSWORD: 'cisAzureClientCertificatePassword',
+  CLIENT_CERTIFICATE_PASSWORD: 'passwordInput-client-certificate-password',
   CLIENT_USERNAME: 'cisAzureClientUsername',
   CLIENT_PASSWORD: 'cisAzureClientPassword',
 };
@@ -136,6 +137,12 @@ export default function (providerContext: FtrProviderContext) {
           CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS.CLIENT_CERTIFICATE_PATH,
           clientCertificatePath
         );
+
+        await cisIntegration.fillInTextField(
+          CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS.CLIENT_CERTIFICATE_PASSWORD,
+          clientCertificatePassword
+        );
+
         await cisIntegration.clickSaveButton();
         await pageObjects.header.waitUntilLoadingHasFinished();
         expect((await cisIntegration.getPostInstallModal()) !== undefined).to.be(true);
@@ -155,6 +162,11 @@ export default function (providerContext: FtrProviderContext) {
           (await cisIntegration.getValueInEditPage(
             CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS.CLIENT_CERTIFICATE_PATH
           )) === clientCertificatePath
+        ).to.be(true);
+        expect(
+          (await cisIntegration.getValueInEditPage(
+            CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS.CLIENT_CERTIFICATE_PASSWORD
+          )) === clientCertificatePassword
         ).to.be(true);
       });
     });
@@ -248,6 +260,12 @@ export default function (providerContext: FtrProviderContext) {
           CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS.CLIENT_CERTIFICATE_PATH,
           clientCertificatePath
         );
+
+        await cisIntegration.fillInTextField(
+          CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS.CLIENT_CERTIFICATE_PASSWORD,
+          clientCertificatePassword
+        );
+
         await cisIntegration.clickSaveButton();
         await pageObjects.header.waitUntilLoadingHasFinished();
         expect((await cisIntegration.getPostInstallModal()) !== undefined).to.be(true);

--- a/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/cis_integration_azure.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/cis_integration_azure.ts
@@ -117,7 +117,7 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     describe('Azure Organization Manual Service Principle with Client Certificate', () => {
-      it.only('Azure Organization Manual Service Principle with Client Certificate Workflow', async () => {
+      it('Azure Organization Manual Service Principle with Client Certificate Workflow', async () => {
         await cisIntegration.clickOptionButton(CIS_AZURE_OPTION_TEST_ID);
         await cisIntegration.clickOptionButton(CIS_AZURE_SETUP_FORMAT_TEST_SUBJECTS.MANUAL);
         await cisIntegration.selectValue(

--- a/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/constants.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/constants.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/mki_only/agentless/mki_create_agent.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/mki_only/agentless/mki_create_agent.ts
@@ -85,6 +85,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await cisIntegration.clickOptionButton(CIS_AWS_OPTION_TEST_ID);
       await cisIntegration.clickOptionButton(AWS_SINGLE_ACCOUNT_TEST_ID);
 
+      await cisIntegration.selectSetupTechnology('agent-based');
+      await pageObjects.header.waitUntilLoadingHasFinished();
+
       await cisIntegration.inputIntegrationName(integrationPolicyName);
 
       await cisIntegration.clickSaveButton();


### PR DESCRIPTION
## Summary
This change introduces the ability for integrations to validate dependent fields using the `required_vars` object in the `package-spec`, for example,  a username and password are both required fields.  Additionally,  we can check for a predetermined value in the required_vars.

The [validatePackageRequiredVars](https://github.com/elastic/kibana/pull/207130/files#diff-c419a7e68b4a01dd1cd9b8f7587ba837639f97042db0fae85af4444d9002ea10R60) `validatePackagePolicy` function integrates with `validatePackagePolicy` functions and [adds](https://github.com/elastic/kibana/pull/207130/files#diff-c419a7e68b4a01dd1cd9b8f7587ba837639f97042db0fae85af4444d9002ea10R270) the invalid `required_vars` to the `validationResults` object.  Validating the required_vars is all dependent on the inputs.stream being enable

```
{
    "name": null,
    "description": null,
    "namespace": null,
    "inputs": {
        "cspm-cloudbeat/cis_aws": {
            "streams": {
                "cloud_security_posture.findings": {
                    "vars": {
                        ...
                    },
                    "required_vars": {
                        "assume_role": [
                            {
                                "name": "role_arn",
                                "invalid": true
                            }
                        ],
                        "direct_access_keys": [
                            {
                                "name": "aws.credentials.type",
                                "invalid": true
                            },
                            {
                                "name": "access_key_id",
                                "invalid": true
                            },
                            {
                                "name": "secret_access_key",
                                "invalid": true
                            }
                        ],
               
                    }
                }
            }
        },
    },
    "vars": {
        "posture": null,
        "deployment": null
    }
}

```

We have [enhanced the CSPM integration](https://github.com/elastic/kibana/pull/207130) to support required_vars, as such, since the CSPM integration is a custom Fleet extension and the behaviour is only one package policy stream can be enabled,  the CSPM UI only needs to know if there are `required_vars` that are invalid to [show the error state](https://github.com/elastic/kibana/pull/207130/files#diff-b1350d9e843233595d145d8ac2bff85ad17e18c0a264df435dc2a2670bf4520bR400).

https://github.com/user-attachments/assets/42808ebf-2286-4f2f-b787-b76b3541ea44

#### Follow Up
This solution primarily addresses the concerns for the CSPM integration and reads the `streams/input/vars`, a [follow-up issue](https://github.com/elastic/kibana/issues/208315) has been created to include any `vars` to validate required_vars and introduce Fleet native integration UI to show invalid fields

#### Depends On
- https://github.com/elastic/integrations/pull/12363

##### Related Issues
- https://github.com/elastic/package-spec/issues/744
- https://github.com/elastic/security-team/issues/10623
- Follow up https://github.com/elastic/kibana/issues/208315


### Checklist
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->