### PR TITLE
[8.x] [kbn-scout-reporting] escape html characters in html report (#206987)

### DIFF
--- a/packages/kbn-scout-reporting/src/helpers/index.ts
+++ b/packages/kbn-scout-reporting/src/helpers/index.ts
@@ -8,6 +8,6 @@
  */
 
 export { getPluginManifestData, type PluginManifest } from './plugin_manifest';
-export { stripFilePath, parseStdout } from './text_processing';
+export { excapeHtmlCharacters, stripFilePath, parseStdout } from './text_processing';
 export { getRunTarget, stripRunCommand } from './cli_processing';
 export { getTestIDForTitle, generateTestRunId } from './test_id_generator';

--- a/packages/kbn-scout-reporting/src/helpers/text_processing.ts
+++ b/packages/kbn-scout-reporting/src/helpers/text_processing.ts
@@ -21,3 +21,6 @@ export function parseStdout(stdout: Array<string | Buffer>): string {
   // Escape special HTML characters
   return stripANSI(stdoutContent);
 }
+
+export const excapeHtmlCharacters = (htmlText: string): string =>
+  htmlText.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');

--- a/packages/kbn-scout-reporting/src/reporting/playwright/failed_test/failed_test_reporter.ts
+++ b/packages/kbn-scout-reporting/src/reporting/playwright/failed_test/failed_test_reporter.ts
@@ -36,6 +36,7 @@ import {
   getTestIDForTitle,
   stripRunCommand,
   stripFilePath,
+  excapeHtmlCharacters,
 } from '../../../helpers';
 
 /**
@@ -105,7 +106,9 @@ export class ScoutFailedTestReporter implements Reporter {
         duration: result.duration,
         error: {
           message: result.error?.message ? stripFilePath(result.error.message) : undefined,
-          stack_trace: result.error?.stack ? stripFilePath(result.error.stack) : undefined,
+          stack_trace: result.error?.stack
+            ? excapeHtmlCharacters(stripFilePath(result.error.stack))
+            : undefined,
         },
         stdout: result.stdout ? parseStdout(result.stdout) : undefined,
         attachments: result.attachments.map((attachment) => ({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[kbn-scout-reporting] escape html characters in html report (#206987)](https://github.com/elastic/kibana/pull/206987)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-01-17T09:16:15Z","message":"[kbn-scout-reporting] escape html characters in html report (#206987)\n\n## Summary\r\n\r\nFixing `Error details` section not properly displaying html characters\r\nin error stacktrace.\r\n\r\nBefore:\r\n\r\n<img width=\"1347\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/1821751f-3a89-46a6-bf55-ed2fe845a196\"\r\n/>\r\n\r\nAfter: \r\n\r\n<img width=\"1347\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/83526d8a-ca3c-4b62-a01e-69029f0e8e7e\"\r\n/>","sha":"158146402e936cac3fce881c47900a49283e7360","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","backport:prev-minor","test:scout"],"title":"[kbn-scout-reporting] escape html characters in html report","number":206987,"url":"https://github.com/elastic/kibana/pull/206987","mergeCommit":{"message":"[kbn-scout-reporting] escape html characters in html report (#206987)\n\n## Summary\r\n\r\nFixing `Error details` section not properly displaying html characters\r\nin error stacktrace.\r\n\r\nBefore:\r\n\r\n<img width=\"1347\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/1821751f-3a89-46a6-bf55-ed2fe845a196\"\r\n/>\r\n\r\nAfter: \r\n\r\n<img width=\"1347\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/83526d8a-ca3c-4b62-a01e-69029f0e8e7e\"\r\n/>","sha":"158146402e936cac3fce881c47900a49283e7360"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/206987","number":206987,"mergeCommit":{"message":"[kbn-scout-reporting] escape html characters in html report (#206987)\n\n## Summary\r\n\r\nFixing `Error details` section not properly displaying html characters\r\nin error stacktrace.\r\n\r\nBefore:\r\n\r\n<img width=\"1347\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/1821751f-3a89-46a6-bf55-ed2fe845a196\"\r\n/>\r\n\r\nAfter: \r\n\r\n<img width=\"1347\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/83526d8a-ca3c-4b62-a01e-69029f0e8e7e\"\r\n/>","sha":"158146402e936cac3fce881c47900a49283e7360"}}]}] BACKPORT-->