### PR TITLE
[8.17] Fixed an error with missing uids in the cases detail page (#207228)

### DIFF
--- a/x-pack/plugins/cases/server/client/user_actions/users.test.ts
+++ b/x-pack/plugins/cases/server/client/user_actions/users.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createUserActionServiceMock } from '../../services/mocks';
+import { createMockClient } from '../metrics/test_utils/client';
+import { createCasesClientMockArgs } from '../mocks';
+import { getUsers } from './users';
+import { mockCases } from '../../mocks';
+import type { CaseResolveResponse } from '../../../common/types/api';
+import { getUserProfiles } from '../cases/utils';
+
+jest.mock('../cases/utils');
+
+const getUserProfilesMock = getUserProfiles as jest.Mock;
+
+describe('getUsers', () => {
+  const casesClient = createMockClient();
+
+  casesClient.cases.resolve.mockResolvedValue({
+    case: mockCases[0].attributes,
+  } as CaseResolveResponse);
+
+  const clientArgs = createCasesClientMockArgs();
+  const userActionService = createUserActionServiceMock();
+
+  userActionService.getUsers.mockResolvedValue({
+    participants: [
+      {
+        id: 'foo',
+        owner: 'bar',
+        user: { email: '', full_name: '', username: '', profile_uid: '' },
+      },
+      {
+        id: 'foo',
+        owner: 'bar',
+        user: { email: '', full_name: '', username: '', profile_uid: 'some_profile_id' },
+      },
+    ],
+    assignedAndUnassignedUsers: new Set([]),
+  });
+  getUserProfilesMock.mockResolvedValue(new Map());
+  clientArgs.services.userActionService = userActionService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('removes empty uids from getUserProfiles call', async () => {
+    await getUsers({ caseId: 'test-case' }, casesClient, clientArgs);
+
+    expect(getUserProfilesMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      new Set(['some_profile_id']),
+      expect.any(String)
+    );
+  });
+});

--- a/x-pack/plugins/cases/server/client/user_actions/users.ts
+++ b/x-pack/plugins/cases/server/client/user_actions/users.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isString } from 'lodash';
+import { isEmpty, isString } from 'lodash';
 import type { UserProfileAvatarData, UserProfileWithAvatar } from '@kbn/user-profile-components';
 import type { GetCaseUsersResponse } from '../../../common/types/api';
 import { GetCaseUsersResponseRt } from '../../../common/types/api';
