### PR TITLE
[8.x] [SecuritySolution] Update Entity Store Dashboard to prompt for Service Entity Type  (#207336)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -7452,6 +7452,10 @@ paths:
             schema:
               type: object
               properties:
+                entityTypes:
+                  items:
+                    $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'
+                  type: array
                 fieldHistoryLength:
                   default: 10
                   description: The number of historical values to keep for each field.

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -13033,8 +13033,6 @@ paths:
             schema:
               type: object
               properties:
-                enrichPolicyExecutionInterval:
-                  $ref: '#/components/schemas/Security_Entity_Analytics_API_Interval'
                 entityTypes:
                   items:
                     $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -13033,6 +13033,8 @@ paths:
             schema:
               type: object
               properties:
+                enrichPolicyExecutionInterval:
+                  $ref: '#/components/schemas/Security_Entity_Analytics_API_Interval'
                 entityTypes:
                   items:
                     $ref: '#/components/schemas/Security_Entity_Analytics_API_EntityType'

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/enable.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/enable.gen.ts
@@ -16,7 +16,7 @@
 
 import { z } from '@kbn/zod';
 
-import { IndexPattern, EntityType, Interval, EngineDescriptor } from './common.gen';
+import { IndexPattern, EntityType, EngineDescriptor } from './common.gen';
 
 export type InitEntityStoreRequestBody = z.infer<typeof InitEntityStoreRequestBody>;
 export const InitEntityStoreRequestBody = z.object({
@@ -27,7 +27,6 @@ export const InitEntityStoreRequestBody = z.object({
   indexPattern: IndexPattern.optional(),
   filter: z.string().optional(),
   entityTypes: z.array(EntityType).optional(),
-  enrichPolicyExecutionInterval: Interval.optional(),
 });
 export type InitEntityStoreRequestBodyInput = z.input<typeof InitEntityStoreRequestBody>;
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/enable.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/entity_analytics/entity_store/enable.gen.ts
@@ -16,7 +16,7 @@
 
 import { z } from '@kbn/zod';
 
-import { IndexPattern, EntityType, EngineDescriptor } from './common.gen';
+import { IndexPattern, EntityType, Interval, EngineDescriptor } from './common.gen';
 
 export type InitEntityStoreRequestBody = z.infer<typeof InitEntityStoreRequestBody>;
 export const InitEntityStoreRequestBody = z.object({
@@ -27,6 +27,7 @@ export const InitEntityStoreRequestBody = z.object({
   indexPattern: IndexPattern.optional(),
   filter: z.string().optional(),
   entityTypes: z.array(EntityType).optional(),
+  enrichPolicyExecutionInterval: Interval.optional(),
 });
 export type InitEntityStoreRequestBodyInput = z.input<typeof InitEntityStoreRequestBody>;
 

--- a/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/asset_criticality/parse_asset_criticality_csv_row.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/entity_analytics/asset_criticality/parse_asset_criticality_csv_row.test.ts
@@ -54,7 +54,7 @@ describe('parseAssetCriticalityCsvRow', () => {
 
     // @ts-ignore result can now only be InvalidRecord
     expect(result.error).toMatchInlineSnapshot(
-      `"Invalid entity type \\"invalid\\", expected to be one of: user, host"`
+      `"Invalid entity type \\"invalid\\", expected to be one of: user, host, service"`
     );
   });
 
@@ -68,7 +68,7 @@ describe('parseAssetCriticalityCsvRow', () => {
 
     // @ts-ignore result can now only be InvalidRecord
     expect(result.error).toMatchInlineSnapshot(
-      `"Invalid entity type \\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...\\", expected to be one of: user, host"`
+      `"Invalid entity type \\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...\\", expected to be one of: user, host, service"`
     );
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -234,7 +234,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables the Service Entity Store. The Entity Store feature will install the service engine by default.
    */
-  serviceEntityStoreEnabled: false,
+  serviceEntityStoreEnabled: true,
 
   /**
    * Enables the siem migrations feature

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -307,8 +307,6 @@ paths:
             schema:
               type: object
               properties:
-                enrichPolicyExecutionInterval:
-                  $ref: '#/components/schemas/Interval'
                 entityTypes:
                   items:
                     $ref: '#/components/schemas/EntityType'

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -307,6 +307,8 @@ paths:
             schema:
               type: object
               properties:
+                enrichPolicyExecutionInterval:
+                  $ref: '#/components/schemas/Interval'
                 entityTypes:
                   items:
                     $ref: '#/components/schemas/EntityType'

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -307,8 +307,6 @@ paths:
             schema:
               type: object
               properties:
-                enrichPolicyExecutionInterval:
-                  $ref: '#/components/schemas/Interval'
                 entityTypes:
                   items:
                     $ref: '#/components/schemas/EntityType'

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_entity_analytics_api_2023_10_31.bundled.schema.yaml
@@ -307,6 +307,8 @@ paths:
             schema:
               type: object
               properties:
+                enrichPolicyExecutionInterval:
+                  $ref: '#/components/schemas/Interval'
                 entityTypes:
                   items:
                     $ref: '#/components/schemas/EntityType'

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/entity_store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/api/entity_store.ts
@@ -7,7 +7,7 @@
 import { useMemo } from 'react';
 import type { GetEntityStoreStatusResponse } from '../../../common/api/entity_analytics/entity_store/status.gen';
 import type {
-  InitEntityStoreRequestBody,
+  InitEntityStoreRequestBodyInput,
   InitEntityStoreResponse,
 } from '../../../common/api/entity_analytics/entity_store/enable.gen';
 import type {
@@ -24,9 +24,7 @@ export const useEntityStoreRoutes = () => {
   const http = useKibana().services.http;
 
   return useMemo(() => {
-    const enableEntityStore = async (
-      options: InitEntityStoreRequestBody = { fieldHistoryLength: 10 }
-    ) => {
+    const enableEntityStore = async (options: InitEntityStoreRequestBodyInput = {}) => {
       return http.fetch<InitEntityStoreResponse>('/api/entity_store/enable', {
         method: 'POST',
         version: API_VERSIONS.public.v1,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/hooks/use_entity_store.ts
@@ -10,7 +10,10 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { IHttpFetchError } from '@kbn/core-http-browser';
 import type { GetEntityStoreStatusResponse } from '../../../../../common/api/entity_analytics/entity_store/status.gen';
-import type { InitEntityStoreResponse } from '../../../../../common/api/entity_analytics/entity_store/enable.gen';
+import type {
+  InitEntityStoreRequestBodyInput,
+  InitEntityStoreResponse,
+} from '../../../../../common/api/entity_analytics/entity_store/enable.gen';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 import type { EntityType } from '../../../../../common/api/entity_analytics';
 import {
@@ -47,18 +50,28 @@ export const useEntityStoreStatus = (opts: Options = {}) => {
 };
 
 export const ENABLE_STORE_STATUS_KEY = ['POST', 'ENABLE_ENTITY_STORE'];
-export const useEnableEntityStoreMutation = (options?: UseMutationOptions<{}>) => {
+export const useEnableEntityStoreMutation = (
+  options?: UseMutationOptions<
+    InitEntityStoreResponse,
+    ResponseError,
+    InitEntityStoreRequestBodyInput
+  >
+) => {
   const { telemetry } = useKibana().services;
   const queryClient = useQueryClient();
   const { enableEntityStore } = useEntityStoreRoutes();
 
-  return useMutation<InitEntityStoreResponse, ResponseError>(
-    () => {
+  return useMutation<
+    InitEntityStoreResponse,
+    ResponseError,
+    Partial<InitEntityStoreRequestBodyInput>
+  >(
+    (params) => {
       telemetry?.reportEvent(EntityEventTypes.EntityStoreEnablementToggleClicked, {
         timestamp: new Date().toISOString(),
         action: 'start',
       });
-      return enableEntityStore();
+      return enableEntityStore(params);
     },
     {
       mutationKey: ENABLE_STORE_STATUS_KEY,

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_store_management_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_store_management_page.tsx
@@ -96,7 +96,7 @@ export const EntityStoreManagementPage = () => {
     if (isEntityStoreEnabled(entityStoreStatus.data?.status)) {
       stopEntityEngineMutation.mutate();
     } else {
-      enableStoreMutation.mutate();
+      enableStoreMutation.mutate({});
     }
   }, [entityStoreStatus.data?.status, stopEntityEngineMutation, enableStoreMutation]);
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.test.ts
@@ -19,6 +19,8 @@ import { mockGlobalState } from '../../../../public/common/mock';
 import type { EntityDefinition } from '@kbn/entities-schema';
 import { convertToEntityManagerDefinition } from './entity_definitions/entity_manager_conversion';
 import { EntityType } from '../../../../common/search_strategy';
+import type { InitEntityEngineResponse } from '../../../../common/api/entity_analytics';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 
 const definition: EntityDefinition = convertToEntityManagerDefinition(
   {
@@ -56,6 +58,7 @@ describe('EntityStoreDataClient', () => {
     appClient: {} as AppClient,
     config: {} as EntityStoreConfig,
     experimentalFeatures: mockGlobalState.app.enableExperimental,
+    taskManager: {} as TaskManagerStartContract,
   });
 
   const defaultSearchParams = {
@@ -336,6 +339,35 @@ describe('EntityStoreDataClient', () => {
           ],
         },
       ]);
+    });
+  });
+
+  describe('enable entities', () => {
+    let spyInit: jest.SpyInstance;
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+      spyInit = jest
+        .spyOn(dataClient, 'init')
+        .mockImplementation(() => Promise.resolve({} as InitEntityEngineResponse));
+    });
+
+    it('only enable engine for the given entityType', async () => {
+      await dataClient.enable({
+        entityTypes: [EntityType.host],
+        fieldHistoryLength: 1,
+      });
+
+      expect(spyInit).toHaveBeenCalledWith(EntityType.host, expect.anything(), expect.anything());
+    });
+
+    it('does not enable engine when the given entity type is disabled', async () => {
+      await dataClient.enable({
+        entityTypes: [EntityType.universal],
+        fieldHistoryLength: 1,
+      });
+
+      expect(spyInit).not.toHaveBeenCalled();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
@@ -219,7 +219,12 @@ export class EntityStoreDataClient {
       new Promise<T>((resolve) => setTimeout(() => fn().then(resolve), 0));
 
     const { experimentalFeatures } = this.options;
-    const enginesTypes = getEnabledStoreEntityTypes(experimentalFeatures);
+    const enabledEntityTypes = getEnabledStoreEntityTypes(experimentalFeatures);
+
+    // When entityTypes param is defined it only enables the engines that are provided
+    const enginesTypes = entityTypes
+      ? (entityTypes as EntityType[]).filter((type) => enabledEntityTypes.includes(type))
+      : enabledEntityTypes;
 
     const promises = enginesTypes.map((entity) =>
       run(() =>

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_risk_scores.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_score/calculate_risk_scores.test.ts
@@ -164,7 +164,7 @@ describe('calculateRiskScores()', () => {
       expect(response).toHaveProperty('scores');
       expect(response.scores.host).toHaveLength(2);
       expect(response.scores.user).toHaveLength(2);
-      expect(response.scores.service).toHaveLength(0);
+      expect(response.scores.service).toHaveLength(2);
     });
 
     it('calculates risk score for service when the experimental flag is enabled', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[SecuritySolution] Update Entity Store Dashboard to prompt for Service Entity Type  (#207336)](https://github.com/elastic/kibana/pull/207336)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2025-01-23T10:46:46Z","message":"[SecuritySolution] Update Entity Store Dashboard to prompt for Service Entity Type  (#207336)\n\n## Summary\n\n* Display a callout to install uninstalled entity types\n* It will be displayed when the entity store is running, but some\navailable entity types are not installed\n* Add `entityTypes` param to the init entity store API\n* Enable `serviceEntityStoreEnabled` flag by default\n### Checklist\n\n\n### How to test it?\n* Disable the experimental flag on\n`x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts`\n* Open `Manage/Entity Store/Engine Status`\n* Verify that the service entity store is NOT installed\n* Reenable the flag on\n`x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts`\n* Open the Entity Dashboard page\n* It should display a callout to install more entity types\n* Click \"enable\"\n* It should install the service entity store\n* Open `Manage/Entity Store/Engine Status`\n* Verify that the service entity store IS installed\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"5c59f3bdcdd9524667047ed546c6370015ed96d2","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.0.0","Team: SecuritySolution","release_note:feature","Theme: entity_analytics","Feature:Entity Analytics","Team:Entity Analytics","backport:version","v8.18.0"],"title":"[SecuritySolution] Update Entity Store Dashboard to prompt for Service Entity Type ","number":207336,"url":"https://github.com/elastic/kibana/pull/207336","mergeCommit":{"message":"[SecuritySolution] Update Entity Store Dashboard to prompt for Service Entity Type  (#207336)\n\n## Summary\n\n* Display a callout to install uninstalled entity types\n* It will be displayed when the entity store is running, but some\navailable entity types are not installed\n* Add `entityTypes` param to the init entity store API\n* Enable `serviceEntityStoreEnabled` flag by default\n### Checklist\n\n\n### How to test it?\n* Disable the experimental flag on\n`x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts`\n* Open `Manage/Entity Store/Engine Status`\n* Verify that the service entity store is NOT installed\n* Reenable the flag on\n`x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts`\n* Open the Entity Dashboard page\n* It should display a callout to install more entity types\n* Click \"enable\"\n* It should install the service entity store\n* Open `Manage/Entity Store/Engine Status`\n* Verify that the service entity store IS installed\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"5c59f3bdcdd9524667047ed546c6370015ed96d2"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/207336","number":207336,"mergeCommit":{"message":"[SecuritySolution] Update Entity Store Dashboard to prompt for Service Entity Type  (#207336)\n\n## Summary\n\n* Display a callout to install uninstalled entity types\n* It will be displayed when the entity store is running, but some\navailable entity types are not installed\n* Add `entityTypes` param to the init entity store API\n* Enable `serviceEntityStoreEnabled` flag by default\n### Checklist\n\n\n### How to test it?\n* Disable the experimental flag on\n`x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts`\n* Open `Manage/Entity Store/Engine Status`\n* Verify that the service entity store is NOT installed\n* Reenable the flag on\n`x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts`\n* Open the Entity Dashboard page\n* It should display a callout to install more entity types\n* Click \"enable\"\n* It should install the service entity store\n* Open `Manage/Entity Store/Engine Status`\n* Verify that the service entity store IS installed\n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"5c59f3bdcdd9524667047ed546c6370015ed96d2"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->