### PR TITLE
[Security Solution] Fix editing in KQL Query Bar

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -699,6 +699,7 @@ export const QueryBarTopRow = React.memo(
             isDisabled={props.isDisabled}
             appName={appName}
             submitOnBlur={props.submitOnBlur}
+            bubbleSubmitEvent={true}
             deps={{
               unifiedSearch,
               data,

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.scss
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.scss
@@ -52,7 +52,6 @@
     overflow-x: auto;
     overflow-y: auto;
     white-space: pre;
-    max-height: calc(35vh - 100px);
     min-height: $euiFormControlHeight;
   }
 

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.tsx
@@ -733,8 +733,8 @@ export default class QueryStringInputUI extends PureComponent<QueryStringInputPr
   handleAutoHeight = onRaf(() => {
     if (this.inputRef !== null && document.activeElement === this.inputRef) {
       this.inputRef.classList.add('kbnQueryBar__textarea--autoHeight');
-      this.inputRef.style.setProperty('height', `${this.inputRef.scrollHeight}px`, 'important');
-    }
+      this.inputRef.style.setProperty('height', '165px', 'important');
+      this.inputRef.style.setProperty('max-height', `165px`);    }
   });
 
   handleRemoveHeight = onRaf(() => {

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.tsx
@@ -359,7 +359,7 @@ export default class QueryStringInputUI extends PureComponent<QueryStringInputPr
 
   private onQueryStringChange = (value: string) => {
     this.setState({
-      isSuggestionsVisible: false,
+      isSuggestionsVisible: true,
       index: null,
       suggestionLimit: 50,
     });
@@ -418,18 +418,20 @@ export default class QueryStringInputUI extends PureComponent<QueryStringInputPr
 
       switch (event.keyCode) {
         case KEY_CODES.DOWN:
-          if (isSuggestionsVisible && index !== null) {
-            event.preventDefault();
-            this.incrementIndex(index);
-            // Note to engineers. `isSuggestionVisible` does not mean the suggestions are visible.
-            // This should likely be fixed, it's more that suggestions can be shown.
-          } else if ((isSuggestionsVisible && index == null) || this.getQueryString() === '') {
-            event.preventDefault();
-            this.setState({ isSuggestionsVisible: true, index: 0 });
+          if (event.altKey) {
+            if (isSuggestionsVisible && index !== null) {
+              event.preventDefault();
+              this.incrementIndex(index);
+              // Note to engineers. `isSuggestionVisible` does not mean the suggestions are visible.
+              // This should likely be fixed, it's more that suggestions can be shown.
+            } else if ((isSuggestionsVisible && index == null) || this.getQueryString() === '') {
+              event.preventDefault();
+              this.setState({ isSuggestionsVisible: true, index: 0 });
+            }
           }
           break;
         case KEY_CODES.UP:
-          if (isSuggestionsVisible && index !== null) {
+          if (event.altKey && isSuggestionsVisible && index !== null) {
             event.preventDefault();
             this.decrementIndex(index);
           }

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_string_input.tsx
@@ -359,7 +359,7 @@ export default class QueryStringInputUI extends PureComponent<QueryStringInputPr
 
   private onQueryStringChange = (value: string) => {
     this.setState({
-      isSuggestionsVisible: true,
+      isSuggestionsVisible: false,
       index: null,
       suggestionLimit: 50,
     });


### PR DESCRIPTION
**Resolves: #203523**

## Summary

Fixing the issue of KQL query bar edit component not showing properly long multiline KQL queries.

The query now isn't fully visible, and it's not possible to navigate with Up/Down keyboard keys. It's also not possible to scroll down, as the component doesn't allow to insert new line symbols.

I am fixing the behavior by:
- setting the `bubbleSubmitEvent={true}` so that the key press can propagate to higher components and be served properly. This fixes the problem of not allowing to enter new lines.
- I propose to change the behavior of Up and Down arrow keys, so that they are handled normally, like in all text areas. Currently, when user presses up or down and the suggestions panel is visible, they only iterate the suggestions (in the suggestions panel), and this is counterintuitive. Also, the whole behavior of this suggestions feels like it's broken, very inconsistent sometimes it shows, sometimes not. I am proposing here to improve the situation by requiring ALT key to be pressed to iterate suggestions (if present). 
- After making the textarea handle new lines normally (when user presses Enter key), there was an issue of extending the textarea down, and there is a problem of positioning context (most likely), which makes the textarea hidden under some of the parents' panel. Fixing this is not easy (it is not enough to bump the z-index property, maybe portal is needed), but I found a way to improve the behavior to acceptable by assigning some fixed value both for height and max-height of the textarea. That way it doesn't grow too big to hide under the parent panel. And it is consistent with the behavior of EQL query, which works the same way, it doesn't grow when user inserts new lines.

# BEFORE
Note: If suggestions are not shown, UP and DOWN keys work correctly I am able to go up and down. But when they are shown, pressing DOWN key moves the focus to the suggestions panel. And from that moment UP and DOWN keys do nothing in the textarea, they only iterate the suggestions.
I am also trying there to insert the new line but it is NOT possible.

https://github.com/user-attachments/assets/43e05c86-f4e4-4663-abca-21c5854b666a

https://github.com/user-attachments/assets/fd678af2-48ee-4a5c-90f4-1a210d00058f

# AFTER 
### After Fixing behavior of keys 
This looks better, but see the weird behavior of the suggestions panel and the text area, no scrolling.

https://github.com/user-attachments/assets/2dc931ba-3ba1-4495-91f0-fc8f9528b420

### After  setting fixed height of the textarea 
Notice that the behavior is much better, the textarea doesn't hide under the parent's panel, the scrollbar works normally, the suggestions panel doesn't get moved down and it doesn't starts in the middle of the parent's panel like above

https://github.com/user-attachments/assets/ffb79d1b-26c7-46c6-9a16-6b0ffde287ea

### More examples
This one with originally higher text area, which now gets smaller, but it works acceptably well

https://github.com/user-attachments/assets/f58eb7e7-9096-4474-b558-bf57f93dfd21


