### PR TITLE
[Security Solution] 10751 app findings group by

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/README.md
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/README.md
@@ -145,3 +145,20 @@ yarn cypress:cloud_security_posture:run:serverless
 ```
 
 Unlike FTR where we have to set server and runner separately, Cypress handles everything in 1 go, so just running the above the script is enough to get it running
+
+### Troubleshooting
+
+If you encounter an error related to running machine learning code, you should add the following string `'xpack.ml.enabled=false'` under the `esTestCluster` property in the `x-pack/test/functional/config.base.js` file.
+
+Example:
+```javascript
+module.exports = {
+  esTestCluster: {
+    // ...existing configuration...
+    serverArgs: [
+      // ...existing arguments...
+      'xpack.ml.enabled=false', // Add this line to disable ML
+    ],
+  },
+  // ...other configurations...
+};

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
@@ -178,6 +178,7 @@ export const FINDINGS_GROUPING_OPTIONS = {
   CLOUD_ACCOUNT_NAME: 'cloud.account.name',
   CLOUD_ACCOUNT_ID: 'cloud.account.id',
   ORCHESTRATOR_CLUSTER_NAME: 'orchestrator.cluster.name',
+  ORCHESTRATOR_CLUSTER_ID: 'orchestrator.cluster.id',
 };
 
 export const VULNERABILITY_FIELDS = {
@@ -225,6 +226,6 @@ the fields from the runtime mappings if they are removed from the Data Table.
 */
 export const CDR_VULNERABILITY_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {};
 export const CDR_MISCONFIGURATION_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {
-  [FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME]: ['orchestrator.cluster.name'],
+  [FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID]: ['orchestrator.cluster.id'],
   [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID]: ['cloud.account.id'],
 };

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
@@ -176,6 +176,7 @@ export const FINDINGS_GROUPING_OPTIONS = {
   RULE_NAME: 'rule.name',
   RULE_SECTION: 'rule.section',
   CLOUD_ACCOUNT_NAME: 'cloud.account.name',
+  CLOUD_ACCOUNT_ID: 'cloud.account.id',
   ORCHESTRATOR_CLUSTER_NAME: 'orchestrator.cluster.name',
 };
 
@@ -225,5 +226,5 @@ the fields from the runtime mappings if they are removed from the Data Table.
 export const CDR_VULNERABILITY_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {};
 export const CDR_MISCONFIGURATION_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {
   [FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME]: ['orchestrator.cluster.name'],
-  [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME]: ['cloud.account.name'],
+  [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID]: ['cloud.account.id'],
 };

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.test.tsx
@@ -47,7 +47,7 @@ describe('AccountsEvaluatedWidget', () => {
         'cloud.provider': 'aws',
         'rule.benchmark.posture_type': 'cspm',
       },
-      ['cloud.account.name']
+      ['cloud.account.id']
     );
   });
 
@@ -64,7 +64,7 @@ describe('AccountsEvaluatedWidget', () => {
       {
         'rule.benchmark.id': 'cis_k8s',
       },
-      ['orchestrator.cluster.name']
+      ['orchestrator.cluster.id']
     );
   });
 });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.tsx
