### PR TITLE
[Security Solution][SIEM migrations] Fix langsmight tracing

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/api/start.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/api/start.ts
@@ -9,6 +9,8 @@ import type { IKibanaResponse, Logger } from '@kbn/core/server';
 import { APMTracer } from '@kbn/langchain/server/tracers/apm';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
 import { buildRouteValidationWithZod } from '@kbn/zod-helpers';
+import type { Callbacks } from '@langchain/core/callbacks/manager';
+import type { LangSmithOptions } from '../../../../../common/siem_migrations/model/common.gen';
 import { SIEM_RULE_MIGRATION_START_PATH } from '../../../../../common/siem_migrations/constants';
 import {
   StartRuleMigrationRequestBody,
@@ -63,17 +65,12 @@ export const registerSiemRuleMigrationsStartRoute = (
               }
             }
 
-            const invocationConfig = {
-              callbacks: [
-                new APMTracer({ projectName: langsmithOptions?.project_name ?? 'default' }, logger),
-                ...getLangSmithTracer({ ...langsmithOptions, logger }),
-              ],
-            };
+            const callbacks = createInvocationCallbacks(langsmithOptions, logger);
 
             const { exists, started } = await ruleMigrationsClient.task.start({
               migrationId,
               connectorId,
-              invocationConfig,
+              invocationConfig: { callbacks },
             });
 
             if (!exists) {
@@ -88,3 +85,15 @@ export const registerSiemRuleMigrationsStartRoute = (
       )
     );
 };
+
+function createInvocationCallbacks(
+  langsmithOptions: LangSmithOptions | undefined,
+  logger: Logger
+): Callbacks {
+  const { api_key: apiKey, project_name: projectName = 'default' } = langsmithOptions ?? {};
+  const callbacks: Callbacks = [new APMTracer({ projectName }, logger)];
+  if (langsmithOptions) {
+    callbacks.push(...getLangSmithTracer({ apiKey, projectName, logger }));
+  }
+  return callbacks;
+}


### PR DESCRIPTION
## Summary

Fixes LangSmith tracing on the API side







<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->