### PR TITLE
fix: [Security:Manage:EntityAnalytics:EntityRiskScore] Entity Risk score on and off toggle button is missing discernible text on Entity Risk score page

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_enable_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_enable_section.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -26,6 +27,7 @@ import { useEnableRiskEngineMutation } from '../api/hooks/use_enable_risk_engine
 import { useDisableRiskEngineMutation } from '../api/hooks/use_disable_risk_engine_mutation';
 import { useAppToasts } from '../../common/hooks/use_app_toasts';
 import type { RiskEngineMissingPrivilegesResponse } from '../hooks/use_missing_risk_engine_privileges';
+import {RISK_ENGINE_STATUS_SWITCH, RISK_ENGINE_STATUS_SWITCH_LABEL} from "../translations";
 
 const MIN_WIDTH_TO_PREVENT_LABEL_FROM_MOVING = '50px';
 const toastOptions = {
@@ -94,12 +96,13 @@ const RiskEngineStatusRow: React.FC<{
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiSwitch
-          label={''}
+          label={i18n.RISK_ENGINE_STATUS_SWITCH_LABEL}
           data-test-subj="risk-score-switch"
           checked={currentRiskEngineStatus === RiskEngineStatusEnum.ENABLED}
           onChange={onSwitchClick}
           disabled={btnIsDisabled}
           aria-describedby={'switchRiskModule'}
+          showLabel={false}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_enable_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_enable_section.tsx
@@ -27,7 +27,6 @@ import { useEnableRiskEngineMutation } from '../api/hooks/use_enable_risk_engine
 import { useDisableRiskEngineMutation } from '../api/hooks/use_disable_risk_engine_mutation';
 import { useAppToasts } from '../../common/hooks/use_app_toasts';
 import type { RiskEngineMissingPrivilegesResponse } from '../hooks/use_missing_risk_engine_privileges';
-import {RISK_ENGINE_STATUS_SWITCH, RISK_ENGINE_STATUS_SWITCH_LABEL} from "../translations";
 
 const MIN_WIDTH_TO_PREVENT_LABEL_FROM_MOVING = '50px';
 const toastOptions = {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/translations.ts
@@ -202,6 +202,13 @@ export const RISK_ENGINE_NEXT_RUN_TIME = (timeInMinutes: string) =>
     values: { timeInMinutes },
   });
 
+export const RISK_ENGINE_STATUS_SWITCH_LABEL = i18n.translate(
+  'xpack.securitySolution.riskScore.riskEngineStatus',
+  {
+    defaultMessage: 'Risk engine status',
+  }
+);
+
 export const RUN_RISK_SCORE_ENGINE = i18n.translate('xpack.securitySolution.riskScore.runEngine', {
   defaultMessage: 'Run Engine',
 });


### PR DESCRIPTION
Closes: #205823

**Description**
Entity Risk score on and off toggle button is missing discernible text on entity risk score page

**Preconditions**
Security -> Manage ->Entity Risk Score page 

**Steps to reproduce**
1.  Open Entity Risk score page
2. Run axe-core through the page
3. Notice that Entity risk score on and off toggle button is missing discernible text which means assistive technologies won't know what to read.


**Changes made**
1. `arial-label` attribute was set for `EuiSwitch`

**Screen**

<img width="1608" alt="image" src="https://github.com/user-attachments/assets/79754c08-9362-4095-81e2-7d0d65c67daf" />
 


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->