### PR TITLE
[EDR Workflows] Fix not aligned text for RunScript

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/common/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/common/translations.ts
@@ -266,8 +266,7 @@ export const CROWDSTRIKE_CONSOLE_COMMANDS = {
       defaultMessage: 'Run a script on the host',
     }),
     helpUsage: i18n.translate('xpack.securitySolution.crowdStrikeConsoleCommands.runscript.about', {
-      defaultMessage: `
-Command Examples for Running Scripts:
+      defaultMessage: `Command Examples for Running Scripts:
 
 1. Executes a script saved in the CrowdStrike cloud with the specified command-line arguments.
 


### PR DESCRIPTION
Before:
<img width="1872" alt="Zrzut ekranu 2025-01-23 o 17 54 10" src="https://github.com/user-attachments/assets/ff014701-69e0-4460-9bd3-a351e9cced80" />


After: 
<img width="2993" alt="Zrzut ekranu 2025-01-23 o 17 49 34" src="https://github.com/user-attachments/assets/c007a990-572a-40a0-836a-22ff5a8b76cf" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->