### PR TITLE
[Obs AI Assistant] Avoid opening multiple flyouts

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
@@ -82,15 +82,7 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
   const [isOpen, setIsOpen] = useState(flyoutSettings.isOpen);
   const [hasBeenOpened, setHasBeenOpened] = useState(isOpen);
   const keyRef = useRef(v4());
-
-  const openFlyout = useCallback(() => {
-    if (!isOpen) {
-      keyRef.current = v4();
-      setHasBeenOpened(true);
-      setFlyoutSettings((prev) => ({ ...prev, isOpen: true }));
-      setIsOpen(true);
-    }
-  }, [isOpen, setFlyoutSettings]);
+  const theme = useTheme();
 
   const chatService = useAbortableAsync(
     ({ signal }) => {
@@ -115,6 +107,15 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
     [service, hasBeenOpened, notifications.toasts]
   );
 
+  const openFlyout = useCallback(() => {
+    if (!isOpen) {
+      keyRef.current = v4();
+      setHasBeenOpened(true);
+      setFlyoutSettings((prev) => ({ ...prev, isOpen: true }));
+      setIsOpen(true);
+    }
+  }, [isOpen, setFlyoutSettings]);
+
   useEffect(() => {
     const conversationSubscription = service.conversations.predefinedConversation$.subscribe(() => {
       openFlyout();
@@ -132,8 +133,6 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
     title: undefined,
     hideConversationList: false,
   };
-
-  const theme = useTheme();
 
   const buttonCss = css`
     padding: 0px 8px;

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/public/components/nav_control/index.tsx
@@ -10,7 +10,6 @@ import { EuiButton, EuiButtonEmpty, EuiLoadingSpinner, EuiToolTip } from '@elast
 import { css } from '@emotion/react';
 import { v4 } from 'uuid';
 import useObservable from 'react-use/lib/useObservable';
-import { debounceTime } from 'rxjs';
 import { i18n } from '@kbn/i18n';
 import { CoreStart } from '@kbn/core-lifecycle-browser';
 import {
@@ -117,11 +116,9 @@ export function NavControl({ isServerless }: { isServerless?: boolean }) {
   );
 
   useEffect(() => {
-    const conversationSubscription = service.conversations.predefinedConversation$
-      .pipe(debounceTime(300))
-      .subscribe(() => {
-        openFlyout();
-      });
+    const conversationSubscription = service.conversations.predefinedConversation$.subscribe(() => {
+      openFlyout();
+    });
 
     return () => {
       conversationSubscription.unsubscribe();


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/204087

### Problem
Sometimes, the flyout opens multiple times, creating a pitch black overlay. And the user have to click multiple times to close the opened flyouts.

### Solution
Make sure only one instance of the flyout can be opened at all times.

### Screen Recording

Before the fix:

https://github.com/user-attachments/assets/72eb8acb-e556-4b67-8231-68f19281d107

After the fix:

https://github.com/user-attachments/assets/438c13df-ed78-4fd8-bb6c-ae09d6a0ff76

Note: This issue still persists with the keyboard shortcut. I tried various ways to make sure the listener is only attached once. But the flyout keeps opening multiple times even with those solutions. I'm assuming the keyboard shortcut it not heavily used by the users. Therefore, I created another issue to get back to it - https://github.com/elastic/kibana/issues/208973

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



