### PR TITLE
[Roles] Add appex-qa as co-codeowners to roles definition files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1589,6 +1589,9 @@ packages/kbn-monaco/src/esql @elastic/kibana-esql
 /.eslintignore @elastic/kibana-operations
 
 # QA - Appex QA
+/packages/kbn-es/src/serverless_resources/project_roles/es/roles.yml @elastic/appex-qa
+/packages/kbn-es/src/serverless_resources/project_roles/oblt/roles.yml @elastic/appex-qa
+/packages/kbn-es/src/serverless_resources/project_roles/security/roles.yml @elastic/appex-qa
 /x-pack/platform/plugins/shared/maps/ui_tests @elastic/appex-qa # temporarily
 /x-pack/platform/plugins/private/discover_enhanced/ui_tests/ @elastic/appex-qa # temporarily
 /x-pack/test/functional/fixtures/package_registry_config.yml @elastic/appex-qa # No usages found


### PR DESCRIPTION
## Summary

Often we've failures on the MKI FTR runs in Buildkite, that are due to our roles files being out of sync.

This is an attempt to get ahead of the problem, or to at least be notified that a change is coming.
