### PR TITLE
[Automatic Import] Fix missing ecs mappings

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/server/graphs/ecs/pipeline.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/graphs/ecs/pipeline.ts
@@ -153,7 +153,7 @@ function needsTypeConversion(sample: unknown, expected: KnownESType): boolean {
   return false;
 }
 
-function generateProcessors(
+export function generateProcessors(
   ecsMapping: object,
   samples: object,
   basePath: FieldPath = []

--- a/x-pack/platform/plugins/shared/automatic_import/server/graphs/ecs/pipeline.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/graphs/ecs/pipeline.ts
@@ -167,10 +167,9 @@ function generateProcessors(
 
   for (const [key, value] of Object.entries(ecsMapping)) {
     const currentPath = [...basePath, key];
-
-    if (value !== null && typeof value === 'object' && value?.target !== null) {
+    if (value !== null && !Array.isArray(value) && typeof value === 'object') {
       const valueKeys = new Set(Object.keys(value));
-      if ([...valueFieldKeys].every((k) => valueKeys.has(k))) {
+      if (value?.target != null && [...valueFieldKeys].every((k) => valueKeys.has(k))) {
         const processor = generateProcessor(
           currentPath,
           value as ECSField,


### PR DESCRIPTION
## Summary

Fix missing ecs mappings.

## Details

If the input is of a multilevel json where there were no ecs mappings identified on first level, For ex:

```
{
  okta_test: {
    audit: {
      actor: [Object],
      authenticationContext: [Object],
      client: [Object],
      debugContext: [Object],
      displayMessage: [Object],
      eventType: [Object],
      legacyEventType: null,
      outcome: [Object],
      published: [Object],
      request: [Object],
      securityContext: [Object],
      severity: [Object],
      target: null,
      transaction: [Object],
      uuid: [Object],
      version: null
    }
  }
}
```

Then there is no `target` field identified and an iteration is triggered to find the ecs mappings in the next level. Since there is no `target` identified the logic exited and further levels were skipped in identifying the mappings.

This PR fixes it and skips handling of Arrays since `rename` processor cannot flatten arrays on its own to map searchable fields. This will handled separately.



<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->