### PR TITLE
Mark xpack.infra.sources.default.fields.message as deprecated in the docs

### DIFF
--- a/docs/settings/general-infra-logs-ui-settings.asciidoc
+++ b/docs/settings/general-infra-logs-ui-settings.asciidoc
@@ -1,5 +1,5 @@
 
-`xpack.infra.sources.default.fields.message`::
+deprecated:[8.18.0] `xpack.infra.sources.default.fields.message`::
 Fields used to display messages in the Logs app. Defaults to `['message', '@message']`.
 
 `xpack.infra.alerting.inventory_threshold.group_by_page_size`::


### PR DESCRIPTION
Mark `xpack.infra.sources.default.fields.message` as deprecated in the docs

Closes https://github.com/elastic/kibana/issues/208679

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->