### PR TITLE
[8.x] [Security Solution][Endpoint] Enable bi-directional response actions and remove tech. preview labels (#207107)

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
@@ -3430,6 +3430,62 @@ Object {
 exports[`Connector type config checks detect connector type changes for: .crowdstrike 4`] = `
 Object {
   "flags": Object {
+    "error": [Function],
+  },
+  "metas": Array [
+    Object {
+      "x-oas-any-type": true,
+    },
+  ],
+  "type": "any",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .crowdstrike 5`] = `
+Object {
+  "flags": Object {
+    "error": [Function],
+  },
+  "metas": Array [
+    Object {
+      "x-oas-any-type": true,
+    },
+  ],
+  "type": "any",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .crowdstrike 6`] = `
+Object {
+  "flags": Object {
+    "error": [Function],
+  },
+  "metas": Array [
+    Object {
+      "x-oas-any-type": true,
+    },
+  ],
+  "type": "any",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .crowdstrike 7`] = `
+Object {
+  "flags": Object {
+    "error": [Function],
+  },
+  "metas": Array [
+    Object {
+      "x-oas-any-type": true,
+    },
+  ],
+  "type": "any",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .crowdstrike 8`] = `
+Object {
+  "flags": Object {
     "default": Object {
       "special": "deep",
     },
@@ -3456,7 +3512,7 @@ Object {
 }
 `;
 
