### PR TITLE
[Security Solution] Fix filtering in Rule Updates table

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_filter_prebuilt_rules_to_upgrade.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_filter_prebuilt_rules_to_upgrade.ts
@@ -31,33 +31,18 @@ export const useFilterPrebuiltRulesToUpgrade = ({
         return false;
       }
 
-      let tagsFilteringResult = true;
-      let ruleSourceFilteringResult = true;
-
-      if (tags && tags.length > 0) {
-        tagsFilteringResult = tags.every((tag) => ruleInfo.current_rule.tags.includes(tag));
+      if (tags?.length && !tags.every((tag) => ruleInfo.current_rule.tags.includes(tag))) {
+        return false;
       }
 
-      if (ruleSource && ruleSource.length > 0) {
-        if (
-          ruleSource.includes(RuleCustomizationEnum.customized) &&
-          ruleSource.includes(RuleCustomizationEnum.not_customized)
-        ) {
-          ruleSourceFilteringResult = true;
-        } else if (
-          ruleSource.includes(RuleCustomizationEnum.customized) &&
-          ruleInfo.current_rule.rule_source.type === 'external'
-        ) {
-          ruleSourceFilteringResult = ruleInfo.current_rule.rule_source.is_customized;
-        } else if (
-          ruleSource.includes(RuleCustomizationEnum.not_customized) &&
-          ruleInfo.current_rule.rule_source.type === 'external'
-        ) {
-          ruleSourceFilteringResult = ruleInfo.current_rule.rule_source.is_customized === false;
+      if (ruleSource?.length === 1 && ruleInfo.current_rule.rule_source.type === 'external') {
+        if (ruleSource.includes(RuleCustomizationEnum.customized)) {
+          return ruleInfo.current_rule.rule_source.is_customized;
         }
+        return ruleInfo.current_rule.rule_source.is_customized === false;
       }
 
-      return tagsFilteringResult && ruleSourceFilteringResult;
+      return true;
     });
   }, [filterOptions, data]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_filter_prebuilt_rules_to_upgrade.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_filter_prebuilt_rules_to_upgrade.ts
@@ -31,8 +31,11 @@ export const useFilterPrebuiltRulesToUpgrade = ({
         return false;
       }
 
+      let tagsFilteringResult = true;
+      let ruleSourceFilteringResult = true;
+
       if (tags && tags.length > 0) {
-        return tags.every((tag) => ruleInfo.current_rule.tags.includes(tag));
+        tagsFilteringResult = tags.every((tag) => ruleInfo.current_rule.tags.includes(tag));
       }
 
       if (ruleSource && ruleSource.length > 0) {
@@ -40,21 +43,21 @@ export const useFilterPrebuiltRulesToUpgrade = ({
           ruleSource.includes(RuleCustomizationEnum.customized) &&
           ruleSource.includes(RuleCustomizationEnum.not_customized)
         ) {
-          return true;
+          ruleSourceFilteringResult = true;
         } else if (
           ruleSource.includes(RuleCustomizationEnum.customized) &&
           ruleInfo.current_rule.rule_source.type === 'external'
         ) {
-          return ruleInfo.current_rule.rule_source.is_customized;
+          ruleSourceFilteringResult = ruleInfo.current_rule.rule_source.is_customized;
         } else if (
           ruleSource.includes(RuleCustomizationEnum.not_customized) &&
           ruleInfo.current_rule.rule_source.type === 'external'
         ) {
-          return ruleInfo.current_rule.rule_source.is_customized === false;
+          ruleSourceFilteringResult = ruleInfo.current_rule.rule_source.is_customized === false;
         }
       }
 
-      return true;
+      return tagsFilteringResult && ruleSourceFilteringResult;
     });
   }, [filterOptions, data]);
 };


### PR DESCRIPTION
**Resolves: #206132**

## Summary

The logic of filtering by Modifications and Tags was incorrect. The condition for filtering by these two things should be combined. I am fixing this in this PR.

## BEFORE
https://github.com/user-attachments/assets/7938dfc9-583a-4a54-9444-291a87e90ddf

## AFTER

https://github.com/user-attachments/assets/5db46670-ab4a-42da-b78f-ca8a8daafbdc

https://github.com/user-attachments/assets/ae001738-a937-4d7d-9305-3b0f296ff81a



<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->