### PR TITLE
[Global Search ] Increase global search z-index

### DIFF
--- a/x-pack/platform/plugins/private/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/platform/plugins/private/global_search_bar/public/components/search_bar.tsx
@@ -395,6 +395,7 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
       emptyMessage={<EmptyMessage />}
       noMatchesMessage={<PopoverPlaceholder basePath={props.basePathUrl} />}
       popoverProps={{
+        zIndex: Number(euiTheme.levels.navigation),
         'data-test-subj': 'nav-search-popover',
         panelClassName: 'navSearch__panel',
         repositionOnScroll: true,


### PR DESCRIPTION
## Summary

This PR increases `zIndex` for the global search bar popover so it stays above navigation menu. `euiTheme.levels.navigation` is the lowest EUI token value that works (`6000`).
Closes: #204763

![Screenshot 2025-01-29 at 03 30 44](https://github.com/user-attachments/assets/45f9e8bd-1450-4b22-b58a-007aa28f0836)
