### PR TITLE
[FTR] Skipped alerting snooze test for FIPS

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
@@ -409,6 +409,7 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
     });
 
     describe('validation', () => {
+      this.tags('skipFIPS');
       it('should return 400 if the id is not in a valid format', async () => {
         const { body: createdRule } = await supertest
           .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule`)

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
@@ -408,7 +408,7 @@ export default function createSnoozeRuleTests({ getService }: FtrProviderContext
       });
     });
 
-    describe('validation', () => {
+    describe('validation', function () {
       this.tags('skipFIPS');
       it('should return 400 if the id is not in a valid format', async () => {
         const { body: createdRule } = await supertest


### PR DESCRIPTION
## Summary

New test has been added for alerting in scope of this  [PR](https://github.com/elastic/kibana/pull/201508/files#diff-9d14ca1fb9743d33cb159a3b6e9c40161e3aaed85192082b09254964bf9101acR218).
We intentionally need to skip this test for FIPS due to [FIPS overrides](https://github.com/elastic/kibana/blob/542a56b4829643d05c47bcc47485dd9baaacea32/packages/kbn-test/src/functional_tests/lib/fips_overrides.ts).

Added `skipFIPS` tag


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->