### PR TITLE
[Inventory] Fix Open Explore in Discover link in a new tab

### DIFF
--- a/x-pack/solutions/observability/plugins/inventory/kibana.jsonc
+++ b/x-pack/solutions/observability/plugins/inventory/kibana.jsonc
@@ -19,7 +19,8 @@
       "unifiedSearch",
       "data",
       "ruleRegistry",
-      "share"
+      "share",
+      "discover"
     ],
     "requiredBundles": ["kibanaReact"],
     "optionalPlugins": ["spaces", "cloud"],

--- a/x-pack/solutions/observability/plugins/inventory/public/hooks/use_discover_redirect.ts
+++ b/x-pack/solutions/observability/plugins/inventory/public/hooks/use_discover_redirect.ts
@@ -6,17 +6,17 @@
  */
 import { useCallback } from 'react';
 import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common/app_locator';
+import { DISCOVER_APP_LOCATOR } from '@kbn/discover-plugin/common';
 import type { InventoryEntity } from '../../common/entities';
 import { useKibana } from './use_kibana';
 import { useUnifiedSearchContext } from './use_unified_search_context';
-
 export const useDiscoverRedirect = (entity: InventoryEntity) => {
   const {
     services: { share, application, entityManager },
   } = useKibana();
   const { discoverDataview } = useUnifiedSearchContext();
   const { dataView } = discoverDataview;
-  const discoverLocator = share.url.locators.get<DiscoverAppLocatorParams>('DISCOVER_APP_LOCATOR');
+  const discoverLocator = share.url.locators.get<DiscoverAppLocatorParams>(DISCOVER_APP_LOCATOR);
 
   const getDiscoverEntitiesRedirectUrl = useCallback(() => {
     const entityKqlFilter = entity

--- a/x-pack/solutions/observability/plugins/inventory/public/hooks/use_discover_redirect.ts
+++ b/x-pack/solutions/observability/plugins/inventory/public/hooks/use_discover_redirect.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import { useCallback } from 'react';
+import type { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common/app_locator';
 import type { InventoryEntity } from '../../common/entities';
 import { useKibana } from './use_kibana';
 import { useUnifiedSearchContext } from './use_unified_search_context';
@@ -15,7 +16,7 @@ export const useDiscoverRedirect = (entity: InventoryEntity) => {
   } = useKibana();
   const { discoverDataview } = useUnifiedSearchContext();
   const { dataView } = discoverDataview;
-  const discoverLocator = share.url.locators.get('DISCOVER_APP_LOCATOR');
+  const discoverLocator = share.url.locators.get<DiscoverAppLocatorParams>('DISCOVER_APP_LOCATOR');
 
   const getDiscoverEntitiesRedirectUrl = useCallback(() => {
     const entityKqlFilter = entity
@@ -24,9 +25,9 @@ export const useDiscoverRedirect = (entity: InventoryEntity) => {
         })
       : '';
 
-    return application.capabilities.discover?.show || !dataView
+    return application.capabilities.discover?.show
       ? discoverLocator?.getRedirectUrl({
-          dataViewId: dataView?.id ?? '',
+          dataViewSpec: dataView?.toMinimalSpec?.(),
           query: { query: entityKqlFilter, language: 'kuery' },
         })
       : undefined;

--- a/x-pack/solutions/observability/plugins/inventory/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/inventory/tsconfig.json
@@ -60,5 +60,6 @@
     "@kbn/kibana-utils-plugin",
     "@kbn/dataset-quality-plugin",
     "@kbn/observability-utils-common",
+    "@kbn/discover-plugin",
   ]
 }


### PR DESCRIPTION
## Summary

Closes #207064

This PR fixes the Explore in Discover link to be able to open it in a new tab using `dataViewSpec: dataView.toMinimalSpec()`.

## How to test it
1. Enable `entityCentricExperience` feature flag
2. Run some synthtrace scenario, for example `node scripts/synthtrace infra_docker_containers`
3. Click into an entity group and select Explore in Discover in any entity.
4. You should be redirected to the data view correctly by clicking or opening in a new tab

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->