### PR TITLE
[Authz] Explicitly added superuser privileges for _invalidate route

### DIFF
--- a/x-pack/platform/plugins/shared/security/server/routes/session_management/invalidate.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/session_management/invalidate.test.ts
@@ -9,6 +9,7 @@ import type { ObjectType } from '@kbn/config-schema';
 import type { RequestHandler, RouteConfig } from '@kbn/core/server';
 import { kibanaResponseFactory } from '@kbn/core/server';
 import { httpServerMock } from '@kbn/core/server/mocks';
+import { ReservedPrivilegesSet } from '@kbn/core-http-server';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 
 import { defineInvalidateSessionsRoutes } from './invalidate';
@@ -48,7 +49,9 @@ describe('Invalidate sessions routes', () => {
         summary: 'Invalidate user sessions',
       });
 
-      expect(routeConfig.security?.authz).toEqual({ requiredPrivileges: ['sessionManagement'] });
+      expect(routeConfig.security?.authz).toEqual({
+        requiredPrivileges: [ReservedPrivilegesSet.superuser],
+      });
 
       const bodySchema = (routeConfig.validate as any).body as ObjectType;
       expect(() => bodySchema.validate({})).toThrowErrorMatchingInlineSnapshot(

--- a/x-pack/platform/plugins/shared/security/server/routes/session_management/invalidate.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/session_management/invalidate.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { ReservedPrivilegesSet } from '@kbn/core-http-server';
 
 import type { RouteDefinitionParams } from '..';
 
@@ -39,7 +40,7 @@ export function defineInvalidateSessionsRoutes({
       },
       security: {
         authz: {
-          requiredPrivileges: ['sessionManagement'],
+          requiredPrivileges: [ReservedPrivilegesSet.superuser],
         },
       },
       options: {


### PR DESCRIPTION
## Summary

There was no `sessionManagement` privilege registered, so the route was  available only for superusers or users with equivalent privileges. Explicitly added `superuser` privileges for `/api/security/session/_invalidate` route.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

__Related: https://github.com/elastic/kibana/issues/198716__


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->