### PR TITLE
[8.x] [Synthetics] Increase lightweight monitors project page size !! (#198696)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -36,15 +36,15 @@ import {
   getSyntheticsEnablementRoute,
 } from './synthetics_service/enablement';
 import { getSyntheticsMonitorRoute } from './monitor_cruds/get_monitor';
-import { deleteSyntheticsMonitorProjectRoute } from './monitor_cruds/delete_monitor_project';
-import { getSyntheticsProjectMonitorsRoute } from './monitor_cruds/get_monitor_project';
+import { deleteSyntheticsMonitorProjectRoute } from './monitor_cruds/project_monitor/delete_monitor_project';
+import { getSyntheticsProjectMonitorsRoute } from './monitor_cruds/project_monitor/get_monitor_project';
 import { runOnceSyntheticsMonitorRoute } from './synthetics_service/run_once_monitor';
 import { getServiceAllowedRoute } from './synthetics_service/get_service_allowed';
 import { testNowMonitorRoute } from './synthetics_service/test_now_monitor';
 import { installIndexTemplatesRoute } from './synthetics_service/install_index_templates';
 import { editSyntheticsMonitorRoute } from './monitor_cruds/edit_monitor';
 import { addSyntheticsMonitorRoute } from './monitor_cruds/add_monitor';
-import { addSyntheticsProjectMonitorRoute } from './monitor_cruds/add_monitor_project';
+import { addSyntheticsProjectMonitorRoute } from './monitor_cruds/project_monitor/add_monitor_project';
 import { syntheticsGetPingsRoute, syntheticsGetPingHeatmapRoute } from './pings';
 import { createGetCurrentStatusRoute } from './overview_status/overview_status';
 import { getHasIntegrationMonitorsRoute } from './fleet/get_has_integration_monitors';

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
@@ -11,7 +11,7 @@ import { isEmpty } from 'lodash';
 import { invalidOriginError } from './add_monitor';
 import { InvalidLocationError } from '../../synthetics_service/project_monitor/normalizers/common_fields';
 import { AddEditMonitorAPI, CreateMonitorPayLoad } from './add_monitor/add_monitor_api';
-import { ELASTIC_MANAGED_LOCATIONS_DISABLED } from './add_monitor_project';
+import { ELASTIC_MANAGED_LOCATIONS_DISABLED } from './project_monitor/add_monitor_project';
 import { getDecryptedMonitor } from '../../saved_objects/synthetics_monitor';
 import { getPrivateLocations } from '../../synthetics_service/get_private_locations';
 import { mergeSourceMonitor } from './formatters/saved_object_to_monitor';

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/get_api_key.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/get_api_key.ts
@@ -7,7 +7,7 @@
 import { schema } from '@kbn/config-schema';
 import { SecurityCreateApiKeyResponse } from '@elastic/elasticsearch/lib/api/types';
 import { IKibanaResponse } from '@kbn/core-http-server';
-import { ELASTIC_MANAGED_LOCATIONS_DISABLED } from './add_monitor_project';
+import { ELASTIC_MANAGED_LOCATIONS_DISABLED } from './project_monitor/add_monitor_project';
 import { SyntheticsRestApiRouteFactory } from '../types';
 import { generateProjectAPIKey } from '../../synthetics_service/get_api_key';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/add_monitor_project.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/add_monitor_project.ts
@@ -7,14 +7,14 @@
 import { schema } from '@kbn/config-schema';
 import { i18n } from '@kbn/i18n';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
-import { validateSpaceId } from './services/validate_space_id';
-import { RouteContext, SyntheticsRestApiRouteFactory } from '../types';
-import { ProjectMonitor } from '../../../common/runtime_types';
+import { validateSpaceId } from '../services/validate_space_id';
+import { RouteContext, SyntheticsRestApiRouteFactory } from '../../types';
+import { ProjectMonitor } from '../../../../common/runtime_types';
 
-import { SYNTHETICS_API_URLS } from '../../../common/constants';
-import { ProjectMonitorFormatter } from '../../synthetics_service/project_monitor/project_monitor_formatter';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { ProjectMonitorFormatter } from '../../../synthetics_service/project_monitor/project_monitor_formatter';
 
-const MAX_PAYLOAD_SIZE = 1048576 * 50; // 20MiB
+const MAX_PAYLOAD_SIZE = 1048576 * 100; // 100MiB
 
 export const addSyntheticsProjectMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'PUT',
