### PR TITLE
[Entity Analytics][Risk Score] Remove beta badge

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_information/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_information/index.tsx
@@ -21,14 +21,10 @@ import {
   EuiText,
   EuiTitle,
   useGeneratedHtmlId,
-  EuiBetaBadge,
-  useEuiTheme,
 } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { css } from '@emotion/react';
 
-import { BETA } from '../../../common/translations';
 import * as i18n from './translations';
 import { useOnOpenCloseHandler } from '../../../helper_hooks';
 import { RiskScoreLevel } from '../severity/common';
@@ -119,7 +115,6 @@ export const RiskInformationButtonEmpty = ({ riskEntity }: { riskEntity: EntityT
 };
 
 export const RiskInformationFlyout = ({ handleOnClose }: { handleOnClose: () => void }) => {
-  const { euiTheme } = useEuiTheme();
   const simpleFlyoutTitleId = useGeneratedHtmlId({
     prefix: 'RiskInformation',
   });
@@ -138,16 +133,6 @@ export const RiskInformationFlyout = ({ handleOnClose }: { handleOnClose: () => 
             <EuiTitle size="m">
               <h2 id={simpleFlyoutTitleId}>{i18n.TITLE}</h2>
             </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiBetaBadge
-              label={BETA}
-              size="s"
-              css={css`
-                color: ${euiTheme.colors.textParagraph};
-                margin-top: ${euiTheme.size.xxs};
-              `}
-            />
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlyoutHeader>


### PR DESCRIPTION
## Summary

This PR removed the Risk Score beta badge in the manage page flyout.


![Screenshot 2025-01-27 at 14 42 04](https://github.com/user-attachments/assets/b738b6f2-5cfa-4409-a088-745a297ca0fa)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->