### PR TITLE
Attempt at fixing failing storybook suites

### DIFF
--- a/src/dev/storybook/aliases.ts
+++ b/src/dev/storybook/aliases.ts
@@ -67,9 +67,8 @@ export const storybookAliases = {
   presentation: 'src/platform/plugins/shared/presentation_util/storybook',
   random_sampling: 'x-pack/platform/packages/private/kbn-random-sampling/.storybook',
   esql_editor: 'src/platform/packages/private/kbn-esql-editor/.storybook',
-  // Skipped, please check and fix https://github.com/elastic/kibana/issues/207227
-  // security_solution: 'x-pack/solutions/security/plugins/security_solution/.storybook',
-  // security_solution_packages: 'x-pack/solutions/security/packages/storybook/config',
+  security_solution: 'x-pack/solutions/security/plugins/security_solution/.storybook',
+  security_solution_packages: 'x-pack/solutions/security/packages/storybook/config',
   serverless: 'packages/serverless/storybook/config',
   shared_ux: 'src/platform/packages/private/shared-ux/storybook/config',
   threat_intelligence: 'x-pack/solutions/security/plugins/threat_intelligence/.storybook',

--- a/src/platform/packages/shared/kbn-discover-utils/src/__mocks__/es_hits.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/__mocks__/es_hits.ts
@@ -61,7 +61,7 @@ export const esHitsMockWithSort = esHitsMock.map((hit) => ({
 }));
 
 const baseDate = new Date('2024-01-1').getTime();
-const dateInc = 100_000_000;
+const dateInc = 100 * 1000 * 1000;
 
 const generateFieldValue = (field: DataViewField, index: number) => {
   switch (field.type) {


### PR DESCRIPTION
## Summary

Attempts at fixing the [failing storybook suites](https://github.com/elastic/kibana/issues/207227). The error is:

```
| ERR! Module parse failed: Identifier directly after number (72:17)
...
| ERR! > var dateInc = 100_000_000;
```

I suspect that for some reason the storybook logic is not able to parse numbers with the underscore `_` separator.