@@ -57,12 +57,14 @@ export const getUsers = async (
     const reporter = theCase.case.created_by;
     const reporterProfileIdAsArray = reporter.profile_uid != null ? [reporter.profile_uid] : [];
 
-    const userProfileUids = new Set([
-      ...assignedAndUnassignedUsers,
-      ...participantsUids,
-      ...assigneesUids,
-      ...reporterProfileIdAsArray,
-    ]);
+    const userProfileUids = new Set(
+      [
+        ...assignedAndUnassignedUsers,
+        ...participantsUids,
+        ...assigneesUids,
+        ...reporterProfileIdAsArray,
+      ].filter((uid) => !isEmpty(uid))
+    );
 
     const userProfiles = await getUserProfiles(securityStartPlugin, userProfileUids, 'avatar');
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Fixed an error with missing uids in the cases detail page (#207228)](https://github.com/elastic/kibana/pull/207228)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Antonio","email":"antonio.coelho@elastic.co"},"sourceCommit":{"committedDate":"2025-01-22T16:15:43Z","message":"Fixed an error with missing uids in the cases detail page (#207228)\n\nFixes #206801\r\n\r\n## Summary\r\n\r\nWhen opening the case detail page we retrieve user profile info for the\r\ndifferent case user actions.\r\n\r\nIf the uid stored in ES is an empty string for any of these user\r\nactions, we get an error that looks like this:\r\n\r\n![Screenshot 2025-01-20 at 12 34\r\n54](https://github.com/user-attachments/assets/175c6920-a4fb-4588-9668-1ba7d73f14f3)\r\n\r\n\r\n### Steps to reproduce/test (thanks @jcger )\r\n\r\n1. Create a user with the `system_indices_superuser` role\r\n2. Create a case and assign a user to it\r\n3. Get the ID of the assignment user action from the case above\r\n```\r\nGET .kibana_alerting_cases/_search\r\n{\r\n  \"query\": {\r\n    \"bool\": {\r\n      \"filter\": [\r\n        {\r\n          \"term\": {\r\n            \"type\": \"cases-user-actions\"\r\n          }\r\n        },\r\n        {\r\n          \"term\": {\r\n            \"cases-user-actions.type\": \"assignees\"\r\n          }\r\n        },\r\n        {\r\n          \"nested\": {\r\n            \"path\": \"references\",\r\n            \"query\": {\r\n              \"bool\": {\r\n                \"filter\": [\r\n                  {\r\n                    \"term\": {\r\n                      \"references.type\": \"cases\"\r\n                    }\r\n                  },\r\n                  {\r\n                    \"term\": {\r\n                      \"references.id\": \"<case_id>\"\r\n                    }\r\n                  }\r\n                ]\r\n              }\r\n            }\r\n          }\r\n        }\r\n      ]\r\n    }\r\n  }\r\n}\r\n```\r\n4. Manually set the `uid` of the assignee to `\"\"`\r\n```\r\nPOST .kibana_alerting_cases/_update/<cases-user-actions-id>\r\n{\r\n  \"script\": {\r\n    \"source\": \"\"\"\r\n        ctx._source[\"cases-user-actions\"].payload.assignees[0].uid = \"\";\r\n    \"\"\"\r\n  }\r\n}\r\n```\r\n\r\nAfter this PR the popup should **not** appear anymore.","sha":"d8e5cbf67f2bae859a18f956c22205b78d3da5aa","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","v9.0.0","Feature:Cases","backport:prev-major","v8.18.0","v8.16.4","v8.17.2"],"title":"Fixed an error with missing uids in the cases detail page","number":207228,"url":"https://github.com/elastic/kibana/pull/207228","mergeCommit":{"message":"Fixed an error with missing uids in the cases detail page (#207228)\n\nFixes #206801\r\n\r\n## Summary\r\n\r\nWhen opening the case detail page we retrieve user profile info for the\r\ndifferent case user actions.\r\n\r\nIf the uid stored in ES is an empty string for any of these user\r\nactions, we get an error that looks like this:\r\n\r\n![Screenshot 2025-01-20 at 12 34\r\n54](https://github.com/user-attachments/assets/175c6920-a4fb-4588-9668-1ba7d73f14f3)\r\n\r\n\r\n### Steps to reproduce/test (thanks @jcger )\r\n\r\n1. Create a user with the `system_indices_superuser` role\r\n2. Create a case and assign a user to it\r\n3. Get the ID of the assignment user action from the case above\r\n```\r\nGET .kibana_alerting_cases/_search\r\n{\r\n  \"query\": {\r\n    \"bool\": {\r\n      \"filter\": [\r\n        {\r\n          \"term\": {\r\n            \"type\": \"cases-user-actions\"\r\n          }\r\n        },\r\n        {\r\n          \"term\": {\r\n            \"cases-user-actions.type\": \"assignees\"\r\n          }\r\n        },\r\n        {\r\n          \"nested\": {\r\n            \"path\": \"references\",\r\n            \"query\": {\r\n              \"bool\": {\r\n                \"filter\": [\r\n                  {\r\n                    \"term\": {\r\n                      \"references.type\": \"cases\"\r\n                    }\r\n                  },\r\n                  {\r\n                    \"term\": {\r\n                      \"references.id\": \"<case_id>\"\r\n                    }\r\n                  }\r\n                ]\r\n              }\r\n            }\r\n          }\r\n        }\r\n      ]\r\n    }\r\n  }\r\n}\r\n```\r\n4. Manually set the `uid` of the assignee to `\"\"`\r\n```\r\nPOST .kibana_alerting_cases/_update/<cases-user-actions-id>\r\n{\r\n  \"script\": {\r\n    \"source\": \"\"\"\r\n        ctx._source[\"cases-user-actions\"].payload.assignees[0].uid = \"\";\r\n    \"\"\"\r\n  }\r\n}\r\n```\r\n\r\nAfter this PR the popup should **not** appear anymore.","sha":"d8e5cbf67f2bae859a18f956c22205b78d3da5aa"}},"sourceBranch":"main","suggestedTargetBranches":["8.16","8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/207228","number":207228,"mergeCommit":{"message":"Fixed an error with missing uids in the cases detail page (#207228)\n\nFixes #206801\r\n\r\n## Summary\r\n\r\nWhen opening the case detail page we retrieve user profile info for the\r\ndifferent case user actions.\r\n\r\nIf the uid stored in ES is an empty string for any of these user\r\nactions, we get an error that looks like this:\r\n\r\n![Screenshot 2025-01-20 at 12 34\r\n54](https://github.com/user-attachments/assets/175c6920-a4fb-4588-9668-1ba7d73f14f3)\r\n\r\n\r\n### Steps to reproduce/test (thanks @jcger )\r\n\r\n1. Create a user with the `system_indices_superuser` role\r\n2. Create a case and assign a user to it\r\n3. Get the ID of the assignment user action from the case above\r\n```\r\nGET .kibana_alerting_cases/_search\r\n{\r\n  \"query\": {\r\n    \"bool\": {\r\n      \"filter\": [\r\n        {\r\n          \"term\": {\r\n            \"type\": \"cases-user-actions\"\r\n          }\r\n        },\r\n        {\r\n          \"term\": {\r\n            \"cases-user-actions.type\": \"assignees\"\r\n          }\r\n        },\r\n        {\r\n          \"nested\": {\r\n            \"path\": \"references\",\r\n            \"query\": {\r\n              \"bool\": {\r\n                \"filter\": [\r\n                  {\r\n                    \"term\": {\r\n                      \"references.type\": \"cases\"\r\n                    }\r\n                  },\r\n                  {\r\n                    \"term\": {\r\n                      \"references.id\": \"<case_id>\"\r\n                    }\r\n                  }\r\n                ]\r\n              }\r\n            }\r\n          }\r\n        }\r\n      ]\r\n    }\r\n  }\r\n}\r\n```\r\n4. Manually set the `uid` of the assignee to `\"\"`\r\n```\r\nPOST .kibana_alerting_cases/_update/<cases-user-actions-id>\r\n{\r\n  \"script\": {\r\n    \"source\": \"\"\"\r\n        ctx._source[\"cases-user-actions\"].payload.assignees[0].uid = \"\";\r\n    \"\"\"\r\n  }\r\n}\r\n```\r\n\r\nAfter this PR the popup should **not** appear anymore.","sha":"d8e5cbf67f2bae859a18f956c22205b78d3da5aa"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/207873","number":207873,"state":"MERGED","mergeCommit":{"sha":"06af0cf9a340eee1f5678af8797c442834c173e7","message":"[8.x] Fixed an error with missing uids in the cases detail page (#207228) (#207873)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [Fixed an error with missing uids in the cases detail page\n(#207228)](https://github.com/elastic/kibana/pull/207228)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT\n[{\"author\":{\"name\":\"Antonio\",\"email\":\"antonio.coelho@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-01-22T16:15:43Z\",\"message\":\"Fixed\nan error with missing uids in the cases detail page (#207228)\\n\\nFixes\n#206801\\r\\n\\r\\n## Summary\\r\\n\\r\\nWhen opening the case detail page we\nretrieve user profile info for the\\r\\ndifferent case user\nactions.\\r\\n\\r\\nIf the uid stored in ES is an empty string for any of\nthese user\\r\\nactions, we get an error that looks like\nthis:\\r\\n\\r\\n![Screenshot 2025-01-20 at 12\n34\\r\\n54](https://github.com/user-attachments/assets/175c6920-a4fb-4588-9668-1ba7d73f14f3)\\r\\n\\r\\n\\r\\n###\nSteps to reproduce/test (thanks @jcger )\\r\\n\\r\\n1. Create a user with\nthe `system_indices_superuser` role\\r\\n2. Create a case and assign a\nuser to it\\r\\n3. Get the ID of the assignment user action from the case\nabove\\r\\n```\\r\\nGET .kibana_alerting_cases/_search\\r\\n{\\r\\n \\\"query\\\":\n{\\r\\n \\\"bool\\\": {\\r\\n \\\"filter\\\": [\\r\\n {\\r\\n \\\"term\\\": {\\r\\n \\\"type\\\":\n\\\"cases-user-actions\\\"\\r\\n }\\r\\n },\\r\\n {\\r\\n \\\"term\\\": {\\r\\n\n\\\"cases-user-actions.type\\\": \\\"assignees\\\"\\r\\n }\\r\\n },\\r\\n {\\r\\n\n\\\"nested\\\": {\\r\\n \\\"path\\\": \\\"references\\\",\\r\\n \\\"query\\\": {\\r\\n\n\\\"bool\\\": {\\r\\n \\\"filter\\\": [\\r\\n {\\r\\n \\\"term\\\": {\\r\\n\n\\\"references.type\\\": \\\"cases\\\"\\r\\n }\\r\\n },\\r\\n {\\r\\n \\\"term\\\": {\\r\\n\n\\\"references.id\\\": \\\"<case_id>\\\"\\r\\n }\\r\\n }\\r\\n ]\\r\\n }\\r\\n }\\r\\n }\\r\\n\n}\\r\\n ]\\r\\n }\\r\\n }\\r\\n}\\r\\n```\\r\\n4. Manually set the `uid` of the\nassignee to `\\\"\\\"`\\r\\n```\\r\\nPOST\n.kibana_alerting_cases/_update/<cases-user-actions-id>\\r\\n{\\r\\n\n\\\"script\\\": {\\r\\n \\\"source\\\": \\\"\\\"\\\"\\r\\n\nctx._source[\\\"cases-user-actions\\\"].payload.assignees[0].uid = \\\"\\\";\\r\\n\n\\\"\\\"\\\"\\r\\n }\\r\\n}\\r\\n```\\r\\n\\r\\nAfter this PR the popup should **not**\nappear\nanymore.\",\"sha\":\"d8e5cbf67f2bae859a18f956c22205b78d3da5aa\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"release_note:skip\",\"Team:ResponseOps\",\"v9.0.0\",\"Feature:Cases\",\"backport:prev-minor\"],\"title\":\"Fixed\nan error with missing uids in the cases detail\npage\",\"number\":207228,\"url\":\"https://github.com/elastic/kibana/pull/207228\",\"mergeCommit\":{\"message\":\"Fixed\nan error with missing uids in the cases detail page (#207228)\\n\\nFixes\n#206801\\r\\n\\r\\n## Summary\\r\\n\\r\\nWhen opening the case detail page we\nretrieve user profile info for the\\r\\ndifferent case user\nactions.\\r\\n\\r\\nIf the uid stored in ES is an empty string for any of\nthese user\\r\\nactions, we get an error that looks like\nthis:\\r\\n\\r\\n![Screenshot 2025-01-20 at 12\n34\\r\\n54](https://github.com/user-attachments/assets/175c6920-a4fb-4588-9668-1ba7d73f14f3)\\r\\n\\r\\n\\r\\n###\nSteps to reproduce/test (thanks @jcger )\\r\\n\\r\\n1. Create a user with\nthe `system_indices_superuser` role\\r\\n2. Create a case and assign a\nuser to it\\r\\n3. Get the ID of the assignment user action from the case\nabove\\r\\n```\\r\\nGET .kibana_alerting_cases/_search\\r\\n{\\r\\n \\\"query\\\":\n{\\r\\n \\\"bool\\\": {\\r\\n \\\"filter\\\": [\\r\\n {\\r\\n \\\"term\\\": {\\r\\n \\\"type\\\":\n\\\"cases-user-actions\\\"\\r\\n }\\r\\n },\\r\\n {\\r\\n \\\"term\\\": {\\r\\n\n\\\"cases-user-actions.type\\\": \\\"assignees\\\"\\r\\n }\\r\\n },\\r\\n {\\r\\n\n\\\"nested\\\": {\\r\\n \\\"path\\\": \\\"references\\\",\\r\\n \\\"query\\\": {\\r\\n\n\\\"bool\\\": {\\r\\n \\\"filter\\\": [\\r\\n {\\r\\n \\\"term\\\": {\\r\\n\n\\\"references.type\\\": \\\"cases\\\"\\r\\n }\\r\\n },\\r\\n {\\r\\n \\\"term\\\": {\\r\\n\n\\\"references.id\\\": \\\"<case_id>\\\"\\r\\n }\\r\\n }\\r\\n ]\\r\\n }\\r\\n }\\r\\n }\\r\\n\n}\\r\\n ]\\r\\n }\\r\\n }\\r\\n}\\r\\n```\\r\\n4. Manually set the `uid` of the\nassignee to `\\\"\\\"`\\r\\n```\\r\\nPOST\n.kibana_alerting_cases/_update/<cases-user-actions-id>\\r\\n{\\r\\n\n\\\"script\\\": {\\r\\n \\\"source\\\": \\\"\\\"\\\"\\r\\n\nctx._source[\\\"cases-user-actions\\\"].payload.assignees[0].uid = \\\"\\\";\\r\\n\n\\\"\\\"\\\"\\r\\n }\\r\\n}\\r\\n```\\r\\n\\r\\nAfter this PR the popup should **not**\nappear\nanymore.\",\"sha\":\"d8e5cbf67f2bae859a18f956c22205b78d3da5aa\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/207228\",\"number\":207228,\"mergeCommit\":{\"message\":\"Fixed\nan error with missing uids in the cases detail page (#207228)\\n\\nFixes\n#206801\\r\\n\\r\\n## Summary\\r\\n\\r\\nWhen opening the case detail page we\nretrieve user profile info for the\\r\\ndifferent case user\nactions.\\r\\n\\r\\nIf the uid stored in ES is an empty string for any of\nthese user\\r\\nactions, we get an error that looks like\nthis:\\r\\n\\r\\n![Screenshot 2025-01-20 at 12\n34\\r\\n54](https://github.com/user-attachments/assets/175c6920-a4fb-4588-9668-1ba7d73f14f3)\\r\\n\\r\\n\\r\\n###\nSteps to reproduce/test (thanks @jcger )\\r\\n\\r\\n1. Create a user with\nthe `system_indices_superuser` role\\r\\n2. Create a case and assign a\nuser to it\\r\\n3. Get the ID of the assignment user action from the case\nabove\\r\\n```\\r\\nGET .kibana_alerting_cases/_search\\r\\n{\\r\\n \\\"query\\\":\n{\\r\\n \\\"bool\\\": {\\r\\n \\\"filter\\\": [\\r\\n {\\r\\n \\\"term\\\": {\\r\\n \\\"type\\\":\n\\\"cases-user-actions\\\"\\r\\n }\\r\\n },\\r\\n {\\r\\n \\\"term\\\": {\\r\\n\n\\\"cases-user-actions.type\\\": \\\"assignees\\\"\\r\\n }\\r\\n },\\r\\n {\\r\\n\n\\\"nested\\\": {\\r\\n \\\"path\\\": \\\"references\\\",\\r\\n \\\"query\\\": {\\r\\n\n\\\"bool\\\": {\\r\\n \\\"filter\\\": [\\r\\n {\\r\\n \\\"term\\\": {\\r\\n\n\\\"references.type\\\": \\\"cases\\\"\\r\\n }\\r\\n },\\r\\n {\\r\\n \\\"term\\\": {\\r\\n\n\\\"references.id\\\": \\\"<case_id>\\\"\\r\\n }\\r\\n }\\r\\n ]\\r\\n }\\r\\n }\\r\\n }\\r\\n\n}\\r\\n ]\\r\\n }\\r\\n }\\r\\n}\\r\\n```\\r\\n4. Manually set the `uid` of the\nassignee to `\\\"\\\"`\\r\\n```\\r\\nPOST\n.kibana_alerting_cases/_update/<cases-user-actions-id>\\r\\n{\\r\\n\n\\\"script\\\": {\\r\\n \\\"source\\\": \\\"\\\"\\\"\\r\\n\nctx._source[\\\"cases-user-actions\\\"].payload.assignees[0].uid = \\\"\\\";\\r\\n\n\\\"\\\"\\\"\\r\\n }\\r\\n}\\r\\n```\\r\\n\\r\\nAfter this PR the popup should **not**\nappear anymore.\",\"sha\":\"d8e5cbf67f2bae859a18f956c22205b78d3da5aa\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Antonio <antonio.coelho@elastic.co>"}},{"branch":"8.16","label":"v8.16.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->