### PR TITLE
Fix useAbortableAsync race condition

### DIFF
--- a/x-pack/solutions/observability/packages/utils_browser/hooks/use_abortable_async.ts
+++ b/x-pack/solutions/observability/packages/utils_browser/hooks/use_abortable_async.ts
@@ -27,13 +27,6 @@ interface UseAbortableAsyncOptions<T> {
   onError?: (error: Error) => void;
 }
 
-interface State<T> {
-  error?: Error;
-  value?: T;
-  loading: boolean;
-  generation: number;
-}
-
 export type UseAbortableAsync<
   TAdditionalParameters extends Record<string, any> = {},
   TAdditionalOptions extends Record<string, any> = {}
@@ -55,39 +48,9 @@ export function useAbortableAsync<T>(
 
   const [refreshId, setRefreshId] = useState(0);
 
-  const [internalState, setInternalState] = useState<State<T>>(() => ({
-    error: undefined,
-    loading: false,
-    value: options?.defaultValue ? options.defaultValue() : undefined,
-    generation: 0,
-  }));
-
-  function updateState(newState: Partial<Omit<State<T>, 'generation'>> & { generation: number }) {
-    setInternalState((currentState) => {
-      if (currentState.generation === newState.generation) {
-        return {
-          ...currentState,
-          ...newState,
-        };
-      }
-      return currentState;
-    });
-  }
-
-  /**
-   * Start a new generation to track the current request.
-   * All state updates from old requests will be ignored if the generation changes.
-   */
-  function startNewGeneration() {
-    const newGeneration = Math.random();
-    setInternalState((currentState) => {
-      return {
-        ...currentState,
-        generation: newGeneration,
-      };
-    });
-    return newGeneration;
-  }
+  const [error, setError] = useState<Error>();
+  const [loading, setLoading] = useState(false);
+  const [value, setValue] = useState<T | undefined>(options?.defaultValue);
 
   useEffect(() => {
     controllerRef.current.abort();
@@ -95,55 +58,35 @@ export function useAbortableAsync<T>(
     const controller = new AbortController();
     controllerRef.current = controller;
 
-    const currentGeneration = startNewGeneration();
-
     if (clearValueOnNext) {
-      updateState({
-        value: undefined,
-        error: undefined,
-        generation: currentGeneration,
-      });
+      setValue(undefined);
+      setError(undefined);
     }
 
     function handleError(err: Error) {
-      updateState({
-        error: err,
-        loading: false,
-        ...(!unsetValueOnError && { value: undefined }),
-        generation: currentGeneration,
-      });
+      setError(err);
+      if (unsetValueOnError) {
+        setValue(undefined);
+      }
+      setLoading(false);
       options?.onError?.(err);
     }
 
     try {
       const response = fn({ signal: controller.signal });
       if (isPromise(response)) {
-        updateState({
-          loading: true,
-          generation: currentGeneration,
-        });
+        setLoading(true);
         response
           .then((nextValue) => {
-            updateState({
-              value: nextValue,
-              error: undefined,
-              generation: currentGeneration,
-            });
+            setError(undefined);
+            setValue(nextValue);
           })
           .catch(handleError)
-          .finally(() => {
-            updateState({
-              loading: false,
-              generation: currentGeneration,
-            });
-          });
+          .finally(() => setLoading(false));
       } else {
-        updateState({
-          loading: false,
-          error: undefined,
-          value: response,
-          generation: currentGeneration,
-        });
+        setError(undefined);
+        setValue(response);
+        setLoading(false);
       }
     } catch (err) {
       handleError(err);
@@ -157,12 +100,12 @@ export function useAbortableAsync<T>(
 
   return useMemo<AbortableAsyncState<T>>(() => {
     return {
-      error: internalState.error,
-      loading: internalState.loading,
-      value: internalState.value,
+      error,
+      loading,
+      value,
       refresh: () => {
         setRefreshId((id) => id + 1);
       },
     } as unknown as AbortableAsyncState<T>;
-  }, [internalState.error, internalState.value, internalState.loading]);
+  }, [error, value, loading]);
 }


### PR DESCRIPTION
`useAbortableAsync` can easily get confused about the current state  - e.g. when a previous invocation gets aborted and a new one is started at the same time, the `loading` state gets set to false _after_ the next invocation got started, so it's false for the time it's running:

![old](https://github.com/user-attachments/assets/6a784b1a-58b2-4951-8d25-9f109bce39c5)

You can see that while typing, the old slow request is aborted properly, but the `loading` state gets lost and the abort error from the last invocation is still set even though a new request is running already.

This is not the only possible issue that could happen here - e.g. if the promise chain throws too late, an unrelated error could be set in the error handling logic, which is not related to the currently running `fn`.

This is hard to fix because as the hook does not control the `fn`, it does not know at which point it resolves, even after a new invocation was started already. The abort signal asks the `fn` nicely to throw with an abort error, but it can't be controlled when that happens.

This PR introduces a notion of the current "generation" and only accepts state updates from the most recent one. 

With this, the new invocation correctly sets the loading state after the abort - what happens to the old promise chain after the abort can't affect the state anymore:
![new](https://github.com/user-attachments/assets/b39dd725-6bf1-4ef1-9eb6-d1463e1ec146)

I'm not sure whether this is the best way to resolve this issue, but I couldn't come up with a better way. Happy to adjust, but I think we need a solution that doesn't assume any special behavior of the passed in `fn`, otherwise this helper will always be super brittle.


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->