### PR TITLE
[index management] unskip api integration test

### DIFF
--- a/x-pack/test/api_integration/apis/management/index_management/settings.ts
+++ b/x-pack/test/api_integration/apis/management/index_management/settings.ts
@@ -15,8 +15,7 @@ export default function ({ getService }: FtrProviderContext) {
   const { createIndex, deleteAllIndices } = indicesHelpers(getService);
   const { getIndexSettings, updateIndexSettings } = settingsApi(getService);
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/208873
-  describe.skip('settings', () => {
+  describe('settings', () => {
     after(async () => await deleteAllIndices());
 
     it('should fetch an index settings', async () => {
@@ -48,7 +47,6 @@ export default function ({ getService }: FtrProviderContext) {
         'max_script_fields',
         'query',
         'format',
-        'frozen',
         'sort',
         'priority',
         'codec',


### PR DESCRIPTION
## Summary

This change follows from https://github.com/elastic/elasticsearch/pull/120539

'frozen' attribute will no longer be returned in 9.0 and greater since there are no longer frozen indices

Closes: https://github.com/elastic/kibana/issues/208873

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->