@@ -37,19 +37,29 @@ export const addSyntheticsProjectMonitorRoute: SyntheticsRestApiRouteFactory = (
     const { projectName } = request.params;
     const decodedProjectName = decodeURI(projectName);
     const monitors = (request.body?.monitors as ProjectMonitor[]) || [];
+    const lightWeightMonitors = monitors.filter((monitor) => monitor.type !== 'browser');
+    const browserMonitors = monitors.filter((monitor) => monitor.type === 'browser');
 
-    if (monitors.length > 250) {
+    if (browserMonitors.length > 250) {
       return response.badRequest({
         body: {
           message: REQUEST_TOO_LARGE,
         },
       });
     }
+    if (lightWeightMonitors.length > 1500) {
+      return response.badRequest({
+        body: {
+          message: REQUEST_TOO_LARGE_LIGHTWEIGHT,
+        },
+      });
+    }
 
     try {
-      const spaceId = await validateSpaceId(routeContext);
-
-      const permissionError = await validatePermissions(routeContext, monitors);
+      const [spaceId, permissionError] = await Promise.all([
+        validateSpaceId(routeContext),
+        validatePermissions(routeContext, monitors),
+      ]);
 
       if (permissionError) {
         return response.forbidden({ body: { message: permissionError } });
@@ -84,10 +94,18 @@ export const addSyntheticsProjectMonitorRoute: SyntheticsRestApiRouteFactory = (
   },
 });
 
-export const REQUEST_TOO_LARGE = i18n.translate('xpack.synthetics.server.project.delete.toolarge', {
+export const REQUEST_TOO_LARGE = i18n.translate('xpack.synthetics.server.project.delete.request', {
   defaultMessage:
-    'Delete request payload is too large. Please send a max of 250 monitors to delete per request',
+    'Request payload is too large. Please send a max of 250 browser monitors per request.',
 });
+
+export const REQUEST_TOO_LARGE_LIGHTWEIGHT = i18n.translate(
+  'xpack.synthetics.server.project.delete.request.lightweight',
+  {
+    defaultMessage:
+      'Request payload is too large. Please send a max of 1500 lightweight monitors per request.',
+  }
+);
 
 export const validatePermissions = async (
   { server, response, request }: RouteContext,

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/delete_monitor_project.ts
@@ -6,13 +6,13 @@
  */
 import { schema } from '@kbn/config-schema';
 import { i18n } from '@kbn/i18n';
-import { DeleteMonitorAPI } from './services/delete_monitor_api';
-import { SyntheticsRestApiRouteFactory } from '../types';
-import { syntheticsMonitorType } from '../../../common/types/saved_objects';
-import { ConfigKey } from '../../../common/runtime_types';
-import { SYNTHETICS_API_URLS } from '../../../common/constants';
-import { getMonitors, getSavedObjectKqlFilter } from '../common';
-import { validateSpaceId } from './services/validate_space_id';
+import { DeleteMonitorAPI } from '../services/delete_monitor_api';
+import { SyntheticsRestApiRouteFactory } from '../../types';
+import { syntheticsMonitorType } from '../../../../common/types/saved_objects';
+import { ConfigKey } from '../../../../common/runtime_types';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { getMonitors, getSavedObjectKqlFilter } from '../../common';
+import { validateSpaceId } from '../services/validate_space_id';
 
 export const deleteSyntheticsMonitorProjectRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'DELETE',
@@ -30,10 +30,10 @@ export const deleteSyntheticsMonitorProjectRoute: SyntheticsRestApiRouteFactory 
     const { projectName } = request.params;
     const { monitors: monitorsToDelete } = request.body;
     const decodedProjectName = decodeURI(projectName);
-    if (monitorsToDelete.length > 250) {
+    if (monitorsToDelete.length > 500) {
       return response.badRequest({
         body: {
-          message: REQUEST_TOO_LARGE,
+          message: REQUEST_TOO_LARGE_DELETE,
         },
       });
     }
@@ -70,7 +70,10 @@ export const deleteSyntheticsMonitorProjectRoute: SyntheticsRestApiRouteFactory 
   },
 });
 
-export const REQUEST_TOO_LARGE = i18n.translate('xpack.synthetics.server.project.delete.toolarge', {
-  defaultMessage:
-    'Delete request payload is too large. Please send a max of 250 monitors to delete per request',
-});
+export const REQUEST_TOO_LARGE_DELETE = i18n.translate(
+  'xpack.synthetics.server.project.delete.tooLarge',
+  {
+    defaultMessage:
+      'Delete request payload is too large. Please send a max of 500 monitors to delete per request',
+  }
+);

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/get_monitor_project.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/monitor_cruds/project_monitor/get_monitor_project.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 import { schema } from '@kbn/config-schema';
-import { SyntheticsRestApiRouteFactory } from '../types';
-import { syntheticsMonitorType } from '../../../common/types/saved_objects';
-import { ConfigKey } from '../../../common/runtime_types';
-import { SYNTHETICS_API_URLS } from '../../../common/constants';
-import { getMonitors } from '../common';
+import { SyntheticsRestApiRouteFactory } from '../../types';
+import { syntheticsMonitorType } from '../../../../common/types/saved_objects';
+import { ConfigKey } from '../../../../common/runtime_types';
+import { SYNTHETICS_API_URLS } from '../../../../common/constants';
+import { getMonitors } from '../../common';
 
 const querySchema = schema.object({
   search_after: schema.maybe(schema.string()),

--- a/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/synthetics_service/project_monitor/project_monitor_formatter.ts
@@ -148,7 +148,7 @@ export class ProjectMonitorFormatter {
         (monitorObj) => monitorObj[ConfigKey.JOURNEY_ID] === monitor.id
       );
 
-      const normM = await this.validateProjectMonitor({
+      const normM = this.validateProjectMonitor({
         monitor,
         publicLocations: this.publicLocations,
         privateLocations: this.privateLocations,
@@ -189,7 +189,7 @@ export class ProjectMonitorFormatter {
     ]);
   };
 
-  validateProjectMonitor = async ({
+  validateProjectMonitor = ({
     monitor,
     publicLocations,
     privateLocations,

--- a/x-pack/test/api_integration/apis/synthetics/add_monitor_project.ts
+++ b/x-pack/test/api_integration/apis/synthetics/add_monitor_project.ts
@@ -12,7 +12,7 @@ import { formatKibanaNamespace } from '@kbn/synthetics-plugin/common/formatters'
 import {
   ELASTIC_MANAGED_LOCATIONS_DISABLED,
   REQUEST_TOO_LARGE,
-} from '@kbn/synthetics-plugin/server/routes/monitor_cruds/add_monitor_project';
+} from '@kbn/synthetics-plugin/server/routes/monitor_cruds/project_monitor/add_monitor_project';
 import { PackagePolicy } from '@kbn/fleet-plugin/common';
 import {
   PROFILE_VALUES_ENUM,

--- a/x-pack/test/api_integration/apis/synthetics/delete_monitor_project.ts
+++ b/x-pack/test/api_integration/apis/synthetics/delete_monitor_project.ts
@@ -6,7 +6,7 @@
  */
 import { v4 as uuidv4 } from 'uuid';
 import { ConfigKey, ProjectMonitorsRequest } from '@kbn/synthetics-plugin/common/runtime_types';
-import { REQUEST_TOO_LARGE } from '@kbn/synthetics-plugin/server/routes/monitor_cruds/delete_monitor_project';
+import { REQUEST_TOO_LARGE_DELETE } from '@kbn/synthetics-plugin/server/routes/monitor_cruds/project_monitor/delete_monitor_project';
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
 import { PackagePolicy } from '@kbn/fleet-plugin/common';
 import expect from '@kbn/expect';
@@ -47,10 +47,10 @@ export default function ({ getService }: FtrProviderContext) {
       projectMonitors = setUniqueIds(getFixtureJson('project_browser_monitor'));
     });
 
-    it('only allows 250 requests at a time', async () => {
+    it('only allows 500 requests at a time', async () => {
       const project = 'test-brower-suite';
       const monitors = [];
-      for (let i = 0; i < 251; i++) {
+      for (let i = 0; i < 550; i++) {
         monitors.push({
           ...projectMonitors.monitors[0],
           id: `test-id-${i}`,
@@ -93,7 +93,7 @@ export default function ({ getService }: FtrProviderContext) {
           .send({ monitors: monitorsToDelete })
           .expect(400);
         const { message } = response.body;
-        expect(message).to.eql(REQUEST_TOO_LARGE);
+        expect(message).to.eql(REQUEST_TOO_LARGE_DELETE);
       } finally {
         await supertest
           .delete(

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/create_monitor_project.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/create_monitor_project.ts
@@ -16,7 +16,7 @@ import {
 } from '@kbn/synthetics-plugin/common/runtime_types';
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
 import { formatKibanaNamespace } from '@kbn/synthetics-plugin/common/formatters';
-import { REQUEST_TOO_LARGE } from '@kbn/synthetics-plugin/server/routes/monitor_cruds/add_monitor_project';
+import { REQUEST_TOO_LARGE } from '@kbn/synthetics-plugin/server/routes/monitor_cruds/project_monitor/add_monitor_project';
 import { PackagePolicy } from '@kbn/fleet-plugin/common';
 import {
   PROFILE_VALUES_ENUM,

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/delete_monitor_project.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/synthetics/delete_monitor_project.ts
@@ -11,7 +11,7 @@ import {
   ProjectMonitorsRequest,
   PrivateLocation,
 } from '@kbn/synthetics-plugin/common/runtime_types';
-import { REQUEST_TOO_LARGE } from '@kbn/synthetics-plugin/server/routes/monitor_cruds/delete_monitor_project';
+import { REQUEST_TOO_LARGE_DELETE } from '@kbn/synthetics-plugin/server/routes/monitor_cruds/project_monitor/delete_monitor_project';
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
 import { PackagePolicy } from '@kbn/fleet-plugin/common';
 import expect from '@kbn/expect';
@@ -61,10 +61,10 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       ]);
     });
 
-    it('only allows 250 requests at a time', async () => {
+    it('only allows 500 requests at a time', async () => {
       const project = 'test-brower-suite';
       const monitors = [];
-      for (let i = 0; i < 251; i++) {
+      for (let i = 0; i < 550; i++) {
         monitors.push({
           ...projectMonitors.monitors[0],
           id: `test-id-${i}`,
@@ -112,7 +112,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
           .send({ monitors: monitorsToDelete })
           .expect(400);
         const { message } = response.body;
-        expect(message).to.eql(REQUEST_TOO_LARGE);
+        expect(message).to.eql(REQUEST_TOO_LARGE_DELETE);
       } finally {
         await supertest
           .delete(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Synthetics] Increase lightweight monitors project page size !! (#198696)](https://github.com/elastic/kibana/pull/198696)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2025-01-16T19:31:42Z","message":"[Synthetics] Increase lightweight monitors project page size !! (#198696)\n\n## Summary\r\n\r\nThis is to support https://github.com/elastic/synthetics/issues/978\r\n\r\nIncrease lightweight monitors project page size, size of light weight\r\nmonitors is minimal, heaving a small size is more of a burden then\r\nadvantage since we do batch operations in kibana !!\r\n\r\n### Why\r\nSince limit is only mostly applicable for browser monitors size, for\r\nlightweight we can safely do bulk operation on large number of monitors\r\nwithout hititng memory or size issues\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Justin Kambic <jk@elastic.co>","sha":"bfcffa1e76d7cdb1050595fc4f3947e92be2227b","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","backport:prev-minor","Team:obs-ux-management"],"title":"[Synthetics] Increase lightweight monitors project page size !!","number":198696,"url":"https://github.com/elastic/kibana/pull/198696","mergeCommit":{"message":"[Synthetics] Increase lightweight monitors project page size !! (#198696)\n\n## Summary\r\n\r\nThis is to support https://github.com/elastic/synthetics/issues/978\r\n\r\nIncrease lightweight monitors project page size, size of light weight\r\nmonitors is minimal, heaving a small size is more of a burden then\r\nadvantage since we do batch operations in kibana !!\r\n\r\n### Why\r\nSince limit is only mostly applicable for browser monitors size, for\r\nlightweight we can safely do bulk operation on large number of monitors\r\nwithout hititng memory or size issues\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Justin Kambic <jk@elastic.co>","sha":"bfcffa1e76d7cdb1050595fc4f3947e92be2227b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/198696","number":198696,"mergeCommit":{"message":"[Synthetics] Increase lightweight monitors project page size !! (#198696)\n\n## Summary\r\n\r\nThis is to support https://github.com/elastic/synthetics/issues/978\r\n\r\nIncrease lightweight monitors project page size, size of light weight\r\nmonitors is minimal, heaving a small size is more of a burden then\r\nadvantage since we do batch operations in kibana !!\r\n\r\n### Why\r\nSince limit is only mostly applicable for browser monitors size, for\r\nlightweight we can safely do bulk operation on large number of monitors\r\nwithout hititng memory or size issues\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Justin Kambic <jk@elastic.co>","sha":"bfcffa1e76d7cdb1050595fc4f3947e92be2227b"}}]}] BACKPORT-->