### PR TITLE
[Search] Update linting rules to apply to all of search

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1618,7 +1618,7 @@ module.exports = {
      */
     {
       // All files
-      files: ['x-pack/solutions/search/plugins/enterprise_search/**/*.{ts,tsx}'],
+      files: ['x-pack/solutions/search/**/*.{ts,tsx}'],
       rules: {
         'import/order': [
           'error',
@@ -1655,8 +1655,6 @@ module.exports = {
         'import/newline-after-import': 'error',
         'react-hooks/exhaustive-deps': 'off',
         'react/jsx-boolean-value': ['error', 'never'],
-        'sort-keys': 1, // warning
-        '@typescript-eslint/member-ordering': [1, { default: { order: 'alphabetically' } }], // warning
         '@typescript-eslint/no-unused-vars': [
           'error',
           { vars: 'all', args: 'after-used', ignoreRestSiblings: true, varsIgnorePattern: '^_' },
@@ -1670,7 +1668,7 @@ module.exports = {
      * Allows snake_case variables in the server, because that's how we return API properties
      */
     {
-      files: ['x-pack/solutions/search/plugins/enterprise_search/server/**/*.{ts,tsx}'],
+      files: ['x-pack/solutions/search/plugins/**/server/**/*.{ts,tsx}'],
       rules: {
         '@typescript-eslint/naming-convention': [
           'error',
@@ -1692,26 +1690,12 @@ module.exports = {
     },
     {
       // Source files only - allow `any` in test/mock files
-      files: ['x-pack/solutions/search/plugins/enterprise_search/**/*.{ts,tsx}'],
+      files: ['x-pack/solutions/search/**/*.{ts,tsx}'],
       excludedFiles: [
-        'x-pack/solutions/search/plugins/enterprise_search/**/*.{test,mock,test_helper}.{ts,tsx}',
+        'x-pack/solutions/search/**/*.{test,mock,test_helper}.{ts,tsx}',
       ],
       rules: {
         '@typescript-eslint/no-explicit-any': 'error',
-      },
-    },
-
-    /**
-     * Serverless Search overrides
-     */
-    {
-      // All files
-      files: [
-        'x-pack/solutions/search/plugins/serverless_search/**/*.{ts,tsx}',
-        'packages/kbn-search-*',
-      ],
-      rules: {
-        '@kbn/telemetry/event_generating_elements_should_be_instrumented': 'error',
       },
     },
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1691,9 +1691,7 @@ module.exports = {
     {
       // Source files only - allow `any` in test/mock files
       files: ['x-pack/solutions/search/**/*.{ts,tsx}'],
-      excludedFiles: [
-        'x-pack/solutions/search/**/*.{test,mock,test_helper}.{ts,tsx}',
-      ],
+      excludedFiles: ['x-pack/solutions/search/**/*.{test,mock,test_helper}.{ts,tsx}'],
       rules: {
         '@typescript-eslint/no-explicit-any': 'error',
       },

--- a/x-pack/solutions/search/packages/kbn-ipynb/components/index.tsx
+++ b/x-pack/solutions/search/packages/kbn-ipynb/components/index.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
 
 import { NotebookDefinition } from '../types';

--- a/x-pack/solutions/search/packages/kbn-ipynb/components/notebook_cell.tsx
+++ b/x-pack/solutions/search/packages/kbn-ipynb/components/notebook_cell.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiMarkdownFormat, EuiCodeBlock, EuiTitle } from '@elastic/eui';
 
 import { NotebookCellType } from '../types';

--- a/x-pack/solutions/search/packages/kbn-ipynb/components/notebook_cell_output.tsx
+++ b/x-pack/solutions/search/packages/kbn-ipynb/components/notebook_cell_output.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiCodeBlock } from '@elastic/eui';
 
 import { NotebookOutputType } from '../types';

--- a/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/components/api_key_flyout_wrapper.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/components/api_key_flyout_wrapper.tsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react';
-import { ApiKeyFlyout, ApiKeyFlyoutProps } from '@kbn/security-api-key-management';
+
 import type { SecurityCreateApiKeyResponse } from '@elastic/elasticsearch/lib/api/types';
+import { ApiKeyFlyout, ApiKeyFlyoutProps } from '@kbn/security-api-key-management';
 
 const API_KEY_NAME = 'Unrestricted API Key';
 

--- a/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/components/api_key_form.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/components/api_key_form.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState } from 'react';
+
 import {
   EuiBadge,
   EuiButton,
@@ -14,12 +15,14 @@ import {
   EuiFlexItem,
   EuiTitle,
 } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { FormInfoField } from '@kbn/search-shared-ui';
-import { ApiKeyFlyoutWrapper } from './api_key_flyout_wrapper';
-import { useSearchApiKey } from '../hooks/use_search_api_key';
+
 import { Status } from '../constants';
+import { useSearchApiKey } from '../hooks/use_search_api_key';
+
+import { ApiKeyFlyoutWrapper } from './api_key_flyout_wrapper';
 
 const API_KEY_MASK = '•'.repeat(60);
 

--- a/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/hooks/use_create_api_key.ts
+++ b/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/hooks/use_create_api_key.ts
@@ -6,8 +6,10 @@
  */
 
 import { useMutation } from '@tanstack/react-query';
-import type { APIKeyCreationResponse } from '@kbn/search-api-keys-server/types';
+
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { APIKeyCreationResponse } from '@kbn/search-api-keys-server/types';
+
 import { APIRoutes } from '../types';
 
 export const useCreateApiKey = ({

--- a/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/hooks/use_search_api_key.ts
+++ b/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/hooks/use_search_api_key.ts
@@ -6,6 +6,7 @@
  */
 
 import { useContext, useEffect } from 'react';
+
 import { ApiKeyContext } from '../providers/search_api_key_provider';
 
 export const useSearchApiKey = () => {

--- a/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/hooks/use_validate_api_key.ts
+++ b/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/hooks/use_validate_api_key.ts
@@ -6,7 +6,9 @@
  */
 
 import { useMutation } from '@tanstack/react-query';
+
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+
 import { APIRoutes } from '../types';
 
 export const useValidateApiKey = (): ((id: string) => Promise<boolean>) => {

--- a/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/providers/search_api_key_provider.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-api-keys-components/src/providers/search_api_key_provider.tsx
@@ -6,8 +6,9 @@
  */
 
 import React, { useCallback, createContext, useState, useMemo, useRef } from 'react';
-import { useCreateApiKey } from '../hooks/use_create_api_key';
+
 import { Status } from '../constants';
+import { useCreateApiKey } from '../hooks/use_create_api_key';
 import { useValidateApiKey } from '../hooks/use_validate_api_key';
 
 const API_KEY_STORAGE_KEY = 'searchApiKey';

--- a/x-pack/solutions/search/packages/kbn-search-api-keys-server/src/lib/create_key.ts
+++ b/x-pack/solutions/search/packages/kbn-search-api-keys-server/src/lib/create_key.ts
@@ -7,6 +7,7 @@
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
+
 import type { APIKeyCreationResponse } from '../../types';
 
 export async function createAPIKey(

--- a/x-pack/solutions/search/packages/kbn-search-api-keys-server/src/lib/get_key_by_id.ts
+++ b/x-pack/solutions/search/packages/kbn-search-api-keys-server/src/lib/get_key_by_id.ts
@@ -7,6 +7,7 @@
 
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
+
 import type { GetApiKeyResponse } from '../../types';
 
 export async function getAPIKeyById(

--- a/x-pack/solutions/search/packages/kbn-search-api-keys-server/src/routes/routes.ts
+++ b/x-pack/solutions/search/packages/kbn-search-api-keys-server/src/routes/routes.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
+import { schema } from '@kbn/config-schema';
 import type { IRouter } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 
-import { schema } from '@kbn/config-schema';
 import { APIRoutes } from '../../types';
-import { getAPIKeyById } from '../lib/get_key_by_id';
 import { createAPIKey } from '../lib/create_key';
+import { getAPIKeyById } from '../lib/get_key_by_id';
 import { fetchClusterHasApiKeys, fetchUserStartPrivileges } from '../lib/privileges';
 
 const API_KEY_NAME = 'Unrestricted API Key';

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/document_list.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/document_list.tsx
@@ -28,10 +28,10 @@ import { i18n } from '@kbn/i18n';
 
 import { FormattedMessage, FormattedNumber } from '@kbn/i18n-react';
 
-import { resultMetaData, resultToFieldFromMappingResponse } from './result/result_metadata';
-
 import { Result } from '..';
+
 import { type ResultProps } from './result/result';
+import { resultMetaData, resultToFieldFromMappingResponse } from './result/result_metadata';
 
 interface DocumentListProps {
   dataTelemetryIdPrefix: string;

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/documents_list.test.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/documents_list.test.tsx
@@ -5,12 +5,17 @@
  * 2.0.
  */
 
-import { I18nProvider } from '@kbn/i18n-react';
-import { render, screen } from '@testing-library/react';
 import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { I18nProvider } from '@kbn/i18n-react';
+
 import { INDEX_DOCUMENTS_META_DEFAULT } from '../types';
+
 import { DocumentList } from './document_list';
 import '@testing-library/jest-dom';
+
 export const DEFAULT_VALUES = {
   dataTelemetryIdPrefix: `entSearchContent-api`,
   docs: [],

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/documents_overview.test.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/documents_overview.test.tsx
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
-import { I18nProvider } from '@kbn/i18n-react';
-import { render, screen } from '@testing-library/react';
 import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { I18nProvider } from '@kbn/i18n-react';
+
 import '@testing-library/jest-dom';
-import { DEFAULT_VALUES } from './documents_list.test';
 import { DocumentList } from './document_list';
+import { DEFAULT_VALUES } from './documents_list.test';
 import { DocumentsOverview } from './documents_overview';
 
 describe('DocumentList', () => {

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/documents_overview.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/documents_overview.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
+import React, { ChangeEvent } from 'react';
+
+import { css } from '@emotion/react';
+
 import { EuiFieldSearch, EuiFlexGroup, EuiFlexItem, EuiPanel, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { ChangeEvent } from 'react';
-import { css } from '@emotion/react';
 
 interface DocumentsProps {
   accessControlSwitch?: React.ReactNode;

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result.tsx
@@ -66,7 +66,7 @@ export const Result: React.FC<ResultProps> = ({
   const toolTipContent = <>{tooltipText}</>;
 
   return (
-    <EuiSplitPanel.Outer hasBorder={true} data-test-subj="search-index-documents-result">
+    <EuiSplitPanel.Outer hasBorder data-test-subj="search-index-documents-result">
       <EuiSplitPanel.Inner paddingSize="m" color="plain" className="resultHeaderContainer">
         <EuiFlexGroup gutterSize="none" alignItems="center">
           <EuiFlexItem>

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result_field.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result_field.tsx
@@ -18,9 +18,10 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
-import { ResultFieldProps } from './result_types';
+
 import { PERMANENTLY_TRUNCATED_FIELDS } from './constants';
 import { ResultFieldValue } from './result_field_value';
+import { ResultFieldProps } from './result_types';
 
 const iconMap: Record<string, string> = {
   boolean: 'tokenBoolean',

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result_field_value.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result_field_value.tsx
@@ -18,6 +18,7 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+
 import { PERMANENTLY_TRUNCATED_FIELDS } from './constants';
 
 interface ResultFieldValueProps {

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result_header.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result_header.tsx
@@ -20,6 +20,7 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+
 import { MetaDataProps } from './result_types';
 
 interface Props {

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result_metadata.ts
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/result_metadata.ts
@@ -10,6 +10,7 @@ import type {
   MappingProperty,
   SearchHit,
 } from '@elastic/elasticsearch/lib/api/types';
+
 import type { MetaDataProps, FieldProps } from './result_types';
 
 const TITLE_KEYS = ['title', 'name'];

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/results_fields.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/results_fields.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { EuiTable, EuiTableBody, EuiTableHeader, EuiTableHeaderCell } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+
 import { ResultField } from './result_field';
 import { ResultFieldProps } from './result_types';
 

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/rich_result_header.tsx
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/components/result/rich_result_header.tsx
@@ -7,6 +7,8 @@
 
 import React, { useState } from 'react';
 
+import { css } from '@emotion/react';
+
 import {
   EuiButton,
   EuiButtonIcon,
@@ -26,8 +28,8 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
-import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
+
 import { MetaDataProps } from './result_types';
 
 interface Props {

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/lib/fetch_search_results.test.ts
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/lib/fetch_search_results.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { ElasticsearchClient } from '@kbn/core/server';
+
 import { DEFAULT_DOCS_PER_PAGE } from '../types';
 
 import { fetchSearchResults } from './fetch_search_results';

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/lib/fetch_search_results.ts
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/lib/fetch_search_results.ts
@@ -7,6 +7,7 @@
 
 import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+
 import { DEFAULT_DOCS_PER_PAGE, Paginate } from '../types';
 import { escapeLuceneChars } from '../utils/escape_lucene_charts';
 import { fetchWithPagination } from '../utils/fetch_with_pagination';

--- a/x-pack/solutions/search/packages/kbn-search-index-documents/utils/fetch_with_pagination.ts
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/utils/fetch_with_pagination.ts
@@ -6,6 +6,7 @@
  */
 
 import { SearchHit, SearchResponse, SearchTotalHits } from '@elastic/elasticsearch/lib/api/types';
+
 import { Paginate } from '../types';
 
 const defaultResult = <T>(data: T[]) => ({

--- a/x-pack/solutions/search/packages/search/shared_ui/src/connector_icon/connector_icon.tsx
+++ b/x-pack/solutions/search/packages/search/shared_ui/src/connector_icon/connector_icon.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiToolTip, EuiIcon } from '@elastic/eui';
 
 interface ConnectorIconProps {

--- a/x-pack/solutions/search/packages/search/shared_ui/src/decorative_horizontal_stepper/decorative_horizontal_stepper.tsx
+++ b/x-pack/solutions/search/packages/search/shared_ui/src/decorative_horizontal_stepper/decorative_horizontal_stepper.tsx
@@ -6,8 +6,10 @@
  */
 
 import React from 'react';
-import { EuiStepsHorizontal, EuiStepsHorizontalProps } from '@elastic/eui';
+
 import { css } from '@emotion/react';
+
+import { EuiStepsHorizontal, EuiStepsHorizontalProps } from '@elastic/eui';
 
 interface DecorativeHorizontalStepperProps {
   stepCount?: number;

--- a/x-pack/solutions/search/packages/search/shared_ui/src/search_empty_prompt/search_empty_prompt.tsx
+++ b/x-pack/solutions/search/packages/search/shared_ui/src/search_empty_prompt/search_empty_prompt.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import {
   EuiFlexGroup,
   EuiFlexItem,

--- a/x-pack/solutions/search/plugins/enterprise_search/cypress.config.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/cypress.config.ts
@@ -24,13 +24,12 @@ export default defineCypressConfig({
   viewportHeight: 900,
   viewportWidth: 1440,
 
-  // eslint-disable-next-line sort-keys
   env: {
     configport: '5601',
     hostname: 'localhost',
     protocol: 'http',
   },
-  // eslint-disable-next-line sort-keys
+
   e2e: {
     baseUrl: 'http://localhost:5601',
     supportFile: './cypress/support/e2e.ts',

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/setup_guide/cloud/instructions.tsx
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-/* eslint-disable sort-keys */
-
 import React from 'react';
 
 import { EuiPageSection, EuiSteps, EuiText, EuiLink, EuiCallOut } from '@elastic/eui';

--- a/x-pack/solutions/search/plugins/search_assistant/public/components/nav_control/index.tsx
+++ b/x-pack/solutions/search/plugins/search_assistant/public/components/nav_control/index.tsx
@@ -5,21 +5,25 @@
  * 2.0.
  */
 import React, { useEffect, useRef, useState } from 'react';
-import { useAbortableAsync } from '@kbn/observability-ai-assistant-plugin/public';
-import { EuiButton, EuiLoadingSpinner, EuiToolTip, useEuiTheme } from '@elastic/eui';
+
 import { css } from '@emotion/react';
-import { v4 } from 'uuid';
+
 import useObservable from 'react-use/lib/useObservable';
-import { i18n } from '@kbn/i18n';
+import { v4 } from 'uuid';
+
+import { EuiButton, EuiLoadingSpinner, EuiToolTip, useEuiTheme } from '@elastic/eui';
+
+import { EuiErrorBoundary } from '@elastic/eui';
 import { useAIAssistantAppService, ChatFlyout } from '@kbn/ai-assistant';
 import { useKibana } from '@kbn/ai-assistant/src/hooks/use_kibana';
 import { AIAssistantPluginStartDependencies } from '@kbn/ai-assistant/src/types';
-import { EuiErrorBoundary } from '@elastic/eui';
+import { AssistantIcon } from '@kbn/ai-assistant-icon';
 import type { CoreStart } from '@kbn/core/public';
+import { i18n } from '@kbn/i18n';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { useAbortableAsync } from '@kbn/observability-ai-assistant-plugin/public';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
-import { AssistantIcon } from '@kbn/ai-assistant-icon';
 
 interface NavControlWithProviderDeps {
   coreStart: CoreStart;

--- a/x-pack/solutions/search/plugins/search_assistant/public/components/nav_control/lazy_nav_control.tsx
+++ b/x-pack/solutions/search/plugins/search_assistant/public/components/nav_control/lazy_nav_control.tsx
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import { dynamic } from '@kbn/shared-ux-utility';
 import React from 'react';
-import { CoreStart } from '@kbn/core-lifecycle-browser';
+
 import { AIAssistantAppService } from '@kbn/ai-assistant';
 import { AIAssistantPluginStartDependencies } from '@kbn/ai-assistant/src/types';
+import { CoreStart } from '@kbn/core-lifecycle-browser';
+import { dynamic } from '@kbn/shared-ux-utility';
 
 const LazyNavControlWithProvider = dynamic(() =>
   import('.').then((m) => ({ default: m.NavControlWithProvider }))

--- a/x-pack/solutions/search/plugins/search_assistant/public/components/page_template.tsx
+++ b/x-pack/solutions/search/plugins/search_assistant/public/components/page_template.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React from 'react';
+
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 
 export function SearchAIAssistantPageTemplate({ children }: { children: React.ReactNode }) {

--- a/x-pack/solutions/search/plugins/search_assistant/public/index.ts
+++ b/x-pack/solutions/search/plugins/search_assistant/public/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { PluginInitializer, PluginInitializerContext } from '@kbn/core/public';
+
 import { PublicConfigType, SearchAssistantPlugin } from './plugin';
 import {
   SearchAssistantPluginSetup,

--- a/x-pack/solutions/search/plugins/search_assistant/public/plugin.tsx
+++ b/x-pack/solutions/search/plugins/search_assistant/public/plugin.tsx
@@ -5,16 +5,18 @@
  * 2.0.
  */
 
-import { type CoreSetup, type Plugin, CoreStart, PluginInitializerContext } from '@kbn/core/public';
-import { createAppService } from '@kbn/ai-assistant';
-import ReactDOM from 'react-dom';
 import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { createAppService } from '@kbn/ai-assistant';
+import { type CoreSetup, type Plugin, CoreStart, PluginInitializerContext } from '@kbn/core/public';
+
+import { NavControlInitiator } from './components/nav_control/lazy_nav_control';
 import type {
   SearchAssistantPluginSetup,
   SearchAssistantPluginStart,
   SearchAssistantPluginStartDependencies,
 } from './types';
-import { NavControlInitiator } from './components/nav_control/lazy_nav_control';
 
 export interface PublicConfigType {
   ui: {

--- a/x-pack/solutions/search/plugins/search_assistant/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_assistant/public/types.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
-import { ObservabilityAIAssistantPublicStart } from '@kbn/observability-ai-assistant-plugin/public';
 import { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import { MlPluginStart } from '@kbn/ml-plugin/public';
+import { ObservabilityAIAssistantPublicStart } from '@kbn/observability-ai-assistant-plugin/public';
 import { SharePluginStart } from '@kbn/share-plugin/public';
 import { TriggersAndActionsUIPublicPluginStart } from '@kbn/triggers-actions-ui-plugin/public';
+import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SearchAssistantPluginSetup {}

--- a/x-pack/solutions/search/plugins/search_assistant/server/index.ts
+++ b/x-pack/solutions/search/plugins/search_assistant/server/index.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import { PluginInitializerContext } from '@kbn/core/server';
+
 import { SearchAssistantPlugin } from './plugin';
 
 export { config } from './config';

--- a/x-pack/solutions/search/plugins/search_assistant/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_assistant/server/plugin.ts
@@ -7,13 +7,12 @@
 
 import type { CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
 
+import { registerFunctions } from './functions';
 import type {
   SearchAssistantPluginSetup,
   SearchAssistantPluginStart,
   SearchAssistantPluginStartDependencies,
 } from './types';
-
-import { registerFunctions } from './functions';
 
 export class SearchAssistantPlugin
   implements

--- a/x-pack/solutions/search/plugins/search_connectors/public/plugin.mock.ts
+++ b/x-pack/solutions/search/plugins/search_connectors/public/plugin.mock.ts
@@ -6,7 +6,9 @@
  */
 
 import { IStaticAssets } from '@kbn/core-http-browser';
+
 import { getConnectorFullTypes } from '../common/lib/connector_types';
+
 import type { SearchConnectorsPluginStart } from './types';
 
 const createStartMock = (): jest.Mocked<SearchConnectorsPluginStart> => ({

--- a/x-pack/solutions/search/plugins/search_connectors/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_connectors/public/plugin.ts
@@ -7,7 +7,9 @@
 
 import { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import { docLinks } from '@kbn/search-connectors';
+
 import { getConnectorFullTypes, getConnectorTypes } from '../common/lib/connector_types';
+
 import {
   SearchConnectorsPluginSetup,
   SearchConnectorsPluginSetupDependencies,

--- a/x-pack/solutions/search/plugins/search_connectors/server/index.ts
+++ b/x-pack/solutions/search/plugins/search_connectors/server/index.ts
@@ -8,6 +8,7 @@
 import { PluginInitializerContext } from '@kbn/core/server';
 
 import { SearchConnectorsPlugin } from './plugin';
+
 export { config } from './config';
 
 //  This exports static code and TypeScript types,

--- a/x-pack/solutions/search/plugins/search_connectors/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_connectors/server/plugin.ts
@@ -12,18 +12,19 @@ import type {
   CoreSetup,
   Logger,
 } from '@kbn/core/server';
-import { ConnectorServerSideDefinition } from '@kbn/search-connectors';
 import { isAgentlessEnabled } from '@kbn/fleet-plugin/server/services/utils/agentless';
+import { ConnectorServerSideDefinition } from '@kbn/search-connectors';
+
 import { getConnectorTypes } from '../common/lib/connector_types';
+
+import { SearchConnectorsConfig } from './config';
+import { AgentlessConnectorDeploymentsSyncService } from './task';
 import type {
   SearchConnectorsPluginSetup as SearchConnectorsPluginSetup,
   SearchConnectorsPluginStart as SearchConnectorsPluginStart,
   SearchConnectorsPluginSetupDependencies,
   SearchConnectorsPluginStartDependencies,
 } from './types';
-
-import { AgentlessConnectorDeploymentsSyncService } from './task';
-import { SearchConnectorsConfig } from './config';
 
 export class SearchConnectorsPlugin
   implements

--- a/x-pack/solutions/search/plugins/search_connectors/server/services/index.test.ts
+++ b/x-pack/solutions/search/plugins/search_connectors/server/services/index.test.ts
@@ -5,11 +5,21 @@
  * 2.0.
  */
 
-import { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import {
   ElasticsearchClientMock,
   elasticsearchClientMock,
 } from '@kbn/core-elasticsearch-client-server-mocks';
+import { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { AgentPolicy, PackagePolicy, PackagePolicyInput } from '@kbn/fleet-plugin/common';
+import { createAgentPolicyMock, createPackagePolicyMock } from '@kbn/fleet-plugin/common/mocks';
+import { AgentPolicyServiceInterface, PackagePolicyClient } from '@kbn/fleet-plugin/server';
+import {
+  createPackagePolicyServiceMock,
+  createMockAgentPolicyService,
+} from '@kbn/fleet-plugin/server/mocks';
+import { MockedLogger, loggerMock } from '@kbn/logging-mocks';
+
 import {
   AgentlessConnectorsInfraService,
   ConnectorMetadata,
@@ -17,15 +27,6 @@ import {
   getConnectorsToDeploy,
   getPoliciesToDelete,
 } from '.';
-import { savedObjectsClientMock } from '@kbn/core/server/mocks';
-import { MockedLogger, loggerMock } from '@kbn/logging-mocks';
-import {
-  createPackagePolicyServiceMock,
-  createMockAgentPolicyService,
-} from '@kbn/fleet-plugin/server/mocks';
-import { AgentPolicyServiceInterface, PackagePolicyClient } from '@kbn/fleet-plugin/server';
-import { AgentPolicy, PackagePolicy, PackagePolicyInput } from '@kbn/fleet-plugin/common';
-import { createAgentPolicyMock, createPackagePolicyMock } from '@kbn/fleet-plugin/common/mocks';
 
 jest.mock('@kbn/fleet-plugin/server/services/epm/packages', () => {
   const mockedGetPackageInfo = ({ pkgName }: { pkgName: string }) => {

--- a/x-pack/solutions/search/plugins/search_connectors/server/services/index.ts
+++ b/x-pack/solutions/search/plugins/search_connectors/server/services/index.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
+import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { PACKAGE_POLICY_SAVED_OBJECT_TYPE, PackagePolicy } from '@kbn/fleet-plugin/common';
 import { AgentPolicyServiceInterface, PackagePolicyClient } from '@kbn/fleet-plugin/server';
-import type { Logger, SavedObjectsClientContract } from '@kbn/core/server';
-import { NATIVE_CONNECTOR_DEFINITIONS, fetchConnectors } from '@kbn/search-connectors';
 import { getPackageInfo } from '@kbn/fleet-plugin/server/services/epm/packages';
+import { NATIVE_CONNECTOR_DEFINITIONS, fetchConnectors } from '@kbn/search-connectors';
 
 export interface ConnectorMetadata {
   id: string;

--- a/x-pack/solutions/search/plugins/search_connectors/server/task.test.ts
+++ b/x-pack/solutions/search/plugins/search_connectors/server/task.test.ts
@@ -5,17 +5,19 @@
  * 2.0.
  */
 
+import { createPackagePolicyMock } from '@kbn/fleet-plugin/common/mocks';
+import { LicensingPluginStart } from '@kbn/licensing-plugin/server';
+import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
 import { loggerMock, MockedLogger } from '@kbn/logging-mocks';
-import { infraSyncTaskRunner } from './task';
+
 import { ConcreteTaskInstance, TaskStatus } from '@kbn/task-manager-plugin/server';
+
 import {
   AgentlessConnectorsInfraService,
   ConnectorMetadata,
   PackagePolicyMetadata,
 } from './services';
-import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
-import { LicensingPluginStart } from '@kbn/licensing-plugin/server';
-import { createPackagePolicyMock } from '@kbn/fleet-plugin/common/mocks';
+import { infraSyncTaskRunner } from './task';
 
 const DATE_1970 = '1970-01-01T00:00:00.000Z';
 

--- a/x-pack/solutions/search/plugins/search_connectors/server/task.ts
+++ b/x-pack/solutions/search/plugins/search_connectors/server/task.ts
@@ -7,24 +7,23 @@
 
 import { Logger, CoreStart, SavedObjectsClient } from '@kbn/core/server';
 
+import { LicensingPluginStart } from '@kbn/licensing-plugin/server';
 import type {
   ConcreteTaskInstance,
   TaskManagerStartContract,
   TaskInstance,
 } from '@kbn/task-manager-plugin/server';
 
-import { LicensingPluginStart } from '@kbn/licensing-plugin/server';
-import type {
-  SearchConnectorsPluginStartDependencies,
-  SearchConnectorsPluginSetupDependencies,
-} from './types';
+import { SearchConnectorsConfig } from './config';
 import {
   AgentlessConnectorsInfraService,
   getConnectorsToDeploy,
   getPoliciesToDelete,
 } from './services';
-
-import { SearchConnectorsConfig } from './config';
+import type {
+  SearchConnectorsPluginStartDependencies,
+  SearchConnectorsPluginSetupDependencies,
+} from './types';
 
 const AGENTLESS_CONNECTOR_DEPLOYMENTS_SYNC_TASK_ID = 'search:agentless-connectors-manager-task';
 const AGENTLESS_CONNECTOR_DEPLOYMENTS_SYNC_TASK_TYPE = 'search:agentless-connectors-manager';

--- a/x-pack/solutions/search/plugins/search_connectors/server/types.ts
+++ b/x-pack/solutions/search/plugins/search_connectors/server/types.ts
@@ -5,15 +5,15 @@
  * 2.0.
  */
 
-import { ConnectorServerSideDefinition } from '@kbn/search-connectors';
+import { CloudSetup } from '@kbn/cloud-plugin/server';
+import { SavedObjectsServiceSetup, SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
 import type { FleetStartContract, FleetSetupContract } from '@kbn/fleet-plugin/server';
+import { LicensingPluginStart } from '@kbn/licensing-plugin/server';
+import { ConnectorServerSideDefinition } from '@kbn/search-connectors';
 import {
   TaskManagerSetupContract,
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
-import { SavedObjectsServiceSetup, SavedObjectsServiceStart } from '@kbn/core-saved-objects-server';
-import { LicensingPluginStart } from '@kbn/licensing-plugin/server';
-import { CloudSetup } from '@kbn/cloud-plugin/server';
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
 

--- a/x-pack/solutions/search/plugins/search_homepage/public/application.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/application.tsx
@@ -7,14 +7,16 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import { CoreStart } from '@kbn/core/public';
-import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
-import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { Router } from '@kbn/shared-ux-router';
-import { SearchHomepageServicesContext } from './types';
-import { HomepageRouter } from './router';
+
 import { UsageTrackerContextProvider } from './contexts/usage_tracker_context';
+import { HomepageRouter } from './router';
+import { SearchHomepageServicesContext } from './types';
 
 export const renderApp = async (
   core: CoreStart,

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/console_link_button.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/console_link_button.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 import React, { useCallback } from 'react';
+
 import { EuiButtonEmpty } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import type { ConsolePluginStart } from '@kbn/console-plugin/public';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { useKibana } from '../hooks/use_kibana';
 import { useUsageTracker } from '../hooks/use_usage_tracker';

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/endpoints_header_action.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/endpoints_header_action.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 import React, { useState, useCallback } from 'react';
+
 import { EuiButtonEmpty, EuiFlexGroup, EuiFlyout, EuiHeaderLinks } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import {
   KibanaWiredConnectionDetailsProvider,
   ConnectionDetailsFlyoutContent,
 } from '@kbn/cloud/connection_details';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { useUsageTracker } from '../hooks/use_usage_tracker';
 

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage.tsx
@@ -6,9 +6,11 @@
  */
 
 import React, { useMemo } from 'react';
+
 import { EuiPageTemplate } from '@elastic/eui';
 
 import { useKibana } from '../hooks/use_kibana';
+
 import { SearchHomepageBody } from './search_homepage_body';
 import { SearchHomepageHeader } from './search_homepage_header';
 

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_body.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 import React from 'react';
-import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 
 import { ConsoleLinkButton } from './console_link_button';
 

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_header.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/search_homepage_header.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React from 'react';
+
 import { EuiPageTemplate, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 

--- a/x-pack/solutions/search/plugins/search_homepage/public/components/stack_app.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/components/stack_app.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import { UsageTrackerContextProvider } from '../contexts/usage_tracker_context';
 import { useKibana } from '../hooks/use_kibana';
+
 import { SearchHomepageBody } from './search_homepage_body';
 import { SearchHomepageHeader } from './search_homepage_header';
 

--- a/x-pack/solutions/search/plugins/search_homepage/public/contexts/usage_tracker_context.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/contexts/usage_tracker_context.tsx
@@ -6,13 +6,14 @@
  */
 
 import React, { createContext, useContext, useMemo } from 'react';
+
 import type {
   UsageCollectionSetup,
   UsageCollectionStart,
 } from '@kbn/usage-collection-plugin/public';
 
-import { createUsageTracker, createEmptyUsageTracker } from '../usage_tracker';
 import { AppUsageTracker } from '../types';
+import { createUsageTracker, createEmptyUsageTracker } from '../usage_tracker';
 
 const UsageTrackerContext = createContext<AppUsageTracker>(createEmptyUsageTracker());
 

--- a/x-pack/solutions/search/plugins/search_homepage/public/feature_flags.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/feature_flags.ts
@@ -6,6 +6,7 @@
  */
 
 import { IUiSettingsClient } from '@kbn/core/public';
+
 import { HOMEPAGE_FEATURE_FLAG_ID } from '../common';
 
 export function isHomepageEnabled(uiSettings: IUiSettingsClient): boolean {

--- a/x-pack/solutions/search/plugins/search_homepage/public/hooks/use_kibana.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/hooks/use_kibana.ts
@@ -6,6 +6,7 @@
  */
 
 import { useKibana as _useKibana } from '@kbn/kibana-react-plugin/public';
+
 import { SearchHomepageServicesContext } from '../types';
 
 export const useKibana = () => _useKibana<SearchHomepageServicesContext>();

--- a/x-pack/solutions/search/plugins/search_homepage/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/plugin.ts
@@ -13,6 +13,7 @@ import {
   PluginInitializerContext,
 } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
+
 import { PLUGIN_ID } from '../common';
 
 import { SearchHomepage } from './embeddable';

--- a/x-pack/solutions/search/plugins/search_homepage/public/router.tsx
+++ b/x-pack/solutions/search/plugins/search_homepage/public/router.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { Route, Routes } from '@kbn/shared-ux-router';
 
 import { SearchHomepagePage } from './components/search_homepage';

--- a/x-pack/solutions/search/plugins/search_homepage/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/types.ts
@@ -6,10 +6,12 @@
  */
 
 import type { ComponentProps, FC } from 'react';
+
 import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { AppMountParameters } from '@kbn/core/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+
 import type { App } from './components/stack_app';
 
 export interface SearchHomepageConfigType {

--- a/x-pack/solutions/search/plugins/search_homepage/public/usage_tracker.ts
+++ b/x-pack/solutions/search/plugins/search_homepage/public/usage_tracker.ts
@@ -10,6 +10,7 @@ import type {
   UsageCollectionSetup,
   UsageCollectionStart,
 } from '@kbn/usage-collection-plugin/public';
+
 import { AppUsageTracker } from './types';
 
 const APP_TRACKER_NAME = 'searchHomepage';

--- a/x-pack/solutions/search/plugins/search_indices/common/index.ts
+++ b/x-pack/solutions/search/plugins/search_indices/common/index.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import type { SearchIndices, SearchStart } from '@kbn/deeplinks-search/deep_links';
 import { SEARCH_INDICES, SEARCH_INDICES_START } from '@kbn/deeplinks-search';
+import type { SearchIndices, SearchStart } from '@kbn/deeplinks-search/deep_links';
 
 export const PLUGIN_ID = 'searchIndices';
 export const PLUGIN_NAME = 'searchIndices';

--- a/x-pack/solutions/search/plugins/search_indices/public/application.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/application.tsx
@@ -7,13 +7,16 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { CoreStart } from '@kbn/core/public';
-import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
-import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import { I18nProvider } from '@kbn/i18n-react';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+import { CoreStart } from '@kbn/core/public';
+import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
+
 import { SearchApiKeyProvider } from '@kbn/search-api-keys-components';
+
 import { UsageTrackerContextProvider } from './contexts/usage_tracker_context';
 import { SearchIndicesServicesContextDeps } from './types';
 

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/create_index.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/create_index.ts
@@ -6,6 +6,7 @@
  */
 
 import { CreateIndexCodeExamples } from '../types';
+
 import {
   CONNECT_CREATE_DEFAULT_INDEX_CMD_DESCRIPTION,
   CONNECT_CREATE_DEFAULT_INDEX_CMD_TITLE,

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/curl.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/curl.ts
@@ -6,8 +6,10 @@
  */
 
 import { i18n } from '@kbn/i18n';
+
 import { API_KEY_PLACEHOLDER, INDEX_PLACEHOLDER } from '../constants';
 import { CodeLanguage, IngestDataCodeDefinition } from '../types';
+
 import { CreateIndexLanguageExamples } from './types';
 
 export const CURL_INFO: CodeLanguage = {

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/ingest_data.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/ingest_data.ts
@@ -6,13 +6,14 @@
  */
 
 import { i18n } from '@kbn/i18n';
+
 import { IngestDataCodeExamples } from '../types';
 
+import { INSTALL_INSTRUCTIONS_TITLE, INSTALL_INSTRUCTIONS_DESCRIPTION } from './constants';
+import { CurlIngestDataExample } from './curl';
 import { JSIngestDataExample } from './javascript';
 import { PythonIngestDataExample } from './python';
 import { ConsoleIngestDataExample } from './sense';
-import { CurlIngestDataExample } from './curl';
-import { INSTALL_INSTRUCTIONS_TITLE, INSTALL_INSTRUCTIONS_DESCRIPTION } from './constants';
 
 const addMappingsTitle = i18n.translate(
   'xpack.searchIndices.codeExamples.serverless.denseVector.mappingsTitle',

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
@@ -6,8 +6,10 @@
  */
 
 import { i18n } from '@kbn/i18n';
+
 import { API_KEY_PLACEHOLDER, INDEX_PLACEHOLDER } from '../constants';
 import { CodeLanguage, IngestDataCodeDefinition } from '../types';
+
 import { CreateIndexLanguageExamples } from './types';
 
 export const JAVASCRIPT_INFO: CodeLanguage = {

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/python.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/python.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+
 import { API_KEY_PLACEHOLDER, INDEX_PLACEHOLDER } from '../constants';
 import {
   CodeLanguage,

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/sense.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/sense.ts
@@ -7,6 +7,7 @@
 
 import { INDEX_PLACEHOLDER } from '../constants';
 import { IngestDataCodeDefinition } from '../types';
+
 import { CreateIndexLanguageExamples } from './types';
 
 export const ConsoleCreateIndexExamples: CreateIndexLanguageExamples = {

--- a/x-pack/solutions/search/plugins/search_indices/public/components/connection_details/connection_details.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/connection_details/connection_details.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 
 import { FormInfoField } from '@kbn/search-shared-ui';
+
 import { useElasticsearchUrl } from '../../hooks/use_elasticsearch_url';
 
 export const ConnectionDetails: React.FC = () => {

--- a/x-pack/solutions/search/plugins/search_indices/public/components/create_index/create_index.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/create_index/create_index.tsx
@@ -11,6 +11,7 @@ import type { IndicesStatusResponse } from '../../../common';
 
 import { AnalyticsEvents } from '../../analytics/constants';
 import { AvailableLanguages } from '../../code_examples';
+import { WorkflowId } from '../../code_examples/workflows';
 import { useUserPrivilegesQuery } from '../../hooks/api/use_user_permissions';
 import { useKibana } from '../../hooks/use_kibana';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
@@ -20,10 +21,10 @@ import { getDefaultCodingLanguage } from '../../utils/language';
 
 import { CreateIndexPanel } from '../shared/create_index_panel';
 
+import { useWorkflow } from '../shared/hooks/use_workflow';
+
 import { CreateIndexCodeView } from './create_index_code_view';
 import { CreateIndexUIView } from './create_index_ui_view';
-import { WorkflowId } from '../../code_examples/workflows';
-import { useWorkflow } from '../shared/hooks/use_workflow';
 
 function initCreateIndexState() {
   const defaultIndexName = generateRandomIndexName();

--- a/x-pack/solutions/search/plugins/search_indices/public/components/create_index/create_index_page.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/create_index/create_index_page.tsx
@@ -6,18 +6,19 @@
  */
 
 import React, { useMemo } from 'react';
-import { i18n } from '@kbn/i18n';
 
 import { EuiLoadingLogo } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 
-import { useKibana } from '../../hooks/use_kibana';
 import { useIndicesStatusQuery } from '../../hooks/api/use_indices_status';
+import { useKibana } from '../../hooks/use_kibana';
+import { usePageChrome } from '../../hooks/use_page_chrome';
+import { IndexManagementBreadcrumbs } from '../shared/breadcrumbs';
 import { LoadIndicesStatusError } from '../shared/load_indices_status_error';
 
 import { CreateIndex } from './create_index';
-import { usePageChrome } from '../../hooks/use_page_chrome';
-import { IndexManagementBreadcrumbs } from '../shared/breadcrumbs';
 
 const CreateIndexLabel = i18n.translate('xpack.searchIndices.createIndex.docTitle', {
   defaultMessage: 'Create Index',

--- a/x-pack/solutions/search/plugins/search_indices/public/components/create_index/create_index_ui_view.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/create_index/create_index_ui_view.tsx
@@ -9,13 +9,12 @@ import React, { useCallback, useState } from 'react';
 
 import type { UserStartPrivilegesResponse } from '../../../common';
 import { AnalyticsEvents } from '../../analytics/constants';
-import { CreateIndexFormState } from '../../types';
-import { CreateIndexForm } from '../shared/create_index_form';
-import { useUsageTracker } from '../../hooks/use_usage_tracker';
-import { isValidIndexName } from '../../utils/indices';
-import { useCreateIndex } from '../shared/hooks/use_create_index';
-
 import { useKibana } from '../../hooks/use_kibana';
+import { useUsageTracker } from '../../hooks/use_usage_tracker';
+import { CreateIndexFormState } from '../../types';
+import { isValidIndexName } from '../../utils/indices';
+import { CreateIndexForm } from '../shared/create_index_form';
+import { useCreateIndex } from '../shared/hooks/use_create_index';
 
 export interface CreateIndexUIViewProps {
   formState: CreateIndexFormState;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/create_index/hooks/use_indices_redirect.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/create_index/hooks/use_indices_redirect.tsx
@@ -9,12 +9,12 @@ import { useEffect, useState } from 'react';
 
 import type { IndicesStatusResponse } from '../../../../common';
 
+import { AnalyticsEvents } from '../../../analytics/constants';
+import { useUsageTracker } from '../../../contexts/usage_tracker_context';
 import { useKibana } from '../../../hooks/use_kibana';
 
 import { getFirstNewIndexName } from '../../../utils/indices';
 import { navigateToIndexDetails } from '../../utils';
-import { useUsageTracker } from '../../../contexts/usage_tracker_context';
-import { AnalyticsEvents } from '../../../analytics/constants';
 
 export const useIndicesRedirect = (indicesStatus?: IndicesStatusResponse) => {
   const { application, http } = useKibana().services;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/add_documents_code_example.test.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/add_documents_code_example.test.tsx
@@ -6,10 +6,14 @@
  */
 
 import React from 'react';
+
 import { render } from '@testing-library/react';
-import { AddDocumentsCodeExample, exampleTexts } from './add_documents_code_example';
-import { generateSampleDocument } from '../../utils/document_generation';
+
 import { MappingProperty } from '@elastic/elasticsearch/lib/api/types';
+
+import { generateSampleDocument } from '../../utils/document_generation';
+
+import { AddDocumentsCodeExample, exampleTexts } from './add_documents_code_example';
 
 jest.mock('../../utils/language', () => ({
   getDefaultCodingLanguage: jest.fn().mockReturnValue('python'),

--- a/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/add_documents_code_example.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/add_documents_code_example.tsx
@@ -6,25 +6,26 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
+
 import { MappingProperty } from '@elastic/elasticsearch/lib/api/types';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { useSearchApiKey } from '@kbn/search-api-keys-components';
 import { TryInConsoleButton } from '@kbn/try-in-console';
 
-import { useSearchApiKey } from '@kbn/search-api-keys-components';
+import { AnalyticsEvents } from '../../analytics/constants';
+import { AvailableLanguages, LanguageOptions, Languages } from '../../code_examples';
+import { WorkflowId } from '../../code_examples/workflows';
+import { useUsageTracker } from '../../contexts/usage_tracker_context';
+import { useElasticsearchUrl } from '../../hooks/use_elasticsearch_url';
 import { useKibana } from '../../hooks/use_kibana';
 import { IngestCodeSnippetParameters } from '../../types';
-import { LanguageSelector } from '../shared/language_selector';
-import { useElasticsearchUrl } from '../../hooks/use_elasticsearch_url';
-import { useUsageTracker } from '../../contexts/usage_tracker_context';
-import { AvailableLanguages, LanguageOptions, Languages } from '../../code_examples';
-import { AnalyticsEvents } from '../../analytics/constants';
-import { CodeSample } from '../shared/code_sample';
 import { generateSampleDocument } from '../../utils/document_generation';
 import { getDefaultCodingLanguage } from '../../utils/language';
+import { CodeSample } from '../shared/code_sample';
 import { GuideSelector } from '../shared/guide_selector';
 import { useWorkflow } from '../shared/hooks/use_workflow';
-import { WorkflowId } from '../../code_examples/workflows';
+import { LanguageSelector } from '../shared/language_selector';
 
 export const exampleTexts = [
   'Yellowstone National Park is one of the largest national parks in the United States. It ranges from the Wyoming to Montana and Idaho, and contains an area of 2,219,791 acress across three different states. Its most famous for hosting the geyser Old Faithful and is centered on the Yellowstone Caldera, the largest super volcano on the American continent. Yellowstone is host to hundreds of species of animal, many of which are endangered or threatened. Most notably, it contains free-ranging herds of bison and elk, alongside bears, cougars and wolves. The national park receives over 4.5 million visitors annually and is a UNESCO World Heritage Site.',

--- a/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/document_list.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/document_list.tsx
@@ -6,15 +6,17 @@
  */
 
 import React from 'react';
+
 import { MappingProperty, SearchHit } from '@elastic/elasticsearch/lib/api/types';
 
+import { EuiSpacer } from '@elastic/eui';
 import { Result, resultMetaData, resultToField } from '@kbn/search-index-documents';
 
-import { EuiSpacer } from '@elastic/eui';
-
 import { reorderFieldsInImportance } from '@kbn/search-index-documents';
-import { RecentDocsActionMessage } from './recent_docs_action_message';
+
 import { useDeleteDocument } from '../../hooks/api/use_delete_document';
+
+import { RecentDocsActionMessage } from './recent_docs_action_message';
 
 export interface DocumentListProps {
   indexName: string;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/index_documents.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/index_documents.tsx
@@ -8,11 +8,13 @@
 import React, { useMemo } from 'react';
 
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiProgress, EuiSpacer } from '@elastic/eui';
-import { useIndexMapping } from '../../hooks/api/use_index_mappings';
-import { AddDocumentsCodeExample } from './add_documents_code_example';
-import { IndexDocuments as IndexDocumentsType } from '../../hooks/api/use_document_search';
-import { DocumentList } from './document_list';
+
 import type { UserStartPrivilegesResponse } from '../../../common';
+import { IndexDocuments as IndexDocumentsType } from '../../hooks/api/use_document_search';
+import { useIndexMapping } from '../../hooks/api/use_index_mappings';
+
+import { AddDocumentsCodeExample } from './add_documents_code_example';
+import { DocumentList } from './document_list';
 
 interface IndexDocumentsProps {
   indexName: string;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/recent_docs_action_message.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/recent_docs_action_message.tsx
@@ -7,8 +7,9 @@
 
 import React from 'react';
 
-import { i18n } from '@kbn/i18n';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiLink, EuiPanel } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
 import { useKibana } from '../../hooks/use_kibana';
 
 import { DEFAULT_PAGE_SIZE } from './constants';

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/delete_index_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/delete_index_modal.tsx
@@ -5,10 +5,13 @@
  * 2.0.
  */
 import React, { Fragment, useEffect } from 'react';
-import { i18n } from '@kbn/i18n';
+
 import { EuiConfirmModal } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+
 import { useDeleteIndex } from '../../hooks/api/use_delete_index';
+
 interface DeleteIndexModelProps {
   onCancel: () => void;
   indexName: string;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page.tsx
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useParams } from 'react-router-dom';
+
 import {
   EuiPageTemplate,
   EuiFlexItem,
@@ -15,32 +19,34 @@ import {
   useEuiTheme,
   EuiButton,
 } from '@elastic/eui';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { FormattedMessage } from '@kbn/i18n-react';
-import { i18n } from '@kbn/i18n';
+
 import { SectionLoading } from '@kbn/es-ui-shared-plugin/public';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { ApiKeyForm } from '@kbn/search-api-keys-components';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
-import { useNavigateToDiscover } from '../../hooks/use_navigate_to_discover';
+
+import { AnalyticsEvents } from '../../analytics/constants';
+import { useUsageTracker } from '../../contexts/usage_tracker_context';
+import { useIndexDocumentSearch } from '../../hooks/api/use_document_search';
 import { useIndex } from '../../hooks/api/use_index';
-import { useKibana } from '../../hooks/use_kibana';
-import { ConnectionDetails } from '../connection_details/connection_details';
-import { QuickStats } from '../quick_stats/quick_stats';
 import { useIndexMapping } from '../../hooks/api/use_index_mappings';
+import { useUserPrivilegesQuery } from '../../hooks/api/use_user_permissions';
+import { useKibana } from '../../hooks/use_kibana';
+import { useNavigateToDiscover } from '../../hooks/use_navigate_to_discover';
+import { usePageChrome } from '../../hooks/use_page_chrome';
+import { SearchIndexDetailsTabs } from '../../routes';
+import { ConnectionDetails } from '../connection_details/connection_details';
 import { IndexDocuments } from '../index_documents/index_documents';
+import { QuickStats } from '../quick_stats/quick_stats';
+
+import { IndexManagementBreadcrumbs } from '../shared/breadcrumbs';
+
 import { DeleteIndexModal } from './delete_index_modal';
 import { IndexloadingError } from './details_page_loading_error';
-import { SearchIndexDetailsTabs } from '../../routes';
 import { SearchIndexDetailsMappings } from './details_page_mappings';
-import { SearchIndexDetailsSettings } from './details_page_settings';
 import { SearchIndexDetailsPageMenuItemPopover } from './details_page_menu_item';
-import { useIndexDocumentSearch } from '../../hooks/api/use_document_search';
-import { useUsageTracker } from '../../contexts/usage_tracker_context';
-import { AnalyticsEvents } from '../../analytics/constants';
-import { useUserPrivilegesQuery } from '../../hooks/api/use_user_permissions';
-import { usePageChrome } from '../../hooks/use_page_chrome';
-import { IndexManagementBreadcrumbs } from '../shared/breadcrumbs';
+import { SearchIndexDetailsSettings } from './details_page_settings';
 
 export const SearchIndexDetailsPage = () => {
   const indexName = decodeURIComponent(useParams<{ indexName: string }>().indexName);

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_loading_error.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_loading_error.tsx
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import React from 'react';
+
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -12,8 +14,8 @@ import {
   EuiPageTemplate,
   EuiText,
 } from '@elastic/eui';
-import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+
 interface IndexloadingErrorProps {
   error: {
     title: string;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_mappings.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_mappings.tsx
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
+import React from 'react';
+
+import { useMemo } from 'react';
+
 import { EuiSpacer } from '@elastic/eui';
 import { Index } from '@kbn/index-management-shared-types';
-import React from 'react';
-import { useMemo } from 'react';
-import { useKibana } from '../../hooks/use_kibana';
+
 import type { UserStartPrivilegesResponse } from '../../../common';
+import { useKibana } from '../../hooks/use_kibana';
 
 export interface SearchIndexDetailsMappingsProps {
   index?: Index;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_menu_item.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_menu_item.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React, { ReactElement, useMemo, useState } from 'react';
+
 import {
   EuiButtonIcon,
   EuiContextMenuItem,
@@ -14,10 +16,10 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { ReactElement, useMemo, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useKibana } from '../../hooks/use_kibana';
+
 import type { UserStartPrivilegesResponse } from '../../../common';
+import { useKibana } from '../../hooks/use_kibana';
 
 interface SearchIndexDetailsPageMenuItemPopoverProps {
   handleDeleteIndexModal: () => void;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_settings.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices/details_page_settings.tsx
@@ -7,9 +7,11 @@
 
 import React from 'react';
 import { useMemo } from 'react';
+
 import { EuiSpacer } from '@elastic/eui';
-import { useKibana } from '../../hooks/use_kibana';
+
 import type { UserStartPrivilegesResponse } from '../../../common';
+import { useKibana } from '../../hooks/use_kibana';
 
 interface SearchIndexDetailsSettingsProps {
   indexName: string;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/indices_router.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/indices_router.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 import React from 'react';
-import { Route, Router, Routes } from '@kbn/shared-ux-router';
+
 import { Redirect } from 'react-router-dom';
+
+import { Route, Router, Routes } from '@kbn/shared-ux-router';
 
 import { useKibana } from '../hooks/use_kibana';
 import {
@@ -15,8 +17,9 @@ import {
   SEARCH_INDICES_DETAILS_TABS_PATH,
   CREATE_INDEX_PATH,
 } from '../routes';
-import { SearchIndexDetailsPage } from './indices/details_page';
+
 import { CreateIndexPage } from './create_index/create_index_page';
+import { SearchIndexDetailsPage } from './indices/details_page';
 
 export const SearchIndicesRouter: React.FC = () => {
   const { application, history } = useKibana().services;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/quick_stats/mappings_convertor.test.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/quick_stats/mappings_convertor.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { Mappings } from '../../types';
+
 import { countVectorBasedTypesFromMappings } from './mappings_convertor';
 
 describe('mappings convertor', () => {

--- a/x-pack/solutions/search/plugins/search_indices/public/components/quick_stats/mappings_convertor.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/quick_stats/mappings_convertor.ts
@@ -6,6 +6,7 @@
  */
 
 import type { MappingProperty, MappingPropertyBase } from '@elastic/elasticsearch/lib/api/types';
+
 import type { Mappings } from '../../types';
 
 interface VectorFieldTypes {

--- a/x-pack/solutions/search/plugins/search_indices/public/components/quick_stats/quick_stats.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/quick_stats/quick_stats.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { useMemo, useState } from 'react';
-import type { Index } from '@kbn/index-management-shared-types';
 
 import {
   EuiFlexGroup,
@@ -18,11 +17,14 @@ import {
   EuiButton,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import type { Index } from '@kbn/index-management-shared-types';
+
+import { IndexDocuments } from '../../hooks/api/use_document_search';
+import { useKibana } from '../../hooks/use_kibana';
 import { Mappings } from '../../types';
+
 import { countVectorBasedTypesFromMappings } from './mappings_convertor';
 import { QuickStat } from './quick_stat';
-import { useKibana } from '../../hooks/use_kibana';
-import { IndexDocuments } from '../../hooks/api/use_document_search';
 
 export interface QuickStatsProps {
   index: Index;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/api_key_callout.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/api_key_callout.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/code_sample.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/code_sample.tsx
@@ -8,6 +8,7 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 
 import React from 'react';
+
 import {
   EuiCodeBlock,
   EuiFlexItem,

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/create_index_code_view.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/create_index_code_view.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React, { useMemo } from 'react';
+
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -13,22 +14,23 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useSearchApiKey } from '@kbn/search-api-keys-components';
 import { TryInConsoleButton } from '@kbn/try-in-console';
 
-import { useSearchApiKey } from '@kbn/search-api-keys-components';
-import { i18n } from '@kbn/i18n';
 import { Languages, AvailableLanguages, LanguageOptions } from '../../code_examples';
 
-import { useUsageTracker } from '../../hooks/use_usage_tracker';
-import { useKibana } from '../../hooks/use_kibana';
+import { Workflow, WorkflowId } from '../../code_examples/workflows';
 import { useElasticsearchUrl } from '../../hooks/use_elasticsearch_url';
+import { useKibana } from '../../hooks/use_kibana';
+import { useUsageTracker } from '../../hooks/use_usage_tracker';
+
+import { CreateIndexCodeExamples } from '../../types';
 
 import { APIKeyCallout } from './api_key_callout';
 import { CodeSample } from './code_sample';
-import { LanguageSelector } from './language_selector';
 import { GuideSelector } from './guide_selector';
-import { Workflow, WorkflowId } from '../../code_examples/workflows';
-import { CreateIndexCodeExamples } from '../../types';
+import { LanguageSelector } from './language_selector';
 
 export interface CreateIndexCodeViewProps {
   selectedLanguage: AvailableLanguages;
@@ -75,7 +77,7 @@ export const CreateIndexCodeView = ({
   return (
     <EuiFlexGroup direction="column" data-test-subj="createIndexCodeView">
       {canCreateApiKey && (
-        <EuiFlexItem grow={true}>
+        <EuiFlexItem grow>
           <APIKeyCallout apiKey={apiKey} />
         </EuiFlexItem>
       )}

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/create_index_form.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/create_index_form.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import {
   EuiButton,
   EuiFieldText,

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/create_index_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/create_index_panel.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useMemo } from 'react';
+
 import {
   EuiButtonEmpty,
   EuiButtonGroup,

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/guide_selector.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/guide_selector.tsx
@@ -9,7 +9,9 @@ import React from 'react';
 
 import { EuiCard, EuiText, EuiFlexGroup, EuiFlexItem, EuiTourStep } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+
 import { WorkflowId, workflows } from '../../code_examples/workflows';
+
 import { useGuideTour } from './hooks/use_guide_tour';
 
 interface GuideSelectorProps {

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/hooks/use_workflow.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/hooks/use_workflow.tsx
@@ -6,17 +6,18 @@
  */
 
 import { useState } from 'react';
+
+import {
+  DefaultCodeExamples,
+  DenseVectorCodeExamples,
+  SemanticCodeExamples,
+} from '../../../code_examples/create_index';
 import {
   DenseVectorIngestDataCodeExamples,
   SemanticIngestDataCodeExamples,
   DefaultIngestDataCodeExamples,
 } from '../../../code_examples/ingest_data';
 import { WorkflowId, workflows } from '../../../code_examples/workflows';
-import {
-  DefaultCodeExamples,
-  DenseVectorCodeExamples,
-  SemanticCodeExamples,
-} from '../../../code_examples/create_index';
 
 const workflowIdToCreateIndexExamples = (type: WorkflowId) => {
   switch (type) {

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/language_selector.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/language_selector.tsx
@@ -6,11 +6,12 @@
  */
 
 import React, { useMemo } from 'react';
+
 import { EuiIcon, EuiSuperSelect, EuiText, EuiFlexGroup } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 import { AvailableLanguages } from '../../code_examples';
+import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 import { CodeLanguage } from '../../types';
 
 export interface LanguageSelectorProps {

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/load_indices_status_error.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/load_indices_status_error.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiCodeBlock, EuiEmptyPrompt } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 

--- a/x-pack/solutions/search/plugins/search_indices/public/components/start/create_index.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/start/create_index.tsx
@@ -9,14 +9,13 @@ import React, { useCallback, useState } from 'react';
 
 import type { UserStartPrivilegesResponse } from '../../../common';
 import { AnalyticsEvents } from '../../analytics/constants';
+import { useKibana } from '../../hooks/use_kibana';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
 import { CreateIndexFormState } from '../../types';
 import { isValidIndexName } from '../../utils/indices';
 
-import { useCreateIndex } from '../shared/hooks/use_create_index';
 import { CreateIndexForm } from '../shared/create_index_form';
-
-import { useKibana } from '../../hooks/use_kibana';
+import { useCreateIndex } from '../shared/hooks/use_create_index';
 
 export interface CreateIndexUIViewProps {
   formState: CreateIndexFormState;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/start/elasticsearch_start.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/start/elasticsearch_start.tsx
@@ -6,25 +6,27 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
+
 import { i18n } from '@kbn/i18n';
 
 import type { IndicesStatusResponse } from '../../../common';
 
 import { AnalyticsEvents } from '../../analytics/constants';
 import { AvailableLanguages } from '../../code_examples';
+import { WorkflowId } from '../../code_examples/workflows';
+import { useUserPrivilegesQuery } from '../../hooks/api/use_user_permissions';
+import { useKibana } from '../../hooks/use_kibana';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
+import { CreateIndexFormState, CreateIndexViewMode } from '../../types';
 import { generateRandomIndexName } from '../../utils/indices';
 import { getDefaultCodingLanguage } from '../../utils/language';
 
-import { CreateIndexUIView } from './create_index';
 import { CreateIndexCodeView } from '../shared/create_index_code_view';
-import { CreateIndexFormState, CreateIndexViewMode } from '../../types';
 
 import { CreateIndexPanel } from '../shared/create_index_panel';
-import { useKibana } from '../../hooks/use_kibana';
-import { useUserPrivilegesQuery } from '../../hooks/api/use_user_permissions';
-import { WorkflowId } from '../../code_examples/workflows';
 import { useWorkflow } from '../shared/hooks/use_workflow';
+
+import { CreateIndexUIView } from './create_index';
 
 function initCreateIndexState(): CreateIndexFormState {
   const defaultIndexName = generateRandomIndexName();

--- a/x-pack/solutions/search/plugins/search_indices/public/components/start/hooks/use_indices_redirect.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/start/hooks/use_indices_redirect.tsx
@@ -9,11 +9,11 @@ import { useEffect, useState } from 'react';
 
 import type { IndicesStatusResponse } from '../../../../common';
 
+import { AnalyticsEvents } from '../../../analytics/constants';
+import { useUsageTracker } from '../../../contexts/usage_tracker_context';
 import { useKibana } from '../../../hooks/use_kibana';
 
 import { navigateToIndexDetails } from '../../utils';
-import { useUsageTracker } from '../../../contexts/usage_tracker_context';
-import { AnalyticsEvents } from '../../../analytics/constants';
 
 export const useIndicesRedirect = (indicesStatus?: IndicesStatusResponse) => {
   const { application, http } = useKibana().services;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/start/start_page.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/start/start_page.tsx
@@ -6,19 +6,21 @@
  */
 
 import React, { useMemo } from 'react';
-import { i18n } from '@kbn/i18n';
 
 import { EuiLoadingLogo, EuiPageTemplate } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 
-import { useKibana } from '../../hooks/use_kibana';
 import { useIndicesStatusQuery } from '../../hooks/api/use_indices_status';
+import { useKibana } from '../../hooks/use_kibana';
 
-import { useIndicesRedirect } from './hooks/use_indices_redirect';
-import { ElasticsearchStart } from './elasticsearch_start';
-import { LoadIndicesStatusError } from '../shared/load_indices_status_error';
-import { IndexManagementBreadcrumbs } from '../shared/breadcrumbs';
 import { usePageChrome } from '../../hooks/use_page_chrome';
+import { IndexManagementBreadcrumbs } from '../shared/breadcrumbs';
+import { LoadIndicesStatusError } from '../shared/load_indices_status_error';
+
+import { ElasticsearchStart } from './elasticsearch_start';
+import { useIndicesRedirect } from './hooks/use_indices_redirect';
 
 const PageTitle = i18n.translate('xpack.searchIndices.startPage.docTitle', {
   defaultMessage: 'Create your first index',

--- a/x-pack/solutions/search/plugins/search_indices/public/components/utils.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/utils.ts
@@ -8,6 +8,7 @@
 import { generatePath } from 'react-router-dom';
 
 import type { ApplicationStart, HttpSetup } from '@kbn/core/public';
+
 import { INDICES_APP_BASE, SEARCH_INDICES_DETAILS_PATH } from '../routes';
 
 const INDEX_DETAILS_FULL_PATH = `${INDICES_APP_BASE}${SEARCH_INDICES_DETAILS_PATH}`;

--- a/x-pack/solutions/search/plugins/search_indices/public/contexts/usage_tracker_context.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/contexts/usage_tracker_context.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { createContext, useContext, useMemo } from 'react';
+
 import type {
   UsageCollectionSetup,
   UsageCollectionStart,

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_delete_document.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_delete_document.ts
@@ -5,11 +5,14 @@
  * 2.0.
  */
 
-import { AcknowledgedResponseBase } from '@elastic/elasticsearch/lib/api/types';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { AcknowledgedResponseBase } from '@elastic/elasticsearch/lib/api/types';
 import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+
 import { MutationKeys, QueryKeys } from '../../constants';
 import { useKibana } from '../use_kibana';
+
 import { INDEX_SEARCH_POLLING, IndexDocuments } from './use_document_search';
 
 interface DeleteDocumentParams {

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_delete_index.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_delete_index.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { AcknowledgedResponseBase } from '@elastic/elasticsearch/lib/api/types';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { AcknowledgedResponseBase } from '@elastic/elasticsearch/lib/api/types';
+
 import { QueryKeys } from '../../constants';
 import { useKibana } from '../use_kibana';
 

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_document_search.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_document_search.ts
@@ -5,12 +5,14 @@
  * 2.0.
  */
 
+import { useQuery } from '@tanstack/react-query';
+
 import { Pagination } from '@elastic/eui';
 import { SearchHit } from '@kbn/es-types';
 import { pageToPagination, Paginate } from '@kbn/search-index-documents';
-import { useQuery } from '@tanstack/react-query';
-import { useKibana } from '../use_kibana';
+
 import { QueryKeys, DEFAULT_DOCUMENT_PAGE_SIZE } from '../../constants';
+import { useKibana } from '../use_kibana';
 
 export interface IndexDocuments {
   meta: Pagination;

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_index.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_index.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import type { Index } from '@kbn/index-management-shared-types';
 import { useQuery } from '@tanstack/react-query';
+
+import type { Index } from '@kbn/index-management-shared-types';
+
 import { QueryKeys } from '../../constants';
 import { useKibana } from '../use_kibana';
 

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_index_mappings.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/api/use_index_mappings.ts
@@ -6,9 +6,10 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { useKibana } from '../use_kibana';
-import { Mappings } from '../../types';
+
 import { QueryKeys } from '../../constants';
+import { Mappings } from '../../types';
+import { useKibana } from '../use_kibana';
 
 const POLLING_INTERVAL = 15 * 1000;
 export const useIndexMapping = (indexName: string) => {

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/use_asset_base_path.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/use_asset_base_path.ts
@@ -6,6 +6,7 @@
  */
 
 import { PLUGIN_ID } from '../../common';
+
 import { useKibana } from './use_kibana';
 
 export const useAssetBasePath = () => {

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/use_elasticsearch_url.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/use_elasticsearch_url.ts
@@ -6,9 +6,10 @@
  */
 
 import { useEffect, useState } from 'react';
-import { useKibana } from './use_kibana';
 
 import { ELASTICSEARCH_URL_PLACEHOLDER } from '../constants';
+
+import { useKibana } from './use_kibana';
 
 export const useElasticsearchUrl = (): string => {
   const {

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/use_kibana.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/use_kibana.ts
@@ -6,6 +6,7 @@
  */
 
 import { useKibana as _useKibana } from '@kbn/kibana-react-plugin/public';
+
 import { SearchIndicesServicesContext } from '../types';
 
 export const useKibana = () => _useKibana<SearchIndicesServicesContext>();

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/use_navigate_to_discover.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/use_navigate_to_discover.ts
@@ -6,6 +6,7 @@
  */
 
 import { useCallback } from 'react';
+
 import { useKibana } from './use_kibana';
 
 const DISCOVER_LOCATOR_ID = 'DISCOVER_APP_LOCATOR';

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/use_page_chrome.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/use_page_chrome.ts
@@ -6,7 +6,9 @@
  */
 
 import { useEffect } from 'react';
+
 import type { ChromeBreadcrumb } from '@kbn/core-chrome-browser';
+
 import { useKibana } from './use_kibana';
 
 export const usePageChrome = (docTitle: string, breadcrumbs: ChromeBreadcrumb[]) => {

--- a/x-pack/solutions/search/plugins/search_indices/public/locators/index.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/locators/index.ts
@@ -6,6 +6,7 @@
  */
 import { SharePluginSetup } from '@kbn/share-plugin/public';
 import { SerializableRecord } from '@kbn/utility-types';
+
 import { CreateIndexLocatorDefinition } from './create_index_locator';
 import { SearchIndicesLocatorDefinition } from './search_indices_locator';
 

--- a/x-pack/solutions/search/plugins/search_indices/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/plugin.ts
@@ -5,12 +5,23 @@
  * 2.0.
  */
 
+import { Subscription } from 'rxjs';
+
 import type { CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
 import { SEARCH_INDICES_CREATE_INDEX } from '@kbn/deeplinks-search/constants';
 import { i18n } from '@kbn/i18n';
 
-import { Subscription } from 'rxjs';
+import { INDICES_APP_ID, START_APP_ID } from '../common';
 import { docLinks } from '../common/doc_links';
+
+import { registerLocators } from './locators';
+import {
+  CREATE_INDEX_PATH,
+  INDICES_APP_BASE,
+  START_APP_BASE,
+  SearchIndexDetailsTabValues,
+} from './routes';
+import { initQueryClient } from './services/query_client';
 import type {
   AppPluginSetupDependencies,
   SearchIndicesAppPluginStartDependencies,
@@ -18,15 +29,6 @@ import type {
   SearchIndicesPluginStart,
   SearchIndicesServicesContextDeps,
 } from './types';
-import { initQueryClient } from './services/query_client';
-import { INDICES_APP_ID, START_APP_ID } from '../common';
-import {
-  CREATE_INDEX_PATH,
-  INDICES_APP_BASE,
-  START_APP_BASE,
-  SearchIndexDetailsTabValues,
-} from './routes';
-import { registerLocators } from './locators';
 
 export class SearchIndicesPlugin
   implements Plugin<SearchIndicesPluginSetup, SearchIndicesPluginStart>

--- a/x-pack/solutions/search/plugins/search_indices/public/services/query_client.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/services/query_client.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import type { IToasts } from '@kbn/core/public';
 import { QueryClient, MutationCache, QueryCache } from '@tanstack/react-query';
+
+import type { IToasts } from '@kbn/core/public';
+
 import { getErrorCode, getErrorMessage, isKibanaServerError } from '../utils/errors';
 
 export function initQueryClient(toasts: IToasts): QueryClient {

--- a/x-pack/solutions/search/plugins/search_indices/public/services/usage_tracker.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/services/usage_tracker.ts
@@ -10,6 +10,7 @@ import type {
   UsageCollectionSetup,
   UsageCollectionStart,
 } from '@kbn/usage-collection-plugin/public';
+
 import { AppUsageTracker } from '../types';
 
 const APP_TRACKER_NAME = 'searchIndices';

--- a/x-pack/solutions/search/plugins/search_indices/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/types.ts
@@ -5,22 +5,23 @@
  * 2.0.
  */
 
+import type { MappingProperty, MappingPropertyBase } from '@elastic/elasticsearch/lib/api/types';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
 import type { ConsolePluginSetup, ConsolePluginStart } from '@kbn/console-plugin/public';
-import type { SearchNavigationPluginStart } from '@kbn/search-navigation/public';
 import type { AppMountParameters, CoreStart } from '@kbn/core/public';
+import type { AppDeepLinkId } from '@kbn/core-chrome-browser';
+import type {
+  IndexManagementPluginSetup,
+  IndexManagementPluginStart,
+} from '@kbn/index-management-shared-types';
+import type { SearchNavigationPluginStart } from '@kbn/search-navigation/public';
+import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
 import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import type {
   UsageCollectionSetup,
   UsageCollectionStart,
 } from '@kbn/usage-collection-plugin/public';
-import type { MappingProperty, MappingPropertyBase } from '@elastic/elasticsearch/lib/api/types';
-import type {
-  IndexManagementPluginSetup,
-  IndexManagementPluginStart,
-} from '@kbn/index-management-shared-types';
-import type { AppDeepLinkId } from '@kbn/core-chrome-browser';
-import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
+
 import type { AvailableLanguages } from './code_examples';
 
 export interface SearchIndicesPluginSetup {

--- a/x-pack/solutions/search/plugins/search_indices/server/lib/documents.test.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/lib/documents.test.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import { deleteDocument } from './documents';
-import { Logger } from '@kbn/logging';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { Logger } from '@kbn/logging';
+
+import { deleteDocument } from './documents';
 
 describe('deleteDocument', () => {
   let mockClient: jest.Mocked<ElasticsearchClient>;

--- a/x-pack/solutions/search/plugins/search_indices/server/lib/status.test.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/lib/status.test.ts
@@ -11,6 +11,7 @@ import type {
 } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import type { Logger } from '@kbn/logging';
+
 import { fetchIndicesStatus, fetchUserStartPrivileges } from './status';
 
 const mockLogger = {

--- a/x-pack/solutions/search/plugins/search_indices/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/plugin.ts
@@ -13,8 +13,8 @@ import type {
   Logger,
 } from '@kbn/core/server';
 
-import type { SearchIndicesPluginSetup, SearchIndicesPluginStart } from './types';
 import { defineRoutes } from './routes';
+import type { SearchIndicesPluginSetup, SearchIndicesPluginStart } from './types';
 
 export class SearchIndicesPlugin
   implements Plugin<SearchIndicesPluginSetup, SearchIndicesPluginStart>

--- a/x-pack/solutions/search/plugins/search_indices/server/routes/documents.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/routes/documents.ts
@@ -6,8 +6,8 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { i18n } from '@kbn/i18n';
 import type { IRouter } from '@kbn/core/server';
+import { i18n } from '@kbn/i18n';
 import type { Logger } from '@kbn/logging';
 
 import { INDEX_DOCUMENT_ROUTE } from '../../common/routes';

--- a/x-pack/solutions/search/plugins/search_indices/server/routes/index.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/routes/index.ts
@@ -9,9 +9,10 @@ import type { IRouter } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 
 import { registerSearchApiKeysRoutes } from '@kbn/search-api-keys-server';
+
+import { registerDocumentRoutes } from './documents';
 import { registerIndicesRoutes } from './indices';
 import { registerStatusRoutes } from './status';
-import { registerDocumentRoutes } from './documents';
 
 export function defineRoutes(router: IRouter, logger: Logger) {
   registerIndicesRoutes(router, logger);

--- a/x-pack/solutions/search/plugins/search_indices/server/routes/indices.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/routes/indices.ts
@@ -6,11 +6,11 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import { i18n } from '@kbn/i18n';
 import type { IRouter } from '@kbn/core/server';
+import { i18n } from '@kbn/i18n';
 import type { Logger } from '@kbn/logging';
-import { DEFAULT_DOCS_PER_PAGE } from '@kbn/search-index-documents/types';
 import { fetchSearchResults } from '@kbn/search-index-documents/lib';
+import { DEFAULT_DOCS_PER_PAGE } from '@kbn/search-index-documents/types';
 
 import { POST_CREATE_INDEX_ROUTE, SEARCH_DOCUMENTS_ROUTE } from '../../common/routes';
 import { CreateIndexRequest } from '../../common/types';

--- a/x-pack/solutions/search/plugins/search_indices/server/routes/status.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/routes/status.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
+import { schema } from '@kbn/config-schema';
 import type { IRouter } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
 
-import { schema } from '@kbn/config-schema';
 import { GET_STATUS_ROUTE, GET_USER_PRIVILEGES_ROUTE } from '../../common/routes';
 import { fetchIndicesStatus, fetchUserStartPrivileges } from '../lib/status';
 

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/application.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/application.tsx
@@ -7,11 +7,13 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import { CoreStart } from '@kbn/core/public';
-import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
-import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { Router } from '@kbn/shared-ux-router';
+
 import { AppPluginStartDependencies } from './types';
 
 export const renderApp = async (

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/add_inference_endpoints/add_inference_flyout_wrapper.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/add_inference_endpoints/add_inference_flyout_wrapper.test.tsx
@@ -5,14 +5,17 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
 import { Form, useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
-import React from 'react';
 import { I18nProvider } from '@kbn/i18n-react';
 
-import { AddInferenceFlyoutWrapper } from './add_inference_flyout_wrapper';
 import { mockProviders } from '../../utils/test_utils/test_utils';
+
+import { AddInferenceFlyoutWrapper } from './add_inference_flyout_wrapper';
 
 const mockAddEndpoint = jest.fn();
 const onClose = jest.fn();

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/add_inference_endpoints/add_inference_flyout_wrapper.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/add_inference_endpoints/add_inference_flyout_wrapper.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import {
   EuiButtonEmpty,
   EuiFlexGroup,
@@ -16,7 +18,6 @@ import {
   EuiTitle,
   useGeneratedHtmlId,
 } from '@elastic/eui';
-import React from 'react';
 
 import { InferenceForm } from './inference_form';
 import * as i18n from './translations';

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/add_inference_endpoints/inference_form.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/add_inference_endpoints/inference_form.tsx
@@ -5,14 +5,17 @@
  * 2.0.
  */
 
-import { Form, useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import React, { useCallback, useState } from 'react';
-import { InferenceServiceFormFields } from '@kbn/inference-endpoint-ui-common';
+
 import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import * as i18n from './translations';
+import { Form, useForm } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
+import { InferenceServiceFormFields } from '@kbn/inference-endpoint-ui-common';
+
 import { useAddEndpoint } from '../../hooks/use_add_endpoint';
-import { InferenceEndpoint } from '../../types';
 import { useKibana } from '../../hooks/use_kibana';
+import { InferenceEndpoint } from '../../types';
+
+import * as i18n from './translations';
 
 interface InferenceFormProps {
   onSubmitSuccess: (state: boolean) => void;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/multi_select_filter.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/multi_select_filter.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { render, fireEvent, waitFor } from '@testing-library/react';
+
 import { MultiSelectFilter, MultiSelectFilterOption } from './multi_select_filter';
 
 describe('MultiSelectFilter', () => {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/multi_select_filter.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/multi_select_filter.tsx
@@ -5,6 +5,11 @@
  * 2.0.
  */
 
+import React, { useState } from 'react';
+
+import { css } from '@emotion/react';
+import _ from 'lodash';
+
 import {
   EuiFilterButton,
   EuiFilterGroup,
@@ -16,9 +21,7 @@ import {
   EuiTextColor,
   useEuiTheme,
 } from '@elastic/eui';
-import { css } from '@emotion/react';
-import React, { useState } from 'react';
-import _ from 'lodash';
+
 import * as i18n from './translations';
 
 export interface MultiSelectFilterOption {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/service_provider_filter.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/service_provider_filter.tsx
@@ -6,8 +6,10 @@
  */
 
 import React from 'react';
+
 import { SERVICE_PROVIDERS } from '../render_table_columns/render_service_provider/service_provider';
 import type { FilterOptions, ServiceProviderKeys } from '../types';
+
 import { MultiSelectFilter, MultiSelectFilterOption } from './multi_select_filter';
 import * as i18n from './translations';
 

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/task_type_filter.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/filter/task_type_filter.tsx
@@ -6,8 +6,10 @@
  */
 
 import React from 'react';
+
 import { TaskTypes } from '../../../../common/types';
 import { FilterOptions } from '../types';
+
 import { MultiSelectFilter, MultiSelectFilterOption } from './multi_select_filter';
 import * as i18n from './translations';
 

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/index_item.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/index_item.test.tsx
@@ -5,12 +5,14 @@
  * 2.0.
  */
 
-import { render, fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 
-import { IndexItem } from './index_item';
-import { InferenceUsageInfo } from '../../../../types';
+import { render, fireEvent, screen } from '@testing-library/react';
+
 import { useKibana } from '../../../../../../hooks/use_kibana';
+import { InferenceUsageInfo } from '../../../../types';
+
+import { IndexItem } from './index_item';
 
 jest.mock('../../../../../../hooks/use_kibana');
 const mockUseKibana = useKibana as jest.Mock;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/index_item.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/index_item.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React, { useCallback } from 'react';
+
 import {
   EuiBadge,
   EuiFlexGroup,
@@ -16,14 +18,13 @@ import {
   EuiIcon,
   EuiSpacer,
 } from '@elastic/eui';
-import React, { useCallback } from 'react';
 import { ENTERPRISE_SEARCH_CONTENT_APP_ID } from '@kbn/deeplinks-search';
 
 import { SEARCH_INDICES } from '@kbn/deeplinks-search/constants';
 
 import { useKibana } from '../../../../../../hooks/use_kibana';
-import { InferenceUsageInfo } from '../../../../types';
 import { SERVERLESS_INDEX_MANAGEMENT_URL } from '../../../../constants';
+import { InferenceUsageInfo } from '../../../../types';
 
 interface UsageProps {
   usageItem: InferenceUsageInfo;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/list_usage_results.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/list_usage_results.test.tsx
@@ -6,8 +6,10 @@
  */
 
 import React from 'react';
-import { ListUsageResults } from './list_usage_results';
+
 import { render, screen, fireEvent } from '@testing-library/react';
+
+import { ListUsageResults } from './list_usage_results';
 
 describe('ListUsageResults', () => {
   const items = [

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/list_usage_results.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/list_usage_results.tsx
@@ -6,10 +6,12 @@
  */
 
 import React, { useState } from 'react';
+
 import { EuiFieldSearch, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 import { InferenceUsageInfo } from '../../../../types';
 import * as i18n from '../delete/confirm_delete_endpoint/translations';
+
 import { IndexItem } from './index_item';
 import { PipelineItem } from './pipeline_item';
 
@@ -27,9 +29,9 @@ export const ListUsageResults: React.FC<ListUsageResultsProps> = ({ list }) => {
           placeholder={i18n.SEARCH_LABEL}
           value={term}
           onChange={(e) => setTerm(e.target.value)}
-          isClearable={true}
+          isClearable
           aria-label={i18n.SEARCH_ARIA_LABEL}
-          fullWidth={true}
+          fullWidth
           data-test-subj="usageFieldSearch"
         />
       </EuiFlexItem>

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/pipeline_item.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/pipeline_item.test.tsx
@@ -5,12 +5,14 @@
  * 2.0.
  */
 
-import { render, fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 
-import { PipelineItem } from './pipeline_item';
-import { InferenceUsageInfo } from '../../../../types';
+import { render, fireEvent, screen } from '@testing-library/react';
+
 import { useKibana } from '../../../../../../hooks/use_kibana';
+import { InferenceUsageInfo } from '../../../../types';
+
+import { PipelineItem } from './pipeline_item';
 
 jest.mock('../../../../../../hooks/use_kibana');
 const mockUseKibana = useKibana as jest.Mock;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/pipeline_item.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/pipeline_item.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React, { useCallback } from 'react';
+
 import {
   EuiBadge,
   EuiFlexGroup,
@@ -16,12 +18,11 @@ import {
   EuiIcon,
   EuiSpacer,
 } from '@elastic/eui';
-import React, { useCallback } from 'react';
 import { MANAGEMENT_APP_ID } from '@kbn/deeplinks-management/constants';
 
 import { useKibana } from '../../../../../../hooks/use_kibana';
-import { InferenceUsageInfo } from '../../../../types';
 import { PIPELINE_URL } from '../../../../constants';
+import { InferenceUsageInfo } from '../../../../types';
 
 interface UsageProps {
   usageItem: InferenceUsageInfo;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/render_message_with_icon.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/render_message_with_icon.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText } from '@elastic/eui';
 import React from 'react';
+
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText } from '@elastic/eui';
 
 interface RenderMessageWithIconProps {
   icon: string;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/scan_usage_results.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/scan_usage_results.test.tsx
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import { render, fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 
-import { ScanUsageResults } from './scan_usage_results';
+import { render, fireEvent, screen } from '@testing-library/react';
+
 import { useKibana } from '../../../../../../hooks/use_kibana';
+
+import { ScanUsageResults } from './scan_usage_results';
 
 jest.mock('../../../../../../hooks/use_kibana');
 const mockUseKibana = useKibana as jest.Mock;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/scan_usage_results.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/component/scan_usage_results.tsx
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import React from 'react';
+
+import { css } from '@emotion/react';
+
 import {
   EuiCheckbox,
   EuiFlexGroup,
@@ -14,17 +18,18 @@ import {
   EuiText,
   EuiButtonEmpty,
 } from '@elastic/eui';
-import React from 'react';
-import { euiThemeVars } from '@kbn/ui-theme';
-import { css } from '@emotion/react';
 import { ENTERPRISE_SEARCH_CONTENT_APP_ID } from '@kbn/deeplinks-search';
 
 import { SEARCH_INDICES } from '@kbn/deeplinks-search/constants';
-import { InferenceUsageInfo } from '../../../../types';
+import { euiThemeVars } from '@kbn/ui-theme';
+
 import { useKibana } from '../../../../../../hooks/use_kibana';
-import { RenderMessageWithIcon } from './render_message_with_icon';
+import { InferenceUsageInfo } from '../../../../types';
+
 import * as i18n from '../delete/confirm_delete_endpoint/translations';
+
 import { ListUsageResults } from './list_usage_results';
+import { RenderMessageWithIcon } from './render_message_with_icon';
 
 interface ScanUsageResultsProps {
   list: InferenceUsageInfo[];
@@ -64,7 +69,7 @@ export const ScanUsageResults: React.FC<ScanUsageResultsProps> = ({
         />
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiPanel hasBorder={true}>
+        <EuiPanel hasBorder>
           <EuiFlexGroup gutterSize="m" direction="column">
             <EuiFlexItem>
               <EuiFlexGroup justifyContent="spaceBetween" gutterSize="s" alignItems="center">
@@ -104,7 +109,7 @@ export const ScanUsageResults: React.FC<ScanUsageResultsProps> = ({
         <EuiHorizontalRule margin="s" />
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiPanel hasBorder={true}>
+        <EuiPanel hasBorder>
           <EuiCheckbox
             data-test-subj="warningCheckbox"
             id={'ignoreWarningCheckbox'}

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/copy_id/copy_id_action.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/copy_id/copy_id_action.test.tsx
@@ -5,9 +5,12 @@
  * 2.0.
  */
 
-import { renderReactTestingLibraryWithI18n as render } from '@kbn/test-jest-helpers';
 import React from 'react';
+
+import { renderReactTestingLibraryWithI18n as render } from '@kbn/test-jest-helpers';
+
 import { useKibana } from '../../../../../../hooks/use_kibana';
+
 import { CopyIDAction } from './copy_id_action';
 
 const mockInferenceEndpoint = {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/copy_id/copy_id_action.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/copy_id/copy_id_action.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import { EuiButtonIcon, EuiCopy } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
+
 import { useKibana } from '../../../../../../hooks/use_kibana';
 
 interface CopyIDActionProps {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/confirm_delete_endpoint/index.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/confirm_delete_endpoint/index.test.tsx
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { render, fireEvent, screen } from '@testing-library/react';
-import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import React from 'react';
-import { ConfirmDeleteEndpointModal } from '.';
-import * as i18n from './translations';
+
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { render, fireEvent, screen } from '@testing-library/react';
+
 import { useScanUsage } from '../../../../../../../hooks/use_scan_usage';
+
+import * as i18n from './translations';
+
+import { ConfirmDeleteEndpointModal } from '.';
 
 jest.mock('../../../../../../../hooks/use_scan_usage');
 const mockUseScanUsage = useScanUsage as jest.Mock;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/confirm_delete_endpoint/index.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/confirm_delete_endpoint/index.tsx
@@ -6,15 +6,18 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { EuiButtonEmpty, EuiConfirmModal, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+
 import { css } from '@emotion/react';
+
+import { EuiButtonEmpty, EuiConfirmModal, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import { euiThemeVars } from '@kbn/ui-theme';
 
-import * as i18n from './translations';
 import { useScanUsage } from '../../../../../../../hooks/use_scan_usage';
 import { InferenceEndpointUI, InferenceUsageInfo } from '../../../../../types';
 import { RenderMessageWithIcon } from '../../component/render_message_with_icon';
 import { ScanUsageResults } from '../../component/scan_usage_results';
+
+import * as i18n from './translations';
 
 interface ConfirmDeleteEndpointModalProps {
   onCancel: () => void;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/confirm_delete_endpoint/translations.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/confirm_delete_endpoint/translations.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+
 export * from '../../../../../../../../common/translations';
 
 export const DELETE_TITLE = i18n.translate(

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/delete_action.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/delete_action.test.tsx
@@ -5,12 +5,14 @@
  * 2.0.
  */
 
-import { render, screen, fireEvent } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
-import { DeleteAction } from './delete_action';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+
 import { InferenceEndpointUI } from '../../../../types';
+
+import { DeleteAction } from './delete_action';
 
 describe('Delete Action', () => {
   const mockProvider = {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/delete_action.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_actions/actions/delete/delete_action.tsx
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
+import React, { useState } from 'react';
+
 import { EuiButtonIcon } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useState } from 'react';
-import { isEndpointPreconfigured } from '../../../../../../utils/preconfigured_endpoint_helper';
+
 import { useDeleteEndpoint } from '../../../../../../hooks/use_delete_endpoint';
+import { isEndpointPreconfigured } from '../../../../../../utils/preconfigured_endpoint_helper';
 import { InferenceEndpointUI } from '../../../../types';
+
 import { ConfirmDeleteEndpointModal } from './confirm_delete_endpoint';
 
 interface DeleteActionProps {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_endpoint/endpoint_info.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_endpoint/endpoint_info.test.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { render, screen } from '@testing-library/react';
 import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
 import { EndpointInfo } from './endpoint_info';
 
 describe('RenderEndpoint component tests', () => {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_endpoint/endpoint_info.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_endpoint/endpoint_info.tsx
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import React from 'react';
+
+import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
+
 import { isEndpointPreconfigured } from '../../../../utils/preconfigured_endpoint_helper';
-import * as i18n from './translations';
+
 import { isProviderTechPreview } from '../../../../utils/reranker_helper';
+
+import * as i18n from './translations';
 
 export interface EndpointInfoProps {
   inferenceId: string;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/service_provider.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/service_provider.test.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { render, screen } from '@testing-library/react';
 import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
 import { ServiceProvider } from './service_provider';
 
 jest.mock('@kbn/ml-trained-models-utils', () => ({

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/service_provider.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_service_provider/service_provider.tsx
@@ -5,24 +5,27 @@
  * 2.0.
  */
 
-import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText } from '@elastic/eui';
 import React from 'react';
+
+import { EuiBadge, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText } from '@elastic/eui';
 import {
   ELASTIC_MODEL_DEFINITIONS,
   InferenceAPIConfigResponse,
 } from '@kbn/ml-trained-models-utils';
-import elasticIcon from '../../../../assets/images/providers/elastic.svg';
-import huggingFaceIcon from '../../../../assets/images/providers/hugging_face.svg';
-import cohereIcon from '../../../../assets/images/providers/cohere.svg';
-import openAIIcon from '../../../../assets/images/providers/open_ai.svg';
+
+import alibabaCloudAISearchIcon from '../../../../assets/images/providers/alibaba_cloud_ai_search.svg';
+import amazonBedrockIcon from '../../../../assets/images/providers/amazon_bedrock.svg';
 import azureAIStudioIcon from '../../../../assets/images/providers/azure_ai_studio.svg';
 import azureOpenAIIcon from '../../../../assets/images/providers/azure_open_ai.svg';
+import cohereIcon from '../../../../assets/images/providers/cohere.svg';
+import elasticIcon from '../../../../assets/images/providers/elastic.svg';
 import googleAIStudioIcon from '../../../../assets/images/providers/google_ai_studio.svg';
+import huggingFaceIcon from '../../../../assets/images/providers/hugging_face.svg';
 import mistralIcon from '../../../../assets/images/providers/mistral.svg';
-import amazonBedrockIcon from '../../../../assets/images/providers/amazon_bedrock.svg';
-import alibabaCloudAISearchIcon from '../../../../assets/images/providers/alibaba_cloud_ai_search.svg';
+import openAIIcon from '../../../../assets/images/providers/open_ai.svg';
 import watsonxAIIcon from '../../../../assets/images/providers/watsonx_ai.svg';
 import { ServiceProviderKeys } from '../../types';
+
 import * as i18n from './translations';
 
 interface ServiceProviderProps {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_task_type/task_type.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_task_type/task_type.test.tsx
@@ -5,9 +5,12 @@
  * 2.0.
  */
 
-import { TaskTypes } from '../../../../../common/types';
-import { render, screen } from '@testing-library/react';
 import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { TaskTypes } from '../../../../../common/types';
+
 import { TaskType } from './task_type';
 
 describe('TaskType component', () => {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_task_type/task_type.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/render_table_columns/render_task_type/task_type.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { EuiBadge } from '@elastic/eui';
 import React from 'react';
+
+import { EuiBadge } from '@elastic/eui';
+
 import { TaskTypes } from '../../../../../common/types';
 
 interface TaskTypeProps {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/search/table_search.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/search/table_search.test.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-import { render, screen, fireEvent } from '@testing-library/react';
-import { TableSearch } from './table_search';
 import React from 'react';
+
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { TableSearch } from './table_search';
 
 describe('TableSearchComponent', () => {
   const mockSetSearchKey = jest.fn();

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/search/table_search.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/search/table_search.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { EuiFieldSearch } from '@elastic/eui';
 import React, { useCallback } from 'react';
+
+import { EuiFieldSearch } from '@elastic/eui';
 
 interface TableSearchComponentProps {
   searchKey: string;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.test.tsx
@@ -6,10 +6,13 @@
  */
 
 import React from 'react';
+
 import { screen } from '@testing-library/react';
 import { render } from '@testing-library/react';
-import { TabularPage } from './tabular_page';
+
 import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
+
+import { TabularPage } from './tabular_page';
 
 const inferenceEndpoints = [
   {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/tabular_page.tsx
@@ -9,21 +9,22 @@ import React, { useCallback } from 'react';
 
 import { EuiBasicTable, EuiBasicTableColumn, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
-import { TaskTypes } from '../../../common/types';
-import * as i18n from '../../../common/translations';
 
-import { useTableData } from '../../hooks/use_table_data';
-import { FilterOptions, InferenceEndpointUI } from './types';
+import * as i18n from '../../../common/translations';
+import { TaskTypes } from '../../../common/types';
 
 import { useAllInferenceEndpointsState } from '../../hooks/use_all_inference_endpoints_state';
+import { useTableData } from '../../hooks/use_table_data';
+
 import { ServiceProviderFilter } from './filter/service_provider_filter';
 import { TaskTypeFilter } from './filter/task_type_filter';
-import { TableSearch } from './search/table_search';
+import { CopyIDAction } from './render_table_columns/render_actions/actions/copy_id/copy_id_action';
+import { DeleteAction } from './render_table_columns/render_actions/actions/delete/delete_action';
 import { EndpointInfo } from './render_table_columns/render_endpoint/endpoint_info';
 import { ServiceProvider } from './render_table_columns/render_service_provider/service_provider';
 import { TaskType } from './render_table_columns/render_task_type/task_type';
-import { DeleteAction } from './render_table_columns/render_actions/actions/delete/delete_action';
-import { CopyIDAction } from './render_table_columns/render_actions/actions/copy_id/copy_id_action';
+import { TableSearch } from './search/table_search';
+import { FilterOptions, InferenceEndpointUI } from './types';
 
 interface TabularPageProps {
   inferenceEndpoints: InferenceAPIConfigResponse[];

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/types.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/all_inference_endpoints/types.ts
@@ -6,7 +6,9 @@
  */
 
 import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
+
 import { TaskTypes } from '../../types';
+
 export const INFERENCE_ENDPOINTS_TABLE_PER_PAGE_VALUES = [25, 50, 100];
 
 export enum ServiceProviderKeys {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/app.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/app.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { InferenceEndpoints } from './inference_endpoints';
 
 export const App: React.FC = () => {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/endpoints_router.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/endpoints_router.tsx
@@ -9,9 +9,8 @@ import React from 'react';
 
 import { Route, Routes } from '@kbn/shared-ux-router';
 
-import { INFERENCE_ENDPOINTS_PATH } from './routes';
-
 import { InferenceEndpoints } from './inference_endpoints';
+import { INFERENCE_ENDPOINTS_PATH } from './routes';
 
 export const EndpointsRouter: React.FC = () => {
   return (

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/inference_endpoints.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/inference_endpoints.tsx
@@ -10,9 +10,10 @@ import React, { useState } from 'react';
 import { EuiPageTemplate } from '@elastic/eui';
 
 import { useQueryInferenceEndpoints } from '../hooks/use_inference_endpoints';
+
+import { AddInferenceFlyoutWrapper } from './add_inference_endpoints/add_inference_flyout_wrapper';
 import { TabularPage } from './all_inference_endpoints/tabular_page';
 import { InferenceEndpointsHeader } from './inference_endpoints_header';
-import { AddInferenceFlyoutWrapper } from './add_inference_endpoints/add_inference_flyout_wrapper';
 
 export const InferenceEndpoints: React.FC = () => {
   const { data } = useQueryInferenceEndpoints();

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/inference_endpoints_header.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/components/inference_endpoints_header.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import { EuiPageTemplate, EuiButtonEmpty, EuiButton } from '@elastic/eui';
 import React from 'react';
-import * as i18n from '../../common/translations';
+
+import { EuiPageTemplate, EuiButtonEmpty, EuiButton } from '@elastic/eui';
+
 import { docLinks } from '../../common/doc_links';
+import * as i18n from '../../common/translations';
 import { useTrainedModelPageUrl } from '../hooks/use_trained_model_page_url';
 
 interface InferenceEndpointsHeaderProps {
@@ -24,7 +26,7 @@ export const InferenceEndpointsHeader: React.FC<InferenceEndpointsHeaderProps> =
       data-test-subj="allInferenceEndpointsPage"
       pageTitle={i18n.INFERENCE_ENDPOINT_LABEL}
       description={i18n.MANAGE_INFERENCE_ENDPOINTS_LABEL}
-      bottomBorder={true}
+      bottomBorder
       rightSideItems={[
         <EuiButton
           iconType="plusInCircle"

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/translations.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/translations.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+
 export * from '../../common/translations';
 
 export const ENDPOINT_DELETION_FAILED = i18n.translate(

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_add_endpoint.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_add_endpoint.test.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
-import { useAddEndpoint } from './use_add_endpoint';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
 import * as i18n from './translations';
+import { useAddEndpoint } from './use_add_endpoint';
 import { useKibana } from './use_kibana';
 
 const wrapper = ({ children }: { children: React.ReactNode }) => {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_add_endpoint.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_add_endpoint.ts
@@ -8,10 +8,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { KibanaServerError } from '@kbn/kibana-utils-plugin/common';
-import { useKibana } from './use_kibana';
-import * as i18n from './translations';
+
 import { INFERENCE_ENDPOINTS_QUERY_KEY } from '../../common/constants';
 import { InferenceEndpoint } from '../types';
+
+import * as i18n from './translations';
+import { useKibana } from './use_kibana';
 
 interface MutationArgs {
   inferenceEndpoint: InferenceEndpoint;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_all_inference_endpoints_state.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_all_inference_endpoints_state.tsx
@@ -7,13 +7,12 @@
 
 import { useCallback, useState } from 'react';
 
+import { DEFAULT_INFERENCE_ENDPOINTS_TABLE_STATE } from '../components/all_inference_endpoints/constants';
 import type {
   QueryParams,
   AllInferenceEndpointsTableState,
   FilterOptions,
 } from '../components/all_inference_endpoints/types';
-
-import { DEFAULT_INFERENCE_ENDPOINTS_TABLE_STATE } from '../components/all_inference_endpoints/constants';
 
 interface UseAllInferenceEndpointsStateReturn {
   queryParams: QueryParams;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_delete_endpoint.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_delete_endpoint.test.tsx
@@ -5,12 +5,14 @@
  * 2.0.
  */
 
-import { waitFor, renderHook } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useKibana } from './use_kibana';
-import { useDeleteEndpoint } from './use_delete_endpoint';
-import * as i18n from './translations';
 import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { waitFor, renderHook } from '@testing-library/react';
+
+import * as i18n from './translations';
+import { useDeleteEndpoint } from './use_delete_endpoint';
+import { useKibana } from './use_kibana';
 
 jest.mock('./use_kibana');
 

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_delete_endpoint.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_delete_endpoint.tsx
@@ -6,11 +6,13 @@
  */
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { KibanaServerError } from '@kbn/kibana-utils-plugin/common';
-import { useKibana } from './use_kibana';
-import * as i18n from './translations';
 
 import { INFERENCE_ENDPOINTS_QUERY_KEY } from '../../common/constants';
+
+import * as i18n from './translations';
+import { useKibana } from './use_kibana';
 
 interface MutationArgs {
   type: string;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_inference_endpoints.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_inference_endpoints.ts
@@ -6,10 +6,13 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+
 import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
-import { APIRoutes } from '../types';
-import { useKibana } from './use_kibana';
+
 import { INFERENCE_ENDPOINTS_QUERY_KEY } from '../../common/constants';
+import { APIRoutes } from '../types';
+
+import { useKibana } from './use_kibana';
 
 export const useQueryInferenceEndpoints = () => {
   const { services } = useKibana();

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_inference_endpoints_breadcrumbs.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_inference_endpoints_breadcrumbs.ts
@@ -8,6 +8,7 @@
 import { useEffect } from 'react';
 
 import * as i18n from '../../common/translations';
+
 import { useKibana } from './use_kibana';
 
 export const useInferenceEndpointsBreadcrumbs = () => {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_kibana.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_kibana.ts
@@ -6,6 +6,7 @@
  */
 
 import { useKibana as _useKibana } from '@kbn/kibana-react-plugin/public';
+
 import { AppServicesContext } from '../types';
 
 export const useKibana = () => _useKibana<AppServicesContext>();

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_scan_usage.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_scan_usage.test.tsx
@@ -6,11 +6,12 @@
  */
 
 import React from 'react';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { waitFor, renderHook } from '@testing-library/react';
 
-import { useScanUsage } from './use_scan_usage';
 import { useKibana } from './use_kibana';
+import { useScanUsage } from './use_scan_usage';
 
 jest.mock('./use_kibana');
 

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_scan_usage.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_scan_usage.tsx
@@ -6,8 +6,10 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { useKibana } from './use_kibana';
+
 import { InferenceUsageResponse } from '../types';
+
+import { useKibana } from './use_kibana';
 
 interface ScanUsageProps {
   type: string;

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_table_data.test.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_table_data.test.tsx
@@ -5,14 +5,19 @@
  * 2.0.
  */
 
-import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
-import { renderHook } from '@testing-library/react';
-import { QueryParams } from '../components/all_inference_endpoints/types';
-import { useTableData } from './use_table_data';
-import { INFERENCE_ENDPOINTS_TABLE_PER_PAGE_VALUES } from '../components/all_inference_endpoints/types';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+
+import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
+
 import { TRAINED_MODEL_STATS_QUERY_KEY } from '../../common/constants';
+import { QueryParams } from '../components/all_inference_endpoints/types';
+
+import { INFERENCE_ENDPOINTS_TABLE_PER_PAGE_VALUES } from '../components/all_inference_endpoints/types';
+
+import { useTableData } from './use_table_data';
 
 const inferenceEndpoints = [
   {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_table_data.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_table_data.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
+import { useMemo } from 'react';
+
 import type { EuiTableSortingType } from '@elastic/eui';
 import { Pagination } from '@elastic/eui';
 import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
-import { useMemo } from 'react';
+
 import { TaskTypes } from '../../common/types';
 import { DEFAULT_TABLE_LIMIT } from '../components/all_inference_endpoints/constants';
 import {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_trained_model_page_url.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_trained_model_page_url.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useState } from 'react';
+
 import { useKibana } from './use_kibana';
 
 export const useTrainedModelPageUrl = () => {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_trained_model_stats.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/hooks/use_trained_model_stats.ts
@@ -6,9 +6,12 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+
 import { InferenceStatsResponse } from '@kbn/ml-plugin/public/application/services/ml_api_service/trained_models';
-import { useKibana } from './use_kibana';
+
 import { TRAINED_MODEL_STATS_QUERY_KEY } from '../../common/constants';
+
+import { useKibana } from './use_kibana';
 
 export const useTrainedModelStats = () => {
   const { services } = useKibana();

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/inference_endpoints_overview.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/inference_endpoints_overview.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useMemo } from 'react';
+
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 
 import { App } from './components/app';

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/inference_endpoints_router.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/inference_endpoints_router.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-import { Route, Routes } from '@kbn/shared-ux-router';
 import React from 'react';
 import { Redirect } from 'react-router-dom';
+
+import { Route, Routes } from '@kbn/shared-ux-router';
+
 import { InferenceEndpointsOverview } from './inference_endpoints_overview';
 
 import { ROOT_PATH, SEARCH_INFERENCE_ENDPOINTS_PATH } from './routes';

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/locators.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/locators.ts
@@ -10,6 +10,7 @@ import type { SharePluginSetup } from '@kbn/share-plugin/public';
 import type { SerializableRecord } from '@kbn/utility-types';
 
 import { PLUGIN_ID } from '../common/constants';
+
 import { SEARCH_INFERENCE_ENDPOINTS_PATH } from './routes';
 
 export function registerLocators(share: SharePluginSetup) {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/plugin.ts
@@ -17,8 +17,12 @@ import {
   PluginInitializerContext,
 } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
+
 import { PLUGIN_ID, PLUGIN_NAME } from '../common/constants';
 import { docLinks } from '../common/doc_links';
+
+import { INFERENCE_ENDPOINTS_PATH } from './components/routes';
+import { registerLocators } from './locators';
 import {
   AppPluginSetupDependencies,
   AppPluginStartDependencies,
@@ -26,8 +30,6 @@ import {
   SearchInferenceEndpointsPluginSetup,
   SearchInferenceEndpointsPluginStart,
 } from './types';
-import { registerLocators } from './locators';
-import { INFERENCE_ENDPOINTS_PATH } from './components/routes';
 
 export class SearchInferenceEndpointsPlugin
   implements Plugin<SearchInferenceEndpointsPluginSetup, SearchInferenceEndpointsPluginStart>

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/providers/inference_endpoints_provider.tsx
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/providers/inference_endpoints_provider.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React, { FC, PropsWithChildren } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const queryClient = new QueryClient({});
 

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/types.ts
@@ -7,11 +7,11 @@
 
 import type { ConsolePluginSetup, ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { AppMountParameters, CoreStart } from '@kbn/core/public';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { MlPluginStart } from '@kbn/ml-plugin/public';
-import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import type { SearchNavigationPluginStart } from '@kbn/search-navigation/public';
 import type { ServerlessPluginStart } from '@kbn/serverless/public';
-import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
+import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 
 export * from '../common/types';
 

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/reranker_helper.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/reranker_helper.ts
@@ -6,6 +6,7 @@
  */
 
 import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
+
 export const isProviderTechPreview = (provider: InferenceAPIConfigResponse) => {
   if (hasModelId(provider)) {
     return provider.task_type === 'rerank' && provider.service_settings?.model_id?.startsWith('.');

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/test_utils/test_utils.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/public/utils/test_utils/test_utils.ts
@@ -6,6 +6,7 @@
  */
 
 import { FieldType } from '@kbn/inference-endpoint-ui-common';
+
 import { InferenceProvider } from '../../types';
 
 export const mockProviders: InferenceProvider[] = [

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/server/lib/add_inference_endpoint.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/server/lib/add_inference_endpoint.ts
@@ -9,6 +9,7 @@ import { InferenceTaskType } from '@elastic/elasticsearch/lib/api/typesWithBodyK
 import { ElasticsearchClient } from '@kbn/core/server';
 import type { Config, Secrets } from '@kbn/inference-endpoint-ui-common';
 import type { Logger } from '@kbn/logging';
+
 import { unflattenObject } from '../utils/unflatten_object';
 
 export const addInferenceEndpoint = async (

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/server/lib/delete_inference_endpoint.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/server/lib/delete_inference_endpoint.ts
@@ -7,6 +7,7 @@
 
 import { InferenceTaskType } from '@elastic/elasticsearch/lib/api/types';
 import { ElasticsearchClient } from '@kbn/core/server';
+
 import { TaskTypes } from '../../common/types';
 
 function isTaskType(type?: string): type is InferenceTaskType {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/server/lib/fetch_inference_services.test.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/server/lib/fetch_inference_services.test.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-import { fetchInferenceServices } from './fetch_inference_services';
 import { ElasticsearchClient } from '@kbn/core/server';
+
 import { mockProviders } from '../../public/utils/test_utils/test_utils';
+
+import { fetchInferenceServices } from './fetch_inference_services';
 
 describe('fetch inference services', () => {
   beforeEach(() => {

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/server/lib/fetch_inference_services.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/server/lib/fetch_inference_services.ts
@@ -6,6 +6,7 @@
  */
 
 import { ElasticsearchClient } from '@kbn/core/server';
+
 import { InferenceProvider } from '../types';
 
 export const fetchInferenceServices = async (

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/server/plugin.ts
@@ -14,6 +14,9 @@ import {
   PluginInitializerContext,
 } from '@kbn/core/server';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
+
+import { PLUGIN_ID, PLUGIN_NAME } from '../common/constants';
+
 import { defineRoutes } from './routes';
 import {
   SearchInferenceEndpointsPluginSetup,
@@ -21,7 +24,6 @@ import {
   SearchInferenceEndpointsPluginStart,
   SearchInferenceEndpointsPluginStartDependencies,
 } from './types';
-import { PLUGIN_ID, PLUGIN_NAME } from '../common/constants';
 
 export class SearchInferenceEndpointsPlugin
   implements

--- a/x-pack/solutions/search/plugins/search_inference_endpoints/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_inference_endpoints/server/routes.ts
@@ -5,14 +5,15 @@
  * 2.0.
  */
 
-import { IRouter } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
+import { IRouter } from '@kbn/core/server';
 import type { Logger } from '@kbn/logging';
+
+import { addInferenceEndpoint } from './lib/add_inference_endpoint';
+import { deleteInferenceEndpoint } from './lib/delete_inference_endpoint';
 import { fetchInferenceEndpoints } from './lib/fetch_inference_endpoints';
 import { APIRoutes, InferenceEndpoint } from './types';
 import { errorHandler } from './utils/error_handler';
-import { deleteInferenceEndpoint } from './lib/delete_inference_endpoint';
-import { addInferenceEndpoint } from './lib/add_inference_endpoint';
 
 export function defineRoutes({ logger, router }: { logger: Logger; router: IRouter }) {
   router.get(

--- a/x-pack/solutions/search/plugins/search_notebooks/common/constants.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/common/constants.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+
 import { Notebook } from './types';
 
 export const INTRODUCTION_NOTEBOOK: Notebook = {

--- a/x-pack/solutions/search/plugins/search_notebooks/public/components/loading_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/components/loading_panel.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React from 'react';
+
 import { EuiPanel, EuiLoadingSpinner } from '@elastic/eui';
 
 export const LoadingPanel = () => (

--- a/x-pack/solutions/search/plugins/search_notebooks/public/components/notebooks_button.tsx
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/components/notebooks_button.tsx
@@ -6,9 +6,10 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
+
 import { EuiButton, EuiButtonEmpty } from '@elastic/eui';
 import { EmbeddedConsoleViewButtonProps } from '@kbn/console-plugin/public';
+import { i18n } from '@kbn/i18n';
 
 export interface SearchNotebooksButtonProps extends EmbeddedConsoleViewButtonProps {
   clearNotebookList: () => void;

--- a/x-pack/solutions/search/plugins/search_notebooks/public/components/notebooks_list.tsx
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/components/notebooks_list.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { NotebookInformation } from '../../common/types';
+
 import { LoadingPanel } from './loading_panel';
 import { SelectionPanel } from './selection_panel';
 

--- a/x-pack/solutions/search/plugins/search_notebooks/public/components/notebooks_view.tsx
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/components/notebooks_view.tsx
@@ -6,13 +6,16 @@
  */
 
 import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
 import { CoreStart } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { AppMetricsTracker, NotebookListValue } from '../types';
 
 import { SearchNotebooks } from './search_notebooks';
-import { AppMetricsTracker, NotebookListValue } from '../types';
 
 export interface SearchNotebooksViewProps {
   core: CoreStart;

--- a/x-pack/solutions/search/plugins/search_notebooks/public/components/search_labs_button_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/components/search_labs_button_panel.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React from 'react';
+
 import { EuiPanel, EuiButton, EuiFlexGroup } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 

--- a/x-pack/solutions/search/plugins/search_notebooks/public/components/search_notebook.tsx
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/components/search_notebook.tsx
@@ -5,11 +5,13 @@
  * 2.0.
  */
 import React, { useEffect } from 'react';
+
 import { EuiPanel } from '@elastic/eui';
 import { NotebookRenderer } from '@kbn/ipynb';
 
 import { useNotebook } from '../hooks/use_notebook';
 import { useUsageTracker } from '../hooks/use_usage_tracker';
+
 import { LoadingPanel } from './loading_panel';
 import { SearchNotebookError } from './search_notebook_error';
 

--- a/x-pack/solutions/search/plugins/search_notebooks/public/components/search_notebook_error.tsx
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/components/search_notebook_error.tsx
@@ -6,9 +6,11 @@
  */
 
 import React from 'react';
+
 import { EuiEmptyPrompt, EuiCodeBlock } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
 import type { AppMetricsTracker } from '../types';
 import { getErrorMessage } from '../utils/get_error_message';
 

--- a/x-pack/solutions/search/plugins/search_notebooks/public/components/search_notebooks.tsx
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/components/search_notebooks.tsx
@@ -11,12 +11,14 @@ import { i18n } from '@kbn/i18n';
 
 import { INTRODUCTION_NOTEBOOK, DEFAULT_NOTEBOOK_ID } from '../../common/constants';
 import { useNotebooksCatalog } from '../hooks/use_notebook_catalog';
+
+import { readNotebookParameter } from '../utils/notebook_query_param';
+
 import { NotebooksList } from './notebooks_list';
+import { SearchLabsButtonPanel } from './search_labs_button_panel';
+import { SearchNotebook } from './search_notebook';
 import { SelectionPanel } from './selection_panel';
 import { TitlePanel } from './title_panel';
-import { SearchNotebook } from './search_notebook';
-import { SearchLabsButtonPanel } from './search_labs_button_panel';
-import { readNotebookParameter } from '../utils/notebook_query_param';
 
 const LIST_PANEL_ID = 'notebooksList';
 const OUTPUT_PANEL_ID = 'notebooksOutput';

--- a/x-pack/solutions/search/plugins/search_notebooks/public/components/selection_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/components/selection_panel.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React from 'react';
+
 import {
   EuiHorizontalRule,
   EuiPanel,

--- a/x-pack/solutions/search/plugins/search_notebooks/public/components/title_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/components/title_panel.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React, { FC, PropsWithChildren } from 'react';
+
 import { EuiHorizontalRule, EuiPanel, EuiText } from '@elastic/eui';
 
 export const TitlePanel: FC<PropsWithChildren<unknown>> = ({ children }) => (

--- a/x-pack/solutions/search/plugins/search_notebooks/public/console_view.tsx
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/console_view.tsx
@@ -6,13 +6,15 @@
  */
 
 import React from 'react';
-import { CoreStart } from '@kbn/core/public';
+
+import { QueryClient } from '@tanstack/react-query';
+
 import type {
   EmbeddedConsoleView,
   EmbeddedConsoleViewButtonProps,
 } from '@kbn/console-plugin/public';
+import { CoreStart } from '@kbn/core/public';
 import { dynamic } from '@kbn/shared-ux-utility';
-import { QueryClient } from '@tanstack/react-query';
 
 import { NotebookListValue, AppMetricsTracker } from './types';
 

--- a/x-pack/solutions/search/plugins/search_notebooks/public/hooks/use_notebook.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/hooks/use_notebook.ts
@@ -7,6 +7,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { Notebook } from '../../common/types';
+
 import { useKibanaServices } from './use_kibana';
 
 export const useNotebook = (id: string) => {

--- a/x-pack/solutions/search/plugins/search_notebooks/public/hooks/use_notebook_catalog.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/hooks/use_notebook_catalog.ts
@@ -7,6 +7,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { NotebookCatalogResponse } from '../../common/types';
+
 import { useKibanaServices } from './use_kibana';
 import { useNotebookList } from './use_notebooks_list';
 

--- a/x-pack/solutions/search/plugins/search_notebooks/public/hooks/use_notebooks_list.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/hooks/use_notebooks_list.ts
@@ -6,7 +6,9 @@
  */
 
 import { useMemo } from 'react';
+
 import { parse } from 'query-string';
+
 import { useKibanaServices } from './use_kibana';
 
 export const readNotebookListFromParam = () => {

--- a/x-pack/solutions/search/plugins/search_notebooks/public/hooks/use_usage_tracker.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/hooks/use_usage_tracker.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { useKibanaServices } from './use_kibana';
 import { AppMetricsTracker } from '../types';
+
+import { useKibanaServices } from './use_kibana';
 
 export const useUsageTracker = (): AppMetricsTracker => {
   const { usageTracker } = useKibanaServices();

--- a/x-pack/solutions/search/plugins/search_notebooks/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/plugin.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { CoreSetup, Plugin, CoreStart } from '@kbn/core/public';
 import { QueryClient, MutationCache, QueryCache } from '@tanstack/react-query';
+
+import { CoreSetup, Plugin, CoreStart } from '@kbn/core/public';
 
 import { notebooksConsoleView } from './console_view';
 import {
@@ -17,8 +18,8 @@ import {
   AppMetricsTracker,
 } from './types';
 import { getErrorCode, getErrorMessage, isKibanaServerError } from './utils/get_error_message';
-import { createUsageTracker } from './utils/usage_tracker';
 import { removeNotebookParameter, setNotebookParameter } from './utils/notebook_query_param';
+import { createUsageTracker } from './utils/usage_tracker';
 
 export class SearchNotebooksPlugin
   implements Plugin<SearchNotebooksPluginSetup, SearchNotebooksPluginStart>

--- a/x-pack/solutions/search/plugins/search_notebooks/public/utils/notebook_query_param.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/utils/notebook_query_param.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import qs from 'query-string';
 import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
+import qs from 'query-string';
 
 function getBaseUrl() {
   return `${window.location.protocol}//${window.location.host}${window.location.pathname}`;

--- a/x-pack/solutions/search/plugins/search_notebooks/public/utils/usage_tracker.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/public/utils/usage_tracker.ts
@@ -10,6 +10,7 @@ import type {
   UsageCollectionSetup,
   UsageCollectionStart,
 } from '@kbn/usage-collection-plugin/public';
+
 import { AppMetricsTracker } from '../types';
 
 const APP_TRACKER_NAME = 'searchNotebooks';

--- a/x-pack/solutions/search/plugins/search_notebooks/server/lib/notebook_catalog.test.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/server/lib/notebook_catalog.test.ts
@@ -6,6 +6,7 @@
  */
 
 import fs from 'fs/promises';
+
 import type { Logger } from '@kbn/logging';
 
 // Mocking dependencies
@@ -19,6 +20,9 @@ const mockLogger: Logger = {
   error: jest.fn(),
 } as Partial<Logger> as Logger;
 
+import { RemoteNotebookCatalog, SearchNotebooksConfig } from '../config';
+import { createNotebooksCache } from '../utils';
+
 import {
   getNotebook,
   getNotebookCatalog,
@@ -27,8 +31,7 @@ import {
   NotebookCatalogFetchOptions,
   getNotebookMetadata,
 } from './notebook_catalog';
-import { createNotebooksCache } from '../utils';
-import { RemoteNotebookCatalog, SearchNotebooksConfig } from '../config';
+
 import { NotebookDefinition } from '@kbn/ipynb';
 
 const emptyNotebookCache = createNotebooksCache();

--- a/x-pack/solutions/search/plugins/search_notebooks/server/lib/notebook_catalog.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/server/lib/notebook_catalog.ts
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import fetch from 'node-fetch';
 import fs from 'fs/promises';
+import fetch from 'node-fetch';
 import path from 'path';
+
 import { i18n } from '@kbn/i18n';
-import type { Logger } from '@kbn/logging';
 import { NotebookDefinition } from '@kbn/ipynb';
+import type { Logger } from '@kbn/logging';
 
 import {
   NotebookCatalog,

--- a/x-pack/solutions/search/plugins/search_notebooks/server/types.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/server/types.ts
@@ -9,8 +9,9 @@ import type { IRouter } from '@kbn/core/server';
 import type { NotebookDefinition } from '@kbn/ipynb';
 import type { Logger } from '@kbn/logging';
 
-import type { SearchNotebooksConfig } from './config';
 import type { NotebookCatalog, NotebookInformation } from '../common/types';
+
+import type { SearchNotebooksConfig } from './config';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SearchNotebooksPluginSetup {}

--- a/x-pack/solutions/search/plugins/search_notebooks/server/utils.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/server/utils.ts
@@ -6,12 +6,14 @@
  */
 
 import { NotebookDefinition } from '@kbn/ipynb';
+
 import {
   NotebookCatalog,
   NotebookCatalogResponse,
   NotebookCatalogSchema,
   NotebookInformation,
 } from '../common/types';
+
 import type {
   CachedNotebook,
   CachedNotebookCatalog,

--- a/x-pack/solutions/search/plugins/search_playground/common/index.ts
+++ b/x-pack/solutions/search/plugins/search_playground/common/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+
 import { Pagination } from './types';
 
 export const PLUGIN_ID = 'searchPlayground';

--- a/x-pack/solutions/search/plugins/search_playground/public/application.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/application.tsx
@@ -7,11 +7,13 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import { CoreStart } from '@kbn/core/public';
-import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
-import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { Router } from '@kbn/shared-ux-router';
+
 import { AppPluginStartDependencies } from './types';
 
 export const renderApp = async (

--- a/x-pack/solutions/search/plugins/search_playground/public/components/app.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/app.tsx
@@ -6,19 +6,24 @@
  */
 
 import React, { useState } from 'react';
-import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 
 import { useWatch } from 'react-hook-form';
-import { QueryMode } from './query_mode/query_mode';
-import { ChatSetupPage } from './setup_page/chat_setup_page';
-import { Header } from './header';
-import { useLoadConnectors } from '../hooks/use_load_connectors';
-import { ChatForm, ChatFormFields, PlaygroundPageMode } from '../types';
-import { Chat } from './chat';
-import { SearchMode } from './search_mode/search_mode';
-import { SearchPlaygroundSetupPage } from './setup_page/search_playground_setup_page';
-import { usePageMode } from '../hooks/use_page_mode';
+
+import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+
 import { useKibana } from '../hooks/use_kibana';
+import { useLoadConnectors } from '../hooks/use_load_connectors';
+
+import { usePageMode } from '../hooks/use_page_mode';
+import { ChatForm, ChatFormFields, PlaygroundPageMode } from '../types';
+
+import { Chat } from './chat';
+import { Header } from './header';
+import { QueryMode } from './query_mode/query_mode';
+import { SearchMode } from './search_mode/search_mode';
+import { ChatSetupPage } from './setup_page/chat_setup_page';
+
+import { SearchPlaygroundSetupPage } from './setup_page/search_playground_setup_page';
 
 export interface AppProps {
   showDocs?: boolean;

--- a/x-pack/solutions/search/plugins/search_playground/public/components/chat.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/chat.tsx
@@ -7,6 +7,9 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
+
+import { v4 as uuidv4 } from 'uuid';
+
 import {
   EuiButtonEmpty,
   EuiButtonIcon,
@@ -18,23 +21,26 @@ import {
   EuiSpacer,
   useEuiTheme,
 } from '@elastic/eui';
-import { v4 as uuidv4 } from 'uuid';
 
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { AnalyticsEvents } from '../analytics/constants';
 import { useAutoBottomScroll } from '../hooks/use_auto_bottom_scroll';
-import { ChatSidebar } from './chat_sidebar';
+
 import { useChat } from '../hooks/use_chat';
+
+import { useUsageTracker } from '../hooks/use_usage_tracker';
 import { ChatForm, ChatFormFields, ChatRequestData, MessageRole } from '../types';
+
+import { transformFromChatMessages } from '../utils/transform_to_messages';
+
+import { ChatSidebar } from './chat_sidebar';
 
 import { MessageList } from './message_list/message_list';
 import { QuestionInput } from './question_input';
 
 import { TelegramIcon } from './telegram_icon';
-import { transformFromChatMessages } from '../utils/transform_to_messages';
-import { useUsageTracker } from '../hooks/use_usage_tracker';
 
 const buildFormData = (formData: ChatForm): ChatRequestData => ({
   connector_id: formData[ChatFormFields.summarizationModel].connectorId!,

--- a/x-pack/solutions/search/plugins/search_playground/public/components/chat_sidebar.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/chat_sidebar.tsx
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import React from 'react';
+
+import { useWatch } from 'react-hook-form';
+
 import {
   EuiButtonEmpty,
   EuiFlexGroup,
@@ -13,14 +17,16 @@ import {
   EuiTitle,
   useEuiTheme,
 } from '@elastic/eui';
-import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useWatch } from 'react-hook-form';
+
 import { docLinks } from '../../common/doc_links';
-import { EditContextPanel } from './edit_context/edit_context_panel';
-import { ChatForm, ChatFormFields } from '../types';
+
 import { useManagementLink } from '../hooks/use_management_link';
+import { ChatForm, ChatFormFields } from '../types';
+
+import { EditContextPanel } from './edit_context/edit_context_panel';
+
 import { SummarizationPanel } from './summarization_panel/summarization_panel';
 
 export const ChatSidebar: React.FC = () => {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/data_action_button.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/data_action_button.tsx
@@ -6,10 +6,14 @@
  */
 
 import React, { useState } from 'react';
-import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiButton } from '@elastic/eui';
+
 import { useWatch } from 'react-hook-form';
+
+import { EuiButton } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+
 import { ChatForm, ChatFormFields } from '../types';
+
 import { SelectIndicesFlyout } from './select_indices_flyout';
 
 export const DataActionButton: React.FC = () => {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/edit_context/edit_context_panel.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/edit_context/edit_context_panel.test.tsx
@@ -6,11 +6,16 @@
  */
 
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
-import { EditContextPanel } from './edit_context_panel';
+
 import { FormProvider, useForm } from 'react-hook-form';
+
+import { render, fireEvent, screen } from '@testing-library/react';
+
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
 import { ChatFormFields } from '../../types';
+
+import { EditContextPanel } from './edit_context_panel';
 
 jest.mock('../../hooks/use_source_indices_field', () => ({
   useSourceIndicesFields: () => ({

--- a/x-pack/solutions/search/plugins/search_playground/public/components/edit_context/edit_context_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/edit_context/edit_context_panel.tsx
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import React from 'react';
+
+import { useController } from 'react-hook-form';
+
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -17,12 +21,11 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React from 'react';
-import { useController } from 'react-hook-form';
+
+import { AnalyticsEvents } from '../../analytics/constants';
 import { useSourceIndicesFields } from '../../hooks/use_source_indices_field';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
 import { ChatForm, ChatFormFields } from '../../types';
-import { AnalyticsEvents } from '../../analytics/constants';
 
 export const EditContextPanel: React.FC = () => {
   const usageTracker = useUsageTracker();

--- a/x-pack/solutions/search/plugins/search_playground/public/components/header.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/header.test.tsx
@@ -8,13 +8,18 @@
 // create @testing-library/react tests for Header component
 // check if EuiButtonGroup is differently labeled based on the selectedPageMode prop
 
-import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { Header } from './header';
-import { ChatFormFields, PlaygroundPageMode } from '../types';
-import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
-import { EuiForm } from '@elastic/eui';
+
 import { FormProvider, useForm } from 'react-hook-form';
+
+import { render, screen } from '@testing-library/react';
+
+import { EuiForm } from '@elastic/eui';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+import { ChatFormFields, PlaygroundPageMode } from '../types';
+
+import { Header } from './header';
 
 const MockFormProvider = ({ children }: { children: React.ReactElement }) => {
   const methods = useForm({

--- a/x-pack/solutions/search/plugins/search_playground/public/components/header.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/header.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import {
   EuiBetaBadge,
   EuiButtonGroup,
@@ -17,12 +19,13 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React from 'react';
+
+import { useSearchPlaygroundFeatureFlag } from '../hooks/use_search_playground_feature_flag';
+import { PlaygroundPageMode } from '../types';
+
+import { ViewMode } from './app';
 import { PlaygroundHeaderDocs } from './playground_header_docs';
 import { Toolbar } from './toolbar';
-import { ViewMode } from './app';
-import { PlaygroundPageMode } from '../types';
-import { useSearchPlaygroundFeatureFlag } from '../hooks/use_search_playground_feature_flag';
 
 interface HeaderProps {
   showDocs?: boolean;

--- a/x-pack/solutions/search/plugins/search_playground/public/components/message_list/assistant_message.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/message_list/assistant_message.test.tsx
@@ -6,10 +6,14 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { AssistantMessage } from './assistant_message';
+
 import { FormProvider, useForm } from 'react-hook-form';
+
+import { render, screen } from '@testing-library/react';
+
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+import { AssistantMessage } from './assistant_message';
 
 // for tooltip
 jest.mock('../../hooks/use_llms_models', () => ({

--- a/x-pack/solutions/search/plugins/search_playground/public/components/message_list/assistant_message.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/message_list/assistant_message.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 
+import { css } from '@emotion/react';
 import moment from 'moment';
 
 import {
@@ -22,13 +23,15 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import { FormattedMessage } from '@kbn/i18n-react';
-import { css } from '@emotion/react';
+
 import { docLinks } from '../../../common/doc_links';
-import { RetrievalDocsFlyout } from './retrieval_docs_flyout';
+
 import type { AIMessage as AIMessageType } from '../../types';
 
-import { CopyActionButton } from './copy_action_button';
 import { CitationsTable } from './citations_table';
+import { CopyActionButton } from './copy_action_button';
+import { RetrievalDocsFlyout } from './retrieval_docs_flyout';
+
 import { TokenEstimateTooltip } from './token_estimate_tooltip';
 
 interface AssistantMessageProps {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/message_list/citations_table.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/message_list/citations_table.test.tsx
@@ -6,7 +6,9 @@
  */
 
 import React from 'react';
+
 import { render, fireEvent } from '@testing-library/react';
+
 import { CitationsTable } from './citations_table';
 
 jest.mock('../../hooks/use_usage_tracker', () => ({

--- a/x-pack/solutions/search/plugins/search_playground/public/components/message_list/citations_table.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/message_list/citations_table.tsx
@@ -6,11 +6,13 @@
  */
 
 import React, { useState } from 'react';
-import { i18n } from '@kbn/i18n';
+
 import { EuiBasicTable, EuiButtonEmpty, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+import { AnalyticsEvents } from '../../analytics/constants';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
 import { AIMessage as AIMessageType, Doc } from '../../types';
-import { AnalyticsEvents } from '../../analytics/constants';
 
 type CitationsTableProps = Pick<AIMessageType, 'citations'>;
 

--- a/x-pack/solutions/search/plugins/search_playground/public/components/message_list/retrieval_docs_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/message_list/retrieval_docs_flyout.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useEffect } from 'react';
+
 import {
   EuiBadge,
   EuiBasicTable,
@@ -23,6 +24,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+
 import { AnalyticsEvents } from '../../analytics/constants';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
 import { Doc } from '../../types';

--- a/x-pack/solutions/search/plugins/search_playground/public/components/message_list/token_estimate_tooltip.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/message_list/token_estimate_tooltip.test.tsx
@@ -6,10 +6,14 @@
  */
 
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
-import { TokenEstimateTooltip } from './token_estimate_tooltip';
+
 import { FormProvider, useForm } from 'react-hook-form';
+
+import { render, fireEvent, screen } from '@testing-library/react';
+
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+import { TokenEstimateTooltip } from './token_estimate_tooltip';
 
 jest.mock('../../hooks/use_llms_models', () => ({
   useLLMsModels: () => [

--- a/x-pack/solutions/search/plugins/search_playground/public/components/message_list/token_estimate_tooltip.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/message_list/token_estimate_tooltip.tsx
@@ -6,6 +6,9 @@
  */
 
 import React, { useState } from 'react';
+
+import { useFormContext } from 'react-hook-form';
+
 import {
   EuiButtonEmpty,
   EuiContextMenu,
@@ -19,7 +22,7 @@ import {
   EuiCallOut,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useFormContext } from 'react-hook-form';
+
 import { docLinks } from '../../../common/doc_links';
 import { useLLMsModels } from '../../hooks/use_llms_models';
 import { ChatForm, ChatFormFields } from '../../types';

--- a/x-pack/solutions/search/plugins/search_playground/public/components/message_list/user_message.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/message_list/user_message.tsx
@@ -7,13 +7,13 @@
 
 import React from 'react';
 
+import { css } from '@emotion/react';
 import moment from 'moment';
 
 import { EuiComment, EuiText, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { UserAvatar } from '@kbn/user-profile-components';
 
-import { css } from '@emotion/react';
 import { useUserProfile } from '../../hooks/use_user_profile';
 import type { Message as MessageType } from '../../types';
 

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_mode.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_mode.test.tsx
@@ -6,11 +6,16 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { QueryMode } from './query_mode';
+
 import { FormProvider, useForm } from 'react-hook-form';
+
+import { render, screen } from '@testing-library/react';
+
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
 import { ChatFormFields } from '../../types';
+
+import { QueryMode } from './query_mode';
 
 jest.mock('../../hooks/use_source_indices_field', () => ({
   useSourceIndicesFields: () => ({

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_mode.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_mode.tsx
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import React, { useEffect, useMemo } from 'react';
+
+import { useController, useWatch } from 'react-hook-form';
+
 import {
   EuiAccordion,
   EuiBasicTable,
@@ -20,13 +24,12 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React, { useEffect, useMemo } from 'react';
-import { useController, useWatch } from 'react-hook-form';
+
+import { docLinks } from '../../../common/doc_links';
+import { AnalyticsEvents } from '../../analytics/constants';
 import { useSourceIndicesFields } from '../../hooks/use_source_indices_field';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
 import { ChatForm, ChatFormFields } from '../../types';
-import { AnalyticsEvents } from '../../analytics/constants';
-import { docLinks } from '../../../common/doc_links';
 import { createQuery } from '../../utils/create_query';
 
 const isQueryFieldSelected = (

--- a/x-pack/solutions/search/plugins/search_playground/public/components/question_input.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/question_input.test.tsx
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
-import { EuiButton, EuiForm } from '@elastic/eui';
 import React, { FormEventHandler } from 'react';
+
 import { fireEvent, render, screen } from '@testing-library/react';
+
+import { EuiButton, EuiForm } from '@elastic/eui';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
 import { QuestionInput } from './question_input';
 
 const mockButton = (
@@ -53,12 +56,7 @@ describe('Question Input', () => {
       render(
         <IntlProvider locale="en">
           <MockChatForm handleSubmit={handleOnSubmitMock}>
-            <QuestionInput
-              value="my question"
-              onChange={() => {}}
-              button={mockButton}
-              isDisabled={true}
-            />
+            <QuestionInput value="my question" onChange={() => {}} button={mockButton} isDisabled />
           </MockChatForm>
         </IntlProvider>
       );

--- a/x-pack/solutions/search/plugins/search_playground/public/components/question_input.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/question_input.tsx
@@ -7,8 +7,8 @@
 
 import React, { useCallback, useState } from 'react';
 
-import { i18n } from '@kbn/i18n';
 import { EuiTextArea, keys, useEuiTheme } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 
 const MAX_HEIGHT = 200;
 

--- a/x-pack/solutions/search/plugins/search_playground/public/components/search_mode/result_list.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/search_mode/result_list.tsx
@@ -7,14 +7,15 @@
 
 import React, { useEffect, useState } from 'react';
 
+import type { IndicesGetMappingResponse, SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { Pagination as PaginationTypeEui } from '@elastic/eui';
+import type { DataView } from '@kbn/data-views-plugin/public';
+import { buildDataTableRecord } from '@kbn/discover-utils';
+import type { EsHitRecord } from '@kbn/discover-utils/types';
 import { DocumentList, pageToPagination } from '@kbn/search-index-documents';
 
-import type { DataView } from '@kbn/data-views-plugin/public';
-import type { EsHitRecord } from '@kbn/discover-utils/types';
-import type { IndicesGetMappingResponse, SearchHit } from '@elastic/elasticsearch/lib/api/types';
-import { buildDataTableRecord } from '@kbn/discover-utils';
 import { UnifiedDocViewerFlyout } from '@kbn/unified-doc-viewer-plugin/public';
-import { Pagination as PaginationTypeEui } from '@elastic/eui';
+
 import { useKibana } from '../../hooks/use_kibana';
 import { Pagination } from '../../types';
 

--- a/x-pack/solutions/search/plugins/search_playground/public/components/search_mode/search_mode.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/search_mode/search_mode.tsx
@@ -5,6 +5,14 @@
  * 2.0.
  */
 
+import React from 'react';
+
+import { Controller, useController, useFormContext } from 'react-hook-form';
+
+import { css } from '@emotion/react';
+
+import { useQueryClient } from '@tanstack/react-query';
+
 import {
   EuiEmptyPrompt,
   EuiFieldText,
@@ -13,17 +21,16 @@ import {
   EuiForm,
   useEuiTheme,
 } from '@elastic/eui';
-import React from 'react';
-import { css } from '@emotion/react';
-import { Controller, useController, useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
-import { useQueryClient } from '@tanstack/react-query';
+
 import { DEFAULT_PAGINATION } from '../../../common';
-import { ResultList } from './result_list';
-import { ChatForm, ChatFormFields, Pagination } from '../../types';
-import { useSearchPreview } from '../../hooks/use_search_preview';
-import { getPaginationFromPage } from '../../utils/pagination_helper';
+
 import { useIndexMappings } from '../../hooks/use_index_mappings';
+import { useSearchPreview } from '../../hooks/use_search_preview';
+import { ChatForm, ChatFormFields, Pagination } from '../../types';
+import { getPaginationFromPage } from '../../utils/pagination_helper';
+
+import { ResultList } from './result_list';
 
 export const SearchMode: React.FC = () => {
   const { euiTheme } = useEuiTheme();

--- a/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.test.tsx
@@ -6,11 +6,15 @@
  */
 
 import React, { FC, PropsWithChildren } from 'react';
+
 import { render, fireEvent, waitFor } from '@testing-library/react';
-import { SelectIndicesFlyout } from './select_indices_flyout';
-import { useSourceIndicesFields } from '../hooks/use_source_indices_field';
-import { useQueryIndices } from '../hooks/use_query_indices';
+
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+import { useQueryIndices } from '../hooks/use_query_indices';
+import { useSourceIndicesFields } from '../hooks/use_source_indices_field';
+
+import { SelectIndicesFlyout } from './select_indices_flyout';
 
 jest.mock('../hooks/use_source_indices_field');
 jest.mock('../hooks/use_query_indices');

--- a/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useState } from 'react';
+
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -21,13 +22,14 @@ import {
   EuiTabbedContent,
   EuiTitle,
 } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
-import { i18n } from '@kbn/i18n';
 import { EuiSelectableOption } from '@elastic/eui/src/components/selectable/selectable_option';
-import { getIndicesWithNoSourceFields } from '../utils/create_query';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
 import { useIndicesFields } from '../hooks/use_indices_fields';
-import { useSourceIndicesFields } from '../hooks/use_source_indices_field';
 import { useQueryIndices } from '../hooks/use_query_indices';
+import { useSourceIndicesFields } from '../hooks/use_source_indices_field';
+import { getIndicesWithNoSourceFields } from '../utils/create_query';
 
 interface SelectIndicesFlyout {
   onClose: () => void;

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/add_data_sources.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/add_data_sources.tsx
@@ -7,8 +7,10 @@
 
 import React, { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { FormattedMessage } from '@kbn/i18n-react';
+
 import { EuiButton, EuiButtonEmpty } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+
 import { ChatForm, ChatFormFields } from '../../types';
 import { SelectIndicesFlyout } from '../select_indices_flyout';
 

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/chat_setup_page.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/chat_setup_page.tsx
@@ -16,10 +16,12 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useQueryIndices } from '../../hooks/use_query_indices';
+
 import { docLinks } from '../../../common/doc_links';
-import { useUsageTracker } from '../../hooks/use_usage_tracker';
 import { AnalyticsEvents } from '../../analytics/constants';
+import { useQueryIndices } from '../../hooks/use_query_indices';
+import { useUsageTracker } from '../../hooks/use_usage_tracker';
+
 import { AddDataSources } from './add_data_sources';
 import { ConnectLLMButton } from './connect_llm_button';
 import { CreateIndexButton } from './create_index_button';

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/connect_llm_button.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/connect_llm_button.test.tsx
@@ -6,11 +6,16 @@
  */
 
 import React from 'react';
+
 import { fireEvent, render as testingLibraryRender, waitFor } from '@testing-library/react';
-import { ConnectLLMButton } from './connect_llm_button';
-import { useKibana } from '../../hooks/use_kibana';
-import { useLoadConnectors } from '../../hooks/use_load_connectors';
+
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+import { useKibana } from '../../hooks/use_kibana';
+
+import { useLoadConnectors } from '../../hooks/use_load_connectors';
+
+import { ConnectLLMButton } from './connect_llm_button';
 
 const render = (children: React.ReactNode) =>
   testingLibraryRender(<IntlProvider locale="en">{children}</IntlProvider>);

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/connect_llm_button.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/connect_llm_button.tsx
@@ -5,14 +5,16 @@
  * 2.0.
  */
 
-import { EuiButton, EuiButtonEmpty } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useEffect, useState } from 'react';
+
+import { EuiButton, EuiButtonEmpty } from '@elastic/eui';
 import { GenerativeAIForSearchPlaygroundConnectorFeatureId } from '@kbn/actions-plugin/common';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { AnalyticsEvents } from '../../analytics/constants';
 import { useKibana } from '../../hooks/use_kibana';
 import { useLoadConnectors } from '../../hooks/use_load_connectors';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
-import { AnalyticsEvents } from '../../analytics/constants';
 
 export const ConnectLLMButton: React.FC = () => {
   const [connectorFlyoutOpen, setConnectorFlyoutOpen] = useState(false);

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/create_index_button.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/create_index_button.test.tsx
@@ -6,9 +6,13 @@
  */
 
 import React, { FC, PropsWithChildren } from 'react';
+
 import { render, fireEvent, waitFor } from '@testing-library/react';
-import { useKibana } from '../../hooks/use_kibana';
+
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+import { useKibana } from '../../hooks/use_kibana';
+
 import { CreateIndexButton } from './create_index_button';
 
 // Mocking the useKibana hook

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/create_index_button.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/create_index_button.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import { EuiButton, EuiCallOut } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import React, { useCallback, useMemo } from 'react';
+
+import { EuiButton, EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
 import { useKibana } from '../../hooks/use_kibana';
 
 export const CreateIndexButton: React.FC = () => {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/search_playground_setup_page.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/search_playground_setup_page.tsx
@@ -16,9 +16,11 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+
+import { AnalyticsEvents } from '../../analytics/constants';
 import { useQueryIndices } from '../../hooks/use_query_indices';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
-import { AnalyticsEvents } from '../../analytics/constants';
+
 import { AddDataSources } from './add_data_sources';
 
 export const SearchPlaygroundSetupPage: React.FC = () => {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/sources_panel/indices_list.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/sources_panel/indices_list.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { EuiFormRow, EuiListGroup, EuiListGroupItem } from '@elastic/eui';
 import React from 'react';
+
+import { EuiFormRow, EuiListGroup, EuiListGroupItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 interface IndicesListProps {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/sources_panel/indices_table.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/sources_panel/indices_table.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import { EuiBasicTable, EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
 
 interface IndicesTableProps {
   indices: string[];

--- a/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/include_citations_field.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/include_citations_field.tsx
@@ -6,10 +6,12 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
+
 import { EuiFormRow, EuiSwitch } from '@elastic/eui';
-import { useUsageTracker } from '../../hooks/use_usage_tracker';
+import { i18n } from '@kbn/i18n';
+
 import { AnalyticsEvents } from '../../analytics/constants';
+import { useUsageTracker } from '../../hooks/use_usage_tracker';
 
 interface IncludeCitationsFieldProps {
   checked: boolean;

--- a/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/instructions_field.tsx
@@ -7,11 +7,13 @@
 
 import React from 'react';
 
+import { isEmpty } from 'lodash';
+
 import { EuiFormRow, EuiTextArea, EuiIconTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { isEmpty } from 'lodash';
-import { useUsageTracker } from '../../hooks/use_usage_tracker';
+
 import { AnalyticsEvents } from '../../analytics/constants';
+import { useUsageTracker } from '../../hooks/use_usage_tracker';
 
 interface InstructionsFieldProps {
   value?: string;

--- a/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/summarization_model.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/summarization_model.test.tsx
@@ -6,11 +6,15 @@
  */
 
 import React from 'react';
+
 import { render as testingLibraryRender } from '@testing-library/react';
-import { SummarizationModel } from './summarization_model';
-import { useManagementLink } from '../../hooks/use_management_link';
+
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+
+import { useManagementLink } from '../../hooks/use_management_link';
 import { LLMs } from '../../types';
+
+import { SummarizationModel } from './summarization_model';
 
 const render = (children: React.ReactNode) =>
   testingLibraryRender(<IntlProvider locale="en">{children}</IntlProvider>);

--- a/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/summarization_model.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/summarization_model.tsx
@@ -18,6 +18,7 @@ import {
 } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
+
 import { AnalyticsEvents } from '../../analytics/constants';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
 import type { LLMModel } from '../../types';

--- a/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/summarization_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/summarization_panel/summarization_panel.tsx
@@ -9,10 +9,13 @@ import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { EuiPanel } from '@elastic/eui';
+
 import { useLLMsModels } from '../../hooks/use_llms_models';
+
+import { ChatForm, ChatFormFields } from '../../types';
+
 import { IncludeCitationsField } from './include_citations_field';
 import { InstructionsField } from './instructions_field';
-import { ChatForm, ChatFormFields } from '../../types';
 import { SummarizationModel } from './summarization_model';
 
 export const SummarizationPanel: React.FC = () => {
@@ -45,7 +48,7 @@ export const SummarizationPanel: React.FC = () => {
       <Controller
         name={ChatFormFields.citations}
         control={control}
-        defaultValue={true}
+        defaultValue
         render={({ field }) => (
           <IncludeCitationsField checked={field.value} onChange={field.onChange} />
         )}

--- a/x-pack/solutions/search/plugins/search_playground/public/components/toolbar.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/toolbar.tsx
@@ -5,11 +5,14 @@
  * 2.0.
  */
 
-import { EuiFlexGroup } from '@elastic/eui';
 import React from 'react';
+
+import { EuiFlexGroup } from '@elastic/eui';
+
+import { PlaygroundPageMode } from '../types';
+
 import { DataActionButton } from './data_action_button';
 import { ViewCodeAction } from './view_code/view_code_action';
-import { PlaygroundPageMode } from '../types';
 
 export const Toolbar: React.FC<{ selectedPageMode: PlaygroundPageMode }> = ({
   selectedPageMode = PlaygroundPageMode.chat,

--- a/x-pack/solutions/search/plugins/search_playground/public/components/view_code/create_api_key_form.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/view_code/create_api_key_form.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React, { Controller, useForm } from 'react-hook-form';
+
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -14,9 +16,9 @@ import {
   EuiFormRow,
   EuiText,
 } from '@elastic/eui';
-import React, { Controller, useForm } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+
 import { useCreateApiKeyQuery } from '../../hooks/use_create_api_key_query';
 import { useKibana } from '../../hooks/use_kibana';
 

--- a/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/dev_tools.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/dev_tools.tsx
@@ -7,8 +7,10 @@
 
 import React from 'react';
 
-import { EuiCodeBlock } from '@elastic/eui';
 import { useFormContext } from 'react-hook-form';
+
+import { EuiCodeBlock } from '@elastic/eui';
+
 import { ChatFormFields } from '../../../types';
 
 export const DevToolsCode: React.FC = () => {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_lang_client.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_lang_client.test.tsx
@@ -6,9 +6,11 @@
  */
 
 import { render } from '@testing-library/react';
-import { PY_LANG_CLIENT } from './py_lang_client'; // Adjust the import path according to your project structure
-import { ES_CLIENT_DETAILS } from '../view_code_flyout';
+
 import { ChatForm } from '../../../types';
+import { ES_CLIENT_DETAILS } from '../view_code_flyout';
+
+import { PY_LANG_CLIENT } from './py_lang_client'; // Adjust the import path according to your project structure
 
 describe('PY_LANG_CLIENT function', () => {
   test('renders with correct content', () => {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_lang_client.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_lang_client.tsx
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
-import { EuiCodeBlock } from '@elastic/eui';
 import React from 'react';
-import { ChatForm } from '../../../types';
+
+import { EuiCodeBlock } from '@elastic/eui';
+
 import { Prompt } from '../../../../common/prompt';
+import { ChatForm } from '../../../types';
+
 import { getESQuery } from './utils';
 
 export const PY_LANG_CLIENT = (formValues: ChatForm, clientDetails: string) => (

--- a/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_langchain_python.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_langchain_python.test.tsx
@@ -6,8 +6,10 @@
  */
 
 import { render } from '@testing-library/react';
-import { ES_CLIENT_DETAILS } from '../view_code_flyout';
+
 import { ChatForm } from '../../../types';
+import { ES_CLIENT_DETAILS } from '../view_code_flyout';
+
 import { LANGCHAIN_PYTHON } from './py_langchain_python';
 
 describe('PY_LANGCHAIN function', () => {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_langchain_python.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_langchain_python.tsx
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
-import { EuiCodeBlock } from '@elastic/eui';
 import React from 'react';
-import { ChatForm } from '../../../types';
+
+import { EuiCodeBlock } from '@elastic/eui';
+
 import { Prompt } from '../../../../common/prompt';
+import { ChatForm } from '../../../types';
+
 import { getESQuery } from './utils';
 
 export const getSourceFields = (sourceFields: ChatForm['source_fields']) => {

--- a/x-pack/solutions/search/plugins/search_playground/public/components/view_code/view_code_action.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/view_code/view_code_action.tsx
@@ -6,10 +6,14 @@
  */
 
 import React, { useState } from 'react';
-import { EuiButton } from '@elastic/eui';
+
 import { useFormContext } from 'react-hook-form';
+
+import { EuiButton } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+
 import { ChatForm, ChatFormFields, PlaygroundPageMode } from '../../types';
+
 import { ViewCodeFlyout } from './view_code_flyout';
 
 export const ViewCodeAction: React.FC<{ selectedPageMode: PlaygroundPageMode }> = ({

--- a/x-pack/solutions/search/plugins/search_playground/public/components/view_code/view_code_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/view_code/view_code_flyout.tsx
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import React, { useEffect, useState } from 'react';
+
+import { useFormContext } from 'react-hook-form';
+
 import {
   EuiFlyout,
   EuiFlyoutBody,
@@ -18,16 +22,16 @@ import {
   EuiButtonEmpty,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React, { useEffect, useState } from 'react';
-import { useFormContext } from 'react-hook-form';
+
+import { MANAGEMENT_API_KEYS } from '../../../common/routes';
 import { AnalyticsEvents } from '../../analytics/constants';
+import { useKibana } from '../../hooks/use_kibana';
 import { useUsageTracker } from '../../hooks/use_usage_tracker';
 import { ChatForm, PlaygroundPageMode } from '../../types';
-import { useKibana } from '../../hooks/use_kibana';
-import { MANAGEMENT_API_KEYS } from '../../../common/routes';
-import { LANGCHAIN_PYTHON } from './examples/py_langchain_python';
-import { PY_LANG_CLIENT } from './examples/py_lang_client';
+
 import { DevToolsCode } from './examples/dev_tools';
+import { PY_LANG_CLIENT } from './examples/py_lang_client';
+import { LANGCHAIN_PYTHON } from './examples/py_langchain_python';
 
 interface ViewCodeFlyoutProps {
   onClose: () => void;

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_ai_assist_chat.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_ai_assist_chat.ts
@@ -6,9 +6,9 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+
 import useSWR, { KeyedMutator } from 'swr';
 import { v4 as uuidv4 } from 'uuid';
-import { fetchApi } from '../utils/api';
 
 import type {
   ChatRequest,
@@ -19,6 +19,7 @@ import type {
   UseChatOptions,
 } from '../types';
 import { MessageRole } from '../types';
+import { fetchApi } from '../utils/api';
 
 const getStreamedResponse = async (
   api: string | ((init: RequestInit) => Promise<Response>),

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_chat.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_chat.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
+import { APIRoutes, UseChatHelpers } from '../types';
+
 import { useAIAssistChat } from './use_ai_assist_chat';
 import { useKibana } from './use_kibana';
-import { APIRoutes, UseChatHelpers } from '../types';
 
 export const useChat = (): UseChatHelpers => {
   const { services } = useKibana();

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_create_api_key_query.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_create_api_key_query.ts
@@ -5,10 +5,13 @@
  * 2.0.
  */
 
-import { useMutation } from '@tanstack/react-query';
 import { useFormContext } from 'react-hook-form';
-import { useKibana } from './use_kibana';
+
+import { useMutation } from '@tanstack/react-query';
+
 import { APIRoutes, ChatFormFields } from '../types';
+
+import { useKibana } from './use_kibana';
 
 interface UseApiKeyQueryParams {
   name: string;

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_index_mappings.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_index_mappings.ts
@@ -5,11 +5,15 @@
  * 2.0.
  */
 
-import { useQuery } from '@tanstack/react-query';
-import type { HttpSetup } from '@kbn/core-http-browser';
-import { IndicesGetMappingResponse } from '@elastic/elasticsearch/lib/api/types';
 import { useFormContext } from 'react-hook-form';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { IndicesGetMappingResponse } from '@elastic/elasticsearch/lib/api/types';
+import type { HttpSetup } from '@kbn/core-http-browser';
+
 import { APIRoutes, ChatForm, ChatFormFields } from '../types';
+
 import { useKibana } from './use_kibana';
 
 export interface FetchIndexMappingsArgs {

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_indices_fields.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_indices_fields.ts
@@ -6,8 +6,10 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { useKibana } from './use_kibana';
+
 import { APIRoutes, IndicesQuerySourceFields } from '../types';
+
+import { useKibana } from './use_kibana';
 
 const initialData = {};
 

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_indices_validation.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_indices_validation.ts
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useState } from 'react';
+
 import { useQueryIndices } from './use_query_indices';
 
 export const useIndicesValidation = (unvalidatedIndices: string[]) => {

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_kibana.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_kibana.ts
@@ -6,6 +6,7 @@
  */
 
 import { useKibana as _useKibana } from '@kbn/kibana-react-plugin/public';
+
 import { AppServicesContext } from '../types';
 
 export const useKibana = () => _useKibana<AppServicesContext>();

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_llms_models.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_llms_models.test.ts
@@ -6,9 +6,11 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { useLoadConnectors } from './use_load_connectors';
-import { useLLMsModels } from './use_llms_models';
+
 import { LLMs } from '../types';
+
+import { useLLMsModels } from './use_llms_models';
+import { useLoadConnectors } from './use_load_connectors';
 
 jest.mock('./use_load_connectors', () => ({
   useLoadConnectors: jest.fn(),

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_llms_models.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_llms_models.ts
@@ -5,14 +5,17 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
 import { useMemo } from 'react';
+
+import { i18n } from '@kbn/i18n';
 import { SERVICE_PROVIDERS } from '@kbn/inference-endpoint-ui-common';
-import type { PlaygroundConnector, InferenceActionConnector, ActionConnector } from '../types';
-import { LLMs } from '../../common/types';
-import { LLMModel } from '../types';
-import { useLoadConnectors } from './use_load_connectors';
+
 import { MODELS } from '../../common/models';
+import { LLMs } from '../../common/types';
+import type { PlaygroundConnector, InferenceActionConnector, ActionConnector } from '../types';
+import { LLMModel } from '../types';
+
+import { useLoadConnectors } from './use_load_connectors';
 
 const isInferenceActionConnector = (
   connector: ActionConnector

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_load_connectors.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_load_connectors.test.ts
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import { loadAllActions as loadConnectors } from '@kbn/triggers-actions-ui-plugin/public/common/constants';
-import { useLoadConnectors } from './use_load_connectors';
-import { useKibana } from './use_kibana';
 import { waitFor, renderHook } from '@testing-library/react';
+
 import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/common/openai/constants';
+import { loadAllActions as loadConnectors } from '@kbn/triggers-actions-ui-plugin/public/common/constants';
+
+import { useKibana } from './use_kibana';
+import { useLoadConnectors } from './use_load_connectors';
 
 const mockedLoadConnectors = loadConnectors as jest.Mock;
 const mockedUseKibana = useKibana as jest.Mock;

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_load_connectors.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_load_connectors.ts
@@ -7,9 +7,10 @@
 
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
-import { loadAllActions as loadConnectors } from '@kbn/triggers-actions-ui-plugin/public/common/constants';
+
 import type { IHttpFetchError, ResponseErrorBody } from '@kbn/core-http-browser';
 import { i18n } from '@kbn/i18n';
+import { isSupportedConnector } from '@kbn/inference-common';
 import {
   OPENAI_CONNECTOR_ID,
   OpenAiProviderType,
@@ -17,10 +18,12 @@ import {
   GEMINI_CONNECTOR_ID,
   INFERENCE_CONNECTOR_ID,
 } from '@kbn/stack-connectors-plugin/public/common';
+import { loadAllActions as loadConnectors } from '@kbn/triggers-actions-ui-plugin/public/common/constants';
 import type { UserConfiguredActionConnector } from '@kbn/triggers-actions-ui-plugin/public/types';
-import { isSupportedConnector } from '@kbn/inference-common';
-import { useKibana } from './use_kibana';
+
 import { LLMs, type ActionConnector, type PlaygroundConnector } from '../types';
+
+import { useKibana } from './use_kibana';
 
 const QUERY_KEY = ['search-playground, load-connectors'];
 

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_load_fields_by_indices.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_load_fields_by_indices.test.ts
@@ -6,12 +6,14 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { useLoadFieldsByIndices } from './use_load_fields_by_indices';
-import { useUsageTracker } from './use_usage_tracker';
-import { useIndicesFields } from './use_indices_fields';
-import { createQuery, getDefaultQueryFields, getDefaultSourceFields } from '../utils/create_query';
+
 import { AnalyticsEvents } from '../analytics/constants';
 import { ChatFormFields } from '../types';
+import { createQuery, getDefaultQueryFields, getDefaultSourceFields } from '../utils/create_query';
+
+import { useIndicesFields } from './use_indices_fields';
+import { useLoadFieldsByIndices } from './use_load_fields_by_indices';
+import { useUsageTracker } from './use_usage_tracker';
 
 // Mock dependencies
 jest.mock('./use_usage_tracker');

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_load_fields_by_indices.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_load_fields_by_indices.ts
@@ -6,17 +6,21 @@
  */
 
 import { useEffect } from 'react';
+
 import { UseFormReturn } from 'react-hook-form/dist/types';
-import { useUsageTracker } from './use_usage_tracker';
+
+import { AnalyticsEvents } from '../analytics/constants';
 import { ChatForm, ChatFormFields } from '../types';
-import { useIndicesFields } from './use_indices_fields';
+
 import {
   createQuery,
   getDefaultQueryFields,
   getDefaultSourceFields,
   IndexFields,
 } from '../utils/create_query';
-import { AnalyticsEvents } from '../analytics/constants';
+
+import { useIndicesFields } from './use_indices_fields';
+import { useUsageTracker } from './use_usage_tracker';
 
 const mergeDefaultAndCurrentValues = (
   defaultFields: IndexFields,

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_management_link.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_management_link.test.ts
@@ -6,8 +6,9 @@
  */
 
 import { waitFor, renderHook } from '@testing-library/react';
-import { useManagementLink } from './use_management_link';
+
 import { useKibana } from './use_kibana';
+import { useManagementLink } from './use_management_link';
 
 jest.mock('./use_kibana', () => ({
   useKibana: jest.fn(),

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_management_link.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_management_link.ts
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
+
 import { useKibana } from './use_kibana';
 
 export const useManagementLink = (connectorId: string) => {

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_page_mode.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_page_mode.ts
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useState } from 'react';
+
 import { PlaygroundPageMode } from '../types';
 
 export const usePageMode = ({

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_query_indices.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_query_indices.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { renderHook } from '@testing-library/react';
+
 import { useQueryIndices } from './use_query_indices';
 
 jest.mock('./use_kibana', () => ({

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_query_indices.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_query_indices.ts
@@ -6,9 +6,12 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+
 import { IndexName } from '@elastic/elasticsearch/lib/api/types';
-import { useKibana } from './use_kibana';
+
 import { APIRoutes } from '../types';
+
+import { useKibana } from './use_kibana';
 
 export const useQueryIndices = (
   {

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_search_playground_feature_flag.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_search_playground_feature_flag.ts
@@ -6,6 +6,7 @@
  */
 
 import { isSearchModeEnabled } from '../utils/feature_flags';
+
 import { useKibana } from './use_kibana';
 
 export const useSearchPlaygroundFeatureFlag = (): boolean => {

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_search_preview.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_search_preview.ts
@@ -5,13 +5,18 @@
  * 2.0.
  */
 
-import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
-import { useQuery } from '@tanstack/react-query';
 import { useFormContext } from 'react-hook-form';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+
 import type { HttpSetup } from '@kbn/core-http-browser';
-import { APIRoutes, ChatForm, ChatFormFields, Pagination } from '../types';
-import { useKibana } from './use_kibana';
+
 import { DEFAULT_PAGINATION } from '../../common';
+import { APIRoutes, ChatForm, ChatFormFields, Pagination } from '../types';
+
+import { useKibana } from './use_kibana';
 
 export interface FetchSearchResultsArgs {
   query: string;

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_source_indices_field.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_source_indices_field.ts
@@ -5,13 +5,17 @@
  * 2.0.
  */
 
-import { useController } from 'react-hook-form';
-import { IndexName } from '@elastic/elasticsearch/lib/api/types';
 import { useCallback } from 'react';
-import { useIndicesFields } from './use_indices_fields';
-import { ChatFormFields } from '../types';
-import { useUsageTracker } from './use_usage_tracker';
+import { useController } from 'react-hook-form';
+
+import { IndexName } from '@elastic/elasticsearch/lib/api/types';
+
 import { AnalyticsEvents } from '../analytics/constants';
+import { ChatFormFields } from '../types';
+
+import { useIndicesFields } from './use_indices_fields';
+
+import { useUsageTracker } from './use_usage_tracker';
 
 export const useSourceIndicesFields = () => {
   const usageTracker = useUsageTracker();

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_source_indices_fields.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_source_indices_fields.test.tsx
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
-import { renderHook, act } from '@testing-library/react';
-import { useUsageTracker } from './use_usage_tracker';
 import { useController } from 'react-hook-form';
-import { useIndicesFields } from './use_indices_fields';
+
+import { renderHook, act } from '@testing-library/react';
+
 import { AnalyticsEvents } from '../analytics/constants';
+
+import { useIndicesFields } from './use_indices_fields';
+
 import { useSourceIndicesFields } from './use_source_indices_field';
+import { useUsageTracker } from './use_usage_tracker';
 
 jest.mock('./use_usage_tracker');
 jest.mock('react-hook-form');

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_usage_tracker.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_usage_tracker.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { renderHook } from '@testing-library/react';
+
 import { useKibana } from './use_kibana';
 import { useUsageTracker } from './use_usage_tracker';
 

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_usage_tracker.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_usage_tracker.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { METRIC_TYPE } from '@kbn/analytics';
 import { useMemo } from 'react';
+
+import { METRIC_TYPE } from '@kbn/analytics';
+
 import { useKibana } from './use_kibana';
 
 const APP_TRACKER_NAME = 'search_playground';

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_user_profile.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_user_profile.ts
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { useQuery } from '@tanstack/react-query';
+
+import { UserProfileWithAvatar } from '@kbn/user-profile-components';
+
 import { useKibana } from './use_kibana';
 
 export const useUserProfile = (): UserProfileWithAvatar | undefined => {

--- a/x-pack/solutions/search/plugins/search_playground/public/locators/index.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/locators/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { type SharePluginSetup } from '@kbn/share-plugin/public';
+
 import { PlaygroundLocatorDefinition, type PlaygroundLocatorParams } from './playground_locator';
 
 export function registerLocators(share: SharePluginSetup) {

--- a/x-pack/solutions/search/plugins/search_playground/public/playground_overview.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/playground_overview.tsx
@@ -6,13 +6,15 @@
  */
 
 import React, { useMemo } from 'react';
+
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+
+import { App } from './components/app';
+import { useKibana } from './hooks/use_kibana';
+import { usePlaygroundBreadcrumbs } from './hooks/use_playground_breadcrumbs';
 import { PlaygroundProvider } from './providers/playground_provider';
 
-import { useKibana } from './hooks/use_kibana';
 import { PlaygroundPageMode } from './types';
-import { App } from './components/app';
-import { usePlaygroundBreadcrumbs } from './hooks/use_playground_breadcrumbs';
 
 interface PlaygroundOverviewProps {
   pageMode?: PlaygroundPageMode;

--- a/x-pack/solutions/search/plugins/search_playground/public/playground_router.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/playground_router.tsx
@@ -5,14 +5,17 @@
  * 2.0.
  */
 
-import { Route, Routes } from '@kbn/shared-ux-router';
 import React from 'react';
+
 import { Redirect } from 'react-router-dom';
+
+import { Route, Routes } from '@kbn/shared-ux-router';
+
+import { useSearchPlaygroundFeatureFlag } from './hooks/use_search_playground_feature_flag';
 import { PlaygroundOverview } from './playground_overview';
 
 import { ROOT_PATH, SEARCH_PLAYGROUND_CHAT_PATH, SEARCH_PLAYGROUND_SEARCH_PATH } from './routes';
 import { PlaygroundPageMode } from './types';
-import { useSearchPlaygroundFeatureFlag } from './hooks/use_search_playground_feature_flag';
 
 export const PlaygroundRouter: React.FC = () => {
   const isSearchModeEnabled = useSearchPlaygroundFeatureFlag();

--- a/x-pack/solutions/search/plugins/search_playground/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/plugin.ts
@@ -17,8 +17,11 @@ import {
   AppUpdater,
   AppStatus,
 } from '@kbn/core/public';
+
 import { PLUGIN_ID, PLUGIN_NAME, PLUGIN_PATH } from '../common';
 import { docLinks } from '../common/doc_links';
+
+import { registerLocators } from './locators';
 import type {
   AppPluginSetupDependencies,
   AppPluginStartDependencies,
@@ -26,7 +29,6 @@ import type {
   SearchPlaygroundPluginSetup,
   SearchPlaygroundPluginStart,
 } from './types';
-import { registerLocators } from './locators';
 
 export class SearchPlaygroundPlugin
   implements Plugin<SearchPlaygroundPluginSetup, SearchPlaygroundPluginStart>

--- a/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.test.tsx
@@ -6,13 +6,18 @@
  */
 
 import React from 'react';
-import { render, waitFor, act } from '@testing-library/react';
-import { FormProvider, LOCAL_STORAGE_KEY } from './form_provider';
-import { useLoadFieldsByIndices } from '../hooks/use_load_fields_by_indices';
-import { useLLMsModels } from '../hooks/use_llms_models';
+
 import * as ReactHookForm from 'react-hook-form';
-import { ChatFormFields } from '../types';
+
 import { useSearchParams } from 'react-router-dom-v5-compat';
+
+import { render, waitFor, act } from '@testing-library/react';
+
+import { useLLMsModels } from '../hooks/use_llms_models';
+import { useLoadFieldsByIndices } from '../hooks/use_load_fields_by_indices';
+import { ChatFormFields } from '../types';
+
+import { FormProvider, LOCAL_STORAGE_KEY } from './form_provider';
 
 jest.mock('../hooks/use_load_fields_by_indices');
 jest.mock('../hooks/use_llms_models');

--- a/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.tsx
@@ -4,13 +4,14 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { FormProvider as ReactHookFormProvider, useForm } from 'react-hook-form';
 import React, { useEffect, useMemo } from 'react';
+import { FormProvider as ReactHookFormProvider, useForm } from 'react-hook-form';
 import { useSearchParams } from 'react-router-dom-v5-compat';
+
 import { useIndicesValidation } from '../hooks/use_indices_validation';
+import { useLLMsModels } from '../hooks/use_llms_models';
 import { useLoadFieldsByIndices } from '../hooks/use_load_fields_by_indices';
 import { ChatForm, ChatFormFields } from '../types';
-import { useLLMsModels } from '../hooks/use_llms_models';
 
 type PartialChatForm = Partial<ChatForm>;
 export const LOCAL_STORAGE_KEY = 'search_playground_session';

--- a/x-pack/solutions/search/plugins/search_playground/public/providers/playground_provider.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/providers/playground_provider.tsx
@@ -6,8 +6,11 @@
  */
 
 import React, { FC } from 'react';
+
 import { QueryClientProvider } from '@tanstack/react-query';
+
 import { queryClient } from '../utils/query_client';
+
 import { FormProvider } from './form_provider';
 
 export const PlaygroundProvider: FC<React.PropsWithChildren<{}>> = ({ children }) => {

--- a/x-pack/solutions/search/plugins/search_playground/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/types.ts
@@ -5,26 +5,28 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import {
   HealthStatus,
   IndexName,
   IndicesStatsIndexMetadataState,
   Uuid,
 } from '@elastic/elasticsearch/lib/api/types';
-import type { NavigationPublicPluginStart } from '@kbn/navigation-plugin/public';
-import React from 'react';
-import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
+import type { ActionConnector } from '@kbn/alerts-ui-shared/src/common/types';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
-import type { TriggersAndActionsUIPublicPluginStart } from '@kbn/triggers-actions-ui-plugin/public';
-import type { AppMountParameters, CoreStart } from '@kbn/core/public';
-import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import type { ConsolePluginStart } from '@kbn/console-plugin/public';
+import type { AppMountParameters, CoreStart } from '@kbn/core/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
+import type { NavigationPublicPluginStart } from '@kbn/navigation-plugin/public';
 import type { SearchNavigationPluginStart } from '@kbn/search-navigation/public';
 import type { SecurityPluginStart } from '@kbn/security-plugin/public';
-import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
-import type { ActionConnector } from '@kbn/alerts-ui-shared/src/common/types';
-import type { ServiceProviderKeys } from '@kbn/inference-endpoint-ui-common';
+import type { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
+import type { TriggersAndActionsUIPublicPluginStart } from '@kbn/triggers-actions-ui-plugin/public';
+import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+
 import type { ChatRequestData, MessageRole, LLMs } from '../common/types';
 
 export * from '../common/types';

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/api.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/api.ts
@@ -6,8 +6,10 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { readDataStream } from './stream';
+
 import { Annotation, Message, MessageRole } from '../types';
+
+import { readDataStream } from './stream';
 
 export async function fetchApi({
   api,

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/create_query.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/create_query.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { IndicesQuerySourceFields } from '../types';
+
 import {
   createQuery,
   getDefaultQueryFields,

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/create_query.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/create_query.ts
@@ -6,6 +6,7 @@
  */
 
 import { RetrieverContainer, SearchHighlight } from '@elastic/elasticsearch/lib/api/types';
+
 import { IndicesQuerySourceFields, QuerySourceFields } from '../types';
 
 export type IndexFields = Record<string, string[]>;

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/feature_flags.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/feature_flags.ts
@@ -6,6 +6,7 @@
  */
 
 import { IUiSettingsClient } from '@kbn/core/public';
+
 import { SEARCH_MODE_FEATURE_FLAG_ID } from '../../common';
 
 export function isSearchModeEnabled(uiSettings: IUiSettingsClient): boolean {

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/transform_to_messages.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/transform_to_messages.test.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { transformFromChatMessages } from './transform_to_messages';
 import { MessageRole, UseChatHelpers, Message, AIMessage } from '../types';
+
+import { transformFromChatMessages } from './transform_to_messages';
 
 describe('transformFromChatMessages', () => {
   it('transforms messages correctly', () => {

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/transform_to_messages.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/transform_to_messages.ts
@@ -13,6 +13,7 @@ import {
   AnnotationDoc,
   AnnotationTokens,
 } from '../types';
+
 import { transformAnnotationToDoc } from './transform_annotation_to_doc';
 
 export const transformFromChatMessages = (messages: UseChatHelpers['messages']): Message[] =>

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/conversational_chain.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/conversational_chain.test.ts
@@ -5,13 +5,16 @@
  * 2.0.
  */
 
-import type { Client } from '@elastic/elasticsearch';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { FakeListChatModel, FakeStreamingLLM } from '@langchain/core/utils/testing';
-import { createAssist as Assist } from '../utils/assist';
-import { ConversationalChain, contextLimitCheck } from './conversational_chain';
+
+import type { Client } from '@elastic/elasticsearch';
+
 import { ChatMessage, MessageRole } from '../types';
+import { createAssist as Assist } from '../utils/assist';
+
+import { ConversationalChain, contextLimitCheck } from './conversational_chain';
 
 describe('conversational chain', () => {
   beforeEach(() => {

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/conversational_chain.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/conversational_chain.ts
@@ -5,29 +5,32 @@
  * 2.0.
  */
 
-import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { DataStreamString } from '@ai-sdk/ui-utils';
 import { Document } from '@langchain/core/documents';
+import { BaseLanguageModel } from '@langchain/core/language_models/base';
+import { BaseMessage } from '@langchain/core/messages';
+import { HumanMessage, AIMessage } from '@langchain/core/messages';
+import { StringOutputParser } from '@langchain/core/output_parsers';
 import {
   ChatPromptTemplate,
   PromptTemplate,
   SystemMessagePromptTemplate,
 } from '@langchain/core/prompts';
 import { Runnable, RunnableLambda, RunnableSequence } from '@langchain/core/runnables';
-import { StringOutputParser } from '@langchain/core/output_parsers';
 import { createDataStream, LangChainAdapter } from 'ai';
 import type { DataStreamWriter } from 'ai';
-import type { DataStreamString } from '@ai-sdk/ui-utils';
-import { BaseLanguageModel } from '@langchain/core/language_models/base';
-import { BaseMessage } from '@langchain/core/messages';
-import { HumanMessage, AIMessage } from '@langchain/core/messages';
+
+import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
 import { ChatMessage } from '../types';
-import { ElasticsearchRetriever } from './elasticsearch_retriever';
-import { renderTemplate } from '../utils/render_template';
 
 import { AssistClient } from '../utils/assist';
 import { getCitations } from '../utils/get_citations';
-import { getTokenEstimate, getTokenEstimateFromMessages } from './token_tracking';
+import { renderTemplate } from '../utils/render_template';
+
+import { ElasticsearchRetriever } from './elasticsearch_retriever';
 import { ContextLimitError } from './errors';
+import { getTokenEstimate, getTokenEstimateFromMessages } from './token_tracking';
 
 interface RAGOptions {
   index: string;

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/elasticsearch_retriever.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/elasticsearch_retriever.ts
@@ -5,14 +5,16 @@
  * 2.0.
  */
 
-import { BaseRetriever, type BaseRetrieverInput } from '@langchain/core/retrievers';
 import { Document } from '@langchain/core/documents';
+import { BaseRetriever, type BaseRetrieverInput } from '@langchain/core/retrievers';
+
 import { Client } from '@elastic/elasticsearch';
 import {
   AggregationsAggregate,
   SearchHit,
   SearchResponse,
 } from '@elastic/elasticsearch/lib/api/types';
+
 import { getValueForSelectedField } from '../utils/get_value_for_selected_field';
 
 export interface ElasticsearchRetrieverInput extends BaseRetrieverInput {

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/fetch_query_source_fields.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/fetch_query_source_fields.test.ts
@@ -29,6 +29,7 @@ import {
   DENSE_PIPELINE_FIELD_CAPS,
   DENSE_OLD_PIPELINE_DOCS,
 } from '../../__mocks__/fetch_query_source_fields.mock';
+
 import {
   fetchFields,
   getModelIdFields,

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/fetch_query_source_fields.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/fetch_query_source_fields.ts
@@ -14,6 +14,7 @@ import {
 } from '@elastic/elasticsearch/lib/api/types';
 
 import { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
+
 import { IndicesQuerySourceFields } from '../types';
 
 interface FieldModelId {

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/get_chat_params.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/get_chat_params.test.ts
@@ -5,17 +5,20 @@
  * 2.0.
  */
 
-import { getChatParams } from './get_chat_params';
+import { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
+import { KibanaRequest, Logger } from '@kbn/core/server';
 import { ActionsClientChatOpenAI, ActionsClientSimpleChatModel } from '@kbn/langchain/server';
+
 import {
   OPENAI_CONNECTOR_ID,
   BEDROCK_CONNECTOR_ID,
   GEMINI_CONNECTOR_ID,
   INFERENCE_CONNECTOR_ID,
 } from '@kbn/stack-connectors-plugin/public/common';
+
 import { Prompt, QuestionRewritePrompt } from '../../common/prompt';
-import { KibanaRequest, Logger } from '@kbn/core/server';
-import { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
+
+import { getChatParams } from './get_chat_params';
 
 jest.mock('@kbn/langchain/server', () => {
   const original = jest.requireActual('@kbn/langchain/server');

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/get_chat_params.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/get_chat_params.ts
@@ -5,20 +5,22 @@
  * 2.0.
  */
 
-import { OPENAI_CONNECTOR_ID } from '@kbn/stack-connectors-plugin/common/openai/constants';
-import { v4 as uuidv4 } from 'uuid';
-import { BEDROCK_CONNECTOR_ID } from '@kbn/stack-connectors-plugin/common/bedrock/constants';
-import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
-import type { KibanaRequest, Logger } from '@kbn/core/server';
 import { BaseLanguageModel } from '@langchain/core/language_models/base';
+import { v4 as uuidv4 } from 'uuid';
+
+import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
 import type { Connector } from '@kbn/actions-plugin/server/application/connector/types';
+import type { KibanaRequest, Logger } from '@kbn/core/server';
 import {
   ActionsClientChatOpenAI,
   ActionsClientSimpleChatModel,
   getDefaultArguments,
 } from '@kbn/langchain/server';
+import { BEDROCK_CONNECTOR_ID } from '@kbn/stack-connectors-plugin/common/bedrock/constants';
 import { GEMINI_CONNECTOR_ID } from '@kbn/stack-connectors-plugin/common/gemini/constants';
 import { INFERENCE_CONNECTOR_ID } from '@kbn/stack-connectors-plugin/common/inference/constants';
+import { OPENAI_CONNECTOR_ID } from '@kbn/stack-connectors-plugin/common/openai/constants';
+
 import { Prompt, QuestionRewritePrompt } from '../../common/prompt';
 
 export const getChatParams = async (

--- a/x-pack/solutions/search/plugins/search_playground/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/plugin.ts
@@ -15,15 +15,16 @@ import {
 } from '@kbn/core/server';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
 
+import { PLUGIN_ID, PLUGIN_NAME } from '../common';
+
 import { sendMessageEvent } from './analytics/events';
+import { defineRoutes } from './routes';
 import {
   SearchPlaygroundPluginSetup,
   SearchPlaygroundPluginSetupDependencies,
   SearchPlaygroundPluginStart,
   SearchPlaygroundPluginStartDependencies,
 } from './types';
-import { defineRoutes } from './routes';
-import { PLUGIN_ID, PLUGIN_NAME } from '../common';
 
 export class SearchPlaygroundPlugin
   implements

--- a/x-pack/solutions/search/plugins/search_playground/server/routes.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/routes.test.ts
@@ -5,14 +5,16 @@
  * 2.0.
  */
 
-import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { MockRouter } from '../__mocks__/router.mock';
+
 import { RequestHandlerContext } from '@kbn/core/server';
 import { coreMock } from '@kbn/core/server/mocks';
-import { MockRouter } from '../__mocks__/router.mock';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+
 import { ConversationalChain } from './lib/conversational_chain';
+import { ContextLimitError } from './lib/errors';
 import { getChatParams } from './lib/get_chat_params';
 import { createRetriever, defineRoutes } from './routes';
-import { ContextLimitError } from './lib/errors';
 
 jest.mock('./lib/get_chat_params', () => ({
   getChatParams: jest.fn(),

--- a/x-pack/solutions/search/plugins/search_playground/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/routes.ts
@@ -6,26 +6,30 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import type { Logger } from '@kbn/logging';
 import { IRouter, StartServicesAccessor } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
+import type { Logger } from '@kbn/logging';
+
 import { PLUGIN_ID } from '../common';
+
+import { isNotNullish } from '../common/is_not_nullish';
+
+import { MODELS } from '../common/models';
+
 import { sendMessageEvent, SendMessageEventData } from './analytics/events';
-import { fetchFields } from './lib/fetch_query_source_fields';
-import { AssistClientOptionsWithClient, createAssist as Assist } from './utils/assist';
 import { ConversationalChain } from './lib/conversational_chain';
-import { errorHandler } from './utils/error_handler';
-import { handleStreamResponse } from './utils/handle_stream_response';
+import { ContextLimitError } from './lib/errors';
+import { fetchIndices } from './lib/fetch_indices';
+import { fetchFields } from './lib/fetch_query_source_fields';
+import { getChatParams } from './lib/get_chat_params';
 import {
   APIRoutes,
   SearchPlaygroundPluginStart,
   SearchPlaygroundPluginStartDependencies,
 } from './types';
-import { getChatParams } from './lib/get_chat_params';
-import { fetchIndices } from './lib/fetch_indices';
-import { isNotNullish } from '../common/is_not_nullish';
-import { MODELS } from '../common/models';
-import { ContextLimitError } from './lib/errors';
+import { AssistClientOptionsWithClient, createAssist as Assist } from './utils/assist';
+import { errorHandler } from './utils/error_handler';
+import { handleStreamResponse } from './utils/handle_stream_response';
 
 export function createRetriever(esQuery: string) {
   return (question: string) => {

--- a/x-pack/solutions/search/plugins/search_playground/server/utils/get_citations.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/utils/get_citations.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { Document } from '@langchain/core/documents';
+
 import { getCitations } from './get_citations';
 
 describe('getCitations', () => {

--- a/x-pack/solutions/search/plugins/search_playground/server/utils/get_value_for_selected_field.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/utils/get_value_for_selected_field.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import { get, has } from 'lodash';
+
+import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 
 export const getValueForSelectedField = (hit: SearchHit, path: string): string => {
   if (!hit) {

--- a/x-pack/solutions/search/plugins/search_playground/server/utils/stream_factory.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/utils/stream_factory.test.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-import { streamFactory } from './stream_factory';
-import { Logger } from '@kbn/logging';
 import { PassThrough } from 'stream';
+
+import { Logger } from '@kbn/logging';
+
+import { streamFactory } from './stream_factory';
 
 describe('streamFactory', () => {
   it('should create a stream with the correct initial state', () => {

--- a/x-pack/solutions/search/plugins/search_playground/server/utils/stream_factory.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/utils/stream_factory.ts
@@ -10,11 +10,11 @@
 // - removed support for ndjson
 // - improved the cloud proxy buffer to work for our use case (works for newline string chunks vs ndjson only)
 
+import { repeat } from 'lodash';
 import { PassThrough } from 'stream';
 
-import type { Logger } from '@kbn/logging';
 import type { ResponseHeaders } from '@kbn/core-http-server';
-import { repeat } from 'lodash';
+import type { Logger } from '@kbn/logging';
 
 const DELIMITER = `
 `;

--- a/x-pack/solutions/search/plugins/search_solution/search_navigation/public/classic_navigation.ts
+++ b/x-pack/solutions/search/plugins/search_solution/search_navigation/public/classic_navigation.ts
@@ -6,9 +6,10 @@
  */
 
 import { type MouseEvent } from 'react';
-import { i18n } from '@kbn/i18n';
+
 import type { CoreStart, ScopedHistory } from '@kbn/core/public';
 import type { ChromeNavLink, EuiSideNavItemTypeEnhanced } from '@kbn/core-chrome-browser';
+import { i18n } from '@kbn/i18n';
 import type { SolutionNavProps } from '@kbn/shared-ux-page-solution-nav';
 
 import type { ClassicNavItem, ClassicNavItemDeepLink, ClassicNavigationFactoryFn } from './types';

--- a/x-pack/solutions/search/plugins/search_solution/search_navigation/public/index.ts
+++ b/x-pack/solutions/search/plugins/search_solution/search_navigation/public/index.ts
@@ -6,6 +6,7 @@
  */
 
 import type { PluginInitializerContext } from '@kbn/core-plugins-browser';
+
 import { SearchNavigationPlugin } from './plugin';
 
 export function plugin(initializerContext: PluginInitializerContext) {

--- a/x-pack/solutions/search/plugins/search_solution/search_navigation/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_solution/search_navigation/public/plugin.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { Subscription } from 'rxjs';
+
 import type {
   CoreSetup,
   CoreStart,
@@ -12,10 +14,10 @@ import type {
   PluginInitializerContext,
   ScopedHistory,
 } from '@kbn/core/public';
-import type { Subscription } from 'rxjs';
 import type { ChromeBreadcrumb, ChromeStyle } from '@kbn/core-chrome-browser';
 import { i18n } from '@kbn/i18n';
 import type { Logger } from '@kbn/logging';
+
 import type {
   SearchNavigationPluginSetup,
   SearchNavigationPluginStart,

--- a/x-pack/solutions/search/plugins/search_solution/search_navigation/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_solution/search_navigation/public/types.ts
@@ -6,8 +6,9 @@
  */
 
 import type { ReactNode } from 'react';
-import type { AppDeepLinkId, ChromeBreadcrumb } from '@kbn/core-chrome-browser';
+
 import type { CoreStart, ScopedHistory } from '@kbn/core/public';
+import type { AppDeepLinkId, ChromeBreadcrumb } from '@kbn/core-chrome-browser';
 import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
 import type { SolutionNavProps } from '@kbn/shared-ux-page-solution-nav';
 

--- a/x-pack/solutions/search/plugins/search_synonyms/public/application.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/application.tsx
@@ -7,14 +7,17 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { CoreStart } from '@kbn/core/public';
-import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
-import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import { I18nProvider } from '@kbn/i18n-react';
-import { Route, Router, Routes } from '@kbn/shared-ux-router';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { AppPluginStartDependencies } from './types';
+
+import { CoreStart } from '@kbn/core/public';
+import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
+import { Route, Router, Routes } from '@kbn/shared-ux-router';
+
 import { SearchSynonymsOverview } from './components/overview/overview';
+import { AppPluginStartDependencies } from './types';
 
 const queryClient = new QueryClient({});
 export const renderApp = async (

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/empty_prompt/empty_prompt.test.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/empty_prompt/empty_prompt.test.tsx
@@ -7,9 +7,11 @@
 
 import React from 'react';
 
-import { EmptyPrompt } from './empty_prompt';
 import { render, screen } from '@testing-library/react';
+
 import { I18nProvider } from '@kbn/i18n-react';
+
+import { EmptyPrompt } from './empty_prompt';
 
 jest.mock('../../../common/doc_links', () => ({
   docLinks: {

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/empty_prompt/empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/empty_prompt/empty_prompt.tsx
@@ -7,6 +7,8 @@
 
 import React from 'react';
 
+import { css } from '@emotion/react';
+
 import {
   EuiButton,
   EuiFlexGrid,
@@ -22,7 +24,7 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { css } from '@emotion/react';
+
 import { docLinks } from '../../../common/doc_links';
 
 export const EmptyPrompt: React.FC = () => {

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/overview/overview.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/overview/overview.tsx
@@ -7,12 +7,13 @@
 
 import React, { useMemo } from 'react';
 
-import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { EuiLoadingSpinner } from '@elastic/eui';
-import { useKibana } from '../../hooks/use_kibana';
-import { SynonymSets } from '../synonym_sets/synonym_sets';
+import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+
 import { useFetchSynonymsSets } from '../../hooks/use_fetch_synonyms_sets';
+import { useKibana } from '../../hooks/use_kibana';
 import { EmptyPrompt } from '../empty_prompt/empty_prompt';
+import { SynonymSets } from '../synonym_sets/synonym_sets';
 
 export const SearchSynonymsOverview = () => {
   const {

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/delete_synonyms_set_modal.test.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/delete_synonyms_set_modal.test.tsx
@@ -7,10 +7,12 @@
 
 import React from 'react';
 
-import { DeleteSynonymsSetModal } from './delete_synonyms_set_modal';
-import { act, fireEvent, render, screen } from '@testing-library/react';
-import { useDeleteSynonymsSet } from '../../hooks/use_delete_synonyms_set';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { useDeleteSynonymsSet } from '../../hooks/use_delete_synonyms_set';
+
+import { DeleteSynonymsSetModal } from './delete_synonyms_set_modal';
 
 jest.mock('../../hooks/use_delete_synonyms_set', () => ({
   useDeleteSynonymsSet: jest.fn(() => ({

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/delete_synonyms_set_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/delete_synonyms_set_modal.tsx
@@ -9,6 +9,7 @@ import React, { useState } from 'react';
 
 import { EuiCodeBlock, EuiConfirmModal } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+
 import { useDeleteSynonymsSet } from '../../hooks/use_delete_synonyms_set';
 
 export interface DeleteSynonymsSetModalProps {

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/synonym_sets.test.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/synonym_sets.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 
 import { render, screen } from '@testing-library/react';
+
 import { SynonymSets } from './synonym_sets';
 
 jest.mock('../../hooks/use_fetch_synonyms_sets', () => ({

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/synonym_sets.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/synonym_sets.tsx
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
+import React, { useState } from 'react';
+
 import { SynonymsGetSynonymsSetsSynonymsSetItem } from '@elastic/elasticsearch/lib/api/types';
 import { EuiBasicTable, EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useState } from 'react';
+
 import { DEFAULT_PAGE_VALUE, paginationToPage } from '../../../common/pagination';
 import { useFetchSynonymsSets } from '../../hooks/use_fetch_synonyms_sets';
+
 import { DeleteSynonymsSetModal } from './delete_synonyms_set_modal';
 
 export const SynonymSets = () => {

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_delete_synonyms_set.test.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_delete_synonyms_set.test.tsx
@@ -7,10 +7,11 @@
 
 import React from 'react';
 
-import { renderHook, waitFor } from '@testing-library/react';
-import { useKibana } from './use_kibana';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
 import { useDeleteSynonymsSet } from './use_delete_synonyms_set';
+import { useKibana } from './use_kibana';
 
 jest.mock('./use_kibana');
 

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_delete_synonyms_set.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_delete_synonyms_set.ts
@@ -6,8 +6,10 @@
  */
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { i18n } from '@kbn/i18n';
 import { KibanaServerError } from '@kbn/kibana-utils-plugin/common';
+
 import { useKibana } from './use_kibana';
 
 interface MutationArgs {

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_synonyms_sets.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_synonyms_sets.ts
@@ -6,9 +6,12 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+
 import type { SynonymsGetSynonymsSetsSynonymsSetItem } from '@elastic/elasticsearch/lib/api/types';
-import { DEFAULT_PAGE_VALUE, Page, Paginate } from '../../common/pagination';
+
 import { APIRoutes } from '../../common/api_routes';
+import { DEFAULT_PAGE_VALUE, Page, Paginate } from '../../common/pagination';
+
 import { useKibana } from './use_kibana';
 
 export const useFetchSynonymsSets = (page: Page = DEFAULT_PAGE_VALUE) => {

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_kibana.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_kibana.ts
@@ -6,6 +6,7 @@
  */
 
 import { useKibana as _useKibana } from '@kbn/kibana-react-plugin/public';
+
 import { AppServicesContext } from '../types';
 
 export const useKibana = () => _useKibana<AppServicesContext>();

--- a/x-pack/solutions/search/plugins/search_synonyms/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/plugin.ts
@@ -6,15 +6,18 @@
  */
 
 import type { CoreSetup, Plugin, AppMountParameters, CoreStart } from '@kbn/core/public';
+
 import { PLUGIN_ID, PLUGIN_NAME, PLUGIN_TITLE } from '../common';
+
+import { docLinks } from '../common/doc_links';
+import { SYNONYMS_UI_FLAG } from '../common/ui_flags';
+
 import {
   AppPluginSetupDependencies,
   AppPluginStartDependencies,
   SearchSynonymsPluginSetup,
   SearchSynonymsPluginStart,
 } from './types';
-import { SYNONYMS_UI_FLAG } from '../common/ui_flags';
-import { docLinks } from '../common/doc_links';
 
 export class SearchSynonymsPlugin
   implements Plugin<SearchSynonymsPluginSetup, SearchSynonymsPluginStart>

--- a/x-pack/solutions/search/plugins/search_synonyms/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/types.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { SearchNavigationPluginStart } from '@kbn/search-navigation/public';
-import { AppMountParameters, CoreStart } from '@kbn/core/public';
 import type { ConsolePluginStart } from '@kbn/console-plugin/public';
+import { AppMountParameters, CoreStart } from '@kbn/core/public';
+import { SearchNavigationPluginStart } from '@kbn/search-navigation/public';
 
 export * from '../common/types';
 export interface AppPluginStartDependencies {

--- a/x-pack/solutions/search/plugins/search_synonyms/server/lib/delete_synonyms_set.test.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/lib/delete_synonyms_set.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { ElasticsearchClient } from '@kbn/core/server';
+
 import { deleteSynonymsSet } from './delete_synonyms_set';
 
 describe('delete synonyms sets lib function', () => {

--- a/x-pack/solutions/search/plugins/search_synonyms/server/lib/fetch_synonym_sets.test.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/lib/fetch_synonym_sets.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { ElasticsearchClient } from '@kbn/core/server';
+
 import { fetchSynonymSets } from './fetch_synonym_sets';
 
 describe('fetch synonym sets lib function', () => {

--- a/x-pack/solutions/search/plugins/search_synonyms/server/lib/fetch_synonym_sets.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/lib/fetch_synonym_sets.ts
@@ -7,6 +7,7 @@
 
 import { SynonymsGetSynonymsSetsSynonymsSetItem } from '@elastic/elasticsearch/lib/api/types';
 import { ElasticsearchClient } from '@kbn/core/server';
+
 import { Page, Paginate, pageToPagination } from '../../common/pagination';
 
 export const fetchSynonymSets = async (

--- a/x-pack/solutions/search/plugins/search_synonyms/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/plugin.ts
@@ -15,14 +15,15 @@ import {
 } from '@kbn/core/server';
 
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
+
+import { PLUGIN_ID, PLUGIN_TITLE } from '../common';
+
+import { defineRoutes } from './routes';
 import {
   SearchSynonymsPluginSetup,
   SearchSynonymsPluginSetupDependencies,
   SearchSynonymsPluginStart,
 } from './types';
-
-import { defineRoutes } from './routes';
-import { PLUGIN_ID, PLUGIN_TITLE } from '../common';
 
 export class SearchSynonymsPlugin
   implements Plugin<SearchSynonymsPluginSetup, SearchSynonymsPluginStart, {}, {}>

--- a/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
@@ -5,14 +5,16 @@
  * 2.0.
  */
 
-import { IRouter, Logger } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
+import { IRouter, Logger } from '@kbn/core/server';
+
 import { APIRoutes } from '../common/api_routes';
 
-import { errorHandler } from './utils/error_handler';
-import { fetchSynonymSets } from './lib/fetch_synonym_sets';
 import { DEFAULT_PAGE_VALUE } from '../common/pagination';
+
 import { deleteSynonymsSet } from './lib/delete_synonyms_set';
+import { fetchSynonymSets } from './lib/fetch_synonym_sets';
+import { errorHandler } from './utils/error_handler';
 
 export function defineRoutes({ logger, router }: { logger: Logger; router: IRouter }) {
   router.get(

--- a/x-pack/solutions/search/plugins/search_synonyms/server/types.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/types.ts
@@ -6,6 +6,7 @@
  */
 
 import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+
 export * from '../common/types';
 
 export interface SearchSynonymsPluginSetupDependencies {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/api_key/api_key.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/api_key/api_key.tsx
@@ -5,6 +5,14 @@
  * 2.0.
  */
 
+import React, { useEffect, useState } from 'react';
+
+import { css } from '@emotion/react';
+
+import {
+  SecurityCreateApiKeyResponse,
+  SecurityUpdateApiKeyResponse,
+} from '@elastic/elasticsearch/lib/api/types';
 import {
   EuiBadge,
   EuiButton,
@@ -19,18 +27,16 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { css } from '@emotion/react';
-import React, { useEffect, useState } from 'react';
+
 import { ApiKeySelectableTokenField } from '@kbn/security-api-key-management';
-import {
-  SecurityCreateApiKeyResponse,
-  SecurityUpdateApiKeyResponse,
-} from '@elastic/elasticsearch/lib/api/types';
-import { useKibanaServices } from '../../hooks/use_kibana';
+
 import { MANAGEMENT_API_KEYS } from '../../../../common/routes';
-import { CreateApiKeyFlyout } from './create_api_key_flyout';
-import './api_key.scss';
 import { useGetApiKeys } from '../../hooks/api/use_api_key';
+import { useKibanaServices } from '../../hooks/use_kibana';
+
+import { CreateApiKeyFlyout } from './create_api_key_flyout';
+
+import './api_key.scss';
 
 function isCreatedResponse(
   value: SecurityCreateApiKeyResponse | SecurityUpdateApiKeyResponse
@@ -59,7 +65,6 @@ export const ApiKeyPanel = ({ setClientApiKey }: { setClientApiKey: (value: stri
       setClientApiKey(apiKey.encoded);
       setIsFlyoutOpen(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiKey]);
 
   return (

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/api_key/create_api_key_flyout.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/api_key/create_api_key_flyout.tsx
@@ -6,12 +6,12 @@
  */
 import React from 'react';
 
-import { ApiKeyFlyout } from '@kbn/security-api-key-management';
 import {
   SecurityCreateApiKeyResponse,
   SecurityUpdateApiKeyResponse,
 } from '@elastic/elasticsearch/lib/api/types';
 import { AuthenticatedUser } from '@kbn/core/public';
+import { ApiKeyFlyout } from '@kbn/security-api-key-management';
 
 const DEFAULT_ROLE_DESCRIPTORS = `{
   "serverless_search": {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/badge_list.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/badge_list.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiBadgeGroup, EuiBadge } from '@elastic/eui';
 
 export interface BadgeListProps {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/common/decorative_horizontal_stepper.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/common/decorative_horizontal_stepper.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiStepsHorizontal, EuiStepsHorizontalProps } from '@elastic/eui';
+
 import { css } from '@emotion/react';
+
+import { EuiStepsHorizontal, EuiStepsHorizontalProps } from '@elastic/eui';
 
 interface DecorativeHorizontalStepperProps {
   stepCount?: number;

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/conector_scheduling_tab/connector_scheduling.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/conector_scheduling_tab/connector_scheduling.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 import React, { useState } from 'react';
+
 import { Connector, ConnectorStatus } from '@kbn/search-connectors';
 import { ConnectorSchedulingComponent } from '@kbn/search-connectors/components/scheduling/connector_scheduling';
+
 import { useConnectorScheduling } from '../../../hooks/api/use_update_connector_scheduling';
 
 interface ConnectorSchedulingPanels {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/api_key_panel.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/api_key_panel.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import {
   EuiPanel,
   EuiFlexGroup,
@@ -18,12 +20,13 @@ import {
   EuiCodeBlock,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { Connector, CONNECTORS_INDEX } from '@kbn/search-connectors';
-import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { Connector, CONNECTORS_INDEX } from '@kbn/search-connectors';
+
 import { OPTIONAL_LABEL } from '../../../../../common/i18n_string';
-import { useCreateApiKey } from '../../../hooks/api/use_create_api_key';
 import { useGetApiKeys } from '../../../hooks/api/use_api_key';
+import { useCreateApiKey } from '../../../hooks/api/use_create_api_key';
+
 interface ApiKeyPanelProps {
   connector: Connector;
 }

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connection_details_panel.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connection_details_panel.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import { EuiPanel, EuiTitle, EuiCode, EuiSpacer, EuiText, EuiCodeBlock } from '@elastic/eui';
-import { ConnectorStatus } from '@kbn/search-connectors';
 import React from 'react';
+
+import { EuiPanel, EuiTitle, EuiCode, EuiSpacer, EuiText, EuiCodeBlock } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { ConnectorStatus } from '@kbn/search-connectors';
+
 import { useElasticsearchUrl } from '../../../hooks/use_elastisearch_url';
 
 interface ConnectionDetailsProps {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_config_fields.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_config_fields.tsx
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle, EuiLink } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
-import { i18n } from '@kbn/i18n';
-import { Connector, ConnectorConfigurationComponent } from '@kbn/search-connectors';
-import { useQueryClient } from '@tanstack/react-query';
 import React, { useEffect } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle, EuiLink } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { Connector, ConnectorConfigurationComponent } from '@kbn/search-connectors';
+
 import { docLinks } from '../../../../../common/doc_links';
 import { useConnector } from '../../../hooks/api/use_connector';
 import { useEditConnectorConfiguration } from '../../../hooks/api/use_connector_configuration';

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_config_panels.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_config_panels.tsx
@@ -5,12 +5,16 @@
  * 2.0.
  */
 
+import React, { useEffect } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+
 import { EuiPanel, EuiSpacer } from '@elastic/eui';
 import { Connector, ConnectorConfigurationComponent } from '@kbn/search-connectors';
-import { useQueryClient } from '@tanstack/react-query';
-import React, { useEffect } from 'react';
+
 import { useConnector } from '../../../hooks/api/use_connector';
 import { useEditConnectorConfiguration } from '../../../hooks/api/use_connector_configuration';
+
 import { ApiKeyPanel } from './api_key_panel';
 import { ConnectionDetails } from './connection_details_panel';
 import { ConnectorIndexnamePanel } from './connector_index_name_panel';

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_configuration.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_configuration.tsx
@@ -6,7 +6,6 @@
  */
 import React, { useEffect, useState } from 'react';
 
-import { Connector, ConnectorStatus } from '@kbn/search-connectors';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -17,18 +16,22 @@ import {
   EuiTabbedContentTab,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { Connector, ConnectorStatus } from '@kbn/search-connectors';
+
 import {
   CONFIGURATION_LABEL,
   OVERVIEW_LABEL,
   SCHEDULING_LABEL,
 } from '../../../../../common/i18n_string';
-import { ConnectorLinkElasticsearch } from './connector_link';
-import { ConnectorConfigFields } from './connector_config_fields';
-import { ConnectorIndexName } from './connector_index_name';
-import { ConnectorConfigurationPanels } from './connector_config_panels';
-import { ConnectorOverview } from './connector_overview';
-import { ConnectorScheduling } from '../conector_scheduling_tab/connector_scheduling';
+
 import { useConnectors } from '../../../hooks/api/use_connectors';
+import { ConnectorScheduling } from '../conector_scheduling_tab/connector_scheduling';
+
+import { ConnectorConfigFields } from './connector_config_fields';
+import { ConnectorConfigurationPanels } from './connector_config_panels';
+import { ConnectorIndexName } from './connector_index_name';
+import { ConnectorLinkElasticsearch } from './connector_link';
+import { ConnectorOverview } from './connector_overview';
 
 interface ConnectorConfigurationProps {
   connector: Connector;

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_index_name.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_index_name.tsx
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import React, { useState } from 'react';
+
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+
 import {
   EuiButton,
   EuiFlexGroup,
@@ -17,19 +21,20 @@ import {
   EuiCode,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { Connector, ConnectorStatus } from '@kbn/search-connectors';
-import React, { useState } from 'react';
-import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { isValidIndexName } from '../../../../utils/validate_index_name';
+import { Connector, ConnectorStatus } from '@kbn/search-connectors';
+
+import { DEFAULT_INGESTION_PIPELINE } from '../../../../../common';
+import { docLinks } from '../../../../../common/doc_links';
 import { SAVE_LABEL } from '../../../../../common/i18n_string';
+import { isValidIndexName } from '../../../../utils/validate_index_name';
 import { useConnector } from '../../../hooks/api/use_connector';
 import { useKibanaServices } from '../../../hooks/use_kibana';
+
 import { ApiKeyPanel } from './api_key_panel';
 import { ConnectorIndexNameForm } from './connector_index_name_form';
 import { SyncScheduledCallOut } from './sync_scheduled_callout';
-import { docLinks } from '../../../../../common/doc_links';
-import { DEFAULT_INGESTION_PIPELINE } from '../../../../../common';
+
 interface ConnectorIndexNameProps {
   connector: Connector;
   isDisabled?: boolean;

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_index_name_form.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_index_name_form.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
+import React, { useEffect, useState } from 'react';
+
 import { EuiForm, EuiFormRow, EuiComboBox } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useEffect, useState } from 'react';
+
 import { isValidIndexName } from '../../../../utils/validate_index_name';
 import { useIndexNameSearch } from '../../../hooks/api/use_index_name_search';
 

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_index_name_panel.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_index_name_panel.tsx
@@ -5,14 +5,18 @@
  * 2.0.
  */
 
+import React, { useEffect, useState } from 'react';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { EuiFlexGroup, EuiFlexItem, EuiButton, EuiSpacer } from '@elastic/eui';
 import { Connector } from '@kbn/search-connectors';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import React, { useEffect, useState } from 'react';
-import { isValidIndexName } from '../../../../utils/validate_index_name';
+
 import { UPDATE_LABEL } from '../../../../../common/i18n_string';
+import { isValidIndexName } from '../../../../utils/validate_index_name';
 import { useConnector } from '../../../hooks/api/use_connector';
 import { useKibanaServices } from '../../../hooks/use_kibana';
+
 import { ConnectorIndexNameForm } from './connector_index_name_form';
 
 interface ConnectorIndexNamePanelProps {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_link.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_link.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import {
   EuiButton,
   EuiCallOut,
@@ -16,9 +18,10 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ConnectorStatus } from '@kbn/search-connectors';
-import React from 'react';
+
 import { docLinks } from '../../../../../common/doc_links';
 import { useAssetBasePath } from '../../../hooks/use_asset_base_path';
+
 import { ConnectionDetails } from './connection_details_panel';
 
 interface ConnectorLinkElasticsearchProps {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_overview.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_overview.tsx
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import React, { useState } from 'react';
+
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+
 import { EuiButton, EuiSpacer, Pagination } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import {
@@ -13,11 +17,11 @@ import {
   pageToPagination,
   SyncJobsTable,
 } from '@kbn/search-connectors';
-import { useQueryClient, useMutation } from '@tanstack/react-query';
-import React, { useState } from 'react';
+
 import { useConnector } from '../../../hooks/api/use_connector';
 import { useSyncJobs } from '../../../hooks/api/use_sync_jobs';
 import { useKibanaServices } from '../../../hooks/use_kibana';
+
 import { SyncScheduledCallOut } from './sync_scheduled_callout';
 
 interface ConnectorOverviewProps {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_privileges_callout.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/connector_privileges_callout.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
-import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 import React from 'react';
+
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
 import { useConnectors } from '../../../hooks/api/use_connectors';
 
 export const ConnectorPrivilegesCallout: React.FC = () => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/sync_scheduled_callout.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_config/sync_scheduled_callout.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import { EuiCallOut, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
 
 export const SyncScheduledCallOut: React.FC = () => {
   return (

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_icon.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connector_icon.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiToolTip, EuiIcon } from '@elastic/eui';
 
 export const ConnectorIcon: React.FC<{ name: string; serviceType: string; iconPath?: string }> = ({

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connectors_table.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/connectors_table.tsx
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import React, { useEffect, useState } from 'react';
+
+import { generatePath } from 'react-router-dom';
+
 import {
   copyToClipboard,
   Criteria,
@@ -34,17 +38,17 @@ import {
   syncStatusToColor,
   syncStatusToText,
 } from '@kbn/search-connectors';
-import React, { useEffect, useState } from 'react';
-import { generatePath } from 'react-router-dom';
+
 import {
   CONNECTORS_LABEL,
   COPY_CONNECTOR_ID_LABEL,
   DELETE_CONNECTOR_LABEL,
 } from '../../../../common/i18n_string';
-import { useConnectors } from '../../hooks/api/use_connectors';
-import { useConnectorTypes } from '../../hooks/api/use_connector_types';
-import { useKibanaServices } from '../../hooks/use_kibana';
 import { EDIT_CONNECTOR_PATH } from '../../constants';
+import { useConnectorTypes } from '../../hooks/api/use_connector_types';
+import { useConnectors } from '../../hooks/api/use_connectors';
+import { useKibanaServices } from '../../hooks/use_kibana';
+
 import { DeleteConnectorModal } from './delete_connector_modal';
 
 export const ConnectorsTable: React.FC = () => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/delete_connector_modal.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/delete_connector_modal.tsx
@@ -5,11 +5,14 @@
  * 2.0.
  */
 
+import React, { useEffect, useState } from 'react';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { AcknowledgedResponseBase } from '@elastic/elasticsearch/lib/api/types';
 import { EuiConfirmModal, EuiFieldText, EuiForm, EuiFormRow } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { AcknowledgedResponseBase } from '@elastic/elasticsearch/lib/api/types';
-import { useMutation } from '@tanstack/react-query';
-import React, { useEffect, useState } from 'react';
+
 import { useKibanaServices } from '../../hooks/use_kibana';
 
 interface DeleteConnectorModalProps {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_connector.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_connector.tsx
@@ -4,6 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
 import {
   EuiButton,
   EuiButtonIcon,
@@ -17,24 +20,25 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
-import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { i18n } from '@kbn/i18n';
 import { copyToClipboard } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
 import {
   CONNECTOR_LABEL,
   COPY_CONNECTOR_ID_LABEL,
   DELETE_CONNECTOR_LABEL,
 } from '../../../../common/i18n_string';
-import { useKibanaServices } from '../../hooks/use_kibana';
-import { EditName } from './edit_name';
-import { EditServiceType } from './edit_service_type';
-import { EditDescription } from './edit_description';
-import { DeleteConnectorModal } from './delete_connector_modal';
-import { ConnectorConfiguration } from './connector_config/connector_configuration';
+
 import { useConnector } from '../../hooks/api/use_connector';
 import { useConnectors } from '../../hooks/api/use_connectors';
+import { useKibanaServices } from '../../hooks/use_kibana';
+
+import { ConnectorConfiguration } from './connector_config/connector_configuration';
 import { ConnectorPrivilegesCallout } from './connector_config/connector_privileges_callout';
+import { DeleteConnectorModal } from './delete_connector_modal';
+import { EditDescription } from './edit_description';
+import { EditName } from './edit_name';
+import { EditServiceType } from './edit_service_type';
 
 export const EditConnector: React.FC = () => {
   const [deleteModalIsOpen, setDeleteModalIsOpen] = useState(false);

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_description.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_description.tsx
@@ -5,9 +5,12 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
-import { css } from '@emotion/react';
 import React, { useEffect, useState } from 'react';
+
+import { css } from '@emotion/react';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import {
   EuiFlexItem,
   EuiFlexGroup,
@@ -18,11 +21,13 @@ import {
   EuiText,
   EuiLink,
 } from '@elastic/eui';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { i18n } from '@kbn/i18n';
 import { Connector } from '@kbn/search-connectors';
+
 import { CANCEL_LABEL, EDIT_LABEL, SAVE_LABEL } from '../../../../common/i18n_string';
-import { useKibanaServices } from '../../hooks/use_kibana';
 import { useConnector } from '../../hooks/api/use_connector';
+import { useKibanaServices } from '../../hooks/use_kibana';
 
 interface EditDescriptionProps {
   isDisabled?: boolean;

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_name.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_name.tsx
@@ -5,9 +5,12 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
-import { css } from '@emotion/react';
 import React, { useEffect, useState } from 'react';
+
+import { css } from '@emotion/react';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import {
   EuiFlexItem,
   EuiFlexGroup,
@@ -19,11 +22,13 @@ import {
   EuiFormLabel,
   EuiSpacer,
 } from '@elastic/eui';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { i18n } from '@kbn/i18n';
 import { Connector } from '@kbn/search-connectors';
+
 import { CANCEL_LABEL, CONNECTOR_LABEL, SAVE_LABEL } from '../../../../common/i18n_string';
-import { useKibanaServices } from '../../hooks/use_kibana';
 import { useConnector } from '../../hooks/api/use_connector';
+import { useKibanaServices } from '../../hooks/use_kibana';
 
 interface EditNameProps {
   isDisabled?: boolean;

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_service_type.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/edit_service_type.tsx
@@ -5,8 +5,11 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
 import React, { useMemo, useCallback } from 'react';
+
+import { css } from '@emotion/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import {
   EuiFlexItem,
   EuiFlexGroup,
@@ -20,19 +23,19 @@ import {
   EuiTextTruncate,
   EuiBadgeGroup,
 } from '@elastic/eui';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { i18n } from '@kbn/i18n';
+
 import { Connector as BaseConnector } from '@kbn/search-connectors';
-import { css } from '@emotion/react';
-import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 
 import { BETA_LABEL, TECH_PREVIEW_LABEL } from '../../../../common/i18n_string';
+import { useConnector } from '../../hooks/api/use_connector';
+import { useConnectorTypes } from '../../hooks/api/use_connector_types';
+import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 
 interface Connector extends BaseConnector {
   iconPath?: string;
 }
 import { useKibanaServices } from '../../hooks/use_kibana';
-import { useConnectorTypes } from '../../hooks/api/use_connector_types';
-import { useConnector } from '../../hooks/api/use_connector';
 
 interface EditServiceTypeProps {
   connector: Connector;

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/elastic_managed_connectors_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/elastic_managed_connectors_empty_prompt.tsx
@@ -6,15 +6,17 @@
  */
 
 import React from 'react';
+
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiIcon, EuiText } from '@elastic/eui';
+import { SERVERLESS_ES_CONNECTORS_ID } from '@kbn/deeplinks-search/constants';
 import { i18n } from '@kbn/i18n';
 import { ConnectorIcon } from '@kbn/search-shared-ui';
 import { SearchEmptyPrompt, DecorativeHorizontalStepper } from '@kbn/search-shared-ui';
-import { SERVERLESS_ES_CONNECTORS_ID } from '@kbn/deeplinks-search/constants';
+
 import { BACK_LABEL, COMING_SOON_LABEL } from '../../../../common/i18n_string';
-import { useKibanaServices } from '../../hooks/use_kibana';
 import { useConnectorTypes } from '../../hooks/api/use_connector_types';
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
+import { useKibanaServices } from '../../hooks/use_kibana';
 
 export const ElasticManagedConnectorsEmptyPrompt: React.FC = () => {
   const connectorTypes = useConnectorTypes();

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/self_managed_connectors_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/self_managed_connectors_empty_prompt.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -16,18 +18,18 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ConnectorIcon } from '@kbn/search-shared-ui';
 import { SearchEmptyPrompt, DecorativeHorizontalStepper } from '@kbn/search-shared-ui';
+
 import { docLinks } from '../../../../common/doc_links';
-import { useKibanaServices } from '../../hooks/use_kibana';
+import { BACK_LABEL } from '../../../../common/i18n_string';
+import { ELASTIC_MANAGED_CONNECTOR_PATH, BASE_CONNECTORS_PATH } from '../../constants';
 import { useConnectorTypes } from '../../hooks/api/use_connector_types';
+import { useConnectors } from '../../hooks/api/use_connectors';
 import { useCreateConnector } from '../../hooks/api/use_create_connector';
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
-import { useConnectors } from '../../hooks/api/use_connectors';
-import { ELASTIC_MANAGED_CONNECTOR_PATH, BASE_CONNECTORS_PATH } from '../../constants';
-import { BACK_LABEL } from '../../../../common/i18n_string';
+import { useKibanaServices } from '../../hooks/use_kibana';
 
 export const SelfManagedConnectorsEmptyPrompt: React.FC = () => {
   const connectorTypes = useConnectorTypes();

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors_callout.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors_callout.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 import React from 'react';
+
 import { EuiButton, EuiCallOut, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { useCreateConnector } from '../hooks/api/use_create_connector';
 import { useConnectors } from '../hooks/api/use_connectors';
+import { useCreateConnector } from '../hooks/api/use_create_connector';
 
 export const ConnectorsCallout = () => {
   const { createConnector, isLoading } = useCreateConnector();

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors_elastic_managed.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors_elastic_managed.tsx
@@ -6,13 +6,17 @@
  */
 
 import React, { useMemo } from 'react';
+
 import { EuiLink, EuiPageTemplate, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { LEARN_MORE_LABEL } from '../../../common/i18n_string';
-import { ElasticManagedConnectorsEmptyPrompt } from './connectors/elastic_managed_connectors_empty_prompt';
-import { useKibanaServices } from '../hooks/use_kibana';
+
 import { docLinks } from '../../../common/doc_links';
+import { LEARN_MORE_LABEL } from '../../../common/i18n_string';
+
+import { useKibanaServices } from '../hooks/use_kibana';
+
+import { ElasticManagedConnectorsEmptyPrompt } from './connectors/elastic_managed_connectors_empty_prompt';
 
 export const ConnectorsElasticManaged = () => {
   const { console: consolePlugin } = useKibanaServices();

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors_ingestion.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors_ingestion.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -17,9 +19,8 @@ import {
 import { i18n } from '@kbn/i18n';
 import { GithubLink } from '@kbn/search-api-panels';
 
-import React from 'react';
-import { useCreateConnector } from '../hooks/api/use_create_connector';
 import { useConnectors } from '../hooks/api/use_connectors';
+import { useCreateConnector } from '../hooks/api/use_create_connector';
 
 export const ConnectorIngestionPanel: React.FC<{ assetBasePath: string }> = ({ assetBasePath }) => {
   const { createConnector } = useCreateConnector();

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors_overview.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors_overview.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import React, { useMemo, useState } from 'react';
+
 import {
   EuiButton,
   EuiCallOut,
@@ -17,19 +19,22 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React, { useMemo, useState } from 'react';
 
 import { GithubLink } from '@kbn/search-api-panels';
-import { SelfManagedConnectorsEmptyPrompt } from './connectors/self_managed_connectors_empty_prompt';
+
 import { docLinks } from '../../../common/doc_links';
+
 import { LEARN_MORE_LABEL } from '../../../common/i18n_string';
+import { BASE_CONNECTORS_PATH, ELASTIC_MANAGED_CONNECTOR_PATH } from '../constants';
 import { useConnectors } from '../hooks/api/use_connectors';
 import { useCreateConnector } from '../hooks/api/use_create_connector';
-import { useKibanaServices } from '../hooks/use_kibana';
-import { ConnectorsTable } from './connectors/connectors_table';
-import { ConnectorPrivilegesCallout } from './connectors/connector_config/connector_privileges_callout';
 import { useAssetBasePath } from '../hooks/use_asset_base_path';
-import { BASE_CONNECTORS_PATH, ELASTIC_MANAGED_CONNECTOR_PATH } from '../constants';
+import { useKibanaServices } from '../hooks/use_kibana';
+
+import { ConnectorPrivilegesCallout } from './connectors/connector_config/connector_privileges_callout';
+import { ConnectorsTable } from './connectors/connectors_table';
+
+import { SelfManagedConnectorsEmptyPrompt } from './connectors/self_managed_connectors_empty_prompt';
 
 const CALLOUT_KEY = 'search.connectors.ElasticManaged.ComingSoon.feedbackCallout';
 

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors_router.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors_router.tsx
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
-import { Route, Routes } from '@kbn/shared-ux-router';
 import React from 'react';
-import { EditConnector } from './connectors/edit_connector';
-import { ConnectorsOverview } from './connectors_overview';
-import { ConnectorsElasticManaged } from './connectors_elastic_managed';
+
+import { Route, Routes } from '@kbn/shared-ux-router';
+
 import { ELASTIC_MANAGED_CONNECTOR_PATH } from '../constants';
+
+import { EditConnector } from './connectors/edit_connector';
+import { ConnectorsElasticManaged } from './connectors_elastic_managed';
+import { ConnectorsOverview } from './connectors_overview';
 
 export const ConnectorsRouter: React.FC = () => {
   return (

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/elasticsearch_header.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/elasticsearch_header.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
+import React from 'react';
+
 import { EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
 
 export const ElasticsearchHeader = () => {
   return (

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/file_upload_callout.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/file_upload_callout.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 import React from 'react';
+
 import { EuiButton, EuiCallOut, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
-import { useKibanaServices } from '../hooks/use_kibana';
 import { FILE_UPLOAD_PATH } from '../constants';
+import { useKibanaServices } from '../hooks/use_kibana';
 
 export const FileUploadCallout = () => {
   const {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_documents/documents.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_documents/documents.tsx
@@ -7,13 +7,13 @@
 
 import React, { useEffect, useState } from 'react';
 
+import { i18n } from '@kbn/i18n';
 import {
   DocumentList,
   DocumentsOverview,
   INDEX_DOCUMENTS_META_DEFAULT,
 } from '@kbn/search-index-documents';
 
-import { i18n } from '@kbn/i18n';
 import { useIndexDocumentSearch } from '../../hooks/api/use_index_documents';
 import { useIndexMappings } from '../../hooks/api/use_index_mappings';
 

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_documents/documents_tab.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_documents/documents_tab.tsx
@@ -5,13 +5,17 @@
  * 2.0.
  */
 
-import { IndexDetailsTab } from '@kbn/index-management-plugin/common/constants';
 import React, { Suspense, lazy } from 'react';
-import { EuiLoadingSpinner } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { CoreStart } from '@kbn/core-lifecycle-browser';
+
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+import { EuiLoadingSpinner } from '@elastic/eui';
+import { CoreStart } from '@kbn/core-lifecycle-browser';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { IndexDetailsTab } from '@kbn/index-management-plugin/common/constants';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 
 import { ServerlessSearchPluginStartDependencies } from '../../../types';

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/api_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/api_empty_prompt.tsx
@@ -6,8 +6,7 @@
  */
 
 import React, { useMemo, useState } from 'react';
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
+
 import {
   EuiEmptyPrompt,
   EuiFlexItem,
@@ -22,6 +21,8 @@ import {
   EuiSteps,
 } from '@elastic/eui';
 import { EuiContainedStepProps } from '@elastic/eui/src/components/steps/steps';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import {
   CodeBox,
   getConsoleRequest,
@@ -31,21 +32,18 @@ import {
   LanguageDefinitionSnippetArguments,
 } from '@kbn/search-api-panels';
 
+import { DEFAULT_INGESTION_PIPELINE } from '../../../../common';
 import { BACK_LABEL } from '../../../../common/i18n_string';
 
-import { useAssetBasePath } from '../../hooks/use_asset_base_path';
-import { useKibanaServices } from '../../hooks/use_kibana';
-import { javaDefinition } from '../languages/java';
-import { languageDefinitions } from '../languages/languages';
-import { LanguageGrid } from '../languages/language_grid';
-
-import { useIngestPipelines } from '../../hooks/api/use_ingest_pipelines';
-import { DEFAULT_INGESTION_PIPELINE } from '../../../../common';
-
 import { API_KEY_PLACEHOLDER, CLOUD_ID_PLACEHOLDER } from '../../constants';
-
-import { ApiKeyPanel } from '../api_key/api_key';
+import { useIngestPipelines } from '../../hooks/api/use_ingest_pipelines';
+import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 import { useElasticsearchUrl } from '../../hooks/use_elastisearch_url';
+import { useKibanaServices } from '../../hooks/use_kibana';
+import { ApiKeyPanel } from '../api_key/api_key';
+import { javaDefinition } from '../languages/java';
+import { LanguageGrid } from '../languages/language_grid';
+import { languageDefinitions } from '../languages/languages';
 
 export interface APIIndexEmptyPromptProps {
   indexName: string;

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/connector_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/connector_empty_prompt.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiButtonEmpty, EuiPanel } from '@elastic/eui';
 
 import { BACK_LABEL } from '../../../../common/i18n_string';

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/connector_setup_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/connector_setup_prompt.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import {
   EuiEmptyPrompt,
   EuiIcon,
@@ -18,9 +19,9 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import { Connector } from '@kbn/search-connectors';
 
-import { useKibanaServices } from '../../hooks/use_kibana';
-import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 import { useConnectorTypes } from '../../hooks/api/use_connector_types';
+import { useAssetBasePath } from '../../hooks/use_asset_base_path';
+import { useKibanaServices } from '../../hooks/use_kibana';
 
 interface ConnectorSetupEmptyPromptProps {
   indexName: string;

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_aliases_flyout.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_aliases_flyout.tsx
@@ -19,8 +19,8 @@ import {
   EuiFlyoutHeader,
   EuiTitle,
 } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 export interface IndexAliasesFlyoutProps {
   aliases: string[];

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_mappings_docs_link.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_mappings_docs_link.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { FunctionComponent } from 'react';
+
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -16,8 +17,8 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { CoreStart } from '@kbn/core/public';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { IndexContent } from '@kbn/index-management-shared-types';
 
 const IndexMappingsDocsLink: FunctionComponent<{ docLinks: CoreStart['docLinks'] }> = ({

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_overview.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_overview.tsx
@@ -6,8 +6,7 @@
  */
 
 import React, { FunctionComponent } from 'react';
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage, FormattedPlural } from '@kbn/i18n-react';
+
 import {
   EuiLoadingSpinner,
   EuiEmptyPrompt,
@@ -21,6 +20,8 @@ import {
   EuiLink,
   EuiSpacer,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage, FormattedPlural } from '@kbn/i18n-react';
 
 import { Index } from '@kbn/index-management-plugin/common/types/indices';
 
@@ -28,9 +29,10 @@ import { docLinks } from '../../../../common/doc_links';
 import { useIndex } from '../../hooks/api/use_index';
 
 import { BadgeList } from '../badge_list';
+
+import { IndexAliasesFlyout } from './index_aliases_flyout';
 import { OverviewEmptyPrompt } from './overview_empty_prompt';
 import { IndexOverviewPanel, IndexOverviewPanelStat } from './overview_panel';
-import { IndexAliasesFlyout } from './index_aliases_flyout';
 
 export interface IndexDetailOverviewProps {
   index: Index;

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_overview_content.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_overview_content.tsx
@@ -6,13 +6,15 @@
  */
 
 import React, { Suspense, lazy } from 'react';
-import { CoreStart } from '@kbn/core/public';
-import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
 import { EuiLoadingSpinner } from '@elastic/eui';
+import { CoreStart } from '@kbn/core/public';
 
 import { IndexContent } from '@kbn/index-management-shared-types';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 
 import { ServerlessSearchPluginStartDependencies } from '../../../types';
 

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/overview_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/overview_empty_prompt.tsx
@@ -6,8 +6,7 @@
  */
 
 import React from 'react';
-import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
+
 import {
   EuiEmptyPrompt,
   EuiFlexItem,
@@ -18,6 +17,8 @@ import {
   EuiPanel,
   EuiTitle,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { Connector } from '@kbn/search-connectors';
 
 import { docLinks } from '../../../../common/doc_links';

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/overview_panel.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/overview_panel.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { FC, PropsWithChildren } from 'react';
+
 import { EuiSpacer, EuiSplitPanel, EuiTitle } from '@elastic/eui';
 
 export interface IndexOverviewPanelProps {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/curl.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/curl.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
 import { i18n } from '@kbn/i18n';
+import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
+
 import { docLinks } from '../../../../common/doc_links';
 
 export const curlDefinition: LanguageDefinition = {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/go.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/go.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
+
 import { docLinks } from '../../../../common/doc_links';
 
 export const goDefinition: LanguageDefinition = {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/javascript.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/javascript.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
 import { i18n } from '@kbn/i18n';
+import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
+
 import { docLinks } from '../../../../common/doc_links';
 
 export const javascriptDefinition: LanguageDefinition = {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/language_grid.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/language_grid.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import {
   EuiFlexGroup,
   EuiFlexGrid,
@@ -17,8 +18,8 @@ import {
   useIsWithinBreakpoints,
 } from '@elastic/eui';
 
-import { LanguageDefinition, Languages } from '@kbn/search-api-panels';
 import { i18n } from '@kbn/i18n';
+import { LanguageDefinition, Languages } from '@kbn/search-api-panels';
 
 export interface LanguageGridProps {
   assetBasePath: string;

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/php.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/php.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
+
 import { docLinks } from '../../../../common/doc_links';
 import { INDEX_NAME_PLACEHOLDER } from '../../constants';
 

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/python.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/python.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
+
 import { docLinks } from '../../../../common/doc_links';
 import { INDEX_NAME_PLACEHOLDER } from '../../constants';
 

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/ruby.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/languages/ruby.ts
@@ -7,6 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
+
 import { docLinks } from '../../../../common/doc_links';
 import { INDEX_NAME_PLACEHOLDER } from '../../constants';
 

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/overview.test.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/overview.test.tsx
@@ -6,7 +6,9 @@
  */
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+
 import { render, core } from '../../test/test_utils';
+
 import { ElasticsearchOverview as Overview } from './overview';
 
 jest.mock('react-router-dom', () => ({

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/overview.tsx
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import React, { useEffect, useMemo, useState, FC, PropsWithChildren } from 'react';
+
+import { useLocation } from 'react-router-dom';
+
 import {
   EuiAvatar,
   EuiButtonEmpty,
@@ -17,6 +21,10 @@ import {
   EuiBadge,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import type {
+  LanguageDefinition,
+  LanguageDefinitionSnippetArguments,
+} from '@kbn/search-api-panels';
 import {
   WelcomeBanner,
   IngestData,
@@ -29,28 +37,25 @@ import {
   PreprocessDataPanel,
 } from '@kbn/search-api-panels';
 
-import React, { useEffect, useMemo, useState, FC, PropsWithChildren } from 'react';
-import type {
-  LanguageDefinition,
-  LanguageDefinitionSnippetArguments,
-} from '@kbn/search-api-panels';
-import { useLocation } from 'react-router-dom';
 import { CloudDetailsPanel } from '@kbn/search-api-panels';
+
 import { DEFAULT_INGESTION_PIPELINE } from '../../../common';
 import { docLinks } from '../../../common/doc_links';
-import { useKibanaServices } from '../hooks/use_kibana';
-import { useAssetBasePath } from '../hooks/use_asset_base_path';
+import { OPTIONAL_LABEL } from '../../../common/i18n_string';
 import { API_KEY_PLACEHOLDER, CLOUD_ID_PLACEHOLDER } from '../constants';
+import { useAssetBasePath } from '../hooks/use_asset_base_path';
+import { useKibanaServices } from '../hooks/use_kibana';
+
 import { javaDefinition } from './languages/java';
-import { languageDefinitions } from './languages/languages';
 import { LanguageGrid } from './languages/language_grid';
+import { languageDefinitions } from './languages/languages';
 import './overview.scss';
 import { ApiKeyPanel } from './api_key/api_key';
 import { ConnectorIngestionPanel } from './connectors_ingestion';
+import { PipelineManageButton } from './pipeline_manage_button';
 import { PipelineOverviewButton } from './pipeline_overview_button';
 import { SelectClientCallouts } from './select_client_callouts';
-import { PipelineManageButton } from './pipeline_manage_button';
-import { OPTIONAL_LABEL } from '../../../common/i18n_string';
+
 import { useIngestPipelines } from '../hooks/api/use_ingest_pipelines';
 import { useElasticsearchUrl } from '../hooks/use_elastisearch_url';
 

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/pipeline_manage_button.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/pipeline_manage_button.tsx
@@ -10,8 +10,8 @@ import React from 'react';
 import { EuiSpacer, EuiText, EuiButtonEmpty } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { useKibanaServices } from '../hooks/use_kibana';
 import { useIngestPipelines } from '../hooks/api/use_ingest_pipelines';
+import { useKibanaServices } from '../hooks/use_kibana';
 
 export const PipelineManageButton: React.FC = () => {
   const { http } = useKibanaServices();

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/pipeline_overview_button.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/pipeline_overview_button.tsx
@@ -10,8 +10,8 @@ import React from 'react';
 import { EuiSpacer, EuiText, EuiButton } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-import { useKibanaServices } from '../hooks/use_kibana';
 import { useIngestPipelines } from '../hooks/api/use_ingest_pipelines';
+import { useKibanaServices } from '../hooks/use_kibana';
 
 export const PipelineOverviewButton: React.FC = () => {
   const { http } = useKibanaServices();

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/select_client_callouts.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/select_client_callouts.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
 import { ConnectorsCallout } from './connectors_callout';

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers/elastic_managed_web_crawlers_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers/elastic_managed_web_crawlers_empty_prompt.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 import React from 'react';
+
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiPanel, EuiText } from '@elastic/eui';
+import { SERVERLESS_ES_WEB_CRAWLERS_ID } from '@kbn/deeplinks-search/constants';
 import { i18n } from '@kbn/i18n';
 import { SearchEmptyPrompt, DecorativeHorizontalStepper } from '@kbn/search-shared-ui';
-import { SERVERLESS_ES_WEB_CRAWLERS_ID } from '@kbn/deeplinks-search/constants';
+
 import { BACK_LABEL, COMING_SOON_LABEL } from '../../../../common/i18n_string';
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 import { useKibanaServices } from '../../hooks/use_kibana';

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers/self_managed_web_crawlers_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers/self_managed_web_crawlers_empty_prompt.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import React from 'react';
+
 import {
   EuiBadge,
   EuiButton,
@@ -16,12 +17,13 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { SearchEmptyPrompt, DecorativeHorizontalStepper } from '@kbn/search-shared-ui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { ELASTIC_MANAGED_WEB_CRAWLERS_PATH, BASE_WEB_CRAWLERS_PATH } from '../../constants';
+import { SearchEmptyPrompt, DecorativeHorizontalStepper } from '@kbn/search-shared-ui';
+
 import { COMING_SOON_LABEL } from '../../../../common/i18n_string';
-import { useKibanaServices } from '../../hooks/use_kibana';
+import { ELASTIC_MANAGED_WEB_CRAWLERS_PATH, BASE_WEB_CRAWLERS_PATH } from '../../constants';
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
+import { useKibanaServices } from '../../hooks/use_kibana';
 
 export const SelfManagedWebCrawlersEmptyPrompt = () => {
   const {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers_elastic_managed.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers_elastic_managed.tsx
@@ -5,12 +5,15 @@
  * 2.0.
  */
 
+import React, { useMemo } from 'react';
+
 import { EuiLink, EuiPageTemplate, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React, { useMemo } from 'react';
+
 import { LEARN_MORE_LABEL } from '../../../common/i18n_string';
 import { useKibanaServices } from '../hooks/use_kibana';
+
 import { ElasticManagedWebCrawlersEmptyPrompt } from './web_crawlers/elastic_managed_web_crawlers_empty_prompt';
 
 export const WebCrawlersElasticManaged = () => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers_overview.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers_overview.tsx
@@ -6,11 +6,14 @@
  */
 
 import React, { useMemo } from 'react';
+
 import { EuiLink, EuiPageTemplate, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+
 import { LEARN_MORE_LABEL } from '../../../common/i18n_string';
 import { useKibanaServices } from '../hooks/use_kibana';
+
 import { SelfManagedWebCrawlersEmptyPrompt } from './web_crawlers/self_managed_web_crawlers_empty_prompt';
 
 export const WebCrawlersOverview = () => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers_router.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers_router.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import { Route, Routes } from '@kbn/shared-ux-router';
 import React from 'react';
-import { WebCrawlersOverview } from './web_crawlers_overview';
+
+import { Route, Routes } from '@kbn/shared-ux-router';
+
 import { WebCrawlersElasticManaged } from './web_crawlers_elastic_managed';
+import { WebCrawlersOverview } from './web_crawlers_overview';
 
 export const WebCrawlersRouter: React.FC = () => {
   return (

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/connectors.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/connectors.tsx
@@ -5,18 +5,21 @@
  * 2.0.
  */
 
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
 import { CoreStart } from '@kbn/core-lifecycle-browser';
 
 import { I18nProvider } from '@kbn/i18n-react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-
-import ReactDOM from 'react-dom';
-import React from 'react';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Router } from '@kbn/shared-ux-router';
+
 import { ServerlessSearchContext } from './hooks/use_kibana';
 
 export async function renderApp(

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/elasticsearch.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/elasticsearch.tsx
@@ -7,12 +7,17 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
 import { CoreStart } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
 import { Route, Router, Routes } from '@kbn/shared-ux-router';
+
 import { ServerlessSearchContext } from './hooks/use_kibana';
 
 export async function renderApp(

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_api_key.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_api_key.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { ApiKey } from '@kbn/security-plugin-types-common';
 import { useQuery } from '@tanstack/react-query';
+
+import { ApiKey } from '@kbn/security-plugin-types-common';
+
 import { useKibanaServices } from '../use_kibana';
 
 export const useGetApiKeys = () => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_connector.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_connector.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { Connector } from '@kbn/search-connectors';
 import { useQuery } from '@tanstack/react-query';
+
+import { Connector } from '@kbn/search-connectors';
+
 import { useKibanaServices } from '../use_kibana';
 
 export const useConnector = (id: string) => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_connector_configuration.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_connector_configuration.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useMutation } from '@tanstack/react-query';
+
 import { useKibanaServices } from '../use_kibana';
 
 export const useEditConnectorConfiguration = (connectorId: string) => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_connectors.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_connectors.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { Connector } from '@kbn/search-connectors';
 import { useQuery } from '@tanstack/react-query';
+
+import { Connector } from '@kbn/search-connectors';
+
 import { useKibanaServices } from '../use_kibana';
 
 export const useConnectors = () => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_create_api_key.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_create_api_key.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useMutation } from '@tanstack/react-query';
+
 import { CREATE_API_KEY_PATH } from '../../../../common/routes';
 import { CreateAPIKeyArgs } from '../../../../common/types';
 import { useKibanaServices } from '../use_kibana';

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_create_connector.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_create_connector.tsx
@@ -6,8 +6,11 @@
  */
 import { useEffect } from 'react';
 import { generatePath } from 'react-router-dom';
+
 import { useMutation } from '@tanstack/react-query';
+
 import { Connector } from '@kbn/search-connectors';
+
 import { EDIT_CONNECTOR_PATH } from '../../constants';
 import { useKibanaServices } from '../use_kibana';
 

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_index_documents.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_index_documents.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
+import { useQuery } from '@tanstack/react-query';
+
 import { Pagination } from '@elastic/eui';
 import { SearchHit } from '@kbn/es-types';
 import { pageToPagination, Paginate } from '@kbn/search-index-documents';
-import { useQuery } from '@tanstack/react-query';
+
 import { useKibanaServices } from '../use_kibana';
 
 interface IndexDocuments {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_index_mappings.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_index_mappings.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
-import { IndicesGetMappingIndexMappingRecord } from '@elastic/elasticsearch/lib/api/types';
 import { useQuery } from '@tanstack/react-query';
+
+import { IndicesGetMappingIndexMappingRecord } from '@elastic/elasticsearch/lib/api/types';
+
 import { useKibanaServices } from '../use_kibana';
 
 export const useIndexMappings = (indexName: string) => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_index_name_search.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_index_name_search.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+
 import { useKibanaServices } from '../use_kibana';
 
 export const useIndexNameSearch = (query: string) => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_ingest_pipelines.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_ingest_pipelines.tsx
@@ -6,7 +6,9 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+
 import { IngestGetPipelineResponse } from '@elastic/elasticsearch/lib/api/types';
+
 import { useKibanaServices } from '../use_kibana';
 
 export const useIngestPipelines = () => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_sync_jobs.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_sync_jobs.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
+import { useQuery } from '@tanstack/react-query';
+
 import { Pagination } from '@elastic/eui';
 import { ConnectorSyncJob, Paginate } from '@kbn/search-connectors';
-import { useQuery } from '@tanstack/react-query';
+
 import { useKibanaServices } from '../use_kibana';
 
 export const useSyncJobs = (

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_update_connector_scheduling.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_update_connector_scheduling.tsx
@@ -10,8 +10,10 @@
  * 2.0.
  */
 
-import { SchedulingConfiguraton } from '@kbn/search-connectors';
 import { useMutation } from '@tanstack/react-query';
+
+import { SchedulingConfiguraton } from '@kbn/search-connectors';
+
 import { useKibanaServices } from '../use_kibana';
 
 export const useConnectorScheduling = (connectorId: string) => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/use_asset_base_path.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/use_asset_base_path.tsx
@@ -6,6 +6,7 @@
  */
 
 import { PLUGIN_ID } from '../../../common';
+
 import { useKibanaServices } from './use_kibana';
 
 export const useAssetBasePath = () => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/use_elastisearch_url.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/use_elastisearch_url.ts
@@ -6,7 +6,9 @@
  */
 
 import { useState, useEffect } from 'react';
+
 import { ELASTICSEARCH_URL_PLACEHOLDER } from '../constants';
+
 import { useKibanaServices } from './use_kibana';
 
 export const useElasticsearchUrl = () => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/use_kibana.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/use_kibana.tsx
@@ -8,11 +8,11 @@
 import { CloudStart } from '@kbn/cloud-plugin/public';
 import { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { AppMountParameters, CoreStart } from '@kbn/core/public';
-import type { SharePluginStart } from '@kbn/share-plugin/public';
 import { useKibana as useKibanaBase } from '@kbn/kibana-react-plugin/public';
-import { AuthenticatedUser } from '@kbn/security-plugin/common';
 import { SearchConnectorsPluginStart } from '@kbn/search-connectors-plugin/public';
+import { AuthenticatedUser } from '@kbn/security-plugin/common';
 import { SecurityPluginStart } from '@kbn/security-plugin-types-public';
+import type { SharePluginStart } from '@kbn/share-plugin/public';
 
 export interface ServerlessSearchContext {
   cloud: CloudStart;

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/web_crawlers.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/web_crawlers.tsx
@@ -5,18 +5,21 @@
  * 2.0.
  */
 
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
 import { CoreStart } from '@kbn/core-lifecycle-browser';
 
 import { I18nProvider } from '@kbn/i18n-react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-
-import ReactDOM from 'react-dom';
-import React from 'react';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Router } from '@kbn/shared-ux-router';
+
 import { ServerlessSearchContext } from './hooks/use_kibana';
 
 export async function renderApp(

--- a/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/navigation_tree.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import type { AppDeepLinkId, NavigationTreeDefinition } from '@kbn/core-chrome-browser';
 import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { AppDeepLinkId, NavigationTreeDefinition } from '@kbn/core-chrome-browser';
 import { i18n } from '@kbn/i18n';
+
 import { CONNECTORS_LABEL, WEB_CRAWLERS_LABEL } from '../common/i18n_string';
 
 export const navigationTree = ({ isAppRegistered }: ApplicationStart): NavigationTreeDefinition => {

--- a/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
@@ -5,6 +5,10 @@
  * 2.0.
  */
 
+import { QueryClient, MutationCache, QueryCache } from '@tanstack/react-query';
+
+import { of } from 'rxjs';
+
 import {
   AppMountParameters,
   CoreSetup,
@@ -15,20 +19,20 @@ import {
 import { i18n } from '@kbn/i18n';
 import { appCategories, appIds } from '@kbn/management-cards-navigation';
 import { AuthenticatedUser } from '@kbn/security-plugin/common';
-import { QueryClient, MutationCache, QueryCache } from '@tanstack/react-query';
-import { of } from 'rxjs';
+
+import { docLinks } from '../common/doc_links';
+
+import { createIndexDocumentsContent } from './application/components/index_documents/documents_tab';
 import { createIndexMappingsDocsLinkContent as createIndexMappingsContent } from './application/components/index_management/index_mappings_docs_link';
 import { createIndexOverviewContent } from './application/components/index_management/index_overview_content';
-import { docLinks } from '../common/doc_links';
+import { navigationTree } from './navigation_tree';
 import {
   ServerlessSearchPluginSetup,
   ServerlessSearchPluginSetupDependencies,
   ServerlessSearchPluginStart,
   ServerlessSearchPluginStartDependencies,
 } from './types';
-import { createIndexDocumentsContent } from './application/components/index_documents/documents_tab';
 import { getErrorCode, getErrorMessage, isKibanaServerError } from './utils/get_error_message';
-import { navigationTree } from './navigation_tree';
 
 export class ServerlessSearchPlugin
   implements

--- a/x-pack/solutions/search/plugins/serverless_search/public/test/test_utils.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/test/test_utils.tsx
@@ -5,18 +5,21 @@
  * 2.0.
  */
 
+import { searchConnectorsMock } from '@kbn/search-connectors-plugin/public/plugin.mock';
+import { userProfileMock } from '@kbn/security-plugin/common/model/user_profile.mock';
+
 import React, { ReactElement, FC, PropsWithChildren } from 'react';
-import { render, RenderOptions } from '@testing-library/react';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, RenderOptions } from '@testing-library/react';
+
+import { cloudMock } from '@kbn/cloud-plugin/public/mocks';
+import { coreMock } from '@kbn/core/public/mocks';
+import { I18nProvider } from '@kbn/i18n-react';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
-import { I18nProvider } from '@kbn/i18n-react';
 
-import { coreMock } from '@kbn/core/public/mocks';
-import { cloudMock } from '@kbn/cloud-plugin/public/mocks';
 import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
-import { userProfileMock } from '@kbn/security-plugin/common/model/user_profile.mock';
-import { searchConnectorsMock } from '@kbn/search-connectors-plugin/public/plugin.mock';
 
 export const core = coreMock.createStart();
 export const services = {

--- a/x-pack/solutions/search/plugins/serverless_search/public/types.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/types.ts
@@ -7,17 +7,17 @@
 
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/public';
 import type { ConsolePluginStart } from '@kbn/console-plugin/public';
-import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/public';
-import type { ManagementSetup, ManagementStart } from '@kbn/management-plugin/public';
-import type { SecurityPluginStart } from '@kbn/security-plugin/public';
-import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
-import type { SharePluginStart } from '@kbn/share-plugin/public';
-import type { IndexManagementPluginStart } from '@kbn/index-management-plugin/public';
 import type { DiscoverSetup } from '@kbn/discover-plugin/public';
+import type { IndexManagementPluginStart } from '@kbn/index-management-plugin/public';
+import type { ManagementSetup, ManagementStart } from '@kbn/management-plugin/public';
 import type {
   SearchIndicesPluginSetup,
   SearchIndicesPluginStart,
 } from '@kbn/search-indices/public';
+import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/public';
+import type { SecurityPluginStart } from '@kbn/security-plugin/public';
+import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
+import type { SharePluginStart } from '@kbn/share-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ServerlessSearchPluginSetup {}

--- a/x-pack/solutions/search/plugins/serverless_search/server/collectors/connectors/telemetry.test.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/collectors/connectors/telemetry.test.ts
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import { registerTelemetryUsageCollector } from './telemetry';
-import { createCollectorFetchContextMock } from '@kbn/usage-collection-plugin/server/mocks';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { collectConnectorStats } from '@kbn/search-connectors';
+import { createCollectorFetchContextMock } from '@kbn/usage-collection-plugin/server/mocks';
+
 import { ConnectorStats } from '../../../common/types';
+
+import { registerTelemetryUsageCollector } from './telemetry';
 
 jest.mock('@kbn/search-connectors', () => ({
   collectConnectorStats: jest.fn(),

--- a/x-pack/solutions/search/plugins/serverless_search/server/index.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/index.ts
@@ -8,6 +8,7 @@
 import { PluginInitializerContext } from '@kbn/core/server';
 
 import { ServerlessSearchPlugin } from './plugin';
+
 export { config } from './config';
 
 //  This exports static code and TypeScript types,

--- a/x-pack/solutions/search/plugins/serverless_search/server/lib/indices/fetch_index.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/lib/indices/fetch_index.ts
@@ -6,6 +6,7 @@
  */
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { fetchConnectorByIndexName } from '@kbn/search-connectors';
+
 import { FetchIndexResult } from '../../../common/types';
 
 export async function fetchIndex(

--- a/x-pack/solutions/search/plugins/serverless_search/server/lib/indices/fetch_indices.test.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/lib/indices/fetch_indices.test.ts
@@ -7,6 +7,7 @@
 
 import { ByteSizeValue } from '@kbn/config-schema';
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+
 import { fetchIndices } from './fetch_indices';
 
 describe('fetch indices lib functions', () => {

--- a/x-pack/solutions/search/plugins/serverless_search/server/lib/indices/fetch_indices.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/lib/indices/fetch_indices.ts
@@ -7,6 +7,7 @@
 
 import { IndicesStatsIndicesStats } from '@elastic/elasticsearch/lib/api/types';
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+
 import { isNotNullish } from '../../../common/utils/is_not_nullish';
 import { isHidden, isClosed } from '../../utils/index_utils';
 

--- a/x-pack/solutions/search/plugins/serverless_search/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/plugin.ts
@@ -13,23 +13,24 @@ import type {
   CoreSetup,
   CoreStart,
 } from '@kbn/core/server';
+import { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import { SEARCH_PROJECT_SETTINGS } from '@kbn/serverless-search-settings';
-import { DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
+
+import { registerTelemetryUsageCollector } from './collectors/connectors/telemetry';
+import type { ServerlessSearchConfig } from './config';
 import { registerApiKeyRoutes } from './routes/api_key_routes';
+import { registerConnectorsRoutes } from './routes/connectors_routes';
 import { registerIndicesRoutes } from './routes/indices_routes';
 
-import type { ServerlessSearchConfig } from './config';
+import { registerIngestPipelineRoutes } from './routes/ingest_pipeline_routes';
+import { registerMappingRoutes } from './routes/mapping_routes';
 import type {
   ServerlessSearchPluginSetup,
   ServerlessSearchPluginStart,
   SetupDependencies,
   StartDependencies,
 } from './types';
-import { registerConnectorsRoutes } from './routes/connectors_routes';
-import { registerTelemetryUsageCollector } from './collectors/connectors/telemetry';
-import { registerMappingRoutes } from './routes/mapping_routes';
-import { registerIngestPipelineRoutes } from './routes/ingest_pipeline_routes';
 
 export interface RouteDependencies {
   http: CoreSetup<StartDependencies>['http'];

--- a/x-pack/solutions/search/plugins/serverless_search/server/routes/api_key_routes.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/routes/api_key_routes.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+
 import { RouteDependencies } from '../plugin';
 import { errorHandler } from '../utils/error_handler';
 

--- a/x-pack/solutions/search/plugins/serverless_search/server/routes/connectors_routes.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/routes/connectors_routes.ts
@@ -21,6 +21,7 @@ import {
   updateConnectorScheduling,
   updateConnectorServiceType,
 } from '@kbn/search-connectors';
+
 import { DEFAULT_INGESTION_PIPELINE } from '../../common';
 import { RouteDependencies } from '../plugin';
 import { errorHandler } from '../utils/error_handler';

--- a/x-pack/solutions/search/plugins/serverless_search/server/routes/indices_routes.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/routes/indices_routes.ts
@@ -10,8 +10,9 @@ import { schema } from '@kbn/config-schema';
 
 import { fetchSearchResults } from '@kbn/search-index-documents/lib';
 import { DEFAULT_DOCS_PER_PAGE } from '@kbn/search-index-documents/types';
-import { fetchIndices } from '../lib/indices/fetch_indices';
+
 import { fetchIndex } from '../lib/indices/fetch_index';
+import { fetchIndices } from '../lib/indices/fetch_indices';
 import { RouteDependencies } from '../plugin';
 import { errorHandler } from '../utils/error_handler';
 

--- a/x-pack/solutions/search/plugins/serverless_search/server/routes/mapping_routes.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/server/routes/mapping_routes.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+
 import { RouteDependencies } from '../plugin';
 import { errorHandler } from '../utils/error_handler';
 


### PR DESCRIPTION
## Summary

This updates the old enterprise search linting rules to apply to all of search. 


Also, I removed the automatic ordering of keys and method properties as I think it was causing more annoyance than usefulness.