### PR TITLE
chore(NA): skip x-pack/solutions/security/plugins/security_solution/public/management cypress e2e tests

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -76,8 +76,10 @@ export const getCypressBaseConfig = (
       e2e: {
         // baseUrl: To override, set Env. variable `CYPRESS_BASE_URL`
         baseUrl: 'http://localhost:5601',
-        supportFile: 'public/management/cypress/support/e2e.ts',
-        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+        supportFile: '',
+        specPattern: '',
+        // supportFile: 'public/management/cypress/support/e2e.ts',
+        // specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -76,10 +76,9 @@ export const getCypressBaseConfig = (
       e2e: {
         // baseUrl: To override, set Env. variable `CYPRESS_BASE_URL`
         baseUrl: 'http://localhost:5601',
-        supportFile: '',
-        specPattern: '',
-        // supportFile: 'public/management/cypress/support/e2e.ts',
-        // specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+        supportFile: 'public/management/cypress/support/e2e.ts',
+        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+        excludeSpecPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -77,8 +77,8 @@ export const getCypressBaseConfig = (
         // baseUrl: To override, set Env. variable `CYPRESS_BASE_URL`
         baseUrl: 'http://localhost:5601',
         supportFile: 'public/management/cypress/support/e2e.ts',
-        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
-        excludeSpecPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+        specPattern: 'public/management/cypress/e2e/serverless/*.cy.{js,jsx,ts,tsx}',
+        // specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,


### PR DESCRIPTION
This PR skips Defend Workflows test suites to unblock main.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->