### PR TITLE
[8.x] Add a warning callout when deleting managed assets (#207329)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -383,6 +383,7 @@ src/platform/packages/private/default-nav/analytics @elastic/kibana-data-discove
 src/platform/packages/private/default-nav/devtools @elastic/kibana-management
 src/platform/packages/private/default-nav/management @elastic/kibana-management
 src/platform/packages/private/default-nav/ml @elastic/ml-ui
+src/platform/packages/shared/kbn-management/delete_managed_assets_callout @elastic/kibana-management
 packages/kbn-dependency-usage @elastic/kibana-security
 packages/kbn-dev-cli-errors @elastic/kibana-operations
 packages/kbn-dev-cli-runner @elastic/kibana-operations
@@ -601,7 +602,6 @@ src/platform/packages/shared/kbn-management/cards_navigation @elastic/kibana-man
 src/platform/plugins/shared/management @elastic/kibana-management
 src/platform/packages/private/kbn-management/settings/application @elastic/kibana-management
 src/platform/packages/private/kbn-management/settings/components/field_category @elastic/kibana-management
-src/platform/packages/shared/kbn-management/delete_managed_assets_callout @elastic/kibana-management
 src/platform/packages/shared/kbn-management/settings/components/field_input @elastic/kibana-management
 src/platform/packages/shared/kbn-management/settings/components/field_row @elastic/kibana-management
 src/platform/packages/private/kbn-management/settings/components/form @elastic/kibana-management

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -601,6 +601,7 @@ src/platform/packages/shared/kbn-management/cards_navigation @elastic/kibana-man
 src/platform/plugins/shared/management @elastic/kibana-management
 src/platform/packages/private/kbn-management/settings/application @elastic/kibana-management
 src/platform/packages/private/kbn-management/settings/components/field_category @elastic/kibana-management
+src/platform/packages/shared/kbn-management/delete_managed_assets_callout @elastic/kibana-management
 src/platform/packages/shared/kbn-management/settings/components/field_input @elastic/kibana-management
 src/platform/packages/shared/kbn-management/settings/components/field_row @elastic/kibana-management
 src/platform/packages/private/kbn-management/settings/components/form @elastic/kibana-management

--- a/package.json
+++ b/package.json
@@ -449,6 +449,7 @@
     "@kbn/default-nav-devtools": "link:src/platform/packages/private/default-nav/devtools",
     "@kbn/default-nav-management": "link:src/platform/packages/private/default-nav/management",
     "@kbn/default-nav-ml": "link:src/platform/packages/private/default-nav/ml",
+    "@kbn/delete-managed-asset-callout": "link:src/platform/packages/shared/kbn-management/delete_managed_assets_callout",
     "@kbn/dev-tools-plugin": "link:src/platform/plugins/shared/dev_tools",
     "@kbn/developer-examples-plugin": "link:examples/developer_examples",
     "@kbn/discover-contextual-components": "link:src/platform/packages/shared/kbn-discover-contextual-components",

--- a/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/README.mdx
+++ b/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/README.mdx
@@ -1,0 +1,15 @@
+---
+id: kbn-management/components/DeleteManagedAssetsCallout
+slug: /kbn-management/components/delete_managed_assets_callout
+title: Delete Managed Assets Callout
+description: A callout component that displays a warning message for when a user is about to delete a managed asset.
+tags: ['management', 'component']
+date: 2025-01-20
+---
+
+This component is used to display a warning callout when a user is about to delete a managed asset.
+
+
+```typescript
+<DeleteManagedAssetsCallout assetName="ingest pipeline" />
+```

--- a/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/index.ts
+++ b/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export type { DeleteManagedAssetsCalloutProps } from './src/callout';
+export { DeleteManagedAssetsCallout } from './src/callout';

--- a/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/kibana.jsonc
+++ b/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/kibana.jsonc
@@ -1,0 +1,7 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/delete-managed-asset-callout",
+  "owner": "@elastic/kibana-management",
+  "group": "platform",
+  "visibility": "shared"
+}

