### PR TITLE
[Security Solution] Fix incorrect default value for History Window Size

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/schedule_item_field/schedule_item_field.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/schedule_item_field/schedule_item_field.test.tsx
@@ -37,6 +37,30 @@ describe('ScheduleItemField', () => {
     expect(mockField.setValue).toHaveBeenCalledWith('5000000s');
   });
 
+  it(`uses the "units" prop when it's passed`, async () => {
+    const mockField = useFormFieldMock<string>({ value: '7d' });
+    const wrapper = mount(
+      <TestProviders>
+        <ScheduleItemField
+          field={mockField}
+          units={['m', 'h', 'd']}
+          dataTestSubj="schedule-item"
+          idAria="idAria"
+        />
+      </TestProviders>
+    );
+
+    expect(wrapper.find('[data-test-subj="interval"]').last().prop('value')).toEqual(7);
+    expect(wrapper.find('[data-test-subj="timeType"]').last().prop('value')).toEqual('d');
+
+    wrapper
+      .find('[data-test-subj="interval"]')
+      .last()
+      .simulate('change', { target: { value: '8' } });
+
+    expect(mockField.setValue).toHaveBeenCalledWith('8d');
+  });
+
   it.each([
     [-10, -5],
     [-5, 0],

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/schedule_item_field/schedule_item_field.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/schedule_item_field/schedule_item_field.tsx
@@ -29,7 +29,7 @@ interface ScheduleItemProps {
   isDisabled?: boolean;
   minValue?: number;
   maxValue?: number;
-  timeTypes?: string[];
+  units?: string[];
   fullWidth?: boolean;
 }
 
@@ -47,10 +47,10 @@ export function ScheduleItemField({
   idAria,
   minValue = Number.MIN_SAFE_INTEGER,
   maxValue = Number.MAX_SAFE_INTEGER,
-  timeTypes = DEFAULT_TIME_DURATION_UNITS,
+  units = DEFAULT_TIME_DURATION_UNITS,
   fullWidth = false,
 }: ScheduleItemProps): JSX.Element {
-  const [timeType, setTimeType] = useState(timeTypes[0]);
+  const [timeType, setTimeType] = useState(units[0]);
   const [timeVal, setTimeVal] = useState<number>(0);
   const { isInvalid, errorMessage } = getFieldValidityAndErrorMessage(field);
   const { value, setValue } = field;
@@ -104,7 +104,7 @@ export function ScheduleItemField({
     }
 
     const isNegative = value.startsWith('-');
-    const durationRegexp = new RegExp(`^\\-?(\\d+)(${timeTypes.join('|')})$`);
+    const durationRegexp = new RegExp(`^\\-?(\\d+)(${units.join('|')})$`);
     const durationMatchArray = value.match(durationRegexp);
 
     if (!durationMatchArray) {
@@ -116,7 +116,7 @@ export function ScheduleItemField({
 
     setTimeVal(time);
     setTimeType(unit);
-  }, [timeType, timeTypes, timeVal, value]);
+  }, [timeType, units, timeVal, value]);
 
   const label = useMemo(
     () => (
@@ -148,7 +148,7 @@ export function ScheduleItemField({
           <EuiSelect
             css={timeUnitSelectStyles}
             fullWidth
-            options={timeTypeOptions.filter((type) => timeTypes.includes(type.value))}
+            options={timeTypeOptions.filter((type) => units.includes(type.value))}
             value={timeType}
             onChange={onChangeTimeType}
             disabled={isDisabled}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/schedule_item_field/schedule_item_field.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation/components/schedule_item_field/schedule_item_field.tsx
@@ -84,7 +84,7 @@ export function ScheduleItemField({
 
   const onChangeTimeVal = useCallback<NonNullable<EuiFieldNumberProps['onChange']>>(
     (e) => {
-      const number = parseInt(e.target.value, 10);
+      const number = e.target.value === '' ? minValue : parseInt(e.target.value, 10);
 
       if (Number.isNaN(number)) {
         return;


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/207348**

## Summary
This PR resolves a bug in the editable History Window Size component, which incorrectly displays "0 seconds" as the default value instead of "7 days". The issue was caused by passing an array of units `(['m', 'h', 'd'])` using an incorrect prop name.

Also, I fixed stuck last digit being stuck when trying to remove it
**Before my changes: can't remove or reset the last digit**

https://github.com/user-attachments/assets/3a7d28ea-ea71-4ee8-8805-902bae1dc3c1

**After my changes: value resets to minValue on last digit removal**

https://github.com/user-attachments/assets/1cba36bb-9127-4197-871e-62b978b3612c


Work started on: 22-Jan-2025




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->