### PR TITLE
[ci] fix typo in hoverable_avatar.test.tsx

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/user_profiles/hoverable_avatar.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/user_profiles/hoverable_avatar.test.tsx
@@ -11,7 +11,7 @@ import { userProfiles } from '../../containers/user_profiles/api.mock';
 import { HoverableAvatar } from './hoverable_avatar';
 
 // Failing: See https://github.com/elastic/kibana/issues/207406
-describe.test('HoverableAvatar', () => {
+describe.skip('HoverableAvatar', () => {
   it('renders the avatar', async () => {
     render(<HoverableAvatar userInfo={userProfiles[0]} />);
 


### PR DESCRIPTION
## Summary
Fixes an erroneous commit from https://github.com/elastic/kibana/issues/207406