### PR TITLE
[Cloud Security POC] Injecting `SecuritySolutionFlyout` controls API

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/findings/findings.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/findings/findings.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
+import React, { useContext, useEffect } from 'react';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { EuiSpacer, EuiTab, EuiTabs, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -12,6 +12,7 @@ import { Redirect, useHistory, useLocation, matchPath } from 'react-router-dom';
 import { Routes, Route } from '@kbn/shared-ux-router';
 import { findingsNavigation } from '@kbn/cloud-security-posture';
 import { useCspSetupStatusApi } from '@kbn/cloud-security-posture/src/hooks/use_csp_setup_status_api';
+import { SecuritySolutionContext } from '../../application/security_solution_context';
 import { Configurations } from '../configurations';
 import { cloudPosturePages } from '../../common/navigation/constants';
 import { LOCAL_STORAGE_FINDINGS_LAST_SELECTED_TAB_KEY } from '../../common/constants';
@@ -59,6 +60,22 @@ const FindingsTabRedirecter = ({ lastTabSelected }: { lastTabSelected?: Findings
 export const Findings = () => {
   const history = useHistory();
   const location = useLocation();
+  const securitySolutionContext = useContext(SecuritySolutionContext);
+
+  const { openFlyout } = securitySolutionContext.useExpandableFlyoutApi();
+
+  useEffect(() => {
+    openFlyout({
+      right: {
+        id: 'user-panel',
+        params: {
+          userName: 'John Doe',
+          scopeId: 'findings-table',
+          contextId: 'findings-table',
+        },
+      },
+    });
+  }, [openFlyout]);
 
   // restore the users most recent tab selection
   const [lastTabSelected, setLastTabSelected] = useLocalStorage<FindingsTabKey>(

--- a/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/routes.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/routes.tsx
@@ -10,6 +10,7 @@ import { CLOUD_SECURITY_POSTURE_BASE_PATH } from '@kbn/cloud-security-posture-co
 import type { CloudSecurityPosturePageId } from '@kbn/cloud-security-posture-plugin/public';
 import { type CspSecuritySolutionContext } from '@kbn/cloud-security-posture-plugin/public';
 import { TrackApplicationView } from '@kbn/usage-collection-plugin/public';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout/src/hooks/use_expandable_flyout_api';
 import type { SecurityPageName, SecuritySubPluginRoutes } from '../app/types';
 import { useKibana } from '../common/lib/kibana';
 import { SecuritySolutionPageWrapper } from '../common/components/page_wrapper';
@@ -25,6 +26,7 @@ const CloudPostureSpyRoute = ({ pageName, ...rest }: { pageName?: CloudSecurityP
 const cspSecuritySolutionContext: CspSecuritySolutionContext = {
   getFiltersGlobalComponent: () => FiltersGlobal,
   getSpyRouteComponent: () => CloudPostureSpyRoute,
+  useExpandableFlyoutApi,
 };
 
 const CloudSecurityPosture = () => {


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/4862a3ee-17fa-47e5-b33b-55443314c65b

This POC demonstrates a simpler solution to share `SecuritySolutionFlyout` with CSP.
It's still using dependency injection, but instead of the previous suggestion of injecting the **panels**, in this proposal we only need to inject the controls scheme to open the flyout.

### Why this even works? (Technical, can skip)

<details><summary>Expand Details (😉)</summary>
<p>


First, It's important to understand how `ExpandableFlyout` works.
This package also exported a provider to register panels into. luckily for us, Security Solution wraps all it's routes with its context provider, `ExpandableFlyoutProvider` is a part of it. Meaning registered panels within Security Solution are available for it's registered routes. 

This is the wrapper:

https://github.com/elastic/kibana/blob/8ba217909651c2539c0e0d46ef411b4e0992be8b/x-pack/solutions/security/plugins/security_solution/public/app/home/template_wrapper/index.tsx#L101-L104

This is where we are getting wrapped:

https://github.com/elastic/kibana/blob/8ba217909651c2539c0e0d46ef411b4e0992be8b/x-pack/solutions/security/plugins/security_solution/public/cloud_security_posture/routes.tsx#L35-L41

**It's not just about being able to inject the function, it's also the fact that we can access panels registered within Security Solution `ExpandableFlyout`**

</p>
</details> 


## Key Improvements:

Addressing [my own comment](https://github.com/elastic/kibana/pull/207126#issuecomment-2605295383) on the previous suggestion

### Type Sharing
There is none, we do not need to create shared type packages because we are only importing an already packaged function - `useExpandFlyoutApi`

### Maintainability and Scaleability
Unlike with the panels options, which would require constant maintenance, and injecting more and more panels over time, this is option is fully maintained on security solution, there is only one source of truth, and therefore will not oppose scaleability issues

### Volume, code readability
Injecting multiple panels, having to untangle and export types from each to a shared package every time, and then reusing those types back in their original definition and in CSP. compared to just a single function

___

### Shared UI between flyouts

I also had a misunderstanding until recently when I've talked with @animehart further to better my understanding on what we try to achieve. I was under the assumption that we want, in addition to be able to use security solution panels, to also inject pure UI components so we can use them to build the new Findings Flyout within CSP. (Sorry if I caused confusion over this @PhilippeOberti @christineweng)

Just in case I was not the only confused by that, I'll reiterate that this was not the case. We plan on rebuilding the Findings Flyout component **inside** Security Solution Plugin. which now makes sense to me for why we don't need to export pure UI components like `<FlyoutHeader />` into packages. its already shared within security solution so its easy to reuse inside it. 

But with this POC, instead of then having to inject the new Findings Flyout **panel** back to CSP, we again can just use the Expand Flyout API to decide which flyout to open. As can be seen from the code example, its just passing a panel ID

```ts
openFlyout({
      right: {
        id: 'user-panel',
        params: {
          userName: 'John Doe',
          scopeId: 'findings-table',
          contextId: 'findings-table',
        },
      },
    });
```

For reference, the panel registration in Security Solution looks like this (using user panel as an example):

https://github.com/elastic/kibana/blob/83e2a16bf8889a97dd3a1460c5fbcba34726197a/x-pack/solutions/security/plugins/security_solution/public/flyout/index.tsx#L124-L127

___

BTW, this could also resurface the decision to make Asset Inventory its own plugin. We can rethink it, but its important to understand that this is only made simple because of this specific implementation of the Expandable Flyout API.

cc: @animehart @acorretti @albertoblaz @opauloh @seanrathier @kfirpeled