### PR TITLE
[React@18] Fix remaining unit tests 

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_apps/view/trusted_apps_list.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_apps/view/trusted_apps_list.test.tsx
@@ -61,9 +61,10 @@ describe('When on the trusted applications page', () => {
 
   it('should search using expected exception item fields', async () => {
     const expectedFilterString = parseQueryFilterToKQL('fooFooFoo', SEARCHABLE_FIELDS);
-    const { findAllByTestId } = render();
+    const { getAllByTestId } = render();
+
     await waitFor(async () => {
-      await expect(findAllByTestId('trustedAppsListPage-card')).resolves.toHaveLength(10);
+      expect(getAllByTestId('trustedAppsListPage-card')).toHaveLength(10);
     });
 
     apiMocks.responseProvider.exceptionsFind.mockClear();

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/actions/open_timeline_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/actions/open_timeline_button.test.tsx
@@ -20,9 +20,10 @@ jest.mock('../../../../sourcerer/containers');
 jest.mock('../../open_timeline/use_timeline_status');
 jest.mock('react-redux', () => {
   const origin = jest.requireActual('react-redux');
+  const mockDispatch = jest.fn();
   return {
     ...origin,
-    useDispatch: jest.fn(),
+    useDispatch: jest.fn(() => mockDispatch),
   };
 });
 jest.mock('react-router-dom', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/use_timeline_types.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/use_timeline_types.tsx
@@ -88,12 +88,7 @@ export const useTimelineTypes = ({
 
   const onFilterClicked = useCallback(
     (tabId: TimelineType, tabStyle: TimelineTabsStyle) => {
-      setTimelineTypes((prevTimelineTypes) => {
-        if (prevTimelineTypes !== tabId) {
-          setTimelineTypes(tabId);
-        }
-        return prevTimelineTypes;
-      });
+      setTimelineTypes(tabId);
     },
     [setTimelineTypes]
   );


### PR DESCRIPTION
## Summary

Part of https://github.com/elastic/kibana/issues/206952

Fixes remaining unit tests that are failing with React@18 

- [x] [[job]](https://buildkite.com/elastic/kibana-pull-request/builds/267663#01946e9c-d646-4bf0-b7d1-e89178a15545) [[logs]](https://buildkite.com/organizations/elastic/pipelines/kibana-pull-request/builds/267663/jobs/01946e9c-d646-4bf0-b7d1-e89178a15545/artifacts/01946ebe-0ca6-411a-b1a0-b7cf20082ade) Jest Tests / OpenTimelineButton should open the modal after clicking on the button 
- [x] [[job]](https://buildkite.com/elastic/kibana-pull-request/builds/267663#01946e9c-d646-4bf0-b7d1-e89178a15545) [[logs]](https://buildkite.com/organizations/elastic/pipelines/kibana-pull-request/builds/267663/jobs/01946e9c-d646-4bf0-b7d1-e89178a15545/artifacts/01946ebe-0ca6-475d-8907-ec37e144ec25) Jest Tests / useTimelineTypes timelineFilters set timelineTypes correctly  
- [x] [[job]](https://buildkite.com/elastic/kibana-pull-request/builds/267663#01946e9c-d644-4c6f-a1e3-ab4a093833c5) [[logs]](https://buildkite.com/organizations/elastic/pipelines/kibana-pull-request/builds/267663/jobs/01946e9c-d644-4c6f-a1e3-ab4a093833c5/artifacts/01946ec3-4184-4b47-9011-ac9315070264) Jest Tests / When on the trusted applications page should search using expected exception item fields 


The idea is that tests should pass with both React 17 and 18. To run a unit tests with React@18:


```
REACT_18=true yarn test:jest src/platform/plugins/private/kibana_overview/public/components/overview/overview.test.tsx
```


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->