### PR TITLE
[Security Solution] Add retrieve results to security solution search strategy

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.test.ts
@@ -10,6 +10,7 @@ import {
   buildEventEnrichmentRawResponseMock,
 } from '../../../../../../common/search_strategy/security_solution/cti/index.mock';
 import { parseEventEnrichmentResponse } from './response';
+import type { IEsSearchResponse } from '@kbn/search-types';
 
 describe('parseEventEnrichmentResponse', () => {
   it('includes an accurate inspect response', async () => {
@@ -100,5 +101,17 @@ describe('parseEventEnrichmentResponse', () => {
         'matched.index': ['filebeat-8.0.0-2021.05.28-000001'],
       }),
     ]);
+  });
+
+  it('returns an empty array when no hits', async () => {
+    const options = buildEventEnrichmentRequestOptionsMock();
+    const response = {
+      rawResponse: {
+        hits: {},
+      },
+    } as IEsSearchResponse;
+    const parsedResponse = await parseEventEnrichmentResponse(options, response);
+
+    expect(parsedResponse.enrichments).toEqual([]);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.ts
@@ -6,6 +6,8 @@
  */
 
 import type { IEsSearchResponse } from '@kbn/search-types';
+import { getOr } from 'lodash/fp';
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import type { EventEnrichmentRequestOptions } from '../../../../../../common/api/search_strategy';
 import { inspectStringifyObject } from '../../../../../utils/build_query';
 import { buildIndicatorEnrichments, getTotalCount } from './helpers';
@@ -19,7 +21,8 @@ export const parseEventEnrichmentResponse = async (
     dsl: [inspectStringifyObject(buildEventEnrichmentQuery(options))],
   };
   const totalCount = getTotalCount(response.rawResponse.hits.total);
-  const enrichments = buildIndicatorEnrichments(response.rawResponse.hits.hits);
+  const hits: SearchHit[] = getOr([], 'rawResponse.hits.hits', response);
+  const enrichments = buildIndicatorEnrichments(hits);
 
   return {
     ...response,

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/index.ts
@@ -29,6 +29,8 @@ export const securitySolutionSearchStrategyProvider = (
     search: (request, options, deps) => {
       const parsedRequest = searchStrategyRequestSchema.parse(request);
       const queryFactory = securitySolutionFactory[parsedRequest.factoryQueryType];
+      // NOTE: without this parameter, .hits.hits can be empty
+      options.retrieveResults = true;
       const dsl = queryFactory.buildDsl(parsedRequest);
 
       return es.search({ ...request, params: dsl }, options, deps).pipe(


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/pull/189031
https://p.elstc.co/paste/pCGQy1nV#B7fBRtGiDq-QN14qT/eE8zPOPWgXP88672NIcbSblaD
Without `options.retrieveResults = true` parameter, `response.rawResponse.hits.hits` from search strategy can be undefined

### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->