### PR TITLE
[Security Solution] [Attack discovery] Additional Alerts filtering tests

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/anonymized_alerts_retriever/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/anonymized_alerts_retriever/index.test.ts
@@ -65,14 +65,39 @@ describe('AnonymizedAlertsRetriever', () => {
       replacement2: 'SRVWIN01',
       replacement3: 'SRVWIN02',
     };
+    const start = '2025-01-01T00:00:00.000Z';
+    const end = '2025-01-02T00:00:00.000Z';
+    const filter = {
+      bool: {
+        must: [],
+        filter: [
+          {
+            match_phrase: {
+              'user.name': 'root',
+            },
+          },
+        ],
+        should: [],
+        must_not: [
+          {
+            match_phrase: {
+              'host.name': 'foo',
+            },
+          },
+        ],
+      },
+    };
 
     const retriever = new AnonymizedAlertsRetriever({
       alertsIndexPattern: 'test-pattern',
       anonymizationFields,
+      end,
       esClient,
+      filter,
       onNewReplacements,
       replacements: mockReplacements,
       size: 10,
+      start,
     });
 
     await retriever._getRelevantDocuments('test-query');
@@ -80,10 +105,13 @@ describe('AnonymizedAlertsRetriever', () => {
     expect(getAnonymizedAlerts as jest.Mock).toHaveBeenCalledWith({
       alertsIndexPattern: 'test-pattern',
       anonymizationFields,
+      end,
       esClient,
+      filter,
       onNewReplacements,
       replacements: mockReplacements,
       size: 10,
+      start,
     });
   });
 

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/helpers/get_anonymized_alerts/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/helpers/get_anonymized_alerts/index.test.ts
@@ -121,6 +121,50 @@ describe('getAnonymizedAlerts', () => {
     });
   });
 
