### PR TITLE
[Cloud Security] Fixing FTR test for agentless default remove Beta badge from CSPM Agentless

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
@@ -1186,7 +1186,7 @@ describe('useSetupTechnology', () => {
     });
   });
 
-  it('should not have global_data_tags when switching from agentless to agent-based policy', async () => {
+  it.only('should not have global_data_tags when switching from agentless to agent-based policy', async () => {
     (useConfig as MockFn).mockReturnValue({
       agentless: {
         enabled: true,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
@@ -1245,5 +1245,20 @@ describe('useSetupTechnology', () => {
         })
       );
     });
+
+    act(() => {
+      result.current.handleSetupTechnologyChange(SetupTechnology.AGENT_BASED);
+    });
+
+    await waitFor(() => {
+      expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
+      expect(setNewAgentPolicy).not.toHaveBeenCalledWith({
+        global_data_tags: [
+          { name: 'organization', value: 'org' },
+          { name: 'division', value: 'div' },
+          { name: 'team', value: 'team' },
+        ],
+      });
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
@@ -1251,6 +1251,7 @@ describe('useSetupTechnology', () => {
     });
 
     await waitFor(() => {
+      expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
       expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
       expect(setNewAgentPolicy).not.toHaveBeenCalledWith({
         global_data_tags: [

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
@@ -1186,7 +1186,7 @@ describe('useSetupTechnology', () => {
     });
   });
 
-  it.only('should not have global_data_tags when switching from agentless to agent-based policy', async () => {
+  it('should not have global_data_tags when switching from agentless to agent-based policy', async () => {
     (useConfig as MockFn).mockReturnValue({
       agentless: {
         enabled: true,
@@ -1213,6 +1213,22 @@ describe('useSetupTechnology', () => {
     );
 
     act(() => {
+      result.current.handleSetupTechnologyChange(SetupTechnology.AGENT_BASED);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
+      expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
+      expect(setNewAgentPolicy).not.toHaveBeenCalledWith({
+        global_data_tags: [
+          { name: 'organization', value: 'org' },
+          { name: 'division', value: 'div' },
+          { name: 'team', value: 'team' },
+        ],
+      });
+    });
+
+    act(() => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
     });
 
@@ -1228,22 +1244,6 @@ describe('useSetupTechnology', () => {
           ],
         })
       );
-    });
-
-    act(() => {
-      result.current.handleSetupTechnologyChange(SetupTechnology.AGENT_BASED);
-    });
-
-    await waitFor(() => {
-      expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
-      expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
-      expect(setNewAgentPolicy).not.toHaveBeenCalledWith({
-        global_data_tags: [
-          { name: 'organization', value: 'org' },
-          { name: 'division', value: 'div' },
-          { name: 'team', value: 'team' },
-        ],
-      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.test.ts
@@ -1213,22 +1213,6 @@ describe('useSetupTechnology', () => {
     );
 
     act(() => {
-      result.current.handleSetupTechnologyChange(SetupTechnology.AGENT_BASED);
-    });
-
-    await waitFor(() => {
-      expect(result.current.selectedSetupTechnology).toBe(SetupTechnology.AGENT_BASED);
-      expect(setNewAgentPolicy).toHaveBeenCalledWith(newAgentPolicyMock);
-      expect(setNewAgentPolicy).not.toHaveBeenCalledWith({
-        global_data_tags: [
-          { name: 'organization', value: 'org' },
-          { name: 'division', value: 'div' },
-          { name: 'team', value: 'team' },
-        ],
-      });
-    });
-
-    act(() => {
       result.current.handleSetupTechnologyChange(SetupTechnology.AGENTLESS);
     });
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -249,18 +249,22 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
           count += data.results.active;
         }
       }
-      setAgentCount(count);
+      if (count !== agentCount) {
+        setAgentCount(count);
+      }
     };
 
     if (selectedPolicyTab === SelectedPolicyTab.NEW) {
-      setAgentCount(0);
+      if (agentCount !== 0) {
+        setAgentCount(0);
+      }
       return;
     }
 
     if (isFleetEnabled && agentPolicyIds.length > 0) {
       getAgentCount();
     }
-  }, [agentPolicyIds, selectedPolicyTab, isFleetEnabled]);
+  }, [agentPolicyIds, selectedPolicyTab, isFleetEnabled, agentCount]);
 
   const handleExtensionViewOnChange = useCallback<
     PackagePolicyEditExtensionComponentProps['onChange']

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -249,15 +249,15 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
           count += data.results.active;
         }
       }
-      if (count !== agentCount) {
-        setAgentCount(count);
-      }
+      // if (count !== agentCount) {
+      setAgentCount(count);
+      // }
     };
 
     if (selectedPolicyTab === SelectedPolicyTab.NEW) {
-      if (agentCount !== 0) {
-        setAgentCount(0);
-      }
+      // if (agentCount !== 0) {
+      setAgentCount(0);
+      // }
       return;
     }
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -249,22 +249,18 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
           count += data.results.active;
         }
       }
-      // if (count !== agentCount) {
       setAgentCount(count);
-      // }
     };
 
     if (selectedPolicyTab === SelectedPolicyTab.NEW) {
-      // if (agentCount !== 0) {
       setAgentCount(0);
-      // }
       return;
     }
 
     if (isFleetEnabled && agentPolicyIds.length > 0) {
       getAgentCount();
     }
-  }, [agentPolicyIds, selectedPolicyTab, isFleetEnabled, agentCount]);
+  }, [agentPolicyIds, selectedPolicyTab, isFleetEnabled]);
 
   const handleExtensionViewOnChange = useCallback<
     PackagePolicyEditExtensionComponentProps['onChange']

