### PR TITLE
[Fleet] Disable `Upgrade agents on this policy` action when 0 agents

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/actions_menu.tsx
@@ -215,6 +215,7 @@ export const AgentPolicyActionMenu = memo<{
                 }}
                 key="upgradeAgents"
                 data-test-subj="agentPolicyActionMenuUpgradeAgentsButton"
+                disabled={(agentPolicy.agents || 0) === 0}
               >
                 <FormattedMessage
                   id="xpack.fleet.agentPolicyActionMenu.upgradeAgentsActionText"
@@ -238,6 +239,7 @@ export const AgentPolicyActionMenu = memo<{
                 }}
                 key="getUninstallCommand"
                 data-test-subj="uninstall-agents-command-menu-item"
+                disabled={(agentPolicy.agents || 0) === 0}
               >
                 <FormattedMessage
                   id="xpack.fleet.agentPolicyActionMenu.getUninstallCommand"

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/list_page/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/list_page/index.test.tsx
@@ -19,8 +19,18 @@ jest.mock('../../../hooks', () => ({
   useGetAgentPoliciesQuery: jest.fn().mockReturnValue({
     data: {
       items: [
-        { id: 'not_managed_policy', is_managed: false, updated_at: '2023-04-06T07:19:29.892Z' },
-        { id: 'managed_policy', is_managed: true, updated_at: '2023-04-07T07:19:29.892Z' },
+        {
+          id: 'not_managed_policy',
+          is_managed: false,
+          updated_at: '2023-04-06T07:19:29.892Z',
+          agents: 1,
+        },
+        {
+          id: 'managed_policy',
+          is_managed: true,
+          updated_at: '2023-04-07T07:19:29.892Z',
+          agents: 1,
+        },
       ],
       total: 2,
     } as GetAgentPoliciesResponse,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/205588

Disable the upgarde and uninstall action on the agent policy when there are 0 agents enrolled.

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/7174540b-9933-48c9-9f74-c51973f7582a" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->