### PR TITLE
[8.x] [Canvas] Fix colors for Borealis (#207012)

### DIFF
--- a/x-pack/platform/plugins/private/canvas/public/components/datasource/datasource_component.js
+++ b/x-pack/platform/plugins/private/canvas/public/components/datasource/datasource_component.js
@@ -191,7 +191,6 @@ export class DatasourceComponent extends PureComponent {
                     size="s"
                     onClick={this.save}
                     fill
-                    color="success"
                     data-test-subj="canvasSaveDatasourceButton"
                   >
                     {strings.getSaveButtonLabel()}

--- a/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.scss
+++ b/x-pack/platform/plugins/private/canvas/public/components/page_manager/page_manager.scss
@@ -33,7 +33,7 @@
 
   .canvasPageManager__addPage {
     width: $euiSizeXXL + $euiSize;
-    background: $euiColorSuccess;
+    background: $euiColorPrimary;
     color: $euiColorGhost;
     opacity: 0;
     animation: buttonPop $euiAnimSpeedNormal $euiAnimSlightResistance;

--- a/x-pack/platform/plugins/private/canvas/public/components/var_config/edit_var.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/var_config/edit_var.tsx
@@ -209,7 +209,6 @@ export const EditVar: FC<Props> = ({ variables, selectedVar, onCancel, onSave })
           <EuiFlexGroup alignItems="center">
             <EuiFlexItem grow={false}>
               <EuiButton
-                color="success"
                 size="s"
                 fill
                 onClick={() =>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Canvas] Fix colors for Borealis (#207012)](https://github.com/elastic/kibana/pull/207012)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Catherine Liu","email":"catherine.liu@elastic.co"},"sourceCommit":{"committedDate":"2025-01-17T16:29:45Z","message":"[Canvas] Fix colors for Borealis (#207012)\n\n## Summary\r\n\r\nCloses #204597.\r\n\r\nThis changes the `success` colored buttons into `primary` colored\r\nbuttons in Canvas. There are no other necessary color/style changes for\r\nBorealis in Canvas.\r\n\r\n<img width=\"1859\" alt=\"Screenshot 2025-01-16 at 3 44 05 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/03febdfa-6f9f-4017-99f2-f6eaf82ad07f\"\r\n/>\r\n\r\n### Variable save button\r\n#### Before\r\n<img width=\"348\" alt=\"Screenshot 2025-01-16 at 3 33 54 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/20cdb998-617e-4a96-9e9f-c497be1682c7\"\r\n/>\r\n\r\n#### After\r\n<img width=\"350\" alt=\"Screenshot 2025-01-16 at 3 34 20 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/b7bf6962-ccd2-4e32-8003-73d7245395f2\"\r\n/>\r\n\r\n\r\n### Add page button\r\n#### Before\r\n<img width=\"952\" alt=\"Screenshot 2025-01-16 at 3 33 06 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/6c9db0c4-46db-47c5-bfe6-44307928bd0b\"\r\n/>\r\n\r\n#### After\r\n<img width=\"804\" alt=\"Screenshot 2025-01-16 at 3 47 20 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/b45f0977-fcad-44a1-be6f-ffb587851e12\"\r\n/>\r\n\r\n### Datasource save button\r\n#### Before\r\n<img width=\"345\" alt=\"Screenshot 2025-01-16 at 3 32 23 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/5f926b8c-057e-4925-a932-1a69b6077980\"\r\n/>\r\n\r\n#### After\r\n<img width=\"181\" alt=\"Screenshot 2025-01-16 at 3 30 58 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/d38bf8c7-6971-4840-8866-9303f963ed3f\"\r\n/>\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...","sha":"cd71ca903b6442165506a1ff0cb37e7b005c00a8","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","loe:small","release_note:skip","impact:critical","backport:skip","v9.0.0","EUI Visual Refresh"],"title":"[Canvas] Fix colors for Borealis","number":207012,"url":"https://github.com/elastic/kibana/pull/207012","mergeCommit":{"message":"[Canvas] Fix colors for Borealis (#207012)\n\n## Summary\r\n\r\nCloses #204597.\r\n\r\nThis changes the `success` colored buttons into `primary` colored\r\nbuttons in Canvas. There are no other necessary color/style changes for\r\nBorealis in Canvas.\r\n\r\n<img width=\"1859\" alt=\"Screenshot 2025-01-16 at 3 44 05 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/03febdfa-6f9f-4017-99f2-f6eaf82ad07f\"\r\n/>\r\n\r\n### Variable save button\r\n#### Before\r\n<img width=\"348\" alt=\"Screenshot 2025-01-16 at 3 33 54 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/20cdb998-617e-4a96-9e9f-c497be1682c7\"\r\n/>\r\n\r\n#### After\r\n<img width=\"350\" alt=\"Screenshot 2025-01-16 at 3 34 20 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/b7bf6962-ccd2-4e32-8003-73d7245395f2\"\r\n/>\r\n\r\n\r\n### Add page button\r\n#### Before\r\n<img width=\"952\" alt=\"Screenshot 2025-01-16 at 3 33 06 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/6c9db0c4-46db-47c5-bfe6-44307928bd0b\"\r\n/>\r\n\r\n#### After\r\n<img width=\"804\" alt=\"Screenshot 2025-01-16 at 3 47 20 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/b45f0977-fcad-44a1-be6f-ffb587851e12\"\r\n/>\r\n\r\n### Datasource save button\r\n#### Before\r\n<img width=\"345\" alt=\"Screenshot 2025-01-16 at 3 32 23 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/5f926b8c-057e-4925-a932-1a69b6077980\"\r\n/>\r\n\r\n#### After\r\n<img width=\"181\" alt=\"Screenshot 2025-01-16 at 3 30 58 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/d38bf8c7-6971-4840-8866-9303f963ed3f\"\r\n/>\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...","sha":"cd71ca903b6442165506a1ff0cb37e7b005c00a8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/207012","number":207012,"mergeCommit":{"message":"[Canvas] Fix colors for Borealis (#207012)\n\n## Summary\r\n\r\nCloses #204597.\r\n\r\nThis changes the `success` colored buttons into `primary` colored\r\nbuttons in Canvas. There are no other necessary color/style changes for\r\nBorealis in Canvas.\r\n\r\n<img width=\"1859\" alt=\"Screenshot 2025-01-16 at 3 44 05 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/03febdfa-6f9f-4017-99f2-f6eaf82ad07f\"\r\n/>\r\n\r\n### Variable save button\r\n#### Before\r\n<img width=\"348\" alt=\"Screenshot 2025-01-16 at 3 33 54 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/20cdb998-617e-4a96-9e9f-c497be1682c7\"\r\n/>\r\n\r\n#### After\r\n<img width=\"350\" alt=\"Screenshot 2025-01-16 at 3 34 20 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/b7bf6962-ccd2-4e32-8003-73d7245395f2\"\r\n/>\r\n\r\n\r\n### Add page button\r\n#### Before\r\n<img width=\"952\" alt=\"Screenshot 2025-01-16 at 3 33 06 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/6c9db0c4-46db-47c5-bfe6-44307928bd0b\"\r\n/>\r\n\r\n#### After\r\n<img width=\"804\" alt=\"Screenshot 2025-01-16 at 3 47 20 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/b45f0977-fcad-44a1-be6f-ffb587851e12\"\r\n/>\r\n\r\n### Datasource save button\r\n#### Before\r\n<img width=\"345\" alt=\"Screenshot 2025-01-16 at 3 32 23 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/5f926b8c-057e-4925-a932-1a69b6077980\"\r\n/>\r\n\r\n#### After\r\n<img width=\"181\" alt=\"Screenshot 2025-01-16 at 3 30 58 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/d38bf8c7-6971-4840-8866-9303f963ed3f\"\r\n/>\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...","sha":"cd71ca903b6442165506a1ff0cb37e7b005c00a8"}}]}] BACKPORT-->