### PR TITLE
[8.x] [Console] Fix flaky autocomplete test for index fields (#208503)

### DIFF
--- a/test/functional/apps/console/_autocomplete.ts
+++ b/test/functional/apps/console/_autocomplete.ts
@@ -374,8 +374,7 @@ GET _search
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/186935
-    describe.skip('index fields autocomplete', () => {
+    describe('index fields autocomplete', () => {
       const indexName = `index_field_test-${Date.now()}-${Math.random()}`;
 
       before(async () => {
@@ -394,7 +393,11 @@ GET _search
 
       it('fields autocomplete only shows fields of the index', async () => {
         await PageObjects.console.clearEditorText();
-        await PageObjects.console.enterText('GET _search\n{\n"fields": ["');
+        await PageObjects.console.enterText('GET _search\n{\n"fields": [');
+        // Wait for the autocomplete request to finish loading
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        // Trigger the autocomplete for the field we previously added
+        await PageObjects.console.enterText('te');
 
         expect(await PageObjects.console.getAutocompleteSuggestion(0)).to.be.eql('test');
         expect(await PageObjects.console.getAutocompleteSuggestion(1)).to.be.eql(undefined);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Console] Fix flaky autocomplete test for index fields (#208503)](https://github.com/elastic/kibana/pull/208503)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ignacio Rivas","email":"rivasign@gmail.com"},"sourceCommit":{"committedDate":"2025-01-29T14:36:02Z","message":"[Console] Fix flaky autocomplete test for index fields (#208503)","sha":"4da814d138cd87e2d03cb3378631327f091ceae9","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","v9.0.0","backport:prev-minor"],"title":"[Console] Fix flaky autocomplete test for index fields","number":208503,"url":"https://github.com/elastic/kibana/pull/208503","mergeCommit":{"message":"[Console] Fix flaky autocomplete test for index fields (#208503)","sha":"4da814d138cd87e2d03cb3378631327f091ceae9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208503","number":208503,"mergeCommit":{"message":"[Console] Fix flaky autocomplete test for index fields (#208503)","sha":"4da814d138cd87e2d03cb3378631327f091ceae9"}}]}] BACKPORT-->