### PR TITLE
[EDR Workflows][8.19] Enable Endpoint data reduction banner feature flag

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -282,7 +282,7 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables banner for informing users about changes in data collection.
    */
-  eventCollectionDataReductionBannerEnabled: false,
+  eventCollectionDataReductionBannerEnabled: true,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;


### PR DESCRIPTION
## Summary

Enables feature flag `xpack.securitySolution.enableExperimental.eventCollectionDataReductionBannerEnabled` to show this:
![image](https://github.com/user-attachments/assets/2ca980c3-f040-4ccf-b86e-9b10c2594b30)

PR that adds (again) the banner:
- #205785
