### PR TITLE
[Streams 🌊] Fix broken breadcrumbs in project nav mode

### DIFF
--- a/src/platform/packages/shared/kbn-typed-react-router-config/src/breadcrumbs/use_breadcrumbs.ts
+++ b/src/platform/packages/shared/kbn-typed-react-router-config/src/breadcrumbs/use_breadcrumbs.ts
@@ -13,11 +13,12 @@ import { MouseEvent, useEffect, useMemo } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { ChromeBreadcrumbsAppendExtension } from '@kbn/core-chrome-browser';
 import type { ServerlessPluginStart } from '@kbn/serverless/public';
+import useObservable from 'react-use/lib/useObservable';
 
 function addClickHandlers(
   breadcrumbs: ChromeBreadcrumb[],
   navigateToHref?: (url: string) => Promise<void>
-) {
+): ChromeBreadcrumb[] {
   return breadcrumbs.map((bc) => ({
     ...bc,
     ...(bc.href
@@ -49,13 +50,21 @@ export const useBreadcrumbs = (
 
   const {
     services: {
-      chrome: { docTitle, setBreadcrumbs: chromeSetBreadcrumbs, setBreadcrumbsAppendExtension },
+      chrome: {
+        docTitle,
+        setBreadcrumbs: chromeSetBreadcrumbs,
+        setBreadcrumbsAppendExtension,
+        getChromeStyle$,
+      },
       application: { getUrlForApp, navigateToUrl },
     },
   } = useKibana<{
     application: ApplicationStart;
     chrome: ChromeStart;
   }>();
+
+  const chromeStyle = useObservable(getChromeStyle$());
+  const isProjectNavigation = chromeStyle === 'project';
 
   const setTitle = docTitle.change;
   const appPath = getUrlForApp(app?.id ?? 'observability-overview') ?? '';
@@ -77,7 +86,7 @@ export const useBreadcrumbs = (
   }, [breadcrumbsAppendExtension, setBreadcrumbsAppendExtension]);
 
   useEffect(() => {
-    const breadcrumbs = serverless
+    const breadcrumbs = isProjectNavigation
       ? extraCrumbs
       : [
           {
@@ -92,10 +101,25 @@ export const useBreadcrumbs = (
         ];
 
     if (setBreadcrumbs) {
-      setBreadcrumbs(addClickHandlers(breadcrumbs, navigateToUrl));
+      const breadcrumbsWithClickHandlers = addClickHandlers(breadcrumbs, navigateToUrl);
+      setBreadcrumbs(breadcrumbsWithClickHandlers, {
+        project: {
+          value: breadcrumbsWithClickHandlers,
+          absolute: true,
+        },
+      });
     }
     if (setTitle) {
       setTitle(getTitleFromBreadCrumbs(breadcrumbs));
     }
-  }, [app?.label, appPath, extraCrumbs, navigateToUrl, serverless, setBreadcrumbs, setTitle]);
+  }, [
+    app?.label,
+    isProjectNavigation,
+    appPath,
+    extraCrumbs,
+    navigateToUrl,
+    serverless,
+    setBreadcrumbs,
+    setTitle,
+  ]);
 };


### PR DESCRIPTION
## 📓 Summary

The shared `useBreadcrumbs` from `@kbn/typed-react-router-config` couldn't apply correctly breadcrumbs in project mode for a couple of reasons:
- the breadcrumbs evaluation was based on the `serverless` plugin existence, while it should rely on the chrome view style
- the setter method from `chrome` didn't account for the specific option to apply the breadcrumbs to a project navigation view.

| Before | After |
|--------|--------|
| <img width="866" alt="before" src="https://github.com/user-attachments/assets/a615405b-e852-4614-b5c2-550780bfd0ba" /> | <img width="852" alt="after" src="https://github.com/user-attachments/assets/04c6c45e-0b6f-4e6c-af3e-ccb7a144a47d" /> | 

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->