### PR TITLE
[EEM] Add limits to ES|QL queries

### DIFF
--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/v2/definitions/source_definition.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/v2/definitions/source_definition.ts
@@ -46,7 +46,7 @@ export async function storeSourceDefinition({
 
   const sources = await runESQLQuery('fetch source definition for conflict check', {
     esClient,
-    query: `FROM ${DEFINITIONS_ALIAS} METADATA _id | WHERE definition_type == "source" AND _id == "${source.type_id}:${source.id}" | KEEP _id`,
+    query: `FROM ${DEFINITIONS_ALIAS} METADATA _id | WHERE definition_type == "source" AND _id == "${source.type_id}:${source.id}" | KEEP _id | LIMIT 1000`,
     logger,
   });
 
@@ -88,7 +88,7 @@ export async function readSourceDefinitions(
     'fetch all source definitions',
     {
       esClient,
-      query: `FROM ${DEFINITIONS_ALIAS} METADATA _source | WHERE definition_type == "source" ${typeFilter} | KEEP _source`,
+      query: `FROM ${DEFINITIONS_ALIAS} METADATA _source | WHERE definition_type == "source" ${typeFilter} | KEEP _source | LIMIT 1000`,
       logger,
     }
   );

--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/v2/definitions/type_definition.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/v2/definitions/type_definition.ts
@@ -29,7 +29,7 @@ export async function storeTypeDefinition({
 
   const types = await runESQLQuery('fetch type definition for conflict check', {
     esClient,
-    query: `FROM ${DEFINITIONS_ALIAS} METADATA _id | WHERE definition_type == "type" AND _id == "${type.id}" | KEEP _id`,
+    query: `FROM ${DEFINITIONS_ALIAS} METADATA _id | WHERE definition_type == "type" AND _id == "${type.id}" | KEEP _id | LIMIT 1000`,
     logger,
   });
 
@@ -65,7 +65,7 @@ export async function readTypeDefinitions(
     'fetch all type definitions',
     {
       esClient,
-      query: `FROM ${DEFINITIONS_ALIAS} METADATA _source | WHERE definition_type == "type" | KEEP _source`,
+      query: `FROM ${DEFINITIONS_ALIAS} METADATA _source | WHERE definition_type == "type" | KEEP _source | LIMIT 1000`,
       logger,
     }
   );
@@ -84,7 +84,7 @@ export async function readTypeDefinitionById(
     'fetch type definition by ID',
     {
       esClient,
-      query: `FROM ${DEFINITIONS_ALIAS} METADATA _id,_source | WHERE definition_type == "type" AND _id == "${id}" | KEEP _source`,
+      query: `FROM ${DEFINITIONS_ALIAS} METADATA _id,_source | WHERE definition_type == "type" AND _id == "${id}" | KEEP _source | LIMIT 1000`,
       logger,
     }
   );

--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/v2/queries/entity_count.test.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/v2/queries/entity_count.test.ts
@@ -26,7 +26,9 @@ describe('getEntityCountQuery', () => {
       end: '2024-11-20T20:00:00.000Z',
     });
 
-    expect(query).toEqual('FROM logs-* | STATS BY service.name::keyword | STATS count = COUNT()');
+    expect(query).toEqual(
+      'FROM logs-* | STATS BY service.name::keyword | STATS count = COUNT() | LIMIT 1000'
+    );
 
     expect(filter).toEqual({
       bool: {
@@ -147,7 +149,8 @@ describe('getEntityCountQuery', () => {
         'EVAL entity.id = CASE(is_source_0, service_name::keyword, is_source_1, service.name::keyword) | ' +
         'WHERE entity.id IS NOT NULL | ' +
         'STATS BY entity.id | ' +
-        'STATS count = COUNT()'
+        'STATS count = COUNT() | ' +
+        'LIMIT 1000'
     );
 
     expect(filter).toEqual({

--- a/x-pack/platform/plugins/shared/entity_manager/server/lib/v2/queries/entity_count.ts
+++ b/x-pack/platform/plugins/shared/entity_manager/server/lib/v2/queries/entity_count.ts
@@ -129,6 +129,7 @@ export function getEntityCountQuery({
     idEvalCommand({ sources }),
     whereCommand({ sources }),
     statsCommand({ sources }),
+    `LIMIT 1000`,
   ]);
 
   const filter = dslFilter({ sources, filters, start, end });


### PR DESCRIPTION
To suppress deprecation warnings in Kibana logs.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->