### PR TITLE
Perform bootstrap before running renovate checks

### DIFF
--- a/.buildkite/scripts/steps/renovate.sh
+++ b/.buildkite/scripts/steps/renovate.sh
@@ -3,5 +3,6 @@
 set -euo pipefail
 
 echo '--- Renovate: validation'
+.buildkite/scripts/bootstrap.sh
 .buildkite/scripts/steps/checks/renovate.sh
 .buildkite/scripts/steps/checks/dependencies_missing_owner.sh


### PR DESCRIPTION
## Summary

Performs a bootstrap prior to validating renovate configuration. Fixes failures similar to https://buildkite.com/elastic/kibana-pull-request/builds/270064#019498cd-ac98-4413-ae7a-58ddc81b854d