### PR TITLE
[SecuritySolution][Timelines] Update privilege

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/routes/timelines/delete_timelines/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/timeline/routes/timelines/delete_timelines/index.ts
@@ -22,7 +22,7 @@ export const deleteTimelinesRoute = (router: SecuritySolutionPluginRouter) => {
       path: TIMELINE_URL,
       security: {
         authz: {
-          requiredPrivileges: ['securitySolution'],
+          requiredPrivileges: ['timeline_write'],
         },
       },
       access: 'public',


### PR DESCRIPTION
## Summary

We forgot to update this privilege in https://github.com/elastic/kibana/pull/201780 . The endpoint only uses the scoped SO client, so this missing privilege declaration does not lead to privilege escalation on the endpoint. There are automated tests that check for the correct privilege access for this and other endpoints.