### PR TITLE
[Security Solution] Fix editing in KQL Query Bar

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -187,6 +187,7 @@ export interface QueryBarTopRowProps<QT extends Query | AggregateQuery = Query> 
   renderQueryInputAppend?: () => React.ReactNode;
   disableExternalPadding?: boolean;
   onESQLDocsFlyoutVisibilityChanged?: ESQLMenuPopoverProps['onESQLDocsFlyoutVisibilityChanged'];
+  bubbleSubmitEvent?: boolean;
 }
 
 export const SharingMetaFields = React.memo(function SharingMetaFields({
@@ -661,7 +662,7 @@ export const QueryBarTopRow = React.memo(
     function renderFilterButtonGroup() {
       return (
         (Boolean(props.showAddFilter) || Boolean(props.prepend)) && (
-          <EuiFlexItem grow={false}>
+          <EuiFlexItem grow={false} className="kbnQueryBar__filterButtonGroup">
             <FilterButtonGroup
               items={[props.prepend, renderAddButton()]}
               attached={renderFilterMenuOnly()}
@@ -699,6 +700,7 @@ export const QueryBarTopRow = React.memo(
             isDisabled={props.isDisabled}
             appName={appName}
             submitOnBlur={props.submitOnBlur}
+            bubbleSubmitEvent={props.bubbleSubmitEvent}
             deps={{
               unifiedSearch,
               data,

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -57,6 +57,7 @@ export interface SearchBarInjectedDeps {
   onFiltersUpdated?: (filters: Filter[]) => void;
   // Autorefresh
   onRefreshChange?: (options: { isPaused: boolean; refreshInterval: number }) => void;
+  bubbleSubmitEvent?: boolean;
 }
 
 export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
@@ -665,6 +666,7 @@ class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> extends C
           renderQueryInputAppend={this.props.renderQueryInputAppend}
           disableExternalPadding={this.props.displayStyle === 'withBorders'}
           onESQLDocsFlyoutVisibilityChanged={this.props.onESQLDocsFlyoutVisibilityChanged}
+          bubbleSubmitEvent={this.props.bubbleSubmitEvent}
         />
       </div>
     );

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/query_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/query_bar/index.tsx
@@ -46,12 +46,14 @@ export const isDataView = (obj: unknown): obj is DataView =>
   obj != null && typeof obj === 'object' && Object.hasOwn(obj, 'getName');
 
 const CustomStylesWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
+  const wrapperClassName = 'ruleEditQueryBarWrapper';
+
   const customCss = css`
-    .kbnQueryBar__filterButtonGroup {
+    .${wrapperClassName} .kbnQueryBar__filterButtonGroup {
       align-self: start;
     }
 
-    .kbnQueryBar__wrap {
+    .${wrapperClassName} .kbnQueryBar__wrap {
       height: auto !important;
     }
   `;
@@ -59,7 +61,7 @@ const CustomStylesWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
   return (
     <>
       <Global styles={customCss} />
-      {children}
+      <div className={wrapperClassName}>{children}</div>
     </>
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/query_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/query_bar/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import { cloneDeep, isEmpty } from 'lodash';
+import type { PropsWithChildren, FC } from 'react';
 import React, { memo, useMemo, useCallback, useState, useEffect } from 'react';
 import deepEqual from 'fast-deep-equal';
 
@@ -16,6 +17,7 @@ import type { DataView } from '@kbn/data-views-plugin/public';
 import type { SearchBarProps } from '@kbn/unified-search-plugin/public';
 import { SearchBar } from '@kbn/unified-search-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
+import { css, Global } from '@emotion/react';
 import { useKibana } from '../../lib/kibana';
 import { convertToQueryType } from './convert_to_query_type';
 
@@ -37,10 +39,30 @@ export interface QueryBarComponentProps {
   onSavedQuery: (savedQuery: SavedQuery | undefined) => void;
   displayStyle?: SearchBarProps['displayStyle'];
   isDisabled?: boolean;
+  bubbleSubmitEvent?: boolean;
 }
 
 export const isDataView = (obj: unknown): obj is DataView =>
   obj != null && typeof obj === 'object' && Object.hasOwn(obj, 'getName');
+
+const CustomStylesWrapper: FC<PropsWithChildren<unknown>> = ({ children }) => {
+  const customCss = css`
+    .kbnQueryBar__filterButtonGroup {
+      align-self: start;
+    }
+
+    .kbnQueryBar__wrap {
+      height: auto !important;
+    }
+  `;
+
+  return (
+    <>
+      <Global styles={customCss} />
+      {children}
+    </>
+  );
+};
 
 export const QueryBar = memo<QueryBarComponentProps>(
   ({
@@ -61,6 +83,7 @@ export const QueryBar = memo<QueryBarComponentProps>(
     dataTestSubj,
     displayStyle,
     isDisabled,
+    bubbleSubmitEvent,
   }) => {
     const { data } = useKibana().services;
     const [dataView, setDataView] = useState<DataView>();
@@ -156,33 +179,36 @@ export const QueryBar = memo<QueryBarComponentProps>(
     const timeHistory = useMemo(() => new TimeHistory(new Storage(localStorage)), []);
     const arrDataView = useMemo(() => (dataView != null ? [dataView] : []), [dataView]);
     return (
-      <SearchBar
-        showSubmitButton={false}
-        dateRangeFrom={dateRangeFrom}
-        dateRangeTo={dateRangeTo}
-        filters={searchBarFilters}
-        indexPatterns={arrDataView}
-        isLoading={isLoading}
-        isRefreshPaused={isRefreshPaused}
-        query={query}
-        onClearSavedQuery={onClearSavedQuery}
-        onFiltersUpdated={onFiltersUpdated}
-        onQueryChange={onQueryChange}
-        onQuerySubmit={onQuerySubmit}
-        onSaved={onSavedQuery}
-        onSavedQueryUpdated={onSavedQueryUpdated}
-        refreshInterval={refreshInterval}
-        showAutoRefreshOnly={false}
-        showFilterBar={!hideSavedQuery}
-        showDatePicker={false}
-        showQueryInput={true}
-        showSaveQuery={true}
-        timeHistory={timeHistory}
-        dataTestSubj={dataTestSubj}
-        savedQuery={savedQuery}
-        displayStyle={isEsql ? 'withBorders' : displayStyle}
-        isDisabled={isDisabled}
-      />
+      <CustomStylesWrapper>
+        <SearchBar
+          showSubmitButton={false}
+          dateRangeFrom={dateRangeFrom}
+          dateRangeTo={dateRangeTo}
+          filters={searchBarFilters}
+          indexPatterns={arrDataView}
+          isLoading={isLoading}
+          isRefreshPaused={isRefreshPaused}
+          query={query}
+          onClearSavedQuery={onClearSavedQuery}
+          onFiltersUpdated={onFiltersUpdated}
+          onQueryChange={onQueryChange}
+          onQuerySubmit={onQuerySubmit}
+          onSaved={onSavedQuery}
+          onSavedQueryUpdated={onSavedQueryUpdated}
+          refreshInterval={refreshInterval}
+          showAutoRefreshOnly={false}
+          showFilterBar={!hideSavedQuery}
+          showDatePicker={false}
+          showQueryInput={true}
+          showSaveQuery={true}
+          timeHistory={timeHistory}
+          dataTestSubj={dataTestSubj}
+          savedQuery={savedQuery}
+          displayStyle={isEsql ? 'withBorders' : displayStyle}
+          isDisabled={isDisabled}
+          bubbleSubmitEvent={bubbleSubmitEvent}
+        />
+      </CustomStylesWrapper>
     );
   }
 );

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/query_bar_field/query_field.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/query_bar_field/query_field.tsx
@@ -45,6 +45,7 @@ export interface QueryBarFieldProps {
   onSavedQueryError?: () => void;
   defaultSavedQuery?: SavedQuery | undefined;
   onOpenTimeline?: (timeline: TimelineModel) => void;
+  bubbleSubmitEvent?: boolean;
 }
 
 const actionTimelineToHide: ActionTimelineToShow[] = ['duplicate', 'createFrom'];
@@ -80,6 +81,7 @@ export const QueryBarField = ({
   resetToSavedQuery,
   onOpenTimeline,
   onSavedQueryError,
+  bubbleSubmitEvent,
 }: QueryBarFieldProps) => {
   const { value: fieldValue, setValue: setFieldValue } = field as FieldHook<FieldValueQueryBar>;
   const [originalHeight, setOriginalHeight] = useState(-1);
@@ -286,6 +288,7 @@ export const QueryBarField = ({
                 hideSavedQuery={false}
                 displayStyle="inPage"
                 isDisabled={isDisabled}
+                bubbleSubmitEvent={bubbleSubmitEvent}
               />
             </div>
           )}

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/index.tsx
@@ -505,6 +505,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
             onSavedQueryError: handleSavedQueryError,
             defaultSavedQuery,
             onOpenTimeline,
+            bubbleSubmitEvent: true,
           } as QueryBarFieldProps
         }
       />

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/kql_query/kql_query_edit.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/final_edit/fields/kql_query/kql_query_edit.tsx
@@ -68,6 +68,7 @@ export function KqlQueryEdit({
           isDisabled: isSavedQueryRule,
           defaultSavedQuery: savedQuery,
           resetToSavedQuery: isSavedQueryRule,
+          bubbleSubmitEvent: true,
         }}
       />
     </>


### PR DESCRIPTION
**Partially resolves: #203523**

## Summary

Fixing the issue of KQL query bar edit component not showing properly long multiline KQL queries.

The query now isn't fully visible, and it's not possible to navigate with Up/Down keyboard keys. It's also not possible to scroll down, as the component doesn't allow to insert new line symbols.

I am fixing the behavior by:
- setting the `bubbleSubmitEvent={true}` so that the key press can propagate to higher components and be served properly. This fixes the problem of not allowing to enter new lines.
- I am not touching the broken behavior of Up/Down arrow keys, which intercepts the event and instead of moving the cursor, iterates items in the Suggestions panel, which is counterintuitive. Separate issue will be created for the Kibana Visualization team.
- I am modifying one css style in Kibana Visualization to set height to and adding a class to set proper alignment of buttons.

# BEFORE
- Not possible to insert new lines. 
- Arrow DOWN takes focus to Suggestions Panel, then together with Arrow UP it is used to iterate the suggestions
- When textarea grows it gets hidden below the parent's panel

https://github.com/user-attachments/assets/d97b81e3-7409-4089-865d-89ee702744f9

# AFTER 
- Possible to insert new lines
- Behavior of DOWN / UP Arrows stays the same 
- When textarea grows the whole panel resizes


https://github.com/user-attachments/assets/3a59923b-0fb1-49e7-b11d-55474f465ca2

https://github.com/user-attachments/assets/48efd325-1c66-43ca-9936-69ef37b4ee7a


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->