### PR TITLE
[POC] Dependency Injection API 

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/application/csp_router.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/application/csp_router.tsx
@@ -12,7 +12,7 @@ import { Routes, Route } from '@kbn/shared-ux-router';
 import { benchmarksNavigation, cloudPosturePages } from '../common/navigation/constants';
 import type { CspSecuritySolutionContext } from '..';
 import { SecuritySolutionContext } from './security_solution_context';
-import * as pages from '../pages';
+import * as Pages from '../pages';
 import { CspRoute } from './csp_route';
 
 const queryClient = new QueryClient({
@@ -22,23 +22,27 @@ const queryClient = new QueryClient({
 /** Props for the cloud security posture router component */
 export interface CspRouterProps {
   securitySolutionContext?: CspSecuritySolutionContext;
+  useExpandableFlyoutApi: any;
 }
 
-export const CspRouter = ({ securitySolutionContext }: CspRouterProps) => {
+export const CspRouter = ({ securitySolutionContext, useExpandableFlyoutApi }: CspRouterProps) => {
   const routerElement = (
     <QueryClientProvider client={queryClient}>
       <Routes>
-        <CspRoute {...cloudPosturePages.findings} component={pages.Findings} />
-        <CspRoute {...cloudPosturePages.dashboard} component={pages.ComplianceDashboard} />
+        <CspRoute {...cloudPosturePages.findings}>
+          <Pages.Findings useExpandableFlyoutApi={useExpandableFlyoutApi} />
+        </CspRoute>
+
+        <CspRoute {...cloudPosturePages.dashboard} component={Pages.ComplianceDashboard} />
         <CspRoute
           {...cloudPosturePages.vulnerability_dashboard}
-          component={pages.VulnerabilityDashboard}
+          component={Pages.VulnerabilityDashboard}
         />
 
         <CspRoute {...cloudPosturePages.benchmarks}>
           <Routes>
-            <CspRoute {...benchmarksNavigation.rules} component={pages.Rules} />
-            <CspRoute {...cloudPosturePages.benchmarks} component={pages.Benchmarks} />
+            <CspRoute {...benchmarksNavigation.rules} component={Pages.Rules} />
+            <CspRoute {...cloudPosturePages.benchmarks} component={Pages.Benchmarks} />
           </Routes>
         </CspRoute>
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/findings/findings.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/findings/findings.tsx
@@ -56,7 +56,7 @@ const FindingsTabRedirecter = ({ lastTabSelected }: { lastTabSelected?: Findings
   );
 };
 
-export const Findings = () => {
+export const Findings = ({ useExpandableFlyoutApi }: { useExpandableFlyoutApi: any }) => {
   const history = useHistory();
   const location = useLocation();
 
@@ -90,6 +90,14 @@ export const Findings = () => {
       pathname === findingsNavigation.vulnerabilities_by_resource.path
     );
   };
+
+  const { openFlyout } = useExpandableFlyoutApi();
+
+  openFlyout({
+    right: {
+      id: 'TestKey',
+    },
+  });
 
   return (
     <>

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/routes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/routes.tsx
@@ -10,6 +10,7 @@ import { CLOUD_SECURITY_POSTURE_BASE_PATH } from '@kbn/cloud-security-posture-co
 import type { CloudSecurityPosturePageId } from '@kbn/cloud-security-posture-plugin/public';
 import { type CspSecuritySolutionContext } from '@kbn/cloud-security-posture-plugin/public';
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout/src/hooks/use_expandable_flyout_api';
 import type { SecurityPageName, SecuritySubPluginRoutes } from '../app/types';
 import { useKibana } from '../common/lib/kibana';
 import { SecuritySolutionPageWrapper } from '../common/components/page_wrapper';
@@ -35,7 +36,10 @@ const CloudSecurityPosture = () => {
     <PluginTemplateWrapper>
       <TrackApplicationView viewId="cloud_security_posture">
         <SecuritySolutionPageWrapper noPadding noTimeline>
-          <CloudSecurityPostureRouter securitySolutionContext={cspSecuritySolutionContext} />
+          <CloudSecurityPostureRouter
+            securitySolutionContext={cspSecuritySolutionContext}
+            useExpandableFlyoutApi={useExpandableFlyoutApi}
+          />
         </SecuritySolutionPageWrapper>
       </TrackApplicationView>
     </PluginTemplateWrapper>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/index.tsx
@@ -158,6 +158,10 @@ const expandableFlyoutDocumentsPanels: ExpandableFlyoutProps['registeredPanels']
       <NetworkPanel {...(props as NetworkExpandableFlyoutProps).params} isPreviewMode />
     ),
   },
+  {
+    key: 'TestKey',
+    component: (props) => <div>{'OMEGA HELLO WORLD, THIS IS JUST TESTING'}</div>,
+  },
 ];
 
 export const SECURITY_SOLUTION_ON_CLOSE_EVENT = `expandable-flyout-on-close-${Flyouts.securitySolution}`;


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



