### PR TITLE
[8.17] [Fleet] Improve reading package archive memory usage (#208869)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -441,10 +441,6 @@ export async function fetchArchiveBuffer({
   const archiveBuffer = await getResponseStreamWithSize(archiveUrl).then(({ stream, size }) =>
     streamToBuffer(stream, size)
   );
-  if (!archiveBuffer) {
-    logger.warn(`Archive Buffer not found`);
-    throw new ArchiveNotFoundError('Archive Buffer not found');
-  }
 
   if (shouldVerify) {
     const verificationResult = await verifyPackageArchiveSignature({

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -56,7 +56,8 @@ import { verifyPackageArchiveSignature } from '../packages/package_verification'
 
 import type { ArchiveIterator } from '../../../../common/types';
 
-import { fetchUrl, getResponse, getResponseStream } from './requests';
+import { fetchUrl, getResponse, getResponseStreamWithSize } from './requests';
+
 import { getRegistryUrl } from './registry_url';
 
 export const splitPkgKey = split;
@@ -436,7 +437,14 @@ export async function fetchArchiveBuffer({
   }
   const registryUrl = getRegistryUrl();
   const archiveUrl = `${registryUrl}${archivePath}`;
-  const archiveBuffer = await getResponseStream(archiveUrl).then(streamToBuffer);
+
+  const archiveBuffer = await getResponseStreamWithSize(archiveUrl).then(({ stream, size }) =>
+    streamToBuffer(stream, size)
+  );
+  if (!archiveBuffer) {
+    logger.warn(`Archive Buffer not found`);
+    throw new ArchiveNotFoundError('Archive Buffer not found');
+  }
 
   if (shouldVerify) {
     const verificationResult = await verifyPackageArchiveSignature({

--- a/x-pack/plugins/fleet/server/services/epm/registry/requests.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/requests.ts
@@ -75,6 +75,23 @@ export async function getResponseStream(
   return res.body;
 }
 
+export async function getResponseStreamWithSize(
+  url: string,
+  retries?: number
+): Promise<{ stream: NodeJS.ReadableStream; size?: number }> {
+  const res = await getResponse(url, retries);
+  if (res) {
+    const contentLengthHeader = res.headers.get('Content-Length');
+    const contentLength = contentLengthHeader ? parseInt(contentLengthHeader, 10) : undefined;
+
+    return {
+      stream: res.body,
+      size: contentLength && !isNaN(contentLength) ? contentLength : undefined,
+    };
+  }
+  throw new RegistryResponseError('isAirGapped config enabled, registry not reacheable');
+}
+
 export async function fetchUrl(url: string, retries?: number): Promise<string> {
   return getResponseStream(url, retries).then(streamToString);
 }

--- a/x-pack/plugins/fleet/server/services/epm/streams.ts
+++ b/x-pack/plugins/fleet/server/services/epm/streams.ts
@@ -15,6 +15,7 @@ export function bufferToStream(buffer: Buffer): PassThrough {
 
 export function streamToString(stream: NodeJS.ReadableStream | Buffer): Promise<string> {
   if (stream instanceof Buffer) return Promise.resolve(stream.toString());
+
   return new Promise((resolve, reject) => {
     const body: string[] = [];
     stream.on('data', (chunk: string) => body.push(chunk));
@@ -23,7 +24,22 @@ export function streamToString(stream: NodeJS.ReadableStream | Buffer): Promise<
   });
 }
 
-export function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+export function streamToBuffer(stream: NodeJS.ReadableStream, size?: number): Promise<Buffer> {
+  if (size) {
+    return new Promise((resolve, reject) => {
+      const data = Buffer.alloc(size);
+      let pos = 0;
+
+      stream.on('data', (chunk: Buffer) => {
+        pos += chunk.copy(data, pos);
+      });
+      stream.on('end', () => {
+        resolve(data);
+      });
+      stream.on('error', reject);
+    });
+  }
+
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Fleet] Improve reading package archive memory usage (#208869)](https://github.com/elastic/kibana/pull/208869)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-01-30T14:03:52Z","message":"[Fleet] Improve reading package archive memory usage (#208869)\n\n## Summary\r\n\r\nRelated to https://github.com/elastic/kibana/issues/208210 \r\n\r\nAs we know the package size from the content-length header we can\r\nimprove how read the archive stream to a buffer.\r\n\r\n## Benchmark \r\n\r\n<img width=\"710\" alt=\"Screenshot 2025-01-29 at 9 23 59 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/79dc1f20-938b-402e-a823-1ab26a07b78e\"\r\n/>","sha":"0a0a4d8b7539fef7ba2c6c0ee0e2e46291f8574e","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","backport:prev-minor","backport:version","v8.17.2"],"title":"[Fleet] Improve reading package archive memory usage","number":208869,"url":"https://github.com/elastic/kibana/pull/208869","mergeCommit":{"message":"[Fleet] Improve reading package archive memory usage (#208869)\n\n## Summary\r\n\r\nRelated to https://github.com/elastic/kibana/issues/208210 \r\n\r\nAs we know the package size from the content-length header we can\r\nimprove how read the archive stream to a buffer.\r\n\r\n## Benchmark \r\n\r\n<img width=\"710\" alt=\"Screenshot 2025-01-29 at 9 23 59 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/79dc1f20-938b-402e-a823-1ab26a07b78e\"\r\n/>","sha":"0a0a4d8b7539fef7ba2c6c0ee0e2e46291f8574e"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208869","number":208869,"mergeCommit":{"message":"[Fleet] Improve reading package archive memory usage (#208869)\n\n## Summary\r\n\r\nRelated to https://github.com/elastic/kibana/issues/208210 \r\n\r\nAs we know the package size from the content-length header we can\r\nimprove how read the archive stream to a buffer.\r\n\r\n## Benchmark \r\n\r\n<img width=\"710\" alt=\"Screenshot 2025-01-29 at 9 23 59 PM\"\r\nsrc=\"https://github.com/user-attachments/assets/79dc1f20-938b-402e-a823-1ab26a07b78e\"\r\n/>","sha":"0a0a4d8b7539fef7ba2c6c0ee0e2e46291f8574e"}},{"branch":"8.17","label":"v8.17.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->