### PR TITLE
[Cloud Security] fix incorrect number of groups when there is a null group

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/components/grouping.mock.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/grouping.mock.tsx
@@ -130,6 +130,9 @@ export const mockGroupingProps = {
     unitsCountWithoutNull: {
       value: 14,
     },
+    nullGroupItems: {
+      doc_count: 1,
+    },
   },
   groupingId: 'test-grouping-id',
   isLoading: false,

--- a/src/platform/packages/shared/kbn-grouping/src/components/grouping.test.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/grouping.test.tsx
@@ -207,6 +207,7 @@ describe('Grouping', () => {
       );
       expect(screen.getByTestId('group-count').textContent).toBe('3 groups');
     });
+
     it('calls custom groupsUnit callback correctly', () => {
       // Provide a custom groupsUnit function in testProps
       const customGroupsUnit = jest.fn(
@@ -224,7 +225,7 @@ describe('Grouping', () => {
       expect(screen.getByTestId('group-count').textContent).toBe('3 custom units');
     });
 
-    it('calls custom groupsUnit callback with hasNullGroup = false', () => {
+    it('calls custom groupsUnit callback with hasNullGroup = false and null group in current page', () => {
       const customGroupsUnit = jest.fn(
         (n, parentSelectedGroup, hasNullGroup) => `${n} custom units`
       );
@@ -247,8 +248,35 @@ describe('Grouping', () => {
         </I18nProvider>
       );
 
-      expect(customGroupsUnit).toHaveBeenCalledWith(3, testProps.selectedGroup, false);
+      expect(customGroupsUnit).toHaveBeenCalledWith(3, testProps.selectedGroup, true);
       expect(screen.getByTestId('group-count').textContent).toBe('3 custom units');
     });
+  });
+
+  it('calls custom groupsUnit callback with hasNullGroup = true and no null group in current page', () => {
+    const customGroupsUnit = jest.fn((n, parentSelectedGroup, hasNullGroup) => `${n} custom units`);
+
+    const customProps = {
+      ...testProps,
+      groupsUnit: customGroupsUnit,
+      data: {
+        ...testProps.data,
+        groupByFields: {
+          ...testProps.data.groupByFields,
+          buckets: testProps?.data?.groupByFields?.buckets?.map(
+            (bucket, index) => (index === 2 ? { ...bucket, isNullGroup: undefined } : bucket) as any
+          ),
+        },
+      },
+    };
+
+    render(
+      <I18nProvider>
+        <Grouping {...customProps} />
+      </I18nProvider>
+    );
+
+    expect(customGroupsUnit).toHaveBeenCalledWith(3, testProps.selectedGroup, true);
+    expect(screen.getByTestId('group-count').textContent).toBe('3 custom units');
   });
 });

--- a/src/platform/packages/shared/kbn-grouping/src/components/grouping.test.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/grouping.test.tsx
@@ -223,5 +223,32 @@ describe('Grouping', () => {
       expect(customGroupsUnit).toHaveBeenCalledWith(3, testProps.selectedGroup, true);
       expect(screen.getByTestId('group-count').textContent).toBe('3 custom units');
     });
+
+    it('calls custom groupsUnit callback with hasNullGroup = false', () => {
+      const customGroupsUnit = jest.fn(
+        (n, parentSelectedGroup, hasNullGroup) => `${n} custom units`
+      );
+
+      const customProps = {
+        ...testProps,
+        groupsUnit: customGroupsUnit,
+        data: {
+          ...testProps.data,
+          nullGroupItems: {
+            ...testProps.data.nullGroupItems,
+            doc_count: 0,
+          },
+        },
+      };
+
+      render(
+        <I18nProvider>
+          <Grouping {...customProps} />
+        </I18nProvider>
+      );
+
+      expect(customGroupsUnit).toHaveBeenCalledWith(3, testProps.selectedGroup, false);
+      expect(screen.getByTestId('group-count').textContent).toBe('3 custom units');
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-grouping/src/components/grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/grouping.tsx
@@ -103,13 +103,10 @@ const GroupingComponent = <T,>({
 
   const groupCount = useMemo(() => data?.groupsCount?.value ?? 0, [data?.groupsCount?.value]);
   const groupCountText = useMemo(() => {
-    const hasNullGroup =
-      data?.groupByFields?.buckets?.some(
-        (groupBucket: GroupingBucket<T>) => groupBucket.isNullGroup
-      ) || false;
+    const hasNullGroup = Boolean(data?.nullGroupItems?.doc_count);
 
     return `${groupsUnit(groupCount, selectedGroup, hasNullGroup)}`;
-  }, [data?.groupByFields?.buckets, groupCount, groupsUnit, selectedGroup]);
+  }, [data?.nullGroupItems, groupCount, groupsUnit, selectedGroup]);
 
   const groupPanels = useMemo(
     () =>

--- a/src/platform/packages/shared/kbn-grouping/src/components/grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/grouping.tsx
@@ -103,10 +103,15 @@ const GroupingComponent = <T,>({
 
   const groupCount = useMemo(() => data?.groupsCount?.value ?? 0, [data?.groupsCount?.value]);
   const groupCountText = useMemo(() => {
+    const hasNullGroupInCurrentPage =
+      data?.groupByFields?.buckets?.some(
+        (groupBucket: GroupingBucket<T>) => groupBucket.isNullGroup
+      ) || false;
+
     const hasNullGroup = Boolean(data?.nullGroupItems?.doc_count);
 
-    return `${groupsUnit(groupCount, selectedGroup, hasNullGroup)}`;
-  }, [data?.nullGroupItems, groupCount, groupsUnit, selectedGroup]);
+    return `${groupsUnit(groupCount, selectedGroup, hasNullGroupInCurrentPage || hasNullGroup)}`;
+  }, [data?.groupByFields?.buckets, data?.nullGroupItems, groupCount, groupsUnit, selectedGroup]);
 
   const groupPanels = useMemo(
     () =>

--- a/src/platform/packages/shared/kbn-grouping/src/components/types.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/components/types.ts
@@ -37,6 +37,9 @@ export interface RootAggregation<T> {
   unitsCountWithoutNull?: {
     value?: number | null;
   };
+  nullGroupItems?: {
+    doc_count?: number;
+  };
 }
 
 export type ParsedRootAggregation<T> = RootAggregation<T> & {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/constants.ts
@@ -47,7 +47,7 @@ export const MISCONFIGURATIONS_GROUPS_UNIT = (
       });
     default:
       return i18n.translate('xpack.csp.findings.groupUnit', {
-        values: { groupCount: totalCount },
+        values: { groupCount },
         defaultMessage: `{groupCount} {groupCount, plural, =1 {group} other {groups}}`,
       });
   }

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.test.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { useLatestFindingsGrouping } from './use_latest_findings_grouping';
+import { useCloudSecurityGrouping } from '../../../components/cloud_security_grouping';
+import { useDataViewContext } from '../../../common/contexts/data_view_context';
+import { useGetCspBenchmarkRulesStatesApi } from '@kbn/cloud-security-posture/src/hooks/use_get_benchmark_rules_state_api';
+import { getGroupingQuery } from '@kbn/grouping';
+import { useGroupedFindings } from './use_grouped_findings';
+
+jest.mock('../../../components/cloud_security_grouping');
+jest.mock('../../../common/contexts/data_view_context');
+jest.mock('@kbn/cloud-security-posture/src/hooks/use_get_benchmark_rules_state_api');
+jest.mock('@kbn/grouping', () => ({
+  getGroupingQuery: jest.fn().mockImplementation((params) => {
+    return {
+      query: { bool: {} },
+    };
+  }),
+  parseGroupingQuery: jest.fn().mockReturnValue({}),
+}));
+jest.mock('./use_grouped_findings');
+
+describe('useLatestFindingsGrouping', () => {
+  const mockGroupPanelRenderer = (
+    selectedGroup: string,
+    fieldBucket: any,
+    nullGroupMessage?: string,
+    isLoading?: boolean
+  ) => <div>Mock Group Panel Renderer</div>;
+  const mockGetGroupStats = jest.fn();
+
+  beforeEach(() => {
+    (useCloudSecurityGrouping as jest.Mock).mockReturnValue({
+      grouping: { selectedGroups: ['cloud.account.id'] },
+    });
+    (useDataViewContext as jest.Mock).mockReturnValue({ dataView: {} });
+    (useGetCspBenchmarkRulesStatesApi as jest.Mock).mockReturnValue({ data: {} });
+    (useGroupedFindings as jest.Mock).mockReturnValue({
+      data: {},
+      isFetching: false,
+    });
+  });
+
+  it('calls getGroupingQuery with correct rootAggregations', () => {
+    renderHook(() =>
+      useLatestFindingsGrouping({
+        groupPanelRenderer: mockGroupPanelRenderer,
+        getGroupStats: mockGetGroupStats,
+        groupingLevel: 0,
+        groupFilters: [],
+        selectedGroup: 'cloud.account.id',
+      })
+    );
+
+    expect(getGroupingQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rootAggregations: [
+          {
+            failedFindings: {
+              filter: {
+                term: {
+                  'result.evaluation': { value: 'failed' },
+                },
+              },
+            },
+            passedFindings: {
+              filter: {
+                term: {
+                  'result.evaluation': { value: 'passed' },
+                },
+              },
+            },
+            nullGroupItems: {
+              missing: { field: 'cloud.account.id' },
+            },
+          },
+        ],
+      })
+    );
+  });
+
+  it('calls getGroupingQuery without nullGroupItems when selectedGroup is "none"', () => {
+    renderHook(() =>
+      useLatestFindingsGrouping({
+        groupPanelRenderer: mockGroupPanelRenderer,
+        getGroupStats: mockGetGroupStats,
+        groupingLevel: 0,
+        groupFilters: [],
+        selectedGroup: 'none',
+      })
+    );
+
+    expect(getGroupingQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rootAggregations: [
+          {
+            failedFindings: {
+              filter: {
+                term: {
+                  'result.evaluation': { value: 'failed' },
+                },
+              },
+            },
+            passedFindings: {
+              filter: {
+                term: {
+                  'result.evaluation': { value: 'passed' },
+                },
+              },
+            },
+          },
+        ],
+      })
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
@@ -230,6 +230,11 @@ export const useLatestFindingsGrouping = ({
             },
           },
         },
+        ...(!isNoneGroup([currentSelectedGroup]) && {
+          nullGroupItems: {
+            missing: { field: currentSelectedGroup },
+          },
+        }),
       },
     ],
   });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
@@ -187,6 +187,15 @@ export const useLatestVulnerabilitiesGrouping = ({
     sort: [{ groupByField: { order: 'desc' } }],
     statsAggregations: getAggregationsByGroupField(currentSelectedGroup),
     runtimeMappings: getRuntimeMappingsByGroupField(currentSelectedGroup),
+    rootAggregations: [
+      {
+        ...(!isNoneGroup([currentSelectedGroup]) && {
+          nullGroupItems: {
+            missing: { field: currentSelectedGroup },
+          },
+        }),
+      },
+    ],
   });
 
   const { data, isFetching } = useGroupedVulnerabilities({

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/translations.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/translations.ts
@@ -44,7 +44,7 @@ export const VULNERABILITIES_GROUPS_UNIT = (
       });
     default:
       return i18n.translate('xpack.csp.vulnerabilities.groupUnit', {
-        values: { groupCount: totalCount },
+        values: { groupCount },
         defaultMessage: `{groupCount} {groupCount, plural, =1 {group} other {groups}}`,
       });
   }


### PR DESCRIPTION
## Summary
This PR fixes group by logic regarding calculation of groups count when there is a null group.

## Video Recording with the fix
https://github.com/user-attachments/assets/14e82bf3-b8d3-4287-8f90-04372be23cf2

## BUG description
The checking of null group is scoped to the findings on a specific page, for example if we have two pages and the null group appears on the second page the number of groups will not be correct on the first page because the null group of was subtracted from the total number of groups. On the second page the number is correct because the null group was fetched in the second page.

### Closes
- https://github.com/elastic/kibana/issues/188138

### Definition of done
- [x] number of groups should be correct across all pages

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct release_note:* label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->