### PR TITLE
[Security GenAI] "Select a Connector" popup does not show up after the user selects any connector and then cancels it from Endpoint Insights. (#208907)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
@@ -224,7 +224,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
             <AddConnectorModal
               actionTypeRegistry={actionTypeRegistry}
               actionTypes={actionTypes}
-              onClose={() => setIsConnectorModalVisible(false)}
+              onClose={cleanupAndCloseModal}
               onSaveConnector={onSaveConnector}
               onSelectActionType={(actionType: ActionType) => setSelectedActionType(actionType)}
               selectedActionType={selectedActionType}


### PR DESCRIPTION
## Summary

BUG: https://github.com/elastic/kibana/issues/208907

This PR fixes the issue where user cannot select a different connector type after mistakenly selecting a wrong one.

### Steps to reproduce without required endpoint installation:

1. Make sure there are no connectors
2. Open "AI Assistant" on one of the security solution pages
3. Press "(+) Add connector" button
4. Connector type selection modal is visible
5. Select "Amazon Bedrock" type (or any other connector type)
6. Cancel the modal
7. Press "(+) Add connector" button again

**ISSUE**: previously selected connector type is being displayed and there is no way to switch between types
**EXPECTED**: we should show connector type selection modal once previous one was closed

### Issue recording

https://github.com/user-attachments/assets/48052bf1-4e00-43b7-a63e-f8a7969b9dbf

### Fixed state recording

https://github.com/user-attachments/assets/48be1cc4-0326-43a1-bd57-bb82fc1f19eb


<!--ONMERGE {"backportTargets":["8.16","8.17","8.x"]} ONMERGE-->