### PR TITLE
[APM] Fix missing exception stack trace 

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
@@ -176,7 +176,7 @@ export async function getErrorGroupMainStatistics({
         error: {
           ...(event.error ?? {}),
           exception:
-            (errorSource?.error.exception?.length ?? 0) > 1
+            (errorSource?.error.exception?.length ?? 0) > 0
               ? errorSource?.error.exception
               : event?.error.exception && [event.error.exception],
         },

--- a/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_sample_details.ts
@@ -159,7 +159,7 @@ export async function getErrorSampleDetails({
       error: {
         ...errorFromFields.error,
         exception:
-          (source?.error.exception?.length ?? 0) > 1
+          (source?.error.exception?.length ?? 0) > 0
             ? source?.error.exception
             : errorFromFields?.error.exception && [errorFromFields.error.exception],
         log: source?.error?.log,

--- a/x-pack/solutions/observability/plugins/apm/server/routes/mobile/crashes/get_crash_groups/get_crash_group_main_statistics.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/mobile/crashes/get_crash_groups/get_crash_group_main_statistics.ts
@@ -142,7 +142,7 @@ export async function getMobileCrashGroupMainStatistics({
         error: {
           ...(event.error ?? {}),
           exception:
-            (errorSource?.error.exception?.length ?? 0) > 1
+            (errorSource?.error.exception?.length ?? 0) > 0
               ? errorSource?.error.exception
               : event?.error.exception && [event.error.exception],
         },

--- a/x-pack/solutions/observability/plugins/apm/server/routes/mobile/errors/get_mobile_error_group_main_statistics.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/mobile/errors/get_mobile_error_group_main_statistics.ts
@@ -143,7 +143,7 @@ export async function getMobileErrorGroupMainStatistics({
         error: {
           ...(event.error ?? {}),
           exception:
-            (errorSource?.error.exception?.length ?? 0) > 1
+            (errorSource?.error.exception?.length ?? 0) > 0
               ? errorSource?.error.exception
               : event?.error.exception && [event.error.exception],
         },

--- a/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/traces/get_trace_items.ts
@@ -166,7 +166,7 @@ export async function getTraceItems({
       error: {
         ...(event.error ?? {}),
         exception:
-          (errorSource?.error.exception?.length ?? 0) > 1
+          (errorSource?.error.exception?.length ?? 0) > 0
             ? errorSource?.error.exception
             : event?.error.exception && [event.error.exception],
         log: errorSource?.error.log,


### PR DESCRIPTION
Closes #203359

## Summary

Fix the incorrect condition that prevents an exception stack trace from being displayed.

| before | after |
|-|-|
| <img width="2560" alt="Screenshot 2025-01-31 at 10 06 00" src="https://github.com/user-attachments/assets/88656d5e-0964-4686-8a03-a07ab8459709" /> | <img width="2560" alt="Screenshot 2025-01-31 at 10 06 38" src="https://github.com/user-attachments/assets/037cbb98-d7cf-4388-8d94-80c32eb5b17f" /> |

## AC:

- [x] Exception stack trace is displayed in APM,
- [x] Tested with native Otel collector,
- [x] ~~Wait until data ingestion is fixed and changes can be tested with v8.16 and higher~~ (not applicable anymore).




<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->