### PR TITLE
chore(NA): update versions after v8.16.4 bump

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -19,7 +19,7 @@
       "previousMajor": true
     },
     {
-      "version": "8.16.3",
+      "version": "8.16.4",
       "branch": "8.16",
       "previousMajor": true
     },


### PR DESCRIPTION
This PR is a simple update of our versions file after the recent bumps.