### PR TITLE
[EDR Workflows] Workflow Insights - Replace Tech Preview label

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights.tsx
@@ -6,7 +6,6 @@
  */
 
 import {
-  EuiHorizontalRule,
   EuiAccordion,
   EuiSpacer,
   EuiText,
@@ -135,7 +134,6 @@ export const WorkflowInsights = React.memo(({ endpointId }: WorkflowInsightsProp
           scanCompleted={scanCompleted && userTriggeredScan}
           endpointId={endpointId}
         />
-        <EuiHorizontalRule />
       </EuiAccordion>
       <EuiSpacer size="l" />
     </>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights.tsx
@@ -114,6 +114,7 @@ export const WorkflowInsights = React.memo(({ endpointId }: WorkflowInsightsProp
                 label={TECHNICAL_PREVIEW}
                 tooltipContent={TECHNICAL_PREVIEW_TOOLTIP}
                 size="s"
+                iconType={'beaker'}
                 data-test-subj={'workflow-insights-tech-preview-badge'}
               />
             </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_results.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/details/components/insights/workflow_insights_results.tsx
@@ -17,6 +17,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiToolTip,
+  EuiHorizontalRule,
 } from '@elastic/eui';
 import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
 import { useUserPrivileges } from '../../../../../../../common/components/user_privileges';
@@ -169,17 +170,20 @@ export const WorkflowInsightsResults = ({
     return null;
   }, [canWriteTrustedApplications, openArtifactCreationPage, results, showEmptyResultsCallout]);
 
+  const showInsights = !!(showEmptyResultsCallout || results?.length);
+
   return (
     <>
-      {showEmptyResultsCallout || results?.length ? (
+      {showInsights && (
         <>
           <EuiText size={'s'}>
             <h4>{WORKFLOW_INSIGHTS.issues.title}</h4>
           </EuiText>
           <EuiSpacer size={'s'} />
         </>
-      ) : null}
+      )}
       <ScrollableContainer hasBorder>{insights}</ScrollableContainer>
+      {showInsights && <EuiHorizontalRule />}
     </>
   );
 };


### PR DESCRIPTION
As requested, changed 
![Screenshot 2025-01-27 at 13 02 26](https://github.com/user-attachments/assets/4d4cfd48-78cc-408c-9963-aa1b261d3927)
to
![Screenshot 2025-01-27 at 12 56 35](https://github.com/user-attachments/assets/65ca37b0-7b2a-4186-b5a6-785281234553)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->