### PR TITLE
[Fleet] fix leaks introduced when optimizing package verification

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/extract.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/archive/extract.ts
@@ -53,7 +53,7 @@ export async function unzipBuffer(
 
     try {
       if (shouldReadBuffer && !shouldReadBuffer(path)) {
-        return onEntry({ path });
+        return await onEntry({ path });
       }
       const entryBuffer = await getZipReadStream(zipfile, entry).then(streamToBuffer);
       await onEntry({ buffer: entryBuffer, path });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/package_verification.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/package_verification.ts
@@ -146,6 +146,14 @@ async function _verifyPackageSignature({
     },
   });
 
+  if (
+    verificationResult.data &&
+    'close' in verificationResult.data &&
+    typeof verificationResult.data.close === 'function'
+  ) {
+    await verificationResult.data.close();
+  }
+
   const signatureVerificationResult = verificationResult.signatures[0];
 
   let isVerified = false;


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/pull/208475 

Fix a leak introduced when optimizing the package verification memory usage. 

The streams that contains the data should be explicitly closed if it's not consumed.