### PR TITLE
[Docs] Backport UA deprecation warning known issue to 8.17 (#207512)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -88,7 +88,13 @@ include::upgrade-notes.asciidoc[]
 [[release-notes-8.17.1]]
 == {kib} 8.17.1
 
-The 8.17.1 release includes the following enhancements and bug fixes.
+The 8.17.1 release includes the following known issues, enhancements, and bug fixes.
+
+[float]
+[[known-issues-8.17.1]]
+=== Known issues
+
+include::CHANGELOG.asciidoc[tag=known-issue-206400]
 
 [float]
 [[enhancement-v8.17.1]]
@@ -116,6 +122,21 @@ Kibana platform::
 coming::[8.17.0]
 
 For information about the {kib} 8.17.0 release, review the following information.
+
+[float]
+[[known-issues-8.17.0]]
+=== Known issues
+
+// tag::known-issue-206400[]
+.Upgrade Assistant displays configured source mode in mappings as critical deprecation issue.
+[%collapsible]
+====
+*Details* +
+When upgrading to a newer version, the Upgrade Assistant displays critical warnings for the deprecation of configuring source mode in mappings. These warnings can safely be ignored.
+
+For more information, refer to https://github.com/elastic/kibana/issues/206400[#206400].
+====
+// end::known-issue-206400[]
 
 [float]
 [[deprecations-8.17.0]]


### PR DESCRIPTION
## Summary

Backporting #207512 to 8.17.

Rel: [#619](https://github.com/orgs/elastic/projects/1232/views/54pane=issue&itemId=94636712&issue=elastic%7Cplatform-docs-team%7C619)
