### PR TITLE
[8.18] [Response Ops][Cases] Functional tests checking cases view - alerts tab (#208964)

### DIFF
--- a/x-pack/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
@@ -32,6 +32,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
   const security = getPageObject('security');
   const kibanaServer = getService('kibanaServer');
   const browser = getService('browser');
+  const esArchiver = getService('esArchiver');
 
   const hasFocus = async (testSubject: string) => {
     const targetElement = await testSubjects.find(testSubject);
@@ -1071,6 +1072,48 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
           await cases.navigation.navigateToSingleCase('cases', theCase.id, 'fake');
           await testSubjects.existOrFail('case-view-tab-title-activity');
         });
+      });
+    });
+
+    describe('Tabs - alerts linked to case', () => {
+      before(async () => {
+        await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/rule_registry/alerts');
+        await cases.navigation.navigateToApp();
+        const theCase = await cases.api.createCase();
+        await cases.casesTable.waitForCasesToBeListed();
+        await retry.try(async () => {
+          await cases.api.createAttachment({
+            caseId: theCase.id,
+            params: {
+              type: AttachmentType.alert,
+              alertId: ['NoxgpHkBqbdrfX07MqXV'],
+              index: '.alerts-observability.apm.alerts',
+              rule: { id: 'id', name: 'name' },
+              owner: theCase.owner,
+            },
+          });
+        });
+      });
+
+      after(async () => {
+        await cases.api.deleteAllCases();
+        await esArchiver.unload('x-pack/test/functional/es_archives/rule_registry/alerts/');
+      });
+
+      beforeEach(async () => {
+        await cases.navigation.navigateToApp();
+        await cases.casesTable.goToFirstListedCase();
+        await header.waitUntilLoadingHasFinished();
+      });
+
+      it('should show the right amount of alerts linked to a case', async () => {
+        const visibleText = await testSubjects.getVisibleText('case-view-alerts-stats-badge');
+        expect(visibleText).to.be('1');
+      });
+
+      it('should render the alerts table when opening the alerts tab', async () => {
+        await testSubjects.click('case-view-tab-title-alerts');
+        await testSubjects.existOrFail('alertsStateTableEmptyState');
       });
     });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Response Ops][Cases] Functional tests checking cases view - alerts tab (#208964)](https://github.com/elastic/kibana/pull/208964)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julian Gernun","email":"17549662+jcger@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-31T13:00:57Z","message":"[Response Ops][Cases] Functional tests checking cases view - alerts tab (#208964)\n\n## Summary\n\nTests missing in https://github.com/elastic/kibana/pull/208672","sha":"b6939f1ddacff57c2d79cf74d761786ace35f239","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:prev-minor","backport:prev-major","v9.1.0"],"number":208964,"url":"https://github.com/elastic/kibana/pull/208964","mergeCommit":{"message":"[Response Ops][Cases] Functional tests checking cases view - alerts tab (#208964)\n\n## Summary\n\nTests missing in https://github.com/elastic/kibana/pull/208672","sha":"b6939f1ddacff57c2d79cf74d761786ace35f239"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","labelRegex":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208964","number":208964,"mergeCommit":{"message":"[Response Ops][Cases] Functional tests checking cases view - alerts tab (#208964)\n\n## Summary\n\nTests missing in https://github.com/elastic/kibana/pull/208672","sha":"b6939f1ddacff57c2d79cf74d761786ace35f239"}},{"url":"https://github.com/elastic/kibana/pull/209106","number":209106,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->