### PR TITLE
[Ingest pipelines] Set outsideClickCloses to false if processor is modified

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/add_processor_form.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/add_processor_form.tsx
@@ -20,7 +20,7 @@ import {
   EuiFlexItem,
 } from '@elastic/eui';
 
-import { Form, FormDataProvider, FormHook } from '../../../../../shared_imports';
+import { Form, FormDataProvider, FormHook, useFormIsModified } from '../../../../../shared_imports';
 import { getProcessorDescriptor } from '../shared';
 
 import { DocumentationButton } from './documentation_button';
@@ -75,9 +75,11 @@ export const AddProcessorForm: FunctionComponent<Props> = ({
     [] /* eslint-disable-line react-hooks/exhaustive-deps */
   );
 
+  const isFormDirty = useFormIsModified({ form });
+
   return (
     <Form data-test-subj="addProcessorForm" form={form} onSubmit={handleSubmit}>
-      <EuiFlyout size="m" maxWidth={720} onClose={closeFlyout}>
+      <EuiFlyout size="m" maxWidth={720} onClose={closeFlyout} outsideClickCloses={!isFormDirty}>
         <EuiFlyoutHeader>
           <EuiFlexGroup gutterSize="xs">
             <EuiFlexItem>

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/edit_processor_form.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/edit_processor_form.tsx
@@ -23,7 +23,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 
-import { Form, FormDataProvider, FormHook } from '../../../../../shared_imports';
+import { Form, FormDataProvider, FormHook, useFormIsModified } from '../../../../../shared_imports';
 import { ProcessorInternal } from '../../types';
 import { useTestPipelineContext } from '../../context';
 import { getProcessorDescriptor } from '../shared';
@@ -153,6 +153,7 @@ export const EditProcessorForm: FunctionComponent<Props> = ({
     flyoutContent = <ProcessorSettingsFields processor={processor} />;
   }
 
+  const isFormDirty = useFormIsModified({ form });
   return (
     <Form data-test-subj="editProcessorForm" form={form} onSubmit={handleSubmit}>
       <EuiFlyout
@@ -162,6 +163,7 @@ export const EditProcessorForm: FunctionComponent<Props> = ({
           resetProcessors();
           closeFlyout();
         }}
+        outsideClickCloses={!isFormDirty}
       >
         <EuiFlyoutHeader>
           <EuiFlexGroup gutterSize="xs">


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/198469
## Summary

When a user is working on adding a processor and click outside the side flyout before saving the changes, their work gets lost. This is especially annoying if the user is working on a complex processor and clicks out of the window unintentionally.

To avoid this, we can take advance of the `outsideClickCloses` prop. When the form has been modified (is dirty), clicking outside the flyout won't close the flyout, so the work done in the processor won't be lost. If nothing has been changed `outsideClickCloses` is set to true.


https://github.com/user-attachments/assets/0d70e16d-d731-4b01-b39e-3026a9c89002

This solution has been verified with @jovana-andjelkovic. 



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->