--- a/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/package.json
+++ b/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/delete-managed-asset-callout",
+  "private": true,
+  "version": "1.0.0",
+  "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0"
+}

--- a/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/src/callout.stories.tsx
+++ b/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/src/callout.stories.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+
+import { DeleteManagedAssetsCallout as Component } from './callout';
+
+export default {
+  title: 'Developer/Delete Managed Assets Callout',
+  description: '',
+};
+
+export const DeleteManagedAssetsCallout = () => {
+  return <Component assetName="ingest pipelines" />;
+};
+
+export const ErrorDeleteManagedAssetsCallout = () => {
+  return <Component assetName="ingest pipelines" color="danger" iconType="trash" />;
+};

--- a/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/src/callout.tsx
+++ b/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/src/callout.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import type { EuiCallOutProps } from '@elastic/eui';
+import { EuiCallOut } from '@elastic/eui';
+
+export interface DeleteManagedAssetsCalloutProps extends EuiCallOutProps {
+  assetName: string;
+  overrideBody?: string;
+}
+
+export const DeleteManagedAssetsCallout = ({
+  assetName,
+  overrideBody,
+  ...overrideCalloutProps
+}: DeleteManagedAssetsCalloutProps) => {
+  return (
+    <EuiCallOut
+      color="warning"
+      iconType="warning"
+      data-test-subj="deleteManagedAssetsCallout"
+      {...overrideCalloutProps}
+    >
+      <p>
+        {overrideBody ??
+          i18n.translate('management.deleteManagedAssetsCallout.body', {
+            defaultMessage: `Elasticsearch automatically re-creates any missing managed {assetName}. If you delete managed {assetName}, the deletion appears as successful, but the {assetName} are immediately re-created and reappear.`,
+            values: { assetName },
+          })}
+      </p>
+    </EuiCallOut>
+  );
+};

--- a/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/tsconfig.json
+++ b/src/platform/packages/shared/kbn-management/delete_managed_assets_callout/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": [
+      "jest",
+      "node",
+      "react"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/i18n",
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -760,6 +760,8 @@
       "@kbn/default-nav-management/*": ["src/platform/packages/private/default-nav/management/*"],
       "@kbn/default-nav-ml": ["src/platform/packages/private/default-nav/ml"],
       "@kbn/default-nav-ml/*": ["src/platform/packages/private/default-nav/ml/*"],
+      "@kbn/delete-managed-asset-callout": ["src/platform/packages/shared/kbn-management/delete_managed_assets_callout"],
+      "@kbn/delete-managed-asset-callout/*": ["src/platform/packages/shared/kbn-management/delete_managed_assets_callout/*"],
       "@kbn/dependency-usage": ["packages/kbn-dependency-usage"],
       "@kbn/dependency-usage/*": ["packages/kbn-dependency-usage/*"],
       "@kbn/dev-cli-errors": ["packages/kbn-dev-cli-errors"],

