### PR TITLE
[Data] Take into account failure-store selector

### DIFF
--- a/src/platform/packages/shared/kbn-es-query/src/utils.test.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/utils.test.ts
@@ -31,7 +31,7 @@ describe('util tests', () => {
       expect(isCCSRemoteIndexName('*:logstash-{now/d-2d}')).toBe(true);
     });
 
-    it('should not validate selctor with wildcard', () => {
+    it('should not validate selector with wildcard', () => {
       expect(isCCSRemoteIndexName('my-data-stream::*')).toBe(false);
     });
 

--- a/src/platform/packages/shared/kbn-es-query/src/utils.test.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/utils.test.ts
@@ -30,5 +30,17 @@ describe('util tests', () => {
     it('should validate CCS pattern', () => {
       expect(isCCSRemoteIndexName('*:logstash-{now/d-2d}')).toBe(true);
     });
+
+    it('should not validate selctor with wildcard', () => {
+      expect(isCCSRemoteIndexName('my-data-stream::*')).toBe(false);
+    });
+
+    it('should not validate index name with selector', () => {
+      expect(isCCSRemoteIndexName('my-data-stream::failures')).toBe(false);
+    });
+
+    it('should not validate wildcard with selector', () => {
+      expect(isCCSRemoteIndexName('-logs-*::data')).toBe(false);
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-es-query/src/utils.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/utils.ts
@@ -42,7 +42,7 @@ export function getDataViewFieldSubtypeMulti(field: HasSubtype) {
  * The index name is assumed to be individual index (no commas) but can contain `-`, wildcards,
  * datemath, remote cluster name and any other syntax permissible in index expression component.
  *
- * 2024/10/11 Implementation taken from https://github.com/smalyshev/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+ * 2025/01/21 Implementation taken from https://github.com/smalyshev/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
  *
  * @param indexExpression
  */
@@ -52,6 +52,11 @@ export function isCCSRemoteIndexName(indexExpression: string): boolean {
     // Thus, whatever it is, this is definitely not a remote index.
     return false;
   }
+
+  const idx = indexExpression.indexOf(':');
+  // Check to make sure the remote cluster separator ':' isn't actually a selector separator '::'
+  const isSelector = indexExpression.startsWith('::', idx);
+
   // Note remote index name also can not start with ':'
-  return indexExpression.indexOf(':') > 0;
+  return idx > 0 && !isSelector;
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/205109

Update CCS check so it doesn't validate failure-store delimiters.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)






<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->