-exports[`Connector type config checks detect connector type changes for: .crowdstrike 5`] = `
+exports[`Connector type config checks detect connector type changes for: .crowdstrike 9`] = `
 Object {
   "flags": Object {
     "default": Object {
@@ -3499,7 +3555,7 @@ Object {
 }
 `;
 
-exports[`Connector type config checks detect connector type changes for: .crowdstrike 6`] = `
+exports[`Connector type config checks detect connector type changes for: .crowdstrike 10`] = `
 Object {
   "flags": Object {
     "default": Object {
@@ -9055,6 +9111,2733 @@ Object {
     },
   ],
   "type": "alternatives",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 1`] = `
+Object {
+  "flags": Object {
+    "default": Object {
+      "special": "deep",
+    },
+    "error": [Function],
+    "presence": "optional",
+  },
+  "keys": Object {
+    "id": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 2`] = `
+Object {
+  "flags": Object {
+    "default": Object {
+      "special": "deep",
+    },
+    "error": [Function],
+    "presence": "optional",
+  },
+  "keys": Object {
+    "aaDeviceId": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "computerDnsName": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "deviceValue": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "exposureLevel": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "healthStatus": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "matches": Array [
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "Active",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "Inactive",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "ImpairedCommunication",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "NoSensorData",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "NoSensorDataImpairedCommunication",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "Unknown",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+            ],
+            "type": "alternatives",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "matches": Array [
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "Active",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "Inactive",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "ImpairedCommunication",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "NoSensorData",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "NoSensorDataImpairedCommunication",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "Unknown",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                ],
+                "type": "alternatives",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "id": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "lastIpAddress": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "lastSeen": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "machineTags": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "onboardingStatus": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "osPlatform": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "page": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "limit": 1,
+          },
+          "name": "min",
+        },
+      ],
+      "type": "number",
+    },
+    "pageSize": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "limit": 1,
+          },
+          "name": "min",
+        },
+        Object {
+          "args": Object {
+            "limit": 1000,
+          },
+          "name": "max",
+        },
+      ],
+      "type": "number",
+    },
+    "rbacGroupId": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "riskScore": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "version": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+  },
+  "type": "object",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 3`] = `
+Object {
+  "flags": Object {
+    "default": Object {
+      "special": "deep",
+    },
+    "error": [Function],
+    "presence": "optional",
+  },
+  "keys": Object {
+    "comment": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+    "id": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 4`] = `
+Object {
+  "flags": Object {
+    "default": Object {
+      "special": "deep",
+    },
+    "error": [Function],
+    "presence": "optional",
+  },
+  "keys": Object {
+    "comment": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+    "id": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 5`] = `
+Object {
+  "flags": Object {
+    "default": Object {
+      "special": "deep",
+    },
+    "error": [Function],
+    "presence": "optional",
+  },
+  "keys": Object {},
+  "type": "object",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 6`] = `
+Object {
+  "flags": Object {
+    "default": Object {
+      "special": "deep",
+    },
+    "error": [Function],
+    "presence": "optional",
+  },
+  "keys": Object {
+    "creationDateTimeUtc": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "id": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "machineId": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "page": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "limit": 1,
+          },
+          "name": "min",
+        },
+      ],
+      "type": "number",
+    },
+    "pageSize": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "limit": 1,
+          },
+          "name": "min",
+        },
+        Object {
+          "args": Object {
+            "limit": 1000,
+          },
+          "name": "max",
+        },
+      ],
+      "type": "number",
+    },
+    "requestor": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "metas": Array [
+              Object {
+                "x-oas-min-length": 1,
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+              Object {
+                "args": Object {
+                  "method": [Function],
+                },
+                "name": "custom",
+              },
+            ],
+            "type": "string",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "metas": Array [
+                  Object {
+                    "x-oas-min-length": 1,
+                  },
+                ],
+                "rules": Array [
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                  Object {
+                    "args": Object {
+                      "method": [Function],
+                    },
+                    "name": "custom",
+                  },
+                ],
+                "type": "string",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "sortDirection": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "allow": Array [
+              "asc",
+            ],
+            "flags": Object {
+              "error": [Function],
+              "only": true,
+            },
+            "type": "any",
+          },
+        },
+        Object {
+          "schema": Object {
+            "allow": Array [
+              "desc",
+            ],
+            "flags": Object {
+              "error": [Function],
+              "only": true,
+            },
+            "type": "any",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "sortField": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+    "status": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "matches": Array [
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "Pending",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "InProgress",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "Succeeded",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "Failed",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "TimeOut",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "Cancelled",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+            ],
+            "type": "alternatives",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "matches": Array [
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "Pending",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "InProgress",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "Succeeded",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "Failed",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "TimeOut",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "Cancelled",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                ],
+                "type": "alternatives",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+    "type": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "matches": Array [
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "matches": Array [
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "RunAntiVirusScan",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "Offboard",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "LiveResponse",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "CollectInvestigationPackage",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "Isolate",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "Unisolate",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "StopAndQuarantineFile",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "RestrictCodeExecution",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+              Object {
+                "schema": Object {
+                  "allow": Array [
+                    "UnrestrictCodeExecution",
+                  ],
+                  "flags": Object {
+                    "error": [Function],
+                    "only": true,
+                  },
+                  "type": "any",
+                },
+              },
+            ],
+            "type": "alternatives",
+          },
+        },
+        Object {
+          "schema": Object {
+            "flags": Object {
+              "error": [Function],
+            },
+            "items": Array [
+              Object {
+                "flags": Object {
+                  "error": [Function],
+                  "presence": "optional",
+                },
+                "matches": Array [
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "RunAntiVirusScan",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "Offboard",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "LiveResponse",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "CollectInvestigationPackage",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "Isolate",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "Unisolate",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "StopAndQuarantineFile",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "RestrictCodeExecution",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                  Object {
+                    "schema": Object {
+                      "allow": Array [
+                        "UnrestrictCodeExecution",
+                      ],
+                      "flags": Object {
+                        "error": [Function],
+                        "only": true,
+                      },
+                      "type": "any",
+                    },
+                  },
+                ],
+                "type": "alternatives",
+              },
+            ],
+            "rules": Array [
+              Object {
+                "args": Object {
+                  "limit": 1,
+                },
+                "name": "min",
+              },
+            ],
+            "type": "array",
+          },
+        },
+      ],
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "alternatives",
+    },
+  },
+  "type": "object",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 7`] = `
+Object {
+  "flags": Object {
+    "default": Object {
+      "special": "deep",
+    },
+    "error": [Function],
+    "presence": "optional",
+  },
+  "keys": Object {
+    "apiUrl": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+    "clientId": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+    "oAuthScope": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+    "oAuthServerUrl": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+    "tenantId": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 8`] = `
+Object {
+  "flags": Object {
+    "default": Object {
+      "special": "deep",
+    },
+    "error": [Function],
+    "presence": "optional",
+  },
+  "keys": Object {
+    "clientSecret": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "metas": Array [
+        Object {
+          "x-oas-min-length": 1,
+        },
+      ],
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;
+
+exports[`Connector type config checks detect connector type changes for: .microsoft_defender_endpoint 9`] = `
+Object {
+  "flags": Object {
+    "default": Object {
+      "special": "deep",
+    },
+    "error": [Function],
+    "presence": "optional",
+  },
+  "keys": Object {
+    "subAction": Object {
+      "flags": Object {
+        "error": [Function],
+      },
+      "rules": Array [
+        Object {
+          "args": Object {
+            "method": [Function],
+          },
+          "name": "custom",
+        },
+      ],
+      "type": "string",
+    },
+    "subActionParams": Object {
+      "flags": Object {
+        "default": Object {
+          "special": "deep",
+        },
+        "error": [Function],
+        "presence": "optional",
+        "unknown": true,
+      },
+      "keys": Object {},
+      "preferences": Object {
+        "stripUnknown": Object {
+          "objects": false,
+        },
+      },
+      "type": "object",
+    },
+  },
+  "type": "object",
 }
 `;
 

--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/connector_types.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/connector_types.test.ts
@@ -11,7 +11,7 @@ import { setupTestServers } from './lib';
 import { connectorTypes } from './mocks/connector_types';
 import { actionsConfigMock } from '../actions_config.mock';
 import { loggerMock } from '@kbn/logging-mocks';
-import { Services } from '../types';
+import type { ActionTypeConfig, Services } from '../types';
 
 jest.mock('../action_type_registry', () => {
   const actual = jest.requireActual('../action_type_registry');
@@ -64,8 +64,20 @@ describe('Connector type config checks', () => {
 
       // SubActionConnector
       if (getService) {
+        let connectorConfig: ActionTypeConfig = {};
+
+        if (connectorTypeId === '.microsoft_defender_endpoint') {
+          connectorConfig = {
+            clientId: 'foo',
+            tenantId: 'foo-foo',
+            oAuthServerUrl: 'https://_fake_auth.com/',
+            oAuthScope: 'some-scope',
+            apiUrl: 'https://_face_api_.com',
+          };
+        }
+
         const subActions = getService({
-          config: {},
+          config: connectorConfig,
           configurationUtilities: actionsConfigMock.create(),
           connector: { id: 'foo', type: 'bar' },
           logger: loggerMock.create(),

--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/mocks/connector_types.ts
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/mocks/connector_types.ts
@@ -33,6 +33,7 @@ export const connectorTypes: string[] = [
   '.sentinelone',
   '.crowdstrike',
   '.inference',
+  '.microsoft_defender_endpoint',
   '.cases',
   '.observability-ai-assistant',
 ];

--- a/x-pack/platform/plugins/shared/actions/tsconfig.json
+++ b/x-pack/platform/plugins/shared/actions/tsconfig.json
@@ -49,7 +49,7 @@
     "@kbn/security-plugin-types-server",
     "@kbn/core-application-common",
     "@kbn/cloud-plugin",
-    "@kbn/core-http-server-utils"
+    "@kbn/core-http-server-utils",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/platform/plugins/shared/stack_connectors/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/experimental_features.ts
@@ -16,8 +16,8 @@ export const allowedExperimentalValues = Object.freeze({
   sentinelOneConnectorOn: true,
   crowdstrikeConnectorOn: true,
   inferenceConnectorOn: true,
-  crowdstrikeConnectorRTROn: false,
-  microsoftDefenderEndpointOn: false,
+  crowdstrikeConnectorRTROn: true,
+  microsoftDefenderEndpointOn: true,
 });
 
 export type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/crowdstrike/crowdstrike.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/crowdstrike/crowdstrike.ts
@@ -35,7 +35,7 @@ export function getConnectorType(): ConnectorTypeModel<
     id: CROWDSTRIKE_CONNECTOR_ID,
     actionTypeTitle: CROWDSTRIKE_TITLE,
     iconClass: lazy(() => import('./logo')),
-    isExperimental: true,
+    isExperimental: false,
     selectMessage: i18n.translate(
       'xpack.stackConnectors.security.crowdstrike.config.selectMessageText',
       {

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/microsoft_defender_endpoint/microsoft_defender_endpoint.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/microsoft_defender_endpoint/microsoft_defender_endpoint.ts
@@ -35,7 +35,7 @@ export function getConnectorType(): ConnectorTypeModel<
     id: MICROSOFT_DEFENDER_ENDPOINT_CONNECTOR_ID,
     actionTypeTitle: MICROSOFT_DEFENDER_ENDPOINT_TITLE,
     iconClass: lazy(() => import('./logo')),
-    isExperimental: true,
+    isExperimental: false,
     selectMessage: i18n.translate(
       'xpack.stackConnectors.security.MicrosoftDefenderEndpointSecrets.config.selectMessageText',
       {

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/sentinelone/sentinelone.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/sentinelone/sentinelone.ts
@@ -35,7 +35,7 @@ export function getConnectorType(): ConnectorTypeModel<
     id: SENTINELONE_CONNECTOR_ID,
     actionTypeTitle: SENTINELONE_TITLE,
     iconClass: lazy(() => import('./logo')),
-    isExperimental: true,
+    isExperimental: false,
     selectMessage: i18n.translate(
       'xpack.stackConnectors.security.sentinelone.config.selectMessageText',
       {

--- a/x-pack/platform/plugins/shared/stack_connectors/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/plugin.test.ts
@@ -131,7 +131,7 @@ describe('Stack Connectors Plugin', () => {
           name: 'Torq',
         })
       );
-      expect(actionsSetup.registerSubActionConnectorType).toHaveBeenCalledTimes(11);
+      expect(actionsSetup.registerSubActionConnectorType).toHaveBeenCalledTimes(12);
       expect(actionsSetup.registerSubActionConnectorType).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({

--- a/x-pack/platform/plugins/shared/task_manager/server/integration_tests/__snapshots__/task_cost_check.test.ts.snap
+++ b/x-pack/platform/plugins/shared/task_manager/server/integration_tests/__snapshots__/task_cost_check.test.ts.snap
@@ -48,6 +48,10 @@ Array [
   },
   Object {
     "cost": 1,
+    "taskType": "actions:.microsoft_defender_endpoint",
+  },
+  Object {
+    "cost": 1,
     "taskType": "actions:.observability-ai-assistant",
   },
   Object {

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/response_actions/is_agent_type_in_tech_preview.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/response_actions/is_agent_type_in_tech_preview.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ResponseActionAgentType } from './constants';
+
+const TECH_PREVIEW_AGENT_TYPE = Object.freeze<Record<ResponseActionAgentType, boolean>>({
+  endpoint: false,
+  microsoft_defender_endpoint: false,
+  crowdstrike: false,
+  sentinel_one: false,
+});
+
+/**
+ * Returns boolean indicating if agent type is in tech preview or not.
+ * @param agentType
+ */
+export const isAgentTypeInTechPreview = (agentType: ResponseActionAgentType) => {
+  return TECH_PREVIEW_AGENT_TYPE[agentType] ?? true;
+};

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -253,8 +253,9 @@ export const allowedExperimentalValues = Object.freeze({
 
   /**
    * Enables CrowdStrike's RunScript RTR command
+   * Release: 8.18/9.0
    */
-  crowdstrikeRunScriptEnabled: false,
+  crowdstrikeRunScriptEnabled: true,
 
   /**
    * Enables the Asset Inventory Entity Store feature.
@@ -268,9 +269,10 @@ export const allowedExperimentalValues = Object.freeze({
   assetInventoryUXEnabled: false,
 
   /**
-   * Enabled Microsoft Defender for  Endpoint actions client
+   * Enabled Microsoft Defender for  Endpoint actions: Isolate and Release.
+   * Release: 8.18/9.0
    */
-  responseActionsMSDefenderEndpointEnabled: false,
+  responseActionsMSDefenderEndpointEnabled: true,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/agents/agent_type_integration/agent_type_integration.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/agents/agent_type_integration/agent_type_integration.test.tsx
@@ -12,6 +12,7 @@ import type { AgentTypeIntegrationProps } from './agent_type_integration';
 import { AgentTypeIntegration, INTEGRATION_SECTION_LABEL } from './agent_type_integration';
 import { getAgentTypeName } from '../../../../translations';
 import { RESPONSE_ACTION_AGENT_TYPE } from '../../../../../../common/endpoint/service/response_actions/constants';
+import { isAgentTypeInTechPreview } from '../../../../../../common/endpoint/service/response_actions/is_agent_type_in_tech_preview';
 
 describe('AgentTypeIntegration component', () => {
   let props: AgentTypeIntegrationProps;
@@ -52,11 +53,7 @@ describe('AgentTypeIntegration component', () => {
       expect(getByTestId('test-tooltipAnchor'));
     });
 
-    if (
-      agentType === 'sentinel_one' ||
-      agentType === 'crowdstrike' ||
-      agentType === 'microsoft_defender_endpoint'
-    ) {
+    if (isAgentTypeInTechPreview(agentType)) {
       it('should display tech preview badge', () => {
         const { getByTestId } = render();
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/agents/agent_type_integration/agent_type_integration.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/endpoint/agents/agent_type_integration/agent_type_integration.tsx
@@ -10,6 +10,7 @@ import type { EuiTextProps } from '@elastic/eui';
 import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem, EuiIconTip, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { isAgentTypeInTechPreview } from '../../../../../../common/endpoint/service/response_actions/is_agent_type_in_tech_preview';
 import { useTestIdGenerator } from '../../../../../management/hooks/use_test_id_generator';
 import { AgentTypeVendorLogo } from '../agent_type_vendor_logo';
 import {
@@ -43,11 +44,7 @@ export const AgentTypeIntegration = memo<AgentTypeIntegrationProps>(
     const testId = useTestIdGenerator(dataTestSubj);
 
     const isTechPreview = useMemo(() => {
-      return (
-        agentType === 'sentinel_one' ||
-        agentType === 'crowdstrike' ||
-        agentType === 'microsoft_defender_endpoint'
-      );
+      return isAgentTypeInTechPreview(agentType);
     }, [agentType]);
 
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_response_actions_list/integration_tests/response_actions_log.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_response_actions_list/integration_tests/response_actions_log.test.tsx
@@ -1854,25 +1854,6 @@ describe('Response actions history', () => {
       ]);
     });
 
-    it('should show only action types when 3rd party vendor feature flags are set to false thus only endpoint available', async () => {
-      mockedContext.setExperimentalFlag({
-        responseActionsSentinelOneV1Enabled: false,
-        responseActionsCrowdstrikeManualHostIsolationEnabled: false,
-      });
-      render({ isFlyout: false });
-      const { getByTestId, getAllByTestId } = renderResult;
-
-      await user.click(getByTestId(`${testPrefix}-${filterPrefix}-popoverButton`));
-      const filterList = getByTestId(`${testPrefix}-${filterPrefix}-popoverList`);
-      expect(filterList).toBeTruthy();
-      expect(getAllByTestId(`${filterPrefix}-option`).length).toEqual(
-        [...RESPONSE_ACTION_TYPE].length
-      );
-      expect(getAllByTestId(`${filterPrefix}-option`).map((option) => option.textContent)).toEqual([
-        'Triggered by rule',
-        'Triggered manually',
-      ]);
-    });
     it('should show a list of agents and action types when opened in page view', async () => {
       mockedContext.setExperimentalFlag({
         responseActionsSentinelOneV1Enabled: true,

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/microsoft_defender_host/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/microsoft_defender_host/index.ts
@@ -235,7 +235,11 @@ const runCli: RunFn = async ({ log, flags }) => {
     }),
     createDetectionEngineMicrosoftDefenderRuleIfNeeded(kbnClient, log, agentPolicyNamespace),
     // Trigger alert on the windows VM
-    msVm.exec('curl -o /tmp/eicar.com.txt https://secure.eicar.org/eicar.com.txt'),
+    msVm.exec('curl -o /tmp/eicar.com.txt https://secure.eicar.org/eicar.com.txt').catch((err) => {
+      log.warning(
+        `Attempted to trigger an alert on host [${msVm.name}], but failed with: ${err.message}`
+      );
+    }),
   ]);
 
   log.info(`Done!

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/sentinelone_host/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/sentinelone_host/index.ts
@@ -233,7 +233,13 @@ const runCli: RunFn = async ({ log, flags }) => {
 
   // Trigger an alert on the SentinelOn host so that we get an alert back in Kibana
   log.info(`Triggering SentinelOne alert`);
-  await s1HostVm.exec('nslookup elastic.co');
+  await s1HostVm
+    .exec('curl -o /tmp/eicar.com.txt https://secure.eicar.org/eicar.com.txt')
+    .catch((err) => {
+      log.warning(
+        `Attempted to trigger an alert on host [${s1HostVm.name}], but failed with: ${err.message}`
+      );
+    });
 
   log.info(`Done!
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][Endpoint] Enable bi-directional response actions and remove tech. preview labels (#207107)](https://github.com/elastic/kibana/pull/207107)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-23T15:32:08Z","message":"[Security Solution][Endpoint] Enable bi-directional response actions and remove tech. preview labels (#207107)\n\n## Summary\r\n\r\n### Stack Connectors\r\n\r\n- Enables feature keys for Crowdstrike and Microsoft Defender for\r\nEndpoint\r\n- Removes \"Technical Preview\" labels from Crowdstrike, SentinelOne and\r\nMicrosoft Defender for Endpoint connectors\r\n\r\n\r\n\r\n### Security Solution\r\n\r\n- Enables feature keys for Crowdstrike and Microsoft Defender for\r\nEndpoint\r\n- Removes \"Technical Preview\" labels from Crowdstrike, SentinelOne and\r\nMicro","sha":"e155277c8e836e615011b7b7ecdfc6a10f42a086","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Defend Workflows","backport:prev-minor","v8.18.0"],"title":"[Security Solution][Endpoint] Enable bi-directional response actions and remove tech. preview labels","number":207107,"url":"https://github.com/elastic/kibana/pull/207107","mergeCommit":{"message":"[Security Solution][Endpoint] Enable bi-directional response actions and remove tech. preview labels (#207107)\n\n## Summary\r\n\r\n### Stack Connectors\r\n\r\n- Enables feature keys for Crowdstrike and Microsoft Defender for\r\nEndpoint\r\n- Removes \"Technical Preview\" labels from Crowdstrike, SentinelOne and\r\nMicrosoft Defender for Endpoint connectors\r\n\r\n\r\n\r\n### Security Solution\r\n\r\n- Enables feature keys for Crowdstrike and Microsoft Defender for\r\nEndpoint\r\n- Removes \"Technical Preview\" labels from Crowdstrike, SentinelOne and\r\nMicro","sha":"e155277c8e836e615011b7b7ecdfc6a10f42a086"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/207107","number":207107,"mergeCommit":{"message":"[Security Solution][Endpoint] Enable bi-directional response actions and remove tech. preview labels (#207107)\n\n## Summary\r\n\r\n### Stack Connectors\r\n\r\n- Enables feature keys for Crowdstrike and Microsoft Defender for\r\nEndpoint\r\n- Removes \"Technical Preview\" labels from Crowdstrike, SentinelOne and\r\nMicrosoft Defender for Endpoint connectors\r\n\r\n\r\n\r\n### Security Solution\r\n\r\n- Enables feature keys for Crowdstrike and Microsoft Defender for\r\nEndpoint\r\n- Removes \"Technical Preview\" labels from Crowdstrike, SentinelOne and\r\nMicro","sha":"e155277c8e836e615011b7b7ecdfc6a10f42a086"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->