### PR TITLE
[8.x] Add warnings to upgrade assistant for search sessions (#206998)

### DIFF
--- a/docs/upgrade-notes.asciidoc
+++ b/docs/upgrade-notes.asciidoc
@@ -2052,6 +2052,3 @@ To monitor endpoints, pages, and user journeys, go to **{observability}** -> **S
 ==== Elastic Security solution
 
 NOTE: For the complete Elastic Security solution release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
-
-
-

--- a/src/platform/plugins/shared/data/server/config_deprecations.test.ts
+++ b/src/platform/plugins/shared/data/server/config_deprecations.test.ts
@@ -62,7 +62,7 @@ describe('Config Deprecations', () => {
     expect(messages).toMatchInlineSnapshot(`
       Array [
         "Setting \\"xpack.data_enhanced.search.sessions\\" has been replaced by \\"data.search.sessions\\"",
-        "Configuring \\"data.search.sessions.enabled\\" is deprecated and will be removed in 9.0.0.",
+        "Configuring \\"data.search.sessions.enabled\\" is deprecated and will be removed in 9.1.0.",
       ]
     `);
   });
@@ -103,7 +103,7 @@ describe('Config Deprecations', () => {
         "You no longer need to configure \\"data.search.sessions.expireInterval\\".",
         "You no longer need to configure \\"data.search.sessions.monitoringTaskTimeout\\".",
         "You no longer need to configure \\"data.search.sessions.notTouchedInProgressTimeout\\".",
-        "Configuring \\"data.search.sessions.enabled\\" is deprecated and will be removed in 9.0.0.",
+        "Configuring \\"data.search.sessions.enabled\\" is deprecated and will be removed in 9.1.0.",
       ]
     `);
   });
@@ -147,7 +147,7 @@ describe('Config Deprecations', () => {
         "You no longer need to configure \\"data.search.sessions.expireInterval\\".",
         "You no longer need to configure \\"data.search.sessions.monitoringTaskTimeout\\".",
         "You no longer need to configure \\"data.search.sessions.notTouchedInProgressTimeout\\".",
-        "Configuring \\"data.search.sessions.enabled\\" is deprecated and will be removed in 9.0.0.",
+        "Configuring \\"data.search.sessions.enabled\\" is deprecated and will be removed in 9.1.0.",
       ]
     `);
   });

