### PR TITLE
Configures PagerDuty Backstage Integration for kbn

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,7 +11,7 @@ metadata:
     github.com/team-slug: elastic/kibana-tech-leads
     buildkite.com/project-slug: elastic/kibana
     sonarqube.org/project-key: elastic_kibana_AYvOkAHeQZlFqhqWIr9
-    pagerduty.com/service-id: P3CJ6U9
+    pagerduty.com/service-id: PC4TBJY
 
   tags:
     - typescript

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,6 +11,7 @@ metadata:
     github.com/team-slug: elastic/kibana-tech-leads
     buildkite.com/project-slug: elastic/kibana
     sonarqube.org/project-key: elastic_kibana_AYvOkAHeQZlFqhqWIr9
+    pagerduty.com/service-id: P3CJ6U9
 
   tags:
     - typescript
@@ -50,6 +51,7 @@ metadata:
     github.com/project-slug: elastic/kibana
     github.com/team-slug: elastic/kibana-tech-leads
     buildkite.com/project-slug: elastic/kibana
+    pagerduty.com/service-id: PC4TBJY
   tags:
     - typescript
     - javascript
@@ -77,6 +79,7 @@ metadata:
     github.com/project-slug: elastic/kibana
     github.com/team-slug: elastic/kibana-tech-leads
     buildkite.com/project-slug: elastic/kibana
+    pagerduty.com/service-id: PC4TBJY
   tags:
     - typescript
     - javascript


### PR DESCRIPTION
Integration services added: kibana-sdh, kibana-serverless

Addresses the call to action to integrate pagerduty with backstage.


