### PR TITLE
Update knn search and query template autocomplete

### DIFF
--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/query/dsl.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/query/dsl.ts
@@ -382,6 +382,35 @@ export const query = (specService: SpecDefinitionsService) => {
       _scope: '',
       query: {},
     },
+    knn: {
+      __template: {
+        field: '',
+        k: 10,
+        num_candidates: 100,
+        query_vector_builder: {
+          text_embedding: {
+            model_id: '',
+            model_text: '',
+          },
+        },
+      },
+      field: '{field}',
+      filter: { __scope_link: 'GLOBAL.filter' },
+      k: 10,
+      num_candidates: 100,
+      query_vector: [],
+      query_vector_builder: {
+        text_embedding: {
+          model_id: '',
+          model_text: '',
+        },
+      },
+      rescore_vector: {
+        oversample: 1.5,
+      },
+      similarity: { __one_of: ['l2_norm', 'cosine', 'dot_product', 'max_inner_product'] },
+      boost: 1.0,
+    },
     match_all: {
       boost: 1,
     },

--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/js/search.ts
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/js/search.ts
@@ -226,6 +226,12 @@ export const search = (specService: SpecDefinitionsService) => {
       knn: {
         __template: {
           field: '',
+          query_vector_builder: {
+            text_embedding: {
+              model_id: '',
+              model_text: '',
+            },
+          },
           k: 10,
           num_candidates: 100,
         },
@@ -236,9 +242,17 @@ export const search = (specService: SpecDefinitionsService) => {
             k: 10,
             num_candidates: 100,
             query_vector: [],
-            query_vector_builder: {},
-            similarity: { __one_of: ['l2_norm', 'cosine', 'dot_product'] },
+            query_vector_builder: {
+              text_embedding: {
+                model_id: '',
+                model_text: '',
+              },
+            },
+            similarity: { __one_of: ['l2_norm', 'cosine', 'dot_product', 'max_inner_product'] },
             boost: 1.0,
+            rescore_vector: {
+              oversample: 1.5,
+            },
           },
           [
             {
@@ -248,8 +262,11 @@ export const search = (specService: SpecDefinitionsService) => {
               num_candidates: 100,
               query_vector: [],
               query_vector_builder: {},
-              similarity: { __one_of: ['l2_norm', 'cosine', 'dot_product'] },
+              similarity: { __one_of: ['l2_norm', 'cosine', 'dot_product', 'max_inner_product'] },
               boost: 1.0,
+              rescore_vector: {
+                oversample: 1.5,
+              },
             },
           ],
         ],


### PR DESCRIPTION
## Summary

Does what it says on the tin - updates autocomplete for [knn search](https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html) and [knn query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-knn-query.html) with vector rescoring introduced in https://github.com/elastic/elasticsearch/pull/119835

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->