### PR TITLE
Updating mget poll interval based on utilization

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/integration_tests/managed_configuration.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/integration_tests/managed_configuration.test.ts
@@ -9,11 +9,32 @@ import sinon from 'sinon';
 import { Client } from '@elastic/elasticsearch';
 import { elasticsearchServiceMock, savedObjectsRepositoryMock } from '@kbn/core/server/mocks';
 import { SavedObjectsErrorHelpers, Logger } from '@kbn/core/server';
+import { schema } from '@kbn/config-schema';
 import { ADJUST_THROUGHPUT_INTERVAL } from '../lib/create_managed_configuration';
 import { TaskManagerPlugin, TaskManagerStartContract } from '../plugin';
 import { coreMock } from '@kbn/core/server/mocks';
 import { TaskManagerConfig } from '../config';
 import { BulkUpdateError } from '../lib/bulk_update_error';
+
+const mockTaskTypeRunFn = jest.fn();
+const mockCreateTaskRunner = jest.fn();
+const mockTaskType = {
+  title: '',
+  description: '',
+  stateSchemaByVersion: {
+    1: {
+      up: (state: Record<string, unknown>) => ({ ...state, baz: state.baz || '' }),
+      schema: schema.object({
+        foo: schema.string(),
+        bar: schema.string(),
+        baz: schema.string(),
+      }),
+    },
+  },
+  createTaskRunner: mockCreateTaskRunner.mockImplementation(() => ({
+    run: mockTaskTypeRunFn,
+  })),
+};
 
 describe('managed configuration', () => {
   let taskManagerStart: TaskManagerStartContract;
@@ -36,56 +57,58 @@ describe('managed configuration', () => {
     },
   };
 
+  const config = {
+    discovery: {
+      active_nodes_lookback: '30s',
+      interval: 10000,
+    },
+    kibanas_per_partition: 2,
+    capacity: 10,
+    max_attempts: 9,
+    poll_interval: 3000,
+    allow_reading_invalid_state: false,
+    version_conflict_threshold: 80,
+    monitored_aggregated_stats_refresh_rate: 60000,
+    monitored_stats_health_verbose_log: {
+      enabled: false,
+      level: 'debug' as const,
+      warn_delayed_task_start_in_seconds: 60,
+    },
+    monitored_stats_required_freshness: 4000,
+    monitored_stats_running_average_window: 50,
+    request_capacity: 1000,
+    monitored_task_execution_thresholds: {
+      default: {
+        error_threshold: 90,
+        warn_threshold: 80,
+      },
+      custom: {},
+    },
+    unsafe: {
+      exclude_task_types: [],
+      authenticate_background_task_utilization: true,
+    },
+    event_loop_delay: {
+      monitor: true,
+      warn_threshold: 5000,
+    },
+    worker_utilization_running_average_window: 5,
+    metrics_reset_interval: 3000,
+    claim_strategy: 'update_by_query',
+    request_timeouts: {
+      update_by_query: 1000,
+    },
+    auto_calculate_default_ech_capacity: false,
+  };
+
   afterEach(() => clock.restore());
 
-  describe('managed poll interval', () => {
+  describe('managed poll interval with default claim strategy', () => {
     beforeEach(async () => {
       jest.resetAllMocks();
       clock = sinon.useFakeTimers();
 
-      const context = coreMock.createPluginInitializerContext<TaskManagerConfig>({
-        discovery: {
-          active_nodes_lookback: '30s',
-          interval: 10000,
-        },
-        kibanas_per_partition: 2,
-        capacity: 10,
-        max_attempts: 9,
-        poll_interval: 3000,
-        allow_reading_invalid_state: false,
-        version_conflict_threshold: 80,
-        monitored_aggregated_stats_refresh_rate: 60000,
-        monitored_stats_health_verbose_log: {
-          enabled: false,
-          level: 'debug' as const,
-          warn_delayed_task_start_in_seconds: 60,
-        },
-        monitored_stats_required_freshness: 4000,
-        monitored_stats_running_average_window: 50,
-        request_capacity: 1000,
-        monitored_task_execution_thresholds: {
-          default: {
-            error_threshold: 90,
-            warn_threshold: 80,
-          },
-          custom: {},
-        },
-        unsafe: {
-          exclude_task_types: [],
-          authenticate_background_task_utilization: true,
-        },
-        event_loop_delay: {
-          monitor: true,
-          warn_threshold: 5000,
-        },
-        worker_utilization_running_average_window: 5,
-        metrics_reset_interval: 3000,
-        claim_strategy: 'update_by_query',
-        request_timeouts: {
-          update_by_query: 1000,
-        },
-        auto_calculate_default_ech_capacity: false,
-      });
+      const context = coreMock.createPluginInitializerContext<TaskManagerConfig>(config);
       logger = context.logger.get('taskManager');
 
       const taskManager = new TaskManagerPlugin(context);
@@ -127,10 +150,7 @@ describe('managed configuration', () => {
       clock.tick(ADJUST_THROUGHPUT_INTERVAL);
 
       expect(logger.warn).toHaveBeenCalledWith(
-        'Poll interval configuration is temporarily increased after Elasticsearch returned 1 "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).'
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        'Poll interval configuration changing from 3000 to 3600 after seeing 1 "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).'
+        'Poll interval configuration changing from 3000 to 3600 after seeing 1 "too many request" and/or "execute [inline] script" error(s).'
       );
       expect(logger.debug).toHaveBeenCalledWith('Task poller now using interval of 3600ms');
     });
@@ -154,10 +174,7 @@ describe('managed configuration', () => {
       clock.tick(100000);
 
       expect(logger.warn).toHaveBeenCalledWith(
-        'Poll interval configuration is temporarily increased after Elasticsearch returned 1 "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).'
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        'Poll interval configuration changing from 3000 to 61000 after seeing 1 "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).'
+        'Poll interval configuration changing from 3000 to 61000 after seeing 1 "too many request" and/or "execute [inline] script" error(s).'
       );
       expect(logger.debug).toHaveBeenCalledWith('Task poller now using interval of 61000ms');
     });
@@ -175,12 +192,109 @@ describe('managed configuration', () => {
       clock.tick(ADJUST_THROUGHPUT_INTERVAL);
 
       expect(logger.warn).toHaveBeenCalledWith(
-        'Poll interval configuration is temporarily increased after Elasticsearch returned 1 "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).'
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        'Poll interval configuration changing from 3000 to 3600 after seeing 1 "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).'
+        'Poll interval configuration changing from 3000 to 3600 after seeing 1 "too many request" and/or "execute [inline] script" error(s).'
       );
       expect(logger.debug).toHaveBeenCalledWith('Task poller now using interval of 3600ms');
+    });
+  });
+
+  describe('managed poll interval with mget claim strategy', () => {
+    beforeEach(async () => {
+      jest.resetAllMocks();
+      clock = sinon.useFakeTimers();
+
+      const context = coreMock.createPluginInitializerContext<TaskManagerConfig>({
+        ...config,
+        poll_interval: 500,
+        claim_strategy: 'mget',
+      });
+      logger = context.logger.get('taskManager');
+
+      const taskManager = new TaskManagerPlugin(context);
+      (
+        await taskManager.setup(coreMock.createSetup(), { usageCollection: undefined })
+      ).registerTaskDefinitions({
+        fooType: mockTaskType,
+      });
+
+      const coreStart = coreMock.createStart();
+      coreStart.elasticsearch = esStart;
+      esStart.client.asInternalUser.child.mockReturnValue(
+        esStart.client.asInternalUser as unknown as Client
+      );
+      coreStart.savedObjects.createInternalRepository.mockReturnValue(savedObjectsClient);
+      taskManagerStart = taskManager.start(coreStart, {});
+
+      // force rxjs timers to fire when they are scheduled for setTimeout(0) as the
+      // sinon fake timers cause them to stall
+      clock.tick(0);
+    });
+
+    test('should increase poll interval when Elasticsearch returns 429 error', async () => {
+      savedObjectsClient.create.mockRejectedValueOnce(
+        SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b')
+      );
+
+      // Cause "too many requests" error to be thrown
+      await expect(
+        taskManagerStart.schedule({
+          taskType: 'fooType',
+          params: { foo: true },
+          state: { foo: 'test', bar: 'test', baz: 'test' },
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"Too Many Requests"`);
+      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Poll interval configuration changing from 500 to 600 after seeing 1 "too many request" and/or "execute [inline] script" error(s).'
+      );
+      expect(logger.debug).toHaveBeenCalledWith('Task poller now using interval of 600ms');
+    });
+    test('should increase poll interval when Elasticsearch returns "cannot execute [inline] scripts" error', async () => {
+      const childEsClient = esStart.client.asInternalUser.child({}) as jest.Mocked<Client>;
+      childEsClient.search.mockImplementationOnce(async () => {
+        throw inlineScriptError;
+      });
+
+      await expect(taskManagerStart.fetch({})).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"cannot execute [inline] scripts\\" error"`
+      );
+
+      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Poll interval configuration changing from 500 to 600 after seeing 1 "too many request" and/or "execute [inline] script" error(s).'
+      );
+      expect(logger.debug).toHaveBeenCalledWith('Task poller now using interval of 600ms');
+    });
+
+    test('should increase poll interval TM untilization is low', async () => {
+      savedObjectsClient.create.mockImplementationOnce(
+        async (type: string, attributes: unknown) => ({
+          id: 'testid',
+          type,
+          attributes,
+          references: [],
+          version: '123',
+        })
+      );
+
+      await taskManagerStart.schedule({
+        taskType: 'fooType',
+        params: { foo: true },
+        state: { foo: 'test', bar: 'test', baz: 'test' },
+      });
+
+      mockTaskTypeRunFn.mockImplementation(() => {
+        return { state: {} };
+      });
+
+      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Poll interval configuration changing from 500 to 3000 after a change in the average task load: 0.'
+      );
+      expect(logger.debug).toHaveBeenCalledWith('Task poller now using interval of 3000ms');
     });
   });
 
@@ -189,49 +303,7 @@ describe('managed configuration', () => {
       jest.resetAllMocks();
       clock = sinon.useFakeTimers();
 
-      const context = coreMock.createPluginInitializerContext<TaskManagerConfig>({
-        discovery: {
-          active_nodes_lookback: '30s',
-          interval: 10000,
-        },
-        kibanas_per_partition: 2,
-        capacity: 10,
-        max_attempts: 9,
-        poll_interval: 3000,
-        allow_reading_invalid_state: false,
-        version_conflict_threshold: 80,
-        monitored_aggregated_stats_refresh_rate: 60000,
-        monitored_stats_health_verbose_log: {
-          enabled: false,
-          level: 'debug' as const,
-          warn_delayed_task_start_in_seconds: 60,
-        },
-        monitored_stats_required_freshness: 4000,
-        monitored_stats_running_average_window: 50,
-        request_capacity: 1000,
-        monitored_task_execution_thresholds: {
-          default: {
-            error_threshold: 90,
-            warn_threshold: 80,
-          },
-          custom: {},
-        },
-        unsafe: {
-          exclude_task_types: [],
-          authenticate_background_task_utilization: true,
-        },
-        event_loop_delay: {
-          monitor: true,
-          warn_threshold: 5000,
-        },
-        worker_utilization_running_average_window: 5,
-        metrics_reset_interval: 3000,
-        claim_strategy: 'update_by_query',
-        request_timeouts: {
-          update_by_query: 1000,
-        },
-        auto_calculate_default_ech_capacity: false,
-      });
+      const context = coreMock.createPluginInitializerContext<TaskManagerConfig>(config);
       logger = context.logger.get('taskManager');
 
       const taskManager = new TaskManagerPlugin(context);
@@ -312,47 +384,8 @@ describe('managed configuration', () => {
       clock = sinon.useFakeTimers();
 
       const context = coreMock.createPluginInitializerContext<TaskManagerConfig>({
-        discovery: {
-          active_nodes_lookback: '30s',
-          interval: 10000,
-        },
-        kibanas_per_partition: 2,
-        capacity: 10,
-        max_attempts: 9,
-        poll_interval: 3000,
-        allow_reading_invalid_state: false,
-        version_conflict_threshold: 80,
-        monitored_aggregated_stats_refresh_rate: 60000,
-        monitored_stats_health_verbose_log: {
-          enabled: false,
-          level: 'debug' as const,
-          warn_delayed_task_start_in_seconds: 60,
-        },
-        monitored_stats_required_freshness: 4000,
-        monitored_stats_running_average_window: 50,
-        request_capacity: 1000,
-        monitored_task_execution_thresholds: {
-          default: {
-            error_threshold: 90,
-            warn_threshold: 80,
-          },
-          custom: {},
-        },
-        unsafe: {
-          exclude_task_types: [],
-          authenticate_background_task_utilization: true,
-        },
-        event_loop_delay: {
-          monitor: true,
-          warn_threshold: 5000,
-        },
-        worker_utilization_running_average_window: 5,
-        metrics_reset_interval: 3000,
+        ...config,
         claim_strategy: 'mget',
-        request_timeouts: {
-          update_by_query: 1000,
-        },
-        auto_calculate_default_ech_capacity: false,
       });
       logger = context.logger.get('taskManager');
 

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.test.ts
@@ -6,15 +6,25 @@
  */
 
 import sinon from 'sinon';
-import { Subject } from 'rxjs';
+import { Subject, startWith, distinctUntilChanged, BehaviorSubject, withLatestFrom } from 'rxjs';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import {
-  createManagedConfiguration,
   ADJUST_THROUGHPUT_INTERVAL,
+  calculateStartingCapacity,
+  countErrors,
+  createCapacityScan,
+  createPollIntervalScan,
   INTERVAL_AFTER_BLOCK_EXCEPTION,
+  TaskManagerUtilizationWindow,
 } from './create_managed_configuration';
 import { mockLogger } from '../test_utils';
-import { CLAIM_STRATEGY_UPDATE_BY_QUERY, CLAIM_STRATEGY_MGET, TaskManagerConfig } from '../config';
+import {
+  CLAIM_STRATEGY_UPDATE_BY_QUERY,
+  CLAIM_STRATEGY_MGET,
+  TaskManagerConfig,
+  DEFAULT_CAPACITY,
+  DEFAULT_POLL_INTERVAL,
+} from '../config';
 import { MsearchError } from './msearch_error';
 import { BulkUpdateError } from './bulk_update_error';
 
@@ -29,123 +39,66 @@ describe('createManagedConfiguration()', () => {
 
   afterEach(() => clock.restore());
 
-  test('returns observables with initialized values', async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      logger,
-      errors$: new Subject<Error>(),
-      config: {
-        capacity: 20,
-        poll_interval: 2,
-      } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 20);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
-  });
-
   test('uses max_workers config as capacity if only max workers is defined', async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      logger,
-      errors$: new Subject<Error>(),
-      config: {
+    const capacity = calculateStartingCapacity(
+      {
         max_workers: 10,
         poll_interval: 2,
       } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 10);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
+      logger,
+      DEFAULT_CAPACITY
+    );
+    expect(capacity).toBe(10);
   });
 
   test('uses max_workers config as capacity but does not exceed MAX_CAPACITY', async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      logger,
-      errors$: new Subject<Error>(),
-      config: {
+    const capacity = calculateStartingCapacity(
+      {
         max_workers: 1000,
         poll_interval: 2,
       } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 50);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
+      logger,
+      DEFAULT_CAPACITY
+    );
+    expect(capacity).toBe(50);
   });
 
   test('uses provided defaultCapacity if neither capacity nor max_workers is defined', async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      defaultCapacity: 500,
-      logger,
-      errors$: new Subject<Error>(),
-      config: {
+    const capacity = calculateStartingCapacity(
+      {
         poll_interval: 2,
       } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 500);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
+      logger,
+      500
+    );
+    expect(capacity).toBe(500);
   });
 
   test('logs warning and uses capacity config if both capacity and max_workers is defined', async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      logger,
-      errors$: new Subject<Error>(),
-      config: {
+    const capacity = calculateStartingCapacity(
+      {
         capacity: 30,
         max_workers: 10,
         poll_interval: 2,
       } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 30);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
+      logger,
+      500
+    );
+    expect(capacity).toBe(30);
     expect(logger.warn).toHaveBeenCalledWith(
       `Both \"xpack.task_manager.capacity\" and \"xpack.task_manager.max_workers\" configs are set, max_workers will be ignored in favor of capacity and the setting should be removed.`
     );
   });
 
   test(`skips errors that aren't about too many requests`, async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
+    const errorSubscription = jest.fn();
     const errors$ = new Subject<Error>();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      errors$,
-      logger,
-      config: {
-        capacity: 10,
-        poll_interval: 100,
-      } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
+    const errorCheck$ = countErrors(errors$, ADJUST_THROUGHPUT_INTERVAL);
+    errorCheck$.subscribe(errorSubscription);
+
     errors$.next(new Error('foo'));
     clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
+    expect(errorSubscription).toHaveBeenCalledTimes(1);
   });
 
   describe('capacity configuration', () => {
@@ -154,16 +107,21 @@ describe('createManagedConfiguration()', () => {
       claimStrategy: string = CLAIM_STRATEGY_UPDATE_BY_QUERY
     ) {
       const errors$ = new Subject<Error>();
+      const errorCheck$ = countErrors(errors$, ADJUST_THROUGHPUT_INTERVAL);
       const subscription = jest.fn();
-      const { capacityConfiguration$ } = createManagedConfiguration({
-        errors$,
-        logger,
-        config: {
-          capacity: startingCapacity,
-          poll_interval: 1,
-          claim_strategy: claimStrategy,
-        } as TaskManagerConfig,
-      });
+      const capacityConfiguration$ = errorCheck$.pipe(
+        createCapacityScan(
+          {
+            capacity: startingCapacity,
+            poll_interval: 1,
+            claim_strategy: claimStrategy,
+          } as TaskManagerConfig,
+          logger,
+          startingCapacity
+        ),
+        startWith(startingCapacity),
+        distinctUntilChanged()
+      );
       capacityConfiguration$.subscribe(subscription);
       return { subscription, errors$ };
     }
@@ -369,19 +327,23 @@ describe('createManagedConfiguration()', () => {
   });
 
   describe('pollInterval configuration', () => {
-    function setupScenario(startingPollInterval: number) {
+    function setupScenario(
+      startingPollInterval: number,
+      claimStrategy: string = CLAIM_STRATEGY_UPDATE_BY_QUERY
+    ) {
       const errors$ = new Subject<Error>();
+      const utilization$ = new BehaviorSubject<number>(100);
+      const errorCheck$ = countErrors(errors$, ADJUST_THROUGHPUT_INTERVAL);
       const subscription = jest.fn();
-      const { pollIntervalConfiguration$ } = createManagedConfiguration({
-        logger,
-        errors$,
-        config: {
-          poll_interval: startingPollInterval,
-          capacity: 20,
-        } as TaskManagerConfig,
-      });
+      const window: TaskManagerUtilizationWindow[] = [];
+      const pollIntervalConfiguration$ = errorCheck$.pipe(
+        withLatestFrom(utilization$),
+        createPollIntervalScan(logger, startingPollInterval, claimStrategy, window),
+        startWith(startingPollInterval),
+        distinctUntilChanged()
+      );
       pollIntervalConfiguration$.subscribe(subscription);
-      return { subscription, errors$ };
+      return { subscription, errors$, utilization$ };
     }
 
     beforeEach(() => {
@@ -391,139 +353,226 @@ describe('createManagedConfiguration()', () => {
 
     afterEach(() => clock.restore());
 
-    test('should increase configuration at the next interval when an error is emitted', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-      expect(subscription).toHaveBeenCalledTimes(1);
-      clock.tick(1);
-      expect(subscription).toHaveBeenCalledTimes(2);
-      expect(subscription).toHaveBeenNthCalledWith(2, 120);
-    });
+    describe('default claim strategy', () => {
+      test('should increase configuration at the next interval when an error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+      });
 
-    test('should increase configuration at the next interval when a 500 error is emitted', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      errors$.next(SavedObjectsErrorHelpers.decorateGeneralError(new Error('a'), 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-      expect(subscription).toHaveBeenCalledTimes(1);
-      clock.tick(1);
-      expect(subscription).toHaveBeenCalledTimes(2);
-      expect(subscription).toHaveBeenNthCalledWith(2, 120);
-    });
+      test('should increase configuration at the next interval when a 500 error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        errors$.next(SavedObjectsErrorHelpers.decorateGeneralError(new Error('a'), 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+      });
 
-    test('should increase configuration at the next interval when a 503 error is emitted', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      errors$.next(SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError('a', 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-      expect(subscription).toHaveBeenCalledTimes(1);
-      clock.tick(1);
-      expect(subscription).toHaveBeenCalledTimes(2);
-      expect(subscription).toHaveBeenNthCalledWith(2, 120);
-    });
+      test('should increase configuration at the next interval when a 503 error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        errors$.next(SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+      });
 
-    test('should increase configuration at the next interval when an error with cluster_block_exception type is emitted, then decreases back to normal', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      errors$.next(
-        new BulkUpdateError({
-          statusCode: 403,
-          message: 'index is blocked',
-          type: 'cluster_block_exception',
-        })
-      );
-      expect(subscription).toHaveBeenNthCalledWith(1, 100);
-      // It emits the error with cluster_block_exception type immediately
-      expect(subscription).toHaveBeenNthCalledWith(2, INTERVAL_AFTER_BLOCK_EXCEPTION);
-      clock.tick(INTERVAL_AFTER_BLOCK_EXCEPTION);
-      expect(subscription).toHaveBeenCalledTimes(3);
-      expect(subscription).toHaveBeenNthCalledWith(3, 100);
-    });
+      test('should increase configuration at the next interval when an error with cluster_block_exception type is emitted, then decreases back to normal', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        errors$.next(
+          new BulkUpdateError({
+            statusCode: 403,
+            message: 'index is blocked',
+            type: 'cluster_block_exception',
+          })
+        );
+        expect(subscription).toHaveBeenNthCalledWith(1, 100);
+        // It emits the error with cluster_block_exception type immediately
+        expect(subscription).toHaveBeenNthCalledWith(2, INTERVAL_AFTER_BLOCK_EXCEPTION);
+        clock.tick(INTERVAL_AFTER_BLOCK_EXCEPTION);
+        expect(subscription).toHaveBeenCalledTimes(3);
+        expect(subscription).toHaveBeenNthCalledWith(3, 100);
+      });
 
-    test('should log a warning when the configuration changes from the starting value', async () => {
-      const { errors$ } = setupScenario(100);
-      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      expect(logger.warn).toHaveBeenCalledWith(
-        'Poll interval configuration is temporarily increased after Elasticsearch returned 1 "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).'
-      );
-    });
-
-    test('should log a warning when an issue occurred in the calculating of the increased poll interval', async () => {
-      const { errors$ } = setupScenario(NaN);
-      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      expect(logger.error).toHaveBeenCalledWith(
-        'Poll interval configuration had an issue calculating the new poll interval: Math.min(Math.ceil(NaN * 1.2), Math.max(60000, NaN)) = NaN, will keep the poll interval unchanged (NaN)'
-      );
-    });
-
-    test('should log a warning when an issue occurred in the calculating of the decreased poll interval', async () => {
-      setupScenario(NaN);
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      expect(logger.error).toHaveBeenCalledWith(
-        'Poll interval configuration had an issue calculating the new poll interval: Math.max(NaN, Math.floor(NaN * 0.95)) = NaN, will keep the poll interval unchanged (NaN)'
-      );
-    });
-
-    test('should decrease configuration back to normal incrementally after an error is emitted', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
-      expect(subscription).toHaveBeenNthCalledWith(2, 120);
-      expect(subscription).toHaveBeenNthCalledWith(3, 114);
-      // 108.3 -> 108 from Math.floor
-      expect(subscription).toHaveBeenNthCalledWith(4, 108);
-      expect(subscription).toHaveBeenNthCalledWith(5, 102);
-      // 96.9 -> 100 from Math.max with the starting value
-      expect(subscription).toHaveBeenNthCalledWith(6, 100);
-      // No new calls due to value not changing and usage of distinctUntilChanged()
-      expect(subscription).toHaveBeenCalledTimes(6);
-    });
-
-    test('should increase configuration when errors keep emitting', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      for (let i = 0; i < 3; i++) {
+      test('should log a warning when the configuration changes from the starting value', async () => {
+        const { errors$ } = setupScenario(100);
         errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
         clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      }
-      expect(subscription).toHaveBeenNthCalledWith(2, 120);
-      expect(subscription).toHaveBeenNthCalledWith(3, 144);
-      // 172.8 -> 173 from Math.ceil
-      expect(subscription).toHaveBeenNthCalledWith(4, 173);
-    });
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Poll interval configuration changing from 100 to 120 after seeing 1 "too many request" and/or "execute [inline] script" error(s).'
+        );
+      });
 
-    test('should limit the upper bound to 60s by default', async () => {
-      const { subscription, errors$ } = setupScenario(3000);
-      for (let i = 0; i < 18; i++) {
+      test('should log a warning when an issue occurred in the calculating of the increased poll interval', async () => {
+        const { errors$ } = setupScenario(NaN);
         errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
         clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      }
-      expect(subscription).toHaveBeenNthCalledWith(2, 3600);
-      expect(subscription).toHaveBeenNthCalledWith(3, 4320);
-      expect(subscription).toHaveBeenNthCalledWith(4, 5184);
-      expect(subscription).toHaveBeenNthCalledWith(5, 6221);
-      expect(subscription).toHaveBeenNthCalledWith(6, 7466);
-      expect(subscription).toHaveBeenNthCalledWith(7, 8960);
-      expect(subscription).toHaveBeenNthCalledWith(8, 10752);
-      expect(subscription).toHaveBeenNthCalledWith(9, 12903);
-      expect(subscription).toHaveBeenNthCalledWith(10, 15484);
-      expect(subscription).toHaveBeenNthCalledWith(11, 18581);
-      expect(subscription).toHaveBeenNthCalledWith(12, 22298);
-      expect(subscription).toHaveBeenNthCalledWith(13, 26758);
-      expect(subscription).toHaveBeenNthCalledWith(14, 32110);
-      expect(subscription).toHaveBeenNthCalledWith(15, 38532);
-      expect(subscription).toHaveBeenNthCalledWith(16, 46239);
-      expect(subscription).toHaveBeenNthCalledWith(17, 55487);
-      expect(subscription).toHaveBeenNthCalledWith(18, 60000);
+        expect(logger.error).toHaveBeenCalledWith(
+          'Poll interval configuration had an issue calculating the new poll interval: Math.min(Math.ceil(NaN * 1.2), Math.max(60000, NaN)) = NaN, will keep the poll interval unchanged (NaN)'
+        );
+      });
+
+      test('should log a warning when an issue occurred in the calculating of the decreased poll interval', async () => {
+        setupScenario(NaN);
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        expect(logger.error).toHaveBeenCalledWith(
+          'Poll interval configuration had an issue calculating the new poll interval: Math.max(NaN, Math.floor(NaN * 0.95)) = NaN, will keep the poll interval unchanged (NaN)'
+        );
+      });
+
+      test('should decrease configuration back to normal incrementally after an error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+        expect(subscription).toHaveBeenNthCalledWith(3, 114);
+        // 108.3 -> 108 from Math.floor
+        expect(subscription).toHaveBeenNthCalledWith(4, 108);
+        expect(subscription).toHaveBeenNthCalledWith(5, 102);
+        // 96.9 -> 100 from Math.max with the starting value
+        expect(subscription).toHaveBeenNthCalledWith(6, 100);
+        // No new calls due to value not changing and usage of distinctUntilChanged()
+        expect(subscription).toHaveBeenCalledTimes(6);
+      });
+
+      test('should increase configuration when errors keep emitting', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        for (let i = 0; i < 3; i++) {
+          errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        }
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+        expect(subscription).toHaveBeenNthCalledWith(3, 144);
+        // 172.8 -> 173 from Math.ceil
+        expect(subscription).toHaveBeenNthCalledWith(4, 173);
+      });
+
+      test('should limit the upper bound to 60s by default', async () => {
+        const { subscription, errors$ } = setupScenario(3000);
+        for (let i = 0; i < 18; i++) {
+          errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        }
+        expect(subscription).toHaveBeenNthCalledWith(2, 3600);
+        expect(subscription).toHaveBeenNthCalledWith(3, 4320);
+        expect(subscription).toHaveBeenNthCalledWith(4, 5184);
+        expect(subscription).toHaveBeenNthCalledWith(5, 6221);
+        expect(subscription).toHaveBeenNthCalledWith(6, 7466);
+        expect(subscription).toHaveBeenNthCalledWith(7, 8960);
+        expect(subscription).toHaveBeenNthCalledWith(8, 10752);
+        expect(subscription).toHaveBeenNthCalledWith(9, 12903);
+        expect(subscription).toHaveBeenNthCalledWith(10, 15484);
+        expect(subscription).toHaveBeenNthCalledWith(11, 18581);
+        expect(subscription).toHaveBeenNthCalledWith(12, 22298);
+        expect(subscription).toHaveBeenNthCalledWith(13, 26758);
+        expect(subscription).toHaveBeenNthCalledWith(14, 32110);
+        expect(subscription).toHaveBeenNthCalledWith(15, 38532);
+        expect(subscription).toHaveBeenNthCalledWith(16, 46239);
+        expect(subscription).toHaveBeenNthCalledWith(17, 55487);
+        expect(subscription).toHaveBeenNthCalledWith(18, 60000);
+      });
+
+      test('should not adjust poll interval dynamically if initial value is > 60s', async () => {
+        const { subscription, errors$ } = setupScenario(65000);
+        for (let i = 0; i < 5; i++) {
+          errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        }
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 65000);
+      });
     });
 
-    test('should not adjust poll interval dynamically if initial value is > 60s', async () => {
-      const { subscription, errors$ } = setupScenario(65000);
-      for (let i = 0; i < 5; i++) {
+    describe('mget claim strategy', () => {
+      test('should increase configuration at the next interval when an error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(100, CLAIM_STRATEGY_MGET);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+      });
+
+      test('should log a warning when the configuration changes from the starting value', async () => {
+        const { errors$ } = setupScenario(100, CLAIM_STRATEGY_MGET);
         errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
         clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      }
-      expect(subscription).toHaveBeenCalledTimes(1);
-      expect(subscription).toHaveBeenNthCalledWith(1, 65000);
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Poll interval configuration changing from 100 to 120 after seeing 1 "too many request" and/or "execute [inline] script" error(s).'
+        );
+      });
+
+      test('should decrease configuration back to normal incrementally after an error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(DEFAULT_POLL_INTERVAL, CLAIM_STRATEGY_MGET);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
+        expect(subscription).toHaveBeenNthCalledWith(2, 3600);
+        expect(subscription).toHaveBeenNthCalledWith(3, 3420);
+        expect(subscription).toHaveBeenNthCalledWith(4, 3249);
+        expect(subscription).toHaveBeenNthCalledWith(5, 3086);
+        expect(subscription).toHaveBeenNthCalledWith(6, 3000);
+        // No new calls due to value not changing and usage of distinctUntilChanged()
+        expect(subscription).toHaveBeenCalledTimes(6);
+      });
+
+      test('should decrease configuration after error and reset to initial poll interval when poll interval < default and TM utilization > 25%', async () => {
+        const { subscription, errors$ } = setupScenario(2800, CLAIM_STRATEGY_MGET);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
+        expect(subscription).toHaveBeenNthCalledWith(2, 3360);
+        expect(subscription).toHaveBeenNthCalledWith(3, 3192);
+        expect(subscription).toHaveBeenNthCalledWith(4, 3032);
+        expect(subscription).toHaveBeenNthCalledWith(5, 2800);
+        // No new calls due to value not changing and usage of distinctUntilChanged()
+        expect(subscription).toHaveBeenCalledTimes(5);
+      });
+
+      test('should decrease configuration after error and reset to default poll interval when poll interval < default and TM utilization > 25%', async () => {
+        const { subscription, errors$, utilization$ } = setupScenario(2800, CLAIM_STRATEGY_MGET);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        for (let i = 0; i < 10; i++) {
+          utilization$.next(20);
+          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        }
+        expect(subscription).toHaveBeenNthCalledWith(2, 3360);
+        expect(subscription).toHaveBeenNthCalledWith(3, 3192);
+        expect(subscription).toHaveBeenNthCalledWith(4, 3032);
+        expect(subscription).toHaveBeenNthCalledWith(5, 3000);
+        // No new calls due to value not changing and usage of distinctUntilChanged()
+        expect(subscription).toHaveBeenCalledTimes(5);
+      });
+
+      test('should change configuration based on TM utilization', async () => {
+        const { subscription, utilization$ } = setupScenario(500, CLAIM_STRATEGY_MGET);
+        const u = [15, 35, 5, 48, 0];
+        for (let i = 0; i < u.length; i++) {
+          utilization$.next(u[i]);
+          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        }
+        expect(subscription).toHaveBeenNthCalledWith(2, 3000);
+        expect(subscription).toHaveBeenNthCalledWith(3, 500);
+        expect(subscription).toHaveBeenNthCalledWith(4, 3000);
+        expect(subscription).toHaveBeenNthCalledWith(5, 500);
+        expect(subscription).toHaveBeenNthCalledWith(6, 3000);
+        expect(subscription).toHaveBeenCalledTimes(6);
+      });
+
+      test('should log a warning when the configuration changes from the starting value based on TM utilization', async () => {
+        const { utilization$ } = setupScenario(100, CLAIM_STRATEGY_MGET);
+        utilization$.next(20);
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Poll interval configuration changing from 100 to 3000 after a change in the average task load: 20.'
+        );
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
@@ -6,11 +6,17 @@
  */
 
 import { interval, merge, of, Observable } from 'rxjs';
-import { filter, mergeScan, map, scan, distinctUntilChanged, startWith } from 'rxjs';
+import { filter, mergeScan, map, scan } from 'rxjs';
+import { sumBy } from 'lodash';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { Logger } from '@kbn/core/server';
 import { isEsCannotExecuteScriptError } from './identify_es_error';
-import { CLAIM_STRATEGY_MGET, DEFAULT_CAPACITY, MAX_CAPACITY, TaskManagerConfig } from '../config';
+import {
+  CLAIM_STRATEGY_MGET,
+  DEFAULT_POLL_INTERVAL,
+  MAX_CAPACITY,
+  TaskManagerConfig,
+} from '../config';
 import { TaskCost } from '../task';
 import { getMsearchStatusCode } from './msearch_error';
 import { getBulkUpdateStatusCode, isClusterBlockException } from './bulk_update_error';
@@ -40,49 +46,23 @@ const CAPACITY_INCREASE_PERCENTAGE = 1.05;
 const POLL_INTERVAL_DECREASE_PERCENTAGE = 0.95;
 const POLL_INTERVAL_INCREASE_PERCENTAGE = 1.2;
 
-interface ManagedConfigurationOpts {
-  config: TaskManagerConfig;
-  defaultCapacity?: number;
-  errors$: Observable<Error>;
-  logger: Logger;
-}
+const TM_UTILIZATION_WINDOW = 15000;
 
 interface ErrorScanResult {
   count: number;
   isBlockException: boolean;
 }
 
-export interface ManagedConfiguration {
-  startingCapacity: number;
-  capacityConfiguration$: Observable<number>;
-  pollIntervalConfiguration$: Observable<number>;
+export interface TaskManagerUtilizationWindow {
+  timestamp: number;
+  utilization: number;
 }
 
-export function createManagedConfiguration({
-  config,
-  defaultCapacity = DEFAULT_CAPACITY,
-  logger,
-  errors$,
-}: ManagedConfigurationOpts): ManagedConfiguration {
-  const errorCheck$ = countErrors(errors$, ADJUST_THROUGHPUT_INTERVAL);
-  const startingCapacity = calculateStartingCapacity(config, logger, defaultCapacity);
-  const startingPollInterval = config.poll_interval;
-  return {
-    startingCapacity,
-    capacityConfiguration$: errorCheck$.pipe(
-      createCapacityScan(config, logger, startingCapacity),
-      startWith(startingCapacity),
-      distinctUntilChanged()
-    ),
-    pollIntervalConfiguration$: errorCheck$.pipe(
-      createPollIntervalScan(logger, startingPollInterval),
-      startWith(startingPollInterval),
-      distinctUntilChanged()
-    ),
-  };
-}
-
-function createCapacityScan(config: TaskManagerConfig, logger: Logger, startingCapacity: number) {
+export function createCapacityScan(
+  config: TaskManagerConfig,
+  logger: Logger,
+  startingCapacity: number
+) {
   return scan(
     (previousCapacity: number, { count: errorCount, isBlockException }: ErrorScanResult) => {
       let newCapacity: number;
@@ -124,10 +104,17 @@ function createCapacityScan(config: TaskManagerConfig, logger: Logger, startingC
   );
 }
 
-function createPollIntervalScan(logger: Logger, startingPollInterval: number) {
+export function createPollIntervalScan(
+  logger: Logger,
+  startingPollInterval: number,
+  claimStrategy: string,
+  window: TaskManagerUtilizationWindow[]
+) {
   return scan(
-    (previousPollInterval: number, { count: errorCount, isBlockException }: ErrorScanResult) => {
+    (previousPollInterval: number, [{ count: errorCount, isBlockException }, tmUtilization]) => {
       let newPollInterval: number;
+      let updatedForCapacity = false;
+      let avgTmUtilization = 0;
       if (isBlockException) {
         newPollInterval = INTERVAL_AFTER_BLOCK_EXCEPTION;
       } else {
@@ -164,18 +151,28 @@ function createPollIntervalScan(logger: Logger, startingPollInterval: number) {
             );
             newPollInterval = previousPollInterval;
           }
+
+          // If the task claim strategy is mget, increase the poll interval if the the avg used capacity over 15s is less than 25%.
+          avgTmUtilization = getAverageUtilization(tmUtilization, window);
+          if (claimStrategy === CLAIM_STRATEGY_MGET && newPollInterval < DEFAULT_POLL_INTERVAL) {
+            updatedForCapacity = true;
+            if (avgTmUtilization < 25) {
+              newPollInterval = DEFAULT_POLL_INTERVAL;
+            } else {
+              // If the the used capacity is greater than or equal to 25% reset the polling interval.
+              newPollInterval = startingPollInterval;
+            }
+          }
         }
       }
-
       if (newPollInterval !== previousPollInterval) {
         if (previousPollInterval !== INTERVAL_AFTER_BLOCK_EXCEPTION) {
-          logger.debug(
-            `Poll interval configuration changing from ${previousPollInterval} to ${newPollInterval} after seeing ${errorCount} "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).`
-          );
-        }
-        if (previousPollInterval === startingPollInterval) {
           logger.warn(
-            `Poll interval configuration is temporarily increased after Elasticsearch returned ${errorCount} "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).`
+            `Poll interval configuration changing from ${previousPollInterval} to ${newPollInterval} after ${
+              updatedForCapacity
+                ? `a change in the average task load: ${avgTmUtilization}.`
+                : `seeing ${errorCount} "too many request" and/or "execute [inline] script" error(s).`
+            }`
           );
         }
       }
@@ -185,7 +182,7 @@ function createPollIntervalScan(logger: Logger, startingPollInterval: number) {
   );
 }
 
-function countErrors(
+export function countErrors(
   errors$: Observable<Error>,
   countInterval: number
 ): Observable<ErrorScanResult> {
@@ -289,4 +286,21 @@ export function calculateStartingCapacity(
 
   // Neither are set, use the given default capacity
   return defaultCapacity;
+}
+
+function getAverageUtilization(
+  utilization: number,
+  window: TaskManagerUtilizationWindow[]
+): number {
+  const currentTime = Date.now();
+  window.push({ timestamp: currentTime, utilization });
+
+  // Remove utilizations outside the 15s window
+  while (window.length > 0 && window[0].timestamp < currentTime - TM_UTILIZATION_WINDOW) {
+    window.shift();
+  }
+
+  // Return the avg utilization
+  const total = sumBy(window, (w) => w.utilization);
+  return total / window.length;
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/monitoring/configuration_statistics.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/monitoring/configuration_statistics.ts
@@ -11,8 +11,8 @@ import { map, startWith } from 'rxjs';
 import { JsonObject } from '@kbn/utility-types';
 import { AggregatedStatProvider } from '../lib/runtime_statistics_aggregator';
 import { CLAIM_STRATEGY_UPDATE_BY_QUERY, TaskManagerConfig } from '../config';
-import { ManagedConfiguration } from '../lib/create_managed_configuration';
 import { getCapacityInCost, getCapacityInWorkers } from '../task_pool';
+import { TaskPollingLifecycle } from '../polling_lifecycle';
 
 const CONFIG_FIELDS_TO_EXPOSE = [
   'request_capacity',
@@ -37,27 +37,40 @@ export type ConfigStat = Pick<
 
 export function createConfigurationAggregator(
   config: TaskManagerConfig,
-  managedConfig: ManagedConfiguration
+  startingCapacity: number,
+  taskPollingLifecycle?: TaskPollingLifecycle
 ): AggregatedStatProvider<ConfigStat> {
+  const pollInterval$ = taskPollingLifecycle
+    ? taskPollingLifecycle.pollIntervalConfiguration$.pipe(
+        startWith(config.poll_interval),
+        map<number, Pick<TaskManagerConfig, 'poll_interval'>>((pollInterval) => ({
+          poll_interval: pollInterval,
+        }))
+      )
+    : of({ poll_interval: config.poll_interval });
+  const capacity$ = taskPollingLifecycle
+    ? taskPollingLifecycle.capacityConfiguration$.pipe(
+        startWith(startingCapacity),
+        map<number, CapacityConfig>((capacity) => ({
+          capacity: {
+            config: capacity,
+            as_workers: getCapacityInWorkers(capacity),
+            as_cost: getCapacityInCost(capacity),
+          },
+        }))
+      )
+    : of({
+        capacity: {
+          config: startingCapacity,
+          as_workers: getCapacityInWorkers(startingCapacity),
+          as_cost: getCapacityInCost(startingCapacity),
+        },
+      });
   return combineLatest([
     of(pick(config, ...CONFIG_FIELDS_TO_EXPOSE)),
     of({ claim_strategy: config.claim_strategy ?? CLAIM_STRATEGY_UPDATE_BY_QUERY }),
-    managedConfig.pollIntervalConfiguration$.pipe(
-      startWith(config.poll_interval),
-      map<number, Pick<TaskManagerConfig, 'poll_interval'>>((pollInterval) => ({
-        poll_interval: pollInterval,
-      }))
-    ),
-    managedConfig.capacityConfiguration$.pipe(
-      startWith(managedConfig.startingCapacity),
-      map<number, CapacityConfig>((capacity) => ({
-        capacity: {
-          config: capacity,
-          as_workers: getCapacityInWorkers(capacity),
-          as_cost: getCapacityInCost(capacity),
-        },
-      }))
-    ),
+    pollInterval$,
+    capacity$,
   ]).pipe(
     map((configurations) => ({
       key: 'configuration',

--- a/x-pack/platform/plugins/shared/task_manager/server/monitoring/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/monitoring/index.ts
@@ -15,7 +15,6 @@ import {
 } from './monitoring_stats_stream';
 import { TaskStore } from '../task_store';
 import { TaskPollingLifecycle } from '../polling_lifecycle';
-import { ManagedConfiguration } from '../lib/create_managed_configuration';
 import { AdHocTaskCounter } from '../lib/adhoc_task_counter';
 import { TaskTypeDictionary } from '../task_type_dictionary';
 
@@ -31,10 +30,10 @@ export interface CreateMonitoringStatsOpts {
   taskStore: TaskStore;
   elasticsearchAndSOAvailability$: Observable<boolean>;
   config: TaskManagerConfig;
-  managedConfig: ManagedConfiguration;
   logger: Logger;
   adHocTaskCounter: AdHocTaskCounter;
   taskDefinitions: TaskTypeDictionary;
+  startingCapacity: number;
   taskPollingLifecycle?: TaskPollingLifecycle;
 }
 

--- a/x-pack/platform/plugins/shared/task_manager/server/monitoring/monitoring_stats_stream.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/monitoring/monitoring_stats_stream.ts
@@ -73,14 +73,14 @@ export function createAggregators({
   taskStore,
   elasticsearchAndSOAvailability$,
   config,
-  managedConfig,
   logger,
   taskDefinitions,
   adHocTaskCounter,
+  startingCapacity,
   taskPollingLifecycle,
 }: CreateMonitoringStatsOpts): AggregatedStatProvider {
   const aggregators: AggregatedStatProvider[] = [
-    createConfigurationAggregator(config, managedConfig),
+    createConfigurationAggregator(config, startingCapacity, taskPollingLifecycle),
 
     createWorkloadAggregator({
       taskStore,

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -35,7 +35,6 @@ import { removeIfExists } from './lib/remove_if_exists';
 import { setupSavedObjects, BACKGROUND_TASK_NODE_SO_NAME, TASK_SO_NAME } from './saved_objects';
 import { TaskDefinitionRegistry, TaskTypeDictionary } from './task_type_dictionary';
 import { AggregationOpts, FetchResult, SearchOpts, TaskStore } from './task_store';
-import { createManagedConfiguration } from './lib/create_managed_configuration';
 import { TaskScheduling } from './task_scheduling';
 import { backgroundTaskUtilizationRoute, healthRoute, metricsRoute } from './routes';
 import { createMonitoringStats, MonitoringStats } from './monitoring';
@@ -48,6 +47,7 @@ import { metricsStream, Metrics } from './metrics';
 import { TaskManagerMetricsCollector } from './metrics/task_metrics_collector';
 import { TaskPartitioner } from './lib/task_partitioner';
 import { getDefaultCapacity } from './lib/get_default_capacity';
+import { calculateStartingCapacity } from './lib/create_managed_configuration';
 import {
   registerMarkRemovedTasksAsUnrecognizedDefinition,
   scheduleMarkRemovedTasksAsUnrecognizedDefinition,
@@ -325,12 +325,7 @@ export class TaskManagerPlugin
       }`
     );
 
-    const managedConfiguration = createManagedConfiguration({
-      config: this.config!,
-      errors$: taskStore.errors$,
-      defaultCapacity,
-      logger: this.logger,
-    });
+    const startingCapacity = calculateStartingCapacity(this.config!, this.logger, defaultCapacity);
 
     // Only poll for tasks if configured to run tasks
     if (this.shouldRunBackgroundTasks) {
@@ -357,8 +352,8 @@ export class TaskManagerPlugin
         usageCounter: this.usageCounter,
         middleware: this.middleware,
         elasticsearchAndSOAvailability$: this.elasticsearchAndSOAvailability$!,
-        ...managedConfiguration,
         taskPartitioner,
+        startingCapacity,
       });
     }
 
@@ -366,11 +361,11 @@ export class TaskManagerPlugin
       taskStore,
       elasticsearchAndSOAvailability$: this.elasticsearchAndSOAvailability$!,
       config: this.config!,
-      managedConfig: managedConfiguration,
       logger: this.logger,
       adHocTaskCounter: this.adHocTaskCounter,
       taskDefinitions: this.definitions,
       taskPollingLifecycle: this.taskPollingLifecycle,
+      startingCapacity,
     }).subscribe((stat) => this.monitoringStats$.next(stat));
 
     metricsStream({

--- a/x-pack/platform/plugins/shared/task_manager/server/polling/delay_on_claim_conflicts.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling/delay_on_claim_conflicts.ts
@@ -15,7 +15,6 @@ import { merge, of, Observable, combineLatest, ReplaySubject } from 'rxjs';
 import { filter, map } from 'rxjs';
 import { Option, none, some, isSome, Some } from 'fp-ts/lib/Option';
 import { isOk } from '../lib/result_type';
-import { ManagedConfiguration } from '../lib/create_managed_configuration';
 import { TaskLifecycleEvent } from '../polling_lifecycle';
 import { isTaskPollingCycleEvent } from '../task_events';
 import { ClaimAndFillPoolResult } from '../lib/fill_pool';
@@ -26,8 +25,8 @@ import { getCapacityInWorkers } from '../task_pool';
  * Emits a delay amount in ms to apply to polling whenever the task store exceeds a threshold of claim claimClashes
  */
 export function delayOnClaimConflicts(
-  capacityConfiguration$: ManagedConfiguration['capacityConfiguration$'],
-  pollIntervalConfiguration$: ManagedConfiguration['pollIntervalConfiguration$'],
+  capacityConfiguration$: Observable<number>,
+  pollIntervalConfiguration$: Observable<number>,
   taskLifecycleEvents$: Observable<TaskLifecycleEvent>,
   claimClashesPercentageThreshold: number,
   runningAverageWindowSize: number

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.mock.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.mock.ts
@@ -9,8 +9,15 @@ import { TaskPollingLifecycle, TaskLifecycleEvent } from './polling_lifecycle';
 import { of, Observable } from 'rxjs';
 
 export const taskPollingLifecycleMock = {
-  create(opts: { isStarted?: boolean; events$?: Observable<TaskLifecycleEvent> }) {
+  create(opts: {
+    isStarted?: boolean;
+    events$?: Observable<TaskLifecycleEvent>;
+    pollIntervalConfiguration$?: Observable<number>;
+    capacityConfiguration$?: Observable<number>;
+  }) {
     return {
+      pollIntervalConfiguration$: opts.pollIntervalConfiguration$ ?? of(),
+      capacityConfiguration$: opts.capacityConfiguration$ ?? of(),
       attemptToRun: jest.fn(),
       stop: jest.fn(),
       get isStarted() {

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
@@ -6,7 +6,7 @@
  */
 
 import sinon from 'sinon';
-import { of, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 
 import { TaskPollingLifecycle, claimAvailableTasks, TaskLifecycleEvent } from './polling_lifecycle';
 import { createInitialMiddleware } from './lib/middleware';
@@ -105,8 +105,6 @@ describe('TaskPollingLifecycle', () => {
     definitions: new TaskTypeDictionary(taskManagerLogger),
     middleware: createInitialMiddleware(),
     startingCapacity: 20,
-    capacityConfiguration$: of(20),
-    pollIntervalConfiguration$: of(100),
     executionContext,
     taskPartitioner: new TaskPartitioner({
       logger: taskManagerLogger,
@@ -154,61 +152,36 @@ describe('TaskPollingLifecycle', () => {
 
     test('provides TaskClaiming with the capacity available when strategy = CLAIM_STRATEGY_UPDATE_BY_QUERY', () => {
       const elasticsearchAndSOAvailability$ = new Subject<boolean>();
-      const capacity$ = new Subject<number>();
 
       new TaskPollingLifecycle({
         ...taskManagerOpts,
         elasticsearchAndSOAvailability$,
-        capacityConfiguration$: capacity$,
+        startingCapacity: 40,
       });
-
       const taskClaimingGetCapacity = (TaskClaiming as jest.Mock<TaskClaimingClass>).mock
         .calls[0][0].getAvailableCapacity;
 
-      capacity$.next(40);
       expect(taskClaimingGetCapacity()).toEqual(40);
       expect(taskClaimingGetCapacity('report')).toEqual(1);
       expect(taskClaimingGetCapacity('quickReport')).toEqual(5);
-
-      capacity$.next(60);
-      expect(taskClaimingGetCapacity()).toEqual(60);
-      expect(taskClaimingGetCapacity('report')).toEqual(1);
-      expect(taskClaimingGetCapacity('quickReport')).toEqual(5);
-
-      capacity$.next(4);
-      expect(taskClaimingGetCapacity()).toEqual(4);
-      expect(taskClaimingGetCapacity('report')).toEqual(1);
-      expect(taskClaimingGetCapacity('quickReport')).toEqual(4);
     });
 
     test('provides TaskClaiming with the capacity available when strategy = CLAIM_STRATEGY_MGET', () => {
       const elasticsearchAndSOAvailability$ = new Subject<boolean>();
-      const capacity$ = new Subject<number>();
 
       new TaskPollingLifecycle({
         ...taskManagerOpts,
         config: { ...taskManagerOpts.config, claim_strategy: CLAIM_STRATEGY_MGET },
         elasticsearchAndSOAvailability$,
-        capacityConfiguration$: capacity$,
+        startingCapacity: 40,
       });
 
       const taskClaimingGetCapacity = (TaskClaiming as jest.Mock<TaskClaimingClass>).mock
         .calls[0][0].getAvailableCapacity;
 
-      capacity$.next(40);
       expect(taskClaimingGetCapacity()).toEqual(80);
       expect(taskClaimingGetCapacity('report')).toEqual(10);
       expect(taskClaimingGetCapacity('quickReport')).toEqual(10);
-
-      capacity$.next(60);
-      expect(taskClaimingGetCapacity()).toEqual(120);
-      expect(taskClaimingGetCapacity('report')).toEqual(10);
-      expect(taskClaimingGetCapacity('quickReport')).toEqual(10);
-
-      capacity$.next(4);
-      expect(taskClaimingGetCapacity()).toEqual(8);
-      expect(taskClaimingGetCapacity('report')).toEqual(8);
-      expect(taskClaimingGetCapacity('quickReport')).toEqual(8);
     });
   });
 
@@ -589,6 +562,32 @@ describe('TaskPollingLifecycle', () => {
         tag: 'err',
         error: new Error(`Partially failed to poll for work: some tasks could not be claimed.`),
       });
+    });
+  });
+
+  describe('pollingLifecycleEvents capacity and poll interval', () => {
+    test('returns observables with initialized values', async () => {
+      const elasticsearchAndSOAvailability$ = new Subject<boolean>();
+      const taskPollingLifecycle = new TaskPollingLifecycle({
+        ...taskManagerOpts,
+        config: {
+          ...taskManagerOpts.config,
+          poll_interval: 2,
+        },
+        elasticsearchAndSOAvailability$,
+      });
+
+      elasticsearchAndSOAvailability$.next(true);
+
+      const capacitySubscription = jest.fn();
+      const pollIntervalSubscription = jest.fn();
+
+      taskPollingLifecycle.capacityConfiguration$.subscribe(capacitySubscription);
+      taskPollingLifecycle.pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
+      expect(capacitySubscription).toHaveBeenCalledTimes(1);
+      expect(capacitySubscription).toHaveBeenNthCalledWith(1, 20);
+      expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
+      expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.mock.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.mock.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { of } from 'rxjs';
 import { TaskStore } from './task_store';
 
 interface TaskStoreOptions {
@@ -38,6 +39,7 @@ export const taskStoreMock = {
       msearch: jest.fn(),
       index,
       taskManagerId,
+      errors$: of(),
     } as unknown as jest.Mocked<TaskStore>;
     return mocked;
   },

--- a/x-pack/test/fleet_api_integration/apis/agents/update_agent_tags.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/update_agent_tags.ts
@@ -38,7 +38,7 @@ export async function pollResult(
         await verifyActionResult();
         resolve({});
       }
-    }, 1000);
+    }, 3000);
   }).catch((e) => {
     throw e;
   });

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/health_route.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/health_route.ts
@@ -133,25 +133,25 @@ export default function ({ getService }: FtrProviderContext) {
     it('should return basic configuration of task manager', async () => {
       const health = await getHealth();
       expect(health.status).to.eql('OK');
-      expect(health.stats.configuration.value).to.eql({
-        poll_interval: 500,
-        monitored_aggregated_stats_refresh_rate: monitoredAggregatedStatsRefreshRate,
-        monitored_stats_running_average_window: 50,
-        monitored_task_execution_thresholds: {
-          custom: {},
-          default: {
-            error_threshold: 90,
-            warn_threshold: 80,
-          },
+      expect(health.stats.configuration.value.monitored_aggregated_stats_refresh_rate).to.eql(
+        monitoredAggregatedStatsRefreshRate
+      );
+      expect(health.stats.configuration.value.monitored_stats_running_average_window).to.eql(50);
+      expect(health.stats.configuration.value.monitored_task_execution_thresholds).to.eql({
+        custom: {},
+        default: {
+          error_threshold: 90,
+          warn_threshold: 80,
         },
-        request_capacity: 1000,
-        capacity: {
-          config: 10,
-          as_workers: 10,
-          as_cost: 20,
-        },
-        claim_strategy: 'mget',
       });
+      expect(health.stats.configuration.value.request_capacity).to.eql(1000);
+      expect(health.stats.configuration.value.capacity).to.eql({
+        config: 10,
+        as_workers: 10,
+        as_cost: 20,
+      });
+      expect(health.stats.configuration.value.claim_strategy).to.eql('mget');
+      expect(typeof health.stats.configuration.value.poll_interval).to.eql('number');
     });
 
     it('should return the task manager workload', async () => {


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



