### PR TITLE
[8.x] [Response Ops][Cases] Fix alerts tab in cases detail page (#208672)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/containers/api.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/containers/api.test.tsx
@@ -152,7 +152,7 @@ describe('Cases API', () => {
       expect(fetchMock).toHaveBeenCalledWith(`${CASES_URL}/${caseId}/resolve`, {
         method: 'GET',
         query: {
-          includeComments: false,
+          includeComments: true,
         },
         signal: abortCtrl.signal,
       });

--- a/x-pack/platform/plugins/shared/cases/public/containers/api.ts
+++ b/x-pack/platform/plugins/shared/cases/public/containers/api.ts
@@ -117,7 +117,7 @@ export const resolveCase = async ({
     `${getCaseDetailsUrl(caseId)}/resolve`,
     {
       method: 'GET',
-      query: { includeComments: false },
+      query: { includeComments: true },
       signal,
     }
   );

--- a/x-pack/platform/plugins/shared/cases/server/routes/api/cases/get_case.ts
+++ b/x-pack/platform/plugins/shared/cases/server/routes/api/cases/get_case.ts
@@ -88,7 +88,15 @@ export const resolveCaseRoute = createCasesRoute({
   routerOptions: {
     access: 'internal',
   },
-  params,
+  params: {
+    ...params,
+    query: schema.object({
+      /**
+       * @deprecated since version 8.1.0
+       */
+      includeComments: schema.boolean({ defaultValue: true, meta: { deprecated: true } }),
+    }),
+  },
   handler: async ({ context, request, response }) => {
     try {
       const caseContext = await context.cases;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Response Ops][Cases] Fix alerts tab in cases detail page (#208672)](https://github.com/elastic/kibana/pull/208672)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julian Gernun","email":"17549662+jcger@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-29T09:59:03Z","message":"[Response Ops][Cases] Fix alerts tab in cases detail page (#208672)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/208290\n\nRollback `includeComments` in `resolve` case endpoint to fix the alerts\ntab in cases detail page. I'll create a new issue to use an alternative\napproach to get the data needed by the alerts tab.\n\n#### To do (might be shipped after FF):\n- [ ] Test the alert tab shows the right amount of alerts in header\n- [ ] Test the alert tab shows the alerts in content table\n\n### QA\n- Create alerts in security\n- Add an alert to a case\n- Check:\n<details>\n<summary>that number of alerts isn't 0 and the alert commet in activity\nlist exist</summary>\n<img width=\"1022\" alt=\"Screenshot 2025-01-29 at 06 53 10\"\nsrc=\"https://github.com/user-attachments/assets/0a95ee88-4c00-4a53-88a7-563560351a73\"\n/>\n\n</details>\n<details>\n  <summary>Table with alert is rendered when in alerts tab</summary>\n<img width=\"559\" alt=\"Screenshot 2025-01-29 at 06 57 27\"\nsrc=\"https://github.com/user-attachments/assets/95242c57-6eac-42e5-9801-534c8d7d6577\"\n/>\n\n</details>","sha":"2063855283688dc6c089c342ee24dc1403cdc877","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","v9.0.0","Feature:Cases","backport:prev-minor","v8.18.0"],"title":"[Response Ops][Cases] Fix alerts tab in cases detail page","number":208672,"url":"https://github.com/elastic/kibana/pull/208672","mergeCommit":{"message":"[Response Ops][Cases] Fix alerts tab in cases detail page (#208672)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/208290\n\nRollback `includeComments` in `resolve` case endpoint to fix the alerts\ntab in cases detail page. I'll create a new issue to use an alternative\napproach to get the data needed by the alerts tab.\n\n#### To do (might be shipped after FF):\n- [ ] Test the alert tab shows the right amount of alerts in header\n- [ ] Test the alert tab shows the alerts in content table\n\n### QA\n- Create alerts in security\n- Add an alert to a case\n- Check:\n<details>\n<summary>that number of alerts isn't 0 and the alert commet in activity\nlist exist</summary>\n<img width=\"1022\" alt=\"Screenshot 2025-01-29 at 06 53 10\"\nsrc=\"https://github.com/user-attachments/assets/0a95ee88-4c00-4a53-88a7-563560351a73\"\n/>\n\n</details>\n<details>\n  <summary>Table with alert is rendered when in alerts tab</summary>\n<img width=\"559\" alt=\"Screenshot 2025-01-29 at 06 57 27\"\nsrc=\"https://github.com/user-attachments/assets/95242c57-6eac-42e5-9801-534c8d7d6577\"\n/>\n\n</details>","sha":"2063855283688dc6c089c342ee24dc1403cdc877"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208672","number":208672,"mergeCommit":{"message":"[Response Ops][Cases] Fix alerts tab in cases detail page (#208672)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/208290\n\nRollback `includeComments` in `resolve` case endpoint to fix the alerts\ntab in cases detail page. I'll create a new issue to use an alternative\napproach to get the data needed by the alerts tab.\n\n#### To do (might be shipped after FF):\n- [ ] Test the alert tab shows the right amount of alerts in header\n- [ ] Test the alert tab shows the alerts in content table\n\n### QA\n- Create alerts in security\n- Add an alert to a case\n- Check:\n<details>\n<summary>that number of alerts isn't 0 and the alert commet in activity\nlist exist</summary>\n<img width=\"1022\" alt=\"Screenshot 2025-01-29 at 06 53 10\"\nsrc=\"https://github.com/user-attachments/assets/0a95ee88-4c00-4a53-88a7-563560351a73\"\n/>\n\n</details>\n<details>\n  <summary>Table with alert is rendered when in alerts tab</summary>\n<img width=\"559\" alt=\"Screenshot 2025-01-29 at 06 57 27\"\nsrc=\"https://github.com/user-attachments/assets/95242c57-6eac-42e5-9801-534c8d7d6577\"\n/>\n\n</details>","sha":"2063855283688dc6c089c342ee24dc1403cdc877"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->