### PR TITLE
[Fleet] Include removed agent policies agent count in confirm modal multiple integration policies

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.test.tsx
@@ -13,7 +13,6 @@ import { createFleetTestRendererMock } from '../../../../../mock';
 
 import {
   useUIExtension,
-  sendGetAgentStatus,
   sendGetOneAgentPolicy,
   sendGetOnePackagePolicy,
   sendUpgradePackagePolicyDryRun,
@@ -24,6 +23,7 @@ import {
   useGetAgentPolicies,
   useMultipleAgentPolicies,
   useGetPackagePolicies,
+  sendBulkGetAgentPoliciesForRq,
 } from '../../../hooks';
 import { useGetOnePackagePolicy } from '../../../../integrations/hooks';
 
@@ -44,6 +44,7 @@ jest.mock('../../../hooks', () => {
   return {
     ...jest.requireActual('../../../hooks'),
     sendGetAgentStatus: jest.fn(),
+    sendBulkGetAgentPoliciesForRq: jest.fn(),
     sendUpdatePackagePolicy: jest.fn(),
     sendGetOnePackagePolicy: jest.fn(),
     sendGetOneAgentPolicy: jest.fn(),
@@ -261,7 +262,7 @@ describe('edit package policy page', () => {
     (sendUpdatePackagePolicy as MockFn).mockResolvedValue({});
     (useStartServices().application.navigateToUrl as MockFn).mockReset();
     (useStartServices().notifications.toasts.addError as MockFn).mockReset();
-    (sendGetAgentStatus as MockFn).mockResolvedValue({ data: { results: { total: 0 } } });
+    (sendBulkGetAgentPoliciesForRq as MockFn).mockResolvedValue({ data: [] });
     (sendBulkGetAgentPolicies as MockFn).mockResolvedValue({
       data: { items: [{ id: 'agent-policy-1', name: 'Agent policy 1' }] },
     });
@@ -477,7 +478,7 @@ describe('edit package policy page', () => {
   });
 
   it('should not show confirmation modal if package is on agentless policy', async () => {
-    (sendGetAgentStatus as MockFn).mockResolvedValue({ data: { results: { total: 1 } } });
+    (sendBulkGetAgentPoliciesForRq as MockFn).mockResolvedValue({ data: [{ agents: 1 }] });
     (useGetOnePackagePolicy as MockFn).mockReturnValue({
       data: {
         item: mockPackagePolicyAgentless,
@@ -529,8 +530,8 @@ describe('edit package policy page', () => {
     beforeEach(() => {
       useMultipleAgentPoliciesMock.mockReturnValue({ canUseMultipleAgentPolicies: true });
 
-      (sendGetAgentStatus as jest.MockedFunction<any>).mockResolvedValue({
-        data: { results: { total: 0 } },
+      (sendBulkGetAgentPoliciesForRq as jest.MockedFunction<any>).mockResolvedValue({
+        data: [],
       });
       jest.clearAllMocks();
     });
@@ -569,7 +570,6 @@ describe('edit package policy page', () => {
             policy_ids: ['agent-policy-1', 'agent-policy-2'],
           })
         );
-        expect(sendGetAgentStatus).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_request/agent_policy.ts
@@ -85,6 +85,18 @@ export const sendBulkGetAgentPolicies = (
   });
 };
 
+export const sendBulkGetAgentPoliciesForRq = (
+  ids: string[],
+  options?: { full?: boolean; ignoreMissing?: boolean }
+) => {
+  return sendRequestForRq<BulkGetAgentPoliciesResponse>({
+    path: agentPolicyRouteService.getBulkGetPath(),
+    method: 'post',
+    body: JSON.stringify({ ids, full: options?.full, ignoreMissing: options?.ignoreMissing }),
+    version: API_VERSIONS.public.v1,
+  });
+};
+
 export const sendGetAgentPolicies = (query?: GetAgentPoliciesRequest['query']) => {
   return sendRequest<GetAgentPoliciesResponse>({
     path: agentPolicyRouteService.getListPath(),


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/kibana/issues/196795

Include removed agent policies agent count in the confirm modal  agent impacted count.

I am wondering if at some point we should simplify that confirm modal and if there is so much value to display agent counts here.

## Tests

With an integration with two agent policies test1 and test2 with agents in only test1

Removing test1 should show a confirm modal with the agent count.

<img width="1124" alt="Screenshot 2025-01-31 at 10 15 53 AM" src="https://github.com/user-attachments/assets/ba91ced6-7812-48c5-8339-8cbde863bcc1" />


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->