### PR TITLE
🌊 POC: Simulate edit changes to processors

### DIFF
--- a/src/platform/packages/shared/kbn-object-utils/src/calculate_object_diff.test.ts
+++ b/src/platform/packages/shared/kbn-object-utils/src/calculate_object_diff.test.ts
@@ -40,4 +40,34 @@ describe('calculateObjectDiff', () => {
     expect(removed).toEqual({});
     expect(updated).toEqual({});
   });
+
+  it('should handle array fields correctly', () => {
+    const { added, removed, updated } = calculateObjectDiff(
+      { alpha: [1, 2, 3], beta: [4, 5, 6] },
+      { alpha: [1, 2, 3], beta: [4, 5, 7] }
+    );
+    expect(added).toEqual({});
+    expect(removed).toEqual({});
+    expect(updated).toEqual({ beta: [undefined, undefined, 7] });
+  });
+
+  it('should detect added and removed array fields', () => {
+    const { added, removed, updated } = calculateObjectDiff(
+      { alpha: [1, 2, 3] },
+      { beta: [4, 5, 6] }
+    );
+    expect(added).toEqual({ beta: [4, 5, 6] });
+    expect(removed).toEqual({ alpha: [1, 2, 3] });
+    expect(updated).toEqual({});
+  });
+
+  it('should handle arrays containing objects correctly', () => {
+    const { added, removed, updated } = calculateObjectDiff(
+      { alpha: [{ beta: 1 }, { gamma: 2 }] },
+      { alpha: [{ beta: 1 }, { gamma: 3 }] }
+    );
+    expect(added).toEqual({});
+    expect(removed).toEqual({});
+    expect(updated).toEqual({ alpha: [{}, { gamma: 3 }] });
+  });
 });

--- a/src/platform/packages/shared/kbn-object-utils/src/calculate_object_diff.ts
+++ b/src/platform/packages/shared/kbn-object-utils/src/calculate_object_diff.ts
@@ -27,6 +27,10 @@ interface ObjectDiffResult<TBase, TCompare> {
   };
 }
 
