### PR TITLE
[8.x] [SecuritySolution] Add enrichPolicyExecutionInterval to entity enablement and init APIs (#207374)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -7567,6 +7567,8 @@ paths:
             schema:
               type: object
               properties:
+                enrichPolicyExecutionInterval:
+                  $ref: '#/components/schemas/Security_Entity_Analytics_API_Interval'
                 fieldHistoryLength:
                   default: 10
                   description: The number of historical values to keep for each field.
@@ -46875,6 +46877,11 @@ components:
       required:
         - dsl
         - response
+    Security_Entity_Analytics_API_Interval:
+      description: Interval in which enrich policy runs. For example, `"1h"` means the rule runs every hour.
+      example: 1h
+      pattern: ^[1-9]\d*[smh]$
+      type: string
     Security_Entity_Analytics_API_RiskEngineScheduleNowErrorResponse:
       type: object
       properties:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -13144,6 +13144,8 @@ paths:
             schema:
               type: object
               properties:
+                enrichPolicyExecutionInterval:
+                  $ref: '#/components/schemas/Security_Entity_Analytics_API_Interval'
                 fieldHistoryLength:
                   default: 10
                   description: The number of historical values to keep for each field.
@@ -35275,6 +35277,11 @@ components:
       required:
         - dsl
         - response
+    Security_Entity_Analytics_API_Interval:
+      description: Interval in which enrich policy runs. For example, `"1h"` means the rule runs every hour.
+      example: 1h
+      pattern: ^[1-9]\d*[smh]$
+      type: string
     Security_Entity_Analytics_API_RiskEngineScheduleNowErrorResponse:
       type: object
       properties:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -13033,6 +13033,12 @@ paths:
             schema:
               type: object
               properties:
+                enrichPolicyExecutionInterval:
+                  $ref: '#/components/schemas/Security_Entity_Analytics_API_Interval'
+                entityTypes:
+                  items:
+                    $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
+                  type: array
                 fieldHistoryLength:
                   default: 10
                   description: The number of historical values to keep for each field.

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/common.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/common.gen.ts
@@ -80,3 +80,9 @@ export const InspectQuery = z.object({
   response: z.array(z.string()),
   dsl: z.array(z.string()),
 });
+
+/**
+ * Interval in which enrich policy runs. For example, `"1h"` means the rule runs every hour.
+ */
+export type Interval = z.infer<typeof Interval>;
+export const Interval = z.string().regex(/^[1-9]\d*[smh]$/);

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/common.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/common.schema.yaml
@@ -113,3 +113,8 @@ components:
       required:
         - dsl
         - response
+    Interval:
+      type: string
+      description: Interval in which enrich policy runs. For example, `"1h"` means the rule runs every hour.
+      pattern: '^[1-9]\d*[smh]$' # any number except zero followed by one of the suffixes 's', 'm', 'h'
+      example: '1h'

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/enable.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/enable.gen.ts
@@ -16,7 +16,7 @@
 
 import { z } from '@kbn/zod';
 
-import { IndexPattern, EngineDescriptor } from './common.gen';
+import { IndexPattern, EntityType, Interval, EngineDescriptor } from './common.gen';
 
 export type InitEntityStoreRequestBody = z.infer<typeof InitEntityStoreRequestBody>;
 export const InitEntityStoreRequestBody = z.object({
@@ -26,6 +26,8 @@ export const InitEntityStoreRequestBody = z.object({
   fieldHistoryLength: z.number().int().optional().default(10),
   indexPattern: IndexPattern.optional(),
   filter: z.string().optional(),
+  entityTypes: z.array(EntityType).optional(),
+  enrichPolicyExecutionInterval: Interval.optional(),
 });
 export type InitEntityStoreRequestBodyInput = z.input<typeof InitEntityStoreRequestBody>;
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/enable.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/enable.schema.yaml
@@ -27,6 +27,12 @@ paths:
                   $ref: './common.schema.yaml#/components/schemas/IndexPattern'
                 filter:
                   type: string
+                entityTypes:
+                  type: array
+                  items:
+                    $ref: './common.schema.yaml#/components/schemas/EntityType'
+                enrichPolicyExecutionInterval:
+                  $ref: './common.schema.yaml#/components/schemas/Interval'
       responses:
         '200':
           description: Successful response

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/engine/init.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/engine/init.gen.ts
@@ -16,7 +16,7 @@
 
 import { z } from '@kbn/zod';
 
-import { EntityType, IndexPattern, EngineDescriptor } from '../common.gen';
+import { EntityType, IndexPattern, Interval, EngineDescriptor } from '../common.gen';
 
 export type InitEntityEngineRequestParams = z.infer<typeof InitEntityEngineRequestParams>;
 export const InitEntityEngineRequestParams = z.object({
@@ -35,6 +35,7 @@ export const InitEntityEngineRequestBody = z.object({
   fieldHistoryLength: z.number().int().optional().default(10),
   indexPattern: IndexPattern.optional(),
   filter: z.string().optional(),
+  enrichPolicyExecutionInterval: Interval.optional(),
 });
 export type InitEntityEngineRequestBodyInput = z.input<typeof InitEntityEngineRequestBody>;
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/engine/init.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/engine/init.schema.yaml
@@ -33,6 +33,8 @@ paths:
                   $ref: '../common.schema.yaml#/components/schemas/IndexPattern'
                 filter:
                   type: string
+                enrichPolicyExecutionInterval:
+                  $ref: '../common.schema.yaml#/components/schemas/Interval'
       responses:
         '200':
           description: Successful response

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -307,6 +307,12 @@ paths:
             schema:
               type: object
               properties:
+                enrichPolicyExecutionInterval:
+                  $ref: '#/components/schemas/Interval'
+                entityTypes:
+                  items:
+                    $ref: '#/components/schemas/EntityType'
+                  type: array
                 fieldHistoryLength:
                   default: 10
                   description: The number of historical values to keep for each field.
@@ -1141,7 +1147,7 @@ components:
         Interval in which enrich policy runs. For example, `"1h"` means the rule
         runs every hour.
       example: 1h
-      pattern: ^[1-9]\d*[smh]$
+      pattern: '^[1-9]\d*[smh]$'
       type: string
     RiskEngineScheduleNowErrorResponse:
       type: object

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -418,6 +418,8 @@ paths:
             schema:
               type: object
               properties:
+                enrichPolicyExecutionInterval:
+                  $ref: '#/components/schemas/Interval'
                 fieldHistoryLength:
                   default: 10
                   description: The number of historical values to keep for each field.
@@ -1134,6 +1136,13 @@ components:
       required:
         - dsl
         - response
+    Interval:
+      description: >-
+        Interval in which enrich policy runs. For example, `"1h"` means the rule
+        runs every hour.
+      example: 1h
+      pattern: ^[1-9]\d*[smh]$
+      type: string
     RiskEngineScheduleNowErrorResponse:
       type: object
       properties:

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -307,15 +307,12 @@ paths:
             schema:
               type: object
               properties:
-<<<<<<< HEAD
-=======
                 enrichPolicyExecutionInterval:
                   $ref: '#/components/schemas/Interval'
                 entityTypes:
                   items:
                     $ref: '#/components/schemas/EntityType'
                   type: array
->>>>>>> 1ca4d967d92 ([SecuritySolution] Add enrichPolicyExecutionInterval to entity enablement and init APIs (#207374))
                 fieldHistoryLength:
                   default: 10
                   description: The number of historical values to keep for each field.
@@ -1150,7 +1147,7 @@ components:
         Interval in which enrich policy runs. For example, `"1h"` means the rule
         runs every hour.
       example: 1h
-      pattern: ^[1-9]\d*[smh]$
+      pattern: '^[1-9]\d*[smh]$'
       type: string
     RiskEngineScheduleNowErrorResponse:
       type: object

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -307,6 +307,15 @@ paths:
             schema:
               type: object
               properties:
+<<<<<<< HEAD
+=======
+                enrichPolicyExecutionInterval:
+                  $ref: '#/components/schemas/Interval'
+                entityTypes:
+                  items:
+                    $ref: '#/components/schemas/EntityType'
+                  type: array
+>>>>>>> 1ca4d967d92 ([SecuritySolution] Add enrichPolicyExecutionInterval to entity enablement and init APIs (#207374))
                 fieldHistoryLength:
                   default: 10
                   description: The number of historical values to keep for each field.
@@ -418,6 +427,8 @@ paths:
             schema:
               type: object
               properties:
+                enrichPolicyExecutionInterval:
+                  $ref: '#/components/schemas/Interval'
                 fieldHistoryLength:
                   default: 10
                   description: The number of historical values to keep for each field.
@@ -1134,6 +1145,13 @@ components:
       required:
         - dsl
         - response
+    Interval:
+      description: >-
+        Interval in which enrich policy runs. For example, `"1h"` means the rule
+        runs every hour.
+      example: 1h
+      pattern: ^[1-9]\d*[smh]$
+      type: string
     RiskEngineScheduleNowErrorResponse:
       type: object
       properties:

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/task/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/task/constants.ts
@@ -8,5 +8,5 @@
 export const SCOPE = ['securitySolution'];
 export const TYPE = 'entity_store:field_retention:enrichment';
 export const VERSION = '1.0.0';
-export const INTERVAL = '1h';
+export const DEFAULT_INTERVAL = '1h';
 export const TIMEOUT = '10m';

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/task/field_retention_enrichment_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/task/field_retention_enrichment_task.ts
@@ -24,7 +24,7 @@ import {
   stateSchemaByVersion,
   type LatestTaskStateSchema as EntityStoreFieldRetentionTaskState,
 } from './state';
-import { INTERVAL, SCOPE, TIMEOUT, TYPE, VERSION } from './constants';
+import { SCOPE, TIMEOUT, TYPE, VERSION } from './constants';
 import type { EntityAnalyticsRoutesDeps } from '../../types';
 
 import { executeFieldRetentionEnrichPolicy } from '../elasticsearch_assets';
@@ -120,10 +120,12 @@ export const startEntityStoreFieldRetentionEnrichTask = async ({
   logger,
   namespace,
   taskManager,
+  interval,
 }: {
   logger: Logger;
   namespace: string;
   taskManager: TaskManagerStartContract;
+  interval: string;
 }) => {
   const taskId = getTaskId(namespace);
   const log = logFactory(logger, taskId);
@@ -136,7 +138,7 @@ export const startEntityStoreFieldRetentionEnrichTask = async ({
       taskType: getTaskName(),
       scope: SCOPE,
       schedule: {
-        interval: INTERVAL,
+        interval,
       },
       state: { ...defaultState, namespace },
       params: { version: VERSION },
@@ -234,7 +236,7 @@ export const runTask = async ({
 
     telemetry.reportEvent(FIELD_RETENTION_ENRICH_POLICY_EXECUTION_EVENT.eventType, {
       duration: taskDurationInSeconds,
-      interval: INTERVAL,
+      interval: taskInstance.schedule?.interval,
     });
 
     // Track entity store usage


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[SecuritySolution] Add enrichPolicyExecutionInterval to entity enablement and init APIs (#207374)](https://github.com/elastic/kibana/pull/207374)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2025-01-24T13:09:12Z","message":"[SecuritySolution] Add enrichPolicyExecutionInterval to entity enablement and init APIs (#207374)\n\n## Summary\n\nAdd `enrichPolicyExecutionInterval`param to entity enablement and init\nAPIs\n\n### How to test?\n* Start kibana\n* Call the entity store enablement API with a short value for\n`enrichPolicyExecutionInterval` param\n* Check in the logs if the enrichment process is running frequently\n* Clear the entity store\n* Call the entity store enablement API without\n`enrichPolicyExecutionInterval` param\n* Check in the logs if the enrichment process is running less frequently\n\n\n**Enable Entity store API call:**\n```\nPOST kbn:/api/entity_store/enable {\n  \"enrichPolicyExecutionInterval\": \"10s\"\n}\n```\n\n**Init Entity store API call:**\n```\nPOST kbn:/api/entity_store/engines/user/init {\n  \"enrichPolicyExecutionInterval\": \"10s\"\n}\n\n```\n\n**Enrich policy log message:**\n```\n   │ info [o.e.x.e.EnrichPolicyRunner] [...] Policy [entity_store_field_retention_user_default_v1.0.0]: Running enrich policy\n```\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1ca4d967d926a3e6295cb08dcd55dcf1adbd351c","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.0.0","Team: SecuritySolution","release_note:feature","Theme: entity_analytics","Feature:Entity Analytics","Team:Entity Analytics","backport:version","v8.18.0"],"title":"[SecuritySolution] Add enrichPolicyExecutionInterval to entity enablement and init APIs","number":207374,"url":"https://github.com/elastic/kibana/pull/207374","mergeCommit":{"message":"[SecuritySolution] Add enrichPolicyExecutionInterval to entity enablement and init APIs (#207374)\n\n## Summary\n\nAdd `enrichPolicyExecutionInterval`param to entity enablement and init\nAPIs\n\n### How to test?\n* Start kibana\n* Call the entity store enablement API with a short value for\n`enrichPolicyExecutionInterval` param\n* Check in the logs if the enrichment process is running frequently\n* Clear the entity store\n* Call the entity store enablement API without\n`enrichPolicyExecutionInterval` param\n* Check in the logs if the enrichment process is running less frequently\n\n\n**Enable Entity store API call:**\n```\nPOST kbn:/api/entity_store/enable {\n  \"enrichPolicyExecutionInterval\": \"10s\"\n}\n```\n\n**Init Entity store API call:**\n```\nPOST kbn:/api/entity_store/engines/user/init {\n  \"enrichPolicyExecutionInterval\": \"10s\"\n}\n\n```\n\n**Enrich policy log message:**\n```\n   │ info [o.e.x.e.EnrichPolicyRunner] [...] Policy [entity_store_field_retention_user_default_v1.0.0]: Running enrich policy\n```\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1ca4d967d926a3e6295cb08dcd55dcf1adbd351c"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/207374","number":207374,"mergeCommit":{"message":"[SecuritySolution] Add enrichPolicyExecutionInterval to entity enablement and init APIs (#207374)\n\n## Summary\n\nAdd `enrichPolicyExecutionInterval`param to entity enablement and init\nAPIs\n\n### How to test?\n* Start kibana\n* Call the entity store enablement API with a short value for\n`enrichPolicyExecutionInterval` param\n* Check in the logs if the enrichment process is running frequently\n* Clear the entity store\n* Call the entity store enablement API without\n`enrichPolicyExecutionInterval` param\n* Check in the logs if the enrichment process is running less frequently\n\n\n**Enable Entity store API call:**\n```\nPOST kbn:/api/entity_store/enable {\n  \"enrichPolicyExecutionInterval\": \"10s\"\n}\n```\n\n**Init Entity store API call:**\n```\nPOST kbn:/api/entity_store/engines/user/init {\n  \"enrichPolicyExecutionInterval\": \"10s\"\n}\n\n```\n\n**Enrich policy log message:**\n```\n   │ info [o.e.x.e.EnrichPolicyRunner] [...] Policy [entity_store_field_retention_user_default_v1.0.0]: Running enrich policy\n```\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1ca4d967d926a3e6295cb08dcd55dcf1adbd351c"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->