### PR TITLE
[Search] tie hasNativeConnectors to agentless being available in cloud

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/mocks/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/mocks/index.ts
@@ -290,6 +290,7 @@ export const createFleetStartContractMock = (): DeeplyMockedKeys<FleetStartContr
 
   const startContract: DeeplyMockedKeys<FleetStartContract> = {
     fleetSetupCompleted: jest.fn(async () => {}),
+    agentless: { enabled: false },
     authz: { fromRequest: jest.fn(async (_) => fleetAuthzMock) },
     packageService: createMockPackageService(),
     agentService: createMockAgentService(),

--- a/x-pack/platform/plugins/shared/fleet/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/plugin.ts
@@ -229,6 +229,9 @@ export interface FleetStartContract {
    * services
    */
   fleetSetupCompleted: () => Promise<void>;
+  agentless: {
+    enabled: boolean;
+  };
   authz: {
     fromRequest(request: KibanaRequest): Promise<FleetAuthz>;
   };
@@ -805,6 +808,9 @@ export class FleetPlugin
     return {
       authz: {
         fromRequest: getAuthzFromRequest,
+      },
+      agentless: {
+        enabled: this.configInitialValue.agentless?.enabled ?? false,
       },
       fleetSetupCompleted: () => fleetSetupPromise,
       packageService: this.setupPackageService(

--- a/x-pack/solutions/search/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/common/__mocks__/initial_app_data.ts
@@ -12,7 +12,7 @@ export const DEFAULT_INITIAL_APP_DATA = {
     hasDefaultIngestPipeline: true,
     hasDocumentLevelSecurityEnabled: true,
     hasIncrementalSyncEnabled: true,
-    hasNativeConnectors: true,
+    hasNativeConnectors: false,
     hasWebCrawler: false,
   },
 };

--- a/x-pack/solutions/search/plugins/enterprise_search/server/__mocks__/routerDependencies.mock.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/__mocks__/routerDependencies.mock.ts
@@ -50,8 +50,10 @@ export const mockConfig: ConfigType = {
 export const mockDependencies = {
   // Mock router should be handled on a per-test basis
   config: mockConfig,
+  enterpriseSearchRequestHandler: mockRequestHandler as any,
+  getSavedObjectsService: jest.fn(),
+  getStartServices: jest.fn(),
   globalConfigService: new GlobalConfigService(),
   log: mockLogger,
-  enterpriseSearchRequestHandler: mockRequestHandler as any,
   ml: mockMl,
 };

--- a/x-pack/solutions/search/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/plugin.ts
@@ -5,31 +5,17 @@
  * 2.0.
  */
 
-import { CloudSetup } from '@kbn/cloud-plugin/server';
 import {
   Plugin,
   PluginInitializerContext,
   CoreSetup,
   Logger,
   SavedObjectsServiceStart,
-  IRouter,
   DEFAULT_APP_CATEGORIES,
 } from '@kbn/core/server';
-import { CustomIntegrationsPluginSetup } from '@kbn/custom-integrations-plugin/server';
-import { DataPluginStart } from '@kbn/data-plugin/server/plugin';
 import { ENTERPRISE_SEARCH_APP_ID } from '@kbn/deeplinks-search';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
-import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
-import { GlobalSearchPluginSetup } from '@kbn/global-search-plugin/server';
-import type { GuidedOnboardingPluginSetup } from '@kbn/guided-onboarding-plugin/server';
 import { i18n } from '@kbn/i18n';
-import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
-import { LogsSharedPluginSetup } from '@kbn/logs-shared-plugin/server';
-import type { MlPluginSetup } from '@kbn/ml-plugin/server';
-import { SearchConnectorsPluginSetup } from '@kbn/search-connectors-plugin/server';
-import { SecurityPluginSetup } from '@kbn/security-plugin/server';
-import { SpacesPluginStart } from '@kbn/spaces-plugin/server';
-import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 
 import {
   ENTERPRISE_SEARCH_OVERVIEW_PLUGIN,
@@ -66,10 +52,7 @@ import { WS_TELEMETRY_NAME } from './collectors/workplace_search/telemetry';
 import { registerEnterpriseSearchIntegrations } from './integrations';
 
 import { entSearchHttpAgent } from './lib/enterprise_search_http_agent';
-import {
-  EnterpriseSearchRequestHandler,
-  IEnterpriseSearchRequestHandler,
-} from './lib/enterprise_search_request_handler';
+import { EnterpriseSearchRequestHandler } from './lib/enterprise_search_request_handler';
 
 import { registerEnterpriseSearchRoutes } from './routes/enterprise_search';
 import { registerAnalyticsRoutes } from './routes/enterprise_search/analytics';
@@ -85,6 +68,7 @@ import { enterpriseSearchTelemetryType } from './saved_objects/enterprise_search
 import { workplaceSearchTelemetryType } from './saved_objects/workplace_search/telemetry';
 
 import { GlobalConfigService } from './services/global_config_service';
+import type { PluginsSetup, PluginsStart, RouteDependencies } from './types';
 import { uiSettings as enterpriseSearchUISettings } from './ui_settings';
 
 import { getConnectorsSearchResultProvider } from './utils/connectors_search_result_provider';
@@ -92,35 +76,6 @@ import { getIndicesSearchResultProvider } from './utils/indices_search_result_pr
 import { getSearchResultProvider } from './utils/search_result_provider';
 
 import { ConfigType } from '.';
-
-interface PluginsSetup {
-  cloud: CloudSetup;
-  customIntegrations?: CustomIntegrationsPluginSetup;
-  features: FeaturesPluginSetup;
-  globalSearch: GlobalSearchPluginSetup;
-  guidedOnboarding?: GuidedOnboardingPluginSetup;
-  logsShared: LogsSharedPluginSetup;
-  ml?: MlPluginSetup;
-  licensing: LicensingPluginStart;
-  searchConnectors?: SearchConnectorsPluginSetup;
-  security: SecurityPluginSetup;
-  usageCollection?: UsageCollectionSetup;
-}
-
-export interface PluginsStart {
-  data: DataPluginStart;
-  spaces?: SpacesPluginStart;
-}
-
-export interface RouteDependencies {
-  config: ConfigType;
-  enterpriseSearchRequestHandler: IEnterpriseSearchRequestHandler;
-  getSavedObjectsService?(): SavedObjectsServiceStart;
-  globalConfigService: GlobalConfigService;
-  log: Logger;
-  ml?: MlPluginSetup;
-  router: IRouter;
-}
 
 export class EnterpriseSearchPlugin implements Plugin<void, void, PluginsSetup, PluginsStart> {
   private readonly config: ConfigType;
@@ -284,14 +239,15 @@ export class EnterpriseSearchPlugin implements Plugin<void, void, PluginsSetup, 
      */
     const router = http.createRouter();
     const enterpriseSearchRequestHandler = new EnterpriseSearchRequestHandler({ config, log });
-    const dependencies = {
-      router,
+    const dependencies: RouteDependencies = {
       config,
-      globalConfigService: this.globalConfigService,
-      log,
       enterpriseSearchRequestHandler,
-      ml,
+      getStartServices,
+      globalConfigService: this.globalConfigService,
       licensing,
+      log,
+      ml,
+      router,
     };
 
     registerConfigDataRoute(dependencies);

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/analytics.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/analytics.ts
@@ -19,7 +19,7 @@ import { analyticsEventsExist } from '../../lib/analytics/analytics_events_exist
 import { createApiKey } from '../../lib/analytics/create_api_key';
 import { deleteAnalyticsCollectionById } from '../../lib/analytics/delete_analytics_collection';
 import { fetchAnalyticsCollections } from '../../lib/analytics/fetch_analytics_collection';
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
 import { createError } from '../../utils/create_error';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/api_keys.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/api_keys.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 import { createApiKey } from '../../lib/indices/create_api_key';
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 
 export function registerApiKeysRoutes({ log, router }: RouteDependencies) {

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
@@ -7,7 +7,8 @@
 
 import { kibanaPackageJson } from '@kbn/repo-info';
 
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
+import { isAgentlessEnabled } from '../../utils/agentless';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 
 export function registerConfigDataRoute({
@@ -15,20 +16,22 @@ export function registerConfigDataRoute({
   config,
   log,
   globalConfigService,
+  getStartServices,
 }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/config_data',
       validate: false,
     },
-    elasticsearchErrorHandler(log, async (_context, _request, response) => {
+    elasticsearchErrorHandler(log, async (context, _request, response) => {
+      const [_core, start] = await getStartServices();
       const data = {
         features: {
           hasConnectors: config.hasConnectors,
           hasDefaultIngestPipeline: config.hasDefaultIngestPipeline,
           hasDocumentLevelSecurityEnabled: config.hasDocumentLevelSecurityEnabled,
           hasIncrementalSyncEnabled: config.hasIncrementalSyncEnabled,
-          hasNativeConnectors: config.hasNativeConnectors,
+          hasNativeConnectors: isAgentlessEnabled(start),
           // 9.x Does not have ent search node, and therefore does not have support for the following
           hasWebCrawler: false,
         },

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
@@ -48,7 +48,7 @@ import { getDefaultPipeline } from '../../lib/pipelines/get_default_pipeline';
 import { updateDefaultPipeline } from '../../lib/pipelines/update_default_pipeline';
 import { updateConnectorPipeline } from '../../lib/pipelines/update_pipeline';
 
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
 import { createError } from '../../utils/create_error';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 import {

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler.ts
@@ -19,7 +19,7 @@ import { fetchCrawlerByIndexName } from '../../../lib/crawler/fetch_crawlers';
 import { recreateConnectorDocument } from '../../../lib/crawler/post_connector';
 import { updateHtmlExtraction } from '../../../lib/crawler/put_html_extraction';
 import { deleteIndex } from '../../../lib/indices/delete_index';
-import { RouteDependencies } from '../../../plugin';
+import type { RouteDependencies } from '../../../types';
 import { createError } from '../../../utils/create_error';
 import { elasticsearchErrorHandler } from '../../../utils/elasticsearch_error_handler';
 

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler_crawl_rules.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler_crawl_rules.ts
@@ -7,7 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { RouteDependencies } from '../../../plugin';
+import type { RouteDependencies } from '../../../types';
 
 export function registerCrawlerCrawlRulesRoutes({
   router,

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler_entry_points.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler_entry_points.ts
@@ -7,7 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { RouteDependencies } from '../../../plugin';
+import type { RouteDependencies } from '../../../types';
 
 export function registerCrawlerEntryPointRoutes({
   router,

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler_extraction_rules.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler_extraction_rules.ts
@@ -7,7 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { RouteDependencies } from '../../../plugin';
+import type { RouteDependencies } from '../../../types';
 
 const extractionRuleSchema = schema.object({
   extraction_rule: schema.object({

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler_multiple_schedules.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler_multiple_schedules.ts
@@ -13,7 +13,7 @@ import { ErrorCode } from '../../../../common/types/error_codes';
 
 import { fetchCrawlerCustomSchedulingByIndexName } from '../../../lib/crawler/fetch_crawler_multiple_schedules';
 import { postCrawlerCustomScheduling } from '../../../lib/crawler/post_crawler_multiple_schedules';
-import { RouteDependencies } from '../../../plugin';
+import type { RouteDependencies } from '../../../types';
 import { createError } from '../../../utils/create_error';
 import { elasticsearchErrorHandler } from '../../../utils/elasticsearch_error_handler';
 

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler_sitemaps.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/crawler/crawler_sitemaps.ts
@@ -7,7 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 
-import { RouteDependencies } from '../../../plugin';
+import type { RouteDependencies } from '../../../types';
 
 export function registerCrawlerSitemapRoutes({
   router,

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/documents.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/documents.ts
@@ -9,7 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 import { ErrorCode } from '../../../common/types/error_codes';
 import { getDocument } from '../../lib/indices/document/get_document';
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 import { isNotFoundException } from '../../utils/identify_exceptions';
 

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
 
 import { registerDocumentRoute } from './documents';
 import { registerIndexRoutes } from './indices';

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -61,7 +61,7 @@ import { getIndexPipelineParameters } from '../../lib/pipelines/get_index_pipeli
 import { getPipeline } from '../../lib/pipelines/get_pipeline';
 import { getMlInferencePipelines } from '../../lib/pipelines/ml_inference/get_ml_inference_pipelines';
 import { revertCustomPipeline } from '../../lib/pipelines/revert_custom_pipeline';
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
 import { createError } from '../../utils/create_error';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 import {

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/mapping.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/mapping.ts
@@ -10,7 +10,7 @@ import { schema } from '@kbn/config-schema';
 import { ErrorCode } from '../../../common/types/error_codes';
 
 import { fetchMapping } from '../../lib/fetch_mapping';
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
 import { createError } from '../../utils/create_error';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 import { isIndexNotFoundException } from '../../utils/identify_exceptions';

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search.ts
@@ -13,7 +13,7 @@ import { ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } from '../../../common/c
 
 import { ErrorCode } from '../../../common/types/error_codes';
 
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
 import { createError } from '../../utils/create_error';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 import { isIndexNotFoundException } from '../../utils/identify_exceptions';

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search_applications.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search_applications.ts
@@ -19,7 +19,7 @@ import { fetchAliasIndices } from '../../lib/search_applications/fetch_alias_ind
 import { fetchIndicesStats } from '../../lib/search_applications/fetch_indices_stats';
 
 import { fetchSearchApplicationFieldCapabilities } from '../../lib/search_applications/field_capabilities';
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
 
 import { createError } from '../../utils/create_error';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/stats.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/stats.ts
@@ -8,7 +8,7 @@
 import { schema } from '@kbn/config-schema';
 
 import { fetchSyncJobsStats } from '../../lib/stats/get_sync_jobs';
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
 
 export function registerStatsRoutes({

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
@@ -10,7 +10,7 @@ import { schema } from '@kbn/config-schema';
 import { ES_TELEMETRY_NAME } from '../../collectors/enterprise_search/telemetry';
 import { incrementUICounter } from '../../collectors/lib/telemetry';
 
-import { RouteDependencies } from '../../plugin';
+import type { RouteDependencies } from '../../types';
 
 const productToTelemetryMap = {
   enterprise_search: ES_TELEMETRY_NAME,

--- a/x-pack/solutions/search/plugins/enterprise_search/server/types.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/types.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/server';
+import type {
+  Logger,
+  SavedObjectsServiceStart,
+  IRouter,
+  StartServicesAccessor,
+} from '@kbn/core/server';
+import type { CustomIntegrationsPluginSetup } from '@kbn/custom-integrations-plugin/server';
+import type { DataPluginStart } from '@kbn/data-plugin/server/plugin';
+import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type { FleetStartContract } from '@kbn/fleet-plugin/server';
+import type { GlobalSearchPluginSetup } from '@kbn/global-search-plugin/server';
+import type { GuidedOnboardingPluginSetup } from '@kbn/guided-onboarding-plugin/server';
+
+import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
+import type { LogsSharedPluginSetup } from '@kbn/logs-shared-plugin/server';
+import type { MlPluginSetup } from '@kbn/ml-plugin/server';
+import type { SearchConnectorsPluginSetup } from '@kbn/search-connectors-plugin/server';
+import type { SecurityPluginSetup } from '@kbn/security-plugin/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
+
+import type { IEnterpriseSearchRequestHandler } from './lib/enterprise_search_request_handler';
+import type { GlobalConfigService } from './services/global_config_service';
+
+import type { ConfigType } from '.';
+
+export interface PluginsSetup {
+  cloud?: CloudSetup;
+  customIntegrations?: CustomIntegrationsPluginSetup;
+  features: FeaturesPluginSetup;
+  globalSearch: GlobalSearchPluginSetup;
+  guidedOnboarding?: GuidedOnboardingPluginSetup;
+  licensing: LicensingPluginStart;
+  logsShared: LogsSharedPluginSetup;
+  ml?: MlPluginSetup;
+  searchConnectors?: SearchConnectorsPluginSetup;
+  security: SecurityPluginSetup;
+  usageCollection?: UsageCollectionSetup;
+}
+
+export interface PluginsStart {
+  cloud?: CloudStart;
+  data: DataPluginStart;
+  fleet?: FleetStartContract;
+  spaces?: SpacesPluginStart;
+}
+
+export interface RouteDependencies {
+  config: ConfigType;
+  enterpriseSearchRequestHandler: IEnterpriseSearchRequestHandler;
+  getSavedObjectsService?(): SavedObjectsServiceStart;
+  getStartServices: StartServicesAccessor<PluginsStart, unknown>;
+  globalConfigService: GlobalConfigService;
+  licensing?: LicensingPluginStart;
+  log: Logger;
+  ml?: MlPluginSetup;
+  router: IRouter;
+}

--- a/x-pack/solutions/search/plugins/enterprise_search/server/utils/agentless.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/utils/agentless.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { PluginsStart } from '../types';
+
+export function isAgentlessEnabled(start: PluginsStart): boolean {
+  return (start?.cloud?.isCloudEnabled ?? false) && (start.fleet?.agentless.enabled ?? false);
+}


### PR DESCRIPTION
## Summary

This PR updates the `hasNativeConnectors` feature value in `enterprise_search` to be set based on if the deployment is in cloud with agentless enabled instead of based on the config value (which will be removed in the future).