### PR TITLE
Search: add deprecation warnings for config values removed in 9.0

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
@@ -7,6 +7,7 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 import { PluginInitializerContext, PluginConfigDescriptor } from '@kbn/core/server';
+import { i18n } from '@kbn/i18n';
 
 export const plugin = async (initializerContext: PluginInitializerContext) => {
   const { EnterpriseSearchPlugin } = await import('./plugin');
@@ -44,7 +45,46 @@ export const configSchema = schema.object({
 export type ConfigType = TypeOf<typeof configSchema>;
 
 export const config: PluginConfigDescriptor<ConfigType> = {
-  deprecations: ({ unused }) => [unused('canDeployEntSearch', { level: 'warning' })],
+  deprecations: ({ deprecate, unused }) => [
+    unused('canDeployEntSearch', { level: 'warning' }),
+    (deprecationConfig, fromPath, addDeprecation, context) => {
+      [
+        deprecate('host', '9.0.0', {
+          documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
+          level: 'critical',
+          title: i18n.translate('xpack.enterpriseSearch.deprecations.config.hostTitle', {
+            defaultMessage: 'Enterprise Search host(s) must be removed',
+          }),
+        }),
+        deprecate('ssl', '9.0.0', {
+          documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
+          level: 'critical',
+          title: ENT_SEARCH_NODE_DEPRECATION_TITLE,
+        }),
+        deprecate('accessCheckTimeout', '9.0.0', {
+          documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
+          level: 'critical',
+          title: ENT_SEARCH_NODE_DEPRECATION_TITLE,
+        }),
+        deprecate('accessCheckTimeoutWarning', '9.0.0', {
+          documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
+          level: 'critical',
+          title: ENT_SEARCH_NODE_DEPRECATION_TITLE,
+        }),
+        deprecate('customHeaders', '9.0.0', {
+          documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
+          level: 'critical',
+          title: ENT_SEARCH_NODE_DEPRECATION_TITLE,
+        }),
+        deprecate('isCloud', '9.0.0', {
+          level: 'critical',
+        }),
+        deprecate('ui', '9.0.0', {
+          level: 'critical',
+        }),
+      ].forEach((deprecation) => deprecation(deprecationConfig, fromPath, addDeprecation, context));
+    },
+  ],
   exposeToBrowser: {
     host: true,
     ui: true,
@@ -53,3 +93,8 @@ export const config: PluginConfigDescriptor<ConfigType> = {
 };
 
 export const CRAWLERS_INDEX = '.ent-search-actastic-crawler2_configurations_v2';
+
+const ENT_SEARCH_NODE_DEPRECATION_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.deprecations.config.nodeValuesTitle',
+  { defaultMessage: 'Enterprise Search connection config values must be removed' }
+);

--- a/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
@@ -89,5 +89,5 @@ export const CRAWLERS_INDEX = '.ent-search-actastic-crawler2_configurations_v2';
 
 const ENT_SEARCH_NODE_DEPRECATION_TITLE = i18n.translate(
   'xpack.enterpriseSearch.deprecations.config.nodeValuesTitle',
-  { defaultMessage: 'Enterprise Search connection config values must be removed' }
+  { defaultMessage: 'Enterprise Search connection values must be removed' }
 );

--- a/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
@@ -89,5 +89,5 @@ export const CRAWLERS_INDEX = '.ent-search-actastic-crawler2_configurations_v2';
 
 const ENT_SEARCH_NODE_DEPRECATION_TITLE = i18n.translate(
   'xpack.enterpriseSearch.deprecations.config.nodeValuesTitle',
-  { defaultMessage: 'Enterprise Search connection values must be removed' }
+  { defaultMessage: 'Enterprise Search configuration values must be removed' }
 );

--- a/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
@@ -75,6 +75,9 @@ export const config: PluginConfigDescriptor<ConfigType> = {
         deprecate('ui', '9.0.0', {
           level: 'critical',
         }),
+        deprecate('appsDisabled', '9.0.0', {
+          level: 'critical',
+        }),
       ].forEach((deprecation) => deprecation(deprecationConfig, fromPath, addDeprecation, context));
     },
   ],

--- a/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
@@ -49,13 +49,6 @@ export const config: PluginConfigDescriptor<ConfigType> = {
     unused('canDeployEntSearch', { level: 'warning' }),
     (deprecationConfig, fromPath, addDeprecation, context) => {
       [
-        deprecate('host', '9.0.0', {
-          documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
-          level: 'critical',
-          title: i18n.translate('xpack.enterpriseSearch.deprecations.config.hostTitle', {
-            defaultMessage: 'Enterprise Search host(s) must be removed',
-          }),
-        }),
         deprecate('ssl', '9.0.0', {
           documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
           level: 'critical',


### PR DESCRIPTION
## Summary

Add `enterpriseSearch` config deprecations for items remove in 9.0.

This is paired with #208856 which removes all the listed values from the `enterprise_search` plugin configuration.

### Screenshots
![image](https://github.com/user-attachments/assets/832a9614-ea8f-4c68-839e-b9e26bd95221)


