### PR TITLE
[Dataset quality] single point for enable/disable failure store

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/context.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/context.ts
@@ -11,7 +11,7 @@ import { ITelemetryClient } from '../../services/telemetry';
 export interface DatasetQualityContextValue {
   service: DatasetQualityControllerStateService;
   telemetryClient: ITelemetryClient;
-  isServerless: boolean;
+  isFailureStoreEnabled: boolean;
 }
 
 export const DatasetQualityContext = createContext({} as DatasetQualityContextValue);

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/dataset_quality.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/dataset_quality.tsx
@@ -29,7 +29,7 @@ export interface CreateDatasetQualityArgs {
   core: CoreStart;
   plugins: DatasetQualityStartDeps;
   telemetryClient: ITelemetryClient;
-  isServerless: boolean;
+  isFailureStoreEnabled: boolean;
 }
 
 export const DatasetQuality = ({
@@ -37,7 +37,7 @@ export const DatasetQuality = ({
   core,
   plugins,
   telemetryClient,
-  isServerless,
+  isFailureStoreEnabled,
 }: DatasetQualityProps & CreateDatasetQualityArgs) => {
   const KibanaContextProviderForPlugin = useKibanaContextForPluginProvider(core, plugins);
 
@@ -45,9 +45,9 @@ export const DatasetQuality = ({
     () => ({
       service: controller.service,
       telemetryClient,
-      isServerless,
+      isFailureStoreEnabled,
     }),
-    [controller.service, isServerless, telemetryClient]
+    [controller.service, isFailureStoreEnabled, telemetryClient]
   );
 
   return (

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/index.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/index.tsx
@@ -19,7 +19,7 @@ export const createDatasetQuality = ({
   core,
   plugins,
   telemetryClient,
-  isServerless,
+  isFailureStoreEnabled,
 }: CreateDatasetQualityArgs) => {
   return ({ controller }: DatasetQualityProps) => {
     return (
@@ -28,7 +28,7 @@ export const createDatasetQuality = ({
         core={core}
         plugins={plugins}
         telemetryClient={telemetryClient}
-        isServerless={isServerless}
+        isFailureStoreEnabled={isFailureStoreEnabled}
       />
     );
   };

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/table/columns.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality/table/columns.tsx
@@ -179,7 +179,7 @@ export const getDatasetQualityTableColumns = ({
   isActiveDataset,
   timeRange,
   urlService,
-  failureStoreEnabled,
+  isFailureStoreEnabled,
 }: {
   fieldFormats: FieldFormatsStart;
   canUserMonitorDataset: boolean;
@@ -192,7 +192,7 @@ export const getDatasetQualityTableColumns = ({
   isActiveDataset: (lastActivity: number) => boolean;
   timeRange: TimeRangeConfig;
   urlService: BrowserUrlService;
-  failureStoreEnabled: boolean;
+  isFailureStoreEnabled: boolean;
 }): Array<EuiBasicTableColumn<DataStreamStat>> => {
   return [
     {
@@ -335,7 +335,7 @@ export const getDatasetQualityTableColumns = ({
       ),
       width: '140px',
     },
-    ...(failureStoreEnabled
+    ...(isFailureStoreEnabled
       ? [
           {
             name: (

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/context.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/context.ts
@@ -11,7 +11,7 @@ import { ITelemetryClient } from '../../services/telemetry';
 export interface DatasetQualityDetailsContextValue {
   service: DatasetQualityDetailsControllerStateService;
   telemetryClient: ITelemetryClient;
-  isServerless: boolean;
+  isFailureStoreEnabled: boolean;
 }
 
 export const DatasetQualityDetailsContext = createContext({} as DatasetQualityDetailsContextValue);

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/index.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/index.tsx
@@ -26,14 +26,14 @@ export interface CreateDatasetQualityArgs {
   core: CoreStart;
   plugins: DatasetQualityStartDeps;
   telemetryClient: ITelemetryClient;
-  isServerless: boolean;
+  isFailureStoreEnabled: boolean;
 }
 
 export const createDatasetQualityDetails = ({
   core,
   plugins,
   telemetryClient,
-  isServerless,
+  isFailureStoreEnabled,
 }: CreateDatasetQualityArgs) => {
   return ({ controller }: DatasetQualityDetailsProps) => {
     const KibanaContextProviderForPlugin = useKibanaContextForPluginProvider(core, plugins);
@@ -42,7 +42,7 @@ export const createDatasetQualityDetails = ({
       () => ({
         service: controller.service,
         telemetryClient,
-        isServerless,
+        isFailureStoreEnabled,
       }),
       [controller.service]
     );

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/overview/document_trends/index.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/overview/document_trends/index.tsx
@@ -61,7 +61,7 @@ const degradedDocsTooltip = (
 // Allow for lazy loading
 // eslint-disable-next-line import/no-default-export
 export default function DocumentTrends({ lastReloadTime }: { lastReloadTime: number }) {
-  const { isServerless } = useDatasetQualityDetailsContext();
+  const { isFailureStoreEnabled } = useDatasetQualityDetailsContext();
   const { timeRange, updateTimeRange, docsTrendChart } = useDatasetQualityDetailsState();
   const {
     dataView,
@@ -82,7 +82,7 @@ export default function DocumentTrends({ lastReloadTime }: { lastReloadTime: num
     [updateTimeRange, timeRange.refresh]
   );
 
-  const accordionTitle = isServerless ? (
+  const accordionTitle = !isFailureStoreEnabled ? (
     <EuiFlexItem
       css={css`
         flex-direction: row;
@@ -128,7 +128,7 @@ export default function DocumentTrends({ lastReloadTime }: { lastReloadTime: num
         <EuiSpacer size="m" />
         <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
           <EuiFlexItem>
-            {!isServerless && (
+            {isFailureStoreEnabled && (
               <EuiButtonGroup
                 data-test-subj="datasetQualityDetailsChartTypeButtonGroup"
                 legend={i18n.translate('xpack.datasetQuality.details.chartTypeLegend', {

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/overview/summary/index.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/overview/summary/index.tsx
@@ -48,7 +48,7 @@ const failedDocsColumnTooltip = (
 // Allow for lazy loading
 // eslint-disable-next-line import/no-default-export
 export default function Summary() {
-  const { isServerless } = useDatasetQualityDetailsContext();
+  const { isFailureStoreEnabled } = useDatasetQualityDetailsContext();
   const {
     isSummaryPanelLoading,
     totalDocsCount,
@@ -103,7 +103,7 @@ export default function Summary() {
           isLoading={isSummaryPanelLoading}
           tooltip={degradedDocsTooltip}
         />
-        {!isServerless && (
+        {isFailureStoreEnabled && (
           <PanelIndicator
             label={overviewPanelDatasetQualityIndicatorFailedDocs}
             value={totalFailedDocsCount}

--- a/x-pack/platform/plugins/shared/dataset_quality/public/controller/dataset_quality/create_controller.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/controller/dataset_quality/create_controller.ts
@@ -23,10 +23,11 @@ type InitialState = DatasetQualityPublicStateUpdate;
 interface Dependencies {
   core: CoreStart;
   dataStreamStatsService: DataStreamsStatsServiceStart;
+  isFailureStoreEnabled: boolean;
 }
 
 export const createDatasetQualityControllerFactory =
-  ({ core, dataStreamStatsService }: Dependencies) =>
+  ({ core, dataStreamStatsService, isFailureStoreEnabled }: Dependencies) =>
   async ({
     initialState = DEFAULT_CONTEXT,
   }: {
@@ -40,6 +41,7 @@ export const createDatasetQualityControllerFactory =
       initialContext,
       toasts: core.notifications.toasts,
       dataStreamStatsClient,
+      isFailureStoreEnabled,
     });
 
     const service = interpret(machine, {

--- a/x-pack/platform/plugins/shared/dataset_quality/public/controller/dataset_quality_details/create_controller.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/controller/dataset_quality_details/create_controller.ts
@@ -22,10 +22,17 @@ interface Dependencies {
   plugins: DatasetQualityStartDeps;
   dataStreamStatsService: DataStreamsStatsServiceStart;
   dataStreamDetailsService: DataStreamDetailsServiceStart;
+  isFailureStoreEnabled: boolean;
 }
 
 export const createDatasetQualityDetailsControllerFactory =
-  ({ core, plugins, dataStreamStatsService, dataStreamDetailsService }: Dependencies) =>
+  ({
+    core,
+    plugins,
+    dataStreamStatsService,
+    dataStreamDetailsService,
+    isFailureStoreEnabled,
+  }: Dependencies) =>
   async ({
     initialState,
   }: {
@@ -44,6 +51,7 @@ export const createDatasetQualityDetailsControllerFactory =
       toasts: core.notifications.toasts,
       dataStreamStatsClient,
       dataStreamDetailsClient,
+      isFailureStoreEnabled,
     });
 
     const service = interpret(machine, {

--- a/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_dataset_quality_details_state.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_dataset_quality_details_state.ts
@@ -15,7 +15,7 @@ import { BasicDataStream } from '../../common/types';
 import { useKibanaContextForPlugin } from '../utils';
 
 export const useDatasetQualityDetailsState = () => {
-  const { service, telemetryClient, isServerless } = useDatasetQualityDetailsContext();
+  const { service, telemetryClient, isFailureStoreEnabled } = useDatasetQualityDetailsContext();
 
   const {
     services: { fieldFormats },
@@ -159,7 +159,7 @@ export const useDatasetQualityDetailsState = () => {
   return {
     service,
     telemetryClient,
-    isServerless,
+    isFailureStoreEnabled,
     fieldFormats,
     isIndexNotFoundError,
     dataStream,

--- a/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_dataset_quality_table.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_dataset_quality_table.tsx
@@ -36,7 +36,7 @@ export const useDatasetQualityTable = () => {
     },
   } = useKibanaContextForPlugin();
 
-  const { service, isServerless } = useDatasetQualityContext();
+  const { service, isFailureStoreEnabled } = useDatasetQualityContext();
 
   const { page, rowsPerPage, sort } = useSelector(service, (state) => state.context.table);
 
@@ -115,7 +115,7 @@ export const useDatasetQualityTable = () => {
         isActiveDataset: isActive,
         timeRange,
         urlService: url,
-        failureStoreEnabled: !isServerless,
+        isFailureStoreEnabled,
       }),
     [
       fieldFormats,
@@ -129,7 +129,7 @@ export const useDatasetQualityTable = () => {
       isActive,
       timeRange,
       url,
-      isServerless,
+      isFailureStoreEnabled,
     ]
   );
 

--- a/x-pack/platform/plugins/shared/dataset_quality/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/plugin.tsx
@@ -46,23 +46,26 @@ export class DatasetQualityPlugin
       http: core.http,
     });
 
+    const isFailureStoreEnabled = !this.isServerless;
+
     const DatasetQuality = createDatasetQuality({
       core,
       plugins,
       telemetryClient,
-      isServerless: this.isServerless,
+      isFailureStoreEnabled,
     });
 
     const createDatasetQualityController = createDatasetQualityControllerLazyFactory({
       core,
       dataStreamStatsService,
+      isFailureStoreEnabled,
     });
 
     const DatasetQualityDetails = createDatasetQualityDetails({
       core,
       plugins,
       telemetryClient,
-      isServerless: this.isServerless,
+      isFailureStoreEnabled,
     });
 
     const createDatasetQualityDetailsController = createDatasetQualityDetailsControllerLazyFactory({
@@ -70,6 +73,7 @@ export class DatasetQualityPlugin
       plugins,
       dataStreamStatsService,
       dataStreamDetailsService,
+      isFailureStoreEnabled,
     });
 
     return {

--- a/x-pack/platform/plugins/shared/dataset_quality/public/plugin.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/plugin.tsx
@@ -46,7 +46,8 @@ export class DatasetQualityPlugin
       http: core.http,
     });
 
-    const isFailureStoreEnabled = !this.isServerless;
+    // TODO: Remove first check once the failure store is enabled
+    const isFailureStoreEnabled = false && !this.isServerless;
 
     const DatasetQuality = createDatasetQuality({
       core,

--- a/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_details_controller/state_machine.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/state_machines/dataset_quality_details_controller/state_machine.ts
@@ -779,6 +779,7 @@ export interface DatasetQualityDetailsControllerStateMachineDependencies {
   toasts: IToasts;
   dataStreamStatsClient: IDataStreamsStatsClient;
   dataStreamDetailsClient: IDataStreamDetailsClient;
+  isFailureStoreEnabled: boolean;
 }
 
 export const createDatasetQualityDetailsControllerStateMachine = ({
@@ -787,6 +788,7 @@ export const createDatasetQualityDetailsControllerStateMachine = ({
   toasts,
   dataStreamStatsClient,
   dataStreamDetailsClient,
+  isFailureStoreEnabled,
 }: DatasetQualityDetailsControllerStateMachineDependencies) =>
   createPureDatasetQualityDetailsControllerStateMachine(initialContext).withConfig({
     actions: {
@@ -851,6 +853,14 @@ export const createDatasetQualityDetailsControllerStateMachine = ({
         return false;
       },
       loadFailedDocsDetails: (context) => {
+        if (!isFailureStoreEnabled) {
+          const unsupportedError = {
+            message: 'Failure store is disabled',
+            statusCode: 501,
+          };
+          return Promise.reject(unsupportedError);
+        }
+
         const { startDate: start, endDate: end } = getDateISORange(context.timeRange);
 
         return dataStreamDetailsClient.getFailedDocsDetails({
@@ -905,6 +915,14 @@ export const createDatasetQualityDetailsControllerStateMachine = ({
         return Promise.resolve();
       },
       loadfailedDocsErrors: (context) => {
+        if (!isFailureStoreEnabled) {
+          const unsupportedError = {
+            message: 'Failure store is disabled',
+            statusCode: 501,
+          };
+          return Promise.reject(unsupportedError);
+        }
+
         if ('expandedQualityIssue' in context && context.expandedQualityIssue) {
           const { startDate: start, endDate: end } = getDateISORange(context.timeRange);
 


### PR DESCRIPTION
This PR aims to introduces a single point for enabling/disabling failureStore.
Also we are disabling Failure store by default.

🎥 Demo

https://github.com/user-attachments/assets/d8151bb1-aa5c-42d9-b042-303861be2525


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->