### PR TITLE
[Controls] Persist `runPastTimeout` setting

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_editor_options.test.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/components/options_list_editor_options.test.tsx
@@ -52,16 +52,27 @@ describe('Options list sorting button', () => {
     return component;
   };
 
-  test('run past timeout', async () => {
-    const component = mountComponent({
-      initialState: getMockedState({ runPastTimeout: false }),
-      field: { type: 'string' } as DataViewField,
+  describe('run past timeout', () => {
+    test('can toggle the setting', async () => {
+      const component = mountComponent({
+        initialState: getMockedState({ runPastTimeout: false }),
+        field: { type: 'string' } as DataViewField,
+      });
+      const toggle = component.getByTestId('optionsListControl__runPastTimeoutAdditionalSetting');
+      expect(toggle.getAttribute('aria-checked')).toBe('false');
+      await userEvent.click(toggle);
+      expect(updateState).toBeCalledWith({ runPastTimeout: true });
+      expect(toggle.getAttribute('aria-checked')).toBe('true');
     });
-    const toggle = component.getByTestId('optionsListControl__runPastTimeoutAdditionalSetting');
-    expect(toggle.getAttribute('aria-checked')).toBe('false');
-    await userEvent.click(toggle);
-    expect(updateState).toBeCalledWith({ runPastTimeout: true });
-    expect(toggle.getAttribute('aria-checked')).toBe('true');
+
+    test('setting is persisted', async () => {
+      const component = mountComponent({
+        initialState: getMockedState({ runPastTimeout: true }),
+        field: { type: 'string' } as DataViewField,
+      });
+      const toggle = component.getByTestId('optionsListControl__runPastTimeoutAdditionalSetting');
+      expect(toggle.getAttribute('aria-checked')).toBe('true');
+    });
   });
 
   test('selection options', async () => {

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
@@ -93,13 +93,17 @@ export const getOptionsListControlFactory = (): DataControlFactory<
       const totalCardinality$ = new BehaviorSubject<number>(0);
 
       const dataControl = initializeDataControl<
-        Pick<OptionsListControlState, 'searchTechnique' | 'singleSelect'>
+        Pick<OptionsListControlState, 'searchTechnique' | 'singleSelect' | 'runPastTimeout'>
       >(
         uuid,
         OPTIONS_LIST_CONTROL,
         'optionsListDataView',
         initialState,
-        { searchTechnique: searchTechnique$, singleSelect: singleSelect$ },
+        {
+          searchTechnique: searchTechnique$,
+          singleSelect: singleSelect$,
+          runPastTimeout: runPastTimeout$,
+        },
         controlGroupApi
       );
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/206459

## Summary

This PR ensures that the `runPastTimeout` setting is persisted for options list controls and the UI reflects the value of this setting. The root cause of this bug is that we weren't sending in the behavior subject for `runPastTimeout$` to the data control's `editorStateManager` when initializing the options list control, which meant that its value could not be set by the options list's `CustomOptionsComponent` - this PR fixes that. 

**Before**

https://github.com/user-attachments/assets/2c9eeab8-67d9-46bc-938e-4d7cb91e435f

**After**

https://github.com/user-attachments/assets/d06b6ffa-b1e9-4ecd-b732-69bd69a8aee9


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->