### PR TITLE
test fix core migrations cluster routing allocation v9

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group3/incompatible_cluster_routing_allocation.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group3/incompatible_cluster_routing_allocation.test.ts
@@ -34,7 +34,7 @@ const { startES } = createTestServers({
   settings: {
     es: {
       license: 'basic',
-      dataArchive: Path.join(__dirname, '..', 'archives', '8.4.0_with_sample_data_logs.zip'),
+      dataArchive: Path.join(__dirname, '..', 'archives', '8.18_with_sample_data_logs.zip'),
     },
   },
 });
@@ -92,8 +92,7 @@ async function updateRoutingAllocations(
   });
 }
 
-// FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/158318
-describe.skip('incompatible_cluster_routing_allocation', () => {
+describe('incompatible_cluster_routing_allocation', () => {
   let client: ElasticsearchClient;
   let root: Root;
 


### PR DESCRIPTION
part of https://github.com/elastic/kibana/issues/158318 (v9)

Updates data archive for cluster routing allocation integration test for v9


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



