### PR TITLE
Revert "[ES `body` removal] `@elastic/response-ops` (#204882)"

### DIFF
--- a/src/platform/packages/shared/kbn-alerting-types/search_strategy_types.ts
+++ b/src/platform/packages/shared/kbn-alerting-types/search_strategy_types.ts
@@ -13,7 +13,7 @@ import type {
   QueryDslFieldAndFormat,
   QueryDslQueryContainer,
   SortCombinations,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { Alert } from './alert_type';
 
 export type RuleRegistrySearchRequest = IEsSearchRequest & {

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/apis/search_alerts/search_alerts.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/apis/search_alerts/search_alerts.ts
@@ -20,7 +20,7 @@ import type {
   QueryDslFieldAndFormat,
   QueryDslQueryContainer,
   SortCombinations,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { EsQuerySnapshot, LegacyField } from '../../types';
 
 export interface SearchAlertsParams {

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_get_alerts_group_aggregations_query.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_get_alerts_group_aggregations_query.ts
@@ -16,7 +16,7 @@ import type {
   AggregationsAggregationContainer,
   QueryDslQueryContainer,
   SortCombinations,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { BASE_RAC_ALERTS_API_PATH } from '../constants';
 
 export interface UseGetAlertsGroupAggregationsQueryProps {

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/types.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/types.ts
@@ -11,10 +11,10 @@ import type {
   Script,
   MappingRuntimeField,
   MappingRuntimeFields,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { RuntimeFieldSpec, RuntimePrimitiveTypes } from '@kbn/data-views-plugin/common';
 import type { BoolQuery } from '@kbn/es-query';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 type RunTimeMappings =
   | Record<string, Omit<RuntimeFieldSpec, 'type'> & { type: RuntimePrimitiveTypes }>

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_all/get_all.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/get_all/get_all.ts
@@ -8,7 +8,7 @@
 /**
  * Get all actions with in-memory connectors
  */
-import * as estypes from '@elastic/elasticsearch/lib/api/types';
+import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { AuditLogger } from '@kbn/security-plugin-types-server';
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
 import { omit } from 'lodash';

--- a/x-pack/platform/plugins/shared/actions/server/data/connector/types/params.ts
+++ b/x-pack/platform/plugins/shared/actions/server/data/connector/types/params.ts
@@ -6,7 +6,7 @@
  */
 
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
-import * as estypes from '@elastic/elasticsearch/lib/api/types';
+import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import { SavedObjectsClient } from '@kbn/core/server';
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_execution_log_aggregation.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_execution_log_aggregation.ts
@@ -6,7 +6,7 @@
  */
 
 import { KueryNode } from '@kbn/es-query';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import Boom from '@hapi/boom';
 import { flatMap, get, isEmpty } from 'lodash';
 import { AggregateEventsBySavedObjectResult } from '@kbn/event-log-plugin/server';

--- a/x-pack/platform/plugins/shared/actions/server/monitoring/register_cluster_collector.ts
+++ b/x-pack/platform/plugins/shared/actions/server/monitoring/register_cluster_collector.ts
@@ -7,7 +7,7 @@
 import type {
   AggregationsKeyedPercentiles,
   AggregationsPercentilesAggregateBase,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { MonitoringCollectionSetup } from '@kbn/monitoring-collection-plugin/server';
 import { aggregateTaskOverduePercentilesForType } from '@kbn/task-manager-plugin/server';
 import { CoreSetup } from '@kbn/core/server';

--- a/x-pack/platform/plugins/shared/actions/server/usage/actions_telemetry.ts
+++ b/x-pack/platform/plugins/shared/actions/server/usage/actions_telemetry.ts
@@ -7,7 +7,7 @@
 
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
-import { AggregationsTermsAggregateBase } from '@elastic/elasticsearch/lib/api/types';
+import { AggregationsTermsAggregateBase } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import {
   AvgActionRunOutcomeByConnectorTypeBucket,
   parseActionRunOutcomeByConnectorTypesBucket,

--- a/x-pack/platform/plugins/shared/actions/server/usage/lib/parse_connector_type_bucket.ts
+++ b/x-pack/platform/plugins/shared/actions/server/usage/lib/parse_connector_type_bucket.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { AggregationsBuckets } from '@elastic/elasticsearch/lib/api/types';
+import { AggregationsBuckets } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { replaceFirstAndLastDotSymbols } from '../actions_telemetry';
 
 export interface AvgActionRunOutcomeByConnectorTypeBucket {

--- a/x-pack/platform/plugins/shared/alerting/common/alert_schema/field_maps/mapping_from_field_map.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/alert_schema/field_maps/mapping_from_field_map.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
+import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { set } from '@kbn/safer-lodash-set';
 import type { FieldMap, MultiField } from '@kbn/alerts-as-data-utils';
 

--- a/x-pack/platform/plugins/shared/alerting/common/rule_tags_aggregation.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/rule_tags_aggregation.ts
@@ -8,7 +8,7 @@
 import type {
   AggregationsAggregationContainer,
   AggregationsCompositeAggregation,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { AggregateOptions } from '../server/application/rule/methods/aggregate/types';
 
 export type RuleTagsAggregationOptions = Pick<AggregateOptions, 'filter' | 'search'> & {

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.test.ts
@@ -442,16 +442,18 @@ describe('Alerts Client', () => {
           );
 
           expect(clusterClient.search).toHaveBeenCalledWith({
-            query: {
-              bool: {
-                filter: [
-                  { term: { 'kibana.alert.rule.uuid': '1' } },
-                  { terms: { 'kibana.alert.uuid': ['abc', 'def', 'xyz'] } },
-                ],
+            body: {
+              query: {
+                bool: {
+                  filter: [
+                    { term: { 'kibana.alert.rule.uuid': '1' } },
+                    { terms: { 'kibana.alert.uuid': ['abc', 'def', 'xyz'] } },
+                  ],
+                },
               },
+              seq_no_primary_term: true,
+              size: 3,
             },
-            seq_no_primary_term: true,
-            size: 3,
             index: useDataStreamForAlerts
               ? '.alerts-test.alerts-default'
               : '.internal.alerts-test.alerts-default-*',
@@ -514,16 +516,18 @@ describe('Alerts Client', () => {
           );
 
           expect(clusterClient.search).toHaveBeenCalledWith({
-            query: {
-              bool: {
-                filter: [
-                  { term: { 'kibana.alert.rule.uuid': '1' } },
-                  { terms: { 'kibana.alert.uuid': ['abc'] } },
-                ],
+            body: {
+              query: {
+                bool: {
+                  filter: [
+                    { term: { 'kibana.alert.rule.uuid': '1' } },
+                    { terms: { 'kibana.alert.uuid': ['abc'] } },
+                  ],
+                },
               },
+              size: 1,
+              seq_no_primary_term: true,
             },
-            size: 1,
-            seq_no_primary_term: true,
             index: useDataStreamForAlerts
               ? '.alerts-test.alerts-default'
               : '.internal.alerts-test.alerts-default-*',
@@ -566,7 +570,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 create: { _id: uuid1, ...(useDataStreamForAlerts ? {} : { require_alias: true }) },
               },
@@ -613,7 +617,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: true,
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 create: { _id: uuid1, ...(useDataStreamForAlerts ? {} : { require_alias: true }) },
               },
@@ -706,7 +710,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 index: {
                   _id: 'abc',
@@ -779,7 +783,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 index: {
                   _id: 'abc',
@@ -914,7 +918,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 create: {
                   _id: 'abc',
@@ -987,7 +991,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 index: {
                   _id: 'def',
@@ -1086,7 +1090,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 index: {
                   _id: 'def',
@@ -1243,7 +1247,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 index: {
                   _id: 'def',
@@ -1361,7 +1365,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 index: {
                   _id: 'def',
@@ -1565,7 +1569,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 index: {
                   _id: 'def',
@@ -2536,7 +2540,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 create: { _id: uuid1, ...(useDataStreamForAlerts ? {} : { require_alias: true }) },
               },
@@ -2810,7 +2814,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 create: {
                   _id: expect.any(String),
@@ -2911,7 +2915,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 create: {
                   _id: 'abc',
@@ -3008,7 +3012,7 @@ describe('Alerts Client', () => {
             index: '.alerts-test.alerts-default',
             refresh: 'wait_for',
             require_alias: !useDataStreamForAlerts,
-            operations: [
+            body: [
               {
                 index: {
                   _id: 'abc',

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/alerts_client.ts
@@ -15,7 +15,7 @@ import {
   ALERT_MAINTENANCE_WINDOW_IDS,
 } from '@kbn/rule-data-utils';
 import { chunk, flatMap, get, isEmpty, keys } from 'lodash';
-import { SearchRequest } from '@elastic/elasticsearch/lib/api/types';
+import { SearchRequest } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { Alert } from '@kbn/alerts-as-data-utils';
 import { DEFAULT_NAMESPACE_STRING } from '@kbn/core-saved-objects-utils-server';
 import { DeepPartial } from '@kbn/utility-types';
@@ -231,7 +231,7 @@ export class AlertsClient<
   }
 
   public async search<Aggregation = unknown>(
-    queryBody: SearchRequest
+    queryBody: SearchRequest['body']
   ): Promise<SearchResult<AlertData, Aggregation>> {
     const esClient = await this.options.elasticsearchClientPromise;
     const index = this.isUsingDataStreams()
@@ -242,7 +242,7 @@ export class AlertsClient<
       aggregations,
     } = await esClient.search<Alert & AlertData, Aggregation>({
       index,
-      ...queryBody,
+      body: queryBody,
       ignore_unavailable: true,
     });
 
@@ -568,7 +568,7 @@ export class AlertsClient<
           refresh: this.isServerless ? true : 'wait_for',
           index: this.indexTemplateAndPattern.alias,
           require_alias: !this.isUsingDataStreams(),
-          operations: bulkBody,
+          body: bulkBody,
         });
 
         // If there were individual indexing errors, they will be returned in the success response

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_summarized_alerts_query.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_summarized_alerts_query.ts
@@ -10,7 +10,7 @@ import {
   SearchRequest,
   SearchTotalHits,
   AggregationsAggregationContainer,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { BoolQuery } from '@kbn/es-query';
 import {
   ALERT_END,
@@ -53,7 +53,7 @@ const getLifecycleAlertsQueryByExecutionUuid = ({
   ruleId,
   excludedAlertInstanceIds,
   alertsFilter,
-}: GetLifecycleAlertsQueryByExecutionUuidParams): SearchRequest[] => {
+}: GetLifecycleAlertsQueryByExecutionUuidParams): Array<SearchRequest['body']> => {
   // lifecycle alerts assign a different action to an alert depending
   // on whether it is new/ongoing/recovered. query for each action in order
   // to get the count of each action type as well as up to the maximum number
@@ -89,7 +89,7 @@ const getLifecycleAlertsQueryByTimeRange = ({
   ruleId,
   excludedAlertInstanceIds,
   alertsFilter,
-}: GetLifecycleAlertsQueryByTimeRangeParams): SearchRequest[] => {
+}: GetLifecycleAlertsQueryByTimeRangeParams): Array<SearchRequest['body']> => {
   return [
     getQueryByTimeRange({
       start,
@@ -124,7 +124,7 @@ const getQueryByExecutionUuid = ({
   excludedAlertInstanceIds,
   action,
   alertsFilter,
-}: GetQueryByExecutionUuidParams): SearchRequest => {
+}: GetQueryByExecutionUuidParams): SearchRequest['body'] => {
   const filter: QueryDslQueryContainer[] = [
     {
       term: {
@@ -187,7 +187,7 @@ const getQueryByTimeRange = ({
   excludedAlertInstanceIds,
   type,
   alertsFilter,
-}: GetQueryByTimeRangeParams<AlertTypes>): SearchRequest => {
+}: GetQueryByTimeRangeParams<AlertTypes>): SearchRequest['body'] => {
   // base query filters the alert documents for a rule by the given time range
   let filter: QueryDslQueryContainer[] = [
     {
@@ -282,7 +282,7 @@ export const getQueryByScopedQueries = ({
   ruleId,
   action,
   maintenanceWindows,
-}: GetQueryByScopedQueriesParams): SearchRequest => {
+}: GetQueryByScopedQueriesParams): SearchRequest['body'] => {
   const filters: QueryDslQueryContainer[] = [
     {
       term: {
@@ -460,7 +460,7 @@ const getLifecycleAlertsQueries = ({
   ruleId,
   excludedAlertInstanceIds,
   alertsFilter,
-}: GetAlertsQueryParams): SearchRequest[] => {
+}: GetAlertsQueryParams): Array<SearchRequest['body']> => {
   let queryBodies;
   if (!!executionUuid) {
     queryBodies = getLifecycleAlertsQueryByExecutionUuid({
@@ -489,7 +489,7 @@ const getContinualAlertsQuery = ({
   ruleId,
   excludedAlertInstanceIds,
   alertsFilter,
-}: GetAlertsQueryParams): SearchRequest => {
+}: GetAlertsQueryParams): SearchRequest['body'] => {
   let queryBody;
   if (!!executionUuid) {
     queryBody = getQueryByExecutionUuid({
@@ -516,7 +516,7 @@ const getMaintenanceWindowAlertsQuery = ({
   ruleId,
   action,
   maintenanceWindows,
-}: GetMaintenanceWindowAlertsQueryParams): SearchRequest => {
+}: GetMaintenanceWindowAlertsQueryParams): SearchRequest['body'] => {
   return getQueryByScopedQueries({
     executionUuid,
     ruleId,

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/inject_analyze_wildcard.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/inject_analyze_wildcard.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 export const injectAnalyzeWildcard = (query: QueryDslQueryContainer): void => {
   if (!query) {

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/sanitize_bulk_response.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/sanitize_bulk_response.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import { TransportResult } from '@elastic/elasticsearch';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { sanitizeBulkErrorResponse } from './sanitize_bulk_response';
 
 // Using https://www.elastic.co/guide/en/elasticsearch/reference/8.11/docs-bulk.html

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/sanitize_bulk_response.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/sanitize_bulk_response.ts
@@ -8,7 +8,7 @@ import { cloneDeep } from 'lodash';
 import { TransportResult } from '@elastic/elasticsearch';
 import { get } from 'lodash';
 import { set } from '@kbn/safer-lodash-set';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 export const sanitizeBulkErrorResponse = (
   response: TransportResult<estypes.BulkResponse, unknown> | estypes.BulkResponse

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/default_lifecycle_policy.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/default_lifecycle_policy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { IlmPolicy } from '@elastic/elasticsearch/lib/api/types';
+import { IlmPolicy } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 /**
  * Default alert index ILM policy

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_concrete_write_index.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_concrete_write_index.test.ts
@@ -6,7 +6,7 @@
  */
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
 import { errors as EsErrors } from '@elastic/elasticsearch';
-import { IndicesGetDataStreamResponse } from '@elastic/elasticsearch/lib/api/types';
+import { IndicesGetDataStreamResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { createConcreteWriteIndex, setConcreteWriteIndex } from './create_concrete_write_index';
 import { getDataStreamAdapter } from './data_stream_adapter';
 
@@ -95,9 +95,11 @@ describe('createConcreteWriteIndex', () => {
         } else {
           expect(clusterClient.indices.create).toHaveBeenCalledWith({
             index: '.internal.alerts-test.alerts-default-000001',
-            aliases: {
-              '.alerts-test.alerts-default': {
-                is_write_index: true,
+            body: {
+              aliases: {
+                '.alerts-test.alerts-default': {
+                  is_write_index: true,
+                },
               },
             },
           });
@@ -307,9 +309,11 @@ describe('createConcreteWriteIndex', () => {
         } else {
           expect(clusterClient.indices.create).toHaveBeenCalledWith({
             index: '.internal.alerts-test.alerts-default-000001',
-            aliases: {
-              '.alerts-test.alerts-default': {
-                is_write_index: true,
+            body: {
+              aliases: {
+                '.alerts-test.alerts-default': {
+                  is_write_index: true,
+                },
               },
             },
           });
@@ -355,9 +359,11 @@ describe('createConcreteWriteIndex', () => {
         if (!useDataStream) {
           expect(clusterClient.indices.create).toHaveBeenCalledWith({
             index: '.internal.alerts-test.alerts-default-000001',
-            aliases: {
-              '.alerts-test.alerts-default': {
-                is_write_index: true,
+            body: {
+              aliases: {
+                '.alerts-test.alerts-default': {
+                  is_write_index: true,
+                },
               },
             },
           });
@@ -393,9 +399,11 @@ describe('createConcreteWriteIndex', () => {
         if (!useDataStream) {
           expect(clusterClient.indices.create).toHaveBeenCalledWith({
             index: '.internal.alerts-test.alerts-default-000001',
-            aliases: {
-              '.alerts-test.alerts-default': {
-                is_write_index: true,
+            body: {
+              aliases: {
+                '.alerts-test.alerts-default': {
+                  is_write_index: true,
+                },
               },
             },
           });
@@ -623,9 +631,11 @@ describe('createConcreteWriteIndex', () => {
         } else {
           expect(clusterClient.indices.create).toHaveBeenCalledWith({
             index: '.internal.alerts-test.alerts-default-000001',
-            aliases: {
-              '.alerts-test.alerts-default': {
-                is_write_index: true,
+            body: {
+              aliases: {
+                '.alerts-test.alerts-default': {
+                  is_write_index: true,
+                },
               },
             },
           });
@@ -660,9 +670,11 @@ describe('createConcreteWriteIndex', () => {
         } else {
           expect(clusterClient.indices.create).toHaveBeenCalledWith({
             index: '.internal.alerts-test.alerts-default-000001',
-            aliases: {
-              '.alerts-test.alerts-default': {
-                is_write_index: true,
+            body: {
+              aliases: {
+                '.alerts-test.alerts-default': {
+                  is_write_index: true,
+                },
               },
             },
           });
@@ -744,21 +756,23 @@ describe('setConcreteWriteIndex', () => {
       'Attempting to set index: .internal.alerts-test.alerts-default-000004 as the write index for alias: .alerts-test.alerts-default.'
     );
     expect(clusterClient.indices.updateAliases).toHaveBeenCalledWith({
-      actions: [
-        {
-          remove: {
-            alias: '.alerts-test.alerts-default',
-            index: '.internal.alerts-test.alerts-default-000004',
+      body: {
+        actions: [
+          {
+            remove: {
+              alias: '.alerts-test.alerts-default',
+              index: '.internal.alerts-test.alerts-default-000004',
+            },
           },
-        },
-        {
-          add: {
-            alias: '.alerts-test.alerts-default',
-            index: '.internal.alerts-test.alerts-default-000004',
-            is_write_index: true,
+          {
+            add: {
+              alias: '.alerts-test.alerts-default',
+              index: '.internal.alerts-test.alerts-default-000004',
+              is_write_index: true,
+            },
           },
-        },
-      ],
+        ],
+      },
     });
     expect(logger.info).toHaveBeenCalledWith(
       'Successfully set index: .internal.alerts-test.alerts-default-000004 as the write index for alias: .alerts-test.alerts-default.'

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_concrete_write_index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_concrete_write_index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { IndicesSimulateIndexTemplateResponse } from '@elastic/elasticsearch/lib/api/types';
+import { IndicesSimulateIndexTemplateResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Logger, ElasticsearchClient } from '@kbn/core/server';
 import { get, sortBy } from 'lodash';
 import { IIndexPatternString } from '../resource_installer_utils';
@@ -45,7 +45,7 @@ const updateTotalFieldLimitSetting = async ({
       () =>
         esClient.indices.putSettings({
           index,
-          settings: { 'index.mapping.total_fields.limit': totalFieldsLimit },
+          body: { 'index.mapping.total_fields.limit': totalFieldsLimit },
         }),
       { logger }
     );
@@ -90,7 +90,7 @@ const updateUnderlyingMapping = async ({
 
   try {
     await retryTransientEsErrors(
-      () => esClient.indices.putMapping({ index, ...simulatedMapping }),
+      () => esClient.indices.putMapping({ index, body: simulatedMapping }),
       { logger }
     );
 
@@ -183,16 +183,18 @@ export async function setConcreteWriteIndex(opts: SetConcreteWriteIndexOpts) {
     await retryTransientEsErrors(
       () =>
         esClient.indices.updateAliases({
-          actions: [
-            { remove: { index: concreteIndex.index, alias: concreteIndex.alias } },
-            {
-              add: {
-                index: concreteIndex.index,
-                alias: concreteIndex.alias,
-                is_write_index: true,
+          body: {
+            actions: [
+              { remove: { index: concreteIndex.index, alias: concreteIndex.alias } },
+              {
+                add: {
+                  index: concreteIndex.index,
+                  alias: concreteIndex.alias,
+                  is_write_index: true,
+                },
               },
-            },
-          ],
+            ],
+          },
         }),
       { logger }
     );

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_component_template.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_component_template.test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 import { elasticsearchServiceMock, loggingSystemMock } from '@kbn/core/server/mocks';
-import { ClusterPutComponentTemplateRequest } from '@elastic/elasticsearch/lib/api/types';
 import { errors as EsErrors } from '@elastic/elasticsearch';
 import { createOrUpdateComponentTemplate } from './create_or_update_component_template';
 import { elasticsearchClientMock } from '@kbn/core-elasticsearch-client-server-mocks';
@@ -14,7 +13,7 @@ const randomDelayMultiplier = 0.01;
 const logger = loggingSystemMock.createLogger();
 const clusterClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
-const ComponentTemplate: ClusterPutComponentTemplateRequest = {
+const ComponentTemplate = {
   name: 'test-mappings',
   _meta: {
     managed: true,
@@ -177,12 +176,14 @@ describe('createOrUpdateComponentTemplate', () => {
     expect(clusterClient.indices.putIndexTemplate).toHaveBeenCalledTimes(1);
     expect(clusterClient.indices.putIndexTemplate).toHaveBeenCalledWith({
       name: existingIndexTemplate.name,
-      ...existingIndexTemplate.index_template,
-      template: {
-        ...existingIndexTemplate.index_template.template,
-        settings: {
-          ...existingIndexTemplate.index_template.template?.settings,
-          'index.mapping.total_fields.limit': 2500,
+      body: {
+        ...existingIndexTemplate.index_template,
+        template: {
+          ...existingIndexTemplate.index_template.template,
+          settings: {
+            ...existingIndexTemplate.index_template.template?.settings,
+            'index.mapping.total_fields.limit': 2500,
+          },
         },
       },
     });
@@ -281,12 +282,14 @@ describe('createOrUpdateComponentTemplate', () => {
     expect(clusterClient.indices.putIndexTemplate).toHaveBeenCalledTimes(1);
     expect(clusterClient.indices.putIndexTemplate).toHaveBeenCalledWith({
       name: existingIndexTemplate.name,
-      ...existingIndexTemplate.index_template,
-      template: {
-        ...existingIndexTemplate.index_template.template,
-        settings: {
-          ...existingIndexTemplate.index_template.template?.settings,
-          'index.mapping.total_fields.limit': 2500,
+      body: {
+        ...existingIndexTemplate.index_template,
+        template: {
+          ...existingIndexTemplate.index_template.template,
+          settings: {
+            ...existingIndexTemplate.index_template.template?.settings,
+            'index.mapping.total_fields.limit': 2500,
+          },
         },
       },
     });

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_component_template.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_component_template.ts
@@ -8,7 +8,7 @@
 import {
   ClusterPutComponentTemplateRequest,
   IndicesGetIndexTemplateIndexTemplateItem,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Logger, ElasticsearchClient } from '@kbn/core/server';
 import { asyncForEach } from '@kbn/std';
 import { retryTransientEsErrors } from './retry_transient_es_errors';
@@ -50,12 +50,14 @@ const getIndexTemplatesUsingComponentTemplate = async (
         () =>
           esClient.indices.putIndexTemplate({
             name: template.name,
-            ...template.index_template,
-            template: {
-              ...template.index_template.template,
-              settings: {
-                ...template.index_template.template?.settings,
-                'index.mapping.total_fields.limit': totalFieldsLimit,
+            body: {
+              ...template.index_template,
+              template: {
+                ...template.index_template.template,
+                settings: {
+                  ...template.index_template.template?.settings,
+                  'index.mapping.total_fields.limit': totalFieldsLimit,
+                },
               },
             },
           }),

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_ilm_policy.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_ilm_policy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { IlmPolicy } from '@elastic/elasticsearch/lib/api/types';
+import { IlmPolicy } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Logger, ElasticsearchClient } from '@kbn/core/server';
 import { retryTransientEsErrors } from './retry_transient_es_errors';
 import { DataStreamAdapter } from './data_stream_adapter';

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_index_template.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_index_template.test.ts
@@ -16,42 +16,44 @@ const clusterClient = elasticsearchServiceMock.createClusterClient().asInternalU
 
 const IndexTemplate = (namespace: string = 'default', useDataStream: boolean = false) => ({
   name: `.alerts-test.alerts-${namespace}-index-template`,
-  _meta: {
-    kibana: {
-      version: '8.6.1',
-    },
-    managed: true,
-    namespace,
-  },
-  composed_of: ['mappings1', 'framework-mappings'],
-  index_patterns: [`.internal.alerts-test.alerts-${namespace}-*`],
-  template: {
-    mappings: {
-      _meta: {
-        kibana: {
-          version: '8.6.1',
-        },
-        managed: true,
-        namespace,
+  body: {
+    _meta: {
+      kibana: {
+        version: '8.6.1',
       },
-      dynamic: false,
+      managed: true,
+      namespace,
     },
-    settings: {
-      auto_expand_replicas: '0-1',
-      hidden: true,
-      ...(useDataStream
-        ? {}
-        : {
-            'index.lifecycle': {
-              name: 'test-ilm-policy',
-              rollover_alias: `.alerts-test.alerts-${namespace}`,
-            },
-          }),
-      'index.mapping.ignore_malformed': true,
-      'index.mapping.total_fields.limit': 2500,
+    composed_of: ['mappings1', 'framework-mappings'],
+    index_patterns: [`.internal.alerts-test.alerts-${namespace}-*`],
+    template: {
+      mappings: {
+        _meta: {
+          kibana: {
+            version: '8.6.1',
+          },
+          managed: true,
+          namespace,
+        },
+        dynamic: false,
+      },
+      settings: {
+        auto_expand_replicas: '0-1',
+        hidden: true,
+        ...(useDataStream
+          ? {}
+          : {
+              'index.lifecycle': {
+                name: 'test-ilm-policy',
+                rollover_alias: `.alerts-test.alerts-${namespace}`,
+              },
+            }),
+        'index.mapping.ignore_malformed': true,
+        'index.mapping.total_fields.limit': 2500,
+      },
     },
+    priority: namespace.length,
   },
-  priority: namespace.length,
 });
 
 const SimulateTemplateResponse = {

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_index_template.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/create_or_update_index_template.ts
@@ -9,7 +9,7 @@ import {
   IndicesPutIndexTemplateRequest,
   MappingTypeMapping,
   Metadata,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Logger, ElasticsearchClient } from '@kbn/core/server';
 import { isEmpty } from 'lodash';
 import { IIndexPatternString } from '../resource_installer_utils';
@@ -57,40 +57,42 @@ export const getIndexTemplate = ({
 
   return {
     name: indexPatterns.template,
-    ...(dataStreamFields.data_stream ? { data_stream: dataStreamFields.data_stream } : {}),
-    index_patterns: dataStreamFields.index_patterns,
-    composed_of: componentTemplateRefs,
-    template: {
-      settings: {
-        auto_expand_replicas: '0-1',
-        hidden: true,
-        ...(dataStreamAdapter.isUsingDataStreams()
-          ? {}
-          : {
-              'index.lifecycle': indexLifecycle,
-            }),
-        'index.mapping.ignore_malformed': true,
-        'index.mapping.total_fields.limit': totalFieldsLimit,
-      },
-      mappings: {
-        dynamic: false,
-        _meta: indexMetadata,
-      },
-      ...(indexPatterns.secondaryAlias
-        ? {
-            aliases: {
-              [indexPatterns.secondaryAlias]: {
-                is_write_index: false,
+    body: {
+      ...(dataStreamFields.data_stream ? { data_stream: dataStreamFields.data_stream } : {}),
+      index_patterns: dataStreamFields.index_patterns,
+      composed_of: componentTemplateRefs,
+      template: {
+        settings: {
+          auto_expand_replicas: '0-1',
+          hidden: true,
+          ...(dataStreamAdapter.isUsingDataStreams()
+            ? {}
+            : {
+                'index.lifecycle': indexLifecycle,
+              }),
+          'index.mapping.ignore_malformed': true,
+          'index.mapping.total_fields.limit': totalFieldsLimit,
+        },
+        mappings: {
+          dynamic: false,
+          _meta: indexMetadata,
+        },
+        ...(indexPatterns.secondaryAlias
+          ? {
+              aliases: {
+                [indexPatterns.secondaryAlias]: {
+                  is_write_index: false,
+                },
               },
-            },
-          }
-        : {}),
-    },
-    _meta: indexMetadata,
+            }
+          : {}),
+      },
+      _meta: indexMetadata,
 
-    // By setting the priority to namespace.length, we ensure that if one namespace is a prefix of another namespace
-    // then newly created indices will use the matching template with the *longest* namespace
-    priority: namespace.length,
+      // By setting the priority to namespace.length, we ensure that if one namespace is a prefix of another namespace
+      // then newly created indices will use the matching template with the *longest* namespace
+      priority: namespace.length,
+    },
   };
 };
 

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/data_stream_adapter.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/data_stream_adapter.ts
@@ -208,9 +208,11 @@ async function createAliasStream(opts: CreateConcreteWriteIndexOpts): Promise<vo
         () =>
           esClient.indices.create({
             index: indexPatterns.name,
-            aliases: {
-              [indexPatterns.alias]: {
-                is_write_index: true,
+            body: {
+              aliases: {
+                [indexPatterns.alias]: {
+                  is_write_index: true,
+                },
               },
             },
           }),

--- a/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
@@ -59,45 +59,42 @@ describe('setAlertsToUntracked()', () => {
       Array [
         Object {
           "allow_no_indices": true,
-          "conflicts": "proceed",
-          "index": Array [
-            "test-index",
-          ],
-          "query": Object {
-            "bool": Object {
-              "must": Array [
-                Object {
-                  "term": Object {
-                    "kibana.alert.status": Object {
-                      "value": "active",
+          "body": Object {
+            "conflicts": "proceed",
+            "query": Object {
+              "bool": Object {
+                "must": Array [
+                  Object {
+                    "term": Object {
+                      "kibana.alert.status": Object {
+                        "value": "active",
+                      },
                     },
                   },
-                },
-                Object {
-                  "bool": Object {
-                    "should": Array [
-                      Object {
-                        "term": Object {
-                          "kibana.alert.rule.uuid": Object {
-                            "value": "test-rule",
+                  Object {
+                    "bool": Object {
+                      "should": Array [
+                        Object {
+                          "term": Object {
+                            "kibana.alert.rule.uuid": Object {
+                              "value": "test-rule",
+                            },
                           },
                         },
-                      },
-                    ],
+                      ],
+                    },
                   },
-                },
-                Object {
-                  "bool": Object {
-                    "should": Array [],
+                  Object {
+                    "bool": Object {
+                      "should": Array [],
+                    },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-          "refresh": true,
-          "script": Object {
-            "lang": "painless",
-            "source": "
+            "script": Object {
+              "lang": "painless",
+              "source": "
       if (!ctx._source.containsKey('kibana.alert.status') || ctx._source['kibana.alert.status'].empty) {
         ctx._source.kibana.alert.status = 'untracked';
         ctx._source.kibana.alert.end = '2023-03-28T22:27:28.159Z';
@@ -107,7 +104,12 @@ describe('setAlertsToUntracked()', () => {
         ctx._source['kibana.alert.end'] = '2023-03-28T22:27:28.159Z';
         ctx._source['kibana.alert.time_range'].lte = '2023-03-28T22:27:28.159Z';
       }",
+            },
           },
+          "index": Array [
+            "test-index",
+          ],
+          "refresh": true,
         },
       ]
     `);
@@ -126,45 +128,42 @@ describe('setAlertsToUntracked()', () => {
       Array [
         Object {
           "allow_no_indices": true,
-          "conflicts": "proceed",
-          "index": Array [
-            "test-index",
-          ],
-          "query": Object {
-            "bool": Object {
-              "must": Array [
-                Object {
-                  "term": Object {
-                    "kibana.alert.status": Object {
-                      "value": "active",
+          "body": Object {
+            "conflicts": "proceed",
+            "query": Object {
+              "bool": Object {
+                "must": Array [
+                  Object {
+                    "term": Object {
+                      "kibana.alert.status": Object {
+                        "value": "active",
+                      },
                     },
                   },
-                },
-                Object {
-                  "bool": Object {
-                    "should": Array [],
+                  Object {
+                    "bool": Object {
+                      "should": Array [],
+                    },
                   },
-                },
-                Object {
-                  "bool": Object {
-                    "should": Array [
-                      Object {
-                        "term": Object {
-                          "kibana.alert.uuid": Object {
-                            "value": "test-alert",
+                  Object {
+                    "bool": Object {
+                      "should": Array [
+                        Object {
+                          "term": Object {
+                            "kibana.alert.uuid": Object {
+                              "value": "test-alert",
+                            },
                           },
                         },
-                      },
-                    ],
+                      ],
+                    },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-          "refresh": true,
-          "script": Object {
-            "lang": "painless",
-            "source": "
+            "script": Object {
+              "lang": "painless",
+              "source": "
       if (!ctx._source.containsKey('kibana.alert.status') || ctx._source['kibana.alert.status'].empty) {
         ctx._source.kibana.alert.status = 'untracked';
         ctx._source.kibana.alert.end = '2023-03-28T22:27:28.159Z';
@@ -174,7 +173,12 @@ describe('setAlertsToUntracked()', () => {
         ctx._source['kibana.alert.end'] = '2023-03-28T22:27:28.159Z';
         ctx._source['kibana.alert.time_range'].lte = '2023-03-28T22:27:28.159Z';
       }",
+            },
           },
+          "index": Array [
+            "test-index",
+          ],
+          "refresh": true,
         },
       ]
     `);
@@ -453,59 +457,63 @@ describe('setAlertsToUntracked()', () => {
 
     expect(clusterClient.updateByQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        query: {
-          bool: {
-            must: [
-              {
-                term: {
-                  'kibana.alert.status': {
-                    value: 'active', // This has to be active
-                  },
-                },
-              },
-            ],
-            filter: [
-              {
-                bool: {
-                  must: {
-                    term: {
-                      'kibana.alert.rule.name': 'test',
+        body: expect.objectContaining({
+          query: {
+            bool: {
+              must: [
+                {
+                  term: {
+                    'kibana.alert.status': {
+                      value: 'active', // This has to be active
                     },
                   },
                 },
-              },
-            ],
+              ],
+              filter: [
+                {
+                  bool: {
+                    must: {
+                      term: {
+                        'kibana.alert.rule.name': 'test',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
           },
-        },
+        }),
       })
     );
 
     expect(clusterClient.search).toHaveBeenCalledWith(
       expect.objectContaining({
-        query: {
-          bool: {
-            must: [
-              {
-                term: {
-                  'kibana.alert.status': {
-                    value: 'untracked', // This has to be untracked
-                  },
-                },
-              },
-            ],
-            filter: [
-              {
-                bool: {
-                  must: {
-                    term: {
-                      'kibana.alert.rule.name': 'test',
+        body: expect.objectContaining({
+          query: {
+            bool: {
+              must: [
+                {
+                  term: {
+                    'kibana.alert.status': {
+                      value: 'untracked', // This has to be untracked
                     },
                   },
                 },
-              },
-            ],
+              ],
+              filter: [
+                {
+                  bool: {
+                    must: {
+                      term: {
+                        'kibana.alert.rule.name': 'test',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
           },
-        },
+        }),
       })
     );
 
@@ -588,30 +596,32 @@ describe('setAlertsToUntracked()', () => {
 
     expect(clusterClient.updateByQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        query: {
-          bool: {
-            must: [
-              {
-                term: {
-                  'kibana.alert.status': {
-                    value: 'active', // This has to be active
-                  },
-                },
-              },
-            ],
-            filter: [
-              {
-                bool: {
-                  must: {
-                    term: {
-                      'kibana.alert.rule.name': 'test',
+        body: expect.objectContaining({
+          query: {
+            bool: {
+              must: [
+                {
+                  term: {
+                    'kibana.alert.status': {
+                      value: 'active', // This has to be active
                     },
                   },
                 },
-              },
-            ],
+              ],
+              filter: [
+                {
+                  bool: {
+                    must: {
+                      term: {
+                        'kibana.alert.rule.name': 'test',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
           },
-        },
+        }),
       })
     );
 

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/aggregate/types/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/aggregate/types/index.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { TypeOf } from '@kbn/config-schema';
 import { KueryNode } from '@kbn/es-query';
 import { aggregateOptionsSchema } from '../schemas';

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/aggregate/validation/validate_rule_aggregation_fields.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/aggregate/validation/validate_rule_aggregation_fields.ts
@@ -6,7 +6,7 @@
  */
 
 import Boom from '@hapi/boom';
-import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 const ALLOW_FIELDS = [
   'alert.attributes.executionStatus.status',

--- a/x-pack/platform/plugins/shared/alerting/server/authorization/alerting_authorization_kuery.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/authorization/alerting_authorization_kuery.ts
@@ -8,7 +8,7 @@
 import { remove } from 'lodash';
 import { EsQueryConfig, nodeBuilder, toElasticsearchQuery, KueryNode } from '@kbn/es-query';
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { AuthorizedRuleTypes } from './alerting_authorization';
 
 export enum AlertingAuthorizationFilterType {

--- a/x-pack/platform/plugins/shared/alerting/server/invalidate_pending_api_keys/task.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/invalidate_pending_api_keys/task.ts
@@ -21,7 +21,7 @@ import {
 import {
   AggregationsStringTermsBucketKeys,
   AggregationsTermsAggregateBase,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ACTION_TASK_PARAMS_SAVED_OBJECT_TYPE } from '@kbn/actions-plugin/server/constants/saved_objects';
 import { InvalidateAPIKeyResult } from '../rules_client';
 import { AlertingConfig } from '../config';

--- a/x-pack/platform/plugins/shared/alerting/server/lib/convert_es_sort_to_event_log_sort.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/convert_es_sort_to_event_log_sort.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import type { Sort, FieldSort, SortCombinations } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  Sort,
+  FieldSort,
+  SortCombinations,
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 const getFormattedSort = (sort: SortCombinations) => {
   if (typeof sort === 'string') {

--- a/x-pack/platform/plugins/shared/alerting/server/lib/get_execution_log_aggregation.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/get_execution_log_aggregation.ts
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { KueryNode } from '@kbn/es-query';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import Boom from '@hapi/boom';
 import { flatMap, get, isEmpty } from 'lodash';
 import { AggregateEventsBySavedObjectResult } from '@kbn/event-log-plugin/server';

--- a/x-pack/platform/plugins/shared/alerting/server/lib/wrap_scoped_cluster_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/wrap_scoped_cluster_client.test.ts
@@ -11,7 +11,7 @@ import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import { createWrappedScopedClusterClientFactory } from './wrap_scoped_cluster_client';
 
 const esQuery = {
-  query: { bool: { filter: { range: { '@timestamp': { gte: 0 } } } } },
+  body: { query: { bool: { filter: { range: { '@timestamp': { gte: 0 } } } } } },
 };
 const eqlQuery = {
   index: 'foo',
@@ -20,7 +20,9 @@ const eqlQuery = {
 const esqlQueryRequest = {
   method: 'POST',
   path: '/_query',
-  query: 'from .kibana_task_manager',
+  body: {
+    query: 'from .kibana_task_manager',
+  },
 };
 
 let logger = loggingSystemMock.create().get();
@@ -71,7 +73,7 @@ describe('wrapScopedClusterClient', () => {
       expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
       expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
       expect(loggingSystemMock.collect(logger).debug[0][0]).toEqual(
-        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}} - with options {} and 5000ms requestTimeout`
+        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"body\":{\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}}} - with options {} and 5000ms requestTimeout`
       );
       expect(loggingSystemMock.collect(logger).trace[0][0]).toEqual(
         `result of executing query for rule .test-rule-type:abcdefg in space my-space: {\"body\":{},\"statusCode\":200,\"headers\":{\"x-elastic-product\":\"Elasticsearch\"},\"warnings\":[],\"meta\":{}}`
@@ -100,7 +102,7 @@ describe('wrapScopedClusterClient', () => {
       expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
       expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
       expect(loggingSystemMock.collect(logger).debug[0][0]).toEqual(
-        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}} - with options {} and 5000ms requestTimeout`
+        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"body\":{\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}}} - with options {} and 5000ms requestTimeout`
       );
       expect(loggingSystemMock.collect(logger).trace[0][0]).toEqual(
         `result of executing query for rule .test-rule-type:abcdefg in space my-space: {\"body\":{},\"statusCode\":200,\"headers\":{\"x-elastic-product\":\"Elasticsearch\"},\"warnings\":[],\"meta\":{}}`
@@ -134,7 +136,7 @@ describe('wrapScopedClusterClient', () => {
       expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
 
       expect(loggingSystemMock.collect(logger).debug[0][0]).toEqual(
-        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}} - with options {\"ignore\":[404],\"requestTimeout\":10000} and 5000ms requestTimeout`
+        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"body\":{\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}}} - with options {\"ignore\":[404],\"requestTimeout\":10000} and 5000ms requestTimeout`
       );
       expect(loggingSystemMock.collect(logger).trace[0][0]).toEqual(
         `result of executing query for rule .test-rule-type:abcdefg in space my-space: {\"body\":{},\"statusCode\":200,\"headers\":{\"x-elastic-product\":\"Elasticsearch\"},\"warnings\":[],\"meta\":{}}`
@@ -159,11 +161,11 @@ describe('wrapScopedClusterClient', () => {
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"something went wrong!"`);
 
       expect(loggingSystemMock.collect(logger).debug[0][0]).toEqual(
-        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}} - with options {}`
+        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"body\":{\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}}} - with options {}`
       );
       expect(logger.trace).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
-        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}} - with options {}`
+        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"body\":{\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}}} - with options {}`
       );
     });
 
@@ -193,7 +195,7 @@ describe('wrapScopedClusterClient', () => {
       expect(stats.esSearchDurationMs).toEqual(0);
 
       expect(loggingSystemMock.collect(logger).debug[0][0]).toEqual(
-        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}} - with options {}`
+        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"body\":{\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}}} - with options {}`
       );
       expect(loggingSystemMock.collect(logger).trace[0][0]).toEqual(
         `result of executing query for rule .test-rule-type:abcdefg in space my-space: {}`
@@ -228,7 +230,7 @@ describe('wrapScopedClusterClient', () => {
       expect(stats.esSearchDurationMs).toEqual(999);
 
       expect(loggingSystemMock.collect(logger).debug[0][0]).toEqual(
-        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}} - with options {}`
+        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"body\":{\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}}} - with options {}`
       );
       expect(loggingSystemMock.collect(logger).trace[0][0]).toEqual(
         `result of executing query for rule .test-rule-type:abcdefg in space my-space: {\"took\":333}`
@@ -256,7 +258,7 @@ describe('wrapScopedClusterClient', () => {
       );
 
       expect(loggingSystemMock.collect(logger).debug[0][0]).toEqual(
-        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}} - with options {}`
+        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"body\":{\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}}} - with options {}`
       );
       expect(logger.trace).not.toHaveBeenCalled();
       expect(logger.warn).not.toHaveBeenCalled();
@@ -457,7 +459,7 @@ describe('wrapScopedClusterClient', () => {
         expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
 
         expect(loggingSystemMock.collect(logger).debug[0][0]).toEqual(
-          'executing ES|QL query for rule .test-rule-type:abcdefg in space my-space - {"method":"POST","path":"/_query","query":"from .kibana_task_manager"} - with options {} and 5000ms requestTimeout'
+          'executing ES|QL query for rule .test-rule-type:abcdefg in space my-space - {"method":"POST","path":"/_query","body":{"query":"from .kibana_task_manager"}} - with options {} and 5000ms requestTimeout'
         );
         expect(logger.warn).not.toHaveBeenCalled();
       });
@@ -483,7 +485,7 @@ describe('wrapScopedClusterClient', () => {
         expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
         expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
         expect(loggingSystemMock.collect(logger).debug[0][0]).toEqual(
-          'executing ES|QL query for rule .test-rule-type:abcdefg in space my-space - {"method":"POST","path":"/_query","query":"from .kibana_task_manager"} - with options {} and 5000ms requestTimeout'
+          'executing ES|QL query for rule .test-rule-type:abcdefg in space my-space - {"method":"POST","path":"/_query","body":{"query":"from .kibana_task_manager"}} - with options {} and 5000ms requestTimeout'
         );
         expect(logger.warn).not.toHaveBeenCalled();
       });
@@ -514,7 +516,7 @@ describe('wrapScopedClusterClient', () => {
         expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
 
         expect(loggingSystemMock.collect(logger).debug[0][0]).toEqual(
-          'executing ES|QL query for rule .test-rule-type:abcdefg in space my-space - {"method":"POST","path":"/_query","query":"from .kibana_task_manager"} - with options {"ignore":[404],"requestTimeout":10000} and 5000ms requestTimeout'
+          'executing ES|QL query for rule .test-rule-type:abcdefg in space my-space - {"method":"POST","path":"/_query","body":{"query":"from .kibana_task_manager"}} - with options {"ignore":[404],"requestTimeout":10000} and 5000ms requestTimeout'
         );
         expect(logger.warn).not.toHaveBeenCalled();
       });
@@ -570,7 +572,7 @@ describe('wrapScopedClusterClient', () => {
         expect(stats.totalSearchDurationMs).toBeGreaterThan(-1);
 
         expect(loggingSystemMock.collect(logger).debug[0][0]).toEqual(
-          `executing ES|QL query for rule .test-rule-type:abcdefg in space my-space - {\"method\":\"POST\",\"path\":\"/_query\",\"query\":\"from .kibana_task_manager\"} - with options {}`
+          `executing ES|QL query for rule .test-rule-type:abcdefg in space my-space - {\"method\":\"POST\",\"path\":\"/_query\",\"body\":{\"query\":\"from .kibana_task_manager\"}} - with options {}`
         );
         expect(logger.warn).not.toHaveBeenCalled();
       });

--- a/x-pack/platform/plugins/shared/alerting/server/lib/wrap_scoped_cluster_client.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/wrap_scoped_cluster_client.ts
@@ -23,7 +23,7 @@ import type {
   SearchRequest as SearchRequestWithBody,
   AggregationsAggregate,
   EqlSearchRequest as EqlSearchRequestWithBody,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { IScopedClusterClient, ElasticsearchClient, Logger } from '@kbn/core/server';
 import { SearchMetrics, RuleInfo } from './types';
 

--- a/x-pack/platform/plugins/shared/alerting/server/monitoring/register_cluster_collector.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/monitoring/register_cluster_collector.ts
@@ -7,7 +7,7 @@
 import type {
   AggregationsKeyedPercentiles,
   AggregationsPercentilesAggregateBase,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { MonitoringCollectionSetup } from '@kbn/monitoring-collection-plugin/server';
 import { aggregateTaskOverduePercentilesForType } from '@kbn/task-manager-plugin/server';
 import { CoreSetup } from '@kbn/core/server';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/suggestions/values_suggestion_alerts.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/suggestions/values_suggestion_alerts.ts
@@ -12,7 +12,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { termsAggSuggestions } from '@kbn/unified-search-plugin/server/autocomplete/terms_agg';
 import type { ConfigSchema } from '@kbn/unified-search-plugin/server/config';
 import { getKbnServerError, reportServerError } from '@kbn/kibana-utils-plugin/server';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ALERT_RULE_CONSUMER, ALERT_RULE_TYPE_ID, SPACE_IDS } from '@kbn/rule-data-utils';
 
 import { verifyAccessAndContext } from '../lib';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/suggestions/values_suggestion_rules.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/suggestions/values_suggestion_rules.ts
@@ -14,7 +14,7 @@ import type { ConfigSchema } from '@kbn/unified-search-plugin/server/config';
 import { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { getKbnServerError, reportServerError } from '@kbn/kibana-utils-plugin/server';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server/src/saved_objects_index_pattern';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 import { verifyAccessAndContext } from '../lib';
 import { ILicenseState } from '../../lib';

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/get_action_error_log.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/get_action_error_log.ts
@@ -6,7 +6,7 @@
  */
 
 import { KueryNode } from '@kbn/es-query';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { SanitizedRuleWithLegacyId } from '../../types';
 import { convertEsSortToEventLogSort } from '../../lib';
 import {

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/get_execution_log.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/methods/get_execution_log.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { KueryNode } from '@kbn/es-query';
 import { SanitizedRuleWithLegacyId } from '../../types';
 import {

--- a/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_execution_log.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rules_client/tests/get_execution_log.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { RulesClient, ConstructorOptions } from '../rules_client';
 import {
   savedObjectsClientMock,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
@@ -477,7 +477,7 @@ describe('Ad Hoc Task Runner', () => {
       index: '.alerts-test.alerts-default',
       refresh: 'wait_for',
       require_alias: !useDataStreamForAlerts,
-      operations: [
+      body: [
         {
           create: {
             _id: UUID,
@@ -745,13 +745,13 @@ describe('Ad Hoc Task Runner', () => {
     const bulkCall = clusterClient.bulk.mock.calls[0][0];
 
     // @ts-ignore
-    expect(bulkCall.operations[1][TIMESTAMP]).toEqual(schedule4.runAt);
+    expect(bulkCall.body[1][TIMESTAMP]).toEqual(schedule4.runAt);
     // @ts-ignore
-    expect(bulkCall.operations[1][ALERT_START]).toEqual(schedule4.runAt);
+    expect(bulkCall.body[1][ALERT_START]).toEqual(schedule4.runAt);
     // @ts-ignore
-    expect(bulkCall.operations[1][ALERT_TIME_RANGE]).toEqual({ gte: schedule4.runAt });
+    expect(bulkCall.body[1][ALERT_TIME_RANGE]).toEqual({ gte: schedule4.runAt });
     // @ts-ignore
-    expect(bulkCall.operations[1][ALERT_RULE_EXECUTION_TIMESTAMP]).toEqual(DATE_1970);
+    expect(bulkCall.body[1][ALERT_RULE_EXECUTION_TIMESTAMP]).toEqual(DATE_1970);
 
     expect(internalSavedObjectsRepository.update).toHaveBeenCalledWith(
       AD_HOC_RUN_SAVED_OBJECT_TYPE,
@@ -852,13 +852,13 @@ describe('Ad Hoc Task Runner', () => {
     const bulkCall = clusterClient.bulk.mock.calls[0][0];
 
     // @ts-ignore
-    expect(bulkCall.operations[1][TIMESTAMP]).toEqual(schedule5.runAt);
+    expect(bulkCall.body[1][TIMESTAMP]).toEqual(schedule5.runAt);
     // @ts-ignore
-    expect(bulkCall.operations[1][ALERT_START]).toEqual(schedule5.runAt);
+    expect(bulkCall.body[1][ALERT_START]).toEqual(schedule5.runAt);
     // @ts-ignore
-    expect(bulkCall.operations[1][ALERT_TIME_RANGE]).toEqual({ gte: schedule5.runAt });
+    expect(bulkCall.body[1][ALERT_TIME_RANGE]).toEqual({ gte: schedule5.runAt });
     // @ts-ignore
-    expect(bulkCall.operations[1][ALERT_RULE_EXECUTION_TIMESTAMP]).toEqual(DATE_1970);
+    expect(bulkCall.body[1][ALERT_RULE_EXECUTION_TIMESTAMP]).toEqual(DATE_1970);
 
     expect(internalSavedObjectsRepository.update).toHaveBeenCalledWith(
       AD_HOC_RUN_SAVED_OBJECT_TYPE,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_alerts_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_alerts_client.test.ts
@@ -593,7 +593,7 @@ describe('Task Runner', () => {
           index: '.alerts-test.alerts-default',
           refresh: 'wait_for',
           require_alias: !useDataStreamForAlerts,
-          operations: [
+          body: [
             {
               create: {
                 _id: '5f6aa57d-3e22-484e-bae8-cbed868f4d28',

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_alerts.ts
@@ -8,7 +8,7 @@
 import type {
   AggregationsTermsAggregateBase,
   AggregationsStringTermsBucketKeys,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
 
 import { NUM_ALERTING_RULE_TYPES } from '../alerting_usage_collector';
@@ -38,14 +38,16 @@ export async function getTotalAlertsCountAggregations({
     const query = {
       index: AAD_INDEX_PATTERN,
       size: 0,
-      query: {
-        match_all: {},
-      },
-      aggs: {
-        by_rule_type_id: {
-          terms: {
-            field: 'kibana.alert.rule.rule_type_id',
-            size: NUM_ALERTING_RULE_TYPES,
+      body: {
+        query: {
+          match_all: {},
+        },
+        aggs: {
+          by_rule_type_id: {
+            terms: {
+              field: 'kibana.alert.rule.rule_type_id',
+              size: NUM_ALERTING_RULE_TYPES,
+            },
           },
         },
       },

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_event_log.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_event_log.ts
@@ -14,7 +14,7 @@ import type {
   AggregationsTermsAggregateBase,
   AggregationsStringTermsBucketKeys,
   AggregationsBuckets,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
 import {
   NUM_ALERTING_RULE_TYPES,
@@ -136,19 +136,21 @@ export async function getExecutionsPerDayCount({
     const query = {
       index: eventLogIndex,
       size: 0,
-      query: getProviderAndActionFilterForTimeRange('execute'),
-      aggs: {
-        ...eventLogAggs,
-        by_rule_type_id: {
-          terms: {
-            field: 'rule.category',
-            size: NUM_ALERTING_RULE_TYPES,
+      body: {
+        query: getProviderAndActionFilterForTimeRange('execute'),
+        aggs: {
+          ...eventLogAggs,
+          by_rule_type_id: {
+            terms: {
+              field: 'rule.category',
+              size: NUM_ALERTING_RULE_TYPES,
+            },
+            aggs: eventLogAggs,
           },
-          aggs: eventLogAggs,
-        },
-        by_execution_status: {
-          terms: {
-            field: 'event.outcome',
+          by_execution_status: {
+            terms: {
+              field: 'event.outcome',
+            },
           },
         },
       },
@@ -227,12 +229,14 @@ export async function getExecutionTimeoutsPerDayCount({
     const query = {
       index: eventLogIndex,
       size: 0,
-      query: getProviderAndActionFilterForTimeRange('execute-timeout'),
-      aggs: {
-        by_rule_type_id: {
-          terms: {
-            field: 'rule.category',
-            size: NUM_ALERTING_RULE_TYPES,
+      body: {
+        query: getProviderAndActionFilterForTimeRange('execute-timeout'),
+        aggs: {
+          by_rule_type_id: {
+            terms: {
+              field: 'rule.category',
+              size: NUM_ALERTING_RULE_TYPES,
+            },
           },
         },
       },

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_kibana.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/get_telemetry_from_kibana.ts
@@ -10,7 +10,7 @@ import type {
   AggregationsCardinalityAggregate,
   AggregationsTermsAggregateBase,
   AggregationsStringTermsBucketKeys,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ElasticsearchClient, Logger, ISavedObjectsRepository } from '@kbn/core/server';
 
 import {
@@ -83,17 +83,18 @@ export async function getTotalCountAggregations({
     const query = {
       index: alertIndex,
       size: 0,
-      query: {
-        bool: {
-          // Aggregate over all rule saved objects
-          filter: [{ term: { type: 'alert' } }],
+      body: {
+        query: {
+          bool: {
+            // Aggregate over all rule saved objects
+            filter: [{ term: { type: 'alert' } }],
+          },
         },
-      },
-      runtime_mappings: {
-        rule_action_count: {
-          type: 'long',
-          script: {
-            source: `
+        runtime_mappings: {
+          rule_action_count: {
+            type: 'long',
+            script: {
+              source: `
                 def alert = params._source['alert'];
                 if (alert != null) {
                   def actions = alert.actions;
@@ -103,13 +104,13 @@ export async function getTotalCountAggregations({
                     emit(0);
                   }
                 }`,
+            },
           },
-        },
-        // Convert schedule interval duration string from rule saved object to interval in seconds
-        rule_schedule_interval: {
-          type: 'long',
-          script: {
-            source: `
+          // Convert schedule interval duration string from rule saved object to interval in seconds
+          rule_schedule_interval: {
+            type: 'long',
+            script: {
+              source: `
                 int parsed = 0;
                 if (doc['alert.schedule.interval'].size() > 0) {
                   def interval = doc['alert.schedule.interval'].value;
@@ -139,13 +140,13 @@ export async function getTotalCountAggregations({
                 }
                 emit(parsed);
               `,
+            },
           },
-        },
-        // Convert throttle interval duration string from rule saved object to interval in seconds
-        rule_throttle_interval: {
-          type: 'long',
-          script: {
-            source: `
+          // Convert throttle interval duration string from rule saved object to interval in seconds
+          rule_throttle_interval: {
+            type: 'long',
+            script: {
+              source: `
                 int parsed = 0;
                 if (doc['alert.throttle'].size() > 0) {
                 def throttle = doc['alert.throttle'].value;
@@ -175,12 +176,12 @@ export async function getTotalCountAggregations({
               }
               emit(parsed);
               `,
+            },
           },
-        },
-        rule_with_tags: {
-          type: 'long',
-          script: {
-            source: `
+          rule_with_tags: {
+            type: 'long',
+            script: {
+              source: `
                def rule = params._source['alert'];
                 if (rule != null && rule.tags != null) {
                   if (rule.tags.size() > 0) {
@@ -189,12 +190,12 @@ export async function getTotalCountAggregations({
                     emit(0);
                   }
                 }`,
+            },
           },
-        },
-        rule_snoozed: {
-          type: 'long',
-          script: {
-            source: `
+          rule_snoozed: {
+            type: 'long',
+            script: {
+              source: `
                 def rule = params._source['alert'];
                 if (rule != null && rule.snoozeSchedule != null) {
                   if (rule.snoozeSchedule.size() > 0) {
@@ -203,23 +204,23 @@ export async function getTotalCountAggregations({
                     emit(0);
                   }
                 }`,
+            },
           },
-        },
-        rule_muted: {
-          type: 'long',
-          script: {
-            source: `
+          rule_muted: {
+            type: 'long',
+            script: {
+              source: `
                 if (doc['alert.muteAll'].value == true) {
                   emit(1);
                 } else {
                   emit(0);
                 }`,
+            },
           },
-        },
-        rule_with_muted_alerts: {
-          type: 'long',
-          script: {
-            source: `
+          rule_with_muted_alerts: {
+            type: 'long',
+            script: {
+              source: `
                 def rule = params._source['alert'];
                 if (rule != null && rule.mutedInstanceIds != null) {
                   if (rule.mutedInstanceIds.size() > 0) {
@@ -228,63 +229,64 @@ export async function getTotalCountAggregations({
                     emit(0);
                   }
                 }`,
+            },
           },
         },
-      },
-      aggs: {
-        by_rule_type_id: {
-          terms: {
-            field: 'alert.alertTypeId',
-            size: NUM_ALERTING_RULE_TYPES,
+        aggs: {
+          by_rule_type_id: {
+            terms: {
+              field: 'alert.alertTypeId',
+              size: NUM_ALERTING_RULE_TYPES,
+            },
           },
-        },
-        max_throttle_time: { max: { field: 'rule_throttle_interval' } },
-        min_throttle_time: { min: { field: 'rule_throttle_interval' } },
-        avg_throttle_time: { avg: { field: 'rule_throttle_interval' } },
-        max_interval_time: { max: { field: 'rule_schedule_interval' } },
-        min_interval_time: { min: { field: 'rule_schedule_interval' } },
-        avg_interval_time: { avg: { field: 'rule_schedule_interval' } },
-        max_actions_count: { max: { field: 'rule_action_count' } },
-        min_actions_count: { min: { field: 'rule_action_count' } },
-        avg_actions_count: { avg: { field: 'rule_action_count' } },
-        by_execution_status: {
-          terms: {
-            field: 'alert.executionStatus.status',
+          max_throttle_time: { max: { field: 'rule_throttle_interval' } },
+          min_throttle_time: { min: { field: 'rule_throttle_interval' } },
+          avg_throttle_time: { avg: { field: 'rule_throttle_interval' } },
+          max_interval_time: { max: { field: 'rule_schedule_interval' } },
+          min_interval_time: { min: { field: 'rule_schedule_interval' } },
+          avg_interval_time: { avg: { field: 'rule_schedule_interval' } },
+          max_actions_count: { max: { field: 'rule_action_count' } },
+          min_actions_count: { min: { field: 'rule_action_count' } },
+          avg_actions_count: { avg: { field: 'rule_action_count' } },
+          by_execution_status: {
+            terms: {
+              field: 'alert.executionStatus.status',
+            },
           },
-        },
-        by_notify_when: {
-          terms: {
-            field: 'alert.notifyWhen',
+          by_notify_when: {
+            terms: {
+              field: 'alert.notifyWhen',
+            },
           },
-        },
-        connector_types_by_consumers: {
-          terms: {
-            field: 'alert.consumer',
-          },
-          aggs: {
-            actions: {
-              nested: {
-                path: 'alert.actions',
-              },
-              aggs: {
-                connector_types: {
-                  terms: {
-                    field: 'alert.actions.actionTypeId',
+          connector_types_by_consumers: {
+            terms: {
+              field: 'alert.consumer',
+            },
+            aggs: {
+              actions: {
+                nested: {
+                  path: 'alert.actions',
+                },
+                aggs: {
+                  connector_types: {
+                    terms: {
+                      field: 'alert.actions.actionTypeId',
+                    },
                   },
                 },
               },
             },
           },
-        },
-        by_search_type: {
-          terms: {
-            field: 'alert.params.searchType',
+          by_search_type: {
+            terms: {
+              field: 'alert.params.searchType',
+            },
           },
+          sum_rules_with_tags: { sum: { field: 'rule_with_tags' } },
+          sum_rules_snoozed: { sum: { field: 'rule_snoozed' } },
+          sum_rules_muted: { sum: { field: 'rule_muted' } },
+          sum_rules_with_muted_alerts: { sum: { field: 'rule_with_muted_alerts' } },
         },
-        sum_rules_with_tags: { sum: { field: 'rule_with_tags' } },
-        sum_rules_snoozed: { sum: { field: 'rule_snoozed' } },
-        sum_rules_muted: { sum: { field: 'rule_muted' } },
-        sum_rules_with_muted_alerts: { sum: { field: 'rule_with_muted_alerts' } },
       },
     };
 
@@ -437,23 +439,25 @@ export async function getTotalCountInUse({
     const query = {
       index: alertIndex,
       size: 0,
-      query: {
-        bool: {
-          // Aggregate over only enabled rule saved objects
-          filter: [{ term: { type: 'alert' } }, { term: { 'alert.enabled': true } }],
-        },
-      },
-      aggs: {
-        namespaces_count: { cardinality: { field: 'namespaces' } },
-        by_rule_type_id: {
-          terms: {
-            field: 'alert.alertTypeId',
-            size: NUM_ALERTING_RULE_TYPES,
+      body: {
+        query: {
+          bool: {
+            // Aggregate over only enabled rule saved objects
+            filter: [{ term: { type: 'alert' } }, { term: { 'alert.enabled': true } }],
           },
         },
-        by_search_type: {
-          terms: {
-            field: 'alert.params.searchType',
+        aggs: {
+          namespaces_count: { cardinality: { field: 'namespaces' } },
+          by_rule_type_id: {
+            terms: {
+              field: 'alert.alertTypeId',
+              size: NUM_ALERTING_RULE_TYPES,
+            },
+          },
+          by_search_type: {
+            terms: {
+              field: 'alert.params.searchType',
+            },
           },
         },
       },

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/group_connectors_by_consumers.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/group_connectors_by_consumers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { AggregationsBuckets } from '@elastic/elasticsearch/lib/api/types';
+import { AggregationsBuckets } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { replaceDotSymbols } from './replace_dots_with_underscores';
 
 export interface ConnectorsByConsumersBucket {

--- a/x-pack/platform/plugins/shared/alerting/server/usage/lib/parse_simple_rule_type_bucket.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/usage/lib/parse_simple_rule_type_bucket.ts
@@ -8,7 +8,7 @@
 import {
   AggregationsBuckets,
   AggregationsStringTermsBucketKeys,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { replaceDotSymbols } from './replace_dots_with_underscores';
 
 export function parseSimpleRuleTypeBucket(

--- a/x-pack/platform/plugins/shared/cases/public/containers/types.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 export * from '../../common/ui';
 

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/alerts/aggregations/hosts.ts
@@ -7,7 +7,7 @@
 
 import { get } from 'lodash';
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { SingleCaseMetricsResponse } from '../../../../../common/types/api';
 import type { AggregationBuilder, AggregationResponse } from '../../types';
 

--- a/x-pack/platform/plugins/shared/cases/server/client/metrics/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/client/metrics/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type {
   CasesMetricsFeatureField,
   SingleCaseMetricsFeatureField,

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/index.ts
@@ -13,7 +13,7 @@ import type {
   SavedObjectsUpdateResponse,
 } from '@kbn/core/server';
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { fromKueryExpression } from '@kbn/es-query';
 import { AttachmentAttributesRt, AttachmentType } from '../../../common/types/domain';
 import { decodeOrThrow } from '../../common/runtime_types';

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/operations/get.ts
@@ -10,7 +10,7 @@ import type {
   SavedObjectsBulkResponse,
   SavedObjectsFindResponse,
 } from '@kbn/core/server';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { FILE_SO_TYPE } from '@kbn/files-plugin/common';
 import { isSOError } from '../../../common/error';
 import { decodeOrThrow } from '../../../common/runtime_types';

--- a/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/attachments/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type {
   Logger,
   SavedObject,

--- a/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/cases/index.ts
@@ -18,7 +18,7 @@ import type {
   SavedObjectsBulkDeleteOptions,
 } from '@kbn/core/server';
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { nodeBuilder } from '@kbn/es-query';
 
 import type { Case, CaseStatuses, User } from '../../../common/types/domain';

--- a/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/services/user_actions/index.ts
@@ -11,7 +11,7 @@ import type {
   SavedObjectsRawDoc,
 } from '@kbn/core/server';
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { KueryNode } from '@kbn/es-query';
 import type { CaseUserActionDeprecatedResponse } from '../../../common/types/api';
 import { UserActionTypes } from '../../../common/types/domain';

--- a/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.ts
@@ -11,7 +11,7 @@ import { reject, isUndefined, isNumber, pick, isEmpty, get } from 'lodash';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import { Logger, ElasticsearchClient } from '@kbn/core/server';
 import util from 'util';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { fromKueryExpression, toElasticsearchQuery, KueryNode, nodeBuilder } from '@kbn/es-query';
 import { IEvent, IValidatedEvent, SAVED_OBJECT_REL_PRIMARY } from '../types';
 import { AggregateOptionsType, FindOptionsType, QueryOptionsType } from '../event_log_client';
@@ -399,7 +399,7 @@ export class ClusterClientAdapter<TDoc extends { body: AliasAny; index: string }
       pick(queryOptions.findOptions, ['start', 'end', 'filter'])
     );
 
-    const body: estypes.SearchRequest = {
+    const body: estypes.SearchRequest['body'] = {
       size: perPage,
       from: (page - 1) * perPage,
       query,
@@ -443,7 +443,7 @@ export class ClusterClientAdapter<TDoc extends { body: AliasAny; index: string }
       pick(queryOptions.findOptions, ['start', 'end', 'filter'])
     );
 
-    const body: estypes.SearchRequest = {
+    const body: estypes.SearchRequest['body'] = {
       size: perPage,
       from: (page - 1) * perPage,
       query,
@@ -487,7 +487,7 @@ export class ClusterClientAdapter<TDoc extends { body: AliasAny; index: string }
       pick(queryOptions.aggregateOptions, ['start', 'end', 'filter'])
     );
 
-    const body: estypes.SearchRequest = {
+    const body: estypes.SearchRequest['body'] = {
       size: 0,
       query,
       aggs,
@@ -523,7 +523,7 @@ export class ClusterClientAdapter<TDoc extends { body: AliasAny; index: string }
       pick(queryOptions.aggregateOptions, ['start', 'end', 'filter'])
     );
 
-    const body: estypes.SearchRequest = {
+    const body: estypes.SearchRequest['body'] = {
       size: 0,
       query,
       aggs,

--- a/x-pack/platform/plugins/shared/event_log/server/es/init.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/es/init.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { asyncForEach } from '@kbn/std';
 import { groupBy } from 'lodash';
 import pRetry, { FailedAttemptError } from 'p-retry';

--- a/x-pack/platform/plugins/shared/event_log/server/event_log_client.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/event_log_client.ts
@@ -9,7 +9,7 @@ import { omit } from 'lodash';
 import { Observable } from 'rxjs';
 import { schema, TypeOf } from '@kbn/config-schema';
 import { IClusterClient, KibanaRequest } from '@kbn/core/server';
-import * as estypes from '@elastic/elasticsearch/lib/api/types';
+import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { SpacesServiceStart } from '@kbn/spaces-plugin/server';
 
 import { KueryNode } from '@kbn/es-query';

--- a/x-pack/platform/plugins/shared/rule_registry/server/rule_data_plugin_service/resource_installer.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/rule_data_plugin_service/resource_installer.ts
@@ -93,8 +93,8 @@ export class ResourceInstaller {
                     logger,
                     esClient: clusterClient,
                     template: {
-                      ...ecsComponentTemplate,
                       name: ECS_COMPONENT_TEMPLATE_NAME,
+                      body: ecsComponentTemplate,
                     },
                     totalFieldsLimit: TOTAL_FIELDS_LIMIT,
                   }),
@@ -103,8 +103,8 @@ export class ResourceInstaller {
               logger,
               esClient: clusterClient,
               template: {
-                ...technicalComponentTemplate,
                 name: TECHNICAL_COMPONENT_TEMPLATE_NAME,
+                body: technicalComponentTemplate,
               },
               totalFieldsLimit: TOTAL_FIELDS_LIMIT,
             }),
@@ -168,11 +168,13 @@ export class ResourceInstaller {
                 esClient: clusterClient,
                 template: {
                   name: indexInfo.getComponentTemplateName(ct.name),
-                  template: {
-                    settings: ct.settings ?? {},
-                    mappings: ct.mappings,
+                  body: {
+                    template: {
+                      settings: ct.settings ?? {},
+                      mappings: ct.mappings,
+                    },
+                    _meta: ct._meta,
                   },
-                  _meta: ct._meta,
                 },
                 totalFieldsLimit: TOTAL_FIELDS_LIMIT,
               });

--- a/x-pack/platform/plugins/shared/stack_alerts/common/build_sorted_events_query.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/common/build_sorted_events_query.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { ESSearchRequest } from '@kbn/es-types';
 
 interface BuildSortedEventsQueryOpts {

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/action_context.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/action_context.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { AlertInstanceContext } from '@kbn/alerting-plugin/server';
 import { EsQueryRuleParams } from './rule_type_params';
 import { Comparator } from '../../../common/comparator_types';

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/util.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/es_query/util.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { SearchResponse } from '@elastic/elasticsearch/lib/api/types';
+import { SearchResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { OnlyEsQueryRuleParams } from './types';
 import { EsQueryRuleParams } from './rule_type_params';
 

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/es_index/index.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/es_index/index.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { validateConfig, validateParams } from '@kbn/actions-plugin/server/lib';
 import { ConnectorUsageCollector } from '@kbn/actions-plugin/server/types';
 import { actionsMock } from '@kbn/actions-plugin/server/mocks';
@@ -202,24 +202,24 @@ describe('execute()', () => {
     });
 
     expect(scopedClusterClient.bulk.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          Object {
-            "index": "index-value",
-            "operations": Array [
+          Array [
+            Array [
               Object {
-                "index": Object {
-                  "op_type": "create",
-                },
-              },
-              Object {
-                "jim": "bob",
+                "body": Array [
+                  Object {
+                    "index": Object {
+                      "op_type": "create",
+                    },
+                  },
+                  Object {
+                    "jim": "bob",
+                  },
+                ],
+                "index": "index-value",
+                "refresh": false,
               },
             ],
-            "refresh": false,
-          },
-        ],
-      ]
+          ]
     `);
 
     // full params
@@ -247,30 +247,30 @@ describe('execute()', () => {
 
     const calls = scopedClusterClient.bulk.mock.calls;
     const timeValue = (
-      (calls[0][0] as estypes.BulkRequest)?.operations?.[1] as Record<string, unknown>
+      ((calls[0][0] as estypes.BulkRequest)?.body as unknown[])[1] as Record<string, unknown>
     ).field_to_use_for_time;
     expect(timeValue).toBeInstanceOf(Date);
-    delete ((calls[0][0] as estypes.BulkRequest)?.operations?.[1] as Record<string, unknown>)
+    delete (((calls[0][0] as estypes.BulkRequest)?.body as unknown[])[1] as Record<string, unknown>)
       .field_to_use_for_time;
     expect(calls).toMatchInlineSnapshot(`
-      Array [
         Array [
-          Object {
-            "index": "index-value",
-            "operations": Array [
-              Object {
-                "index": Object {
-                  "op_type": "create",
+          Array [
+            Object {
+              "body": Array [
+                Object {
+                  "index": Object {
+                    "op_type": "create",
+                  },
                 },
-              },
-              Object {
-                "jimbob": "jr",
-              },
-            ],
-            "refresh": true,
-          },
-        ],
-      ]
+                Object {
+                  "jimbob": "jr",
+                },
+              ],
+              "index": "index-value",
+              "refresh": true,
+            },
+          ],
+        ]
     `);
 
     // minimal params
@@ -301,8 +301,7 @@ describe('execute()', () => {
       Array [
         Array [
           Object {
-            "index": "index-value",
-            "operations": Array [
+            "body": Array [
               Object {
                 "index": Object {
                   "op_type": "create",
@@ -312,6 +311,7 @@ describe('execute()', () => {
                 "jim": "bob",
               },
             ],
+            "index": "index-value",
             "refresh": false,
           },
         ],
@@ -342,32 +342,32 @@ describe('execute()', () => {
     });
 
     expect(scopedClusterClient.bulk.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          Object {
-            "index": "index-value",
-            "operations": Array [
+          Array [
+            Array [
               Object {
-                "index": Object {
-                  "op_type": "create",
-                },
-              },
-              Object {
-                "a": 1,
-              },
-              Object {
-                "index": Object {
-                  "op_type": "create",
-                },
-              },
-              Object {
-                "b": 2,
+                "body": Array [
+                  Object {
+                    "index": Object {
+                      "op_type": "create",
+                    },
+                  },
+                  Object {
+                    "a": 1,
+                  },
+                  Object {
+                    "index": Object {
+                      "op_type": "create",
+                    },
+                  },
+                  Object {
+                    "b": 2,
+                  },
+                ],
+                "index": "index-value",
+                "refresh": false,
               },
             ],
-            "refresh": false,
-          },
-        ],
-      ]
+          ]
     `);
   });
 

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/es_index/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/es_index/index.ts
@@ -25,7 +25,10 @@ import {
   ALERT_HISTORY_PREFIX,
   buildAlertHistoryDocument,
 } from '@kbn/actions-plugin/common';
-import { BulkOperationType, BulkResponseItem } from '@elastic/elasticsearch/lib/api/types';
+import {
+  BulkOperationType,
+  BulkResponseItem,
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 export type ESIndexConnectorType = ConnectorType<
   ConnectorTypeConfigType,
@@ -105,20 +108,20 @@ async function executor(
   const { actionId, config, params, services, logger } = execOptions;
   const index = params.indexOverride || config.index;
 
-  const operations = [];
+  const bulkBody = [];
   for (const document of params.documents) {
     const timeField = config.executionTimeField == null ? '' : config.executionTimeField.trim();
     if (timeField !== '') {
       document[timeField] = new Date();
     }
 
-    operations.push({ index: { op_type: 'create' } });
-    operations.push(document);
+    bulkBody.push({ index: { op_type: 'create' } });
+    bulkBody.push(document);
   }
 
   const bulkParams = {
     index,
-    operations,
+    body: bulkBody,
     refresh: config.refresh,
   };
 

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/bulk_operation_buffer.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/bulk_operation_buffer.ts
@@ -7,7 +7,7 @@
 
 import { Logger } from '@kbn/core/server';
 import { map } from 'lodash';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Subject, race, from } from 'rxjs';
 import { bufferWhen, filter, bufferCount, flatMap, mapTo, first } from 'rxjs';
 import { SavedObjectError } from '@kbn/core-saved-objects-common';

--- a/x-pack/platform/plugins/shared/task_manager/server/metrics/task_metrics_collector.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/metrics/task_metrics_collector.ts
@@ -10,7 +10,7 @@ import {
   AggregationsStringTermsBucket,
   AggregationsStringTermsBucketKeys,
   AggregationsTermsAggregateBase,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Observable, Subject } from 'rxjs';
 import { TaskStore } from '../task_store';
 import {

--- a/x-pack/platform/plugins/shared/task_manager/server/monitoring/workload_statistics.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/monitoring/workload_statistics.test.ts
@@ -21,7 +21,7 @@ import { times } from 'lodash';
 import { taskStoreMock } from '../task_store.mock';
 import { of, Subject } from 'rxjs';
 import { sleep } from '../test_utils';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { TaskTypeDictionary } from '../task_type_dictionary';
 
 type ResponseWithAggs = Omit<estypes.SearchResponse<ConcreteTaskInstance>, 'aggregations'> & {

--- a/x-pack/platform/plugins/shared/task_manager/server/monitoring/workload_statistics.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/monitoring/workload_statistics.ts
@@ -10,7 +10,7 @@ import { mergeMap, map, filter, switchMap, catchError } from 'rxjs';
 import { Logger } from '@kbn/core/server';
 import { JsonObject } from '@kbn/utility-types';
 import { keyBy, mapValues } from 'lodash';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { AggregationResultOf } from '@kbn/es-types';
 import { AggregatedStatProvider } from '../lib/runtime_statistics_aggregator';
 import { parseIntervalAsSecond, asInterval, parseIntervalAsMillisecond } from '../lib/intervals';

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -7,7 +7,7 @@
 
 import { combineLatest, Observable, Subject, BehaviorSubject } from 'rxjs';
 import { map, distinctUntilChanged } from 'rxjs';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type {
   UsageCollectionSetup,
   UsageCollectionStart,

--- a/x-pack/platform/plugins/shared/task_manager/server/queries/aggregate_task_overdue_percentiles_for_type.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/queries/aggregate_task_overdue_percentiles_for_type.ts
@@ -9,7 +9,7 @@ import type {
   AggregationsAggregationContainer,
   QueryDslQueryContainer,
   MappingRuntimeFields,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import {
   IdleTaskWithExpiredRunAt,
   RunningOrClaimingTaskWithExpiredRetryAt,

--- a/x-pack/platform/plugins/shared/task_manager/server/queries/mark_available_tasks_as_claimed.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/queries/mark_available_tasks_as_claimed.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { TaskTypeDictionary } from '../task_type_dictionary';
 import { TaskStatus, TaskPriority, ConcreteTaskInstance } from '../task';
 import {

--- a/x-pack/platform/plugins/shared/task_manager/server/queries/query_clauses.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/queries/query_clauses.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 export interface MustCondition {
   bool: Pick<estypes.QueryDslBoolQuery, 'must'>;

--- a/x-pack/platform/plugins/shared/task_manager/server/removed_tasks/mark_removed_tasks_as_unrecognized.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/removed_tasks/mark_removed_tasks_as_unrecognized.test.ts
@@ -8,7 +8,7 @@
 import { mockLogger } from '../test_utils';
 import { coreMock, elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import { SCHEDULE_INTERVAL, taskRunner } from './mark_removed_tasks_as_unrecognized';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 const createTaskDoc = (id: string = '1'): SearchHit<unknown> => ({
   _index: '.kibana_task_manager_9.0.0_001',

--- a/x-pack/platform/plugins/shared/task_manager/server/removed_tasks/mark_removed_tasks_as_unrecognized.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/removed_tasks/mark_removed_tasks_as_unrecognized.ts
@@ -8,7 +8,7 @@
 import { Logger } from '@kbn/logging';
 import { CoreStart } from '@kbn/core-lifecycle-server';
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { TaskScheduling } from '../task_scheduling';
 import { TaskTypeDictionary } from '../task_type_dictionary';
 import { ConcreteTaskInstance, TaskManagerStartContract } from '..';

--- a/x-pack/platform/plugins/shared/task_manager/server/routes/background_task_utilization.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/routes/background_task_utilization.test.ts
@@ -15,7 +15,7 @@ import { usageCountersServiceMock } from '@kbn/usage-collection-plugin/server/us
 import { MonitoringStats } from '../monitoring';
 import { configSchema, TaskManagerConfig } from '../config';
 import { backgroundTaskUtilizationRoute } from './background_task_utilization';
-import { SecurityHasPrivilegesResponse } from '@elastic/elasticsearch/lib/api/types';
+import { SecurityHasPrivilegesResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 const mockUsageCountersSetup = usageCountersServiceMock.createSetupContract();
 const mockUsageCounter = mockUsageCountersSetup.createUsageCounter('test');

--- a/x-pack/platform/plugins/shared/task_manager/server/saved_objects/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/saved_objects/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type { SavedObjectsServiceSetup } from '@kbn/core/server';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { backgroundTaskNodeMapping, taskMappings } from './mappings';
 import { getMigrations } from './migrations';
 import { TaskManagerConfig } from '../config';

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.test.ts
@@ -7,7 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { Client } from '@elastic/elasticsearch';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import _ from 'lodash';
 import { first } from 'rxjs';
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -14,7 +14,7 @@ import { Subject } from 'rxjs';
 import { omit, defaults, get } from 'lodash';
 import { SavedObjectError } from '@kbn/core-saved-objects-common';
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { SavedObjectsBulkDeleteResponse, Logger } from '@kbn/core/server';
 
 import {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/common/data/lib/build_agg.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/common/data/lib/build_agg.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/types';
+import { AggregationsAggregationContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { DateRangeInfo, getDateRangeInfo } from './date_range_info';
 
 export interface BuildAggregationOpts {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/common/data/lib/parse_aggregation_results.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/common/data/lib/parse_aggregation_results.ts
@@ -10,7 +10,7 @@ import {
   SearchHit,
   SearchHitsMetadata,
   AggregationsSingleMetricAggregateBase,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { Group } from '@kbn/observability-alerting-rule-utils';
 
 export const UngroupedGroupId = 'all documents';

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/action_connector_api/load_execution_log_aggregations.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/action_connector_api/load_execution_log_aggregations.ts
@@ -8,7 +8,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
 import { HttpSetup } from '@kbn/core/public';
-import type { SortOrder } from '@elastic/elasticsearch/lib/api/types';
+import type { SortOrder } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import {
   IExecutionLog,
   ExecutionLogSortFields,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/rule_api/load_action_error_log.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/rule_api/load_action_error_log.ts
@@ -6,7 +6,7 @@
  */
 
 import { HttpSetup } from '@kbn/core/public';
-import type { SortOrder } from '@elastic/elasticsearch/lib/api/types';
+import type { SortOrder } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { IExecutionErrorsResult, ActionErrorLogSortFields } from '@kbn/alerting-plugin/common';
 import { INTERNAL_BASE_ALERTING_API_PATH } from '../../constants';
 import { getFilter } from './get_filter';

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/rule_api/load_execution_log_aggregations.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/lib/rule_api/load_execution_log_aggregations.ts
@@ -8,7 +8,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
 import { HttpSetup } from '@kbn/core/public';
-import type { SortOrder } from '@elastic/elasticsearch/lib/api/types';
+import type { SortOrder } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import {
   IExecutionLog,
   ExecutionLogSortFields,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/alerts_table_state.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/alerts_table_state.tsx
@@ -19,7 +19,7 @@ import {
   EuiCopy,
   EuiDataGridControlColumn,
 } from '@elastic/eui';
-import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
+import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ALERT_CASE_IDS, ALERT_MAINTENANCE_WINDOW_IDS } from '@kbn/rule-data-utils';
 import type { RuleRegistrySearchRequestPagination } from '@kbn/rule-registry-plugin/common';
 import type { BrowserFields } from '@kbn/alerting-types';
@@ -27,7 +27,7 @@ import { Storage } from '@kbn/kibana-utils-plugin/public';
 import type {
   QueryDslQueryContainer,
   SortCombinations,
-} from '@elastic/elasticsearch/lib/api/types';
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useSearchAlertsQuery } from '@kbn/alerts-ui-shared/src/common/hooks/use_search_alerts_query';
 import { DEFAULT_ALERTS_PAGE_SIZE } from '@kbn/alerts-ui-shared/src/common/constants';

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/configuration.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/configuration.tsx
@@ -19,7 +19,7 @@ import {
   ALERT_STATUS,
   TIMESTAMP,
 } from '@kbn/rule-data-utils';
-import { SortCombinations } from '@elastic/elasticsearch/lib/api/types';
+import { SortCombinations } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
 import { i18n } from '@kbn/i18n';
 import { FEATURE_LABEL } from '../translations';

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/hooks/constants.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/hooks/constants.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SortCombinations } from '@elastic/elasticsearch/lib/api/types';
+import type { SortCombinations } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 export const DefaultSort: SortCombinations[] = [
   {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_actions.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_actions.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import { useCallback, useContext, useEffect, useMemo } from 'react';
-import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { ALERT_CASE_IDS, isSiemRuleType } from '@kbn/rule-data-utils';
 import { AlertsTableContext } from '../contexts/alerts_table_context';

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_untrack_alerts_by_query.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_bulk_untrack_alerts_by_query.tsx
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { useMutation } from '@tanstack/react-query';
-import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { INTERNAL_BASE_ALERTING_API_PATH } from '@kbn/alerting-plugin/common';
 import { AlertsQueryContext } from '@kbn/alerts-ui-shared/src/common/contexts/alerts_query_context';
 import { useKibana } from '../../../../common';

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_sorting.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_table/hooks/use_sorting.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SortCombinations } from '@elastic/elasticsearch/lib/api/types';
+import type { SortCombinations } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { EuiDataGridSorting } from '@elastic/eui';
 import { useCallback, useMemo, useState } from 'react';
 

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/field_browser/mock.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/field_browser/mock.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
+import { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { BrowserFields } from '@kbn/rule-registry-plugin/common';
 
 const DEFAULT_INDEX_PATTERN = [

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/types.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/types.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import { QueryDslQueryContainer, SortCombinations } from '@elastic/elasticsearch/lib/api/types';
+import {
+  QueryDslQueryContainer,
+  SortCombinations,
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type {
   EuiDataGridCellPopoverElementProps,
   EuiDataGridCellProps,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/server/data/lib/time_series_query.test.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/server/data/lib/time_series_query.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import * as estypes from '@elastic/elasticsearch/lib/api/types';
+import * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import { Logger } from '@kbn/core/server';
 import { TimeSeriesQuery, timeSeriesQuery, getResultFromEs } from './time_series_query';

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/server/data/lib/time_series_query.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/server/data/lib/time_series_query.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Logger } from '@kbn/core/server';
 import type { ElasticsearchClient } from '@kbn/core/server';
 import { getEsErrorMessage } from '@kbn/alerting-plugin/server';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/risk_score_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/risk_score_data_client.test.ts
@@ -181,12 +181,14 @@ const assertIndexTemplate = (namespace: string) => {
   expect(createOrUpdateIndexTemplate).toHaveBeenCalledWith({
     logger,
     esClient,
-    template: expect.objectContaining({
+    template: {
       name: `.risk-score.risk-score-${namespace}-index-template`,
-      data_stream: { hidden: true },
-      index_patterns: [`risk-score.risk-score-${namespace}`],
-      composed_of: [`.risk-score-mappings-${namespace}`],
-    }),
+      body: expect.objectContaining({
+        data_stream: { hidden: true },
+        index_patterns: [`risk-score.risk-score-${namespace}`],
+        composed_of: [`.risk-score-mappings-${namespace}`],
+      }),
+    },
   });
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/risk_score_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/risk_score_data_client.ts
@@ -169,21 +169,23 @@ export class RiskScoreDataClient {
         esClient,
         template: {
           name: indexPatterns.template,
-          data_stream: { hidden: true },
-          index_patterns: [indexPatterns.alias],
-          composed_of: [nameSpaceAwareMappingsComponentName(namespace)],
-          template: {
-            lifecycle: {},
-            settings: {
-              'index.mapping.total_fields.limit': totalFieldsLimit,
-              'index.default_pipeline': getIngestPipelineName(namespace),
+          body: {
+            data_stream: { hidden: true },
+            index_patterns: [indexPatterns.alias],
+            composed_of: [nameSpaceAwareMappingsComponentName(namespace)],
+            template: {
+              lifecycle: {},
+              settings: {
+                'index.mapping.total_fields.limit': totalFieldsLimit,
+                'index.default_pipeline': getIngestPipelineName(namespace),
+              },
+              mappings: {
+                dynamic: false,
+                _meta: indexMetadata,
+              },
             },
-            mappings: {
-              dynamic: false,
-              _meta: indexMetadata,
-            },
+            _meta: indexMetadata,
           },
-          _meta: indexMetadata,
         },
       });
 

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/delete.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/delete.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import moment from 'moment';
 import { asyncForEach } from '@kbn/std';
-import { GetResponse } from '@elastic/elasticsearch/lib/api/types';
+import { GetResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { UserAtSpaceScenarios } from '../../../../scenarios';
 import {
   getTestRuleData,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/alerts.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/alerts.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { expect as expectExpect } from 'expect';
 import { omit, padStart } from 'lodash';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { IValidatedEvent, nanosToMillis } from '@kbn/event-log-plugin/server';
 import { TaskRunning, TaskRunningStage } from '@kbn/task-manager-plugin/server/task_running';
 import { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/execute_unsecured_action.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/execute_unsecured_action.ts
@@ -7,7 +7,7 @@
 
 import getPort from 'get-port';
 import expect from '@kbn/expect';
-import type { SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
+import type { SearchTotalHits } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { getWebhookServer } from '@kbn/actions-simulators-plugin/server/plugin';
 import { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { ObjectRemover } from '../../../common/lib';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/schedule_unsecured_action.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/schedule_unsecured_action.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type { SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
+import type { SearchTotalHits } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Spaces } from '../../scenarios';
 import { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../../../common/lib';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/alerts_base.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/alerts_base.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { omit } from 'lodash';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Response as SupertestResponse } from 'supertest';
 import { RecoveredActionGroup } from '@kbn/alerting-plugin/common';
 import { TaskRunning, TaskRunningStage } from '@kbn/task-manager-plugin/server/task_running';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alert_severity.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alert_severity.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import type { Alert } from '@kbn/alerts-as-data-utils';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import {
   ALERT_ACTION_GROUP,
   ALERT_SEVERITY_IMPROVING,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import { setTimeout as setTimeoutAsync } from 'timers/promises';
 import type { Alert } from '@kbn/alerts-as-data-utils';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_alert_delay.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_alert_delay.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { get } from 'lodash';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import type { Alert } from '@kbn/alerts-as-data-utils';
 import {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_conflicts.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_conflicts.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { Client } from '@elastic/elasticsearch';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { Alert } from '@kbn/alerts-as-data-utils';
 import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 import { basename } from 'node:path';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_flapping.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_flapping.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { Alert } from '@kbn/alerts-as-data-utils';
 import { RuleNotifyWhen } from '@kbn/alerting-plugin/common';
 import { setTimeout as setTimeoutAsync } from 'timers/promises';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from 'expect';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { RawRule, RawRuleAction } from '@kbn/alerting-plugin/server/types';
 import { FILEBEAT_7X_INDICATOR_PATH } from '@kbn/alerting-plugin/server/saved_objects/migrations';
 import type { SavedObjectReference } from '@kbn/core/server';

--- a/x-pack/test/cases_api_integration/common/lib/alerts.ts
+++ b/x-pack/test/cases_api_integration/common/lib/alerts.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import type SuperTest from 'supertest';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ToolingLog } from '@kbn/tooling-log';
 import { DETECTION_ENGINE_QUERY_SIGNALS_URL } from '@kbn/security-solution-plugin/common/constants';
 import { DetectionAlert } from '@kbn/security-solution-plugin/common/api/detection_engine';

--- a/x-pack/test/cases_api_integration/common/lib/api/index.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/index.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { TransportResult } from '@elastic/elasticsearch';
 import type { Client } from '@elastic/elasticsearch';
 import { GetResponse } from '@elastic/elasticsearch/lib/api/types';

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/migrations.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/migrations.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { TransportResult } from '@elastic/elasticsearch';
 import {
   ConcreteTaskInstance,

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/task_management.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/task_management.ts
@@ -8,7 +8,7 @@
 import moment from 'moment';
 import { random } from 'lodash';
 import expect from '@kbn/expect';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { taskMappings as TaskManagerMapping } from '@kbn/task-manager-plugin/server/saved_objects/mappings';
 import { ConcreteTaskInstance, BulkUpdateTaskResult } from '@kbn/task-manager-plugin/server';
 import { FtrProviderContext } from '../../ftr_provider_context';

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/task_partitions.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/task_partitions.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import { taskMappings as TaskManagerMapping } from '@kbn/task-manager-plugin/server/saved_objects/mappings';
 import { asyncForEach } from '@kbn/std';

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/task_priority.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/task_priority.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import { taskMappings as TaskManagerMapping } from '@kbn/task-manager-plugin/server/saved_objects/mappings';
 import { asyncForEach } from '@kbn/std';

--- a/x-pack/test/task_manager_claimer_update_by_query/test_suites/task_manager/migrations.ts
+++ b/x-pack/test/task_manager_claimer_update_by_query/test_suites/task_manager/migrations.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { TransportResult } from '@elastic/elasticsearch';
 import {
   ConcreteTaskInstance,

--- a/x-pack/test/task_manager_claimer_update_by_query/test_suites/task_manager/task_management.ts
+++ b/x-pack/test/task_manager_claimer_update_by_query/test_suites/task_manager/task_management.ts
@@ -8,7 +8,7 @@
 import moment from 'moment';
 import { random } from 'lodash';
 import expect from '@kbn/expect';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { taskMappings as TaskManagerMapping } from '@kbn/task-manager-plugin/server/saved_objects/mappings';
 import { ConcreteTaskInstance, BulkUpdateTaskResult } from '@kbn/task-manager-plugin/server';
 import { FtrProviderContext } from '../../ftr_provider_context';

--- a/x-pack/test/task_manager_claimer_update_by_query/test_suites/task_manager/task_priority.ts
+++ b/x-pack/test/task_manager_claimer_update_by_query/test_suites/task_manager/task_priority.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import type * as estypes from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import { taskMappings as TaskManagerMapping } from '@kbn/task-manager-plugin/server/saved_objects/mappings';
 import { asyncForEach } from '@kbn/std';


### PR DESCRIPTION
This reverts commit 7bb2dad38f8938569374ce5c99d5e4a2f1ff9b95.

Original PR https://github.com/elastic/kibana/pull/204882 caused errors updating alert data stream index mappings in serverless. This seems to be a difference in the Elasticsearch client code handling requests with a body param vs requests without a body param https://github.com/elastic/elasticsearch-js/commit/a4315a905e818f1aaed39cd3f72b11c65f343842#diff-07b3475acb306ea63796d4e5cc559c073a63b84c8deeb9948d9ef24fb04c6439

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->