### PR TITLE
[`kbn-grid-layout`] Make drag preview absolute positioned

### DIFF
--- a/src/platform/packages/private/kbn-grid-layout/grid/drag_preview.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/drag_preview.tsx
@@ -39,10 +39,10 @@ export const DragPreview = ({
           } else {
             const panel = gridLayout[rowIndex].panels[activePanel.id];
             dragPreviewRef.current.style.display = 'block';
-            dragPreviewRef.current.style.gridColumnStart = `${panel.column + 1}`;
-            dragPreviewRef.current.style.gridColumnEnd = `${panel.column + 1 + panel.width}`;
-            dragPreviewRef.current.style.gridRowStart = `${panel.row + 1}`;
-            dragPreviewRef.current.style.gridRowEnd = `${panel.row + 1 + panel.height}`;
+            dragPreviewRef.current.style.height = `calc(1px * (${panel.height} * (var(--kbnGridRowHeight) + var(--kbnGridGutterSize)) - var(--kbnGridGutterSize)))`;
+            dragPreviewRef.current.style.width = `calc(1px * (${panel.width} * (var(--kbnGridColumnWidth) + var(--kbnGridGutterSize)) - var(--kbnGridGutterSize)))`;
+            dragPreviewRef.current.style.top = `calc(1px * (${panel.row} * (var(--kbnGridRowHeight) + var(--kbnGridGutterSize))))`;
+            dragPreviewRef.current.style.left = `calc(1px * (${panel.column} * (var(--kbnGridColumnWidth) + var(--kbnGridGutterSize))))`;
           }
         });
 
@@ -61,6 +61,7 @@ export const DragPreview = ({
       css={css`
         display: none;
         pointer-events: none;
+        position: absolute;
       `}
     />
   );

--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_row/grid_row.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_row/grid_row.tsx
@@ -213,6 +213,7 @@ export const GridRow = forwardRef<HTMLDivElement, GridRowProps>(
             css={css`
               height: 100%;
               display: grid;
+              position: relative;
               justify-items: stretch;
               transition: background-color 300ms linear;
               ${initialStyles};


### PR DESCRIPTION
## Summary

This PR positions the drag preview via `absolute` positioning. This is a potential fix for `EuiResizeObservers` being fired unnecessarily.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->