### PR TITLE
[Fleet] Fix UI error when agent goes to orphaned state

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/helpers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/helpers.ts
@@ -41,7 +41,7 @@ export function searchHitToAgent(
         return acc;
       }, {} as OutputMap)
     : undefined;
-  const components: FleetServerAgentComponent[] | undefined = hit._source?.components
+  const components: FleetServerAgentComponent[] | undefined = Array.isArray(hit._source?.components)
     ? hit._source?.components.map((component) => ({
         id: component.id,
         type: component.type,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/elastic-agent/issues/6572

It seems that when the orphaned agent service is restarted, it briefly has a component state string, instead of array, that's why the error. The fix checks that the components is an array before calling map.

To verify:
1. Enroll an agent to an agent policy with endpoint integration.
2. Stop agent service so that agent gets into orphaned state.
3. Now restart the service and observe that the error `_hit$_source4.components.map is not a function` no longer appears.

<img width="1531" alt="image" src="https://github.com/user-attachments/assets/c9a957d7-a0d3-4831-90f9-a57479193ee0" />
<img width="1530" alt="image" src="https://github.com/user-attachments/assets/c0aa62f0-708b-463e-9184-01d8641c8f21" />




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->