### PR TITLE
[Security Solution] Bulk endpoints: set deprecation severity to "warning"

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
@@ -66,7 +66,7 @@ export const bulkCreateRulesRoute = (
         options: {
           deprecated: {
             documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
-            severity: 'critical',
+            severity: 'warning',
             reason: {
               type: 'migrate',
               newApiMethod: 'POST',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
@@ -139,7 +139,7 @@ export const bulkDeleteRulesRoute = (
       options: {
         deprecated: {
           documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
-          severity: 'critical',
+          severity: 'warning',
           reason: {
             type: 'migrate',
             newApiMethod: 'POST',
@@ -161,7 +161,7 @@ export const bulkDeleteRulesRoute = (
       options: {
         deprecated: {
           documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
-          severity: 'critical',
+          severity: 'warning',
           reason: {
             type: 'migrate',
             newApiMethod: 'POST',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
@@ -60,7 +60,7 @@ export const bulkPatchRulesRoute = (
         options: {
           deprecated: {
             documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
-            severity: 'critical',
+            severity: 'warning',
             reason: {
               type: 'migrate',
               newApiMethod: 'POST',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
@@ -64,7 +64,7 @@ export const bulkUpdateRulesRoute = (
         options: {
           deprecated: {
             documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
-            severity: 'critical',
+            severity: 'warning',
             reason: {
               type: 'migrate',
               newApiMethod: 'POST',


### PR DESCRIPTION
**Partially addresses: https://github.com/elastic/kibana/issues/193184**
**Is a follow-up to: https://github.com/elastic/kibana/pull/207091**

## Summary
We've recently merged a [PR](https://github.com/elastic/kibana/pull/207091) that added our deprecated bulk endpoints to Upgrade Assistant with "critical" severity. Upon further consideration we decided that a "warning" level is more suitable for these endpoints since we don't want to block upgrades to v9 for users.

This PR sets the severity to "warning". Users would still see the item in Upgrade Assistant, but they won't have necessarily resolve it.

<img width="1277" alt="warnings_shown" src="https://github.com/user-attachments/assets/27ff8d71-ac6d-4221-b05e-0a89caaa325d" />
