### PR TITLE
[Fleet] Fix migrating enrollment api keys for space awareness

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/api_keys/enrollment_api_key.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/api_keys/enrollment_api_key.ts
@@ -119,7 +119,10 @@ export async function getEnrollmentAPIKey(
 
     if (spaceId) {
       if (spaceId === DEFAULT_SPACE_ID) {
-        if (body._source?.namespaces && !body._source?.namespaces.includes(DEFAULT_SPACE_ID)) {
+        if (
+          (body._source?.namespaces?.length ?? 0) > 0 &&
+          !body._source?.namespaces?.includes(DEFAULT_SPACE_ID)
+        ) {
           throw new EnrollmentKeyNotFoundError(`Enrollment api key ${id} not found in namespace`);
         }
       } else if (!body._source?.namespaces?.includes(spaceId)) {

--- a/x-pack/test/fleet_api_integration/apis/space_awareness/api_helper.ts
+++ b/x-pack/test/fleet_api_integration/apis/space_awareness/api_helper.ts
@@ -517,7 +517,8 @@ export class SpaceTestApiClient {
       .post(`${this.getBaseUrl(spaceId)}/internal/fleet/enable_space_awareness`)
       .auth(this.auth.username, this.auth.password)
       .set('kbn-xsrf', 'xxxx')
-      .set('elastic-api-version', '1');
+      .set('elastic-api-version', '1')
+      .expect(200);
 
     return res;
   }

--- a/x-pack/test/fleet_api_integration/apis/space_awareness/space_awareness_migration.ts
+++ b/x-pack/test/fleet_api_integration/apis/space_awareness/space_awareness_migration.ts
@@ -123,6 +123,16 @@ export default function (providerContext: FtrProviderContext) {
         expect(policiesTestSpaceIds.length).to.eql(0);
       });
 
+      it('enrollment api keys should be available', async () => {
+        const defaultSpaceEnrollmentApiKeys = await apiClient.getEnrollmentApiKeys();
+        expect(defaultSpaceEnrollmentApiKeys.items.length).to.eql(3);
+
+        await apiClient.getEnrollmentApiKeys(defaultSpaceEnrollmentApiKeys.items[0].id);
+
+        const testSpaceEnrollmentApiKeys = await apiClient.getEnrollmentApiKeys(TEST_SPACE_1);
+        expect(testSpaceEnrollmentApiKeys.items.length).to.eql(0);
+      });
+
       it('package policies should be migrated to the default space', async () => {
         const policiesDefaultSpaceIds = (await apiClient.getPackagePolicies()).items
           .map(({ id }) => id)


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/207559 

Fix the condition to retrieve one enrollment api keys to works with api key created before the migration to space awareness.

## Tests

I added e2e test to cover that change.

You can manually test this by:
* Without space awareness enabled create an agent policy
* Migrate to space awareness (feature flag + API call)
* Verify you can access the enrolmment api key

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->