### PR TITLE
[React@18] follow up fix tty test

### DIFF
--- a/x-pack/solutions/security/plugins/session_view/public/components/tty_player/hooks.test.tsx
+++ b/x-pack/solutions/security/plugins/session_view/public/components/tty_player/hooks.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { sessionViewIOEventsMock } from '../../../common/mocks/responses/session_view_io_events.mock';
 import { useIOLines, useXtermPlayer, XtermPlayerDeps } from './hooks';
 import type { ProcessEventsPage } from '../../../common';
@@ -179,21 +179,25 @@ describe('TTYPlayer/hooks', () => {
 
       rerender({ ...initialProps, isPlaying: false });
 
-      expect(result.current.terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('256');
-      expect(result.current.terminal.buffer.active.getLine(1)?.translateToString(true)).toBe(',');
-      expect(result.current.terminal.buffer.active.getLine(2)?.translateToString(true)).toBe(
-        '                             Some Companies Puppet instance'
-      );
-      expect(result.current.terminal.buffer.active.getLine(3)?.translateToString(true)).toBe(
-        '             |  |    |       CentOS Stream release 8 on x86_64'
-      );
-      expect(result.current.terminal.buffer.active.getLine(4)?.translateToString(true)).toBe(
-        '  ***********************    Load average: 1.23, 1.01, 0.63'
-      );
-      expect(result.current.terminal.buffer.active.getLine(5)?.translateToString(true)).toBe(
-        '  ************************   '
-      );
-      expect(result.current.currentLine).toBe(LOOPS);
+      await waitFor(() => {
+        expect(result.current.terminal.buffer.active.getLine(0)?.translateToString(true)).toBe(
+          '256'
+        );
+        expect(result.current.terminal.buffer.active.getLine(1)?.translateToString(true)).toBe(',');
+        expect(result.current.terminal.buffer.active.getLine(2)?.translateToString(true)).toBe(
+          '                             Some Companies Puppet instance'
+        );
+        expect(result.current.terminal.buffer.active.getLine(3)?.translateToString(true)).toBe(
+          '             |  |    |       CentOS Stream release 8 on x86_64'
+        );
+        expect(result.current.terminal.buffer.active.getLine(4)?.translateToString(true)).toBe(
+          '  ***********************    Load average: 1.23, 1.01, 0.63'
+        );
+        expect(result.current.terminal.buffer.active.getLine(5)?.translateToString(true)).toBe(
+          '  ************************   '
+        );
+        expect(result.current.currentLine).toBe(LOOPS);
+      });
     });
 
     it('will allow a plain text search highlight on the last line printed', async () => {


### PR DESCRIPTION
## Summary

This piece was left out from the https://github.com/elastic/kibana/pull/206919 (I assume by mistake) 
this waitFor is needed for testing passing with React@18, see https://github.com/elastic/kibana/pull/208339/files#diff-bf9743a8d3aa8ed102d36f9117fb14e455efa23df7da28a4ac44b7efa270899a


```
REACT_18=true yarn test:jest x-pack/solutions/security/plugins/session_view/public/components/tty_player/hooks.test.tsx
```

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->