### PR TITLE
[Rules migration] Allow sorting by `risk_score` field

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/sort.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/sort.ts
@@ -50,6 +50,9 @@ const sortingOptions = {
       },
     ];
   },
+  riskScore(direction: estypes.SortOrder = 'asc'): estypes.SortCombinations[] {
+    return [{ 'elastic_rule.risk_score': direction }];
+  },
   status(direction: estypes.SortOrder = 'asc'): estypes.SortCombinations[] {
     const field = 'translation_result';
     const installedRuleField = 'elastic_rule.id';
@@ -101,6 +104,7 @@ const DEFAULT_SORTING: estypes.Sort = [
   ...sortingOptions.status('desc'),
   ...sortingOptions.matchedPrebuiltRule('desc'),
   ...sortingOptions.severity(),
+  ...sortingOptions.riskScore('desc'),
   ...sortingOptions.updated(),
 ];
 
@@ -110,6 +114,13 @@ const sortingOptionsMap: {
   'elastic_rule.title': sortingOptions.name,
   'elastic_rule.severity': (direction?: estypes.SortOrder) => [
     ...sortingOptions.severity(direction),
+    ...sortingOptions.riskScore(direction),
+    ...sortingOptions.status('desc'),
+    ...sortingOptions.matchedPrebuiltRule('desc'),
+  ],
+  'elastic_rule.risk_score': (direction?: estypes.SortOrder) => [
+    ...sortingOptions.riskScore(direction),
+    ...sortingOptions.severity(direction),
     ...sortingOptions.status('desc'),
     ...sortingOptions.matchedPrebuiltRule('desc'),
   ],
@@ -117,11 +128,13 @@ const sortingOptionsMap: {
     ...sortingOptions.matchedPrebuiltRule(direction),
     ...sortingOptions.status('desc'),
     ...sortingOptions.severity('desc'),
+    ...sortingOptions.riskScore(direction),
   ],
   translation_result: (direction?: estypes.SortOrder) => [
     ...sortingOptions.status(direction),
     ...sortingOptions.matchedPrebuiltRule('desc'),
     ...sortingOptions.severity('desc'),
+    ...sortingOptions.riskScore(direction),
   ],
   updated_at: sortingOptions.updated,
 };


### PR DESCRIPTION
## Summary

[Internal link](https://github.com/elastic/security-team/issues/10820) to the feature details

This PR adds possibility to sort migration rules by `risk_score` field.

https://github.com/user-attachments/assets/97a2bb5b-fc19-45db-ab93-c7f9676aa81c

> [!NOTE]  
> This feature needs `siemMigrationsEnabled` experimental flag enabled to work. 


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->