--- a/src/platform/plugins/shared/data/server/config_deprecations.ts
+++ b/src/platform/plugins/shared/data/server/config_deprecations.ts
@@ -27,12 +27,12 @@ export const configDeprecationProvider: ConfigDeprecationProvider = ({
   unusedFromRoot('data.search.sessions.notTouchedInProgressTimeout', { level }),
 
   // Search sessions config deprecations
-  deprecateFromRoot('data.search.sessions.enabled', '9.0.0', { level }),
-  deprecateFromRoot('data.search.sessions.notTouchedTimeout', '9.0.0', { level }),
-  deprecateFromRoot('data.search.sessions.maxUpdateRetries', '9.0.0', { level }),
-  deprecateFromRoot('data.search.sessions.defaultExpiration', '9.0.0', { level }),
-  deprecateFromRoot('data.search.sessions.management.maxSessions', '9.0.0', { level }),
-  deprecateFromRoot('data.search.sessions.management.refreshInterval', '9.0.0', { level }),
-  deprecateFromRoot('data.search.sessions.management.refreshTimeout', '9.0.0', { level }),
-  deprecateFromRoot('data.search.sessions.management.expiresSoonWarning', '9.0.0', { level }),
+  deprecateFromRoot('data.search.sessions.enabled', '9.1.0', { level }),
+  deprecateFromRoot('data.search.sessions.notTouchedTimeout', '9.1.0', { level }),
+  deprecateFromRoot('data.search.sessions.maxUpdateRetries', '9.1.0', { level }),
+  deprecateFromRoot('data.search.sessions.defaultExpiration', '9.1.0', { level }),
+  deprecateFromRoot('data.search.sessions.management.maxSessions', '9.1.0', { level }),
+  deprecateFromRoot('data.search.sessions.management.refreshInterval', '9.1.0', { level }),
+  deprecateFromRoot('data.search.sessions.management.refreshTimeout', '9.1.0', { level }),
+  deprecateFromRoot('data.search.sessions.management.expiresSoonWarning', '9.1.0', { level }),
 ];

--- a/src/platform/plugins/shared/data/server/deprecations/index.ts
+++ b/src/platform/plugins/shared/data/server/deprecations/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { createSearchSessionsDeprecationsConfig } from './search_sessions';

--- a/src/platform/plugins/shared/data/server/deprecations/search_sessions.ts
+++ b/src/platform/plugins/shared/data/server/deprecations/search_sessions.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type {
+  CoreSetup,
+  DeprecationsDetails,
+  GetDeprecationsContext,
+  RegisterDeprecationsConfig,
+  SavedObjectsFindResult,
+} from '@kbn/core/server';
+import { i18n } from '@kbn/i18n';
+import type { DeprecationDetailsMessage } from '@kbn/core-deprecations-common';
+import { SEARCH_SESSION_TYPE, SearchSessionSavedObjectAttributes } from '../../common';
+
+type SearchSessionAttributes = Pick<
+  SearchSessionSavedObjectAttributes,
+  'name' | 'username' | 'expires'
+>;
+
+export const createSearchSessionsDeprecationsConfig: (
+  core: CoreSetup
+) => RegisterDeprecationsConfig = (core: CoreSetup) => ({
+  getDeprecations: async (context: GetDeprecationsContext): Promise<DeprecationsDetails[]> => {
+    const searchSessionsLink = core.http.basePath.prepend('/app/management/kibana/search_sessions');
+    const [coreStart] = await core.getStartServices();
+    const savedObjectsClient = coreStart.savedObjects.getScopedClient(context.request, {
+      includedHiddenTypes: [SEARCH_SESSION_TYPE],
+    });
+    const results = await savedObjectsClient.find<SearchSessionAttributes>({
+      type: 'search-session',
+      perPage: 1000,
+      fields: ['name', 'username', 'expires'],
+      sortField: 'created',
+      sortOrder: 'desc',
+      namespaces: ['*'],
+    });
+
+    const searchSessions: Array<SavedObjectsFindResult<SearchSessionAttributes>> =
+      results.saved_objects.filter((so) => new Date(so.attributes.expires).getTime() > Date.now());
+
+    if (!searchSessions.length) {
+      return [];
+    }
+
+    return [
+      {
+        title: i18n.translate('data.deprecations.searchSessionsTitle', {
+          defaultMessage: 'Search sessions will be disabled by default',
+        }),
+        message: buildMessage({ searchSessions, searchSessionsLink }),
+        deprecationType: 'feature',
+        level: 'warning',
+        correctiveActions: {
+          manualSteps: [
+            i18n.translate('data.deprecations.searchSessions.manualStepOneMessage', {
+              defaultMessage: 'Navigate to Stack Management > Kibana > Search Sessions',
+            }),
+            i18n.translate('data.deprecations.searchSessions.manualStepTwoMessage', {
+              defaultMessage: 'Delete search sessions that have not expired',
+            }),
+            i18n.translate('data.deprecations.searchSessions.manualStepTwoMessage', {
+              defaultMessage:
+                'Alternatively, to continue using search sessions until 9.1, open the kibana.yml config file and add the following: "data.search.sessions.enabled: true"',
+            }),
+          ],
+        },
+      },
+    ];
+  },
+});
+
+const buildMessage = ({
+  searchSessions,
+  searchSessionsLink,
+}: {
+  searchSessions: Array<SavedObjectsFindResult<SearchSessionAttributes>>;
+  searchSessionsLink: string;
+}): DeprecationDetailsMessage => ({
+  type: 'markdown',
+  content: i18n.translate('data.deprecations.scriptedFieldsMessage', {
+    defaultMessage: `The search sessions feature is deprecated and is disabled by default in 9.0. You currently have {numberOfSearchSessions} active search session(s): [Manage Search Sessions]({searchSessionsLink})`,
+    values: {
+      numberOfSearchSessions: searchSessions.length,
+      searchSessionsLink,
+    },
+  }),
+});

--- a/src/platform/plugins/shared/data/server/plugin.ts
+++ b/src/platform/plugins/shared/data/server/plugin.ts
@@ -13,6 +13,7 @@ import { BfetchServerSetup } from '@kbn/bfetch-plugin/server';
 import { PluginStart as DataViewsServerPluginStart } from '@kbn/data-views-plugin/server';
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { FieldFormatsSetup, FieldFormatsStart } from '@kbn/field-formats-plugin/server';
+import { createSearchSessionsDeprecationsConfig } from './deprecations';
 import { ConfigSchema } from './config';
 import type { ISearchSetup, ISearchStart } from './search';
 import { DatatableUtilitiesService } from './datatable_utilities';
@@ -92,6 +93,7 @@ export class DataServerPlugin
     this.kqlTelemetryService.setup(core, { usageCollection });
 
     core.uiSettings.register(getUiSettings(core.docLinks, this.config.enableUiSettingsValidations));
+    core.deprecations.registerDeprecations(createSearchSessionsDeprecationsConfig(core));
 
     const searchSetup = this.searchService.setup(core, {
       bfetch,

--- a/src/platform/plugins/shared/data/tsconfig.json
+++ b/src/platform/plugins/shared/data/tsconfig.json
@@ -56,6 +56,7 @@
     "@kbn/safer-lodash-set",
     "@kbn/esql-utils",
     "@kbn/shared-ux-table-persist",
+    "@kbn/core-deprecations-common",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add warnings to upgrade assistant for search sessions (#206998)](https://github.com/elastic/kibana/pull/206998)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Lukas Olson","email":"lukas@elastic.co"},"sourceCommit":{"committedDate":"2025-01-28T22:13:53Z","message":"Add warnings to upgrade assistant for search sessions (#206998)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana/issues/203925.\r\nResolves https://github.com/elastic/kibana/issues/205813.\r\n\r\nAdds warning messages to the upgrade assistant if a cluster has\r\nunexpired search sessions, since the feature is being disabled by\r\ndefault and will have to be explicitly re-enabled to manage the\r\nsessions.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Julia Rechkunova <julia.rechkunova@gmail.com>","sha":"b998946003273245f9ea851ad60347c9f83c593a","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:DataDiscovery","Feature:Search Sessions","backport:prev-minor"],"title":"Add warnings to upgrade assistant for search sessions","number":206998,"url":"https://github.com/elastic/kibana/pull/206998","mergeCommit":{"message":"Add warnings to upgrade assistant for search sessions (#206998)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana/issues/203925.\r\nResolves https://github.com/elastic/kibana/issues/205813.\r\n\r\nAdds warning messages to the upgrade assistant if a cluster has\r\nunexpired search sessions, since the feature is being disabled by\r\ndefault and will have to be explicitly re-enabled to manage the\r\nsessions.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Julia Rechkunova <julia.rechkunova@gmail.com>","sha":"b998946003273245f9ea851ad60347c9f83c593a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/206998","number":206998,"mergeCommit":{"message":"Add warnings to upgrade assistant for search sessions (#206998)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana/issues/203925.\r\nResolves https://github.com/elastic/kibana/issues/205813.\r\n\r\nAdds warning messages to the upgrade assistant if a cluster has\r\nunexpired search sessions, since the feature is being disabled by\r\ndefault and will have to be explicitly re-enabled to manage the\r\nsessions.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Julia Rechkunova <julia.rechkunova@gmail.com>","sha":"b998946003273245f9ea851ad60347c9f83c593a"}}]}] BACKPORT-->