### PR TITLE
[Fleet] Fix connector links not visible in agentless flyout

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/next_steps.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/next_steps.tsx
@@ -132,7 +132,7 @@ export const NextSteps = ({
   return (
     <>
       <EuiSpacer size="m" />
-      {nextStepsCards.length > 0 && (
+      {(nextStepsCards.length > 0 || connectorCards.length > 0) && (
         <EuiFlexGroup alignItems="center" direction="row" wrap={true}>
           {nextStepsCards}
           {connectorCards}

--- a/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/step_confirm_data.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agentless_enrollment_flyout/step_confirm_data.tsx
@@ -84,7 +84,7 @@ export const AgentlessStepConfirmData = ({
           <p>
             <FormattedMessage
               id="xpack.fleet.agentlessEnrollmentFlyout.confirmData.failureHelperText"
-              defaultMessage="No integration data receieved in the past {num} minutes. Check out the {troubleshootingGuideLink} for help."
+              defaultMessage="No integration data received in the past {num} minutes. Check out the {troubleshootingGuideLink} for help."
               values={{
                 num: POLLING_TIMEOUT_MS / 1000 / 60,
                 troubleshootingGuideLink: (


### PR DESCRIPTION
Follow up of https://github.com/elastic/kibana/pull/203824

## Summary
This is a small bugfix for connectors not visible in agentless flyout.

## Testing

- Follow the steps here https://github.com/elastic/kibana/pull/203824
- Install elastic-connectors integration `app/fleet/integrations/elastic_connectors-1.0.0/add-integration` and enroll an agent to it
- The enabled connectors should be visible in the flyout

<img width="870" alt="Screenshot 2025-01-23 at 15 28 20" src="https://github.com/user-attachments/assets/19cdcbc4-68d5-4e44-875e-15cd849ab84b" />







<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->