--- a/x-pack/solutions/security/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/common/constants.ts
@@ -174,4 +174,4 @@ export const SINGLE_ACCOUNT = 'single-account';
 
 export const CLOUD_SECURITY_PLUGIN_VERSION = '1.9.0';
 // Cloud Credentials Template url was implemented in 1.10.0-preview01. See PR - https://github.com/elastic/integrations/pull/9828
-export const CLOUD_CREDENTIALS_PACKAGE_VERSION = '1.13.0-preview02';
+export const CLOUD_CREDENTIALS_PACKAGE_VERSION = '1.11.0-preview13';

--- a/x-pack/solutions/security/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/common/constants.ts
@@ -174,4 +174,4 @@ export const SINGLE_ACCOUNT = 'single-account';
 
 export const CLOUD_SECURITY_PLUGIN_VERSION = '1.9.0';
 // Cloud Credentials Template url was implemented in 1.10.0-preview01. See PR - https://github.com/elastic/integrations/pull/9828
-export const CLOUD_CREDENTIALS_PACKAGE_VERSION = '1.11.0-preview13';
+export const CLOUD_CREDENTIALS_PACKAGE_VERSION = '1.13.0-preview02';

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/setup_technology_selector/setup_technology_selector.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/setup_technology_selector/setup_technology_selector.tsx
@@ -9,9 +9,7 @@ import React from 'react';
 
 import { SetupTechnology } from '@kbn/fleet-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { i18n } from '@kbn/i18n';
 import {
-  EuiBetaBadge,
   EuiAccordion,
   EuiFormRow,
   EuiLink,
@@ -19,9 +17,6 @@ import {
   EuiSuperSelect,
   EuiText,
   useGeneratedHtmlId,
-  EuiFlexItem,
-  EuiFlexGroup,
-  useEuiTheme,
 } from '@elastic/eui';
 import {
   SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ,
@@ -37,47 +32,6 @@ export const SetupTechnologySelector = ({
   setupTechnology: SetupTechnology;
   onSetupTechnologyChange: (value: SetupTechnology) => void;
 }) => {
-  const { euiTheme } = useEuiTheme();
-  const agentlessOptionBadge = (isDropDownDisplay: boolean) => {
-    const title = isDropDownDisplay ? (
-      <strong>
-        <FormattedMessage
-          id="xpack.csp.fleetIntegration.setupTechnology.agentlessDrowpownDisplay"
-          defaultMessage="Agentless"
-        />
-      </strong>
-    ) : (
-      <FormattedMessage
-        id="xpack.csp.fleetIntegration.setupTechnology.agentlessInputDisplay"
-        defaultMessage="Agentless"
-      />
-    );
-    return (
-      <EuiFlexGroup alignItems="center" responsive={false}>
-        <EuiFlexItem grow={false}>{title}</EuiFlexItem>
-        <EuiFlexItem css={{ paddingTop: !isDropDownDisplay ? euiTheme.size.xs : undefined }}>
-          <EuiBetaBadge
-            label={i18n.translate(
-              'xpack.csp.fleetIntegration.setupTechnology.agentlessInputDisplay.techPreviewBadge.label',
-              {
-                defaultMessage: 'Beta',
-              }
-            )}
-            size="m"
-            color="hollow"
-            tooltipContent={i18n.translate(
-              'xpack.csp.fleetIntegration.setupTechnology.agentlessInputDisplay.techPreviewBadge.tooltip',
-              {
-                defaultMessage:
-                  'This functionality is in technical preview and may be changed in a future release. Please help us by reporting any bugs.',
-              }
-            )}
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    );
-  };
-
   const options = [
     {
       value: SetupTechnology.AGENT_BASED,
@@ -109,11 +63,21 @@ export const SetupTechnologySelector = ({
     },
     {
       value: SetupTechnology.AGENTLESS,
-      inputDisplay: agentlessOptionBadge(false),
+      inputDisplay: (
+        <FormattedMessage
+          id="xpack.csp.fleetIntegration.setupTechnology.agentlessInputDisplay"
+          defaultMessage="Agentless"
+        />
+      ),
       'data-test-subj': 'setup-technology-agentless-option',
       dropdownDisplay: (
         <>
-          {agentlessOptionBadge(true)}
+          <strong>
+            <FormattedMessage
+              id="xpack.csp.fleetIntegration.setupTechnology.agentlessDrowpownDisplay"
+              defaultMessage="Agentless"
+            />
+          </strong>
           <EuiText size="s" color="subdued">
             <p>
               <FormattedMessage

--- a/x-pack/test/cloud_security_posture_functional/agentless/create_agent.ts
+++ b/x-pack/test/cloud_security_posture_functional/agentless/create_agent.ts
@@ -155,6 +155,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await cisIntegration.clickOptionButton(AWS_SINGLE_ACCOUNT_TEST_ID);
 
       await cisIntegration.inputIntegrationName(integrationPolicyName);
+      await cisIntegration.selectSetupTechnology('agent-based');
+      await pageObjects.header.waitUntilLoadingHasFinished();
 
       await cisIntegration.clickSaveButton();
       await pageObjects.header.waitUntilLoadingHasFinished();

--- a/x-pack/test/cloud_security_posture_functional/agentless/create_agent.ts
+++ b/x-pack/test/cloud_security_posture_functional/agentless/create_agent.ts
@@ -29,7 +29,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const AWS_SINGLE_ACCOUNT_TEST_ID = 'awsSingleTestId';
 
   // Failing: See https://github.com/elastic/kibana/issues/208495
-  describe.skip('Agentless cloud', function () {
+  describe('Agentless cloud', function () {
     let cisIntegration: typeof pageObjects.cisAddIntegration;
     let cisIntegrationAws: typeof pageObjects.cisAddIntegration.cisAws;
     let mockApiServer: http.Server;

--- a/x-pack/test/cloud_security_posture_functional/agentless/security_posture.ts
+++ b/x-pack/test/cloud_security_posture_functional/agentless/security_posture.ts
@@ -6,6 +6,7 @@
  */
 
 import expect from '@kbn/expect';
+import { AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION } from '../constants';
 import type { FtrProviderContext } from '../ftr_provider_context';
 import { AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION } from '../constants';
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/cloud_security_posture_functional/agentless/security_posture.ts
+++ b/x-pack/test/cloud_security_posture_functional/agentless/security_posture.ts
@@ -70,7 +70,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it(`should show cspm with agentless option`, async () => {
-      //   const integrationPolicyName = `cloud_security_posture-${new Date().toISOString()}`;
       await cisIntegration.navigateToAddIntegrationWithVersionPage(
         AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION
       );
@@ -82,7 +81,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       const hasAgentBased = await testSubjects.exists(POLICY_NAME_FIELD);
 
       expect(hasSetupTechnologySelector).to.be(true);
-      expect(hasAgentBased).to.be(true);
+      expect(hasAgentBased).to.be(false);
     });
   });
 }

--- a/x-pack/test/cloud_security_posture_functional/agentless/security_posture.ts
+++ b/x-pack/test/cloud_security_posture_functional/agentless/security_posture.ts
@@ -8,7 +8,6 @@
 import expect from '@kbn/expect';
 import { AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION } from '../constants';
 import type { FtrProviderContext } from '../ftr_provider_context';
-import { AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION } from '../constants';
 // eslint-disable-next-line import/no-default-export
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
@@ -28,7 +27,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const SETUP_TECHNOLOGY_SELECTOR = 'setup-technology-selector-accordion';
 
   // Failing: See https://github.com/elastic/kibana/issues/208533
-  describe.skip('Agentless Security Posture Integration Options', function () {
+  describe('Agentless Security Posture Integration Options', function () {
     let cisIntegration: typeof pageObjects.cisAddIntegration;
 
     before(async () => {


### PR DESCRIPTION
## Summary

CSPM integration 1.13.0 will introduce the is_default set to true for agentless deployment as the default option.  This will introduce some FTR tests that will fail

#### Depends on
- https://github.com/elastic/kibana/pull/208284
- https://github.com/elastic/integrations/pull/12363


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->