### PR TITLE
[API Deprecations] Skip HTTP resources

### DIFF
--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
@@ -23,11 +23,13 @@ import {
 export const getIsAccessApiDeprecation = ({
   isInternalApiRequest,
   isPublicAccess,
+  isHttpResource,
 }: PostValidationMetadata): boolean => {
   const isNotPublicAccess = !isPublicAccess;
   const isNotInternalRequest = !isInternalApiRequest;
+  const isNotHttpResource = !isHttpResource;
 
-  return !!(isNotPublicAccess && isNotInternalRequest);
+  return isNotPublicAccess && isNotInternalRequest && isNotHttpResource;
 };
 
 export const buildApiAccessDeprecationDetails = ({

--- a/src/core/packages/http/router-server-internal/src/route.test.ts
+++ b/src/core/packages/http/router-server-internal/src/route.test.ts
@@ -66,6 +66,7 @@ describe('handle', () => {
         deprecated: undefined,
         isInternalApiRequest: false,
         isPublicAccess: false,
+        isHttpResource: false,
       });
       expect(router.emitPostValidate).toHaveBeenNthCalledWith(2, expect.any(Object), {
         deprecated: {
@@ -75,6 +76,7 @@ describe('handle', () => {
         },
         isInternalApiRequest: false,
         isPublicAccess: false,
+        isHttpResource: false,
       });
     });
 
@@ -109,6 +111,7 @@ describe('handle', () => {
         },
         isInternalApiRequest: false,
         isPublicAccess: false,
+        isHttpResource: false,
       });
     });
   });
@@ -168,6 +171,7 @@ describe('validateHapiRequest', () => {
         deprecated: undefined,
         isInternalApiRequest: false,
         isPublicAccess: true,
+        isHttpResource: false,
       });
     }
     {
@@ -182,6 +186,7 @@ describe('validateHapiRequest', () => {
         deprecated: undefined,
         isInternalApiRequest: false,
         isPublicAccess: true,
+        isHttpResource: false,
       });
     }
   });

--- a/src/core/packages/http/router-server-internal/src/route.ts
+++ b/src/core/packages/http/router-server-internal/src/route.ts
@@ -12,6 +12,7 @@ import {
   type SafeRouteMethod,
   type RouteConfig,
   getRequestValidation,
+  type PostValidationMetadata,
 } from '@kbn/core-http-server';
 import type {
   RouteSecurityGetter,
@@ -205,10 +206,14 @@ function routeSchemasFromRouteConfig<P, Q, B>(
   }
 }
 
-function getPostValidateEventMetadata(request: AnyKibanaRequest, routeInfo: RouteInfo) {
+function getPostValidateEventMetadata(
+  request: AnyKibanaRequest,
+  routeInfo: RouteInfo
+): PostValidationMetadata {
   return {
     deprecated: routeInfo.deprecated,
     isInternalApiRequest: request.isInternalApiRequest,
     isPublicAccess: isPublicAccessApiRoute(routeInfo),
+    isHttpResource: !!routeInfo.httpResource,
   };
 }

--- a/src/core/packages/http/router-server-internal/src/router.ts
+++ b/src/core/packages/http/router-server-internal/src/router.ts
@@ -173,6 +173,7 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
     postValidateConext: PostValidationMetadata = {
       isInternalApiRequest: true,
       isPublicAccess: false,
+      isHttpResource: false,
     }
   ) => {
     const postValidate: RouterEvents = 'onPostValidate';

--- a/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.test.ts
+++ b/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.test.ts
@@ -743,6 +743,7 @@ describe('Versioned route', () => {
           },
           isInternalApiRequest: false,
           isPublicAccess: false,
+          isHttpResource: false,
         }
       );
       expect(router.emitPostValidate).toHaveBeenNthCalledWith(
@@ -756,6 +757,7 @@ describe('Versioned route', () => {
           },
           isInternalApiRequest: false,
           isPublicAccess: false,
+          isHttpResource: false,
         }
       );
     });
@@ -789,6 +791,7 @@ describe('Versioned route', () => {
           },
           isInternalApiRequest: false,
           isPublicAccess: false,
+          isHttpResource: false,
         }
       );
     });

--- a/src/core/packages/http/server/src/router/route.ts
+++ b/src/core/packages/http/server/src/router/route.ts
@@ -532,4 +532,5 @@ export interface PostValidationMetadata {
   deprecated?: RouteDeprecationInfo;
   isInternalApiRequest: boolean;
   isPublicAccess: boolean;
+  isHttpResource: boolean;
 }


### PR DESCRIPTION
## Summary

Follow up to #199026
Related to #199616

When working on #199616, we noticed that we counted (and now logged) all the APIs serving http-resources (like the /bundles/ routes).

This PR improves our filter to avoid counting and logging those ones (they pass the current filters because [they are not categorized as public](https://github.com/elastic/kibana/blob/0311e8ba401de7f78f7211a24ddbbc309916ee00/src/core/packages/http/router-server-internal/src/route.ts#L168-L176), and they are technically not called internally (the browser loads them without the internal header).