### PR TITLE
[FTR] Added skipFIPS tag for copy_to_space test with basic license

### DIFF
--- a/x-pack/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/copy_to_space/copy_to_space.ts
+++ b/x-pack/test/spaces_api_integration/deployment_agnostic/security_and_spaces/apis/copy_to_space/copy_to_space.ts
@@ -32,7 +32,14 @@ export default function copyToSpaceSpacesAndSecuritySuite(
     createMultiNamespaceTestCases,
   } = copyToSpaceTestSuiteFactory(context);
 
-  describe('copy to spaces', () => {
+  const config = context.getService('config');
+  const license = config.get('esTestCluster.license');
+
+  describe('copy to spaces', function () {
+    if (license === 'basic') {
+      this.tags('skipFIPS');
+    }
+
     [
       {
         spaceId: SPACES.DEFAULT.spaceId,


### PR DESCRIPTION
## Summary
`copy_to_space` in `stateful.copy_to_space.config_basic.ts` is intended to be run only with `basic` license, since FIPS overrides it we need to skip that test for FIPS.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
