### PR TITLE
[8.x] [Ingest Pipelines] Fixes processors description (#193183)

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/pipeline_processors_editor.test.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/__jest__/pipeline_processors_editor.test.tsx
@@ -395,4 +395,39 @@ describe('Pipeline Editor', () => {
       assertTestProcessor({ description: processorDescriptions.none, descriptionVisible: false });
     });
   });
+
+  describe('object values', () => {
+    const mockData: Pick<Pipeline, 'processors'> = {
+      processors: [
+        {
+          set: {
+            field: 'test',
+            value: { test: 'test' },
+          },
+        },
+        {
+          append: {
+            field: 'test',
+            value: { test: 'test' },
+          },
+        },
+      ],
+    };
+    it('editor works when value is an object', async () => {
+      onUpdate = jest.fn();
+      testBed = await setup({
+        value: {
+          ...mockData,
+        },
+        onFlyoutOpen: jest.fn(),
+        onUpdate,
+      });
+      expect(testBed.find(`processors>0.inlineTextInputNonEditableText`).text()).toBe(
+        'Sets value of "test" to "{"test":"test"}"'
+      );
+      expect(testBed.find(`processors>1.inlineTextInputNonEditableText`).text()).toBe(
+        'Appends "{"test":"test"}" to the "test" field'
+      );
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/shared/map_processor_type_to_form.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/shared/map_processor_type_to_form.tsx
@@ -10,6 +10,7 @@ import React, { ReactNode } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiCode, EuiLink } from '@elastic/eui';
 
+import { stringifyValueDescription } from './stringify_value_description';
 import { LicenseType } from '../../../../../types';
 
 import {
@@ -128,7 +129,7 @@ export const mapProcessorTypeToDescriptor: MapProcessorTypeToDescriptor = {
         defaultMessage: 'Appends "{value}" to the "{field}" field',
         values: {
           field,
-          value,
+          value: stringifyValueDescription(value),
         },
       }),
   },
@@ -830,7 +831,7 @@ export const mapProcessorTypeToDescriptor: MapProcessorTypeToDescriptor = {
         defaultMessage: 'Sets value of "{field}" to "{value}"',
         values: {
           field,
-          value,
+          value: stringifyValueDescription(value),
         },
       });
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Ingest Pipelines] Update copy in Manage processors (#193183)](https://github.com/elastic/kibana/pull/193183)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)