### PR TITLE
[Security Solution] Remove deprecated bulk endpoints from v9.0.0

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/register_routes.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { DocLinksServiceSetup, Logger } from '@kbn/core/server';
+import type { Logger } from '@kbn/core/server';
 import type { ConfigType } from '../../../../config';
 import type { SetupPlugins } from '../../../../plugin_contract';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
@@ -22,17 +22,12 @@ import { readRuleRoute } from './rules/read_rule/route';
 import { updateRuleRoute } from './rules/update_rule/route';
 import { readTagsRoute } from './tags/read_tags/route';
 import { getCoverageOverviewRoute } from './rules/coverage_overview/route';
-import { bulkCreateRulesRoute } from './rules/bulk_create_rules/route';
-import { bulkUpdateRulesRoute } from './rules/bulk_update_rules/route';
-import { bulkPatchRulesRoute } from './rules/bulk_patch_rules/route';
-import { bulkDeleteRulesRoute } from './rules/bulk_delete_rules/route';
 
 export const registerRuleManagementRoutes = (
   router: SecuritySolutionPluginRouter,
   config: ConfigType,
   ml: SetupPlugins['ml'],
-  logger: Logger,
-  docLinks: DocLinksServiceSetup
+  logger: Logger
 ) => {
   // Rules CRUD
   createRuleRoute(router);
@@ -40,12 +35,6 @@ export const registerRuleManagementRoutes = (
   updateRuleRoute(router);
   patchRuleRoute(router);
   deleteRuleRoute(router);
-
-  // These four bulk endpoints are deprecated and will be removed in 9.0
-  bulkCreateRulesRoute(router, logger, docLinks);
-  bulkUpdateRulesRoute(router, logger, docLinks);
-  bulkPatchRulesRoute(router, logger, docLinks);
-  bulkDeleteRulesRoute(router, logger, docLinks);
 
   // Rules bulk actions
   performBulkActionRoute(router, config, ml, logger);

--- a/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
@@ -79,7 +79,7 @@ export const initRoutes = (
   registerPrebuiltRulesRoutes(router, config);
   registerRuleExceptionsRoutes(router);
   registerManageExceptionsRoutes(router);
-  registerRuleManagementRoutes(router, config, ml, logger, docLinks);
+  registerRuleManagementRoutes(router, config, ml, logger);
   registerRuleMonitoringRoutes(router);
   registerRulePreviewRoutes(
     router,


### PR DESCRIPTION
**Partially addresses: https://github.com/elastic/kibana/issues/193184**
**Is a follow-up to: https://github.com/elastic/kibana/pull/207091**

## Summary
This PR removes deprecated bulk action API endpoints from router, making them unavailable in `v9.0.0` and Serverless.

We've already added an upgrade guide for users of these endpoints in #207091.

Once our team has more free capacity, we'll open another PR to properly remove route handlers and associated code (tests, utils, etc.)

Work started on: 22-Jan-2025