### PR TITLE
[Synthetics] Fix ping heatmap regression when Inspect flag is turned off !!

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/pings/ping_heatmap.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/pings/ping_heatmap.ts
@@ -26,7 +26,7 @@ export const syntheticsGetPingHeatmapRoute: SyntheticsRestApiRouteFactory = () =
   handler: async ({
     syntheticsEsClient,
     request,
-  }): Promise<MonitorStatusHeatmapBucket[] | undefined> => {
+  }): Promise<{ result: MonitorStatusHeatmapBucket[] } | undefined> => {
     const { from, to, interval: intervalInMinutes, monitorId, location } = request.query;
 
     const result = await queryMonitorHeatmap({
@@ -38,6 +38,6 @@ export const syntheticsGetPingHeatmapRoute: SyntheticsRestApiRouteFactory = () =
       intervalInMinutes,
     });
 
-    return result.body.aggregations?.heatmap?.buckets as MonitorStatusHeatmapBucket[];
+    return { result: result.body.aggregations?.heatmap?.buckets as MonitorStatusHeatmapBucket[] };
   },
 });


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/208304 !!

Fix ping heatmap regression when Inspect flag is turned off !!

This flag is turned on auto in dev which caused an issue !!

To reproduce the step, you can turn off the inspect flag in dev mode by removing `this.isDev `from this condition 

https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/synthetics/server/lib.ts#L93

### After

<img width="1726" alt="image" src="https://github.com/user-attachments/assets/ad786351-37e4-4c18-b68e-695880d836e9" />





<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->