### PR TITLE
[Dashboard] improve performance for initial rendering

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_container/component/grid/dashboard_grid.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_container/component/grid/dashboard_grid.tsx
@@ -22,7 +22,11 @@ import { DASHBOARD_GRID_HEIGHT, DASHBOARD_MARGIN_SIZE } from './constants';
 import { DashboardGridItem } from './dashboard_grid_item';
 import { useLayoutStyles } from './use_layout_styles';
 
-export const DashboardGrid = ({ dashboardContainer }: { dashboardContainer?: HTMLElement }) => {
+export const DashboardGrid = ({
+  dashboardContainerRef,
+}: {
+  dashboardContainerRef?: React.MutableRefObject<HTMLElement | null>;
+}) => {
   const dashboardApi = useDashboardApi();
   const layoutStyles = useLayoutStyles();
   const panelRefs = useRef<{ [panelId: string]: React.Ref<HTMLDivElement> }>({});
@@ -103,11 +107,11 @@ export const DashboardGrid = ({ dashboardContainer }: { dashboardContainer?: HTM
           type={type}
           setDragHandles={setDragHandles}
           appFixedViewport={appFixedViewport}
-          dashboardContainer={dashboardContainer}
+          dashboardContainerRef={dashboardContainerRef}
         />
       );
     },
-    [appFixedViewport, dashboardApi, dashboardContainer]
+    [appFixedViewport, dashboardApi, dashboardContainerRef]
   );
 
   const memoizedgridLayout = useMemo(() => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_container/component/grid/dashboard_grid_item.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_container/component/grid/dashboard_grid_item.tsx
@@ -25,7 +25,7 @@ type DivProps = Pick<React.HTMLAttributes<HTMLDivElement>, 'className' | 'style'
 
 export interface Props extends DivProps {
   appFixedViewport?: HTMLElement;
-  dashboardContainer?: HTMLElement;
+  dashboardContainerRef?: React.MutableRefObject<HTMLElement | null>;
   id: DashboardPanelState['explicitInput']['id'];
   index?: number;
   type: DashboardPanelState['type'];
@@ -38,7 +38,7 @@ export const Item = React.forwardRef<HTMLDivElement, Props>(
   (
     {
       appFixedViewport,
-      dashboardContainer,
+      dashboardContainerRef,
       id,
       index,
       type,
@@ -103,7 +103,7 @@ export const Item = React.forwardRef<HTMLDivElement, Props>(
       }
     }, [id, dashboardApi, scrollToPanelId, highlightPanelId, ref, blurPanel]);
 
-    const dashboardContainerTopOffset = dashboardContainer?.offsetTop || 0;
+    const dashboardContainerTopOffset = dashboardContainerRef?.current?.offsetTop || 0;
     const globalNavTopOffset = appFixedViewport?.offsetTop || 0;
 
     const focusStyles = blurPanel

--- a/src/platform/plugins/shared/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
@@ -26,7 +26,11 @@ import { useDashboardApi } from '../../../dashboard_api/use_dashboard_api';
 import { useDashboardInternalApi } from '../../../dashboard_api/use_dashboard_internal_api';
 import { DashboardEmptyScreen } from '../empty_screen/dashboard_empty_screen';
 
-export const DashboardViewport = ({ dashboardContainer }: { dashboardContainer?: HTMLElement }) => {
+export const DashboardViewport = ({
+  dashboardContainerRef,
+}: {
+  dashboardContainerRef?: React.MutableRefObject<HTMLElement | null>;
+}) => {
   const dashboardApi = useDashboardApi();
   const dashboardInternalApi = useDashboardInternalApi();
   const [hasControls, setHasControls] = useState(false);
@@ -136,7 +140,7 @@ export const DashboardViewport = ({ dashboardContainer }: { dashboardContainer?:
         data-description={description}
         data-shared-items-count={panelCount}
       >
-        <DashboardGrid dashboardContainer={dashboardContainer} />
+        <DashboardGrid dashboardContainerRef={dashboardContainerRef} />
       </div>
     </div>
   );

--- a/src/platform/plugins/shared/dashboard/public/dashboard_container/external_api/dashboard_renderer.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_container/external_api/dashboard_renderer.tsx
@@ -46,7 +46,7 @@ export function DashboardRenderer({
   onApiAvailable,
 }: DashboardRendererProps) {
   const dashboardViewport = useRef(null);
-  const dashboardContainer = useRef(null);
+  const dashboardContainerRef = useRef<HTMLElement | null>(null);
   const [dashboardApi, setDashboardApi] = useState<DashboardApi | undefined>();
   const [dashboardInternalApi, setDashboardInternalApi] = useState<
     DashboardInternalApi | undefined
@@ -112,17 +112,13 @@ export function DashboardRenderer({
     }
 
     return dashboardApi && dashboardInternalApi ? (
-      <div className="dashboardContainer" ref={dashboardContainer}>
+      <div className="dashboardContainer" ref={(e) => (dashboardContainerRef.current = e)}>
         <ExitFullScreenButtonKibanaProvider
           coreStart={{ chrome: coreServices.chrome, customBranding: coreServices.customBranding }}
         >
           <DashboardContext.Provider value={dashboardApi}>
             <DashboardInternalContext.Provider value={dashboardInternalApi}>
-              <DashboardViewport
-                dashboardContainer={
-                  dashboardContainer.current ? dashboardContainer.current : undefined
-                }
-              />
+              <DashboardViewport dashboardContainerRef={dashboardContainerRef} />
             </DashboardInternalContext.Provider>
           </DashboardContext.Provider>
         </ExitFullScreenButtonKibanaProvider>


### PR DESCRIPTION
## Summary

While investigating why `renderPanelContents` runs three times on page load (I remove one of 3 in my refactoring [PR](https://github.com/elastic/kibana/pull/206941), but want to understand the second re-render too), I found that the issue is caused by the `useCallback` dependency on `dashboardContainer`. `dashboardContainer` is the HTML element we pass to the grid items. To prevent unnecessary re-renders, I’ve updated it to pass the entire ref instead of the element itself.

I’m unsure if this change might introduce other issues, as I don't know if I caught all the usecases for using it. What I tested (and didn't break) is this flow (and it still works correctly):
- open a dashboard
- for a Lens visualization that's not on top of the screen, click on 'edit' button
- expected behavior: the visualization scrolls to the top of the dashboard container screen, but is not hidden below the header content.

https://github.com/user-attachments/assets/0cba7b14-12f6-4c0d-82b7-3622640634d2

If I replace the line `const dashboardContainerTopOffset = dashboardContainerRef?.current?.offsetTop || 0;` to `const dashboardContainerTopOffset = 0;`, it breaks so I guess we're set :) 

https://github.com/user-attachments/assets/ace393b9-64dd-4d7f-a032-f5924275d818




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->