### PR TITLE
check for active fleet servers

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/fleet_server/index.ts
@@ -86,16 +86,19 @@ export const hasFleetServersForPolicies = async (
 };
 
 /**
- * Check if at least one fleet server agent exists, regardless of its online status
+ * Check if at least one fleet server agent exists.
+ * `activeOnly` flag can be used to filter only active agents.
  */
 export async function hasFleetServers(
   esClient: ElasticsearchClient,
-  soClient: SavedObjectsClientContract
+  soClient: SavedObjectsClientContract,
+  activeOnly: boolean = false
 ) {
   return await hasFleetServersForPolicies(
     esClient,
     soClient,
-    await getFleetServerPolicies(soClient)
+    await getFleetServerPolicies(soClient),
+    activeOnly
   );
 }
 

--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
@@ -55,7 +55,8 @@ export const getRegisteredDeprecations = (
       const hasAgentless = isAgentlessEnabled();
       const hasFleetServer = await hasFleetServers(
         ctx.esClient.asInternalUser,
-        ctx.savedObjectsClient
+        ctx.savedObjectsClient,
+        true // only counts if the Fleet Server is active
       );
       const entSearchDetails = getEnterpriseSearchNodeDeprecation(config, cloud, docsUrl);
       const [crawlerDetails, nativeConnectorsDetails] = await Promise.all([


### PR DESCRIPTION
## Summary

The Upgrade Assistant deprecations for Native Connectors -> Agentless Connectors care about if Fleet Server is _actively_ running, but it seems that the check we're using is whether one was _ever_ running. This change introduces an optional `activeOnly` param to `hasFleetServer`, and uses it for these deprecations. 





