### PR TITLE
fix: [Security:Explore:Users page]Add new timeline or template button dialog cannot be closed

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/bottom_bar/add_timeline_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/bottom_bar/add_timeline_button.tsx
@@ -76,7 +76,7 @@ export const AddTimelineButton = React.memo<AddTimelineButtonComponentProps>(({ 
         <EuiPopover
           button={plusButton}
           isOpen={isPopoverOpen}
-          closePopover={() => setPopover}
+          closePopover={() => setPopover(false)}
           repositionOnScroll
         >
           <EuiFlexGroup alignItems="flexStart" direction="column" gutterSize="none">


### PR DESCRIPTION
Closes: #205377

**Description**
Users don't get stuck on elements, dialogs can be closed by pressing Esc.

**Preconditions**
Security -> Explore -> Users page.

**Steps to reproduce**

1.Navigate to Add new timeline or template button.
2.Press Enter.
3.Press Esc.
4.Press Tab few times.
5.Observe page.


**Changes made:**
1.  Fixed typo, method should be called





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->