### PR TITLE
[8.x] [Entity Analytics][Entity Store] Remove entity store technical preview tag (#208518)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
@@ -18,15 +18,12 @@ import {
   EuiHorizontalRule,
   EuiText,
   EuiButtonEmpty,
-  EuiBetaBadge,
-  EuiToolTip,
   EuiCallOut,
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { TECHNICAL_PREVIEW, TECHNICAL_PREVIEW_TOOLTIP } from '../../../../common/translations';
 import {
   ENABLEMENT_DESCRIPTION_RISK_ENGINE_ONLY,
   ENABLEMENT_DESCRIPTION_ENTITY_STORE_ONLY,
@@ -145,9 +142,6 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
                 }
                 data-test-subj="enablementEntityStoreSwitch"
               />
-              <EuiToolTip content={TECHNICAL_PREVIEW_TOOLTIP}>
-                <EuiBetaBadge label={TECHNICAL_PREVIEW} />
-              </EuiToolTip>
             </EuiFlexGroup>
           </EuiFlexItem>
           {!entityEnginePrivileges || entityEnginePrivileges.has_all_required ? null : (

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_store_management_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_store_management_page.tsx
@@ -22,8 +22,6 @@ import {
   EuiSwitch,
   EuiHealth,
   EuiLoadingSpinner,
-  EuiToolTip,
-  EuiBetaBadge,
   EuiTabs,
   EuiTab,
   EuiButtonEmpty,
@@ -46,7 +44,7 @@ import {
   useEntityStoreStatus,
   useStopEntityEngineMutation,
 } from '../components/entity_store/hooks/use_entity_store';
-import { TECHNICAL_PREVIEW, TECHNICAL_PREVIEW_TOOLTIP } from '../../common/translations';
+
 import { useEntityEnginePrivileges } from '../components/entity_store/hooks/use_entity_engine_privileges';
 import { MissingPrivilegesCallout } from '../components/entity_store/components/missing_privileges_callout';
 import { EngineStatus } from '../components/entity_store/components/engines_status';
@@ -150,15 +148,10 @@ export const EntityStoreManagementPage = () => {
       <EuiPageHeader
         data-test-subj="entityStoreManagementPage"
         pageTitle={
-          <>
-            <FormattedMessage
-              id="xpack.securitySolution.entityAnalytics.entityStoreManagementPage.title"
-              defaultMessage="Entity Store"
-            />{' '}
-            <EuiToolTip content={TECHNICAL_PREVIEW_TOOLTIP}>
-              <EuiBetaBadge label={TECHNICAL_PREVIEW} />
-            </EuiToolTip>
-          </>
+          <FormattedMessage
+            id="xpack.securitySolution.entityAnalytics.entityStoreManagementPage.title"
+            defaultMessage="Entity Store"
+          />
         }
         alignItems="center"
         rightSideItems={


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Entity Analytics][Entity Store] Remove entity store technical preview tag (#208518)](https://github.com/elastic/kibana/pull/208518)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tiago Vila Verde","email":"tiago.vilaverde@elastic.co"},"sourceCommit":{"committedDate":"2025-01-28T23:26:09Z","message":"[Entity Analytics][Entity Store] Remove entity store technical preview tag (#208518)\n\n## Summary\r\n\r\nThis PR removes the Entity Store's technical preview tag.\r\n\r\n\r\n![Screenshot 2025-01-28 at 13 27\r\n08](https://github.com/user-attachments/assets/726ee434-9241-44a3-983b-f8795d82a6c0)","sha":"27d03e1da9dca60b8ecdee95cdc1cf3e2a8429aa","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Theme: entity_analytics","Team:Entity Analytics","backport:version","v8.18.0"],"title":"[Entity Analytics][Entity Store] Remove entity store technical preview tag","number":208518,"url":"https://github.com/elastic/kibana/pull/208518","mergeCommit":{"message":"[Entity Analytics][Entity Store] Remove entity store technical preview tag (#208518)\n\n## Summary\r\n\r\nThis PR removes the Entity Store's technical preview tag.\r\n\r\n\r\n![Screenshot 2025-01-28 at 13 27\r\n08](https://github.com/user-attachments/assets/726ee434-9241-44a3-983b-f8795d82a6c0)","sha":"27d03e1da9dca60b8ecdee95cdc1cf3e2a8429aa"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208518","number":208518,"mergeCommit":{"message":"[Entity Analytics][Entity Store] Remove entity store technical preview tag (#208518)\n\n## Summary\r\n\r\nThis PR removes the Entity Store's technical preview tag.\r\n\r\n\r\n![Screenshot 2025-01-28 at 13 27\r\n08](https://github.com/user-attachments/assets/726ee434-9241-44a3-983b-f8795d82a6c0)","sha":"27d03e1da9dca60b8ecdee95cdc1cf3e2a8429aa"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->