--- a/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/home/index_templates_tab.test.ts
+++ b/x-pack/platform/plugins/shared/index_management/__jest__/client_integration/home/index_templates_tab.test.ts
@@ -455,7 +455,7 @@ describe('Index Templates tab', () => {
           `${API_BASE_PATH}/delete_index_templates`,
           expect.objectContaining({
             body: JSON.stringify({
-              templates: [{ name: templates[0].name, isLegacy }],
+              templates: [{ name: templates[0].name, isLegacy, type: 'default' }],
             }),
           })
         );
@@ -518,7 +518,7 @@ describe('Index Templates tab', () => {
           `${API_BASE_PATH}/delete_index_templates`,
           expect.objectContaining({
             body: JSON.stringify({
-              templates: [{ name: templates[0].name, isLegacy: false }],
+              templates: [{ name: templates[0].name, isLegacy: false, type: 'default' }],
             }),
           })
         );

--- a/x-pack/platform/plugins/shared/index_management/public/application/components/template_delete_modal.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/template_delete_modal.tsx
@@ -6,10 +6,11 @@
  */
 
 import React, { Fragment, useState } from 'react';
-import { EuiConfirmModal, EuiCallOut, EuiCheckbox, EuiBadge } from '@elastic/eui';
+import { EuiConfirmModal, EuiCallOut, EuiCheckbox, EuiBadge, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { DeleteManagedAssetsCallout } from '@kbn/delete-managed-asset-callout';
 import { deleteTemplates } from '../services/api';
 import { notificationService } from '../services/notification';
 
@@ -17,7 +18,7 @@ export const TemplateDeleteModal = ({
   templatesToDelete,
   callback,
 }: {
-  templatesToDelete: Array<{ name: string; isLegacy?: boolean }>;
+  templatesToDelete: Array<{ name: string; isLegacy?: boolean; type?: string }>;
   callback: (data?: { hasDeletedTemplates: boolean }) => void;
 }) => {
   const [isDeleteConfirmed, setIsDeleteConfirmed] = useState<boolean>(false);
@@ -25,6 +26,9 @@ export const TemplateDeleteModal = ({
   const numTemplatesToDelete = templatesToDelete.length;
 
   const hasSystemTemplate = Boolean(templatesToDelete.find(({ name }) => name.startsWith('.')));
+  const managedTemplatesToDelete = templatesToDelete.filter(
+    ({ type }) => type === 'managed'
+  ).length;
 
   const handleDeleteTemplates = () => {
     deleteTemplates(templatesToDelete).then(({ data: { templatesDeleted, errors }, error }) => {
@@ -109,6 +113,17 @@ export const TemplateDeleteModal = ({
       confirmButtonDisabled={hasSystemTemplate ? !isDeleteConfirmed : false}
     >
       <Fragment>
+        {managedTemplatesToDelete > 0 && (
+          <>
+            <DeleteManagedAssetsCallout
+              assetName={i18n.translate('xpack.idxMgmt.deleteTemplatesModal.assetName', {
+                defaultMessage: 'index templates',
+              })}
+            />
+
+            <EuiSpacer size="m" />
+          </>
+        )}
         <p>
           <FormattedMessage
             id="xpack.idxMgmt.deleteTemplatesModal.deleteDescription"
@@ -118,9 +133,20 @@ export const TemplateDeleteModal = ({
         </p>
 
         <ul>
-          {templatesToDelete.map(({ name }) => (
+          {templatesToDelete.map(({ name, type }) => (
             <li key={name}>
               {name}
+              {type === 'managed' && (
+                <>
+                  {' '}
+                  <EuiBadge color="hollow">
+                    <FormattedMessage
+                      id="xpack.idxMgmt.deleteTemplatesModal.managedTemplateLabel"
+                      defaultMessage="Managed"
+                    />
+                  </EuiBadge>
+                </>
+              )}
               {name.startsWith('.') ? (
                 <Fragment>
                   {' '}

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/template_list/template_details/template_details_content.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/template_list/template_details/template_details_content.tsx
@@ -89,7 +89,7 @@ const tabToUiMetricMap: { [key: string]: string } = {
 };
 
 export interface Props {
-  template: { name: string; isLegacy?: boolean };
+  template: { name: string; isLegacy?: boolean; type?: string };
   onClose: () => void;
   editTemplate: (name: string, isLegacy?: boolean) => void;
   cloneTemplate: (name: string, isLegacy?: boolean) => void;
@@ -106,8 +106,9 @@ export const TemplateDetailsContent = ({
   const { uiMetricService } = useServices();
   const { error, data: templateDetails, isLoading } = useLoadIndexTemplate(templateName, isLegacy);
   const isCloudManaged = templateDetails?._kbnMeta.type === 'cloudManaged';
+  const templateType = templateDetails?._kbnMeta.type;
   const [templateToDelete, setTemplateToDelete] = useState<
-    Array<{ name: string; isLegacy?: boolean }>
+    Array<{ name: string; isLegacy?: boolean; type?: string }>
   >([]);
   const [activeTab, setActiveTab] = useState<string>(SUMMARY_TAB_ID);
   const [isPopoverOpen, setIsPopOverOpen] = useState<boolean>(false);
@@ -306,7 +307,11 @@ export const TemplateDetailsContent = ({
                             defaultMessage: 'Delete',
                           }),
                           icon: 'trash',
-                          onClick: () => setTemplateToDelete([{ name: templateName, isLegacy }]),
+                          onClick: () =>
+                            setTemplateToDelete([
+                              { name: templateName, isLegacy, type: templateType },
+                            ]),
+                          'data-test-subj': 'deleteIndexTemplateButton',
                           disabled: isCloudManaged,
                         },
                       ],

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/template_list/template_table/template_table.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/template_list/template_table/template_table.tsx
@@ -42,7 +42,7 @@ export const TemplateTable: React.FunctionComponent<Props> = ({
   const { uiMetricService } = useServices();
   const [selection, setSelection] = useState<TemplateListItem[]>([]);
   const [templatesToDelete, setTemplatesToDelete] = useState<
-    Array<{ name: string; isLegacy?: boolean }>
+    Array<{ name: string; isLegacy?: boolean; type?: string }>
   >([]);
 
   const columns: Array<EuiBasicTableColumn<TemplateListItem>> = [
@@ -182,8 +182,8 @@ export const TemplateTable: React.FunctionComponent<Props> = ({
           icon: 'trash',
           color: 'danger',
           type: 'icon',
-          onClick: ({ name, _kbnMeta: { isLegacy } }: TemplateListItem) => {
-            setTemplatesToDelete([{ name, isLegacy }]);
+          onClick: ({ name, _kbnMeta: { isLegacy, type } }: TemplateListItem) => {
+            setTemplatesToDelete([{ name, isLegacy, type }]);
           },
           isPrimary: true,
           enabled: ({ _kbnMeta: { type } }: TemplateListItem) => type !== 'cloudManaged',
@@ -233,9 +233,10 @@ export const TemplateTable: React.FunctionComponent<Props> = ({
           data-test-subj="deleteTemplatesButton"
           onClick={() =>
             setTemplatesToDelete(
-              selection.map(({ name, _kbnMeta: { isLegacy } }: TemplateListItem) => ({
+              selection.map(({ name, _kbnMeta: { isLegacy, type } }: TemplateListItem) => ({
                 name,
                 isLegacy,
+                type,
               }))
             )
           }

--- a/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_delete_route.ts
+++ b/x-pack/platform/plugins/shared/index_management/server/routes/api/templates/register_delete_route.ts
@@ -17,6 +17,7 @@ const bodySchema = schema.object({
     schema.object({
       name: schema.string(),
       isLegacy: schema.maybe(schema.boolean()),
+      type: schema.maybe(schema.string()),
     })
   ),
 });

--- a/x-pack/platform/plugins/shared/index_management/tsconfig.json
+++ b/x-pack/platform/plugins/shared/index_management/tsconfig.json
@@ -56,6 +56,7 @@
     "@kbn/unsaved-changes-prompt",
     "@kbn/shared-ux-table-persist",
     "@kbn/core-application-browser",
+    "@kbn/delete-managed-asset-callout",
     "@kbn/inference-endpoint-ui-common",
   ],
   "exclude": ["target/**/*"]

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/details_flyout.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/details_flyout.tsx
@@ -39,7 +39,7 @@ export interface Props {
   pipeline: Pipeline;
   onEditClick: (pipelineName: string) => void;
   onCloneClick: (pipelineName: string) => void;
-  onDeleteClick: (pipelineName: string[]) => void;
+  onDeleteClick: (pipelineName: Pipeline[]) => void;
   onClose: () => void;
 }
 
@@ -80,9 +80,10 @@ export const PipelineDetailsFlyout: FunctionComponent<Props> = ({
         defaultMessage: 'Delete',
       }),
       icon: <EuiIcon type="trash" />,
+      'data-test-subj': 'deletePipelineButton',
       onClick: () => {
         setShowPopover(false);
-        onDeleteClick([pipeline.name]);
+        onDeleteClick([pipeline]);
       },
     },
   ];

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/main.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/main.tsx
@@ -57,7 +57,7 @@ export const PipelinesList: React.FunctionComponent<RouteComponentProps> = ({
   const [showFlyout, setShowFlyout] = useState<boolean>(false);
   const [showPopover, setShowPopover] = useState<boolean>(false);
 
-  const [pipelinesToDelete, setPipelinesToDelete] = useState<string[]>([]);
+  const [pipelinesToDelete, setPipelinesToDelete] = useState<Pipeline[]>([]);
 
   const { data, isLoading, error, resendRequest } = services.api.useLoadPipelines();
 

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/table.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/table.tsx
@@ -40,7 +40,7 @@ export interface Props {
   isLoading: boolean;
   onEditPipelineClick: (pipelineName: string) => void;
   onClonePipelineClick: (pipelineName: string) => void;
-  onDeletePipelineClick: (pipelineName: string[]) => void;
+  onDeletePipelineClick: (pipelineName: Pipeline[]) => void;
 }
 
 export const deprecatedPipelineBadge = {
@@ -246,7 +246,7 @@ export const PipelineTable: FunctionComponent<Props> = ({
         selection.length > 0 ? (
           <EuiButton
             data-test-subj="deletePipelinesButton"
-            onClick={() => onDeletePipelineClick(selection.map((pipeline) => pipeline.name))}
+            onClick={() => onDeletePipelineClick(selection)}
             color="danger"
           >
             <FormattedMessage
@@ -423,7 +423,7 @@ export const PipelineTable: FunctionComponent<Props> = ({
             type: 'icon',
             icon: 'trash',
             color: 'danger',
-            onClick: ({ name }) => onDeletePipelineClick([name]),
+            onClick: (pipeline) => onDeletePipelineClick([pipeline]),
           },
         ],
       },

--- a/x-pack/platform/plugins/shared/ingest_pipelines/tsconfig.json
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/tsconfig.json
@@ -38,7 +38,8 @@
     "@kbn/core-http-browser-mocks",
     "@kbn/shared-ux-table-persist",
     "@kbn/core-http-browser",
-    "@kbn/core-plugins-server"
+    "@kbn/core-plugins-server",
+    "@kbn/delete-managed-asset-callout"
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/test/functional/apps/index_management/index_templates_tab/index.ts
+++ b/x-pack/test/functional/apps/index_management/index_templates_tab/index.ts
@@ -10,5 +10,6 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 export default ({ loadTestFile }: FtrProviderContext) => {
   describe('Index Management: index templates tab', function () {
     loadTestFile(require.resolve('./index_template_tab'));
+    loadTestFile(require.resolve('./index_template_list'));
   });
 };

--- a/x-pack/test/functional/apps/index_management/index_templates_tab/index_template_list.ts
+++ b/x-pack/test/functional/apps/index_management/index_templates_tab/index_template_list.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default ({ getPageObjects, getService }: FtrProviderContext) => {
+  const pageObjects = getPageObjects(['common', 'indexManagement', 'header']);
+  const log = getService('log');
+  const security = getService('security');
+  const testSubjects = getService('testSubjects');
+
+  describe('Index template tab -> templates list', function () {
+    before(async () => {
+      await log.debug('Navigating to the index templates tab');
+      await security.testUser.setRoles(['index_management_user']);
+      await pageObjects.common.navigateToApp('indexManagement');
+
+      // Navigate to the templates tab
+      await pageObjects.indexManagement.changeTabs('templatesTab');
+      await pageObjects.header.waitUntilLoadingHasFinished();
+    });
+
+    it('shows warning callout when deleting a managed index template', async () => {
+      // Open the flyout for any managed index template
+      await pageObjects.indexManagement.clickIndexTemplateNameLink('ilm-history-7');
+
+      // Open the manage context menu
+      await testSubjects.click('manageTemplateButton');
+      // Click the delete button
+      await testSubjects.click('deleteIndexTemplateButton');
+
+      // Check if the callout is displayed
+      const calloutExists = await testSubjects.exists('deleteManagedAssetsCallout');
+      expect(calloutExists).to.be(true);
+    });
+  });
+};

--- a/x-pack/test/functional/apps/ingest_pipelines/ingest_pipelines.ts
+++ b/x-pack/test/functional/apps/ingest_pipelines/ingest_pipelines.ts
@@ -77,6 +77,24 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         expect(url).not.to.contain(`pipeline=${pipelinesList[0]}`);
       });
 
+      it('shows warning callout when deleting a managed pipeline', async () => {
+        // Filter results by managed pipelines
+        await testSubjects.click('filtersDropdown');
+        await testSubjects.click('managedFilter');
+
+        // Open the flyout for the first pipeline
+        await pageObjects.ingestPipelines.clickPipelineLink(0);
+
+        // Open the manage context menu
+        await testSubjects.click('managePipelineButton');
+        // Click the delete button
+        await testSubjects.click('deletePipelineButton');
+
+        // Check if the callout is displayed
+        const calloutExists = await testSubjects.exists('deleteManagedAssetsCallout');
+        expect(calloutExists).to.be(true);
+      });
+
       it('sets query params for search and filters when changed', async () => {
         // Set the search input with a test search
         await testSubjects.setValue('pipelineTableSearch', 'test');

--- a/x-pack/test/functional/page_objects/index_management_page.ts
+++ b/x-pack/test/functional/page_objects/index_management_page.ts
@@ -168,6 +168,7 @@ export function IndexManagementPageProvider({ getService }: FtrProviderContext) 
     async clickNextButton() {
       await testSubjects.click('nextButton');
     },
+
     indexDetailsPage: {
       async openIndexDetailsPage(indexOfRow: number) {
         const indexList = await testSubjects.findAll('indexTableIndexNameLink');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5369,6 +5369,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/delete-managed-asset-callout@link:src/platform/packages/shared/kbn-management/delete_managed_assets_callout":
+  version "0.0.0"
+  uid ""
+
 "@kbn/dependency-usage@link:packages/kbn-dependency-usage":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add a warning callout when deleting managed assets (#207329)](https://github.com/elastic/kibana/pull/207329)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ignacio Rivas","email":"rivasign@gmail.com"},"sourceCommit":{"committedDate":"2025-01-28T08:46:58Z","message":"Add a warning callout when deleting managed assets (#207329)","sha":"c8bd387668ed3e6fe0fd71ec9cfbc5be58bbfc5c","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Index Management","Team:Kibana Management","release_note:skip","v9.0.0","Feature:Ingest Node Pipelines","backport:prev-minor"],"title":"Add a warning callout when deleting managed assets","number":207329,"url":"https://github.com/elastic/kibana/pull/207329","mergeCommit":{"message":"Add a warning callout when deleting managed assets (#207329)","sha":"c8bd387668ed3e6fe0fd71ec9cfbc5be58bbfc5c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/207329","number":207329,"mergeCommit":{"message":"Add a warning callout when deleting managed assets (#207329)","sha":"c8bd387668ed3e6fe0fd71ec9cfbc5be58bbfc5c"}}]}] BACKPORT-->