### PR TITLE
[HTTP] Revert postValidate isPublicAccess

### DIFF
--- a/src/core/packages/http/router-server-internal/src/route.ts
+++ b/src/core/packages/http/router-server-internal/src/route.ts
@@ -20,6 +20,7 @@ import type {
   IKibanaResponse,
   RouteAccess,
   RouteConfigOptions,
+  PostValidationMetadata,
 } from '@kbn/core-http-server';
 import { isConfigSchema } from '@kbn/config-schema';
 import { isZod } from '@kbn/zod';
@@ -205,10 +206,13 @@ function routeSchemasFromRouteConfig<P, Q, B>(
   }
 }
 
-function getPostValidateEventMetadata(request: AnyKibanaRequest, routeInfo: RouteInfo) {
+function getPostValidateEventMetadata(
+  request: AnyKibanaRequest,
+  routeInfo: RouteInfo
+): PostValidationMetadata {
   return {
     deprecated: routeInfo.deprecated,
     isInternalApiRequest: request.isInternalApiRequest,
-    isPublicAccess: isPublicAccessApiRoute(routeInfo),
+    isPublicAccess: routeInfo.access === 'public',
   };
 }


### PR DESCRIPTION
## Summary

Follow up to #199026
Related to #199616

When working on #199616, we noticed that we counted (and now logged) all the APIs serving http-resources (like the /bundles/ routes).

After discussing #207725 with the team, we went with reverting the calculation of `isPublicAccess`