### PR TITLE
[Spaces] Skipped api integration tests with FIPS for get_all with basic license

### DIFF
--- a/x-pack/test/spaces_api_integration/security_and_spaces/apis/get_all.ts
+++ b/x-pack/test/spaces_api_integration/security_and_spaces/apis/get_all.ts
@@ -21,7 +21,8 @@ export default function getAllSpacesTestSuite(context: FtrProviderContext) {
   // @ts-expect-error getAllTestSuiteFactory expects only DeploymentAgnosticFtrProviderContext
   const { getAllTest, expectRbacForbidden } = getAllTestSuiteFactory(context);
 
-  describe('get all', () => {
+  describe('get all', function () {
+    this.tags('skipFIPS');
     [
       {
         spaceId: SPACES.DEFAULT.spaceId,


### PR DESCRIPTION
## Summary
`get_all` suite `x-pack/test/spaces_api_integration/security_and_spaces/apis/get_all.ts` is intented to be run only with `basic` license, since FIPS overrides it we need to skip that test for FIPS.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


