### PR TITLE
Tweak copy in Console tour

### DIFF
--- a/src/platform/plugins/shared/console/public/application/components/help_popover.tsx
+++ b/src/platform/plugins/shared/console/public/application/components/help_popover.tsx
@@ -121,7 +121,7 @@ export const HelpPopover = ({ button, isOpen, closePopover, resetTour }: HelpPop
           <p>
             {i18n.translate('console.helpPopover.description', {
               defaultMessage:
-                'Console is an interactive UI for calling Elasticsearch and Kibana APIs and viewing their responses. Search your data, manage settings, and more, using Query DSL and REST API syntax.',
+                'Console is an interactive UI for calling Elasticsearch and Kibana APIs and viewing their responses. Search your data, manage settings, and more',
             })}
           </p>
         </EuiText>

--- a/src/platform/plugins/shared/console/public/application/containers/main/get_tour_steps.tsx
+++ b/src/platform/plugins/shared/console/public/application/containers/main/get_tour_steps.tsx
@@ -29,7 +29,7 @@ export function getTourSteps(docLinks: DocLinksStart['links']) {
         <EuiText>
           {i18n.translate('console.tour.shellStepContent', {
             defaultMessage:
-              'Console is an interactive UI for calling Elasticsearch and Kibana APIs and viewing their responses. Use Query DSL syntax to search your data, manage settings, and more.',
+              'Console is an interactive UI for calling Elasticsearch and Kibana APIs and viewing their responses. Search your data, manage settings, and more using Elastic query languages.',
           })}
         </EuiText>
       ),


### PR DESCRIPTION
WIP

The previous copy was actually misleading since Console accepts multiple query syntaxes beyond just Query DSL. So this change improves accuracy by:

- Removing the specific mention of "Query DSL" that made it seem like that was the only supported syntax
- Using the more accurate broader term "Elastic query languages" in the tour step
- In the help popover, focusing on the core functionality without specifying syntax at all

# TODO

- [ ] Agree on where in docs we want to link to under this copy