### PR TITLE
[Alert details page] Fix exception in loading alert history stats

### DIFF
--- a/x-pack/solutions/observability/packages/alert_details/src/hooks/use_alerts_history.test.tsx
+++ b/x-pack/solutions/observability/packages/alert_details/src/hooks/use_alerts_history.test.tsx
@@ -174,7 +174,7 @@ describe('useAlertsHistory', () => {
         '{"size":0,"rule_type_ids":["apm"],"consumers":["foo"],"query":{"bool":{"must":[' +
         '{"term":{"kibana.alert.rule.uuid":"cfd36e60-ef22-11ed-91eb-b7893acacfe2"}},' +
         '{"term":{"kibana.alert.instance.id":"instance-1"}},' +
-        '{"range":{"kibana.alert.time_range":{"from":"2023-04-10T00:00:00.000Z","to":"2023-05-10T00:00:00.000Z"}}}]}},' +
+        '{"range":{"kibana.alert.time_range":{"gte":"2023-04-10T00:00:00.000Z","lte":"2023-05-10T00:00:00.000Z"}}}]}},' +
         '"aggs":{"histogramTriggeredAlerts":{"date_histogram":{"field":"kibana.alert.start","fixed_interval":"1d",' +
         '"extended_bounds":{"min":"2023-04-10T00:00:00.000Z","max":"2023-05-10T00:00:00.000Z"}}},' +
         '"avgTimeToRecoverUS":{"filter":{"term":{"kibana.alert.status":"recovered"}},' +
@@ -217,7 +217,7 @@ describe('useAlertsHistory', () => {
       body:
         '{"size":0,"rule_type_ids":["apm"],"query":{"bool":{"must":[' +
         '{"term":{"kibana.alert.rule.uuid":"cfd36e60-ef22-11ed-91eb-b7893acacfe2"}},' +
-        '{"range":{"kibana.alert.time_range":{"from":"2023-04-10T00:00:00.000Z","to":"2023-05-10T00:00:00.000Z"}}}]}},' +
+        '{"range":{"kibana.alert.time_range":{"gte":"2023-04-10T00:00:00.000Z","lte":"2023-05-10T00:00:00.000Z"}}}]}},' +
         '"aggs":{"histogramTriggeredAlerts":{"date_histogram":{"field":"kibana.alert.start","fixed_interval":"1d",' +
         '"extended_bounds":{"min":"2023-04-10T00:00:00.000Z","max":"2023-05-10T00:00:00.000Z"}}},' +
         '"avgTimeToRecoverUS":{"filter":{"term":{"kibana.alert.status":"recovered"}},' +

--- a/x-pack/solutions/observability/packages/alert_details/src/hooks/use_alerts_history.ts
+++ b/x-pack/solutions/observability/packages/alert_details/src/hooks/use_alerts_history.ts
@@ -150,7 +150,10 @@ export async function fetchTriggeredAlertsHistory({
                 : []),
               {
                 range: {
-                  [ALERT_TIME_RANGE]: dateRange,
+                  [ALERT_TIME_RANGE]: {
+                    gte: dateRange.from,
+                    lte: dateRange.to,
+                  },
                 },
               },
             ],


### PR DESCRIPTION
## Summary

This PR fixes the following bug on the alert details page, not sure what has changed to cause this issue:

```
Error: Unable to retrieve alert details for alert with id of "undefined" or with query "{"bool":{"must":[{"term":{"kibana.alert.rule.uuid":"f90968a7-8723-4bf6-9472-1053a4e70ec1"}},{"term":{"kibana.alert.instance.id":"host-2"}},{"range":{"kibana.alert.time_range":{"from":"now-30d","to":"now+1d"}}}]}}" and operation find 
Error: ResponseError: x_content_parse_exception
        Caused by:
                x_content_parse_exception: [1:333] [bool] failed to parse field [must]
        Root causes:
                parsing_exception: [range] query does not support [from]
```

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/929e6f63-4d23-4e4b-9f3b-a878a543a53c)|![image](https://github.com/user-attachments/assets/5490f768-06df-4b69-9d14-e6b9be7dc6fa)|

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->