### PR TITLE
[Rule Migration] Add inference connector as supported LLM type

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/connectors/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/connectors/constants.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export const AIActionTypeIds = ['.bedrock', '.gen-ai', '.gemini'];
+export const AIActionTypeIds = ['.bedrock', '.gen-ai', '.gemini', '.inference'];

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/util/actions_client_chat.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/util/actions_client_chat.ts
@@ -5,16 +5,16 @@
  * 2.0.
  */
 
+import type { ActionsClient } from '@kbn/actions-plugin/server';
+import type { Logger } from '@kbn/core/server';
 import type { ActionsClientSimpleChatModel } from '@kbn/langchain/server';
 import {
   ActionsClientBedrockChatModel,
   ActionsClientChatOpenAI,
   ActionsClientChatVertexAI,
 } from '@kbn/langchain/server';
-import type { Logger } from '@kbn/core/server';
-import type { ActionsClient } from '@kbn/actions-plugin/server';
-import type { ActionsClientChatOpenAIParams } from '@kbn/langchain/server/language_models/chat_openai';
 import type { CustomChatModelInput as ActionsClientBedrockChatModelParams } from '@kbn/langchain/server/language_models/bedrock_chat';
+import type { ActionsClientChatOpenAIParams } from '@kbn/langchain/server/language_models/chat_openai';
 import type { CustomChatModelInput as ActionsClientChatVertexAIParams } from '@kbn/langchain/server/language_models/gemini_chat';
 import type { CustomChatModelInput as ActionsClientSimpleChatModelParams } from '@kbn/langchain/server/language_models/simple_chat_model';
 
@@ -39,6 +39,7 @@ const llmTypeDictionary: Record<string, string> = {
   [`.gen-ai`]: `openai`,
   [`.bedrock`]: `bedrock`,
   [`.gemini`]: `gemini`,
+  [`.inference`]: `inference`,
 };
 
 export class ActionsClientChat {
@@ -83,6 +84,7 @@ export class ActionsClientChat {
       case 'gemini':
         return ActionsClientChatVertexAI;
       case 'openai':
+      case 'inference':
       default:
         return ActionsClientChatOpenAI;
     }


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

Adds .inference as a supported type, so it can be tested with EIS both with custom providers and the default EIS provider.




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->