### PR TITLE
Revert "[SKIP ON MKI] 4 files from .../security/common_configs/config.group5"

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/discover/group1/_discover.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/group1/_discover.ts
@@ -32,8 +32,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   };
 
   describe('discover test', function describeIndexTests() {
-    // see details: https://github.com/elastic/kibana/issues/208982
-    this.tags(['failsOnMKI']);
     before(async function () {
       log.debug('load kibana index with default index pattern');
       await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/discover');

--- a/x-pack/test_serverless/functional/test_suites/common/discover/group2/_data_grid_doc_table.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/group2/_data_grid_doc_table.ts
@@ -33,8 +33,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const security = getService('security');
 
   describe('discover data grid doc table', function describeIndexTests() {
-    // see details: https://github.com/elastic/kibana/issues/208982
-    this.tags(['failsOnMKI']);
     before(async function () {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       log.debug('load kibana index with default index pattern');

--- a/x-pack/test_serverless/functional/test_suites/common/discover/group4/_adhoc_data_views.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/group4/_adhoc_data_views.ts
@@ -41,8 +41,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   };
 
   describe('adhoc data views', function () {
-    // see details: https://github.com/elastic/kibana/issues/208982
-    this.tags(['failsOnMKI']);
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await kibanaServer.importExport.load('test/functional/fixtures/kbn_archiver/discover.json');

--- a/x-pack/test_serverless/functional/test_suites/common/discover/group6/_unsaved_changes_badge.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/group6/_unsaved_changes_badge.ts
@@ -32,8 +32,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   };
 
   describe('discover unsaved changes badge', function describeIndexTests() {
-    // see details: https://github.com/elastic/kibana/issues/208982
-    this.tags(['failsOnMKI']);
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');


### PR DESCRIPTION
## Summary

This reverts commit ff0781834cc654012c990ed7d0133c98a574916b.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)