### PR TITLE
search: update index details document poll interval to 30s

### DIFF
--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_document_search.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_document_search.ts
@@ -22,7 +22,7 @@ const DEFAULT_PAGINATION = {
   size: DEFAULT_DOCUMENT_PAGE_SIZE,
   total: 0,
 };
-export const INDEX_SEARCH_POLLING = 5 * 1000;
+export const INDEX_SEARCH_POLLING = 30000;
 export const useIndexDocumentSearch = (indexName: string) => {
   const {
     services: { http },


### PR DESCRIPTION
## Summary

Updating the search indices index details document search polling
interval from 5s to 30s. 5s was very aggressive and faster than all the
other intervals we use for this page. Increasing to 30s will instead
make this call the slowest, which should be more reasonable for
searching for the documents we show in the index details page.
