### PR TITLE
[SecuritySolution] Cold Frozen tier SearchStrategies

### DIFF
--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/schema.ts
@@ -126,6 +126,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'securitySolution:excludeColdAndFrozenTiersInEntityFlyout': {
+    type: 'boolean',
+    _meta: { description: 'Non-default value of setting.' },
+  },
   'securitySolution:enableCcsWarning': {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/management/types.ts
@@ -71,6 +71,7 @@ export interface UsageStats {
   'securitySolution:enableNewsFeed': boolean;
   'securitySolution:enableAssetCriticality': boolean;
   'securitySolution:excludeColdAndFrozenTiersInAnalyzer': boolean;
+  'securitySolution:excludeColdAndFrozenTiersInEntityFlyout': boolean;
   'securitySolution:enableCcsWarning': boolean;
   'securitySolution:enableVisualizationsInFlyout': boolean;
   'securitySolution:enableGraphVisualization': boolean;

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -10481,6 +10481,12 @@
             "description": "Non-default value of setting."
           }
         },
+        "securitySolution:excludeColdAndFrozenTiersInEntityFlyout": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Non-default value of setting."
+          }
+        },
         "securitySolution:enableCcsWarning": {
           "type": "boolean",
           "_meta": {

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -169,9 +169,8 @@ export const ENABLE_NEWS_FEED_SETTING = 'securitySolution:enableNewsFeed' as con
 export const EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ANALYZER =
   'securitySolution:excludeColdAndFrozenTiersInAnalyzer' as const;
 
-/** This Kibana Advanced Setting allows users to enable/disable querying cold and frozen data tiers in entity flyout */
-export const EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT =
-  'securitySolution:excludeColdAndFrozenTiersInEntityFlyout' as const;
+/** This Kibana Advanced Setting allows users to enable/disable querying cold and frozen data tiers */
+export const EXCLUDE_COLD_AND_FROZEN_TIERS = 'securitySolution:excludeColdAndFrozenTiers' as const;
 
 /** This Kibana Advanced Setting enables the warnings for CCS read permissions */
 export const ENABLE_CCS_READ_WARNING_SETTING = 'securitySolution:enableCcsWarning' as const;

--- a/x-pack/solutions/security/plugins/security_solution/common/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/constants.ts
@@ -169,6 +169,10 @@ export const ENABLE_NEWS_FEED_SETTING = 'securitySolution:enableNewsFeed' as con
 export const EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ANALYZER =
   'securitySolution:excludeColdAndFrozenTiersInAnalyzer' as const;
 
+/** This Kibana Advanced Setting allows users to enable/disable querying cold and frozen data tiers in entity flyout */
+export const EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT =
+  'securitySolution:excludeColdAndFrozenTiersInEntityFlyout' as const;
+
 /** This Kibana Advanced Setting enables the warnings for CCS read permissions */
 export const ENABLE_CCS_READ_WARNING_SETTING = 'securitySolution:enableCcsWarning' as const;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/__mocks__/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/all/__mocks__/index.ts
@@ -712,4 +712,5 @@ export const mockDeps = {
   savedObjectsClient: {} as SavedObjectsClientContract,
   endpointContext: createMockEndpointAppContext(),
   request: {} as KibanaRequest,
+  dsl: {} as SearchStrategyDependencies,
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/index.ts
@@ -7,7 +7,7 @@
 
 import { get } from 'lodash/fp';
 
-import type { IEsSearchResponse } from '@kbn/search-types';
+import type { IEsSearchResponse, ISearchRequestParams } from '@kbn/search-types';
 import type {
   IScopedClusterClient,
   KibanaRequest,
@@ -19,7 +19,6 @@ import type {
   HostsQueries,
   EndpointFields,
 } from '../../../../../../common/search_strategy/security_solution/hosts';
-
 import { inspectStringifyObject } from '../../../../../utils/build_query';
 import type { SecuritySolutionFactory } from '../../types';
 import { buildHostDetailsQuery } from './query.host_details.dsl';
@@ -27,7 +26,7 @@ import { formatHostItem, getHostEndpoint } from './helpers';
 import type { EndpointAppContext } from '../../../../../endpoint/types';
 
 export const hostDetails: SecuritySolutionFactory<HostsQueries.details> = {
-  buildDsl: (options) => buildHostDetailsQuery(options),
+  buildDsl: buildHostDetailsQuery,
   parse: async (
     options,
     response: IEsSearchResponse<HostAggEsData>,
@@ -36,12 +35,13 @@ export const hostDetails: SecuritySolutionFactory<HostsQueries.details> = {
       savedObjectsClient: SavedObjectsClientContract;
       endpointContext: EndpointAppContext;
       request: KibanaRequest;
+      dsl: ISearchRequestParams;
     }
   ): Promise<HostDetailsStrategyResponse> => {
     const aggregations = get('aggregations', response.rawResponse);
 
     const inspect = {
-      dsl: [inspectStringifyObject(buildHostDetailsQuery(options))],
+      dsl: [inspectStringifyObject(deps?.dsl)],
     };
 
     if (aggregations == null) {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/hosts/details/query.host_details.dsl.ts
@@ -7,21 +7,16 @@
 
 import type { ISearchRequestParams } from '@kbn/search-types';
 import { cloudFieldsMap, hostFieldsMap } from '@kbn/securitysolution-ecs';
-import type { SearchStrategyDependencies } from '@kbn/data-plugin/server';
 import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
-import { EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT } from '../../../../../../common/constants';
 import type { HostDetailsRequestOptions } from '../../../../../../common/search_strategy/security_solution';
 import { reduceFields } from '../../../../../utils/build_query/reduce_fields';
 import { HOST_DETAILS_FIELDS, buildFieldsTermAggregation } from './helpers';
+import type { SecuritySolutionSearchStrategyBuildDslDeps } from '../../types';
 
-export const buildHostDetailsQuery = async (
+export const buildHostDetailsQuery = (
   { hostName, defaultIndex, timerange: { from, to } }: HostDetailsRequestOptions,
-  deps?: SearchStrategyDependencies
-): Promise<ISearchRequestParams> => {
-  const isColdFrozenTierDisabled = await deps?.uiSettingsClient.get<boolean>(
-    EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT
-  );
-
+  deps: SecuritySolutionSearchStrategyBuildDslDeps
+): ISearchRequestParams => {
   const esFields = reduceFields(HOST_DETAILS_FIELDS, {
     ...hostFieldsMap,
     ...cloudFieldsMap,
@@ -40,16 +35,8 @@ export const buildHostDetailsQuery = async (
     },
   ];
 
-  if (isColdFrozenTierDisabled) {
-    filter.push({
-      bool: {
-        must_not: {
-          terms: {
-            _tier: ['data_frozen', 'data_cold'],
-          },
-        },
-      },
-    });
+  if (deps.coldFrozenTierFilter) {
+    filter.push(deps.coldFrozenTierFilter);
   }
 
   const dslQuery = {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/last_first_seen/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/last_first_seen/index.ts
@@ -20,10 +20,11 @@ import type { SecuritySolutionFactory } from '../types';
 import { buildFirstOrLastSeenQuery } from './query.first_or_last_seen.dsl';
 
 export const firstOrLastSeen: SecuritySolutionFactory<typeof FirstLastSeenQuery> = {
-  buildDsl: (options) => buildFirstOrLastSeenQuery(options),
+  buildDsl: buildFirstOrLastSeenQuery,
   parse: async (
     options,
-    response: IEsSearchResponse<unknown>
+    response: IEsSearchResponse<unknown>,
+    deps
   ): Promise<FirstLastSeenStrategyResponse> => {
     firstLastSeenRequestOptionsSchema.parse(options);
 
@@ -35,7 +36,7 @@ export const firstOrLastSeen: SecuritySolutionFactory<typeof FirstLastSeenQuery>
     );
 
     const inspect = {
-      dsl: [inspectStringifyObject(buildFirstOrLastSeenQuery(options))],
+      dsl: [inspectStringifyObject(deps?.dsl)],
     };
 
     const { order } = options;

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/last_first_seen/query.first_or_last_seen.dsl.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/last_first_seen/query.first_or_last_seen.dsl.ts
@@ -8,11 +8,19 @@
 import type { FirstLastSeenRequestOptions } from '../../../../../common/api/search_strategy';
 
 import { createQueryFilterClauses } from '../../../../utils/build_query';
+import type { SecuritySolutionSearchStrategyBuildDslDeps } from '../types';
 
-export const buildFirstOrLastSeenQuery = (options: FirstLastSeenRequestOptions) => {
+export const buildFirstOrLastSeenQuery = (
+  options: FirstLastSeenRequestOptions,
+  deps: SecuritySolutionSearchStrategyBuildDslDeps
+) => {
   const { field, value, defaultIndex, order, filterQuery } = options;
 
   const filter = [...createQueryFilterClauses(filterQuery), { term: { [field]: value } }];
+
+  if (deps.coldFrozenTierFilter) {
+    filter.push(deps.coldFrozenTierFilter);
+  }
 
   const dslQuery = {
     allow_no_indices: true,

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/services/observed_details/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/services/observed_details/index.ts
@@ -16,15 +16,16 @@ import type { ObservedServiceDetailsStrategyResponse } from '../../../../../../c
 import { formatServiceItem } from './helpers';
 
 export const observedServiceDetails: SecuritySolutionFactory<ServicesQueries.observedDetails> = {
-  buildDsl: (options) => buildObservedServiceDetailsQuery(options),
+  buildDsl: buildObservedServiceDetailsQuery,
   parse: async (
     options,
-    response: IEsSearchResponse<unknown>
+    response: IEsSearchResponse<unknown>,
+    deps
   ): Promise<ObservedServiceDetailsStrategyResponse> => {
     const aggregations = response.rawResponse.aggregations;
 
     const inspect = {
-      dsl: [inspectStringifyObject(buildObservedServiceDetailsQuery(options))],
+      dsl: [inspectStringifyObject(deps?.dsl)],
     };
 
     if (aggregations == null) {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
@@ -12,7 +12,7 @@ import type {
 } from '@kbn/core/server';
 import type { IEsSearchResponse, ISearchRequestParams } from '@kbn/search-types';
 import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
-import type { SearchStrategyDependencies } from '@kbn/data-plugin/server';
+import type { QueryDslQueryContainer } from '@kbn/data-views-plugin/common/types';
 import type {
   FactoryQueryTypes,
   StrategyRequestType,
@@ -20,11 +20,14 @@ import type {
 } from '../../../../common/search_strategy/security_solution';
 import type { EndpointAppContext } from '../../../endpoint/types';
 
+export interface SecuritySolutionSearchStrategyBuildDslDeps {
+  coldFrozenTierFilter: QueryDslQueryContainer | undefined;
+}
 export interface SecuritySolutionFactory<T extends FactoryQueryTypes> {
   buildDsl: (
     options: StrategyRequestType<T>,
-    deps?: SearchStrategyDependencies
-  ) => ISearchRequestParams | Promise<ISearchRequestParams>;
+    deps: SecuritySolutionSearchStrategyBuildDslDeps
+  ) => ISearchRequestParams;
   parse: (
     options: StrategyRequestType<T>,
     response: IEsSearchResponse,

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/types.ts
@@ -12,6 +12,7 @@ import type {
 } from '@kbn/core/server';
 import type { IEsSearchResponse, ISearchRequestParams } from '@kbn/search-types';
 import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
+import type { SearchStrategyDependencies } from '@kbn/data-plugin/server';
 import type {
   FactoryQueryTypes,
   StrategyRequestType,
@@ -20,7 +21,10 @@ import type {
 import type { EndpointAppContext } from '../../../endpoint/types';
 
 export interface SecuritySolutionFactory<T extends FactoryQueryTypes> {
-  buildDsl: (options: StrategyRequestType<T>) => ISearchRequestParams;
+  buildDsl: (
+    options: StrategyRequestType<T>,
+    deps?: SearchStrategyDependencies
+  ) => ISearchRequestParams | Promise<ISearchRequestParams>;
   parse: (
     options: StrategyRequestType<T>,
     response: IEsSearchResponse,
@@ -31,6 +35,7 @@ export interface SecuritySolutionFactory<T extends FactoryQueryTypes> {
       request: KibanaRequest;
       spaceId?: string;
       ruleDataClient?: IRuleDataClient | null;
+      dsl: ISearchRequestParams;
     }
   ) => Promise<StrategyResponseType<T>>;
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/index.ts
@@ -16,15 +16,16 @@ import type { ObservedUserDetailsStrategyResponse } from '../../../../../../comm
 import { formatUserItem } from './helpers';
 
 export const observedUserDetails: SecuritySolutionFactory<UsersQueries.observedDetails> = {
-  buildDsl: (options) => buildObservedUserDetailsQuery(options),
+  buildDsl: buildObservedUserDetailsQuery,
   parse: async (
     options,
-    response: IEsSearchResponse<unknown>
+    response: IEsSearchResponse<unknown>,
+    deps
   ): Promise<ObservedUserDetailsStrategyResponse> => {
     const aggregations = response.rawResponse.aggregations;
 
     const inspect = {
-      dsl: [inspectStringifyObject(buildObservedUserDetailsQuery(options))],
+      dsl: [inspectStringifyObject(deps?.dsl)],
     };
 
     if (aggregations == null) {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.ts
@@ -7,17 +7,26 @@
 
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { ISearchRequestParams } from '@kbn/search-types';
+import type { SearchStrategyDependencies } from '@kbn/data-plugin/server';
+import { EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT } from '../../../../../../common/constants';
 import type { ObservedUserDetailsRequestOptions } from '../../../../../../common/api/search_strategy';
 import { createQueryFilterClauses } from '../../../../../utils/build_query';
 import { buildFieldsTermAggregation } from '../../hosts/details/helpers';
 import { USER_FIELDS } from './helpers';
 
-export const buildObservedUserDetailsQuery = ({
-  userName,
-  defaultIndex,
-  timerange: { from, to },
-  filterQuery,
-}: ObservedUserDetailsRequestOptions): ISearchRequestParams => {
+export const buildObservedUserDetailsQuery = async (
+  {
+    userName,
+    defaultIndex,
+    timerange: { from, to },
+    filterQuery,
+  }: ObservedUserDetailsRequestOptions,
+  deps?: SearchStrategyDependencies
+): Promise<ISearchRequestParams> => {
+  const isColdFrozenTierDisabled = await deps?.uiSettingsClient.get<boolean>(
+    EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT
+  );
+
   const filter: QueryDslQueryContainer[] = [
     ...createQueryFilterClauses(filterQuery),
     { term: { 'user.name': userName } },
@@ -31,6 +40,18 @@ export const buildObservedUserDetailsQuery = ({
       },
     },
   ];
+
+  if (isColdFrozenTierDisabled) {
+    filter.push({
+      bool: {
+        must_not: {
+          terms: {
+            _tier: ['data_frozen', 'data_cold'],
+          },
+        },
+      },
+    });
+  }
 
   const dslQuery = {
     allow_no_indices: true,

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/factory/users/observed_details/query.observed_user_details.dsl.ts
@@ -7,26 +7,21 @@
 
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { ISearchRequestParams } from '@kbn/search-types';
-import type { SearchStrategyDependencies } from '@kbn/data-plugin/server';
-import { EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT } from '../../../../../../common/constants';
 import type { ObservedUserDetailsRequestOptions } from '../../../../../../common/api/search_strategy';
 import { createQueryFilterClauses } from '../../../../../utils/build_query';
 import { buildFieldsTermAggregation } from '../../hosts/details/helpers';
 import { USER_FIELDS } from './helpers';
+import type { SecuritySolutionSearchStrategyBuildDslDeps } from '../../types';
 
-export const buildObservedUserDetailsQuery = async (
+export const buildObservedUserDetailsQuery = (
   {
     userName,
     defaultIndex,
     timerange: { from, to },
     filterQuery,
   }: ObservedUserDetailsRequestOptions,
-  deps?: SearchStrategyDependencies
-): Promise<ISearchRequestParams> => {
-  const isColdFrozenTierDisabled = await deps?.uiSettingsClient.get<boolean>(
-    EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT
-  );
-
+  deps: SecuritySolutionSearchStrategyBuildDslDeps
+): ISearchRequestParams => {
   const filter: QueryDslQueryContainer[] = [
     ...createQueryFilterClauses(filterQuery),
     { term: { 'user.name': userName } },
@@ -41,16 +36,8 @@ export const buildObservedUserDetailsQuery = async (
     },
   ];
 
-  if (isColdFrozenTierDisabled) {
-    filter.push({
-      bool: {
-        must_not: {
-          terms: {
-            _tier: ['data_frozen', 'data_cold'],
-          },
-        },
-      },
-    });
+  if (deps.coldFrozenTierFilter) {
+    filter.push(deps.coldFrozenTierFilter);
   }
 
   const dslQuery = {

--- a/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/search_strategy/security_solution/index.ts
@@ -13,7 +13,7 @@ import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import { ENHANCED_ES_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
 import type { z } from '@kbn/zod';
 import type { ISearchRequestParams } from '@kbn/search-types';
-import { EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT } from '../../../common/constants';
+import { EXCLUDE_COLD_AND_FROZEN_TIERS } from '../../../common/constants';
 import { searchStrategyRequestSchema } from '../../../common/api/search_strategy';
 import { securitySolutionFactory } from './factory';
 import type { EndpointAppContext } from '../../endpoint/types';
@@ -47,7 +47,7 @@ export const securitySolutionSearchStrategyProvider = (
 
       // Provide the ability to exclude cold and frozen tiers
       const dslPromise: Promise<ISearchRequestParams> = deps?.uiSettingsClient
-        .get<boolean>(EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT)
+        .get<boolean>(EXCLUDE_COLD_AND_FROZEN_TIERS)
         .then((excludeColdFrozenTier) => {
           return queryFactory.buildDsl(parsedRequest, {
             coldFrozenTierFilter: excludeColdFrozenTier

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -42,6 +42,7 @@ import {
   EXCLUDED_DATA_TIERS_FOR_RULE_EXECUTION,
   ENABLE_VISUALIZATIONS_IN_FLYOUT_SETTING,
   ENABLE_GRAPH_VISUALIZATION_SETTING,
+  EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT,
 } from '../common/constants';
 import type { ExperimentalFeatures } from '../common/experimental_features';
 import { LogLevelSetting } from '../common/api/detection_engine/rule_monitoring';
@@ -199,6 +200,27 @@ export const initUiSettings = (
         {
           defaultMessage:
             '<p>When enabled, cold and frozen tiers will be skipped in analyzer queries</p>',
+          values: { p: (chunks) => `<p>${chunks}</p>` },
+        }
+      ),
+      type: 'boolean',
+      category: [APP_ID],
+      requiresPageReload: true,
+      schema: schema.boolean(),
+    },
+    [EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT]: {
+      name: i18n.translate(
+        'xpack.securitySolution.uiSettings.excludeColdAndFrozenTiersInEntityFlyout',
+        {
+          defaultMessage: 'Exclude cold and frozen tiers in Entity Flyout',
+        }
+      ),
+      value: true,
+      description: i18n.translate(
+        'xpack.securitySolution.uiSettings.excludeColdAndFrozenTiersInEntityFlyoutDescription',
+        {
+          defaultMessage:
+            '<p>When enabled, cold and frozen tiers will be skipped in entity flyout queries</p>',
           values: { p: (chunks) => `<p>${chunks}</p>` },
         }
       ),

--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -42,7 +42,7 @@ import {
   EXCLUDED_DATA_TIERS_FOR_RULE_EXECUTION,
   ENABLE_VISUALIZATIONS_IN_FLYOUT_SETTING,
   ENABLE_GRAPH_VISUALIZATION_SETTING,
-  EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT,
+  EXCLUDE_COLD_AND_FROZEN_TIERS,
 } from '../common/constants';
 import type { ExperimentalFeatures } from '../common/experimental_features';
 import { LogLevelSetting } from '../common/api/detection_engine/rule_monitoring';
@@ -208,19 +208,18 @@ export const initUiSettings = (
       requiresPageReload: true,
       schema: schema.boolean(),
     },
-    [EXCLUDE_COLD_AND_FROZEN_TIERS_IN_ENTITY_FLYOUT]: {
+    [EXCLUDE_COLD_AND_FROZEN_TIERS]: {
       name: i18n.translate(
         'xpack.securitySolution.uiSettings.excludeColdAndFrozenTiersInEntityFlyout',
         {
-          defaultMessage: 'Exclude cold and frozen tiers in Entity Flyout',
+          defaultMessage: 'Exclude cold and frozen tiers',
         }
       ),
       value: true,
       description: i18n.translate(
         'xpack.securitySolution.uiSettings.excludeColdAndFrozenTiersInEntityFlyoutDescription',
         {
-          defaultMessage:
-            '<p>When enabled, cold and frozen tiers will be skipped in entity flyout queries</p>',
+          defaultMessage: '<p>When enabled, cold and frozen tiers will be skipped</p>',
           values: { p: (chunks) => `<p>${chunks}</p>` },
         }
       ),


### PR DESCRIPTION
## Summary

POC on how to add the cold/frozen filter to search strategies.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



