### PR TITLE
[8.17] [Fleet] Fix source mode rollover (#207133)

### DIFF
--- a/x-pack/plugins/fleet/server/constants/fleet_es_assets.ts
+++ b/x-pack/plugins/fleet/server/constants/fleet_es_assets.ts
@@ -11,7 +11,7 @@ import { getESAssetMetadata } from '../services/epm/elasticsearch/meta';
 
 const meta = getESAssetMetadata();
 
-export const FLEET_INSTALL_FORMAT_VERSION = '1.4.0';
+export const FLEET_INSTALL_FORMAT_VERSION = '1.4.1';
 
 export const FLEET_AGENT_POLICIES_SCHEMA_VERSION = '1.1.1';
 

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -1140,7 +1140,8 @@ const updateExistingDataStream = async ({
   // Trigger a rollover if the index mode or source type has changed
   if (
     currentIndexMode !== settings?.index?.mode ||
-    currentSourceType !== settings?.index?.source?.mode ||
+    // @ts-expect-error Property 'source.mode' does not exist on type 'IndicesMappingLimitSettings'
+    currentSourceType !== settings?.index?.mapping?.source?.mode ||
     dynamicDimensionMappingsChanged
   ) {
     if (options?.skipDataStreamRollover === true) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Fleet] Fix source mode rollover (#207133)](https://github.com/elastic/kibana/pull/207133)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-01-20T14:47:16Z","message":"[Fleet] Fix source mode rollover (#207133)","sha":"a39898bf26e1eebd88fdf4f551f89683f71f6ddb","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","backport:prev-minor","backport:8.17"],"title":"[Fleet] Fix source mode rollover","number":207133,"url":"https://github.com/elastic/kibana/pull/207133","mergeCommit":{"message":"[Fleet] Fix source mode rollover (#207133)","sha":"a39898bf26e1eebd88fdf4f551f89683f71f6ddb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/207133","number":207133,"mergeCommit":{"message":"[Fleet] Fix source mode rollover (#207133)","sha":"a39898bf26e1eebd88fdf4f551f89683f71f6ddb"}},{"url":"https://github.com/elastic/kibana/pull/207209","number":207209,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->