### PR TITLE
[ci] Don't start APM/Profiling cypress if pre-checks don't pass

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -487,7 +487,6 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
-    depends_on: build
     timeout_in_minutes: 120
     parallelism: 3
     retry:
@@ -503,7 +502,6 @@ steps:
       provider: gcp
       machineType: n2-standard-4
       preemptible: true
-    depends_on: build
     timeout_in_minutes: 120
     parallelism: 3
     retry:


### PR DESCRIPTION
## Summary
https://buildkite.com/elastic/kibana-on-merge/builds/60136 shows how even though some preliminary checks failed, some cypress tests started after the build step was successful. It's probably because they had explicit dependencies, but only on a subset of the pre-checks.

<!--ONMERGE {"backportTargets":["7.17","8.16","8.17","8.x"]} ONMERGE-->