### PR TITLE
[8.x] [Security Solution] [EDR Workflows] Adds upgrade notes for management deprecated apis (#206903)

### DIFF
--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -50,6 +50,34 @@ For Elastic Security release information, refer to {security-guide}/release-note
 ==== Kibana APIs
 
 [discrete]
+[[breaking-199598]]
+.Remove deprecated endpoint management endpoints (9.0.0)
+[%collapsible]
+====
+*Details* +
+--
+* `POST /api/endpoint/isolate` has been replaced by `POST /api/endpoint/action/isolate`
+* `POST /api/endpoint/unisolate` has been replaced by `POST /api/endpoint/action/unisolate`
+* `GET /api/endpoint/policy/summaries` has been deprecated without replacement. Will be removed in v9.0.0
+* `POST /api/endpoint/suggestions/{suggestion_type}` has been deprecated without replacement. Will be removed in v9.0.0
+* `GET /api/endpoint/action_log/{agent_id}` has been deprecated without replacement. Will be removed in v9.0.0
+* `GET /api/endpoint/metadata/transforms` has been deprecated without replacement. Will be removed in v9.0.0
+--
+
+*Impact* +
+Deprecated endpoints will fail with a 404 status code starting from version 9.0.0
+
+*Action* +
+--
+* Remove references to `GET /api/endpoint/policy/summaries` endpoint.
+* Remove references to `POST /api/endpoint/suggestions/{suggestion_type}` endpoint.
+* Remove references to `GET /api/endpoint/action_log/{agent_id}` endpoint.
+* Remove references to `GET /api/endpoint/metadata/transforms` endpoint.
+* Replace references to deprecated endpoints with the replacements listed in the breaking change details.
+--
+====
+
+[discrete]
 [[breaking-201550]]
 .Removed legacy alerting endpoints (9.0.0)
 [%collapsible]

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -516,6 +516,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       detectionEngineOverview: `${SECURITY_SOLUTION_DOCS}detection-engine-overview.html`,
       aiAssistant: `${SECURITY_SOLUTION_DOCS}security-assistant.html`,
       signalsMigrationApi: `${SECURITY_SOLUTION_DOCS}signals-migration-api.html`,
+      legacyEndpointManagementApiDeprecations: `${KIBANA_DOCS}breaking-changes-summary.html#breaking-199598`,
     },
     query: {
       eql: `${ELASTICSEARCH_DOCS}eql.html`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -378,6 +378,7 @@ export interface DocLinks {
     };
     readonly detectionEngineOverview: string;
     readonly signalsMigrationApi: string;
+    readonly legacyEndpointManagementApiDeprecations: string;
   };
   readonly query: {
     readonly eql: string;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution] [EDR Workflows] Adds upgrade notes for management deprecated apis (#206903)](https://github.com/elastic/kibana/pull/206903)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"David Sánchez","email":"david.sanchezsoler@elastic.co"},"sourceCommit":{"committedDate":"2025-01-21T14:56:03Z","message":"[Security Solution] [EDR Workflows] Adds upgrade notes for management deprecated apis (#206903)\n\n## Summary\r\n\r\nIt adds upgrade notes and create docs link for Endpoint management\r\ndeprecated apis in 9.0.\r\n\r\nThis pr is for main (9.0) and 8.x (8.18) and will follow up with this\r\none on 8.x branch: https://github.com/elastic/kibana/pull/206904 in\r\norder to add these notes to the Upgrade Assistant for these deprecated\r\napi's\r\n\r\nThe Api routes were already removed in this pr (only in main):\r\nhttps://github.com/elastic/kibana/pull/199598\r\n\r\n---------\r\n\r\nCo-authored-by: natasha-moore-elastic <137783811+natasha-moore-elastic@users.noreply.github.com>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"adb6cded6ab778b59378f5be78a8ed563470b5aa","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:deprecation","v9.0.0","Team:Defend Workflows","backport:version","v8.18.0"],"title":"[Security Solution] [EDR Workflows] Adds upgrade notes for management deprecated apis","number":206903,"url":"https://github.com/elastic/kibana/pull/206903","mergeCommit":{"message":"[Security Solution] [EDR Workflows] Adds upgrade notes for management deprecated apis (#206903)\n\n## Summary\r\n\r\nIt adds upgrade notes and create docs link for Endpoint management\r\ndeprecated apis in 9.0.\r\n\r\nThis pr is for main (9.0) and 8.x (8.18) and will follow up with this\r\none on 8.x branch: https://github.com/elastic/kibana/pull/206904 in\r\norder to add these notes to the Upgrade Assistant for these deprecated\r\napi's\r\n\r\nThe Api routes were already removed in this pr (only in main):\r\nhttps://github.com/elastic/kibana/pull/199598\r\n\r\n---------\r\n\r\nCo-authored-by: natasha-moore-elastic <137783811+natasha-moore-elastic@users.noreply.github.com>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"adb6cded6ab778b59378f5be78a8ed563470b5aa"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/206903","number":206903,"mergeCommit":{"message":"[Security Solution] [EDR Workflows] Adds upgrade notes for management deprecated apis (#206903)\n\n## Summary\r\n\r\nIt adds upgrade notes and create docs link for Endpoint management\r\ndeprecated apis in 9.0.\r\n\r\nThis pr is for main (9.0) and 8.x (8.18) and will follow up with this\r\none on 8.x branch: https://github.com/elastic/kibana/pull/206904 in\r\norder to add these notes to the Upgrade Assistant for these deprecated\r\napi's\r\n\r\nThe Api routes were already removed in this pr (only in main):\r\nhttps://github.com/elastic/kibana/pull/199598\r\n\r\n---------\r\n\r\nCo-authored-by: natasha-moore-elastic <137783811+natasha-moore-elastic@users.noreply.github.com>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"adb6cded6ab778b59378f5be78a8ed563470b5aa"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->