### PR TITLE
[8.17] [search profiler] Move profile button inline with index field (#202253)

### DIFF
--- a/x-pack/plugins/searchprofiler/public/application/components/profile_query_editor/profile_query_editor.tsx
+++ b/x-pack/plugins/searchprofiler/public/application/components/profile_query_editor/profile_query_editor.tsx
@@ -12,11 +12,10 @@ import {
   EuiForm,
   EuiFieldText,
   EuiFormRow,
-  EuiButton,
-  EuiText,
+  EuiButtonIcon,
   EuiFlexGroup,
-  EuiSpacer,
   EuiFlexItem,
+  EuiToolTip,
 } from '@elastic/eui';
 
 import { decompressFromEncodedURIComponent } from 'lz-string';
@@ -87,6 +86,22 @@ export const ProfileQueryEditor = memo(() => {
   );
   const licenseEnabled = getLicenseStatus().valid;
 
+  const tooltipContentDisabled = i18n.translate(
+    'xpack.searchProfiler.formProfileButton.noLicenseTooltip',
+    {
+      defaultMessage: 'You need an active license to use Search Profiler',
+    }
+  );
+
+  const tooltipContentEnabled = i18n.translate(
+    'xpack.searchProfiler.sendRequestButtonTooltipContent',
+    {
+      defaultMessage: 'Click to send request',
+    }
+  );
+
+  const tooltipContent = !licenseEnabled ? tooltipContentDisabled : tooltipContentEnabled;
+
   return (
     <EuiFlexGroup
       responsive={false}
@@ -99,15 +114,17 @@ export const ProfileQueryEditor = memo(() => {
       {/* Form */}
       <EuiFlexItem grow={false}>
         <EuiForm>
-          <EuiFlexGroup direction="row" gutterSize="s">
+          <EuiFlexGroup responsive={false} direction="row" gutterSize="s" alignItems="flexEnd">
             <EuiFlexItem>
               <EuiFormRow
+                fullWidth
                 label={i18n.translate('xpack.searchProfiler.formIndexLabel', {
                   defaultMessage: 'Index',
                 })}
               >
                 <EuiFieldText
                   data-test-subj="indexName"
+                  fullWidth
                   disabled={!licenseEnabled}
                   inputRef={(ref) => {
                     if (ref) {
@@ -117,6 +134,21 @@ export const ProfileQueryEditor = memo(() => {
                   }}
                 />
               </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip content={tooltipContent}>
+                <EuiButtonIcon
+                  iconType={'playFilled'}
+                  data-test-subj={!licenseEnabled ? 'disabledProfileButton' : 'profileButton'}
+                  disabled={!licenseEnabled}
+                  onClick={licenseEnabled ? handleProfileClick : undefined}
+                  size="m"
+                  display="base"
+                  aria-label={i18n.translate('xpack.searchProfiler.formProfileButtonLabel', {
+                    defaultMessage: 'Profile',
+                  })}
+                />
+              </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiForm>
@@ -135,33 +167,6 @@ export const ProfileQueryEditor = memo(() => {
           editorValue={editorValue}
           licenseEnabled={licenseEnabled}
         />
-      </EuiFlexItem>
-
-      {/* Button */}
-      <EuiFlexItem grow={false}>
-        <EuiFlexGroup
-          className="prfDevTool__profileButtonContainer"
-          gutterSize="none"
-          direction="row"
-        >
-          <EuiFlexItem grow={5}>
-            <EuiSpacer size="s" />
-          </EuiFlexItem>
-          <EuiFlexItem grow={5}>
-            <EuiButton
-              data-test-subj="profileButton"
-              fill
-              disabled={!licenseEnabled}
-              onClick={() => handleProfileClick()}
-            >
-              <EuiText>
-                {i18n.translate('xpack.searchProfiler.formProfileButtonLabel', {
-                  defaultMessage: 'Profile',
-                })}
-              </EuiText>
-            </EuiButton>
-          </EuiFlexItem>
-        </EuiFlexGroup>
       </EuiFlexItem>
     </EuiFlexGroup>
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[search profiler] Move profile button inline with index field (#202253)](https://github.com/elastic/kibana/pull/202253)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Matthew Kime","email":"matt@mattki.me"},"sourceCommit":{"committedDate":"2025-01-22T04:01:43Z","message":"[search profiler] Move profile button inline with index field (#202253)\n\n## Summary\r\n\r\nAt smaller window sizes, the `Profile` button disappears beneath the\r\ncode editor. Lets move it to the top and shrink it.\r\n\r\n<img width=\"1051\" alt=\"Screenshot 2024-11-30 at 11 47 27 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\">","sha":"c12c88d243840d498b767a5f9b29f2748d4b2ff3","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","Feature:Search Profiler","backport missing","v9.0.0","backport:prev-major","v8.18.0","v8.16.4","v8.17.2"],"title":"[search profiler] Move profile button inline with index field","number":202253,"url":"https://github.com/elastic/kibana/pull/202253","mergeCommit":{"message":"[search profiler] Move profile button inline with index field (#202253)\n\n## Summary\r\n\r\nAt smaller window sizes, the `Profile` button disappears beneath the\r\ncode editor. Lets move it to the top and shrink it.\r\n\r\n<img width=\"1051\" alt=\"Screenshot 2024-11-30 at 11 47 27 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\">","sha":"c12c88d243840d498b767a5f9b29f2748d4b2ff3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/202253","number":202253,"mergeCommit":{"message":"[search profiler] Move profile button inline with index field (#202253)\n\n## Summary\r\n\r\nAt smaller window sizes, the `Profile` button disappears beneath the\r\ncode editor. Lets move it to the top and shrink it.\r\n\r\n<img width=\"1051\" alt=\"Screenshot 2024-11-30 at 11 47 27 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\">","sha":"c12c88d243840d498b767a5f9b29f2748d4b2ff3"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/207648","number":207648,"state":"MERGED","mergeCommit":{"sha":"5db51893984383cfd76eeb91a63ec23cfaa32f50","message":"[8.x] [search profiler] Move profile button inline with index field (#202253) (#207648)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[search profiler] Move profile button inline with index field\n(#202253)](https://github.com/elastic/kibana/pull/202253)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Matthew\nKime\",\"email\":\"matt@mattki.me\"},\"sourceCommit\":{\"committedDate\":\"2025-01-22T04:01:43Z\",\"message\":\"[search\nprofiler] Move profile button inline with index field (#202253)\\n\\n##\nSummary\\r\\n\\r\\nAt smaller window sizes, the `Profile` button disappears\nbeneath the\\r\\ncode editor. Lets move it to the top and shrink\nit.\\r\\n\\r\\n<img width=\\\"1051\\\" alt=\\\"Screenshot 2024-11-30 at 11 47\n27 PM\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\\\">\",\"sha\":\"c12c88d243840d498b767a5f9b29f2748d4b2ff3\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Team:Kibana\nManagement\",\"release_note:skip\",\"Feature:Search\nProfiler\",\"v9.0.0\",\"backport:prev-major\"],\"title\":\"[search profiler]\nMove profile button inline with index\nfield\",\"number\":202253,\"url\":\"https://github.com/elastic/kibana/pull/202253\",\"mergeCommit\":{\"message\":\"[search\nprofiler] Move profile button inline with index field (#202253)\\n\\n##\nSummary\\r\\n\\r\\nAt smaller window sizes, the `Profile` button disappears\nbeneath the\\r\\ncode editor. Lets move it to the top and shrink\nit.\\r\\n\\r\\n<img width=\\\"1051\\\" alt=\\\"Screenshot 2024-11-30 at 11 47\n27 PM\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\\\">\",\"sha\":\"c12c88d243840d498b767a5f9b29f2748d4b2ff3\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/202253\",\"number\":202253,\"mergeCommit\":{\"message\":\"[search\nprofiler] Move profile button inline with index field (#202253)\\n\\n##\nSummary\\r\\n\\r\\nAt smaller window sizes, the `Profile` button disappears\nbeneath the\\r\\ncode editor. Lets move it to the top and shrink\nit.\\r\\n\\r\\n<img width=\\\"1051\\\" alt=\\\"Screenshot 2024-11-30 at 11 47\n27 PM\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\\\">\",\"sha\":\"c12c88d243840d498b767a5f9b29f2748d4b2ff3\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Matthew Kime <matt@mattki.me>"}},{"branch":"8.16","label":"v8.16.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/208480","number":208480,"state":"MERGED","mergeCommit":{"sha":"c38604245273dd3e40e15e308828178f2d9788b8","message":"[8.16] [search profiler] Move profile button inline with index field (#202253) (#208480)\n\n# Backport\r\n\r\nThis will backport the following commits from `main` to `8.16`:\r\n- [[search profiler] Move profile button inline with index field\r\n(#202253)](https://github.com/elastic/kibana/pull/202253)\r\n\r\n<!--- Backport version: 9.6.4 -->\r\n\r\n### Questions ?\r\nPlease refer to the [Backport tool\r\ndocumentation](https://github.com/sorenlouv/backport)\r\n\r\n<!--BACKPORT [{\"author\":{\"name\":\"Matthew\r\nKime\",\"email\":\"matt@mattki.me\"},\"sourceCommit\":{\"committedDate\":\"2025-01-22T04:01:43Z\",\"message\":\"[search\r\nprofiler] Move profile button inline with index field (#202253)\\n\\n##\r\nSummary\\r\\n\\r\\nAt smaller window sizes, the `Profile` button disappears\r\nbeneath the\\r\\ncode editor. Lets move it to the top and shrink\r\nit.\\r\\n\\r\\n<img width=\\\"1051\\\" alt=\\\"Screenshot 2024-11-30 at 11 47\r\n27 PM\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\\\">\",\"sha\":\"c12c88d243840d498b767a5f9b29f2748d4b2ff3\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Team:Kibana\r\nManagement\",\"release_note:skip\",\"Feature:Search\r\nProfiler\",\"v9.0.0\",\"backport:prev-major\",\"v8.18.0\"],\"title\":\"[search\r\nprofiler] Move profile button inline with index\r\nfield\",\"number\":202253,\"url\":\"https://github.com/elastic/kibana/pull/202253\",\"mergeCommit\":{\"message\":\"[search\r\nprofiler] Move profile button inline with index field (#202253)\\n\\n##\r\nSummary\\r\\n\\r\\nAt smaller window sizes, the `Profile` button disappears\r\nbeneath the\\r\\ncode editor. Lets move it to the top and shrink\r\nit.\\r\\n\\r\\n<img width=\\\"1051\\\" alt=\\\"Screenshot 2024-11-30 at 11 47\r\n27 PM\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\\\">\",\"sha\":\"c12c88d243840d498b767a5f9b29f2748d4b2ff3\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/202253\",\"number\":202253,\"mergeCommit\":{\"message\":\"[search\r\nprofiler] Move profile button inline with index field (#202253)\\n\\n##\r\nSummary\\r\\n\\r\\nAt smaller window sizes, the `Profile` button disappears\r\nbeneath the\\r\\ncode editor. Lets move it to the top and shrink\r\nit.\\r\\n\\r\\n<img width=\\\"1051\\\" alt=\\\"Screenshot 2024-11-30 at 11 47\r\n27 PM\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\\\">\",\"sha\":\"c12c88d243840d498b767a5f9b29f2748d4b2ff3\"}},{\"branch\":\"8.x\",\"label\":\"v8.18.0\",\"branchLabelMappingKey\":\"^v8.18.0$\",\"isSourceBranch\":false,\"url\":\"https://github.com/elastic/kibana/pull/207648\",\"number\":207648,\"state\":\"MERGED\",\"mergeCommit\":{\"sha\":\"5db51893984383cfd76eeb91a63ec23cfaa32f50\",\"message\":\"[8.x]\r\n[search profiler] Move profile button inline with index field (#202253)\r\n(#207648)\\n\\n# Backport\\n\\nThis will backport the following commits from\r\n`main` to `8.x`:\\n- [[search profiler] Move profile button inline with\r\nindex\r\nfield\\n(#202253)](https://github.com/elastic/kibana/pull/202253)\\n\\n<!---\r\nBackport version: 9.4.3 -->\\n\\n### Questions ?\\nPlease refer to the\r\n[Backport\r\ntool\\ndocumentation](https://github.com/sqren/backport)\\n\\n<!--BACKPORT\r\n[{\\\"author\\\":{\\\"name\\\":\\\"Matthew\\nKime\\\",\\\"email\\\":\\\"matt@mattki.me\\\"},\\\"sourceCommit\\\":{\\\"committedDate\\\":\\\"2025-01-22T04:01:43Z\\\",\\\"message\\\":\\\"[search\\nprofiler]\r\nMove profile button inline with index field\r\n(#202253)\\\\n\\\\n##\\nSummary\\\\r\\\\n\\\\r\\\\nAt smaller window sizes, the\r\n`Profile` button disappears\\nbeneath the\\\\r\\\\ncode editor. Lets move it\r\nto the top and shrink\\nit.\\\\r\\\\n\\\\r\\\\n<img width=\\\\\\\"1051\\\\\\\"\r\nalt=\\\\\\\"Screenshot 2024-11-30 at 11\r\n47\\n27 PM\\\\\\\"\\\\r\\\\nsrc=\\\\\\\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\\\\\\\">\\\",\\\"sha\\\":\\\"c12c88d243840d498b767a5f9b29f2748d4b2ff3\\\",\\\"branchLabelMapping\\\":{\\\"^v9.0.0$\\\":\\\"main\\\",\\\"^v8.18.0$\\\":\\\"8.x\\\",\\\"^v(\\\\\\\\d+).(\\\\\\\\d+).\\\\\\\\d+$\\\":\\\"$1.$2\\\"}},\\\"sourcePullRequest\\\":{\\\"labels\\\":[\\\"Team:Kibana\\nManagement\\\",\\\"release_note:skip\\\",\\\"Feature:Search\\nProfiler\\\",\\\"v9.0.0\\\",\\\"backport:prev-major\\\"],\\\"title\\\":\\\"[search\r\nprofiler]\\nMove profile button inline with\r\nindex\\nfield\\\",\\\"number\\\":202253,\\\"url\\\":\\\"https://github.com/elastic/kibana/pull/202253\\\",\\\"mergeCommit\\\":{\\\"message\\\":\\\"[search\\nprofiler]\r\nMove profile button inline with index field\r\n(#202253)\\\\n\\\\n##\\nSummary\\\\r\\\\n\\\\r\\\\nAt smaller window sizes, the\r\n`Profile` button disappears\\nbeneath the\\\\r\\\\ncode editor. Lets move it\r\nto the top and shrink\\nit.\\\\r\\\\n\\\\r\\\\n<img width=\\\\\\\"1051\\\\\\\"\r\nalt=\\\\\\\"Screenshot 2024-11-30 at 11\r\n47\\n27 PM\\\\\\\"\\\\r\\\\nsrc=\\\\\\\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\\\\\\\">\\\",\\\"sha\\\":\\\"c12c88d243840d498b767a5f9b29f2748d4b2ff3\\\"}},\\\"sourceBranch\\\":\\\"main\\\",\\\"suggestedTargetBranches\\\":[],\\\"targetPullRequestStates\\\":[{\\\"branch\\\":\\\"main\\\",\\\"label\\\":\\\"v9.0.0\\\",\\\"branchLabelMappingKey\\\":\\\"^v9.0.0$\\\",\\\"isSourceBranch\\\":true,\\\"state\\\":\\\"MERGED\\\",\\\"url\\\":\\\"https://github.com/elastic/kibana/pull/202253\\\",\\\"number\\\":202253,\\\"mergeCommit\\\":{\\\"message\\\":\\\"[search\\nprofiler]\r\nMove profile button inline with index field\r\n(#202253)\\\\n\\\\n##\\nSummary\\\\r\\\\n\\\\r\\\\nAt smaller window sizes, the\r\n`Profile` button disappears\\nbeneath the\\\\r\\\\ncode editor. Lets move it\r\nto the top and shrink\\nit.\\\\r\\\\n\\\\r\\\\n<img width=\\\\\\\"1051\\\\\\\"\r\nalt=\\\\\\\"Screenshot 2024-11-30 at 11\r\n47\\n27 PM\\\\\\\"\\\\r\\\\nsrc=\\\\\\\"https://github.com/user-attachments/assets/1d8b99cd-1b07-43cc-8d75-597b37f74e59\\\\\\\">\\\",\\\"sha\\\":\\\"c12c88d243840d498b767a5f9b29f2748d4b2ff3\\\"}}]}]\\nBACKPORT-->\\n\\nCo-authored-by:\r\nMatthew Kime <matt@mattki.me>\"}}]}] BACKPORT-->\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>"}},{"branch":"8.17","label":"v8.17.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/208650","number":208650,"state":"MERGED","mergeCommit":{"sha":"a50aa46a20724e01ef3e08d97cc65388a25966e1","message":"Revert \"[8.17] [search profiler] Move profile button inline with index field (#202253)\" (#208650)\n\nReverts elastic/kibana#207877\r\n\r\nToo many changes for a patch release. Going to backport a subset of\r\n#202253"}}]}] BACKPORT-->