+  it('calls getOpenAndAcknowledgedAlertsQuery with the optional filter parameters', async () => {
+    const start = '2025-01-01T00:00:00.000Z';
+    const end = '2025-01-02T00:00:00.000Z';
+    const filter = {
+      bool: {
+        must: [],
+        filter: [
+          {
+            match_phrase: {
+              'user.name': 'root',
+            },
+          },
+        ],
+        should: [],
+        must_not: [
+          {
+            match_phrase: {
+              'host.name': 'foo',
+            },
+          },
+        ],
+      },
+    };
+
+    await getAnonymizedAlerts({
+      alertsIndexPattern,
+      end,
+      esClient: mockEsClient,
+      filter,
+      replacements: mockReplacements,
+      size,
+      start,
+    });
+
+    expect(getOpenAndAcknowledgedAlertsQuery).toHaveBeenCalledWith({
+      alertsIndexPattern,
+      anonymizationFields: [],
+      end,
+      filter,
+      size,
+      start,
+    });
+  });
+
   it('returns the expected transformed (anonymized) raw data', async () => {
     const result = await getAnonymizedAlerts({
       alertsIndexPattern,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/state/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/state/index.test.ts
@@ -112,4 +112,65 @@ describe('getDefaultGraphState', () => {
 
     expect(state.unrefinedResults?.default?.()).toBeNull();
   });
+
+  it('returns the expected default end', () => {
+    const state = getDefaultGraphState();
+
+    expect(state.end?.default?.()).toBeUndefined();
+  });
+
+  it('returns the expected end when it is provided', () => {
+    const end = '2025-01-02T00:00:00.000Z';
+
+    const state = getDefaultGraphState({ end });
+
+    expect(state.end?.default?.()).toEqual(end);
+  });
+
+  it('returns the expected default filter to be undefined', () => {
+    const state = getDefaultGraphState();
+
+    expect(state.filter?.default?.()).toBeUndefined();
+  });
+
+  it('returns the expected filter when it is provided', () => {
+    const filter = {
+      bool: {
+        must: [],
+        filter: [
+          {
+            match_phrase: {
+              'user.name': 'root',
+            },
+          },
+        ],
+        should: [],
+        must_not: [
+          {
+            match_phrase: {
+              'host.name': 'foo',
+            },
+          },
+        ],
+      },
+    };
+
+    const state = getDefaultGraphState({ filter });
+
+    expect(state.filter?.default?.()).toEqual(filter);
+  });
+
+  it('returns the expected default start to be undefined', () => {
+    const state = getDefaultGraphState();
+
+    expect(state.start?.default?.()).toBeUndefined();
+  });
+
+  it('returns the expected start when it is provided', () => {
+    const start = '2025-01-01T00:00:00.000Z';
+
+    const state = getDefaultGraphState({ start });
+
+    expect(state.start?.default?.()).toEqual(start);
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/header/index.test.tsx
@@ -28,6 +28,20 @@ jest.mock('@kbn/elastic-assistant-common', () => {
   };
 });
 
+const defaultProps = {
+  stats: null,
+  connectorId: 'testConnectorId',
+  connectorsAreConfigured: true,
+  isDisabledActions: false,
+  isLoading: false,
+  localStorageAttackDiscoveryMaxAlerts: `${DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS}`,
+  onCancel: jest.fn(),
+  onGenerate: jest.fn(),
+  onConnectorIdSelected: jest.fn(),
+  openFlyout: jest.fn(),
+  setLocalStorageAttackDiscoveryMaxAlerts: jest.fn(),
+};
+
 describe('Actions', () => {
   beforeEach(() => {
     (useAssistantAvailability as jest.Mock).mockReturnValue({
@@ -42,19 +56,7 @@ describe('Actions', () => {
   it('renders the connector selector', () => {
     render(
       <TestProviders>
-        <Header
-          stats={null}
-          connectorId="testConnectorId"
-          connectorsAreConfigured={true}
-          isDisabledActions={false}
-          isLoading={false}
-          localStorageAttackDiscoveryMaxAlerts={`${DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS}`}
-          onCancel={jest.fn()}
-          onGenerate={jest.fn()}
-          onConnectorIdSelected={jest.fn()}
-          openFlyout={jest.fn()}
-          setLocalStorageAttackDiscoveryMaxAlerts={jest.fn()}
-        />
+        <Header {...defaultProps} />
       </TestProviders>
     );
 
@@ -68,19 +70,7 @@ describe('Actions', () => {
 
     render(
       <TestProviders>
-        <Header
-          stats={null}
-          connectorId="testConnectorId"
-          connectorsAreConfigured={connectorsAreConfigured}
-          isDisabledActions={false}
-          isLoading={false}
-          localStorageAttackDiscoveryMaxAlerts={`${DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS}`}
-          onCancel={jest.fn()}
-          onGenerate={jest.fn()}
-          onConnectorIdSelected={jest.fn()}
-          openFlyout={jest.fn()}
-          setLocalStorageAttackDiscoveryMaxAlerts={jest.fn()}
-        />
+        <Header {...defaultProps} connectorsAreConfigured={connectorsAreConfigured} />
       </TestProviders>
     );
 
@@ -94,19 +84,7 @@ describe('Actions', () => {
 
     render(
       <TestProviders>
-        <Header
-          stats={null}
-          connectorId="testConnectorId"
-          connectorsAreConfigured={true}
-          isDisabledActions={false}
-          isLoading={false}
-          localStorageAttackDiscoveryMaxAlerts={`${DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS}`}
-          onCancel={jest.fn()}
-          onConnectorIdSelected={jest.fn()}
-          onGenerate={onGenerate}
-          openFlyout={jest.fn()}
-          setLocalStorageAttackDiscoveryMaxAlerts={jest.fn()}
-        />
+        <Header {...defaultProps} onGenerate={onGenerate} />
       </TestProviders>
     );
 
@@ -122,19 +100,7 @@ describe('Actions', () => {
 
     render(
       <TestProviders>
-        <Header
-          stats={null}
-          connectorId="testConnectorId"
-          connectorsAreConfigured={true}
-          isDisabledActions={false}
-          isLoading={isLoading}
-          localStorageAttackDiscoveryMaxAlerts={`${DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS}`}
-          onCancel={jest.fn()}
-          onConnectorIdSelected={jest.fn()}
-          onGenerate={jest.fn()}
-          openFlyout={jest.fn()}
-          setLocalStorageAttackDiscoveryMaxAlerts={jest.fn()}
-        />
+        <Header {...defaultProps} isLoading={isLoading} />
       </TestProviders>
     );
 
@@ -149,19 +115,7 @@ describe('Actions', () => {
 
     render(
       <TestProviders>
-        <Header
-          stats={null}
-          connectorId="testConnectorId"
-          connectorsAreConfigured={true}
-          isDisabledActions={false}
-          isLoading={isLoading}
-          localStorageAttackDiscoveryMaxAlerts={`${DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS}`}
-          onCancel={onCancel}
-          onConnectorIdSelected={jest.fn()}
-          onGenerate={jest.fn()}
-          openFlyout={jest.fn()}
-          setLocalStorageAttackDiscoveryMaxAlerts={jest.fn()}
-        />
+        <Header {...defaultProps} isLoading={isLoading} onCancel={onCancel} />
       </TestProviders>
     );
 
@@ -176,19 +130,7 @@ describe('Actions', () => {
 
     render(
       <TestProviders>
-        <Header
-          stats={null}
-          connectorId={connectorId}
-          connectorsAreConfigured={true}
-          isDisabledActions={false}
-          isLoading={false}
-          localStorageAttackDiscoveryMaxAlerts={`${DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS}`}
-          onCancel={jest.fn()}
-          onConnectorIdSelected={jest.fn()}
-          onGenerate={jest.fn()}
-          openFlyout={jest.fn()}
-          setLocalStorageAttackDiscoveryMaxAlerts={jest.fn()}
-        />
+        <Header {...defaultProps} connectorId={connectorId} />
       </TestProviders>
     );
 
@@ -203,19 +145,7 @@ describe('Actions', () => {
 
     render(
       <TestProviders>
-        <Header
-          stats={null}
-          connectorId="testConnectorId"
-          connectorsAreConfigured={true}
-          isDisabledActions={false}
-          isLoading={false}
-          localStorageAttackDiscoveryMaxAlerts={`${DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS}`}
-          onCancel={jest.fn()}
-          onConnectorIdSelected={jest.fn()}
-          onGenerate={jest.fn()}
-          openFlyout={openFlyout}
-          setLocalStorageAttackDiscoveryMaxAlerts={jest.fn()}
-        />
+        <Header {...defaultProps} openFlyout={openFlyout} />
       </TestProviders>
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/helpers.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { showEmptyPrompt, showNoAlertsPrompt, showWelcomePrompt } from './helpers';
+import { getDefaultQuery, showEmptyPrompt, showNoAlertsPrompt, showWelcomePrompt } from './helpers';
 
 describe('helpers', () => {
   describe('showNoAlertsPrompt', () => {
@@ -147,6 +147,14 @@ describe('helpers', () => {
       });
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('getDefaultQuery', () => {
+    it('returns the expected default', () => {
+      const result = getDefaultQuery();
+
+      expect(result).toEqual({ language: 'kuery', query: '' });
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_formatted_time/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_formatted_time/index.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getFormattedDate } from '.';
+
+describe('getFormattedDate', () => {
+  it('returns null if date is null', () => {
+    const result = getFormattedDate({
+      date: null, // <-- null
+      dateFormat: 'YYYY-MM-DD',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null if date is undefined', () => {
+    const result = getFormattedDate({
+      date: undefined, // <-- undefined
+      dateFormat: 'YYYY-MM-DD',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns the original date if it cannot be parsed', () => {
+    const result = getFormattedDate({
+      date: 'now', // <-- this relative date cannot be parsed
+      dateFormat: 'YYYY-MM-DD',
+    });
+
+    expect(result).toBe('now');
+  });
+
+  it('returns the formatted date if the date is valid', () => {
+    const result = getFormattedDate({
+      date: '2024-10-25T11:12:13Z', // <-- valid
+      dateFormat: 'YYYY-MM-DD',
+    });
+
+    expect(result).toBe('2024-10-25');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_loading_message/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/get_loading_message/index.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getLoadingMessage } from '.';
+import { DEFAULT_END, DEFAULT_START } from '@kbn/elastic-assistant-common';
+import {
+  AI_IS_CURRENTLY_ANALYZING,
+  AI_IS_CURRENTLY_ANALYZING_FROM,
+  AI_IS_CURRENTLY_ANALYZING_RANGE,
+} from '../../translations';
+
+describe('getLoadingMessage', () => {
+  it('returns AI_IS_CURRENTLY_ANALYZING when start and end are the defaults', () => {
+    const result = getLoadingMessage({
+      alertsCount: 5,
+      start: DEFAULT_START, // <-- default
+      end: DEFAULT_END, // <-- default
+    });
+
+    expect(result).toBe(AI_IS_CURRENTLY_ANALYZING(5));
+  });
+
+  it('returns AI_IS_CURRENTLY_ANALYZING_RANGE when NON-default start and end are provided', () => {
+    const result = getLoadingMessage({
+      alertsCount: 10,
+      start: '2025-01-01T00:00:00Z', // <-- non-default
+      end: '2025-01-02T00:00:00Z', // <-- non-default
+    });
+
+    expect(result).toBe(
+      AI_IS_CURRENTLY_ANALYZING_RANGE({
+        alertsCount: 10,
+        start: '2025-01-01T00:00:00Z',
+        end: '2025-01-02T00:00:00Z',
+      })
+    );
+  });
+
+  it('returns AI_IS_CURRENTLY_ANALYZING_FROM when only start is provided', () => {
+    const result = getLoadingMessage({
+      alertsCount: 15,
+      start: '2025-01-01T00:00:00Z', // <-- only start
+    });
+
+    expect(result).toBe(
+      AI_IS_CURRENTLY_ANALYZING_FROM({
+        alertsCount: 15,
+        from: '2025-01-01T00:00:00Z',
+      })
+    );
+  });
+
+  it('returns AI_IS_CURRENTLY_ANALYZING when neither start nor end are provided', () => {
+    const result = getLoadingMessage({
+      alertsCount: 20,
+    });
+
+    expect(result).toBe(AI_IS_CURRENTLY_ANALYZING(20));
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/loading_callout/loading_messages/index.test.tsx
@@ -5,39 +5,120 @@
  * 2.0.
  */
 
+import { defaultAssistantFeatures } from '@kbn/elastic-assistant-common';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { LoadingMessages } from '.';
 import { TestProviders } from '../../../../common/mock';
-import { ATTACK_DISCOVERY_GENERATION_IN_PROGRESS } from '../translations';
+
+jest.mock('@kbn/elastic-assistant-common', () => {
+  const original = jest.requireActual('@kbn/elastic-assistant-common');
+
+  return {
+    ...original,
+    defaultAssistantFeatures: {
+      ...original.defaultAssistantFeatures,
+      attackDiscoveryAlertFiltering: jest.mocked<boolean>(false), // <-- feature flag is off by default
+    },
+  };
+});
 
 describe('LoadingMessages', () => {
-  it('renders the expected loading message', () => {
-    render(
-      <TestProviders>
-        <LoadingMessages alertsContextCount={20} localStorageAttackDiscoveryMaxAlerts={'30'} />
-      </TestProviders>
-    );
-    const attackDiscoveryGenerationInProgress = screen.getByTestId(
-      'attackDiscoveryGenerationInProgress'
-    );
+  beforeEach(() => {
+    jest.clearAllMocks();
 
-    expect(attackDiscoveryGenerationInProgress).toHaveTextContent(
-      ATTACK_DISCOVERY_GENERATION_IN_PROGRESS
-    );
+    (defaultAssistantFeatures.attackDiscoveryAlertFiltering as jest.Mocked<boolean>) = false; // reset feature flag to off
   });
 
-  it('renders the loading message with the expected alerts count', () => {
+  it('renders the expected loading message, when the attackDiscoveryAlertFiltering feature flag is off', () => {
     render(
       <TestProviders>
-        <LoadingMessages alertsContextCount={20} localStorageAttackDiscoveryMaxAlerts={'30'} />
+        <LoadingMessages alertsContextCount={20} localStorageAttackDiscoveryMaxAlerts={undefined} />
       </TestProviders>
     );
     const aiCurrentlyAnalyzing = screen.getByTestId('aisCurrentlyAnalyzing');
 
     expect(aiCurrentlyAnalyzing).toHaveTextContent(
       'AI is analyzing up to 20 alerts in the last 24 hours to generate discoveries.'
+    );
+  });
+
+  it('renders a special-case loading message for the default relative range (of the last 24 hours), when attackDiscoveryAlertFiltering is on', () => {
+    (defaultAssistantFeatures.attackDiscoveryAlertFiltering as jest.Mocked<boolean>) = true; // <-- feature flag is on
+
+    render(
+      <TestProviders>
+        <LoadingMessages
+          alertsContextCount={20}
+          localStorageAttackDiscoveryMaxAlerts={'30'}
+          start={'now-24h'} // <-- special-case default relative range
+          end={'now'}
+        />
+      </TestProviders>
+    );
+    const aiCurrentlyAnalyzing = screen.getByTestId('aisCurrentlyAnalyzing');
+
+    expect(aiCurrentlyAnalyzing).toHaveTextContent(
+      'AI is analyzing up to 20 alerts in the last 24 hours to generate discoveries.'
+    );
+  });
+
+  it('renders the expected loading message for a NON-default relative date range, when attackDiscoveryAlertFiltering is on', () => {
+    (defaultAssistantFeatures.attackDiscoveryAlertFiltering as jest.Mocked<boolean>) = true;
+
+    render(
+      <TestProviders>
+        <LoadingMessages
+          alertsContextCount={20}
+          localStorageAttackDiscoveryMaxAlerts={'30'}
+          start={'now-72h'} // <-- NON-default relative date range
+          end={'now'}
+        />
+      </TestProviders>
+    );
+    const aiCurrentlyAnalyzing = screen.getByTestId('aisCurrentlyAnalyzing');
+
+    expect(aiCurrentlyAnalyzing).toHaveTextContent(
+      'AI is analyzing up to 20 alerts from now-72h to now to generate discoveries.'
+    );
+  });
+
+  it('renders the expected loading message for an absolute date range, when attackDiscoveryAlertFiltering is on', () => {
+    (defaultAssistantFeatures.attackDiscoveryAlertFiltering as jest.Mocked<boolean>) = true;
+
+    render(
+      <TestProviders>
+        <LoadingMessages
+          alertsContextCount={20}
+          localStorageAttackDiscoveryMaxAlerts={'30'}
+          start={'2025-01-01T00:00:00.000Z'}
+          end={'2025-01-02T00:00:00.000Z'}
+        />
+      </TestProviders>
+    );
+    const aiCurrentlyAnalyzing = screen.getByTestId('aisCurrentlyAnalyzing');
+
+    expect(aiCurrentlyAnalyzing).toHaveTextContent(
+      /AI is analyzing up to 20 alerts from \w+ \d+, \d+ @ \d+:\d+:\d+.\d+ to \w+ \d+, \d+ @ \d+:\d+:\d+.\d+ to generate discoveries./
+    );
+  });
+
+  it('renders the expected loading message with the default max alerts (from local storage) when alertsContextCount is null', () => {
+    (defaultAssistantFeatures.attackDiscoveryAlertFiltering as jest.Mocked<boolean>) = true;
+
+    render(
+      <TestProviders>
+        <LoadingMessages
+          alertsContextCount={null} // <-- null
+          localStorageAttackDiscoveryMaxAlerts={'30'} // <-- default fallback
+        />
+      </TestProviders>
+    );
+    const aiCurrentlyAnalyzing = screen.getByTestId('aisCurrentlyAnalyzing');
+
+    expect(aiCurrentlyAnalyzing).toHaveTextContent(
+      'AI is analyzing up to 30 alerts in the last 24 hours to generate discoveries.'
     );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/local_storage/deserialize_filters/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/local_storage/deserialize_filters/index.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FilterStateStore } from '@kbn/es-query';
+
+import { deserializeFilters } from '.';
+
+describe('deserializeFilters', () => {
+  it('returns an empty array if the input is NOT valid JSON', () => {
+    const result = deserializeFilters('invalid JSON');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array if the input does not match the schema', () => {
+    const result = deserializeFilters(JSON.stringify({ invalid: 'does not match schema' }));
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an array of filters if the input matches the schema', () => {
+    const validFilters = [
+      {
+        $state: { store: FilterStateStore.APP_STATE },
+        meta: { key: 'value' },
+        query: { match: { field: 'value' } },
+      },
+    ];
+
+    const result = deserializeFilters(JSON.stringify(validFilters));
+
+    expect(result).toEqual(validFilters);
+  });
+
+  it('returns an empty array if the input is an empty string', () => {
+    const result = deserializeFilters('');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array if the input is null', () => {
+    const result = deserializeFilters(null as unknown as string);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array if the input is undefined', () => {
+    const result = deserializeFilters(undefined as unknown as string);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/local_storage/deserialize_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/local_storage/deserialize_query/index.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { deserializeQuery } from '.';
+import { getDefaultQuery } from '../../helpers';
+
+describe('deserializeQuery', () => {
+  it('returns the parsed query when a valid JSON string is provided', () => {
+    const jsonString = JSON.stringify({ query: 'host.name: *', language: 'kuery' });
+
+    const result = deserializeQuery(jsonString);
+
+    expect(result).toEqual({ query: 'host.name: *', language: 'kuery' });
+  });
+
+  it('returns the default query when an invalid JSON string is provided', () => {
+    const jsonString = 'invalid json';
+
+    const result = deserializeQuery(jsonString);
+
+    expect(result).toEqual(getDefaultQuery());
+  });
+
+  it('returns the default query when a JSON string does not match the schema', () => {
+    const jsonString = JSON.stringify({ invalid: 'this does not match the schema' });
+
+    const result = deserializeQuery(jsonString);
+
+    expect(result).toEqual(getDefaultQuery());
+  });
+
+  it('returns the parsed query when it is valid', () => {
+    const jsonString = JSON.stringify({ query: { match_all: {} }, language: 'kuery' });
+
+    const result = deserializeQuery(jsonString);
+
+    expect(result).toEqual({ query: { match_all: {} }, language: 'kuery' });
+  });
+
+  it('returns the default query when query is missing', () => {
+    const jsonString = JSON.stringify({ language: 'kuery' }); // <-- missing query
+
+    const result = deserializeQuery(jsonString);
+
+    expect(result).toEqual(getDefaultQuery());
+  });
+
+  it('returns the default query when language is missing', () => {
+    const jsonString = JSON.stringify({ query: 'host.name: *' });
+
+    const result = deserializeQuery(jsonString);
+
+    expect(result).toEqual(getDefaultQuery());
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_selection_query/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_selection_query/index.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { AlertSelectionQuery } from '.';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { TestProviders } from '../../../../../common/mock';
+import { useSourcererDataView } from '../../../../../sourcerer/containers';
+
+jest.mock('../../../../../common/lib/kibana');
+jest.mock('../../../../../sourcerer/containers');
+
+const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
+const mockUseSourcererDataView = useSourcererDataView as jest.MockedFunction<
+  typeof useSourcererDataView
+>;
+
+describe('AlertSelectionQuery', () => {
+  const defaultProps = {
+    end: 'now',
+    filters: [],
+    query: { query: '', language: 'kuery' },
+    setEnd: jest.fn(),
+    setFilters: jest.fn(),
+    setQuery: jest.fn(),
+    setStart: jest.fn(),
+    start: 'now-15m',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseKibana.mockReturnValue({
+      services: {
+        unifiedSearch: {
+          ui: {
+            SearchBar: () => <div data-test-subj="mockSearchBar" />,
+          },
+        },
+      },
+    } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+
+    mockUseSourcererDataView.mockReturnValue({
+      sourcererDataView: {},
+      loading: false,
+    } as unknown as jest.Mocked<ReturnType<typeof useSourcererDataView>>);
+  });
+
+  it('renders the SearchBar', () => {
+    render(
+      <TestProviders>
+        <AlertSelectionQuery {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('mockSearchBar')).toBeInTheDocument();
+  });
+
+  it('renders the date picker', () => {
+    render(
+      <TestProviders>
+        <AlertSelectionQuery {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('alertSelectionDatePicker')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_selection_range/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_selection_range/index.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { AlertSelectionRange } from '.';
+import { SEND_FEWER_ALERTS, SET_NUMBER_OF_ALERTS_TO_ANALYZE } from '../translations';
+
+const defaultProps = {
+  maxAlerts: 100,
+  setMaxAlerts: jest.fn(),
+};
+
+describe('AlertSelectionRange', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the title', () => {
+    render(<AlertSelectionRange {...defaultProps} />);
+
+    expect(screen.getByTestId('title')).toHaveTextContent(SET_NUMBER_OF_ALERTS_TO_ANALYZE);
+  });
+
+  it('renders the AlertsRange', () => {
+    render(<AlertSelectionRange {...defaultProps} />);
+
+    expect(screen.getByTestId('alertsRange')).toBeInTheDocument();
+  });
+
+  it('renders the send fewer alerts text', () => {
+    render(<AlertSelectionRange {...defaultProps} />);
+
+    expect(screen.getByTestId('sendFewerAlerts')).toHaveTextContent(SEND_FEWER_ALERTS);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/get_esql_keep_statement/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/get_esql_keep_statement/index.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getEsqlKeepStatement } from '.';
+
+describe('getEsqlKeepStatement', () => {
+  it('renames the field when tableStackBy0 is "kibana.alert.rule.name"', () => {
+    const result = getEsqlKeepStatement('kibana.alert.rule.name');
+
+    expect(result).toBe(
+      '| RENAME kibana.alert.rule.name AS `Rule name`\n| KEEP `Rule name`, Count'
+    );
+  });
+
+  it('does NOT rename the field when tableStackBy0 is NOT "kibana.alert.rule.name"', () => {
+    const result = getEsqlKeepStatement('some.other.field');
+
+    expect(result).toBe('| KEEP `some.other.field`, Count');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/index.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAlertSummaryEsqlQuery } from '.';
+
+describe('getAlertSummaryEsqlQuery', () => {
+  it('returns the expected query when tableStackBy0 is kibana.alert.rule.name', () => {
+    const query = getAlertSummaryEsqlQuery({
+      alertsIndexPattern: 'alerts-*',
+      maxAlerts: 100,
+      tableStackBy0: 'kibana.alert.rule.name',
+    });
+
+    expect(query).toBe(
+      `FROM alerts-* METADATA _id, _index, _version
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| SORT kibana.alert.risk_score DESC, @timestamp DESC
+| LIMIT 100
+| STATS Count = count() by \`kibana.alert.rule.name\`
+| SORT Count DESC
+| RENAME kibana.alert.rule.name AS \`Rule name\`
+| KEEP \`Rule name\`, Count\n`
+    );
+  });
+
+  it('returns the expected query when tableStackBy0 is NOT kibana.alert.rule.name', () => {
+    const query = getAlertSummaryEsqlQuery({
+      alertsIndexPattern: 'alerts-*',
+      maxAlerts: 100,
+      tableStackBy0: 'kibana.alert.severity',
+    });
+
+    expect(query).toBe(
+      `FROM alerts-* METADATA _id, _index, _version
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| SORT kibana.alert.risk_score DESC, @timestamp DESC
+| LIMIT 100
+| STATS Count = count() by \`kibana.alert.severity\`
+| SORT Count DESC
+| KEEP \`kibana.alert.severity\`, Count\n`
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_lens_attributes/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_lens_attributes/index.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAlertSummaryLensAttributes, DEFAULT_PAGE_SIZE } from '.';
+import * as i18n from '../../translations';
+import type { Sorting } from '../../types';
+
+describe('getAlertSummaryLensAttributes', () => {
+  const esqlQuery = 'FROM alerts';
+  const tableStackBy0 = 'kibana.alert.rule.name';
+  const sorting: Sorting = { columnId: '@timestamp', direction: 'asc' };
+
+  it("returns the expected query when tableStackBy0 is 'kibana.alert.rule.name'", () => {
+    const result = getAlertSummaryLensAttributes({ esqlQuery, tableStackBy0 });
+
+    expect(result).toEqual({
+      references: [],
+      state: {
+        adHocDataViews: {},
+        datasourceStates: {
+          textBased: {
+            layers: {
+              '094d6c10-a28a-4780-8a0c-5789b73e4cef': {
+                columns: [
+                  {
+                    columnId: 'tableStackBy0',
+                    fieldName: 'Rule name',
+                  },
+                  {
+                    columnId: 'count',
+                    fieldName: 'Count',
+                    inMetricDimension: true,
+                    meta: {
+                      type: 'number',
+                      esType: 'long',
+                    },
+                  },
+                ],
+                index: 'F2772070-4F12-4603-A318-82F98BA69DAB',
+                query: {
+                  esql: esqlQuery,
+                },
+                timeField: '@timestamp',
+              },
+            },
+          },
+        },
+        filters: [],
+        query: {
+          language: 'kuery',
+          query: '',
+        },
+        visualization: {
+          columns: [
+            {
+              columnId: 'tableStackBy0',
+              width: 300,
+            },
+            {
+              columnId: 'count',
+              summaryRow: 'sum',
+            },
+          ],
+          layerId: '094d6c10-a28a-4780-8a0c-5789b73e4cef',
+          layerType: 'data',
+          paging: {
+            enabled: true,
+            size: DEFAULT_PAGE_SIZE,
+          },
+          sorting: {},
+        },
+      },
+      title: i18n.ALERTS_SUMMARY,
+      visualizationType: 'lnsDatatable',
+    });
+  });
+
+  it("returns the expected query when tableStackBy0 is NOT 'kibana.alert.rule.name'", () => {
+    const customTableStackBy0 = 'user.name';
+
+    const result = getAlertSummaryLensAttributes({ esqlQuery, tableStackBy0: customTableStackBy0 });
+
+    expect(
+      result.state.datasourceStates.textBased?.layers['094d6c10-a28a-4780-8a0c-5789b73e4cef']
+        .columns[0].fieldName
+    ).toBe(customTableStackBy0);
+  });
+
+  it('returns lens attributes with a custom page size', () => {
+    const customPageSize = 20;
+    const result = getAlertSummaryLensAttributes({
+      defaultPageSize: customPageSize,
+      esqlQuery,
+      tableStackBy0,
+    });
+
+    expect((result.state.visualization as { paging: { size: number } }).paging.size).toBe(
+      customPageSize
+    );
+  });
+
+  it('returns lens attributes with the expected sorting', () => {
+    const result = getAlertSummaryLensAttributes({ esqlQuery, tableStackBy0, sorting });
+
+    expect((result.state.visualization as { sorting: typeof sorting }).sorting).toEqual(sorting);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alerts_preview_tab/get_alerts_preview_esql_query/get_esql_keep_statement/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alerts_preview_tab/get_alerts_preview_esql_query/get_esql_keep_statement/index.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getEsqlKeepStatement } from '.';
+
+describe('getEsqlKeepStatement', () => {
+  it("renames the rule name (and risk score) when tableStackBy0 is 'kibana.alert.rule.name'", () => {
+    const result = getEsqlKeepStatement('kibana.alert.rule.name');
+
+    expect(result).toBe(
+      '| RENAME kibana.alert.rule.name AS `Rule name`, kibana.alert.risk_score AS `Risk score`\n| KEEP `Rule name`, `Risk score`, @timestamp, host.name, user.name'
+    );
+  });
+
+  it("it does NOT rename the table stack by field when tableStackBy0 is NOT 'kibana.alert.rule.name'", () => {
+    const result = getEsqlKeepStatement('some.other.field');
+
+    expect(result).toBe(
+      '| RENAME kibana.alert.risk_score AS `Risk score`\n| KEEP `some.other.field`, `Risk score`, @timestamp, host.name, user.name'
+    );
+  });
+
+  it('returns the expected statement when tableStackBy0 is an empty string', () => {
+    const result = getEsqlKeepStatement('');
+    expect(result).toBe(
+      '| RENAME kibana.alert.risk_score AS `Risk score`\n| KEEP ``, `Risk score`, @timestamp, host.name, user.name'
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alerts_preview_tab/get_alerts_preview_esql_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alerts_preview_tab/get_alerts_preview_esql_query/index.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getAlertsPreviewEsqlQuery } from '.';
+
+describe('getAlertsPreviewEsqlQuery', () => {
+  it('returns a query with a renamed rule name field when tableStackBy0 is "kibana.alert.rule.name"', () => {
+    const result = getAlertsPreviewEsqlQuery({
+      alertsIndexPattern: 'alerts-*',
+      maxAlerts: 10,
+      tableStackBy0: 'kibana.alert.rule.name',
+    });
+
+    expect(result).toBe(
+      `FROM alerts-* METADATA _id, _index, _version
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| SORT kibana.alert.risk_score DESC, @timestamp DESC
+| LIMIT 10
+| RENAME kibana.alert.rule.name AS \`Rule name\`, kibana.alert.risk_score AS \`Risk score\`
+| KEEP \`Rule name\`, \`Risk score\`, @timestamp, host.name, user.name\n`
+    );
+  });
+
+  it('returns a query where the rule name field is NOT renamed when tableStackBy0 is "some.other.field"', () => {
+    const result = getAlertsPreviewEsqlQuery({
+      alertsIndexPattern: 'alerts-*',
+      maxAlerts: 10,
+      tableStackBy0: 'some.other.field',
+    });
+
+    expect(result).toBe(
+      `FROM alerts-* METADATA _id, _index, _version
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| SORT kibana.alert.risk_score DESC, @timestamp DESC
+| LIMIT 10
+| RENAME kibana.alert.risk_score AS \`Risk score\`
+| KEEP \`some.other.field\`, \`Risk score\`, @timestamp, host.name, user.name\n`
+    );
+  });
+
+  it('returns the expected query when tableStackBy0 is an empty string', () => {
+    const result = getAlertsPreviewEsqlQuery({
+      alertsIndexPattern: 'alerts-*',
+      maxAlerts: 10,
+      tableStackBy0: '',
+    });
+
+    expect(result).toBe(
+      `FROM alerts-* METADATA _id, _index, _version
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| SORT kibana.alert.risk_score DESC, @timestamp DESC
+| LIMIT 10
+| RENAME kibana.alert.risk_score AS \`Risk score\`
+| KEEP \`\`, \`Risk score\`, @timestamp, host.name, user.name\n`
+    );
+  });
+
+  it('applies a LIMIT using the specified maxAlerts', () => {
+    const result = getAlertsPreviewEsqlQuery({
+      alertsIndexPattern: 'alerts-*',
+      maxAlerts: 5,
+      tableStackBy0: 'kibana.alert.rule.name',
+    });
+
+    expect(result).toBe(
+      `FROM alerts-* METADATA _id, _index, _version
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| SORT kibana.alert.risk_score DESC, @timestamp DESC
+| LIMIT 5
+| RENAME kibana.alert.rule.name AS \`Rule name\`, kibana.alert.risk_score AS \`Risk score\`
+| KEEP \`Rule name\`, \`Risk score\`, @timestamp, host.name, user.name\n`
+    );
+  });
+
+  it('returns the specified alertsIndexPattern', () => {
+    const result = getAlertsPreviewEsqlQuery({
+      alertsIndexPattern: 'custom-alerts-*',
+      maxAlerts: 10,
+      tableStackBy0: 'kibana.alert.rule.name',
+    });
+
+    expect(result).toBe(
+      `FROM custom-alerts-* METADATA _id, _index, _version
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| SORT kibana.alert.risk_score DESC, @timestamp DESC
+| LIMIT 10
+| RENAME kibana.alert.rule.name AS \`Rule name\`, kibana.alert.risk_score AS \`Risk score\`
+| KEEP \`Rule name\`, \`Risk score\`, @timestamp, host.name, user.name\n`
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alerts_preview_tab/get_alerts_preview_lens_attributes/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alerts_preview_tab/get_alerts_preview_lens_attributes/index.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LensAttributes } from '../../../../../../common/components/visualization_actions/types';
+import { getAlertsPreviewLensAttributes, DEFAULT_PAGE_SIZE } from '.';
+import * as i18n from '../../translations';
+import type { Sorting } from '../../types';
+
+describe('getAlertsPreviewLensAttributes', () => {
+  const esqlQuery = 'FROM alerts';
+  const tableStackBy0 = 'some.field';
+  const sorting: Sorting = { columnId: '@timestamp', direction: 'asc' };
+
+  it('returns the default page size when it is NOT provided', () => {
+    const result: LensAttributes = getAlertsPreviewLensAttributes({ esqlQuery, tableStackBy0 });
+
+    expect((result.state.visualization as { paging: { size: number } }).paging.size).toBe(
+      DEFAULT_PAGE_SIZE
+    );
+  });
+
+  it('returns the provided page size when specified via defaultPageSize', () => {
+    const customPageSize = 20;
+    const result = getAlertsPreviewLensAttributes({
+      esqlQuery,
+      tableStackBy0,
+      defaultPageSize: customPageSize,
+    });
+
+    expect((result.state.visualization as { paging: { size: number } }).paging.size).toBe(
+      customPageSize
+    );
+  });
+
+  it('returns the expected esqlQuery', () => {
+    const result = getAlertsPreviewLensAttributes({ esqlQuery, tableStackBy0 });
+
+    expect(
+      result.state.datasourceStates.textBased?.layers?.['320760EB-4185-43EB-985B-94B9240C57E7']
+        ?.query?.esql
+    ).toBe(esqlQuery);
+  });
+
+  it('returns the expected columnId', () => {
+    const result = getAlertsPreviewLensAttributes({ esqlQuery, tableStackBy0 });
+
+    expect(
+      result.state.datasourceStates.textBased?.layers?.['320760EB-4185-43EB-985B-94B9240C57E7']
+        ?.columns[0].columnId
+    ).toBe('tableStackBy0');
+  });
+
+  it('returns the expected sorting configuration', () => {
+    const result = getAlertsPreviewLensAttributes({ esqlQuery, tableStackBy0, sorting });
+
+    expect((result.state.visualization as { sorting: typeof sorting }).sorting).toEqual(sorting);
+  });
+
+  it('returns the expected title', () => {
+    const result = getAlertsPreviewLensAttributes({ esqlQuery, tableStackBy0 });
+
+    expect(result.title).toBe(i18n.ALERTS_PREVIEW);
+  });
+
+  it('returns the expected visualization type', () => {
+    const result = getAlertsPreviewLensAttributes({ esqlQuery, tableStackBy0 });
+
+    expect(result.visualizationType).toBe('lnsDatatable');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/helpers/get_common_time_ranges/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/helpers/get_common_time_ranges/index.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getCommonTimeRanges } from '.';
+
+describe('getCommonTimeRanges', () => {
+  it('returns the correct time ranges', () => {
+    const timeRanges = getCommonTimeRanges();
+
+    expect(timeRanges).toEqual([
+      { end: 'now', label: 'Today', start: 'now/d' },
+      { end: 'now', label: 'This week', start: 'now/w' },
+      { end: 'now', label: 'Last 15 minutes', start: 'now-15m' },
+      { end: 'now', label: 'Last 30 minutes', start: 'now-30m' },
+      { end: 'now', label: 'Last 1 hour', start: 'now-1h' },
+      { end: 'now', label: 'Last 24 hours', start: 'now-24h' },
+      { end: 'now', label: 'Last 7 days', start: 'now-7d' },
+      { end: 'now', label: 'Last 30 days', start: 'now-30d' },
+      { end: 'now', label: 'Last 90 days', start: 'now-90d' },
+      { end: 'now', label: 'Last 1 year', start: 'now-1y' },
+    ]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/helpers/get_first_column_name/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/helpers/get_first_column_name/index.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getFirstColumnName } from '.';
+
+describe('getFirstColumnName', () => {
+  it('returns the (static, intentionally NON-i18n) "Rule name" text when tableStackBy0 is "kibana.alert.rule.name"', () => {
+    const tableStackBy0 = 'kibana.alert.rule.name';
+
+    const result = getFirstColumnName(tableStackBy0);
+
+    expect(result).toBe('Rule name');
+  });
+
+  it('returns the input string when tableStackBy0 is NOT "kibana.alert.rule.name"', () => {
+    const tableStackBy0 = 'some.other.field';
+
+    const result = getFirstColumnName(tableStackBy0);
+
+    expect(result).toEqual(tableStackBy0);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/helpers/get_max_alerts/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/helpers/get_max_alerts/index.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS } from '@kbn/elastic-assistant';
+import { getMaxAlerts } from '.';
+
+describe('getMaxAlerts', () => {
+  it('returns the default value when maxAlerts is not a number', () => {
+    expect(getMaxAlerts('not-a-number')).toBe(DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS);
+  });
+
+  it('returns the default value when maxAlerts is a negative number', () => {
+    expect(getMaxAlerts('-1')).toBe(DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS);
+  });
+
+  it('returns the default value when maxAlerts is zero', () => {
+    expect(getMaxAlerts('0')).toBe(DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS);
+  });
+
+  it('returns the numeric value when maxAlerts is a positive integer', () => {
+    expect(getMaxAlerts('5')).toBe(5);
+  });
+
+  it('returns the default value when maxAlerts is a positive decimal', () => {
+    expect(getMaxAlerts('5.5')).toBe(DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS);
+  });
+
+  it('returns the default value when maxAlerts is an empty string', () => {
+    expect(getMaxAlerts('')).toBe(DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS);
+  });
+
+  it('returns the default value when maxAlerts is a string with spaces', () => {
+    expect(getMaxAlerts('   ')).toBe(DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/helpers/get_max_alerts/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/helpers/get_max_alerts/index.ts
@@ -11,10 +11,9 @@ import { DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS } from '@kbn/elastic-assistant';
  * ensures maxAlerts is a positive number, otherwise returns the default value
  */
 export const getMaxAlerts = (maxAlerts: string): number => {
-  const defaultMaxAlerts = Number(DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS);
   const numericMaxAlerts = Number(maxAlerts);
 
   const isMaxAlertsValid = Number.isInteger(numericMaxAlerts) && numericMaxAlerts > 0;
 
-  return isMaxAlertsValid ? numericMaxAlerts : defaultMaxAlerts;
+  return isMaxAlertsValid ? numericMaxAlerts : DEFAULT_ATTACK_DISCOVERY_MAX_ALERTS;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/helpers/get_tabs/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/helpers/get_tabs/index.test.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getTabs } from '.';
+import { ALERTS_PREVIEW, ALERT_SUMMARY } from '../../translations';
+
+const mockProps = {
+  alertsPreviewStackBy0: 'mockAlertsPreviewStackBy0',
+  alertSummaryStackBy0: 'mockAlertSummaryStackBy0',
+  end: 'now',
+  filters: [],
+  maxAlerts: 100,
+  query: { query: '', language: 'kuery' },
+  setAlertsPreviewStackBy0: jest.fn(),
+  setAlertSummaryStackBy0: jest.fn(),
+  start: 'now-7',
+};
+
+describe('getTabs', () => {
+  it('returns the alert summary tab with the expected name', () => {
+    const tabs = getTabs(mockProps);
+
+    expect(tabs[0].name).toBe(ALERT_SUMMARY);
+  });
+
+  it('returns the alerts preview tab with the expected name', () => {
+    const tabs = getTabs(mockProps);
+
+    expect(tabs[1].name).toBe(ALERTS_PREVIEW);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/index.test.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { AlertSelection } from '.';
+import { useKibana } from '../../../../common/lib/kibana';
+import { TestProviders } from '../../../../common/mock';
+import { useSourcererDataView } from '../../../../sourcerer/containers';
+import { CUSTOMIZE_THE_ALERTS } from './translations';
+
+jest.mock('react-router', () => ({
+  matchPath: jest.fn(),
+  useLocation: jest.fn().mockReturnValue({
+    search: '',
+  }),
+  withRouter: jest.fn(),
+}));
+jest.mock('../../../../common/lib/kibana');
+jest.mock('../../../../sourcerer/containers');
+
+const defaultProps = {
+  alertsPreviewStackBy0: 'defaultAlertPreview',
+  alertSummaryStackBy0: 'defaultAlertSummary',
+  end: '2024-10-01T00:00:00.000Z',
+  filters: [],
+  maxAlerts: 100,
+  query: { query: '', language: 'kuery' },
+  setAlertsPreviewStackBy0: jest.fn(),
+  setAlertSummaryStackBy0: jest.fn(),
+  setEnd: jest.fn(),
+  setFilters: jest.fn(),
+  setMaxAlerts: jest.fn(),
+  setQuery: jest.fn(),
+  setStart: jest.fn(),
+  start: '2024-09-01T00:00:00.000Z',
+};
+
+const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
+const mockUseSourcererDataView = useSourcererDataView as jest.MockedFunction<
+  typeof useSourcererDataView
+>;
+
+describe('AlertSelection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseKibana.mockReturnValue({
+      services: {
+        lens: {
+          EmbeddableComponent: () => <div data-test-subj="mockEmbeddableComponent" />,
+        },
+        unifiedSearch: {
+          ui: {
+            SearchBar: () => <div data-test-subj="mockSearchBar" />,
+          },
+        },
+      },
+    } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+
+    mockUseSourcererDataView.mockReturnValue({
+      sourcererDataView: {},
+      loading: false,
+    } as unknown as jest.Mocked<ReturnType<typeof useSourcererDataView>>);
+  });
+
+  it('renders the customize alerts text', () => {
+    render(
+      <TestProviders>
+        <AlertSelection {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByText(CUSTOMIZE_THE_ALERTS)).toBeInTheDocument();
+  });
+
+  it('renders the AlertSelectionQuery', () => {
+    render(
+      <TestProviders>
+        <AlertSelection {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('customizeAlerts')).toBeInTheDocument();
+  });
+
+  it('renders the AlertSelectionRange', () => {
+    render(
+      <TestProviders>
+        <AlertSelection {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('alertSelection')).toBeInTheDocument();
+  });
+
+  it('selects the first tab by default', () => {
+    render(
+      <TestProviders>
+        <AlertSelection {...defaultProps} />
+      </TestProviders>
+    );
+
+    const firstTab = screen.getAllByRole('tab')[0];
+
+    expect(firstTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('changes the selected tab on click', () => {
+    render(
+      <TestProviders>
+        <AlertSelection {...defaultProps} />
+      </TestProviders>
+    );
+
+    const secondTab = screen.getAllByRole('tab')[1];
+    expect(secondTab).toHaveAttribute('aria-selected', 'false'); // precondition: the first tab is selected
+
+    fireEvent.click(secondTab);
+
+    expect(secondTab).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/preview_tab/index.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { PreviewTab } from '.';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { TestProviders } from '../../../../../common/mock';
+import { useSignalIndex } from '../../../../../detections/containers/detection_engine/alerts/use_signal_index';
+import { useSourcererDataView } from '../../../../../sourcerer/containers';
+
+jest.mock('../../../../../common/lib/kibana');
+jest.mock('../../../../../sourcerer/containers');
+jest.mock('../../../../../detections/containers/detection_engine/alerts/use_signal_index');
+jest.mock('react-router-dom', () => ({
+  matchPath: jest.fn(),
+  useLocation: jest.fn().mockReturnValue({
+    search: '',
+  }),
+  withRouter: jest.fn(),
+}));
+
+const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
+const mockUseSourcererDataView = useSourcererDataView as jest.MockedFunction<
+  typeof useSourcererDataView
+>;
+const mockUseSignalIndex = useSignalIndex as jest.MockedFunction<typeof useSignalIndex>;
+
+describe('PreviewTab', () => {
+  const defaultProps = {
+    embeddableId: 'test-embeddable-id',
+    end: '2024-09-01T00:00:00.000Z',
+    filters: [],
+    getLensAttributes: jest.fn(),
+    getPreviewEsqlQuery: jest.fn(),
+    maxAlerts: 100,
+    query: { query: '', language: 'kuery' },
+    setTableStackBy0: jest.fn(),
+    start: '2024-08-01T00:00:00.000Z',
+    tableStackBy0: '',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseKibana.mockReturnValue({
+      services: {
+        lens: {
+          EmbeddableComponent: () => <div data-test-subj="mockEmbeddableComponent" />,
+        },
+        unifiedSearch: {
+          ui: {
+            SearchBar: () => <div data-test-subj="mockSearchBar" />,
+          },
+        },
+      },
+    } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+
+    mockUseSourcererDataView.mockReturnValue({
+      sourcererDataView: {},
+      loading: false,
+    } as unknown as jest.Mocked<ReturnType<typeof useSourcererDataView>>);
+
+    mockUseSignalIndex.mockReturnValue({
+      loading: false,
+      signalIndexExists: true,
+      signalIndexName: 'mock-signal-index',
+      signalIndexMappingOutdated: false,
+      createDeSignalIndex: jest.fn(),
+    });
+  });
+
+  it('renders the preview tab', () => {
+    render(
+      <TestProviders>
+        <PreviewTab {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('previewTab')).toBeInTheDocument();
+  });
+
+  it('renders the StackByComboBox', () => {
+    render(
+      <TestProviders>
+        <PreviewTab {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('selectField')).toBeInTheDocument();
+  });
+
+  it('renders the reset button', () => {
+    render(
+      <TestProviders>
+        <PreviewTab {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('reset')).toBeInTheDocument();
+  });
+
+  it('calls setTableStackBy0 with the RESET_FIELD when the reset button is clicked', () => {
+    render(
+      <TestProviders>
+        <PreviewTab {...defaultProps} />
+      </TestProviders>
+    );
+
+    fireEvent.click(screen.getByTestId('reset'));
+
+    expect(defaultProps.setTableStackBy0).toHaveBeenCalledWith('kibana.alert.rule.name');
+  });
+
+  it('renders the empty prompt when tableStackBy0 is empty', () => {
+    render(
+      <TestProviders>
+        <PreviewTab {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getByTestId('emptyPrompt')).toBeInTheDocument();
+  });
+
+  it('does NOT render the empty prompt when tableStackBy0 is NOT empty', () => {
+    render(
+      <TestProviders>
+        <PreviewTab {...defaultProps} tableStackBy0="test" />
+      </TestProviders>
+    );
+
+    expect(screen.queryByTestId('emptyPrompt')).not.toBeInTheDocument();
+  });
+
+  it('returns null when signalIndexName is null', () => {
+    mockUseSignalIndex.mockReturnValue({
+      loading: false,
+      signalIndexExists: false,
+      signalIndexName: null, // <-- signalIndexName is null
+      signalIndexMappingOutdated: false,
+      createDeSignalIndex: jest.fn(),
+    });
+
+    const { container } = render(
+      <TestProviders>
+        <PreviewTab {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/use_data_view/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/use_data_view/index.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useDataView } from '.';
+import { useKibana } from '../../../../../common/lib/kibana';
+
+jest.mock('../../../../../common/lib/kibana');
+
+describe('useDataView', () => {
+  const dataViewSpec = { title: 'test' };
+  const mockDataViews = {
+    create: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        dataViews: mockDataViews,
+      },
+    });
+  });
+
+  it('returns undefined on initial render', () => {
+    const { result } = renderHook(() => useDataView({ dataViewSpec, loading: true }));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns a DataView when a valid dataViewSpec is provided', async () => {
+    const mockDataView = { id: 'mockDataViewId', title: 'test' };
+    mockDataViews.create.mockResolvedValue(mockDataView);
+
+    const { result } = renderHook(() => useDataView({ dataViewSpec, loading: false }));
+    await waitFor(() => {});
+
+    expect(result.current).toEqual(mockDataView);
+  });
+
+  it('returns undefined if dataViews.create throws an error', async () => {
+    mockDataViews.create.mockRejectedValue(new Error('simulated error'));
+
+    const { result } = renderHook(() => useDataView({ dataViewSpec, loading: false }));
+    await waitFor(() => {});
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alerts_preview/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alerts_preview/index.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AlertConsumers } from '@kbn/rule-registry-plugin/common/technical_rule_data_field_names';
+import { SECURITY_SOLUTION_RULE_TYPE_IDS } from '@kbn/securitysolution-rules';
+import { render } from '@testing-library/react';
+import React from 'react';
+import * as uuid from 'uuid';
+
+import { AlertsPreview } from '.';
+import { useKibana } from '../../../../common/lib/kibana';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('mocked-uuid'),
+}));
+
+jest.mock('../../../../common/lib/kibana', () => ({
+  useKibana: jest.fn().mockReturnValue({
+    services: {
+      triggersActionsUi: {
+        actionTypeRegistry: {
+          has: jest.fn(),
+          register: jest.fn(),
+          get: jest.fn(),
+          list: jest.fn(),
+        },
+        alertsTableConfigurationRegistry: {
+          objectTypes: {},
+          has: jest.fn(),
+          register: jest.fn(),
+          get: jest.fn(),
+          getActions: jest.fn(),
+          list: jest.fn(),
+          update: jest.fn(),
+          getAlertConfigIdPerRuleTypes: jest.fn(),
+        },
+        getAlertsStateTable: jest.fn().mockReturnValue(<div>{'Mocked Alerts Table'}</div>),
+        ruleTypeRegistry: {
+          has: jest.fn(),
+          register: jest.fn(),
+          get: jest.fn(),
+          list: jest.fn(),
+        },
+      },
+    },
+  }),
+}));
+
+describe('AlertsPreview', () => {
+  it('renders the alerts preview', () => {
+    const query = { bool: {} };
+    const size = 10;
+
+    const { getByTestId } = render(<AlertsPreview query={query} size={size} />);
+
+    expect(getByTestId('alertsPreview')).toBeInTheDocument();
+  });
+
+  it('invokes getAlertsStateTable with the expected props', () => {
+    const query = { bool: {} };
+    const size = 10;
+
+    render(<AlertsPreview query={query} size={size} />);
+
+    expect(useKibana().services.triggersActionsUi.getAlertsStateTable).toHaveBeenCalledWith({
+      alertsTableConfigurationRegistry:
+        useKibana().services.triggersActionsUi.alertsTableConfigurationRegistry,
+      configurationId: 'securitySolution-rule-details',
+      consumers: [AlertConsumers.SIEM],
+      id: `attack-discovery-alerts-preview-${uuid.v4()}`,
+      initialPageSize: size,
+      query,
+      ruleTypeIds: SECURITY_SOLUTION_RULE_TYPE_IDS,
+      showAlertStatusWithFlapping: false,
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/index.test.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SettingsFlyout } from '.';
+import { useKibana } from '../../../common/lib/kibana';
+import { TestProviders } from '../../../common/mock';
+import { useSourcererDataView } from '../../../sourcerer/containers';
+import { ATTACK_DISCOVERY_SETTINGS } from './translations';
+
+jest.mock('../../../common/lib/kibana');
+jest.mock('../../../sourcerer/containers');
+jest.mock('react-router-dom', () => ({
+  matchPath: jest.fn(),
+  useLocation: jest.fn().mockReturnValue({
+    search: '',
+  }),
+  withRouter: jest.fn(),
+}));
+
+const defaultProps = {
+  end: undefined,
+  filters: undefined,
+  localStorageAttackDiscoveryMaxAlerts: undefined,
+  onClose: jest.fn(),
+  query: undefined,
+  setEnd: jest.fn(),
+  setFilters: jest.fn(),
+  setLocalStorageAttackDiscoveryMaxAlerts: jest.fn(),
+  setQuery: jest.fn(),
+  setStart: jest.fn(),
+  start: undefined,
+};
+
+const mockUseKibana = useKibana as jest.MockedFunction<typeof useKibana>;
+const mockUseSourcererDataView = useSourcererDataView as jest.MockedFunction<
+  typeof useSourcererDataView
+>;
+
+describe('SettingsFlyout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseKibana.mockReturnValue({
+      services: {
+        lens: {
+          EmbeddableComponent: () => <div data-test-subj="mockEmbeddableComponent" />,
+        },
+        unifiedSearch: {
+          ui: {
+            SearchBar: () => <div data-test-subj="mockSearchBar" />,
+          },
+        },
+      },
+    } as unknown as jest.Mocked<ReturnType<typeof useKibana>>);
+
+    mockUseSourcererDataView.mockReturnValue({
+      sourcererDataView: {},
+      loading: false,
+    } as unknown as jest.Mocked<ReturnType<typeof useSourcererDataView>>);
+  });
+
+  it('renders the flyout title', () => {
+    render(
+      <TestProviders>
+        <SettingsFlyout {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(screen.getAllByTestId('title')[0]).toHaveTextContent(ATTACK_DISCOVERY_SETTINGS);
+  });
+
+  it('invokes onClose when the close button is clicked', () => {
+    render(
+      <TestProviders>
+        <SettingsFlyout {...defaultProps} />
+      </TestProviders>
+    );
+
+    const closeButton = screen.getByTestId('euiFlyoutCloseButton');
+    fireEvent.click(closeButton);
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  describe('when the save button is clicked', () => {
+    beforeEach(() => {
+      render(
+        <TestProviders>
+          <SettingsFlyout {...defaultProps} />
+        </TestProviders>
+      );
+
+      const save = screen.getByTestId('save');
+      fireEvent.click(save);
+    });
+
+    it('invokes setEnd', () => {
+      expect(defaultProps.setEnd).toHaveBeenCalled();
+    });
+
+    it('invokes setFilters', () => {
+      expect(defaultProps.setFilters).toHaveBeenCalled();
+    });
+
+    it('invokes setQuery', () => {
+      expect(defaultProps.setQuery).toHaveBeenCalled();
+    });
+
+    it('invokes setStart', () => {
+      expect(defaultProps.setStart).toHaveBeenCalled();
+    });
+
+    it('invokes setLocalStorageAttackDiscoveryMaxAlerts', () => {
+      expect(defaultProps.setLocalStorageAttackDiscoveryMaxAlerts).toHaveBeenCalled();
+    });
+
+    it('invokes onClose', () => {
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/parse_filter_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/parse_filter_query/index.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EMPTY_BOOL_FILTER_QUERY, isEmptyBoolFilterQuery, parseFilterQuery } from '.';
+
+const validQuery = {
+  bool: { must: [{ match: { field: 'value' } }], filter: [], should: [], must_not: [] },
+};
+
+describe('parseFilterQuery', () => {
+  describe('isEmptyBoolFilterQuery', () => {
+    it('returns true if filterQuery is undefined', () => {
+      const result = isEmptyBoolFilterQuery(undefined);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true if filterQuery is an empty bool filter query', () => {
+      const result = isEmptyBoolFilterQuery(EMPTY_BOOL_FILTER_QUERY);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false if filterQuery is NOT an empty bool filter query', () => {
+      const result = isEmptyBoolFilterQuery(validQuery);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false if filterQuery does NOT have a bool property', () => {
+      const hasNoBool = { must: [] };
+
+      const result = isEmptyBoolFilterQuery(hasNoBool);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  it('returns undefined if kqlError is NOT null', () => {
+    const result = parseFilterQuery({
+      filterQuery: JSON.stringify(validQuery),
+      kqlError: new Error('Test error'), // <-- an error occurred
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined if filterQuery is undefined', () => {
+    const result = parseFilterQuery({
+      filterQuery: undefined, // <-- undefined
+      kqlError: undefined,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined if filterQuery is NOT valid JSON', () => {
+    const result = parseFilterQuery({
+      filterQuery: 'this is NOT valid JSON', // <-- invalid JSON
+      kqlError: undefined,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined if the parsed filterQuery does NOT have a bool property', () => {
+    const result = parseFilterQuery({
+      filterQuery: '{"must": []}', // <-- missing bool property
+      kqlError: undefined,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined if parsed filterQuery is an empty bool filter query', () => {
+    const result = parseFilterQuery({
+      filterQuery: JSON.stringify(EMPTY_BOOL_FILTER_QUERY), // <-- empty bool filter query
+      kqlError: undefined,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns the parsed filterQuery if it is a valid bool filter query', () => {
+    const result = parseFilterQuery({
+      filterQuery: JSON.stringify(validQuery), // <-- valid bool filter query
+      kqlError: undefined,
+    });
+
+    expect(result).toEqual(validQuery);
+  });
+});


### PR DESCRIPTION
### [Security Solution] [Attack discovery] Additional Alerts filtering tests

This PR adds additional unit test coverage to the Attack discovery _Alerts filtering_ feature, introduced in <https://github.com/elastic/kibana/pull/205070>

![00_alerts_filtering](https://github.com/user-attachments/assets/1a81413b-b8f4-4965-a006-25fb529668a6)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->