### PR TITLE
Ignore SO service and ES status when polling for tasks

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.test.ts
@@ -249,6 +249,17 @@ describe('createManagedConfiguration()', () => {
     });
 
     describe('mget claim strategy', () => {
+      test('should not decrease configuration at the next interval when an error without status code is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(10);
+        errors$.next(new Error());
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 10);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 10);
+      });
+
       test('should decrease configuration at the next interval when an msearch 429 error is emitted', async () => {
         const { subscription, errors$ } = setupScenario(10);
         errors$.next(new MsearchError(429));
@@ -271,9 +282,31 @@ describe('createManagedConfiguration()', () => {
         expect(subscription).toHaveBeenNthCalledWith(2, 8);
       });
 
+      test('should decrease configuration at the next interval when an msearch 502 error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(10);
+        errors$.next(new MsearchError(502));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 10);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 8);
+      });
+
       test('should decrease configuration at the next interval when an msearch 503 error is emitted', async () => {
         const { subscription, errors$ } = setupScenario(10);
         errors$.next(new MsearchError(503));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 10);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 8);
+      });
+
+      test('should decrease configuration at the next interval when an msearch 504 error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(10);
+        errors$.next(new MsearchError(504));
         clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
         expect(subscription).toHaveBeenCalledTimes(1);
         expect(subscription).toHaveBeenNthCalledWith(1, 10);

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
@@ -200,15 +200,9 @@ function countErrors(
           SavedObjectsErrorHelpers.isGeneralError(e) ||
           isEsCannotExecuteScriptError(e) ||
           getMsearchStatusCode(e) === 429 ||
-          getMsearchStatusCode(e) === 500 ||
-          getMsearchStatusCode(e) === 502 ||
-          getMsearchStatusCode(e) === 503 ||
-          getMsearchStatusCode(e) === 504 ||
+          (getMsearchStatusCode(e) !== undefined && getMsearchStatusCode(e)! >= 500) ||
           getBulkUpdateStatusCode(e) === 429 ||
-          getBulkUpdateStatusCode(e) === 500 ||
-          getBulkUpdateStatusCode(e) === 502 ||
-          getBulkUpdateStatusCode(e) === 503 ||
-          getBulkUpdateStatusCode(e) === 504 ||
+          (getBulkUpdateStatusCode(e) !== undefined && getBulkUpdateStatusCode(e)! >= 500) ||
           isClusterBlockException(e)
       )
     )

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
@@ -201,10 +201,14 @@ function countErrors(
           isEsCannotExecuteScriptError(e) ||
           getMsearchStatusCode(e) === 429 ||
           getMsearchStatusCode(e) === 500 ||
+          getMsearchStatusCode(e) === 502 ||
           getMsearchStatusCode(e) === 503 ||
+          getMsearchStatusCode(e) === 504 ||
           getBulkUpdateStatusCode(e) === 429 ||
           getBulkUpdateStatusCode(e) === 500 ||
+          getBulkUpdateStatusCode(e) === 502 ||
           getBulkUpdateStatusCode(e) === 503 ||
+          getBulkUpdateStatusCode(e) === 504 ||
           isClusterBlockException(e)
       )
     )

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -356,7 +356,6 @@ export class TaskManagerPlugin
         taskStore,
         usageCounter: this.usageCounter,
         middleware: this.middleware,
-        elasticsearchAndSOAvailability$: this.elasticsearchAndSOAvailability$!,
         ...managedConfiguration,
         taskPartitioner,
       });

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -356,6 +356,7 @@ export class TaskManagerPlugin
         taskStore,
         usageCounter: this.usageCounter,
         middleware: this.middleware,
+        elasticsearchAndSOAvailability$: this.elasticsearchAndSOAvailability$!,
         ...managedConfiguration,
         taskPartitioner,
       });

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
@@ -57,7 +57,6 @@ export type TaskPollingLifecycleOpts = {
   taskStore: TaskStore;
   config: TaskManagerConfig;
   middleware: Middleware;
-  elasticsearchAndSOAvailability$: Observable<boolean>;
   executionContext: ExecutionContextStart;
   usageCounter?: UsageCounter;
   taskPartitioner: TaskPartitioner;
@@ -107,8 +106,6 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     middleware,
     capacityConfiguration$,
     pollIntervalConfiguration$,
-    // Elasticsearch and SavedObjects availability status
-    elasticsearchAndSOAvailability$,
     config,
     taskStore,
     definitions,
@@ -193,18 +190,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
 
     this.subscribeToPoller(this.poller.events$);
 
-    elasticsearchAndSOAvailability$.subscribe((areESAndSOAvailable) => {
-      if (areESAndSOAvailable) {
-        // start polling for work
-        this.poller.start();
-      } else if (!areESAndSOAvailable) {
-        this.logger.info(
-          `Stopping the task poller because Elasticsearch and/or saved-objects service became unavailable`
-        );
-        this.poller.stop();
-        this.pool.cancelRunningTasks();
-      }
-    });
+    this.poller.start();
   }
 
   public get events(): Observable<TaskLifecycleEvent> {


### PR DESCRIPTION
Resolves: #203470

This PR removes the codes that stop task polling when Elasticsearch or SO service is unavailable.
So the TM relies only on the back pressure mechanism.
502 and 504 status codes are also added to be sure that all the possible reasons that stops ES or SO are covered by the back pressure.

## To verify:

Force Elasticsearch version check to throw an error:
https://github.com/elastic/kibana/blob/main/src/core/packages/elasticsearch/server-internal/src/version_check/ensure_es_version.ts#L189

Then mock the response of `this.esClientWithoutRetries.msearch` in task store [here](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/task_manager/server/task_store.ts#L584)

Example:

```
    const responses = [
      {
        error: {
          type: 'not found',
        },
        took: 1000,
        timed_out: false,
        hits: { hits: [] },
        _shards: {
          failed: 1,
          successful: 0,
          total: 1,
        },
        status: 503,
      },
    ];
  ```  
  Expect[ back pressure](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts#L182) to return a longer poll interval.


