### PR TITLE
[EDR Workflows] Debug failing vagrant task in Cypress test

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -2121,6 +2121,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     context?: RequestHandlerContext,
     request?: KibanaRequest
   ): Promise<void> {
+    const logger = appContextService.getLogger();
     const externalCallbacks = appContextService.getExternalCallbacks('packagePolicyPostDelete');
     const errorsThrown: Error[] = [];
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -2124,14 +2124,13 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     const logger = appContextService.getLogger();
     const externalCallbacks = appContextService.getExternalCallbacks('packagePolicyPostDelete');
     const errorsThrown: Error[] = [];
-
-    logger.warn('External callbacks', externalCallbacks);
+    logger.info(`External callbacks ${externalCallbacks}`);
     if (externalCallbacks && externalCallbacks.size > 0) {
       for (const callback of externalCallbacks) {
         // Failures from an external callback should not prevent other external callbacks from being
         // executed. Errors (if any) will be collected and `throw`n after processing the entire set
         try {
-          logger.warn('Deleted Policies try running callback', deletedPackagePolicies);
+          logger.info(`Deleted Policies try running callback ${deletedPackagePolicies}`);
           await callback(deletedPackagePolicies, soClient, esClient, context, request);
         } catch (error) {
           errorsThrown.push(error);

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -2125,13 +2125,13 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     const externalCallbacks = appContextService.getExternalCallbacks('packagePolicyPostDelete');
     const errorsThrown: Error[] = [];
 
-    logger.error('External callbacks', externalCallbacks);
+    logger.warn('External callbacks', externalCallbacks);
     if (externalCallbacks && externalCallbacks.size > 0) {
       for (const callback of externalCallbacks) {
         // Failures from an external callback should not prevent other external callbacks from being
         // executed. Errors (if any) will be collected and `throw`n after processing the entire set
         try {
-          logger.warning('Deleted Policies try running callback', deletedPackagePolicies);
+          logger.warn('Deleted Policies try running callback', deletedPackagePolicies);
           await callback(deletedPackagePolicies, soClient, esClient, context, request);
         } catch (error) {
           errorsThrown.push(error);

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -2124,11 +2124,13 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     const externalCallbacks = appContextService.getExternalCallbacks('packagePolicyPostDelete');
     const errorsThrown: Error[] = [];
 
+    logger.error('External callbacks', externalCallbacks);
     if (externalCallbacks && externalCallbacks.size > 0) {
       for (const callback of externalCallbacks) {
         // Failures from an external callback should not prevent other external callbacks from being
         // executed. Errors (if any) will be collected and `throw`n after processing the entire set
         try {
+          logger.warning('Deleted Policies try running callback', deletedPackagePolicies);
           await callback(deletedPackagePolicies, soClient, esClient, context, request);
         } catch (error) {
           errorsThrown.push(error);

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/response_actions/document_signing.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/response_actions/document_signing.cy.ts
@@ -22,6 +22,7 @@ import { enableAllPolicyProtections } from '../../tasks/endpoint_policy';
 import { createEndpointHost } from '../../tasks/create_endpoint_host';
 import { deleteAllLoadedEndpointData } from '../../tasks/delete_all_endpoint_data';
 
+// test
 describe('Document signing:', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
   let indexedPolicy: IndexedFleetEndpointPolicyResponse;
   let policy: PolicyData;

--- a/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vm_services.ts
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/endpoint/common/vm_services.ts
@@ -378,8 +378,14 @@ export const createVagrantHostVmClient = (
     let response;
     try {
       // Check for running Vagrant/Ruby processes before suspending
-      let vagrantProcesses = await execa.command(`ps aux | grep vagrant`, execaOptions);
-      let rubyProcesses = await execa.command(`ps aux | grep ruby`, execaOptions);
+      let vagrantProcesses = await execa.command(`ps -ef | grep vagrant`, {
+        ...execaOptions,
+        shell: true,
+      });
+      let rubyProcesses = await execa.command(`ps -ef | grep ruby`, {
+        ...execaOptions,
+        shell: true,
+      });
 
       log.warning(`Checking for running Vagrant processes:\n${vagrantProcesses.stdout}`);
       log.warning(`Checking for running Ruby processes:\n${rubyProcesses.stdout}`);
@@ -399,8 +405,11 @@ export const createVagrantHostVmClient = (
         await new Promise((resolve) => setTimeout(resolve, 5000)); // Wait 5 seconds before retrying
 
         // Check again after waiting
-        vagrantProcesses = await execa.command(`ps aux | grep vagrant`, execaOptions);
-        rubyProcesses = await execa.command(`ps aux | grep ruby`, execaOptions);
+        vagrantProcesses = await execa.command(`ps -ef | grep vagrant`, {
+          ...execaOptions,
+          shell: true,
+        });
+        rubyProcesses = await execa.command(`ps -ef | grep ruby`, { ...execaOptions, shell: true });
         retries++;
       }
 


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



