### PR TITLE
make fast, probably wont work

### DIFF
--- a/.buildkite/scripts/steps/test/jest_parallel.sh
+++ b/.buildkite/scripts/steps/test/jest_parallel.sh
@@ -15,11 +15,9 @@ if [[ "$1" == 'jest.config.js' ]]; then
   # we used to run jest tests in parallel but started to see a lot of flakiness in libraries like react-dom/test-utils:
   # https://github.com/elastic/kibana/issues/141477
   # parallelism="-w2"
-  parallelism="--runInBand"
   TEST_TYPE="unit"
 else
   # run integration tests in-band
-  parallelism="--runInBand"
   TEST_TYPE="integration"
 fi
 

--- a/packages/kbn-test/src/mocha/junit_report_generation.test.js
+++ b/packages/kbn-test/src/mocha/junit_report_generation.test.js
@@ -56,7 +56,7 @@ describe('dev/mocha/junit report generation', () => {
     expect(testsuite.$.time).toMatch(DURATION_REGEX);
     expect(testsuite.$.timestamp).toMatch(ISO_DATE_SEC_REGEX);
     const expectedCommandLine = process.env.CI
-      ? 'node scripts/jest --config=packages/kbn-test/jest.config.js --runInBand --coverage=false --passWithNoTests'
+      ? 'node scripts/jest --config=packages/kbn-test/jest.config.js --coverage=false --passWithNoTests'
       : 'node node_modules/jest-worker/build/workers/processChild.js';
 
     expect(testsuite.$).toMatchObject({

--- a/scripts/jest_integration.js
+++ b/scripts/jest_integration.js
@@ -8,5 +8,4 @@
  */
 
 require('../src/setup_node_env');
-process.argv.push('--runInBand');
 require('@kbn/test').runJest('jest.integration.config.js');


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



