### PR TITLE
[Obs AI Assistant] reduce RxJS observable usage

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/chat/route.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/chat/route.ts
@@ -270,7 +270,7 @@ async function chatComplete(
     scopes,
   });
 
-  const response$ = client.complete({
+  const response$ = await client.complete({
     messages,
     connectorId,
     conversationId,

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.test.ts
@@ -284,7 +284,7 @@ describe('Observability AI Assistant client', () => {
         });
 
       stream = observableIntoStream(
-        client.complete({
+        await client.complete({
           connectorId: 'foo',
           messages: [system('This is a system message'), user('How many alerts do I have?')],
           functionClient: functionClientMock,


### PR DESCRIPTION
## Summary
Reduce the usage of RxJS observables in `ObservabilityAIAssistantClient.complete` where they aren’t strictly necessary.
- **Replace Simple Observable Values with Promises**
For values like `messagesWithUpdatedSystemMessage$`, `userInstructions$`, and `title$` that depend on single values or one-time results, you can replace their observable usage with promises.

- **Refactor Complex Observable Streams into Utility Functions**
Isolate RxJS usage for complex patterns into utility functions/modules. For example:
```typescript
function createObservableForStreaming(events: Observable<Event[]>): Observable<Event> {
  return events.pipe(
    mergeMap((eventArray) => eventArray),
    shareReplay()
  );
}
```
- **Preserve RxJS for Streaming and Complex Flows**
For streaming events or flows that require handling multiple values (e.g., `nextEvents$` and `output$`), keep RxJS to handle the real-time stream of events and data flow.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)




