### PR TITLE
Add nodes limit as a temporary workaround for upcoming release

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/common/constants.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/common/constants.ts
@@ -17,3 +17,5 @@ export const SHOW_SEARCH_BAR_BUTTON_TOUR_STORAGE_KEY =
   'securitySolution.graphInvestigation:showSearchBarButtonTour' as const;
 export const TOGGLE_SEARCH_BAR_STORAGE_KEY =
   'securitySolution.graphInvestigation:toggleSearchBarState' as const;
+
+export const GRAPH_NODES_LIMIT = 100;

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/graph_investigation.tsx
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/graph/src/components/graph_investigation/graph_investigation.tsx
@@ -20,7 +20,7 @@ import useSessionStorage from 'react-use/lib/useSessionStorage';
 import { Graph, isEntityNode } from '../../..';
 import { type UseFetchGraphDataParams, useFetchGraphData } from '../../hooks/use_fetch_graph_data';
 import { GRAPH_INVESTIGATION_TEST_ID } from '../test_ids';
-import { EVENT_ID, TOGGLE_SEARCH_BAR_STORAGE_KEY } from '../../common/constants';
+import { EVENT_ID, GRAPH_NODES_LIMIT, TOGGLE_SEARCH_BAR_STORAGE_KEY } from '../../common/constants';
 import { Actions } from '../controls/actions';
 import { AnimatedSearchBarContainer, useBorder } from './styles';
 import { CONTROLLED_BY_GRAPH_INVESTIGATION_FILTER, addFilter } from './search_filters';
@@ -195,6 +195,7 @@ export const GraphInvestigation = memo<GraphInvestigationProps>(
           start: timeRange.from,
           end: timeRange.to,
         },
+        nodesLimit: GRAPH_NODES_LIMIT,
       },
       options: {
         refetchOnWindowFocus: false,


### PR DESCRIPTION
## Summary

We decided to add nodes limit of 100 for the upcoming release.
This decision will be revisited in 9.1 development cycle once we will work out the grouping capability

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->