### PR TITLE
Add message in ua linking to deprecated debug logs docs

### DIFF
--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
@@ -33,6 +33,7 @@ export const getIsAccessApiDeprecation = ({
 export const buildApiAccessDeprecationDetails = ({
   apiUsageStats,
   deprecatedApiDetails,
+  docLinks,
 }: BuildApiDeprecationDetailsParams): DomainDeprecationDetails<ApiDeprecationDetails> => {
   const { apiId, apiTotalCalls, totalMarkedAsResolved } = apiUsageStats;
   const { routeVersion, routePath, routeDeprecationOptions, routeMethod } = deprecatedApiDetails;
@@ -43,7 +44,7 @@ export const buildApiAccessDeprecationDetails = ({
     apiId,
     title: getApiDeprecationTitle(deprecatedApiDetails),
     level: deprecationLevel,
-    message: getApiDeprecationMessage(deprecatedApiDetails, apiUsageStats),
+    message: getApiDeprecationMessage(deprecatedApiDetails, apiUsageStats, docLinks),
     documentationUrl: routeDeprecationOptions?.documentationUrl,
     correctiveActions: {
       manualSteps: getApiDeprecationsManualSteps(),

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/i18n_texts.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/i18n_texts.ts
@@ -79,7 +79,7 @@ export const getApiDeprecationMessage = (
     type: 'markdown',
     content: i18n.translate('core.deprecations.apiAccessDeprecation.enableDebugLogsMessage', {
       defaultMessage:
-        'To include information about deprecated API calls in debug logs, edit your Kibana configuration as detailed in [the documentation]({enableDeprecationHttpDebugLogsLink}).',
+        'To include information in debug logs about calls to APIs that are internal to Elastic, edit your Kibana configuration as detailed in [the documentation]({enableDeprecationHttpDebugLogsLink}).',
       values: {
         enableDeprecationHttpDebugLogsLink: docLinks.links.logging.enableDeprecationHttpDebugLogs,
       },

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/i18n_texts.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/i18n_texts.ts
@@ -11,6 +11,8 @@ import { RouterDeprecatedApiDetails } from '@kbn/core-http-server';
 import { CoreDeprecatedApiUsageStats } from '@kbn/core-usage-data-server';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
+import { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
+import type { DeprecationDetailsMessage } from '@kbn/core-deprecations-common';
 
 export const getApiDeprecationTitle = (
   details: Pick<RouterDeprecatedApiDetails, 'routePath' | 'routeMethod'>
@@ -31,8 +33,9 @@ export const getApiDeprecationMessage = (
     RouterDeprecatedApiDetails,
     'routePath' | 'routeMethod' | 'routeDeprecationOptions'
   >,
-  apiUsageStats: CoreDeprecatedApiUsageStats
-): string[] => {
+  apiUsageStats: CoreDeprecatedApiUsageStats,
+  docLinks: DocLinksServiceSetup
+): Array<string | DeprecationDetailsMessage> => {
   const { routePath, routeMethod, routeDeprecationOptions } = details;
   const { apiLastCalledAt, apiTotalCalls, markedAsResolvedLastCalledAt, totalMarkedAsResolved } =
     apiUsageStats;
@@ -41,7 +44,7 @@ export const getApiDeprecationMessage = (
   const wasResolvedBefore = totalMarkedAsResolved > 0;
   const routeWithMethod = `${routeMethod.toUpperCase()} ${routePath}`;
 
-  const messages = [
+  const messages: Array<string | DeprecationDetailsMessage> = [
     i18n.translate('core.deprecations.apiAccessDeprecation.apiCallsDetailsMessage', {
       defaultMessage:
         'The API "{routeWithMethod}" has been called {apiTotalCalls} times. The last call was on {apiLastCalledAt}.',
@@ -72,6 +75,16 @@ export const getApiDeprecationMessage = (
         'Internal APIs are meant to be used by Elastic services only. You should not use them. External access to these APIs will be restricted.',
     })
   );
+  messages.push({
+    type: 'markdown',
+    content: i18n.translate('core.deprecations.apiAccessDeprecation.enableDebugLogsMessage', {
+      defaultMessage:
+        'To include information about deprecated API calls in debug logs, edit your Kibana configuration as detailed in [the documentation]({enableDeprecationHttpDebugLogsLink}).',
+      values: {
+        enableDeprecationHttpDebugLogsLink: docLinks.links.logging.enableDeprecationHttpDebugLogs,
+      },
+    }),
+  });
 
   if (routeDeprecationOptions?.message) {
     // Surfaces additional deprecation messages passed into the route in UA

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/register_api_depercation_info.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/register_api_depercation_info.test.ts
@@ -413,7 +413,7 @@ describe('#registerApiDeprecationsInfo', () => {
               "The API \\"POST /internal/api/\\" has been called 13 times. The last call was on Sunday, September 1, 2024 6:06 AM -04:00.",
               "Internal APIs are meant to be used by Elastic services only. You should not use them. External access to these APIs will be restricted.",
               Object {
-                "content": "To include information about deprecated API calls in debug logs, edit your Kibana configuration as detailed in [the documentation](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
+                "content": "To include information in debug logs about calls to APIs that are internal to Elastic, edit your Kibana configuration as detailed in [the documentation](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
                 "type": "markdown",
               },
             ],

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/register_api_depercation_info.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/register_api_depercation_info.test.ts
@@ -20,12 +20,15 @@ import {
   coreUsageDataServiceMock,
   coreUsageStatsClientMock,
 } from '@kbn/core-usage-data-server-mocks';
+import { docLinksServiceMock } from '@kbn/core-doc-links-server-mocks';
 import _ from 'lodash';
+import type { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import { CoreDeprecatedApiUsageStats } from '@kbn/core-usage-data-server';
 
 describe('#registerApiDeprecationsInfo', () => {
   const deprecationsFactory = mockDeprecationsFactory.create();
   const deprecationsRegistry = mockDeprecationsRegistry.create();
+  const docLinks: DocLinksServiceSetup = docLinksServiceMock.createSetupContract();
   let usageClientMock: ReturnType<typeof coreUsageStatsClientMock.create>;
   let http: ReturnType<typeof httpServiceMock.createInternalSetupContract>;
   let coreUsageData: ReturnType<typeof coreUsageDataServiceMock.createSetupContract>;
@@ -47,7 +50,7 @@ describe('#registerApiDeprecationsInfo', () => {
 
   it('registers api deprecations', async () => {
     deprecationsFactory.getRegistry.mockReturnValue(deprecationsRegistry);
-    registerApiDeprecationsInfo({ deprecationsFactory, coreUsageData, http });
+    registerApiDeprecationsInfo({ deprecationsFactory, coreUsageData, http, docLinks });
 
     expect(deprecationsFactory.getRegistry).toBeCalledWith('core.api_deprecations');
     expect(deprecationsRegistry.registerDeprecations).toBeCalledTimes(1);
@@ -93,7 +96,7 @@ describe('#registerApiDeprecationsInfo', () => {
       );
 
     it('returns removed type deprecated route', async () => {
-      const getDeprecations = createGetApiDeprecations({ coreUsageData, http });
+      const getDeprecations = createGetApiDeprecations({ coreUsageData, http, docLinks });
       const deprecatedRoute = createDeprecatedRouteDetails({
         routePath: '/api/test_removed/',
         routeDeprecationOptions: { reason: { type: 'remove' } },
@@ -129,6 +132,10 @@ describe('#registerApiDeprecationsInfo', () => {
             "level": "critical",
             "message": Array [
               "The API \\"GET /api/test_removed/\\" has been called 13 times. The last call was on Sunday, September 1, 2024 6:06 AM -04:00.",
+              Object {
+                "content": "To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
+                "type": "markdown",
+              },
               "This issue has been marked as resolved on Thursday, October 17, 2024 8:06 AM -04:00 but the API has been called 12 times since.",
             ],
             "title": "The \\"GET /api/test_removed/\\" route is removed",
@@ -138,7 +145,7 @@ describe('#registerApiDeprecationsInfo', () => {
     });
 
     it('returns migrated type deprecated route', async () => {
-      const getDeprecations = createGetApiDeprecations({ coreUsageData, http });
+      const getDeprecations = createGetApiDeprecations({ coreUsageData, http, docLinks });
       const deprecatedRoute = createDeprecatedRouteDetails({
         routePath: '/api/test_migrated/',
         routeDeprecationOptions: {
@@ -176,6 +183,10 @@ describe('#registerApiDeprecationsInfo', () => {
             "level": "critical",
             "message": Array [
               "The API \\"GET /api/test_migrated/\\" has been called 13 times. The last call was on Sunday, September 1, 2024 6:06 AM -04:00.",
+              Object {
+                "content": "To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
+                "type": "markdown",
+              },
               "This issue has been marked as resolved on Thursday, October 17, 2024 8:06 AM -04:00 but the API has been called 12 times since.",
             ],
             "title": "The \\"GET /api/test_migrated/\\" route is migrated to a different API",
@@ -185,7 +196,7 @@ describe('#registerApiDeprecationsInfo', () => {
     });
 
     it('returns bumped type deprecated route', async () => {
-      const getDeprecations = createGetApiDeprecations({ coreUsageData, http });
+      const getDeprecations = createGetApiDeprecations({ coreUsageData, http, docLinks });
       const deprecatedRoute = createDeprecatedRouteDetails({
         routePath: '/api/test_bumped/',
         routeDeprecationOptions: { reason: { type: 'bump', newApiVersion: '444' } },
@@ -221,6 +232,10 @@ describe('#registerApiDeprecationsInfo', () => {
             "level": "critical",
             "message": Array [
               "The API \\"GET /api/test_bumped/\\" has been called 13 times. The last call was on Sunday, September 1, 2024 6:06 AM -04:00.",
+              Object {
+                "content": "To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
+                "type": "markdown",
+              },
               "This issue has been marked as resolved on Thursday, October 17, 2024 8:06 AM -04:00 but the API has been called 12 times since.",
             ],
             "title": "The \\"GET /api/test_bumped/\\" route has a newer version available",
@@ -230,7 +245,7 @@ describe('#registerApiDeprecationsInfo', () => {
     });
 
     it('returns deprecated type deprecated route', async () => {
-      const getDeprecations = createGetApiDeprecations({ coreUsageData, http });
+      const getDeprecations = createGetApiDeprecations({ coreUsageData, http, docLinks });
       const deprecatedRoute = createDeprecatedRouteDetails({
         routePath: '/api/test_deprecated/',
         routeDeprecationOptions: { reason: { type: 'deprecate' }, message: 'additional message' },
@@ -265,6 +280,10 @@ describe('#registerApiDeprecationsInfo', () => {
             "level": "critical",
             "message": Array [
               "The API \\"GET /api/test_deprecated/\\" has been called 13 times. The last call was on Sunday, September 1, 2024 6:06 AM -04:00.",
+              Object {
+                "content": "To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
+                "type": "markdown",
+              },
               "This issue has been marked as resolved on Thursday, October 17, 2024 8:06 AM -04:00 but the API has been called 12 times since.",
               "additional message",
             ],
@@ -275,7 +294,7 @@ describe('#registerApiDeprecationsInfo', () => {
     });
 
     it('does not return resolved deprecated route', async () => {
-      const getDeprecations = createGetApiDeprecations({ coreUsageData, http });
+      const getDeprecations = createGetApiDeprecations({ coreUsageData, http, docLinks });
       const deprecatedRoute = createDeprecatedRouteDetails({ routePath: '/api/test_resolved/' });
       http.getRegisteredDeprecatedApis.mockReturnValue([deprecatedRoute]);
       usageClientMock.getDeprecatedApiUsageStats.mockResolvedValue([
@@ -290,7 +309,7 @@ describe('#registerApiDeprecationsInfo', () => {
     });
 
     it('returns never resolved deprecated route', async () => {
-      const getDeprecations = createGetApiDeprecations({ coreUsageData, http });
+      const getDeprecations = createGetApiDeprecations({ coreUsageData, http, docLinks });
       const deprecatedRoute = createDeprecatedRouteDetails({
         routePath: '/api/test_never_resolved/',
       });
@@ -328,6 +347,10 @@ describe('#registerApiDeprecationsInfo', () => {
             "level": "critical",
             "message": Array [
               "The API \\"GET /api/test_never_resolved/\\" has been called 13 times. The last call was on Sunday, September 1, 2024 6:06 AM -04:00.",
+              Object {
+                "content": "To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
+                "type": "markdown",
+              },
             ],
             "title": "The \\"GET /api/test_never_resolved/\\" route is removed",
           },
@@ -336,7 +359,7 @@ describe('#registerApiDeprecationsInfo', () => {
     });
 
     it('does not return deprecated routes that have never been called', async () => {
-      const getDeprecations = createGetApiDeprecations({ coreUsageData, http });
+      const getDeprecations = createGetApiDeprecations({ coreUsageData, http, docLinks });
       const deprecatedRoute = createDeprecatedRouteDetails({
         routePath: '/api/test_never_resolved/',
       });

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/register_api_depercation_info.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/register_api_depercation_info.test.ts
@@ -133,7 +133,7 @@ describe('#registerApiDeprecationsInfo', () => {
             "message": Array [
               "The API \\"GET /api/test_removed/\\" has been called 13 times. The last call was on Sunday, September 1, 2024 6:06 AM -04:00.",
               Object {
-                "content": "To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
+                "content": "To include information about deprecated API calls in debug logs, edit your Kibana configuration as detailed in [the documentation](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
                 "type": "markdown",
               },
               "This issue has been marked as resolved on Thursday, October 17, 2024 8:06 AM -04:00 but the API has been called 12 times since.",
@@ -184,7 +184,7 @@ describe('#registerApiDeprecationsInfo', () => {
             "message": Array [
               "The API \\"GET /api/test_migrated/\\" has been called 13 times. The last call was on Sunday, September 1, 2024 6:06 AM -04:00.",
               Object {
-                "content": "To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
+                "content": "To include information about deprecated API calls in debug logs, edit your Kibana configuration as detailed in [the documentation](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
                 "type": "markdown",
               },
               "This issue has been marked as resolved on Thursday, October 17, 2024 8:06 AM -04:00 but the API has been called 12 times since.",
@@ -233,7 +233,7 @@ describe('#registerApiDeprecationsInfo', () => {
             "message": Array [
               "The API \\"GET /api/test_bumped/\\" has been called 13 times. The last call was on Sunday, September 1, 2024 6:06 AM -04:00.",
               Object {
-                "content": "To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
+                "content": "To include information about deprecated API calls in debug logs, edit your Kibana configuration as detailed in [the documentation](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
                 "type": "markdown",
               },
               "This issue has been marked as resolved on Thursday, October 17, 2024 8:06 AM -04:00 but the API has been called 12 times since.",
@@ -281,7 +281,7 @@ describe('#registerApiDeprecationsInfo', () => {
             "message": Array [
               "The API \\"GET /api/test_deprecated/\\" has been called 13 times. The last call was on Sunday, September 1, 2024 6:06 AM -04:00.",
               Object {
-                "content": "To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
+                "content": "To include information about deprecated API calls in debug logs, edit your Kibana configuration as detailed in [the documentation](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
                 "type": "markdown",
               },
               "This issue has been marked as resolved on Thursday, October 17, 2024 8:06 AM -04:00 but the API has been called 12 times since.",
@@ -348,7 +348,7 @@ describe('#registerApiDeprecationsInfo', () => {
             "message": Array [
               "The API \\"GET /api/test_never_resolved/\\" has been called 13 times. The last call was on Sunday, September 1, 2024 6:06 AM -04:00.",
               Object {
-                "content": "To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
+                "content": "To include information about deprecated API calls in debug logs, edit your Kibana configuration as detailed in [the documentation](https://www.elastic.co/guide/en/kibana/test-branch/logging-settings.html#enable-http-debug-logs).",
                 "type": "markdown",
               },
             ],

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/register_api_depercation_info.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/register_api_depercation_info.ts
@@ -15,7 +15,11 @@ import { buildApiDeprecationId } from './api_deprecation_id';
 import type { ApiDeprecationsServiceDeps } from './types';
 
 export const createGetApiDeprecations =
-  ({ http, coreUsageData }: Pick<ApiDeprecationsServiceDeps, 'coreUsageData' | 'http'>) =>
+  ({
+    http,
+    coreUsageData,
+    docLinks,
+  }: Pick<ApiDeprecationsServiceDeps, 'coreUsageData' | 'http' | 'docLinks'>) =>
   async (): Promise<DeprecationsDetails[]> => {
     const usageClient = coreUsageData.getClient();
     const deprecatedApis = http.getRegisteredDeprecatedApis();
@@ -43,6 +47,7 @@ export const createGetApiDeprecations =
             return buildApiRouteDeprecationDetails({
               apiUsageStats,
               deprecatedApiDetails,
+              docLinks,
             });
           }
           // if no access is specified then internal is the default
@@ -51,6 +56,7 @@ export const createGetApiDeprecations =
             return buildApiAccessDeprecationDetails({
               apiUsageStats,
               deprecatedApiDetails,
+              docLinks,
             });
           }
         }
@@ -61,10 +67,11 @@ export const registerApiDeprecationsInfo = ({
   deprecationsFactory,
   http,
   coreUsageData,
+  docLinks,
 }: ApiDeprecationsServiceDeps): void => {
   const deprecationsRegistery = deprecationsFactory.getRegistry('core.api_deprecations');
 
   deprecationsRegistery.registerDeprecations({
-    getDeprecations: createGetApiDeprecations({ http, coreUsageData }),
+    getDeprecations: createGetApiDeprecations({ http, coreUsageData, docLinks }),
   });
 };

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/i18n_texts.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/i18n_texts.ts
@@ -9,6 +9,7 @@
 
 import { RouterDeprecatedApiDetails } from '@kbn/core-http-server';
 import { CoreDeprecatedApiUsageStats } from '@kbn/core-usage-data-server';
+import type { DocLinksServiceSetup } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
 
@@ -37,7 +38,8 @@ export const getApiDeprecationTitle = (details: RouterDeprecatedApiDetails) => {
 
 export const getApiDeprecationMessage = (
   details: RouterDeprecatedApiDetails,
-  apiUsageStats: CoreDeprecatedApiUsageStats
+  apiUsageStats: CoreDeprecatedApiUsageStats,
+  docLinks: DocLinksServiceSetup
 ): string[] => {
   const { routePath, routeMethod, routeDeprecationOptions } = details;
   if (!routeDeprecationOptions) {
@@ -58,6 +60,13 @@ export const getApiDeprecationMessage = (
         routeWithMethod,
         apiTotalCalls,
         apiLastCalledAt: moment(apiLastCalledAt).format('LLLL Z'),
+      },
+    }),
+    i18n.translate('core.deprecations.apiRouteDeprecation.enableDebugLogsMessage', {
+      defaultMessage:
+        'To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, see {enableDeprecationHttpDebugLogsLink}.',
+      values: {
+        enableDeprecationHttpDebugLogsLink: docLinks.links.logging.enableDeprecationHttpDebugLogs,
       },
     }),
   ];

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/i18n_texts.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/i18n_texts.ts
@@ -9,10 +9,10 @@
 
 import { RouterDeprecatedApiDetails } from '@kbn/core-http-server';
 import { CoreDeprecatedApiUsageStats } from '@kbn/core-usage-data-server';
-import type { DocLinksServiceSetup } from '@kbn/core/server';
 import type { DeprecationDetailsMessage } from '@kbn/core-deprecations-common';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
+import { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 
 export const getApiDeprecationTitle = (details: RouterDeprecatedApiDetails) => {
   const { routePath, routeMethod, routeDeprecationOptions } = details;

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/i18n_texts.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/i18n_texts.ts
@@ -10,6 +10,7 @@
 import { RouterDeprecatedApiDetails } from '@kbn/core-http-server';
 import { CoreDeprecatedApiUsageStats } from '@kbn/core-usage-data-server';
 import type { DocLinksServiceSetup } from '@kbn/core/server';
+import type { DeprecationDetailsMessage } from '@kbn/core-deprecations-common';
 import { i18n } from '@kbn/i18n';
 import moment from 'moment';
 
@@ -40,7 +41,7 @@ export const getApiDeprecationMessage = (
   details: RouterDeprecatedApiDetails,
   apiUsageStats: CoreDeprecatedApiUsageStats,
   docLinks: DocLinksServiceSetup
-): string[] => {
+): Array<string | DeprecationDetailsMessage> => {
   const { routePath, routeMethod, routeDeprecationOptions } = details;
   if (!routeDeprecationOptions) {
     throw new Error(`Router "deprecated" param is missing for path "${routePath}".`);
@@ -52,7 +53,7 @@ export const getApiDeprecationMessage = (
   const wasResolvedBefore = totalMarkedAsResolved > 0;
   const routeWithMethod = `${routeMethod.toUpperCase()} ${routePath}`;
 
-  const messages = [
+  const messages: Array<string | DeprecationDetailsMessage> = [
     i18n.translate('core.deprecations.apiRouteDeprecation.apiCallsDetailsMessage', {
       defaultMessage:
         'The API "{routeWithMethod}" has been called {apiTotalCalls} times. The last call was on {apiLastCalledAt}.',
@@ -62,13 +63,16 @@ export const getApiDeprecationMessage = (
         apiLastCalledAt: moment(apiLastCalledAt).format('LLLL Z'),
       },
     }),
-    i18n.translate('core.deprecations.apiRouteDeprecation.enableDebugLogsMessage', {
-      defaultMessage:
-        'To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, see {enableDeprecationHttpDebugLogsLink}.',
-      values: {
-        enableDeprecationHttpDebugLogsLink: docLinks.links.logging.enableDeprecationHttpDebugLogs,
-      },
-    }),
+    {
+      type: 'markdown',
+      content: i18n.translate('core.deprecations.apiRouteDeprecation.enableDebugLogsMessage', {
+        defaultMessage:
+          'To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link]({enableDeprecationHttpDebugLogsLink}).',
+        values: {
+          enableDeprecationHttpDebugLogsLink: docLinks.links.logging.enableDeprecationHttpDebugLogs,
+        },
+      }),
+    },
   ];
 
   if (wasResolvedBefore) {

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/i18n_texts.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/i18n_texts.ts
@@ -67,7 +67,7 @@ export const getApiDeprecationMessage = (
       type: 'markdown',
       content: i18n.translate('core.deprecations.apiRouteDeprecation.enableDebugLogsMessage', {
         defaultMessage:
-          'To enable debug logs for deprecated API calls, modify the Kibana configuration. For more information, [follow this link]({enableDeprecationHttpDebugLogsLink}).',
+          'To include information about deprecated API calls in debug logs, edit your Kibana configuration as detailed in [the documentation]({enableDeprecationHttpDebugLogsLink}).',
         values: {
           enableDeprecationHttpDebugLogsLink: docLinks.links.logging.enableDeprecationHttpDebugLogs,
         },

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/route_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/route_deprecations.ts
@@ -33,6 +33,7 @@ export const getIsRouteApiDeprecation = ({
 export const buildApiRouteDeprecationDetails = ({
   apiUsageStats,
   deprecatedApiDetails,
+  docLinks,
 }: BuildApiDeprecationDetailsParams): DomainDeprecationDetails<ApiDeprecationDetails> => {
   const { apiId, apiTotalCalls, totalMarkedAsResolved } = apiUsageStats;
   const { routeVersion, routePath, routeDeprecationOptions, routeMethod } = deprecatedApiDetails;
@@ -46,7 +47,7 @@ export const buildApiRouteDeprecationDetails = ({
     apiId,
     title: getApiDeprecationTitle(deprecatedApiDetails),
     level: deprecationLevel,
-    message: getApiDeprecationMessage(deprecatedApiDetails, apiUsageStats),
+    message: getApiDeprecationMessage(deprecatedApiDetails, apiUsageStats, docLinks),
     documentationUrl: routeDeprecationOptions.documentationUrl,
     correctiveActions: {
       manualSteps: getApiDeprecationsManualSteps(deprecatedApiDetails),

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/types.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/types.ts
@@ -11,7 +11,7 @@ import type { InternalHttpServiceSetup } from '@kbn/core-http-server-internal';
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { RouterDeprecatedApiDetails } from '@kbn/core-http-server';
 import type { CoreDeprecatedApiUsageStats } from '@kbn/core-usage-data-server';
-import type { DocLinksServiceSetup } from '@kbn/core/server';
+import { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import type { DeprecationsFactory } from '../../deprecations_factory';
 
 export interface ApiDeprecationsServiceDeps {

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/types.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/types.ts
@@ -11,15 +11,18 @@ import type { InternalHttpServiceSetup } from '@kbn/core-http-server-internal';
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { RouterDeprecatedApiDetails } from '@kbn/core-http-server';
 import type { CoreDeprecatedApiUsageStats } from '@kbn/core-usage-data-server';
+import type { DocLinksServiceSetup } from '@kbn/core/server';
 import type { DeprecationsFactory } from '../../deprecations_factory';
 
 export interface ApiDeprecationsServiceDeps {
   deprecationsFactory: DeprecationsFactory;
   http: InternalHttpServiceSetup;
   coreUsageData: InternalCoreUsageDataSetup;
+  docLinks: DocLinksServiceSetup;
 }
 
 export interface BuildApiDeprecationDetailsParams {
   apiUsageStats: CoreDeprecatedApiUsageStats;
   deprecatedApiDetails: RouterDeprecatedApiDetails;
+  docLinks: DocLinksServiceSetup;
 }

--- a/src/core/packages/deprecations/server-internal/src/deprecations_service.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_service.test.ts
@@ -18,6 +18,8 @@ import { coreUsageDataServiceMock } from '@kbn/core-usage-data-server-mocks';
 import { configServiceMock } from '@kbn/config-mocks';
 import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
 import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { docLinksServiceMock } from '@kbn/core-doc-links-server-mocks';
+import type { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import { DeprecationsService, DeprecationsSetupDeps } from './deprecations_service';
 import { firstValueFrom } from 'rxjs';
 
@@ -37,7 +39,8 @@ describe('DeprecationsService', () => {
     coreUsageData = coreUsageDataServiceMock.createSetupContract();
     router = httpServiceMock.createRouter();
     http.createRouter.mockReturnValue(router);
-    deprecationsCoreSetupDeps = { http, coreUsageData, logging: loggingMock };
+    const docLinks: DocLinksServiceSetup = docLinksServiceMock.createSetupContract();
+    deprecationsCoreSetupDeps = { http, coreUsageData, logging: loggingMock, docLinks };
   });
 
   afterEach(() => {

--- a/src/core/packages/deprecations/server-internal/src/deprecations_service.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_service.ts
@@ -22,6 +22,7 @@ import type {
 import { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import { type InternalLoggingServiceSetup } from '@kbn/core-logging-server-internal';
+import type { DocLinksServiceSetup } from '@kbn/core/server';
 import { DeprecationsFactory } from './deprecations_factory';
 import { registerRoutes } from './routes';
 import { config as deprecationConfig, DeprecationConfigType } from './deprecation_config';
@@ -51,6 +52,7 @@ export interface DeprecationsSetupDeps {
   http: InternalHttpServiceSetup;
   coreUsageData: InternalCoreUsageDataSetup;
   logging: InternalLoggingServiceSetup;
+  docLinks: DocLinksServiceSetup;
 }
 
 /** @internal */
@@ -70,6 +72,7 @@ export class DeprecationsService
     http,
     coreUsageData,
     logging,
+    docLinks,
   }: DeprecationsSetupDeps): Promise<InternalDeprecationsServiceSetup> {
     this.logger.debug('Setting up Deprecations service');
 
@@ -106,6 +109,7 @@ export class DeprecationsService
       deprecationsFactory: this.deprecationsFactory,
       http,
       coreUsageData,
+      docLinks,
     });
 
     const deprecationsFactory = this.deprecationsFactory;

--- a/src/core/packages/deprecations/server-internal/src/deprecations_service.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_service.ts
@@ -22,7 +22,7 @@ import type {
 import { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import { type InternalLoggingServiceSetup } from '@kbn/core-logging-server-internal';
-import type { DocLinksServiceSetup } from '@kbn/core/server';
+import { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import { DeprecationsFactory } from './deprecations_factory';
 import { registerRoutes } from './routes';
 import { config as deprecationConfig, DeprecationConfigType } from './deprecation_config';

--- a/src/core/packages/deprecations/server-internal/tsconfig.json
+++ b/src/core/packages/deprecations/server-internal/tsconfig.json
@@ -39,6 +39,7 @@
     "@kbn/core-usage-data-server-mocks",
     "@kbn/core-http-router-server-internal",
     "@kbn/core-logging-server-internal",
+    "@kbn/core-doc-links-server",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/deprecations/server-internal/tsconfig.json
+++ b/src/core/packages/deprecations/server-internal/tsconfig.json
@@ -40,6 +40,7 @@
     "@kbn/core-http-router-server-internal",
     "@kbn/core-logging-server-internal",
     "@kbn/core-doc-links-server",
+    "@kbn/core-doc-links-server-mocks",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/root/server-internal/src/server.ts
+++ b/src/core/packages/root/server-internal/src/server.ts
@@ -308,6 +308,7 @@ export class Server {
       http: httpSetup,
       coreUsageData: coreUsageDataSetup,
       logging: loggingSetup,
+      docLinks: docLinksSetup,
     });
 
     const savedObjectsSetup = await this.savedObjects.setup({

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -414,6 +414,9 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
     server: {
       protocol: `${KIBANA_DOCS}settings.html#server-protocol`,
     },
+    logging: {
+      enableDeprecationHttpDebugLogs: `${KIBANA_DOCS}logging-settings.html#enable-http-debug-logs`,
+    },
     securitySolution: {
       artifactControl: `${SECURITY_SOLUTION_DOCS}artifact-control.html`,
       avcResults: `${ELASTIC_WEBSITE_URL}blog/elastic-security-av-comparatives-business-test`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -279,6 +279,9 @@ export interface DocLinks {
   readonly server: {
     readonly protocol: string;
   };
+  readonly logging: {
+    readonly enableDeprecationHttpDebugLogs: string;
+  };
   readonly securitySolution: {
     readonly aiAssistant: string;
     readonly artifactControl: string;


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/208570

Add a message in UA with a link to the new config that enables debug logs when a deprecated API is called.

<img width="485" alt="Screenshot 2025-01-29 at 17 16 33" src="https://github.com/user-attachments/assets/ce796b38-c7af-4f0c-bcca-74512c909208" />

To try this you can call a deprecated API and look for the warnings in UA.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.







<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->