### PR TITLE
[React@18] fix When on the host isolation exceptions page should search using expected exception item fields

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/integration_tests/host_isolation_exceptions_list.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/integration_tests/host_isolation_exceptions_list.test.tsx
@@ -60,10 +60,10 @@ describe('When on the host isolation exceptions page', () => {
   it('should search using expected exception item fields', async () => {
     const expectedFilterString = parseQueryFilterToKQL('fooFooFoo', SEARCHABLE_FIELDS);
     const { renderResult, apiMocks, user } = prepareTest();
-    const { findAllByTestId } = renderResult;
+    const { getAllByTestId } = renderResult;
 
-    await waitFor(async () => {
-      expect(await findAllByTestId(`${pageTestId}-card`)).toHaveLength(10);
+    await waitFor(() => {
+      expect(getAllByTestId(`${pageTestId}-card`)).toHaveLength(10);
     });
 
     apiMocks.responseProvider.exceptionsFind.mockClear();


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/pull/208339#issuecomment-2615621371

- [ ] [[job]](https://buildkite.com/elastic/kibana-pull-request/builds/270417#0194a78a-264a-4056-8026-2be65f9e16b9) [[logs]](https://buildkite.com/organizations/elastic/pipelines/kibana-pull-request/builds/270417/jobs/0194a78a-264a-4056-8026-2be65f9e16b9/artifacts/0194a7ad-2ab6-40c2-a11c-685683bbb663) Jest Integration Tests / When on the host isolation exceptions page should search using expected exception item fields


Fix the test so it passes with React@18


```
REACT_18=true node scripts/jest --config=x-pack/solutions/security/plugins/security_solution/jest.integration.config.js /x-pack/solutions/security/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/integration_tests/host_isolation_exceptions_list.test.tsx
```


We already saw a very similar timeout failure here: https://github.com/elastic/kibana/pull/207195/files#r1922454027


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->