### PR TITLE
[8.x] [Logs UI] Add callout for legacy log views (#208242)

### DIFF
--- a/x-pack/platform/plugins/shared/logs_shared/public/components/log_stream/legacy_log_view_callout.tsx
+++ b/x-pack/platform/plugins/shared/logs_shared/public/components/log_stream/legacy_log_view_callout.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiCallOut, EuiLink } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import React from 'react';
+
+export const LegacyLogViewCallout: React.FC<{ upgradeAssistantUrl?: string }> = ({
+  upgradeAssistantUrl,
+}) => {
+  const UpgradeAssistant = upgradeAssistantUrl ? (
+    <EuiLink href={upgradeAssistantUrl}>{upgradeAssistantLabel}</EuiLink>
+  ) : (
+    upgradeAssistantLabel
+  );
+
+  return (
+    <EuiCallOut title={legacyLogViewTitle} color="warning" iconType="alert">
+      <p>
+        <FormattedMessage
+          id="xpack.logsShared.logStream.legacyLogViewDescription"
+          defaultMessage="This view uses a deprecated configuration. Use the {UpgradeAssistant} to migrate to a supported configuration."
+          values={{
+            UpgradeAssistant,
+          }}
+        />
+      </p>
+    </EuiCallOut>
+  );
+};
+
+const legacyLogViewTitle = i18n.translate('xpack.logsShared.logStream.legacyLogViewTitle', {
+  defaultMessage: 'Deprecated Log Source Configuration',
+});
+
+const upgradeAssistantLabel = i18n.translate(
+  'xpack.logsShared.logStream.upgradeAssistantLinkText',
+  {
+    defaultMessage: 'Upgrade Assistant',
+  }
+);

--- a/x-pack/platform/plugins/shared/logs_shared/public/components/log_stream/log_stream.tsx
+++ b/x-pack/platform/plugins/shared/logs_shared/public/components/log_stream/log_stream.tsx
@@ -5,8 +5,10 @@
  * 2.0.
  */
 
+import { EuiSpacer } from '@elastic/eui';
 import type { HttpStart } from '@kbn/core-http-browser';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { MANAGEMENT_APP_LOCATOR } from '@kbn/deeplinks-management/constants';
 import { buildEsQuery, Filter, Query } from '@kbn/es-query';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
@@ -17,7 +19,11 @@ import { noop } from 'lodash';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import usePrevious from 'react-use/lib/usePrevious';
 import { LogEntryCursor } from '../../../common/log_entry';
-import { defaultLogViewsStaticConfig, LogViewReference } from '../../../common/log_views';
+import {
+  defaultLogViewsStaticConfig,
+  logSourcesKibanaAdvancedSettingRT,
+  LogViewReference,
+} from '../../../common/log_views';
 import { BuiltEsQuery, useLogStream } from '../../containers/logs/log_stream';
 import { useLogView } from '../../hooks/use_log_view';
 import { LogViewsClient } from '../../services/log_views';
@@ -25,6 +31,7 @@ import { LogColumnRenderConfiguration } from '../../utils/log_column_render_conf
 import { useKibanaQuerySettings } from '../../utils/use_kibana_query_settings';
 import { useLogEntryFlyout } from '../logging/log_entry_flyout';
 import { ScrollableLogTextStreamView, VisibleInterval } from '../logging/log_text_stream';
