### PR TITLE
[Asset Inventory] Fix privileges required error

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/links.ts
@@ -8,11 +8,15 @@
 import { i18n } from '@kbn/i18n';
 
 import { INVENTORY } from '../app/translations';
-import { ASSET_INVENTORY_PATH, SecurityPageName, SERVER_APP_ID } from '../../common/constants';
+import {
+  ASSET_INVENTORY_PATH,
+  SecurityPageName,
+  SECURITY_FEATURE_ID,
+} from '../../common/constants';
 import type { LinkItem } from '../common/links/types';
 
 export const links: LinkItem = {
-  capabilities: [`${SERVER_APP_ID}.show`],
+  capabilities: [`${SECURITY_FEATURE_ID}.show`],
   globalNavPosition: 10,
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.inventory', {


### PR DESCRIPTION
## Summary

This PR fixes the Privileges Required error when accessing the Asset Inventory page introduced by #201780, due to changes on the `siem` capability being migrated to `siemV2`.

<img width="943" alt="image" src="https://github.com/user-attachments/assets/91fd6041-73b0-42e7-94b7-f4acadc25329" />


In order to fix it, the capability was changed to `siemV2.
