### PR TITLE
[React@18] fix When on the host isolation exceptions page 

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/integration_tests/host_isolation_exceptions_list.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/integration_tests/host_isolation_exceptions_list.test.tsx
@@ -160,10 +160,10 @@ describe('When on the host isolation exceptions page', () => {
 
       it('should hide the Create and Edit actions when host isolation exceptions write authz is not allowed, but HIE entries exist', async () => {
         const { renderResult, user } = prepareTest();
-        const { findAllByTestId, queryByTestId, getByTestId } = await renderResult;
+        const { getAllByTestId, queryByTestId, getByTestId } = await renderResult;
 
-        await waitFor(async () => {
-          await expect(findAllByTestId(`${pageTestId}-card`)).resolves.toHaveLength(10);
+        await waitFor(() => {
+          expect(getAllByTestId(`${pageTestId}-card`)).toHaveLength(10);
         });
         await getFirstCard(user, renderResult, {
           showActions: true,
@@ -177,10 +177,10 @@ describe('When on the host isolation exceptions page', () => {
 
       it('should allow Delete action', async () => {
         const { apiMocks, renderResult, user } = prepareTest();
-        const { findAllByTestId, getByTestId } = await renderResult;
+        const { getAllByTestId, getByTestId } = await renderResult;
 
-        await waitFor(async () => {
-          await expect(findAllByTestId(`${pageTestId}-card`)).resolves.toHaveLength(10);
+        await waitFor(() => {
+          expect(getAllByTestId(`${pageTestId}-card`)).toHaveLength(10);
         });
         await getFirstCard(user, renderResult, {
           showActions: true,


### PR DESCRIPTION
## Summary

follow up to https://github.com/elastic/kibana/pull/208396

I missed similar failures in the same suite, probably because was `only` focused on a single test 🤕  sorry for the noise

Fix the whole suite so it passes with React@18 

```
REACT_18=true node scripts/jest --config=x-pack/solutions/security/plugins/security_solution/jest.integration.config.js /x-pack/solutions/security/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/integration_tests/host_isolation_exceptions_list.test.tsx
```


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->