### PR TITLE
[8.x] [FTR][Synonyms UI] Add Synonyms overview FTRs (#208723)

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -99,3 +99,6 @@ aiAssistantManagementSelection.preferredAIAssistantType: "observability"
 xpack.observabilityAiAssistantManagement.logSourcesEnabled: false
 xpack.observabilityAiAssistantManagement.spacesEnabled: false
 xpack.observabilityAiAssistantManagement.visibilityEnabled: false
+
+# Synonyms UI
+xpack.searchSynonyms.enabled: true

--- a/x-pack/test/functional/page_objects/index.ts
+++ b/x-pack/test/functional/page_objects/index.ts
@@ -54,6 +54,7 @@ import { UserProfilePageProvider } from './user_profile_page';
 import { WatcherPageObject } from './watcher_page';
 import { SearchProfilerPageProvider } from './search_profiler_page';
 import { SearchPlaygroundPageProvider } from './search_playground_page';
+import { SearchSynonymsPageProvider } from './search_synonyms_page';
 import { SearchClassicNavigationProvider } from './search_classic_navigation';
 
 // just like services, PageObjects are defined as a map of
@@ -97,6 +98,7 @@ export const pageObjects = {
   searchClassicNavigation: SearchClassicNavigationProvider,
   searchProfiler: SearchProfilerPageProvider,
   searchPlayground: SearchPlaygroundPageProvider,
+  searchSynonyms: SearchSynonymsPageProvider,
   searchSessionsManagement: SearchSessionsPageProvider,
   security: SecurityPageObject,
   shareSavedObjectsToSpace: ShareSavedObjectsToSpacePageProvider,

--- a/x-pack/test/functional/page_objects/search_synonyms_page.ts
+++ b/x-pack/test/functional/page_objects/search_synonyms_page.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../ftr_provider_context';
+
+export function SearchSynonymsPageProvider({ getService }: FtrProviderContext) {
+  const testSubjects = getService('testSubjects');
+
+  return {
+    SynonymsGetStartedPage: {
+      async expectSynonymsGetStartedPageComponentsToExist() {
+        await testSubjects.existOrFail('searchSynonymsEmptyPromptGetStartedButton');
+      },
+    },
+    SynonymsSetsListPage: {
+      async expectSynonymsSetsListPageComponentsToExist() {
+        await testSubjects.existOrFail('synonyms-set-table');
+        await testSubjects.existOrFail('synonyms-set-item-rule-count');
+      },
+    },
+  };
+}

--- a/x-pack/test_serverless/functional/test_suites/search/config.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/config.ts
@@ -30,6 +30,7 @@ export default createTestConfig({
     '--xpack.dataUsage.autoops.api.url=http://localhost:9000',
     `--xpack.dataUsage.autoops.api.tls.certificate=${KBN_CERT_PATH}`,
     `--xpack.dataUsage.autoops.api.tls.key=${KBN_KEY_PATH}`,
+    '--xpack.searchSynonyms.enabled=true',
   ],
   apps: {
     serverlessElasticsearch: {

--- a/x-pack/test_serverless/functional/test_suites/search/index.feature_flags.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/index.feature_flags.ts
@@ -14,5 +14,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('../common/platform_security/navigation/management_nav_cards.ts'));
     loadTestFile(require.resolve('../common/platform_security/roles.ts'));
     loadTestFile(require.resolve('../common/spaces/multiple_spaces_enabled.ts'));
+    loadTestFile(require.resolve('./search_synonyms/search_synonyms_overview'));
   });
 }

--- a/x-pack/test_serverless/functional/test_suites/search/search_synonyms/search_synonyms_overview.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/search_synonyms/search_synonyms_overview.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const pageObjects = getPageObjects([
+    'svlCommonPage',
+    'svlCommonNavigation',
+    'searchSynonyms',
+    'embeddedConsole',
+    'common',
+  ]);
+  const browser = getService('browser');
+  const es = getService('es');
+  const kibanaServer = getService('kibanaServer');
+
+  describe('Serverless Synonyms Overview', function () {
+    before(async () => {
+      await kibanaServer.uiSettings.update({ 'searchSynonyms:synonymsEnabled': 'true' });
+      await pageObjects.svlCommonPage.loginWithRole('admin');
+      await pageObjects.svlCommonNavigation.sidenav.clickLink({
+        deepLinkId: 'searchSynonyms',
+      });
+    });
+    describe('Synonyms get started Page', () => {
+      it('is loaded successfully', async () => {
+        await pageObjects.searchSynonyms.SynonymsGetStartedPage.expectSynonymsGetStartedPageComponentsToExist();
+      });
+    });
+
+    describe('synonyms sets list page', () => {
+      before(async () => {
+        await es.transport.request({
+          path: '_synonyms/test',
+          method: 'PUT',
+          body: {
+            synonyms_set: [
+              {
+                id: 'rule1',
+                synonyms: 'a, b, c',
+              },
+              {
+                id: 'rule2',
+                synonyms: 'd, e, f',
+              },
+            ],
+          },
+        });
+      });
+      it('loads successfully', async () => {
+        await browser.refresh();
+        await pageObjects.searchSynonyms.SynonymsSetsListPage.expectSynonymsSetsListPageComponentsToExist();
+      });
+      after(async () => {
+        await es.transport.request({
+          path: '_synonyms/test',
+          method: 'DELETE',
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[FTR][Synonyms UI] Add Synonyms overview FTRs (#208723)](https://github.com/elastic/kibana/pull/208723)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Efe Gürkan YALAMAN","email":"efeguerkan.yalaman@elastic.co"},"sourceCommit":{"committedDate":"2025-01-30T00:46:08Z","message":"[FTR][Synonyms UI] Add Synonyms overview FTRs (#208723)\n\n## Summary\r\n\r\nAdds FTR tests for synonyms\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"a172cb5691d610c6c5d4404b6378d7bf039be892","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Search","backport:version","v8.18.0"],"title":"[FTR][Synonyms UI] Add Synonyms overview FTRs","number":208723,"url":"https://github.com/elastic/kibana/pull/208723","mergeCommit":{"message":"[FTR][Synonyms UI] Add Synonyms overview FTRs (#208723)\n\n## Summary\r\n\r\nAdds FTR tests for synonyms\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"a172cb5691d610c6c5d4404b6378d7bf039be892"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208723","number":208723,"mergeCommit":{"message":"[FTR][Synonyms UI] Add Synonyms overview FTRs (#208723)\n\n## Summary\r\n\r\nAdds FTR tests for synonyms\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"a172cb5691d610c6c5d4404b6378d7bf039be892"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->