### PR TITLE
[8.x] [Cloud Security] changed findings group by name to group by id (#206379)

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
@@ -171,6 +171,7 @@ export const DEFAULT_GROUPING_TABLE_HEIGHT = 512;
 
 export const FINDINGS_GROUPING_OPTIONS = {
   NONE: 'none',
+  RESOURCE_ID: 'resource.id',
   RESOURCE_NAME: 'resource.name',
   RULE_NAME: 'rule.name',
   RULE_SECTION: 'rule.section',

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/compliance_dashboard/dashboard_sections/summary_section.tsx
@@ -131,7 +131,7 @@ export const SummarySection = ({
             data-test-subj="dashboard-view-all-resources"
             onClick={() => {
               navToFindings(getPolicyTemplateQuery(dashboardType), [
-                FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME,
+                FINDINGS_GROUPING_OPTIONS.RESOURCE_ID,
               ]);
             }}
           >

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
@@ -25,7 +25,7 @@ export const MISCONFIGURATIONS_GROUPS_UNIT = (
   const groupCount = hasNullGroup ? totalCount - 1 : totalCount;
 
   switch (selectedGroup) {
-    case FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME:
+    case FINDINGS_GROUPING_OPTIONS.RESOURCE_ID:
       return i18n.translate('xpack.csp.findings.groupUnit.resource', {
         values: { groupCount },
         defaultMessage: `{groupCount} {groupCount, plural, =1 {resource} other {resources}}`,
@@ -79,9 +79,9 @@ export const NULL_GROUPING_MESSAGES = {
 export const defaultGroupingOptions: GroupOption[] = [
   {
     label: i18n.translate('xpack.csp.findings.latestFindings.groupByResource', {
-      defaultMessage: 'Resource',
+      defaultMessage: 'Resource ID',
     }),
-    key: FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME,
+    key: FINDINGS_GROUPING_OPTIONS.RESOURCE_ID,
   },
   {
     label: i18n.translate('xpack.csp.findings.latestFindings.groupByRuleName', {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/latest_findings_group_renderer.tsx
@@ -31,10 +31,10 @@ import { NULL_GROUPING_MESSAGES, NULL_GROUPING_UNIT } from './constants';
 import { FINDINGS_GROUPING_COUNTER } from '../test_subjects';
 
 export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation> = (
-  selectedGroup,
-  bucket,
-  nullGroupMessage,
-  isLoading
+  selectedGroup: string,
+  bucket: RawBucket<FindingsGroupingAggregation>,
+  nullGroupMessage: string | undefined,
+  isLoading: boolean | undefined
 ) => {
   if (isLoading) {
     return <LoadingGroup />;
@@ -45,8 +45,22 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
     <NullGroup title={title} field={selectedGroup} unit={NULL_GROUPING_UNIT} />
   );
 
+  const getGroupPanelTitle = () => {
+    const resourceId = bucket.resourceName?.buckets?.[0]?.key;
+
+    if (resourceId) {
+      return (
+        <>
+          <strong>{resourceId}</strong> - {bucket.key_as_string}
+        </>
+      );
+    }
+
+    return <strong>{bucket.key_as_string}</strong>;
+  };
+
   switch (selectedGroup) {
-    case FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME:
+    case FINDINGS_GROUPING_OPTIONS.RESOURCE_ID:
       return nullGroupMessage ? (
         renderNullGroup(NULL_GROUPING_MESSAGES.RESOURCE_NAME)
       ) : (
@@ -66,7 +80,7 @@ export const groupPanelRenderer: GroupPanelRenderer<FindingsGroupingAggregation>
                     `}
                     title={bucket.resourceName?.buckets?.[0]?.key as string}
                   >
-                    <strong>{bucket.key_as_string}</strong> {bucket.resourceName?.buckets?.[0]?.key}
+                    {getGroupPanelTitle()}
                   </EuiTextBlockTruncate>
                 </EuiText>
               </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
@@ -86,10 +86,10 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
   ];
 
   switch (field) {
-    case FINDINGS_GROUPING_OPTIONS.RESOURCE_NAME:
+    case FINDINGS_GROUPING_OPTIONS.RESOURCE_ID:
       return [
         ...aggMetrics,
-        getTermAggregation('resourceName', 'resource.id'),
+        getTermAggregation('resourceName', 'resource.name'),
         getTermAggregation('resourceSubType', 'resource.sub_type'),
       ];
     case FINDINGS_GROUPING_OPTIONS.RULE_NAME:

--- a/x-pack/test/cloud_security_posture_functional/pages/findings_grouping.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings_grouping.ts
@@ -182,7 +182,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       it('groups findings by resource and sort by compliance score desc', async () => {
         const groupSelector = await findings.groupSelector();
         await groupSelector.openDropDown();
-        await groupSelector.setValue('Resource');
+        await groupSelector.setValue('Resource ID');
 
         const grouping = await findings.findingsGrouping();
 
@@ -414,7 +414,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await groupSelector.openDropDown();
         await groupSelector.setValue('None');
         await groupSelector.openDropDown();
-        await groupSelector.setValue('Resource');
+        await groupSelector.setValue('Resource ID');
 
         // Filter bar uses the field's customLabel in the DataView
         await filterBar.addFilter({ field: 'rule.name', operation: 'is', value: ruleName1 });
@@ -515,12 +515,12 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
         const groupSelector = await findings.groupSelector();
         await groupSelector.openDropDown();
-        await groupSelector.setValue('Resource');
+        await groupSelector.setValue('Resource ID');
 
         const grouping = await findings.findingsGrouping();
 
         const groupCount = await grouping.getGroupCount();
-        expect(groupCount).to.be(`${resourceGroupCount + 1} resources`);
+        expect(groupCount).to.be(`${resourceGroupCount} resources`);
 
         const unitCount = await grouping.getUnitCount();
         expect(unitCount).to.be(`${findingsCount + 1} findings`);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Cloud Security] changed findings group by name to group by id (#206379)](https://github.com/elastic/kibana/pull/206379)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Prozorov","email":"alex.prozorov@elastic.co"},"sourceCommit":{"committedDate":"2025-01-16T16:24:10Z","message":"[Cloud Security] changed findings group by name to group by id (#206379)\n\n## Summary\r\nThis PR fixes group by logic in the findings table to be based on\r\nresource.id instead of resource.name.\r\n\r\n### Screenshots\r\n\r\n![image](https://github.com/user-attachments/assets/5d480501-9f44-4395-82bd-e069b4a3c3f7)\r\n\r\n\r\n\r\n### Closes\r\n- https://github.com/elastic/security-team/issues/9782\r\n\r\n### Definition of done\r\n- [x] When grouping findings by Resource, the findings are grouped by\r\nresource.id\r\n- [x] The group title should still contain resource.name for better UX\r\nin combination with the id\r\n- [x] The label in the grouping properties should be Resource ID, not\r\njust Resource\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct release_note:* label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"22e047a1f62331cbf80b886b7a4275b1143b3446","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","good first issue","release_note:skip","backport:skip","v9.0.0","Team:Cloud Security"],"title":"[Cloud Security] changed findings group by name to group by id","number":206379,"url":"https://github.com/elastic/kibana/pull/206379","mergeCommit":{"message":"[Cloud Security] changed findings group by name to group by id (#206379)\n\n## Summary\r\nThis PR fixes group by logic in the findings table to be based on\r\nresource.id instead of resource.name.\r\n\r\n### Screenshots\r\n\r\n![image](https://github.com/user-attachments/assets/5d480501-9f44-4395-82bd-e069b4a3c3f7)\r\n\r\n\r\n\r\n### Closes\r\n- https://github.com/elastic/security-team/issues/9782\r\n\r\n### Definition of done\r\n- [x] When grouping findings by Resource, the findings are grouped by\r\nresource.id\r\n- [x] The group title should still contain resource.name for better UX\r\nin combination with the id\r\n- [x] The label in the grouping properties should be Resource ID, not\r\njust Resource\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct release_note:* label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"22e047a1f62331cbf80b886b7a4275b1143b3446"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/206379","number":206379,"mergeCommit":{"message":"[Cloud Security] changed findings group by name to group by id (#206379)\n\n## Summary\r\nThis PR fixes group by logic in the findings table to be based on\r\nresource.id instead of resource.name.\r\n\r\n### Screenshots\r\n\r\n![image](https://github.com/user-attachments/assets/5d480501-9f44-4395-82bd-e069b4a3c3f7)\r\n\r\n\r\n\r\n### Closes\r\n- https://github.com/elastic/security-team/issues/9782\r\n\r\n### Definition of done\r\n- [x] When grouping findings by Resource, the findings are grouped by\r\nresource.id\r\n- [x] The group title should still contain resource.name for better UX\r\nin combination with the id\r\n- [x] The label in the grouping properties should be Resource ID, not\r\njust Resource\r\n\r\n### Checklist\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct release_note:* label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"22e047a1f62331cbf80b886b7a4275b1143b3446"}}]}] BACKPORT-->