### PR TITLE
[8.x] [Cloud Security] New deployment mode selector design and various unit test fixed (#208645)

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
@@ -41,7 +41,6 @@ import { useParams } from 'react-router-dom';
 import { createReactQueryResponse } from '../../test/fixtures/react_query';
 import { useCspSetupStatusApi } from '@kbn/cloud-security-posture/src/hooks/use_csp_setup_status_api';
 import { usePackagePolicyList } from '../../common/api/use_package_policy_list';
-import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 import {
   AWS_CREDENTIALS_TYPE_OPTIONS_TEST_SUBJ,
   AWS_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ,
@@ -51,7 +50,6 @@ import {
   CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS,
   CIS_GCP_OPTION_TEST_SUBJ,
   GCP_CREDENTIALS_TYPE_OPTIONS_TEST_SUBJ,
-  SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ,
   SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ,
   SUBSCRIPTION_NOT_ALLOWED_TEST_SUBJECT,
 } from '../test_subjects';
@@ -1505,17 +1503,12 @@ describe('<CspPolicyTemplateForm />', () => {
     it('should render setup technology selector for AWS and allow to select agentless', async () => {
       const newPackagePolicy = getMockPolicyAWS();
 
-      const { getByTestId, getByRole } = render(
+      const { getByTestId, getByLabelText } = render(
         <WrappedComponent newPolicy={newPackagePolicy} isAgentlessEnabled={true} />
-      );
-
-      const setupTechnologySelectorAccordion = getByTestId(
-        SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ
       );
       const setupTechnologySelector = getByTestId(SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ);
 
       // default state
-      expect(setupTechnologySelectorAccordion).toBeInTheDocument();
       expect(setupTechnologySelector).toBeInTheDocument();
       expect(setupTechnologySelector).toHaveTextContent(/agent-based/i);
 
@@ -1526,8 +1519,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       // select agent-based and check for cloudformation option
       await userEvent.click(setupTechnologySelector);
-      const agentlessOption = getByRole('option', { name: /agentless/i });
-      await waitForEuiPopoverOpen();
+      const agentlessOption = getByLabelText(/agentless/i);
       await userEvent.click(agentlessOption);
 
       const awsCredentialsTypeSelector = getByTestId(AWS_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ);
@@ -1547,7 +1539,7 @@ describe('<CspPolicyTemplateForm />', () => {
     it.skip('should render setup technology selector for GCP for organisation account type', async () => {
       const newPackagePolicy = getMockPolicyGCP();
 
-      const { getByTestId, queryByTestId, getByRole } = render(
+      const { getByTestId, queryByTestId, getByLabelText } = render(
         <WrappedComponent
           newPolicy={newPackagePolicy}
           isAgentlessEnabled={true}
@@ -1559,9 +1551,6 @@ describe('<CspPolicyTemplateForm />', () => {
       const gcpSelectorButton = getByTestId(CIS_GCP_OPTION_TEST_SUBJ);
       await userEvent.click(gcpSelectorButton);
 
-      const setupTechnologySelectorAccordion = queryByTestId(
-        SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ
-      );
       const setupTechnologySelector = getByTestId(SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ);
       const orgIdField = queryByTestId(CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.ORGANIZATION_ID);
       const projectIdField = queryByTestId(CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.PROJECT_ID);
@@ -1576,7 +1565,6 @@ describe('<CspPolicyTemplateForm />', () => {
       );
 
       // default state for GCP with the Org selected
-      expect(setupTechnologySelectorAccordion).toBeInTheDocument();
       expect(setupTechnologySelector).toBeInTheDocument();
       expect(setupTechnologySelector).toHaveTextContent(/agentless/i);
       expect(orgIdField).toBeInTheDocument();
@@ -1587,8 +1575,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       // select agent-based and check for Cloud Shell option
       await userEvent.click(setupTechnologySelector);
-      const agentBasedOption = getByRole('option', { name: /agent-based/i });
-      await waitForEuiPopoverOpen();
+      const agentBasedOption = getByLabelText(/agent-based/i);
       await userEvent.click(agentBasedOption);
       await waitFor(() => {
         expect(getByTestId(GCP_CREDENTIALS_TYPE_OPTIONS_TEST_SUBJ.CLOUD_SHELL)).toBeInTheDocument();
@@ -1613,9 +1600,6 @@ describe('<CspPolicyTemplateForm />', () => {
       const gcpSelectorButton = getByTestId(CIS_GCP_OPTION_TEST_SUBJ);
       await userEvent.click(gcpSelectorButton);
 
-      const setupTechnologySelectorAccordion = queryByTestId(
-        SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ
-      );
       const setupTechnologySelector = queryByTestId(SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ);
       const orgIdField = queryByTestId(CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.ORGANIZATION_ID);
       const projectIdField = queryByTestId(CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.PROJECT_ID);
@@ -1630,7 +1614,6 @@ describe('<CspPolicyTemplateForm />', () => {
       );
 
       // default state for GCP with the Org selected
-      expect(setupTechnologySelectorAccordion).toBeInTheDocument();
       expect(setupTechnologySelector).toBeInTheDocument();
       expect(setupTechnologySelector).toHaveTextContent(/agentless/i);
       expect(orgIdField).not.toBeInTheDocument();
@@ -1643,7 +1626,7 @@ describe('<CspPolicyTemplateForm />', () => {
     it('should render setup technology selector for Azure for Organisation type', async () => {
       const newPackagePolicy = getMockPolicyAzure();
 
-      const { getByTestId, queryByTestId, getByRole } = render(
+      const { getByTestId, queryByTestId, getByLabelText } = render(
         <WrappedComponent
           newPolicy={newPackagePolicy}
           isAgentlessEnabled={true}
@@ -1655,13 +1638,9 @@ describe('<CspPolicyTemplateForm />', () => {
       const azureSelectorButton = getByTestId(CIS_AZURE_OPTION_TEST_SUBJ);
       await userEvent.click(azureSelectorButton);
 
-      const setupTechnologySelectorAccordion = queryByTestId(
-        SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ
-      );
       const setupTechnologySelector = getByTestId(SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ);
 
       // default state for Azure with the Org selected
-      expect(setupTechnologySelectorAccordion).toBeInTheDocument();
       expect(setupTechnologySelector).toBeInTheDocument();
       expect(setupTechnologySelector).toHaveTextContent(/agent-based/i);
       await waitFor(() => {
@@ -1671,8 +1650,7 @@ describe('<CspPolicyTemplateForm />', () => {
 
       // select agent-based and check for ARM template option
       await userEvent.click(setupTechnologySelector);
-      const agentlessOption = getByRole('option', { name: /agentless/i });
-      await waitForEuiPopoverOpen();
+      const agentlessOption = getByLabelText(/agentless/i);
       await userEvent.click(agentlessOption);
 
       const tenantIdField = queryByTestId(CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS.TENANT_ID);
@@ -1681,7 +1659,6 @@ describe('<CspPolicyTemplateForm />', () => {
       const armTemplateSelector = queryByTestId(CIS_AZURE_SETUP_FORMAT_TEST_SUBJECTS.ARM_TEMPLATE);
       const manualSelector = queryByTestId(CIS_AZURE_SETUP_FORMAT_TEST_SUBJECTS.MANUAL);
 
-      expect(setupTechnologySelectorAccordion).toBeInTheDocument();
       expect(setupTechnologySelector).toBeInTheDocument();
       expect(setupTechnologySelector).toHaveTextContent(/agentless/i);
       expect(tenantIdField).toBeInTheDocument();
@@ -1696,7 +1673,7 @@ describe('<CspPolicyTemplateForm />', () => {
         'azure.account_type': { value: 'single-account', type: 'text' },
       });
 
-      const { getByTestId, queryByTestId, getByRole } = render(
+      const { getByTestId, queryByTestId, getByLabelText } = render(
         <WrappedComponent
           newPolicy={newPackagePolicy}
           isAgentlessEnabled={true}
@@ -1708,15 +1685,11 @@ describe('<CspPolicyTemplateForm />', () => {
       const azureSelectorButton = getByTestId(CIS_AZURE_OPTION_TEST_SUBJ);
       await userEvent.click(azureSelectorButton);
 
-      const setupTechnologySelectorAccordion = queryByTestId(
-        SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ
-      );
       const setupTechnologySelector = getByTestId(SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ);
 
       // select agentless and check for ARM template option
       await userEvent.click(setupTechnologySelector);
-      const agentlessOption = getByRole('option', { name: /agentless/i });
-      await waitForEuiPopoverOpen();
+      const agentlessOption = getByLabelText(/agentless/i);
       await userEvent.click(agentlessOption);
 
       const tenantIdField = queryByTestId(CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS.TENANT_ID);
@@ -1726,7 +1699,6 @@ describe('<CspPolicyTemplateForm />', () => {
       const manualSelector = queryByTestId(CIS_AZURE_SETUP_FORMAT_TEST_SUBJECTS.MANUAL);
 
       // default state for Azure with the Org selected
-      expect(setupTechnologySelectorAccordion).toBeInTheDocument();
       expect(setupTechnologySelector).toBeInTheDocument();
       expect(setupTechnologySelector).toHaveTextContent(/agentless/i);
       expect(tenantIdField).toBeInTheDocument();
@@ -1743,11 +1715,9 @@ describe('<CspPolicyTemplateForm />', () => {
         <WrappedComponent newPolicy={newPackagePolicy} isAgentlessEnabled={true} />
       );
 
-      const setupTechnologySelectorAccordion = queryByTestId(
-        SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ
-      );
+      const setupTechnologySelector = queryByTestId(SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ);
 
-      expect(setupTechnologySelectorAccordion).not.toBeInTheDocument();
+      expect(setupTechnologySelector).not.toBeInTheDocument();
     });
 
     it('should not render setup technology selector for CNVM', () => {
@@ -1757,11 +1727,9 @@ describe('<CspPolicyTemplateForm />', () => {
         <WrappedComponent newPolicy={newPackagePolicy} isAgentlessEnabled={true} />
       );
 
-      const setupTechnologySelectorAccordion = queryByTestId(
-        SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ
-      );
+      const setupTechnologySelector = queryByTestId(SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ);
 
-      expect(setupTechnologySelectorAccordion).not.toBeInTheDocument();
+      expect(setupTechnologySelector).not.toBeInTheDocument();
     });
   });
 

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/setup_technology_selector/setup_technology_selector.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/setup_technology_selector/setup_technology_selector.tsx
@@ -5,23 +5,21 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import { SetupTechnology } from '@kbn/fleet-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
+
 import {
-  EuiAccordion,
-  EuiFormRow,
-  EuiLink,
   EuiSpacer,
-  EuiSuperSelect,
-  EuiText,
   useGeneratedHtmlId,
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiRadioGroup,
+  EuiTitle,
+  EuiRadioGroupOption,
 } from '@elastic/eui';
-import {
-  SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ,
-  SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ,
-} from '../../test_subjects';
+import { SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ } from '../../test_subjects';
 
 export const SetupTechnologySelector = ({
   disabled,
@@ -32,110 +30,98 @@ export const SetupTechnologySelector = ({
   setupTechnology: SetupTechnology;
   onSetupTechnologyChange: (value: SetupTechnology) => void;
 }) => {
-  const options = [
+  const radioGroupItemId1 = useGeneratedHtmlId({
+    prefix: 'radioGroupItem',
+    suffix: 'agentless',
+  });
+  const radioGroupItemId2 = useGeneratedHtmlId({
+    prefix: 'radioGroupItem',
+    suffix: 'agentbased',
+  });
+  const radioOptions: EuiRadioGroupOption[] = [
     {
-      value: SetupTechnology.AGENT_BASED,
-      'data-test-subj': 'setup-technology-agent-based-option',
-      inputDisplay: (
-        <FormattedMessage
-          id="xpack.csp.fleetIntegration.setupTechnology.agentbasedInputDisplay"
-          defaultMessage="Agent-based"
-        />
-      ),
-      dropdownDisplay: (
-        <>
-          <strong>
-            <FormattedMessage
-              id="xpack.csp.fleetIntegration.setupTechnology.agentbasedDrowpownDisplay"
-              defaultMessage="Agent-based"
-            />
-          </strong>
-          <EuiText size="s" color="subdued">
+      id: radioGroupItemId1,
+      value: SetupTechnology.AGENTLESS,
+      label: (
+        <EuiFlexGroup gutterSize="xs" direction="column" aria-label={'Deployment Modes Selection'}>
+          <EuiFlexItem grow={false}>
+            <p>
+              <strong>
+                <FormattedMessage
+                  id="xpack.csp.fleetIntegration.setupTechnology.agentlessRadioLabel"
+                  defaultMessage="Agentless"
+                />
+              </strong>
+            </p>
+          </EuiFlexItem>
+          <EuiFlexItem>
             <p>
               <FormattedMessage
-                id="xpack.csp.fleetIntegration.setupTechnology.agentbasedDrowpownDescription"
-                defaultMessage="Set up the integration with an agent"
+                id="xpack.csp.fleetIntegration.setupTechnology.agentBasedRadioDescription"
+                defaultMessage="Setup integration without an agent"
               />
             </p>
-          </EuiText>
-        </>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       ),
     },
     {
-      value: SetupTechnology.AGENTLESS,
-      inputDisplay: (
-        <FormattedMessage
-          id="xpack.csp.fleetIntegration.setupTechnology.agentlessInputDisplay"
-          defaultMessage="Agentless"
-        />
-      ),
-      'data-test-subj': 'setup-technology-agentless-option',
-      dropdownDisplay: (
-        <>
-          <strong>
-            <FormattedMessage
-              id="xpack.csp.fleetIntegration.setupTechnology.agentlessDrowpownDisplay"
-              defaultMessage="Agentless"
-            />
-          </strong>
-          <EuiText size="s" color="subdued">
+      id: radioGroupItemId2,
+      value: SetupTechnology.AGENT_BASED,
+      label: (
+        <EuiFlexGroup gutterSize="xs" direction="column" aria-label={'Agent-based'}>
+          <EuiFlexItem grow={false}>
             <p>
-              <FormattedMessage
-                id="xpack.csp.fleetIntegration.setupTechnology.agentlessDrowpownDescription"
-                defaultMessage="Set up the integration without an agent"
-              />
+              <strong>
+                <FormattedMessage
+                  id="xpack.csp.fleetIntegration.setupTechnology.agentBasedRadioLabel"
+                  defaultMessage="Agent-based"
+                />
+              </strong>
             </p>
-          </EuiText>
-        </>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <FormattedMessage
+              id="xpack.csp.fleetIntegration.setupTechnology.agentBasedRadioDescription"
+              defaultMessage="Deploy Elastic Agent into your Cloud Account"
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       ),
     },
   ];
 
+  const [radioIdSelected, setRadioIdSelected] = useState(
+    SetupTechnology.AGENTLESS === setupTechnology ? radioGroupItemId1 : radioGroupItemId2
+  );
+
+  const onChange = (optionId: string) => {
+    setRadioIdSelected(optionId);
+    onSetupTechnologyChange(
+      optionId === radioGroupItemId1 ? SetupTechnology.AGENTLESS : SetupTechnology.AGENT_BASED
+    );
+  };
+
   return (
     <>
       <EuiSpacer size="l" />
-      <EuiAccordion
-        isDisabled={disabled}
-        initialIsOpen={disabled}
-        id={useGeneratedHtmlId({ prefix: 'setup-type' })}
-        buttonContent={
-          <EuiLink disabled={disabled}>
-            <FormattedMessage
-              id="xpack.csp.fleetIntegration.setupTechnology.advancedOptionsLabel"
-              defaultMessage="Advanced options"
-            />
-          </EuiLink>
-        }
-        data-test-subj={SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ}
-      >
-        <EuiSpacer size="l" />
-        <EuiFormRow
-          fullWidth
-          label={
-            <FormattedMessage
-              id="xpack.csp.fleetIntegration.setupTechnology.setupTechnologyLabel"
-              defaultMessage="Setup technology"
-            />
-          }
-        >
-          <EuiSuperSelect
-            disabled={disabled}
-            options={options}
-            valueOfSelected={setupTechnology}
-            placeholder={
-              <FormattedMessage
-                id="xpack.csp.fleetIntegration.setupTechnology.setupTechnologyPlaceholder"
-                defaultMessage="Select the setup technology"
-              />
-            }
-            onChange={onSetupTechnologyChange}
-            itemLayoutAlign="top"
-            hasDividers
-            fullWidth
-            data-test-subj={SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ}
+      <EuiTitle size="xs">
+        <h2>
+          <FormattedMessage
+            id="xpack.csp.setupTechnologySelector.deploymentOptionsTitle"
+            defaultMessage="Deployment Options"
           />
-        </EuiFormRow>
-      </EuiAccordion>
+        </h2>
+      </EuiTitle>
+      <EuiSpacer size="l" />
+      <EuiRadioGroup
+        disabled={disabled}
+        data-test-subj={SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ}
+        options={radioOptions}
+        idSelected={radioIdSelected}
+        onChange={(id) => onChange(id)}
+        name="radio group"
+      />
     </>
   );
 };

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/test_subjects.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/test_subjects.ts
@@ -66,8 +66,11 @@ export const GCP_CREDENTIALS_TYPE_OPTIONS_TEST_SUBJ = {
 export const CIS_GCP_OPTION_TEST_SUBJ = 'cisGcpTestId';
 export const CIS_AZURE_OPTION_TEST_SUBJ = 'cisAzureTestId';
 
-export const SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ = 'setup-technology-selector-accordion';
 export const SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ = 'setup-technology-selector';
+export const SETUP_TECHNOLOGY_SELECTOR_AGENTLESS_TEST_SUBJ =
+  'setup-technology-selector-agentless-radio';
+export const SETUP_TECHNOLOGY_SELECTOR_AGENT_BASED_TEST_SUBJ =
+  'setup-technology-selector-agentbased-radio';
 export const AZURE_CREDENTIALS_TYPE_SELECTOR_TEST_SUBJ = 'azure-credentials-type-selector';
 export const CIS_AZURE_INPUT_FIELDS_TEST_SUBJECTS = {
   TENANT_ID: 'cisAzureTenantId',

--- a/x-pack/test/cloud_security_posture_functional/agentless/security_posture.ts
+++ b/x-pack/test/cloud_security_posture_functional/agentless/security_posture.ts
@@ -24,7 +24,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const CNVM_RADIO_OPTION = 'policy-template-radio-button-vuln_mgmt';
 
   const POLICY_NAME_FIELD = 'createAgentPolicyNameField';
-  const SETUP_TECHNOLOGY_SELECTOR = 'setup-technology-selector-accordion';
 
   describe.skip('Agentless Security Posture Integration Options', function () {
     let cisIntegration: typeof pageObjects.cisAddIntegration;
@@ -45,7 +44,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await cisIntegration.clickOptionButton(KSPM_RADIO_OPTION);
       await pageObjects.header.waitUntilLoadingHasFinished();
 
-      const hasSetupTechnologySelector = await testSubjects.exists(SETUP_TECHNOLOGY_SELECTOR);
+      const hasSetupTechnologySelector = await testSubjects.exists(
+        cisIntegration.testSubjectIds.SETUP_TECHNOLOGY_SELECTOR
+      );
       const hasAgentBased = await testSubjects.exists(POLICY_NAME_FIELD);
 
       expect(hasSetupTechnologySelector).to.be(false);
@@ -61,7 +62,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await cisIntegration.clickOptionButton(CNVM_RADIO_OPTION);
       await pageObjects.header.waitUntilLoadingHasFinished();
 
-      const hasSetupTechnologySelector = await testSubjects.exists(SETUP_TECHNOLOGY_SELECTOR);
+      const hasSetupTechnologySelector = await testSubjects.exists(
+        cisIntegration.testSubjectIds.SETUP_TECHNOLOGY_SELECTOR
+      );
       const hasAgentBased = await testSubjects.exists(POLICY_NAME_FIELD);
 
       expect(hasSetupTechnologySelector).to.be(false);
@@ -76,7 +79,9 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await cisIntegration.clickOptionButton(CSPM_RADIO_OPTION);
       await pageObjects.header.waitUntilLoadingHasFinished();
 
-      const hasSetupTechnologySelector = await testSubjects.exists(SETUP_TECHNOLOGY_SELECTOR);
+      const hasSetupTechnologySelector = await testSubjects.exists(
+        cisIntegration.testSubjectIds.SETUP_TECHNOLOGY_SELECTOR
+      );
       const hasAgentBased = await testSubjects.exists(POLICY_NAME_FIELD);
 
       expect(hasSetupTechnologySelector).to.be(true);

--- a/x-pack/test/cloud_security_posture_functional/page_objects/add_cis_integration_form_page.ts
+++ b/x-pack/test/cloud_security_posture_functional/page_objects/add_cis_integration_form_page.ts
@@ -18,8 +18,6 @@ export function AddCisIntegrationFormPageProvider({
   const PageObjects = getPageObjects(['common', 'header']);
   const browser = getService('browser');
 
-  const SETUP_TECHNOLOGY_SELECTOR = 'setup-technology-selector';
-  const SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ = 'setup-technology-selector-accordion';
   const AWS_CREDENTIAL_SELECTOR = 'aws-credentials-type-selector';
 
   const testSubjectIds = {
@@ -27,8 +25,8 @@ export function AddCisIntegrationFormPageProvider({
     CIS_AWS_OPTION_TEST_ID: 'cisAwsTestId',
     AWS_CREDENTIAL_SELECTOR: 'aws-credentials-type-selector',
     SETUP_TECHNOLOGY_SELECTOR: 'setup-technology-selector',
-    SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ: 'setup-technology-selector-accordion',
-    SETUP_TECHNOLOGY_SELECTOR_AGENTLESS_OPTION: 'setup-technology-agentless-option',
+    SETUP_TECHNOLOGY_SELECTOR_AGENTLESS_RADIO: 'setup-technology-agentless-radio',
+    SETUP_TECHNOLOGY_SELECTOR_AGENT_BASED_RADIO: 'setup-technology-agent-based-radio',
     DIRECT_ACCESS_KEYS: 'direct_access_keys',
     DIRECT_ACCESS_KEY_ID_TEST_ID: 'awsDirectAccessKeyId',
     DIRECT_ACCESS_SECRET_KEY_TEST_ID: 'passwordInput-secret-access-key',
@@ -300,19 +298,13 @@ export function AddCisIntegrationFormPageProvider({
   };
 
   const selectSetupTechnology = async (setupTechnology: 'agentless' | 'agent-based') => {
-    await clickAccordianButton(SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ);
-    await clickOptionButton(SETUP_TECHNOLOGY_SELECTOR);
-
-    const agentOption = await testSubjects.find(
-      setupTechnology === 'agentless'
-        ? 'setup-technology-agentless-option'
-        : 'setup-technology-agent-based-option'
-    );
-    await agentOption.click();
+    const radioGroup = await testSubjects.find(testSubjectIds.SETUP_TECHNOLOGY_SELECTOR);
+    const radio = await radioGroup.findByCssSelector(`input[value='${setupTechnology}']`);
+    await radio.click();
   };
 
   const showSetupTechnologyComponent = async () => {
-    return await testSubjects.exists(SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ);
+    return await testSubjects.exists(testSubjectIds.SETUP_TECHNOLOGY_SELECTOR);
   };
 
   const selectAwsCredentials = async (credentialType: 'direct' | 'temporary') => {
@@ -436,10 +428,8 @@ export function AddCisIntegrationFormPageProvider({
     const directAccessSecretKey = 'directAccessSecretKeyTest';
 
     await clickOptionButton(testSubjectIds.CIS_AWS_OPTION_TEST_ID);
-    await clickAccordianButton(testSubjectIds.SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ);
-    await clickOptionButton(testSubjectIds.SETUP_TECHNOLOGY_SELECTOR);
 
-    await clickOptionButton(testSubjectIds.SETUP_TECHNOLOGY_SELECTOR_AGENTLESS_OPTION);
+    await clickOptionButton(testSubjectIds.SETUP_TECHNOLOGY_SELECTOR_AGENTLESS_RADIO);
     await selectValue(testSubjectIds.AWS_CREDENTIAL_SELECTOR, 'direct_access_keys');
     await fillInTextField(testSubjectIds.DIRECT_ACCESS_KEY_ID_TEST_ID, directAccessKeyId);
     await fillInTextField(testSubjectIds.DIRECT_ACCESS_SECRET_KEY_TEST_ID, directAccessSecretKey);
@@ -451,9 +441,7 @@ export function AddCisIntegrationFormPageProvider({
 
     await clickOptionButton(testSubjectIds.CIS_GCP_OPTION_TEST_ID);
     await clickOptionButton(testSubjectIds.GCP_SINGLE_ACCOUNT_TEST_ID);
-    await clickAccordianButton(testSubjectIds.SETUP_TECHNOLOGY_SELECTOR_ACCORDION_TEST_SUBJ);
-    await clickOptionButton(testSubjectIds.SETUP_TECHNOLOGY_SELECTOR);
-    await clickOptionButton(testSubjectIds.SETUP_TECHNOLOGY_SELECTOR_AGENTLESS_OPTION);
+    await clickOptionButton(testSubjectIds.SETUP_TECHNOLOGY_SELECTOR_AGENTLESS_RADIO);
     await fillInTextField(testSubjectIds.PRJ_ID_TEST_ID, projectId);
     await fillInTextField(testSubjectIds.CREDENTIALS_JSON_TEST_ID, credentialJson);
   };

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/constants.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION = '1.13.0-preview02';

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cloud_security_posture/agentless_api/create_agent.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { CLOUD_CREDENTIALS_PACKAGE_VERSION } from '@kbn/cloud-security-posture-plugin/common/constants';
 import * as http from 'http';
 import expect from '@kbn/expect';
 import { setupMockServer } from './mock_agentless_api';
+import { AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION } from './constants';
 import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const mockAgentlessApiService = setupMockServer();
@@ -43,7 +43,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     it(`should create agentless-agent`, async () => {
       const integrationPolicyName = `cloud_security_posture-${new Date().toISOString()}`;
       await cisIntegration.navigateToAddIntegrationCspmWithVersionPage(
-        CLOUD_CREDENTIALS_PACKAGE_VERSION
+        AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION
       );
 
       await cisIntegration.clickOptionButton(CIS_AWS_OPTION_TEST_ID);
@@ -88,16 +88,16 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       const integrationPolicyName = `cloud_security_posture-${new Date().toISOString()}`;
 
       await cisIntegration.navigateToAddIntegrationCspmWithVersionPage(
-        CLOUD_CREDENTIALS_PACKAGE_VERSION
+        AGENTLESS_SECURITY_POSTURE_PACKAGE_VERSION
       );
 
       await cisIntegration.clickOptionButton(CIS_AWS_OPTION_TEST_ID);
       await cisIntegration.clickOptionButton(AWS_SINGLE_ACCOUNT_TEST_ID);
 
+      await cisIntegration.inputIntegrationName(integrationPolicyName);
+
       await cisIntegration.selectSetupTechnology('agent-based');
       await pageObjects.header.waitUntilLoadingHasFinished();
-
-      await cisIntegration.inputIntegrationName(integrationPolicyName);
 
       await cisIntegration.clickSaveButton();
       await pageObjects.header.waitUntilLoadingHasFinished();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Cloud Security] New deployment mode selector design and various unit test fixed (#208645)](https://github.com/elastic/kibana/pull/208645)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"seanrathier","email":"sean.rathier@gmail.com"},"sourceCommit":{"committedDate":"2025-01-29T03:11:18Z","message":"[Cloud Security] New deployment mode selector design and various unit test fixed (#208645)","sha":"12461c41eeeee6643d76c05be20ecf86829a2238","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Cloud Security","backport:prev-minor"],"title":"[Cloud Security] New deployment mode selector design and various unit test fixed","number":208645,"url":"https://github.com/elastic/kibana/pull/208645","mergeCommit":{"message":"[Cloud Security] New deployment mode selector design and various unit test fixed (#208645)","sha":"12461c41eeeee6643d76c05be20ecf86829a2238"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208645","number":208645,"mergeCommit":{"message":"[Cloud Security] New deployment mode selector design and various unit test fixed (#208645)","sha":"12461c41eeeee6643d76c05be20ecf86829a2238"}}]}] BACKPORT-->