### PR TITLE
[EDR Workflows][Staged rollout] Add artifact channel to Alert flyout's highlighted fields

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/event_details/get_alert_summary_rows.tsx
@@ -63,6 +63,7 @@ const alwaysDisplayedFields: EventSummaryField[] = [
   }),
 
   // ** //
+  { id: 'Endpoint.policy.applied.artifacts.global.channel' },
   { id: 'user.name' },
   { id: 'rule.name' },
   { id: 'cloud.provider' },

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_exceptions/utils/helpers.test.tsx
@@ -1806,6 +1806,9 @@ describe('Exception helpers', () => {
           };
         }),
         {
+          id: 'Endpoint.policy.applied.artifacts.global.channel',
+        },
+        {
           id: 'user.name',
         },
         {


### PR DESCRIPTION
## Summary

This PR adds `Endpoint.policy.applied.artifacts.global.channel` to the highlighted fields of an alert. This field shows the users, which artifact channel was used to update the rules on an Endpoint using Elastic Defend integration.

Based on the structure of the highlighted fields, I think it makes sense to add it to the 'always displayed fields', but not 100% sure on it, so I'm happy to take suggestions.

<img width="731" alt="image" src="https://github.com/user-attachments/assets/952dfc92-e9c4-4b38-8fba-8fc6a5e07ed8" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->