@@ -64,7 +64,7 @@ export const AccountsEvaluatedWidget = ({
   const navToFindingsByCloudProvider = (provider: string) => {
     navToFindings(
       { 'cloud.provider': provider, 'rule.benchmark.posture_type': CSPM_POLICY_TEMPLATE },
-      [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME]
+      [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID]
     );
   };
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/accounts_evaluated_widget.tsx
@@ -70,7 +70,7 @@ export const AccountsEvaluatedWidget = ({
 
   const navToFindingsByCisBenchmark = (cisBenchmark: string) => {
     navToFindings({ 'rule.benchmark.id': cisBenchmark }, [
-      FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME,
+      FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID,
     ]);
   };
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
@@ -190,7 +190,7 @@ const getBenchmarkTableColumns = (
       const isKspmBenchmark = ['cis_k8s', 'cis_eks'].includes(benchmark.id);
       const groupByField = isKspmBenchmark
         ? FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME
-        : FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME;
+        : FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID;
 
       return (
         <EuiButtonEmpty

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/benchmarks/benchmarks_table.tsx
@@ -145,14 +145,12 @@ const getBenchmarkTableColumns = (
     'data-test-subj': TEST_SUBJ.BENCHMARKS_TABLE_COLUMNS.APPLICABLE_TO,
     render: (benchmarkId: BenchmarksCisId) => {
       return (
-        <>
-          <EuiFlexGroup gutterSize="s" alignItems="center">
-            <EuiFlexItem grow={false}>
-              <CISBenchmarkIcon type={benchmarkId} size={'l'} />
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>{getBenchmarkApplicableTo(benchmarkId)}</EuiFlexItem>
-          </EuiFlexGroup>
-        </>
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <CISBenchmarkIcon type={benchmarkId} size={'l'} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>{getBenchmarkApplicableTo(benchmarkId)}</EuiFlexItem>
+        </EuiFlexGroup>
       );
     },
   },
@@ -189,7 +187,7 @@ const getBenchmarkTableColumns = (
 
       const isKspmBenchmark = ['cis_k8s', 'cis_eks'].includes(benchmark.id);
       const groupByField = isKspmBenchmark
-        ? FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME
+        ? FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID
         : FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID;
 
       return (

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmark_details_box.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmark_details_box.tsx
@@ -38,7 +38,7 @@ export const BenchmarkDetailsBox = ({ benchmark }: { benchmark: BenchmarkData })
 
   const handleClickCluster = () =>
     navToFindings(getBenchmarkIdQuery(benchmark), [
-      FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME,
+      FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID,
     ]);
 
   const getBenchmarkInfo = (benchmarkId: string, cloudAssetCount: number): BenchmarkInfo => {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmark_details_box.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/benchmark_details_box.tsx
@@ -34,7 +34,7 @@ export const BenchmarkDetailsBox = ({ benchmark }: { benchmark: BenchmarkData })
   const navToFindings = useNavigateFindings();
 
   const handleClickCloudProvider = () =>
-    navToFindings(getBenchmarkIdQuery(benchmark), [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME]);
+    navToFindings(getBenchmarkIdQuery(benchmark), [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID]);
 
   const handleClickCluster = () =>
     navToFindings(getBenchmarkIdQuery(benchmark), [

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
@@ -35,7 +35,7 @@ export const MISCONFIGURATIONS_GROUPS_UNIT = (
         values: { groupCount },
         defaultMessage: `{groupCount} {groupCount, plural, =1 {rule} other {rules}}`,
       });
-    case FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME:
+    case FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID:
       return i18n.translate('xpack.csp.findings.groupUnit.cloudAccount', {
         values: { groupCount },
         defaultMessage: `{groupCount} {groupCount, plural, =1 {cloud account} other {cloud accounts}}`,
@@ -91,9 +91,9 @@ export const defaultGroupingOptions: GroupOption[] = [
   },
   {
     label: i18n.translate('xpack.csp.findings.latestFindings.groupByCloudAccount', {
-      defaultMessage: 'Cloud account',
+      defaultMessage: 'Cloud account ID',
     }),
-    key: FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME,
+    key: FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID,
   },
   {
     label: i18n.translate('xpack.csp.findings.latestFindings.groupByKubernetesCluster', {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
@@ -40,7 +40,7 @@ export const MISCONFIGURATIONS_GROUPS_UNIT = (
         values: { groupCount },
         defaultMessage: `{groupCount} {groupCount, plural, =1 {cloud account} other {cloud accounts}}`,
       });
-    case FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME:
+    case FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID:
       return i18n.translate('xpack.csp.findings.groupUnit.kubernetes', {
         values: { groupCount },
         defaultMessage: `{groupCount} {groupCount, plural, =1 {kubernetes cluster} other {kubernetes clusters}}`,
@@ -67,10 +67,9 @@ export const NULL_GROUPING_MESSAGES = {
   CLOUD_ACCOUNT_NAME: i18n.translate('xpack.csp.findings.grouping.cloudAccount.nullGroupTitle', {
     defaultMessage: 'No cloud account',
   }),
-  ORCHESTRATOR_CLUSTER_NAME: i18n.translate(
-    'xpack.csp.findings.grouping.kubernetes.nullGroupTitle',
-    { defaultMessage: 'No Kubernetes cluster' }
-  ),
+  ORCHESTRATOR_CLUSTER_ID: i18n.translate('xpack.csp.findings.grouping.kubernetes.nullGroupTitle', {
+    defaultMessage: 'No Kubernetes cluster',
+  }),
   DEFAULT: i18n.translate('xpack.csp.findings.grouping.default.nullGroupTitle', {
     defaultMessage: 'No grouping',
   }),
@@ -97,9 +96,9 @@ export const defaultGroupingOptions: GroupOption[] = [
   },
   {
     label: i18n.translate('xpack.csp.findings.latestFindings.groupByKubernetesCluster', {
-      defaultMessage: 'Kubernetes cluster',
+      defaultMessage: 'Kubernetes cluster ID',
     }),
-    key: FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME,
+    key: FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID,
   },
 ];
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
@@ -45,20 +45,23 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
     <NullGroup title={title} field={selectedGroup} unit={NULL_GROUPING_UNIT} />
   );
 
-  const getGroupPanelTitle = () => {
-    const resourceId = bucket.resourceName?.buckets?.[0]?.key;
+  const getGroupPanelTitle = (primaryField: string) => {
+    const primaryFieldValue = bucket[primaryField]?.buckets?.[0]?.key;
 
-    if (resourceId) {
-      return (
-        <>
-          <strong>{resourceId}</strong> - {bucket.key_as_string}
-        </>
-      );
+    switch (primaryField) {
+      case 'resourceName':
+      case 'accountName':
+        return (
+          <>
+            <strong>{primaryFieldValue}</strong> - {bucket.key_as_string}
+          </>
+        );
     }
 
     return <strong>{bucket.key_as_string}</strong>;
   };
 
+  console.log("bucket1 ", bucket);
   switch (selectedGroup) {
     case FINDINGS_GROUPING_OPTIONS.RESOURCE_ID:
       return nullGroupMessage ? (
@@ -80,7 +83,7 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
                     `}
                     title={bucket.resourceName?.buckets?.[0]?.key as string}
                   >
-                    {getGroupPanelTitle()}
+                    {getGroupPanelTitle('resourceName')}
                   </EuiTextBlockTruncate>
                 </EuiText>
               </EuiFlexItem>
@@ -115,7 +118,7 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
           </EuiFlexItem>
         </EuiFlexGroup>
       );
-    case FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME:
+    case FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID:
       return nullGroupMessage ? (
         renderNullGroup(NULL_GROUPING_MESSAGES.CLOUD_ACCOUNT_NAME)
       ) : (
@@ -131,9 +134,7 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
           <EuiFlexItem>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
-                <EuiText size="s">
-                  <strong>{bucket.key_as_string}</strong>
-                </EuiText>
+                <EuiText size="s">{getGroupPanelTitle('accountName')}</EuiText>
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiText size="xs" color="subdued">

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
@@ -14,7 +14,7 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { GroupPanelRenderer, GroupStatsItem, RawBucket } from '@kbn/grouping/src';
+import { GenericBuckets, GroupPanelRenderer, GroupStatsItem, RawBucket } from '@kbn/grouping/src';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { getAbbreviatedNumber } from '@kbn/cloud-security-posture-common';
@@ -45,9 +45,9 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
     <NullGroup title={title} field={selectedGroup} unit={NULL_GROUPING_UNIT} />
   );
 
-  const getGroupPanelTitle = (aggregationField?: string) => {
+  const getGroupPanelTitle = (aggregationField?: keyof FindingsGroupingAggregation) => {
     const aggregationFieldValue = aggregationField
-      ? bucket[aggregationField]?.buckets?.[0]?.key
+      ? (bucket[aggregationField] as { buckets?: GenericBuckets[] })?.buckets?.[0]?.key
       : null;
 
     if (aggregationFieldValue) {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
@@ -45,23 +45,20 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
     <NullGroup title={title} field={selectedGroup} unit={NULL_GROUPING_UNIT} />
   );
 
-  const getGroupPanelTitle = (primaryField: string) => {
-    const primaryFieldValue = bucket[primaryField]?.buckets?.[0]?.key;
+  const getGroupPanelTitle = (aggregationField?: string) => {
+    const aggregationFieldValue = aggregationField ? [aggregationField]?.buckets?.[0]?.key : null;
 
-    switch (primaryField) {
-      case 'resourceName':
-      case 'accountName':
-        return (
-          <>
-            <strong>{primaryFieldValue}</strong> - {bucket.key_as_string}
-          </>
-        );
+    if (aggregationFieldValue) {
+      return (
+        <>
+          <strong>{aggregationFieldValue}</strong> - {bucket.key_as_string}
+        </>
+      );
     }
 
     return <strong>{bucket.key_as_string}</strong>;
   };
 
-  console.log("bucket1 ", bucket);
   switch (selectedGroup) {
     case FINDINGS_GROUPING_OPTIONS.RESOURCE_ID:
       return nullGroupMessage ? (
@@ -104,9 +101,7 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
           <EuiFlexItem>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
-                <EuiText size="s">
-                  <strong>{bucket.key_as_string}</strong>
-                </EuiText>
+                <EuiText size="s"> {getGroupPanelTitle()}</EuiText>
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiText size="xs" color="subdued">
@@ -120,7 +115,7 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
       );
     case FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID:
       return nullGroupMessage ? (
-        renderNullGroup(NULL_GROUPING_MESSAGES.CLOUD_ACCOUNT_NAME)
+        renderNullGroup(NULL_GROUPING_MESSAGES.CLOUD_ACCOUNT_ID)
       ) : (
         <EuiFlexGroup alignItems="center" gutterSize="m">
           {benchmarkId && (
@@ -145,9 +140,9 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
           </EuiFlexItem>
         </EuiFlexGroup>
       );
-    case FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME:
+    case FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID:
       return nullGroupMessage ? (
-        renderNullGroup(NULL_GROUPING_MESSAGES.ORCHESTRATOR_CLUSTER_NAME)
+        renderNullGroup(NULL_GROUPING_MESSAGES.ORCHESTRATOR_CLUSTER_ID)
       ) : (
         <EuiFlexGroup alignItems="center" gutterSize="m">
           {benchmarkId && (
@@ -161,9 +156,7 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
           <EuiFlexItem>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
-                <EuiText size="s">
-                  <strong>{bucket.key_as_string}</strong>
-                </EuiText>
+                <EuiText size="s">{getGroupPanelTitle('clusterName')}</EuiText>
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiText size="xs" color="subdued">
@@ -182,9 +175,7 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
           <EuiFlexItem>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
-                <EuiText size="s">
-                  <strong>{bucket.key_as_string}</strong>
-                </EuiText>
+                <EuiText size="s">{getGroupPanelTitle()}</EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
@@ -46,7 +46,9 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
   );
 
   const getGroupPanelTitle = (aggregationField?: string) => {
-    const aggregationFieldValue = aggregationField ? [aggregationField]?.buckets?.[0]?.key : null;
+    const aggregationFieldValue = aggregationField
+      ? bucket[aggregationField]?.buckets?.[0]?.key
+      : null;
 
     if (aggregationFieldValue) {
       return (
@@ -115,7 +117,7 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
       );
     case FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID:
       return nullGroupMessage ? (
-        renderNullGroup(NULL_GROUPING_MESSAGES.CLOUD_ACCOUNT_ID)
+        renderNullGroup(NULL_GROUPING_MESSAGES.CLOUD_ACCOUNT_NAME)
       ) : (
         <EuiFlexGroup alignItems="center" gutterSize="m">
           {benchmarkId && (

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_grouped_findings.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_grouped_findings.tsx
@@ -61,6 +61,12 @@ export interface FindingsGroupingAggregation {
   benchmarkId?: {
     buckets?: GenericBuckets[];
   };
+  accountName?: {
+    buckets?: GenericBuckets[];
+  };
+  clusterName?: {
+    buckets?: GenericBuckets[];
+  };
   isLoading?: boolean;
 }
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
@@ -105,11 +105,12 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
         getTermAggregation('benchmarkId', 'rule.benchmark.id'),
         getTermAggregation('accountName', 'cloud.account.name'),
       ];
-    case FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME:
+    case FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID:
       return [
         ...aggMetrics,
         getTermAggregation('benchmarkName', 'rule.benchmark.name'),
         getTermAggregation('benchmarkId', 'rule.benchmark.id'),
+        getTermAggregation('clusterName', 'orchestrator.cluster.name'),
       ];
   }
   return aggMetrics;

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
@@ -98,11 +98,12 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
         getTermAggregation('benchmarkName', 'rule.benchmark.name'),
         getTermAggregation('benchmarkVersion', 'rule.benchmark.version'),
       ];
-    case FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_NAME:
+    case FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID:
       return [
         ...aggMetrics,
         getTermAggregation('benchmarkName', 'rule.benchmark.name'),
         getTermAggregation('benchmarkId', 'rule.benchmark.id'),
+        getTermAggregation('accountName', 'cloud.account.name'),
       ];
     case FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_NAME:
       return [

--- a/x-pack/test/cloud_security_posture_functional/pages/findings_grouping.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings_grouping.ts
@@ -296,14 +296,14 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           }
         );
       });
-      it('groups findings by cloud account and sort by compliance score desc', async () => {
+      it('groups findings by cloud account id and sort by compliance score desc', async () => {
         const groupSelector = await findings.groupSelector();
         await groupSelector.openDropDown();
         await groupSelector.setValue('None');
         await groupSelector.openDropDown();
-        await groupSelector.setValue('Cloud account');
-
+        await groupSelector.setValue('Cloud account ID');
         const grouping = await findings.findingsGrouping();
+        const noCloudAccountGroupTitle = 'No cloud account';
 
         const groupCount = await grouping.getGroupCount();
         expect(groupCount).to.be('2 cloud accounts');
@@ -314,12 +314,14 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         const cloudNameOrder = [
           {
             cloudName: 'Account 2',
+            cloudId: '2',
             findingsCount: '1',
             complianceScore: '0%',
             benchmarkName: data[3].rule.benchmark.name,
           },
           {
             cloudName: 'Account 1',
+            cloudId: '1',
             findingsCount: '1',
             complianceScore: '100%',
             benchmarkName: data[2].rule.benchmark.name,
@@ -334,11 +336,15 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         await asyncForEach(
           cloudNameOrder,
-          async ({ cloudName, complianceScore, findingsCount, benchmarkName }, index) => {
+          async ({ cloudName, complianceScore, findingsCount, benchmarkName, cloudId }, index) => {
             const groupRow = await grouping.getRowAtIndex(index);
-            expect(await groupRow.getVisibleText()).to.contain(cloudName);
+            const groupTitle =
+              cloudName === noCloudAccountGroupTitle
+                ? noCloudAccountGroupTitle
+                : `${cloudName} - ${cloudId}`;
+            expect(await groupRow.getVisibleText()).to.contain(groupTitle);
 
-            if (cloudName !== 'No cloud account') {
+            if (cloudName !== noCloudAccountGroupTitle) {
               expect(await groupRow.getVisibleText()).to.contain(benchmarkName);
             }
 
@@ -353,36 +359,33 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           }
         );
       });
-      it('groups findings by Kubernetes cluster and sort by compliance score desc', async () => {
+      it('groups findings by Kubernetes cluster id and sort by compliance score desc', async () => {
         const groupSelector = await findings.groupSelector();
         await groupSelector.openDropDown();
         await groupSelector.setValue('None');
         await groupSelector.openDropDown();
-        await groupSelector.setValue('Kubernetes cluster');
+        await groupSelector.setValue('Kubernetes cluster ID');
+        const noKuberenetsClusterGroupTitle = 'No Kubernetes cluster';
 
         const grouping = await findings.findingsGrouping();
 
         const groupCount = await grouping.getGroupCount();
-        expect(groupCount).to.be('2 kubernetes clusters');
+        expect(groupCount).to.be('1 kubernetes cluster');
 
         const unitCount = await grouping.getUnitCount();
+
         expect(unitCount).to.be('4 findings');
 
         const kubernetesOrder = [
           {
             clusterName: 'Cluster 1',
-            findingsCount: '1',
-            complianceScore: '0%',
+            clusterId: '1',
+            findingsCount: '2',
+            complianceScore: '50%',
             benchmarkName: data[0].rule.benchmark.name,
           },
           {
-            clusterName: 'Cluster 2',
-            findingsCount: '1',
-            complianceScore: '100%',
-            benchmarkName: data[1].rule.benchmark.name,
-          },
-          {
-            clusterName: 'No Kubernetes cluster',
+            clusterName: noKuberenetsClusterGroupTitle,
             findingsCount: '2',
             complianceScore: '50%',
           },
@@ -390,12 +393,21 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         await asyncForEach(
           kubernetesOrder,
-          async ({ clusterName, complianceScore, findingsCount, benchmarkName }, index) => {
+          async (
+            { clusterName, complianceScore, findingsCount, benchmarkName, clusterId },
+            index
+          ) => {
             const groupRow = await grouping.getRowAtIndex(index);
-            expect(await groupRow.getVisibleText()).to.contain(clusterName);
-            if (clusterName !== 'No Kubernetes cluster') {
+            const groupTitle =
+              clusterName === noKuberenetsClusterGroupTitle
+                ? noKuberenetsClusterGroupTitle
+                : `${clusterName} - ${clusterId}`;
+
+            expect(await groupRow.getVisibleText()).to.contain(groupTitle);
+            if (clusterName !== noKuberenetsClusterGroupTitle) {
               expect(await groupRow.getVisibleText()).to.contain(benchmarkName);
             }
+
             expect(
               await (
                 await groupRow.findByTestSubject('cloudSecurityFindingsComplianceScore')


### PR DESCRIPTION
## Summary

This PR updates the group by mechanism with the following logic:
cloud.account.id and orchestrator.cluster.id instead of cloud.account.name and orchestrator.cluster.name for grouping on the Findings page.

### Screenshots
![image](https://github.com/user-attachments/assets/b5760b62-4afb-433f-b962-40695711ac52)
![image](https://github.com/user-attachments/assets/d6a968b0-bb17-49a4-b47e-c9c8fda2495e)


### Closes
https://github.com/elastic/security-team/issues/10751

### DOD
- [x] Group By Cloud account should use cloud.account.id for grouping. cloud.account.name should still be displayed, for user's convenience, consult with the design
- [x] Group By Kubernetes cluster should use orchestrator.cluster.id for grouping. orchestrator.cluster.name should still be displayed, for user's convenience, consult with the design





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->