+import { LegacyLogViewCallout } from './legacy_log_view_callout';
 import { LogStreamErrorBoundary } from './log_stream_error_boundary';
 
 interface LogStreamPluginDeps {
@@ -117,6 +124,11 @@ export const LogStreamContent = ({
   const {
     services: { http, data, share, logsDataAccess },
   } = useKibana<LogStreamPluginDeps>();
+
+  const upgradeAssistantUrl = share.url.locators
+    .get(MANAGEMENT_APP_LOCATOR)
+    ?.useUrl({ sectionId: 'stack', appId: 'upgrade_assistant/kibana_deprecations' });
+
   if (http == null || data == null || share == null || logsDataAccess == null) {
     throw new Error(
       `<LogStream /> cannot access kibana core services.
@@ -148,10 +160,18 @@ Read more at https://github.com/elastic/kibana/blob/main/src/platform/plugins/sh
     isLoading: isLoadingLogView,
     load: loadLogView,
     resolvedLogView,
+    logView: currentLogView,
   } = useLogView({
     initialLogViewReference: logView,
     logViews,
   });
+
+  const isLegacyLogView = useMemo(
+    () =>
+      currentLogView != null &&
+      !logSourcesKibanaAdvancedSettingRT.is(currentLogView?.attributes.logIndices),
+    [currentLogView]
+  );
 
   const parsedQuery = useMemo<BuiltEsQuery | undefined>(() => {
     if (typeof query === 'object' && 'bool' in query) {
@@ -270,35 +290,44 @@ Read more at https://github.com/elastic/kibana/blob/main/src/platform/plugins/sh
   );
 
   return (
-    <ScrollableLogTextStreamView
-      target={center ? center : entries.length ? entries[entries.length - 1].cursor : null}
-      columnConfigurations={columnConfigurations}
-      items={streamItems}
-      scale="medium"
-      wrap={true}
-      isReloading={isReloading}
-      isLoadingMore={isLoadingMore}
-      isStreaming={isStreaming}
-      hasMoreBeforeStart={hasMoreBefore}
-      hasMoreAfterEnd={hasMoreAfter}
-      lastLoadedTime={lastLoadedTime}
-      jumpToTarget={noop}
-      reportVisibleInterval={handlePagination}
-      reloadItems={fetchEntries}
-      onOpenLogEntryFlyout={showFlyoutAction ? openLogEntryFlyout : undefined}
-      highlightedItem={highlight ?? null}
-      currentHighlightKey={null}
-      startDateExpression={startDateExpression}
-      endDateExpression={endDateExpression}
-      updateDateRange={noop}
-      startLiveStreaming={noop}
-      hideScrollbar={false}
-    />
+    <>
+      {isLegacyLogView ? (
+        <>
+          <LegacyLogViewCallout upgradeAssistantUrl={upgradeAssistantUrl} />
+          <EuiSpacer size="s" />
+        </>
+      ) : null}
+      <ScrollableLogTextStreamView
+        target={center ? center : entries.length ? entries[entries.length - 1].cursor : null}
+        columnConfigurations={columnConfigurations}
+        items={streamItems}
+        scale="medium"
+        wrap={true}
+        isReloading={isReloading}
+        isLoadingMore={isLoadingMore}
+        isStreaming={isStreaming}
+        hasMoreBeforeStart={hasMoreBefore}
+        hasMoreAfterEnd={hasMoreAfter}
+        lastLoadedTime={lastLoadedTime}
+        jumpToTarget={noop}
+        reportVisibleInterval={handlePagination}
+        reloadItems={fetchEntries}
+        onOpenLogEntryFlyout={showFlyoutAction ? openLogEntryFlyout : undefined}
+        highlightedItem={highlight ?? null}
+        currentHighlightKey={null}
+        startDateExpression={startDateExpression}
+        endDateExpression={endDateExpression}
+        updateDateRange={noop}
+        startLiveStreaming={noop}
+        hideScrollbar={false}
+      />
+    </>
   );
 };
 
 const LogStreamContainer = euiStyled.div`
   display: flex;
+  flex-direction: column;
   background-color: ${(props) => props.theme.eui.euiColorEmptyShade};
 `;
 

--- a/x-pack/platform/plugins/shared/logs_shared/tsconfig.json
+++ b/x-pack/platform/plugins/shared/logs_shared/tsconfig.json
@@ -55,5 +55,6 @@
     "@kbn/spaces-plugin",
     "@kbn/analytics",
     "@kbn/usage-collection-plugin",
+    "@kbn/deeplinks-management",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Logs UI] Add callout for legacy log views (#208242)](https://github.com/elastic/kibana/pull/208242)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Felix Stürmer","email":"weltenwort@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-28T23:25:02Z","message":"[Logs UI] Add callout for legacy log views (#208242)\n\nThis adds a call-out to the deprecated logs stream component with\r\ninformation on how to migrate. That includes a link to the Kibana\r\ndeprecations in the upgrade assistant.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"538054fcbf822cc4ea8d8f36df772fc5f29b6335","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor","Team:obs-ux-logs"],"title":"[Logs UI] Add callout for legacy log views","number":208242,"url":"https://github.com/elastic/kibana/pull/208242","mergeCommit":{"message":"[Logs UI] Add callout for legacy log views (#208242)\n\nThis adds a call-out to the deprecated logs stream component with\r\ninformation on how to migrate. That includes a link to the Kibana\r\ndeprecations in the upgrade assistant.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"538054fcbf822cc4ea8d8f36df772fc5f29b6335"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208242","number":208242,"mergeCommit":{"message":"[Logs UI] Add callout for legacy log views (#208242)\n\nThis adds a call-out to the deprecated logs stream component with\r\ninformation on how to migrate. That includes a link to the Kibana\r\ndeprecations in the upgrade assistant.\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"538054fcbf822cc4ea8d8f36df772fc5f29b6335"}}]}] BACKPORT-->