### PR TITLE
[8.x] [Synonyms UI] Search synonyms rule flyout (#208564)

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -9,6 +9,7 @@ xpack.securitySolution.enabled: false
 xpack.search.notebooks.enabled: false
 xpack.searchPlayground.enabled: false
 xpack.searchInferenceEndpoints.enabled: false
+xpack.searchSynonyms.enabled: false
 
 ## Fine-tune the observability solution feature privileges. Also, refer to `serverless.yml` for the project-agnostic overrides.
 xpack.features.overrides:

--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -10,6 +10,7 @@ xpack.observabilityAIAssistant.enabled: false
 xpack.search.notebooks.enabled: false
 xpack.searchPlayground.enabled: false
 xpack.searchInferenceEndpoints.enabled: false
+xpack.searchSynonyms.enabled: false
 
 ## Fine-tune the security solution feature privileges. Also, refer to `serverless.yml` for the project-agnostic overrides.
 xpack.features.overrides:
@@ -154,6 +155,6 @@ xpack.index_management.enableProjectLevelRetentionChecks: true
 # Experimental Security Solution features
 
 # These features are disabled in Serverless until fully tested
-xpack.securitySolution.enableExperimental: 
+xpack.securitySolution.enableExperimental:
   - entityStoreDisabled
   - siemMigrationsDisabled

--- a/x-pack/solutions/search/plugins/search_synonyms/common/api_routes.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/common/api_routes.ts
@@ -11,4 +11,5 @@ export enum APIRoutes {
   SYNONYM_SETS = '/internal/search_synonyms/synonyms',
   SYNONYM_SET_ID = '/internal/search_synonyms/synonyms/{synonymsSetId}',
   SYNONYM_SET_ID_RULE_ID = '/internal/search_synonyms/synonyms/{synonymsSetId}/{ruleId}',
+  GENERATE_SYNONYM_RULE_ID = '/internal/search_synonyms/synonyms/{synonymsSetId}/generate',
 }

--- a/x-pack/solutions/search/plugins/search_synonyms/common/pagination.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/common/pagination.ts
@@ -7,7 +7,7 @@
 
 export const DEFAULT_PAGE_VALUE: Page = {
   from: 0,
-  size: 10,
+  size: 25,
 };
 
 export interface Pagination {

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/empty_prompt/empty_prompt.test.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/empty_prompt/empty_prompt.test.tsx
@@ -24,7 +24,7 @@ describe('Synonyms Overview Empty Prompt', () => {
   it('renders', () => {
     render(
       <Wrapper>
-        <EmptyPrompt />
+        <EmptyPrompt getStartedAction={() => {}} />
       </Wrapper>
     );
     expect(screen.getByTestId('searchSynonymsEmptyPromptGetStartedButton')).toBeInTheDocument();

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/empty_prompt/empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/empty_prompt/empty_prompt.tsx
@@ -25,7 +25,10 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import { docLinks } from '../../../common/doc_links';
 
-export const EmptyPrompt: React.FC = () => {
+interface EmptyPromptProps {
+  getStartedAction: () => void;
+}
+export const EmptyPrompt: React.FC<EmptyPromptProps> = ({ getStartedAction }) => {
   const { euiTheme } = useEuiTheme();
   return (
     <EuiFlexGroup direction="row" gutterSize="l" alignItems="center" justifyContent="center">
@@ -64,6 +67,7 @@ export const EmptyPrompt: React.FC = () => {
                       data-test-subj="searchSynonymsEmptyPromptGetStartedButton"
                       color="primary"
                       fill
+                      onClick={getStartedAction}
                     >
                       <FormattedMessage
                         id="xpack.searchSynonyms.emptyPrompt.getStartedButton"

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/overview/overview.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/overview/overview.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import {
@@ -21,12 +21,14 @@ import { useKibana } from '../../hooks/use_kibana';
 import { SynonymSets } from '../synonym_sets/synonym_sets';
 import { useFetchSynonymsSets } from '../../hooks/use_fetch_synonyms_sets';
 import { EmptyPrompt } from '../empty_prompt/empty_prompt';
+import { CreateSynonymsSetModal } from '../synonym_sets/create_new_set_modal';
 
 export const SearchSynonymsOverview = () => {
   const {
     services: { console: consolePlugin, history, searchNavigation },
   } = useKibana();
   const { data: synonymsData, isInitialLoading } = useFetchSynonymsSets();
+  const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
 
   const embeddableConsole = useMemo(
     () => (consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null),
@@ -48,7 +50,7 @@ export const SearchSynonymsOverview = () => {
         rightSideItems={[
           <EuiFlexGroup alignItems="center">
             <EuiFlexItem grow={false}>
-              <EuiLink>
+              <EuiLink data-test-subj="searchSynonymsSearchSynonymsOverviewApiDocumentationLink">
                 <FormattedMessage
                   id="xpack.searchSynonyms.synonymsSetDetail.documentationLink"
                   defaultMessage="API Documentation"
@@ -56,7 +58,14 @@ export const SearchSynonymsOverview = () => {
               </EuiLink>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton fill iconType="plusInCircle">
+              <EuiButton
+                data-test-subj="searchSynonymsSearchSynonymsOverviewCreateButton"
+                fill
+                iconType="plusInCircle"
+                onClick={() => {
+                  setIsCreateModalVisible(true);
+                }}
+              >
                 <FormattedMessage
                   id="xpack.searchSynonyms.synonymsSetDetail.createButton"
                   defaultMessage="Create"
@@ -74,13 +83,24 @@ export const SearchSynonymsOverview = () => {
         </EuiText>
       </KibanaPageTemplate.Header>
       <KibanaPageTemplate.Section restrictWidth>
+        {isCreateModalVisible && (
+          <CreateSynonymsSetModal
+            onClose={() => {
+              setIsCreateModalVisible(false);
+            }}
+          />
+        )}
         {isInitialLoading && <EuiLoadingSpinner />}
 
         {!isInitialLoading && synonymsData && synonymsData._meta.totalItemCount > 0 && (
           <SynonymSets />
         )}
         {!isInitialLoading && synonymsData && synonymsData._meta.totalItemCount === 0 && (
-          <EmptyPrompt />
+          <EmptyPrompt
+            getStartedAction={() => {
+              setIsCreateModalVisible(true);
+            }}
+          />
         )}
       </KibanaPageTemplate.Section>
       {embeddableConsole}

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/create_new_set_modal.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/create_new_set_modal.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFieldText,
+  EuiForm,
+  EuiFormRow,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import { formatSynonymsSetName } from '../../utils/synonyms_utils';
+import { usePutSynonymsSet } from '../../hooks/use_put_synonyms_set';
+
+interface CreateSynonymsSetModalProps {
+  onClose: () => void;
+}
+export const CreateSynonymsSetModal = ({ onClose }: CreateSynonymsSetModalProps) => {
+  const titleId = useGeneratedHtmlId({ prefix: 'createSynonymsSetModalTitle' });
+  const formId = useGeneratedHtmlId({ prefix: 'createSynonymsSetModalForm' });
+
+  const [name, setName] = useState('');
+  const [rawName, setRawName] = useState('');
+  const { mutate: createSynonymsSet } = usePutSynonymsSet(() => {
+    onClose();
+  });
+  return (
+    <EuiModal onClose={onClose}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle id={titleId}>
+          <FormattedMessage
+            id="xpack.searchSynonyms.createSynonymsSetModal.title"
+            defaultMessage="Name your synonyms set"
+          />
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        <EuiForm
+          id={formId}
+          component="form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            createSynonymsSet({ synonymsSetId: name });
+          }}
+        >
+          <EuiFormRow
+            label={i18n.translate('xpack.searchSynonyms.createSynonymsSetModal.nameLabel', {
+              defaultMessage: 'Name',
+            })}
+            helpText={
+              !!rawName
+                ? i18n.translate('xpack.searchSynonyms.createSynonymsSetModal.nameHelpText', {
+                    defaultMessage: 'Your synonyms set will be named: {name}',
+                    values: { name },
+                  })
+                : undefined
+            }
+          >
+            <EuiFieldText
+              data-test-subj="searchSynonymsCreateSynonymsSetModalFieldText"
+              value={rawName}
+              onChange={(e) => {
+                setRawName(e.target.value);
+                setName(formatSynonymsSetName(e.target.value));
+              }}
+            />
+          </EuiFormRow>
+        </EuiForm>
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButtonEmpty
+          data-test-subj="searchSynonymsCreateSynonymsSetModalCancelButton"
+          onClick={onClose}
+        >
+          <FormattedMessage
+            id="xpack.searchSynonyms.createSynonymsSetModal.cancelButton"
+            defaultMessage="Cancel"
+          />
+        </EuiButtonEmpty>
+        <EuiButton
+          data-test-subj="searchSynonymsCreateSynonymsSetModalCreateButton"
+          form={formId}
+          fill
+          disabled={!name}
+          onClick={() => {
+            createSynonymsSet({ synonymsSetId: name });
+          }}
+        >
+          <FormattedMessage
+            id="xpack.searchSynonyms.createSynonymsSetModal.createButton"
+            defaultMessage="Create"
+          />
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/synonym_sets.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonym_sets/synonym_sets.tsx
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
+import React, { useState } from 'react';
+
 import { SynonymsGetSynonymsSetsSynonymsSetItem } from '@elastic/elasticsearch/lib/api/types';
 import { EuiBasicTable, EuiBasicTableColumn, EuiLink } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useState } from 'react';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { useKibana } from '../../hooks/use_kibana';
 import { PLUGIN_ROUTE_ROOT } from '../../../common/api_routes';
 import { DEFAULT_PAGE_VALUE, paginationToPage } from '../../../common/pagination';
 import { useFetchSynonymsSets } from '../../hooks/use_fetch_synonyms_sets';
@@ -17,20 +18,20 @@ import { DeleteSynonymsSetModal } from './delete_synonyms_set_modal';
 
 export const SynonymSets = () => {
   const {
-    services: { application },
+    services: { application, http },
   } = useKibana();
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_VALUE.size);
   const { from } = paginationToPage({ pageIndex, pageSize, totalItemCount: 0 });
   const { data: synonyms } = useFetchSynonymsSets({ from, size: pageSize });
-  const [synonymsSetToDelete, setSynonymsSetToDelete] = React.useState<string | null>(null);
+  const [synonymsSetToDelete, setSynonymsSetToDelete] = useState<string | null>(null);
 
   if (!synonyms) {
     return null;
   }
 
   const pagination = {
-    initialPageSize: 10,
+    initialPageSize: 25,
     pageSizeOptions: [10, 25, 50],
     ...synonyms._meta,
     pageSize,
@@ -44,7 +45,12 @@ export const SynonymSets = () => {
       }),
       render: (name: string) => (
         <div data-test-subj="synonyms-set-item-name">
-          <EuiLink onClick={() => application?.navigateToUrl(`${PLUGIN_ROUTE_ROOT}/sets/${name}`)}>
+          <EuiLink
+            data-test-subj="searchSynonymsColumnsLink"
+            onClick={() =>
+              application.navigateToUrl(http.basePath.prepend(`${PLUGIN_ROUTE_ROOT}/sets/${name}`))
+            }
+          >
             {name}
           </EuiLink>
         </div>
@@ -90,7 +96,9 @@ export const SynonymSets = () => {
           color: 'text',
           type: 'icon',
           onClick: (synonymsSet: SynonymsGetSynonymsSetsSynonymsSetItem) =>
-            application?.navigateToUrl(`${PLUGIN_ROUTE_ROOT}/sets/${synonymsSet.synonyms_set}`),
+            application.navigateToUrl(
+              http.basePath.prepend(`${PLUGIN_ROUTE_ROOT}/sets/${synonymsSet.synonyms_set}`)
+            ),
         },
       ],
     },

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/empty_rules_cards.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/empty_rules_cards.tsx
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiBadge,
+  EuiButton,
+  EuiCard,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+
+interface SynonymsSetEmptyRulesCardsProps {
+  onCreateRule: (type: 'equivalent' | 'explicit') => void;
+}
+export const SynonymsSetEmptyRulesCards: React.FC<SynonymsSetEmptyRulesCardsProps> = ({
+  onCreateRule,
+}) => {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <EuiFlexGroup gutterSize="l">
+      <EuiFlexItem
+        css={css`
+          min-width: ${euiTheme.base * 24}px;
+        `}
+      >
+        <EuiCard
+          hasBorder
+          textAlign="left"
+          title={i18n.translate(
+            'xpack.searchSynonyms.synonymsSetEmptyRulesCards.equivalent.title',
+            {
+              defaultMessage: 'Equivalent',
+            }
+          )}
+          description={i18n.translate(
+            'xpack.searchSynonyms.synonymsSetEmptyRulesCards.equivalent.description',
+            {
+              defaultMessage: 'Defines groups of words that are the same.',
+            }
+          )}
+          footer={
+            <EuiFlexGroup direction="column">
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  data-test-subj="searchSynonymsSynonymsSetEmptyRulesCardsAddEquivalentRuleButton"
+                  color="primary"
+                  onClick={() => onCreateRule('equivalent')}
+                >
+                  {i18n.translate(
+                    'xpack.searchSynonyms.synonymsSetEmptyRulesCards.equivalent.addRuleButton',
+                    {
+                      defaultMessage: 'Add equivalent rule',
+                    }
+                  )}
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          }
+        >
+          <EuiFlexGroup direction="column" gutterSize="s" justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <EuiHorizontalRule margin="s" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup direction="row" gutterSize="xs">
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow">
+                    {i18n.translate(
+                      'xpack.searchSynonyms.synonymsSetEmptyRulesCards.equivalent.example.computer',
+                      {
+                        defaultMessage: 'computer',
+                      }
+                    )}
+                  </EuiBadge>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow">
+                    {i18n.translate(
+                      'xpack.searchSynonyms.synonymsSetEmptyRulesCards.equivalent.example.laptop',
+                      {
+                        defaultMessage: 'laptop',
+                      }
+                    )}
+                  </EuiBadge>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow">
+                    {i18n.translate(
+                      'xpack.searchSynonyms.synonymsSetEmptyRulesCards.equivalent.example.pc',
+                      {
+                        defaultMessage: 'pc',
+                      }
+                    )}
+                  </EuiBadge>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiCard>
+      </EuiFlexItem>
+      <EuiFlexItem
+        css={css`
+          min-width: ${euiTheme.base * 24}px;
+        `}
+      >
+        <EuiCard
+          textAlign="left"
+          hasBorder
+          title={i18n.translate('xpack.searchSynonyms.synonymsSetEmptyRulesCards.explicit.title', {
+            defaultMessage: 'Explicit',
+          })}
+          description={i18n.translate(
+            'xpack.searchSynonyms.synonymsSetEmptyRulesCards.explicit.description',
+            {
+              defaultMessage: 'Matches a group of words to another word.',
+            }
+          )}
+          footer={
+            <EuiFlexGroup direction="column">
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  data-test-subj="searchSynonymsSynonymsSetEmptyRulesCardsAddExplicitRuleButton"
+                  color="primary"
+                  onClick={() => onCreateRule('explicit')}
+                >
+                  {i18n.translate(
+                    'xpack.searchSynonyms.synonymsSetEmptyRulesCards.explicit.addRuleButton',
+                    {
+                      defaultMessage: 'Add explicit rule',
+                    }
+                  )}
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          }
+        >
+          <EuiFlexGroup direction="column" gutterSize="s" justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <EuiHorizontalRule margin="s" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup direction="row" gutterSize="xs">
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow">
+                    {i18n.translate(
+                      'xpack.searchSynonyms.synonymsSetEmptyRulesCards.explicit.example.jacket',
+                      {
+                        defaultMessage: 'jacket',
+                      }
+                    )}
+                  </EuiBadge>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow">
+                    {i18n.translate(
+                      'xpack.searchSynonyms.synonymsSetEmptyRulesCards.equivalent.example.parka',
+                      {
+                        defaultMessage: 'parka',
+                      }
+                    )}
+                  </EuiBadge>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="s">
+                    <b>{'=>'}</b>
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow">
+                    {i18n.translate(
+                      'xpack.searchSynonyms.synonymsSetEmptyRulesCards.equivalent.example.coat',
+                      {
+                        defaultMessage: 'coat',
+                      }
+                    )}
+                  </EuiBadge>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiCard>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/empty_rules_table.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/empty_rules_table.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiTitle } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import { docLinks } from '../../../common/doc_links';
+import { SynonymsSetEmptyRulesCards } from './empty_rules_cards';
+
+interface SynonymsSetEmptyRuleTableProps {
+  onCreateRule: (type: 'equivalent' | 'explicit') => void;
+}
+export const SynonymsSetEmptyRuleTable: React.FC<SynonymsSetEmptyRuleTableProps> = ({
+  onCreateRule,
+}) => {
+  return (
+    <EuiFlexGroup direction="column" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiTitle>
+          <h2>
+            {i18n.translate('xpack.searchSynonyms.synonymsSetEmptyRuleTable.title', {
+              defaultMessage: 'Select a rule type',
+            })}
+          </h2>
+        </EuiTitle>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiLink
+          data-test-subj="searchSynonymsSynonymsSetEmptyRuleTableViewDocumentationLink"
+          href={docLinks.synonymsApi}
+        >
+          {i18n.translate('xpack.searchSynonyms.synonymsSetEmptyRuleTable.viewDocumentation', {
+            defaultMessage: 'View documentation',
+          })}
+        </EuiLink>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <SynonymsSetEmptyRulesCards onCreateRule={onCreateRule} />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/synonyms_set_detail.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/synonyms_set_detail.tsx
@@ -8,8 +8,6 @@
 import { useParams } from 'react-router-dom';
 import React, { useMemo } from 'react';
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
-import { EuiButton, EuiButtonIcon, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n-react';
 import { useKibana } from '../../hooks/use_kibana';
 import { SynonymsSetRuleTable } from './synonyms_set_rule_table';
 
@@ -17,7 +15,6 @@ export const SynonymsSetDetail = () => {
   const { synonymsSetId = '' } = useParams<{
     synonymsSetId?: string;
   }>();
-
   const {
     services: { console: consolePlugin, history, searchNavigation },
   } = useKibana();
@@ -36,26 +33,7 @@ export const SynonymsSetDetail = () => {
       solutionNav={searchNavigation?.useClassicNavigation(history)}
       color="primary"
     >
-      <KibanaPageTemplate.Header
-        pageTitle={synonymsSetId}
-        restrictWidth
-        color="primary"
-        rightSideItems={[
-          <EuiFlexGroup alignItems="center">
-            <EuiFlexItem grow={false}>
-              <EuiButton color="text" iconType="endpoint">
-                <FormattedMessage
-                  id="xpack.searchSynonyms.synonymsSetDetail.connectToApiButton"
-                  defaultMessage="Connect to API"
-                />
-              </EuiButton>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiButtonIcon iconType="boxesHorizontal" size="m" color="text" />
-            </EuiFlexItem>
-          </EuiFlexGroup>,
-        ]}
-      />
+      <KibanaPageTemplate.Header pageTitle={synonymsSetId} restrictWidth color="primary" />
       <KibanaPageTemplate.Section restrictWidth>
         {synonymsSetId && <SynonymsSetRuleTable synonymsSetId={synonymsSetId} />}
       </KibanaPageTemplate.Section>

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/synonyms_set_rule_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/synonyms_set_rule_flyout.tsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiFormRow,
+  EuiHealth,
+  EuiText,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { SynonymsSynonymRule } from '@elastic/elasticsearch/lib/api/types';
+import {
+  getExplicitSynonym,
+  isExplicitSynonym,
+  synonymsOptionToString,
+  synonymsStringToOption,
+} from '../../utils/synonyms_utils';
+import { usePutSynonymsRule } from '../../hooks/use_put_synonyms_rule';
+
+interface SynonymsRuleFlyoutProps {
+  onClose: () => void;
+  flyoutMode: 'create' | 'edit';
+  synonymsRule: SynonymsSynonymRule;
+  synonymsSetId: string;
+  renderExplicit?: boolean;
+}
+
+export const SynonymsRuleFlyout: React.FC<SynonymsRuleFlyoutProps> = ({
+  flyoutMode,
+  synonymsRule,
+  onClose,
+  renderExplicit = false,
+  synonymsSetId,
+}) => {
+  const flyoutHeadingId = useGeneratedHtmlId({ prefix: 'synonymsRuleFlyoutHeading' });
+
+  const { mutate: putSynonymsRule } = usePutSynonymsRule(() => onClose());
+
+  const synonyms = synonymsRule.synonyms.trim();
+  const isExplicit = renderExplicit || isExplicitSynonym(synonyms);
+
+  const [from, to] =
+    flyoutMode === 'create' ? ['', ''] : isExplicit ? getExplicitSynonym(synonyms) : [synonyms, ''];
+
+  const [selectedFromTerms, setSelectedFromTerms] = useState<EuiComboBoxOptionOption[]>(
+    synonymsStringToOption(from)
+  );
+
+  const [selectedToTerms, setSelectedToTerms] = useState<EuiComboBoxOptionOption[]>(
+    synonymsStringToOption(to)
+  );
+
+  const hasChanges =
+    synonyms.trim() !==
+    synonymsOptionToString({ fromTerms: selectedFromTerms, toTerms: selectedToTerms, isExplicit });
+
+  return (
+    <EuiFlyout onClose={onClose}>
+      <EuiFlyoutHeader hasBorder aria-labelledby={flyoutHeadingId}>
+        {flyoutMode === 'edit' ? (
+          <EuiText>
+            <b>
+              {i18n.translate('xpack.searchSynonyms.synonymsSetRuleFlyout.title.ruleId', {
+                defaultMessage: 'Rule ID: {ruleId}',
+                values: { ruleId: synonymsRule.id },
+              })}
+            </b>
+          </EuiText>
+        ) : (
+          <EuiFormRow
+            label={i18n.translate('xpack.searchSynonyms.synonymsSetRuleFlyout.title.ruleId', {
+              defaultMessage: 'Rule ID',
+            })}
+          >
+            <EuiFieldText
+              data-test-subj="searchSynonymsSynonymsRuleFlyoutFieldText"
+              value={synonymsRule.id}
+            />
+          </EuiFormRow>
+        )}
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiFormRow
+          label={i18n.translate('xpack.searchSynonyms.synonymsSetRuleFlyout.synonyms', {
+            defaultMessage: 'Add terms to match against',
+          })}
+        >
+          <EuiComboBox
+            title="Synonyms"
+            id="synonyms"
+            options={selectedFromTerms}
+            selectedOptions={selectedFromTerms}
+            onChange={(options) => {
+              setSelectedFromTerms(options);
+            }}
+            onCreateOption={(searchValue, options = []) => {
+              if (!searchValue.trim()) {
+                return;
+              }
+              if (!options.find((option) => option.label.trim() === searchValue.toLowerCase())) {
+                setSelectedFromTerms([
+                  ...selectedFromTerms,
+                  { label: searchValue, key: searchValue },
+                ]);
+              }
+            }}
+          />
+        </EuiFormRow>
+        {isExplicit && (
+          <EuiFormRow
+            label={i18n.translate('xpack.searchSynonyms.synonymsSetRuleFlyout.synonymsTo', {
+              defaultMessage: 'Map to this term',
+            })}
+          >
+            <EuiComboBox
+              title="Synonyms"
+              id="synonyms-to"
+              options={selectedToTerms}
+              selectedOptions={selectedToTerms}
+              onChange={(options) => {
+                setSelectedToTerms(options);
+              }}
+              onCreateOption={(searchValue, options = []) => {
+                if (!searchValue.trim()) {
+                  return;
+                }
+                if (!options.find((option) => option.label.trim() === searchValue.toLowerCase())) {
+                  setSelectedToTerms([
+                    ...selectedToTerms,
+                    { label: searchValue, key: searchValue },
+                  ]);
+                }
+              }}
+            />
+          </EuiFormRow>
+        )}
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+          <EuiFlexItem grow={false}>
+            {hasChanges && (
+              <EuiHealth color="primary">
+                {i18n.translate('xpack.searchSynonyms.synonymsSetRuleFlyout.unsavedChanges', {
+                  defaultMessage: 'Synonym rule has unsaved changes',
+                })}
+              </EuiHealth>
+            )}
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  data-test-subj="searchSynonymsSynonymsRuleFlyoutResetChangesButton"
+                  iconType={'refresh'}
+                  disabled={!hasChanges}
+                  onClick={() => {
+                    setSelectedFromTerms(synonymsStringToOption(from));
+                    setSelectedToTerms(synonymsStringToOption(to));
+                  }}
+                >
+                  {i18n.translate('xpack.searchSynonyms.synonymsSetRuleFlyout.reset', {
+                    defaultMessage: 'Reset changes',
+                  })}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  data-test-subj="searchSynonymsSynonymsRuleFlyoutSaveButton"
+                  fill
+                  onClick={() => {
+                    if (!synonymsRule.id) {
+                      return;
+                    }
+                    putSynonymsRule({
+                      synonymsSetId,
+                      ruleId: synonymsRule.id,
+                      synonyms: synonymsOptionToString({
+                        fromTerms: selectedFromTerms,
+                        toTerms: selectedToTerms,
+                        isExplicit,
+                      }),
+                    });
+                  }}
+                >
+                  {i18n.translate('xpack.searchSynonyms.synonymsSetRuleFlyout.save', {
+                    defaultMessage: 'Save',
+                  })}
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </EuiFlyout>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/synonyms_set_rule_table.test.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/synonyms_set_rule_table.test.tsx
@@ -39,6 +39,29 @@ jest.mock('../../hooks/use_fetch_synonyms_set', () => ({
   }),
 }));
 
+jest.mock('../../hooks/use_fetch_generated_rule_id', () => ({
+  useFetchGeneratedRuleId: () => ({
+    mutate: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/use_fetch_synonym_rule', () => ({
+  useFetchSynonymRule: () => ({
+    data: {
+      id: 'rule_id_3',
+      synonyms: 'explicit-from => explicit-to',
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+jest.mock('../../hooks/use_put_synonyms_rule', () => ({
+  usePutSynonymsRule: () => ({
+    mutate: jest.fn(),
+  }),
+}));
+
 describe('SynonymSetDetail table', () => {
   it('should render the list with synonym rules', () => {
     render(<SynonymsSetRuleTable synonymsSetId="synonymSetId" />);

--- a/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/synonyms_set_rule_table.tsx
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/components/synonyms_set_detail/synonyms_set_rule_table.tsx
@@ -5,14 +5,17 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   EuiBasicTable,
   EuiBasicTableColumn,
+  EuiButton,
   EuiButtonIcon,
   EuiCode,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiPopover,
+  EuiPopoverTitle,
   EuiText,
 } from '@elastic/eui';
 import { SynonymsSynonymRule } from '@elastic/elasticsearch/lib/api/types';
@@ -21,18 +24,41 @@ import { DEFAULT_PAGE_VALUE, paginationToPage } from '../../../common/pagination
 import { useFetchSynonymsSet } from '../../hooks/use_fetch_synonyms_set';
 import { getExplicitSynonym, isExplicitSynonym } from '../../utils/synonyms_utils';
 import { DeleteSynonymRuleModal } from './delete_synonym_rule_modal';
+import { SynonymsSetEmptyRuleTable } from './empty_rules_table';
+import { SynonymsSetEmptyRulesCards } from './empty_rules_cards';
+import { SynonymsRuleFlyout } from './synonyms_set_rule_flyout';
+import { useFetchSynonymRule } from '../../hooks/use_fetch_synonym_rule';
+import { useFetchGeneratedRuleId } from '../../hooks/use_fetch_generated_rule_id';
 
 export const SynonymsSetRuleTable = ({ synonymsSetId = '' }: { synonymsSetId: string }) => {
-  const [pageIndex, setPageIndex] = React.useState(0);
-  const [pageSize, setPageSize] = React.useState(DEFAULT_PAGE_VALUE.size);
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_VALUE.size);
   const { from } = paginationToPage({ pageIndex, pageSize, totalItemCount: 0 });
-  const [synonymRuleToDelete, setSynonymRuleToDelete] = React.useState<string | null>(null);
-  const { data, isLoading } = useFetchSynonymsSet(synonymsSetId, { from, size: pageSize });
+  const [synonymRuleToDelete, setSynonymRuleToDelete] = useState<string | null>(null);
+  const { data, isLoading, isInitialLoading } = useFetchSynonymsSet(synonymsSetId, {
+    from,
+    size: pageSize,
+  });
+  const [addNewRulePopoverOpen, setAddNewRulePopoverOpen] = useState(false);
+
+  const [isRuleFlyoutOpen, setIsRuleFlyoutOpen] = useState(false);
+  const [synonymsRuleToEdit, setSynonymsRuleToEdit] = useState<string | null>(null);
+  const [generatedId, setGeneratedId] = useState<string | null>(null);
+  const { data: synonymsRule } = useFetchSynonymRule(synonymsSetId, synonymsRuleToEdit || '');
+  const [ruleTypeToCreate, setRuleTypeToCreate] = useState<'equivalent' | 'explicit' | null>(null);
+
+  const { mutate: generateRuleId } = useFetchGeneratedRuleId((ruleId) => {
+    if (synonymsSetId && ruleTypeToCreate) {
+      setGeneratedId(ruleId);
+      setIsRuleFlyoutOpen(true);
+      setAddNewRulePopoverOpen(false);
+    }
+  });
 
   if (!data) return null;
 
   const pagination = {
-    initialPageSize: 10,
+    initialPageSize: 25,
     pageSizeOptions: [10, 25, 50],
     ...data._meta,
     pageSize,
@@ -45,7 +71,7 @@ export const SynonymsSetRuleTable = ({ synonymsSetId = '' }: { synonymsSetId: st
       name: i18n.translate('xpack.searchSynonyms.synonymsSetTable.synonymsColumn', {
         defaultMessage: 'Synonyms',
       }),
-      render: (synonyms: string) => {
+      render: (synonyms: string, synonymRule: SynonymsSynonymRule) => {
         const isExplicit = isExplicitSynonym(synonyms);
         const [explicitFrom = '', explicitTo = ''] = isExplicit ? getExplicitSynonym(synonyms) : [];
 
@@ -53,6 +79,7 @@ export const SynonymsSetRuleTable = ({ synonymsSetId = '' }: { synonymsSetId: st
           <EuiFlexGroup responsive={false}>
             <EuiFlexItem grow={false}>
               <EuiButtonIcon
+                data-test-subj="searchSynonymsColumnsButton"
                 iconType="expand"
                 aria-label={i18n.translate(
                   'xpack.searchSynonyms.synonymsSetTable.expandSynonyms.aria.label',
@@ -60,6 +87,12 @@ export const SynonymsSetRuleTable = ({ synonymsSetId = '' }: { synonymsSetId: st
                     defaultMessage: 'Expand synonyms rule',
                   }
                 )}
+                onClick={() => {
+                  if (synonymRule.id) {
+                    setSynonymsRuleToEdit(synonymRule.id);
+                    setIsRuleFlyoutOpen(true);
+                  }
+                }}
               />
             </EuiFlexItem>
             {isExplicit ? (
@@ -117,7 +150,12 @@ export const SynonymsSetRuleTable = ({ synonymsSetId = '' }: { synonymsSetId: st
           ),
           icon: 'pencil',
           type: 'icon',
-          onClick: () => {},
+          onClick: (synonymRule: SynonymsSynonymRule) => {
+            if (synonymRule.id) {
+              setSynonymsRuleToEdit(synonymRule.id);
+              setIsRuleFlyoutOpen(true);
+            }
+          },
         },
       ],
     },
@@ -132,17 +170,88 @@ export const SynonymsSetRuleTable = ({ synonymsSetId = '' }: { synonymsSetId: st
           closeDeleteModal={() => setSynonymRuleToDelete(null)}
         />
       )}
-      <EuiBasicTable
-        data-test-subj="synonyms-set-table"
-        items={data.data}
-        columns={columns}
-        loading={isLoading}
-        pagination={pagination}
-        onChange={({ page }) => {
-          setPageIndex(page.index);
-          setPageSize(page.size);
-        }}
-      />
+      {data.data.length === 0 && !isInitialLoading && (
+        <SynonymsSetEmptyRuleTable
+          onCreateRule={(type: 'equivalent' | 'explicit') => {
+            setRuleTypeToCreate(type);
+            generateRuleId({ synonymsSetId });
+          }}
+        />
+      )}
+
+      {isRuleFlyoutOpen && generatedId ? (
+        <SynonymsRuleFlyout
+          synonymsSetId={synonymsSetId}
+          onClose={() => {
+            setIsRuleFlyoutOpen(false);
+            setSynonymsRuleToEdit(null);
+            setGeneratedId(null);
+            setRuleTypeToCreate(null);
+          }}
+          flyoutMode={'create'}
+          synonymsRule={{ id: generatedId, synonyms: '' }}
+          renderExplicit={ruleTypeToCreate === 'explicit'}
+        />
+      ) : (
+        synonymsRule && (
+          <SynonymsRuleFlyout
+            synonymsSetId={synonymsSetId}
+            onClose={() => {
+              setIsRuleFlyoutOpen(false);
+              setSynonymsRuleToEdit(null);
+              setGeneratedId(null);
+              setRuleTypeToCreate(null);
+            }}
+            flyoutMode={'edit'}
+            synonymsRule={synonymsRule}
+          />
+        )
+      )}
+      {data.data.length !== 0 && (
+        <>
+          <EuiPopover
+            button={
+              <EuiButton
+                data-test-subj="searchSynonymsSynonymsSetRuleTableAddRuleButton"
+                iconType="plusInCircle"
+                onClick={() => {
+                  setAddNewRulePopoverOpen(true);
+                }}
+              >
+                {i18n.translate('xpack.searchSynonyms.synonymsSetTable.addRuleButton', {
+                  defaultMessage: 'Add rule',
+                })}
+              </EuiButton>
+            }
+            isOpen={addNewRulePopoverOpen}
+            closePopover={() => setAddNewRulePopoverOpen(false)}
+          >
+            <EuiPopoverTitle>
+              {i18n.translate('xpack.searchSynonyms.synonymsSetTable.addRule.title', {
+                defaultMessage: 'Select a rule type',
+              })}
+            </EuiPopoverTitle>
+            <SynonymsSetEmptyRulesCards
+              onCreateRule={(type: 'equivalent' | 'explicit') => {
+                setRuleTypeToCreate(type);
+                generateRuleId({ synonymsSetId });
+              }}
+            />
+          </EuiPopover>
+
+          <EuiBasicTable
+            data-test-subj="synonyms-set-table"
+            items={data.data}
+            columns={columns}
+            loading={isLoading}
+            pagination={pagination}
+            onChange={({ page }) => {
+              setPageIndex(page.index);
+              setPageSize(page.size);
+            }}
+          />
+        </>
+      )}
     </>
   );
 };

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_generated_rule_id.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_generated_rule_id.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useMutation } from '@tanstack/react-query';
+import { useKibana } from './use_kibana';
+
+export const useFetchGeneratedRuleId = (
+  onSuccess: (data: string) => void,
+  onError?: () => void
+) => {
+  const {
+    services: { http },
+  } = useKibana();
+
+  return useMutation(
+    async ({ synonymsSetId }: { synonymsSetId: string }) => {
+      return await http.post<{ id: string }>(
+        `/internal/search_synonyms/synonyms/${synonymsSetId}/generate`
+      );
+    },
+    {
+      onSuccess: (data) => {
+        onSuccess(data.id);
+      },
+      onError: () => {
+        if (onError) {
+          onError();
+        }
+      },
+    }
+  );
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_synonym_rule.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_fetch_synonym_rule.ts
@@ -21,5 +21,6 @@ export const useFetchSynonymRule = (synonymsSetId: string, ruleId: string) => {
         `/internal/search_synonyms/synonyms/${synonymsSetId}/${ruleId}`
       );
     },
+    enabled: !!synonymsSetId && !!ruleId,
   });
 };

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_put_synonyms_rule.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_put_synonyms_rule.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { KibanaServerError } from '@kbn/kibana-utils-plugin/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { SynonymsPutSynonymRuleResponse } from '@elastic/elasticsearch/lib/api/types';
+import { useKibana } from './use_kibana';
+
+interface MutationArgs {
+  synonymsSetId: string;
+  ruleId: string;
+  synonyms: string;
+}
+
+export const usePutSynonymsRule = (onSuccess?: () => void, onError?: (error: string) => void) => {
+  const queryClient = useQueryClient();
+  const {
+    services: { http, notifications },
+  } = useKibana();
+
+  return useMutation(
+    async ({ synonymsSetId, ruleId, synonyms }: MutationArgs) => {
+      return await http.put<SynonymsPutSynonymRuleResponse>(
+        `/internal/search_synonyms/synonyms/${synonymsSetId}/${ruleId}`,
+        {
+          body: JSON.stringify({
+            synonyms,
+          }),
+        }
+      );
+    },
+    {
+      onSuccess: (_, { ruleId }) => {
+        queryClient.invalidateQueries(['synonyms-sets-fetch']);
+        queryClient.invalidateQueries(['synonyms-rule-fetch']);
+        notifications?.toasts?.addSuccess({
+          title: i18n.translate('xpack.searchSynonyms.putSynonymsRuleSuccess', {
+            defaultMessage: 'Synonyms rule {ruleId} updated',
+            values: { ruleId },
+          }),
+        });
+        if (onSuccess) {
+          onSuccess();
+        }
+      },
+      onError: (error: { body: KibanaServerError }) => {
+        if (onError) {
+          onError(error.body.message);
+        } else {
+          notifications?.toasts?.addError(new Error(error.body.message), {
+            title: i18n.translate('xpack.searchSynonyms.putSynonymsRuleError', {
+              defaultMessage: 'Error updating synonyms rule',
+            }),
+            toastMessage: error.body.message,
+          });
+        }
+      },
+    }
+  );
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_put_synonyms_set.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/hooks/use_put_synonyms_set.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { SynonymsPutSynonymResponse } from '@elastic/elasticsearch/lib/api/types';
+import { i18n } from '@kbn/i18n';
+import { KibanaServerError } from '@kbn/kibana-utils-plugin/common';
+import { PLUGIN_ROUTE_ROOT } from '../../common/api_routes';
+import { useKibana } from './use_kibana';
+
+interface MutationArgs {
+  synonymsSetId: string;
+}
+
+export const usePutSynonymsSet = (onSuccess?: () => void, onError?: (error: string) => void) => {
+  const queryClient = useQueryClient();
+  const {
+    services: { http, notifications, application },
+  } = useKibana();
+
+  return useMutation(
+    async ({ synonymsSetId }: MutationArgs) => {
+      return await http.put<SynonymsPutSynonymResponse>(
+        `/internal/search_synonyms/synonyms/${synonymsSetId}`
+      );
+    },
+    {
+      onSuccess: (_, { synonymsSetId }) => {
+        queryClient.invalidateQueries(['synonyms-sets-fetch']);
+        queryClient.invalidateQueries(['synonyms-rule-fetch']);
+        notifications?.toasts?.addSuccess({
+          title: i18n.translate('xpack.searchSynonyms.putSynonymsSetSuccess', {
+            defaultMessage: 'Synonyms set added',
+          }),
+        });
+        if (onSuccess) {
+          onSuccess();
+        }
+        application.navigateToUrl(
+          http.basePath.prepend(`${PLUGIN_ROUTE_ROOT}/sets/${synonymsSetId}`)
+        );
+      },
+      onError: (error: { body: KibanaServerError }) => {
+        if (onError) {
+          onError(error.body.message);
+        } else {
+          notifications?.toasts?.addError(new Error(error.body.message), {
+            title: i18n.translate('xpack.searchSynonyms.putSynonymsSetError', {
+              defaultMessage: 'Error putting synonyms set',
+            }),
+            toastMessage: error.body.message,
+          });
+        }
+      },
+    }
+  );
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/public/utils/synonyms_utils.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/public/utils/synonyms_utils.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { EuiComboBoxOptionOption } from '@elastic/eui';
+
 export const isExplicitSynonym = (synonym: string) => {
   return synonym.trim().includes('=>');
 };
@@ -12,3 +14,30 @@ export const isExplicitSynonym = (synonym: string) => {
 export const getExplicitSynonym = (synonym: string) => {
   return [synonym.split('=>')[0].trim(), synonym.split('=>')[1].trim()];
 };
+
+export const formatSynonymsSetName = (rawName: string) =>
+  rawName
+    .trim()
+    .replace(/[^a-zA-Z0-9]+/g, '-') // Replace all special/non-alphanumerical characters with dashes
+    .replace(/^[-]+|[-]+$/g, '') // Strip all leading and trailing dashes
+    .toLowerCase();
+
+export const synonymsStringToOption = (synonyms: string) =>
+  synonyms.length === 0
+    ? []
+    : synonyms
+        .trim()
+        .split(',')
+        .map((s, index) => ({ label: s, key: index + '-' + s }));
+export const synonymsOptionToString = ({
+  fromTerms,
+  toTerms,
+  isExplicit,
+}: {
+  fromTerms: EuiComboBoxOptionOption[];
+  toTerms: EuiComboBoxOptionOption[];
+  isExplicit: boolean;
+}) =>
+  `${fromTerms.map((s) => s.label).join(',')}${
+    isExplicit ? ' => ' + toTerms.map((s) => s.label).join(',') : ''
+  }`;

--- a/x-pack/solutions/search/plugins/search_synonyms/server/config.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/config.ts
@@ -9,7 +9,7 @@ import { schema, TypeOf } from '@kbn/config-schema';
 import { PluginConfigDescriptor } from '@kbn/core/server';
 
 const configSchema = schema.object({
-  enabled: schema.boolean({ defaultValue: false }),
+  enabled: schema.boolean({ defaultValue: true }),
 });
 
 export type SearchPlaygroundConfig = TypeOf<typeof configSchema>;

--- a/x-pack/solutions/search/plugins/search_synonyms/server/lib/fetch_unique_rule_id.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/lib/fetch_unique_rule_id.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { ElasticsearchClient } from '@kbn/core/server';
+
+export const fetchUniqueRuleId = async (
+  client: ElasticsearchClient,
+  synonymsSetId: string
+): Promise<string> => {
+  // Try to generate a unique rule ID arbitrary times
+  for (let i = 0; i < 20; i++) {
+    const randomizedId = `rule-${uuidv4().split('-')[4]}`;
+    try {
+      await client.synonyms.getSynonymRule({
+        set_id: synonymsSetId,
+        rule_id: randomizedId,
+      });
+    } catch (e) {
+      return randomizedId;
+    }
+  }
+  throw new Error('Unable to generate a unique rule ID');
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/server/lib/put_synonyms_rule.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/lib/put_synonyms_rule.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SynonymsPutSynonymRuleResponse } from '@elastic/elasticsearch/lib/api/types';
+import { ElasticsearchClient } from '@kbn/core/server';
+
+export const putSynonymsRule = async (
+  client: ElasticsearchClient,
+  synonymsSetId: string,
+  ruleId: string,
+  synonyms: string
+): Promise<SynonymsPutSynonymRuleResponse> => {
+  return client.synonyms.putSynonymRule({
+    set_id: synonymsSetId,
+    rule_id: ruleId,
+    synonyms,
+  });
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/server/lib/put_synonyms_set.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/lib/put_synonyms_set.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SynonymsPutSynonymResponse } from '@elastic/elasticsearch/lib/api/types';
+import { ElasticsearchClient } from '@kbn/core/server';
+
+export const putSynonymsSet = async (
+  client: ElasticsearchClient,
+  synonymsSetId: string
+): Promise<SynonymsPutSynonymResponse> => {
+  return client.synonyms.putSynonym({
+    id: synonymsSetId,
+    body: {
+      synonyms_set: [],
+    },
+  });
+};

--- a/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
@@ -16,6 +16,9 @@ import { deleteSynonymsSet } from './lib/delete_synonyms_set';
 import { fetchSynonymsSet } from './lib/fetch_synonyms_set';
 import { deleteSynonymRule } from './lib/delete_synonym_rule';
 import { fetchSynonymRule } from './lib/fetch_synonym_rule';
+import { putSynonymsSet } from './lib/put_synonyms_set';
+import { fetchUniqueRuleId } from './lib/fetch_unique_rule_id';
+import { putSynonymsRule } from './lib/put_synonyms_rule';
 
 export function defineRoutes({ logger, router }: { logger: Logger; router: IRouter }) {
   router.get(
@@ -262,6 +265,160 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       const synonymsSetId = request.params.synonymsSetId;
       const ruleId = request.params.ruleId;
       const result = await deleteSynonymRule(asCurrentUser, synonymsSetId, ruleId);
+      return response.ok({
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: result,
+      });
+    })
+  );
+
+  router.put(
+    {
+      path: APIRoutes.SYNONYM_SET_ID,
+      options: {
+        access: 'internal',
+        tags: ['synonyms:write', 'synonyms:read'],
+      },
+      security: {
+        authz: {
+          requiredPrivileges: ['synonyms:write', 'synonyms:read'],
+        },
+      },
+      validate: {
+        params: schema.object({
+          synonymsSetId: schema.string(),
+        }),
+      },
+    },
+    errorHandler(logger)(async (context, request, response) => {
+      const core = await context.core;
+      const {
+        client: { asCurrentUser },
+      } = core.elasticsearch;
+      const user = core.security.authc.getCurrentUser();
+      if (!user) {
+        return response.customError({
+          statusCode: 502,
+          body: 'Could not retrieve current user, security plugin is not ready',
+        });
+      }
+      const hasSearchSynonymsPrivilege = await asCurrentUser.security.hasPrivileges({
+        cluster: ['manage_search_synonyms'],
+      });
+      if (!hasSearchSynonymsPrivilege.has_all_requested) {
+        return response.forbidden({
+          body: "Your user doesn't have manage_search_synonyms privileges",
+        });
+      }
+      const synonymsSetId = request.params.synonymsSetId;
+      const result = await putSynonymsSet(asCurrentUser, synonymsSetId);
+      return response.ok({
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: result,
+      });
+    })
+  );
+
+  router.post(
+    {
+      path: APIRoutes.GENERATE_SYNONYM_RULE_ID,
+      options: {
+        access: 'internal',
+        tags: ['synonyms:write', 'synonyms:read'],
+      },
+      security: {
+        authz: {
+          requiredPrivileges: ['synonyms:write', 'synonyms:read'],
+        },
+      },
+      validate: {
+        params: schema.object({
+          synonymsSetId: schema.string(),
+        }),
+      },
+    },
+    errorHandler(logger)(async (context, request, response) => {
+      const core = await context.core;
+      const {
+        client: { asCurrentUser },
+      } = core.elasticsearch;
+      const user = core.security.authc.getCurrentUser();
+      if (!user) {
+        return response.customError({
+          statusCode: 502,
+          body: 'Could not retrieve current user, security plugin is not ready',
+        });
+      }
+      const hasSearchSynonymsPrivilege = await asCurrentUser.security.hasPrivileges({
+        cluster: ['manage_search_synonyms'],
+      });
+      if (!hasSearchSynonymsPrivilege.has_all_requested) {
+        return response.forbidden({
+          body: "Your user doesn't have manage_search_synonyms privileges",
+        });
+      }
+      const synonymsSetId = request.params.synonymsSetId;
+      const result = await fetchUniqueRuleId(asCurrentUser, synonymsSetId);
+      return response.ok({
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: { id: result },
+      });
+    })
+  );
+
+  router.put(
+    {
+      path: APIRoutes.SYNONYM_SET_ID_RULE_ID,
+      options: {
+        access: 'internal',
+        tags: ['synonyms:write', 'synonyms:read'],
+      },
+      security: {
+        authz: {
+          requiredPrivileges: ['synonyms:write', 'synonyms:read'],
+        },
+      },
+      validate: {
+        params: schema.object({
+          synonymsSetId: schema.string(),
+          ruleId: schema.string(),
+        }),
+        body: schema.object({
+          synonyms: schema.string(),
+        }),
+      },
+    },
+    errorHandler(logger)(async (context, request, response) => {
+      const core = await context.core;
+      const {
+        client: { asCurrentUser },
+      } = core.elasticsearch;
+      const user = core.security.authc.getCurrentUser();
+      if (!user) {
+        return response.customError({
+          statusCode: 502,
+          body: 'Could not retrieve current user, security plugin is not ready',
+        });
+      }
+      const hasSearchSynonymsPrivilege = await asCurrentUser.security.hasPrivileges({
+        cluster: ['manage_search_synonyms'],
+      });
+      if (!hasSearchSynonymsPrivilege.has_all_requested) {
+        return response.forbidden({
+          body: "Your user doesn't have manage_search_synonyms privileges",
+        });
+      }
+      const synonymsSetId = request.params.synonymsSetId;
+      const ruleId = request.params.ruleId;
+      const synonyms = request.body.synonyms;
+
+      const result = await putSynonymsRule(asCurrentUser, synonymsSetId, ruleId, synonyms);
       return response.ok({
         headers: {
           'content-type': 'application/json',

--- a/x-pack/test/api_integration/apis/features/features/features.ts
+++ b/x-pack/test/api_integration/apis/features/features/features.ts
@@ -131,6 +131,7 @@ export default function ({ getService }: FtrProviderContext) {
             'rulesSettings',
             'uptime',
             'searchInferenceEndpoints',
+            'searchSynonyms',
             'searchPlayground',
             'siemV2',
             'slo',

--- a/x-pack/test/api_integration/apis/security/privileges.ts
+++ b/x-pack/test/api_integration/apis/security/privileges.ts
@@ -61,6 +61,7 @@ export default function ({ getService }: FtrProviderContext) {
       observabilityAIAssistant: ['all', 'read', 'minimal_all', 'minimal_read'],
       slo: ['all', 'read', 'minimal_all', 'minimal_read'],
       searchPlayground: ['all', 'read', 'minimal_all', 'minimal_read'],
+      searchSynonyms: ['all', 'read', 'minimal_all', 'minimal_read'],
       searchInferenceEndpoints: ['all', 'read', 'minimal_all', 'minimal_read'],
       fleetv2: [
         'all',

--- a/x-pack/test/api_integration/apis/security/privileges_basic.ts
+++ b/x-pack/test/api_integration/apis/security/privileges_basic.ts
@@ -56,6 +56,7 @@ export default function ({ getService }: FtrProviderContext) {
             securitySolutionNotes: ['all', 'read', 'minimal_all', 'minimal_read'],
             securitySolutionTimeline: ['all', 'read', 'minimal_all', 'minimal_read'],
             searchPlayground: ['all', 'read', 'minimal_all', 'minimal_read'],
+            searchSynonyms: ['all', 'read', 'minimal_all', 'minimal_read'],
             searchInferenceEndpoints: ['all', 'read', 'minimal_all', 'minimal_read'],
             fleetv2: ['all', 'read', 'minimal_all', 'minimal_read'],
             fleet: ['all', 'read', 'minimal_all', 'minimal_read'],
@@ -153,6 +154,7 @@ export default function ({ getService }: FtrProviderContext) {
             observabilityAIAssistant: ['all', 'read', 'minimal_all', 'minimal_read'],
             slo: ['all', 'read', 'minimal_all', 'minimal_read'],
             searchPlayground: ['all', 'read', 'minimal_all', 'minimal_read'],
+            searchSynonyms: ['all', 'read', 'minimal_all', 'minimal_read'],
             searchInferenceEndpoints: ['all', 'read', 'minimal_all', 'minimal_read'],
             fleetv2: [
               'agent_policies_all',

--- a/x-pack/test/spaces_api_integration/spaces_only/telemetry/telemetry.ts
+++ b/x-pack/test/spaces_api_integration/spaces_only/telemetry/telemetry.ts
@@ -87,6 +87,7 @@ export default function ({ getService }: FtrProviderContext) {
         enterpriseSearchAnalytics: 0,
         searchInferenceEndpoints: 0,
         searchPlayground: 0,
+        searchSynonyms: 0,
         siem: 0,
         siemV2: 0,
         securitySolutionCases: 0,

--- a/x-pack/test/ui_capabilities/security_and_spaces/tests/nav_links.ts
+++ b/x-pack/test/ui_capabilities/security_and_spaces/tests/nav_links.ts
@@ -68,7 +68,6 @@ export default function navLinksTests({ getService }: FtrProviderContext) {
                 'enterpriseSearchAnalytics',
                 'searchPlayground',
                 'searchInferenceEndpoints',
-                'searchSynonyms',
                 'guidedOnboardingFeature',
                 'securitySolutionAssistant',
                 'securitySolutionAttackDiscovery',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Synonyms UI] Search synonyms rule flyout (#208564)](https://github.com/elastic/kibana/pull/208564)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Efe Gürkan YALAMAN","email":"efeguerkan.yalaman@elastic.co"},"sourceCommit":{"committedDate":"2025-01-29T21:55:52Z","message":"[Synonyms UI] Search synonyms rule flyout (#208564)\n\n## Summary\r\n\r\nAdds search synonym rule flyout.\r\nAdds endpoints and hooks for synonym rule management.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/e43b4a40-6452-4cfd-921f-2bde1219f219\r\n\r\n\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2cb7bea5f3e7686faa5dfbf11b8c7d270fdcdd34","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Search","backport:version","v8.18.0"],"title":"[Synonyms UI] Search synonyms rule flyout","number":208564,"url":"https://github.com/elastic/kibana/pull/208564","mergeCommit":{"message":"[Synonyms UI] Search synonyms rule flyout (#208564)\n\n## Summary\r\n\r\nAdds search synonym rule flyout.\r\nAdds endpoints and hooks for synonym rule management.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/e43b4a40-6452-4cfd-921f-2bde1219f219\r\n\r\n\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2cb7bea5f3e7686faa5dfbf11b8c7d270fdcdd34"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208564","number":208564,"mergeCommit":{"message":"[Synonyms UI] Search synonyms rule flyout (#208564)\n\n## Summary\r\n\r\nAdds search synonym rule flyout.\r\nAdds endpoints and hooks for synonym rule management.\r\n\r\n\r\nhttps://github.com/user-attachments/assets/e43b4a40-6452-4cfd-921f-2bde1219f219\r\n\r\n\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2cb7bea5f3e7686faa5dfbf11b8c7d270fdcdd34"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->