### PR TITLE
[Automatic Import]Add missing fields into AWS S3 manifest

### DIFF
--- a/x-pack/platform/plugins/shared/integration_assistant/server/templates/manifest/aws_s3_manifest.yml.njk
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/templates/manifest/aws_s3_manifest.yml.njk
@@ -177,3 +177,65 @@
       required: false
       show_user: false
       description: The duration that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.  The maximum is 12 hours.
+    - name: credential_profile_name
+      type: text
+      title: Credential Profile Name
+      multi: false
+      required: false
+      show_user: false
+      description: Profile name in shared credentials file.
+    - name: shared_credential_file
+      type: text
+      title: Shared Credential File
+      multi: false
+      required: false
+      show_user: false
+      description: Directory of the shared credentials file
+    - name: endpoint
+      type: text
+      title: Endpoint
+      multi: false
+      required: false
+      show_user: false
+      description: URL of the entry point for an AWS web service.
+    - name: default_region
+      type: text
+      title: Default AWS Region
+      multi: false
+      required: false
+      show_user: false
+      default: ""
+      description: >-
+        Default region to use prior to connecting to region specific services/endpoints if no AWS region is set from environment variable, credentials or instance profile. If none of the above are set and no default region is set as well, `us-east-1` is used. A region, either from environment variable, credentials or instance profile or from this default region setting, needs to be set when using regions in non-regular AWS environments such as AWS China or US Government Isolated.
+    - name: access_key_id
+      type: password
+      title: Access Key ID
+      multi: false
+      required: false
+      show_user: true
+      description: First part of access key.
+      secret: true
+    - name: secret_access_key
+      type: password
+      title: Secret Access Key
+      multi: false
+      required: false
+      show_user: true
+      description: Second part of access key.
+      secret: true
+    - name: session_token
+      type: password
+      title: Session Token
+      multi: false
+      required: false
+      show_user: true
+      description: Required when using temporary security credentials.
+      secret: true
+    - name: proxy_url
+      type: text
+      title: Proxy URL
+      multi: false
+      required: false
+      show_user: false
+      description: >-
+        URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>. Please ensure your username and password are in URL encoded format.


### PR DESCRIPTION
## Summary

This PR adds missing fields in `aws-s3-manifest.yml` generated for datastream to be able to add the right data into the agent input.
<img width="612" alt="image" src="https://github.com/user-attachments/assets/f0e94a37-a410-42a3-adaf-7588715a30ad" />


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)






<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->