### PR TITLE
[Connectors] Give API key access to connector system indices

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -849,6 +849,7 @@ it('Returns the Elastic Connectors permissions for elastic_connectors package', 
         {
           names: ['.elastic-connectors*'],
           privileges: ELASTIC_CONNECTORS_INDEX_PERMISSIONS,
+          allow_restricted_indices: true,
         },
         {
           names: ['content-*', '.search-acl-filter-*'],

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -293,6 +293,7 @@ function connectorServicePermissions(packagePolicyId: string): [string, Security
         {
           names: ['.elastic-connectors*'],
           privileges: ELASTIC_CONNECTORS_INDEX_PERMISSIONS,
+          allow_restricted_indices: true,
         },
         {
           names: ['content-*', '.search-acl-filter-*'],

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/components/manual_configuration.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/create_connector/components/manual_configuration.tsx
@@ -119,7 +119,7 @@ POST /_security/api_key
           "privileges": [
             "all"
           ],
-          "allow_restricted_indices": false
+          "allow_restricted_indices": true
         }
       ]
     }

--- a/x-pack/solutions/search/plugins/enterprise_search/server/lib/indices/generate_api_key.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/lib/indices/generate_api_key.ts
@@ -31,6 +31,7 @@ export const generateApiKey = async (
         cluster: ['monitor', 'manage_connector'],
         index: [
           {
+            allow_restricted_indices: true,
             names: [indexName, aclIndexName, `${CONNECTORS_INDEX}*`],
             privileges: ['all'],
           },


### PR DESCRIPTION
Connector indices will be external-managed system indices in 9.0 (see [relevant ES PR](https://github.com/elastic/elasticsearch/pull/118991)). This means direct access to the indices is restricted to users who have access to restricted indices, and requests contain an appropriate product header.

During testing it surfaced that the API keys we generate for Connectors don't provide enough permissions for this direct access. The Connector codebase still has several direct calls to the Connector indices. If a user tries to run a Connector with an API key generated in Kibana, that Connector will error out when it tries to make these calls.

The E&T team triaged this and determined the level of effort to get the Connector codebase to stop making direct index requests was so great that it was basically a new feature, and so shouldn't be pursued this late in development.