+function isAllUndefined(obj: unknown): boolean {
+  return Array.isArray(obj) && obj.every((value) => value === undefined);
+}
+
 /**
  * Compares two JSON objects and calculates the added and removed properties, including nested properties.
  * @param oldObj - The base object.
@@ -66,6 +70,20 @@ export function calculateObjectDiff<TBase extends Obj, TCompare extends Obj>(
         );
         if (isEmpty(addedMap[key])) delete addedMap[key];
         if (isEmpty(removedMap[key])) delete removedMap[key];
+      } else if (Array.isArray(base[key]) && Array.isArray(compare[key])) {
+        addedMap[key] = [];
+        removedMap[key] = [];
+        updatedMap[key] = [];
+        diffRecursive(
+          base[key] as Obj,
+          compare[key] as Obj,
+          addedMap[key] as Obj,
+          removedMap[key] as Obj,
+          updatedMap[key] as Obj
+        );
+        if (isAllUndefined(addedMap[key])) delete addedMap[key];
+        if (isAllUndefined(removedMap[key])) delete removedMap[key];
+        if (isAllUndefined(updatedMap[key])) delete updatedMap[key];
       } else if (base[key] !== compare[key]) {
         updatedMap[key] = compare[key];
       }

--- a/src/platform/packages/shared/kbn-object-utils/src/calculate_object_diff.ts
+++ b/src/platform/packages/shared/kbn-object-utils/src/calculate_object_diff.ts
@@ -85,7 +85,6 @@ export function calculateObjectDiff<TBase extends Obj, TCompare extends Obj>(
         if (isAllUndefined(removedMap[key])) delete removedMap[key];
         if (isAllUndefined(updatedMap[key])) delete updatedMap[key];
       } else if (base[key] !== compare[key]) {
-        console.log(key, base[key], compare[key]);
         updatedMap[key] = compare[key];
       }
     }

--- a/src/platform/packages/shared/kbn-object-utils/src/calculate_object_diff.ts
+++ b/src/platform/packages/shared/kbn-object-utils/src/calculate_object_diff.ts
@@ -67,6 +67,7 @@ export function calculateObjectDiff<TBase extends Obj, TCompare extends Obj>(
         if (isEmpty(addedMap[key])) delete addedMap[key];
         if (isEmpty(removedMap[key])) delete removedMap[key];
       } else if (base[key] !== compare[key]) {
+        console.log(key, base[key], compare[key]);
         updatedMap[key] = compare[key];
       }
     }

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_enrichment/flyout/index.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_enrichment/flyout/index.tsx
@@ -44,6 +44,7 @@ export interface AddProcessorFlyoutProps extends ProcessorFlyoutProps {
 }
 export interface EditProcessorFlyoutProps extends ProcessorFlyoutProps {
   processor: EnrichmentUIProcessorDefinition;
+  index: number;
   onDeleteProcessor: (id: string) => void;
   onUpdateProcessor: (id: string, processor: EnrichmentUIProcessorDefinition) => void;
 }
@@ -129,7 +130,10 @@ export function EditProcessorFlyout({
   onDeleteProcessor,
   onUpdateProcessor,
   processor,
+  definition,
+  index,
 }: EditProcessorFlyoutProps) {
+  console.log('index', index);
   const processorType = 'grok' in processor.config ? 'grok' : 'dissect';
 
   const defaultValues = useMemo(
@@ -157,6 +161,13 @@ export function EditProcessorFlyout({
     onDeleteProcessor(processor.id);
     onClose();
   };
+
+  const { error, isLoading, refreshSamples, simulation, samples, simulate } =
+    useProcessingSimulator({
+      definition,
+      condition: { field: formFields.field, operator: 'exists' },
+      index,
+    });
 
   return (
     <ProcessorFlyoutTemplate
@@ -195,6 +206,16 @@ export function EditProcessorFlyout({
           {formFields.type === 'dissect' && <DissectProcessorForm />}
           <EuiHorizontalRule />
           <DangerZone onDeleteProcessor={handleProcessorDelete} />
+          <ProcessorOutcomePreview
+            definition={definition}
+            formFields={formFields}
+            simulation={simulation}
+            samples={samples}
+            onSimulate={simulate}
+            onRefreshSamples={refreshSamples}
+            simulationError={error}
+            isLoading={isLoading}
+          />
         </EuiForm>
       </FormProvider>
     </ProcessorFlyoutTemplate>

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_enrichment/flyout/processor_outcome_preview.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_enrichment/flyout/processor_outcome_preview.tsx
@@ -104,7 +104,8 @@ export const ProcessorOutcomePreview = ({
       case 'outcome_filter_matched':
       case 'outcome_filter_all':
       default:
-        return [formFields.field, ...detectedFieldsColumns];
+        const allFields = new Set([formFields.field, ...detectedFieldsColumns]);
+        return Array.from(allFields);
     }
   }, [formFields.field, detectedFieldsColumns, selectedDocsFilter]);
 

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_enrichment/page_content.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_enrichment/page_content.tsx
@@ -118,6 +118,7 @@ export function StreamDetailEnrichmentContent({
               <DraggableProcessorListItem
                 key={processor.id}
                 idx={idx}
+                index={idx}
                 definition={definition}
                 processor={processor}
                 onUpdateProcessor={updateProcessor}

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_enrichment/processors_list.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_enrichment/processors_list.tsx
@@ -45,6 +45,7 @@ export const DraggableProcessorListItem = ({
 );
 
 interface ProcessorListItemProps {
+  index: number;
   definition: ReadStreamDefinition;
   processor: EnrichmentUIProcessorDefinition;
   hasShadow: EuiPanelProps['hasShadow'];
@@ -53,6 +54,7 @@ interface ProcessorListItemProps {
 }
 
 const ProcessorListItem = ({
+  index,
   definition,
   processor,
   hasShadow = false,
@@ -94,6 +96,7 @@ const ProcessorListItem = ({
       </EuiFlexGroup>
       {isEditProcessorOpen && (
         <EditProcessorFlyout
+          index={index}
           key={`edit-processor`}
           definition={definition}
           processor={processor}


### PR DESCRIPTION
Store the names of the fields that were present in the original document to be able to strip them out to simulate.