### PR TITLE
SKA: Flag `@kbn/observability-synthetics-test-data` as devOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1467,6 +1467,7 @@
     "@kbn/manifest": "link:packages/kbn-manifest",
     "@kbn/mock-idp-plugin": "link:packages/kbn-mock-idp-plugin",
     "@kbn/mock-idp-utils": "link:packages/kbn-mock-idp-utils",
+    "@kbn/observability-synthetics-test-data": "link:x-pack/solutions/observability/packages/synthetics_test_data",
     "@kbn/openapi-bundler": "link:packages/kbn-openapi-bundler",
     "@kbn/openapi-generator": "link:packages/kbn-openapi-generator",
     "@kbn/optimizer": "link:packages/kbn-optimizer",

--- a/package.json
+++ b/package.json
@@ -708,7 +708,6 @@
     "@kbn/observability-onboarding-plugin": "link:x-pack/solutions/observability/plugins/observability_onboarding",
     "@kbn/observability-plugin": "link:x-pack/solutions/observability/plugins/observability",
     "@kbn/observability-shared-plugin": "link:x-pack/solutions/observability/plugins/observability_shared",
-    "@kbn/observability-synthetics-test-data": "link:x-pack/solutions/observability/packages/synthetics_test_data",
     "@kbn/observability-utils-browser": "link:x-pack/solutions/observability/packages/utils_browser",
     "@kbn/observability-utils-common": "link:x-pack/solutions/observability/packages/utils_common",
     "@kbn/observability-utils-server": "link:x-pack/solutions/observability/packages/utils_server",

--- a/x-pack/solutions/observability/packages/synthetics_test_data/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/synthetics_test_data/kibana.jsonc
@@ -3,5 +3,6 @@
   "id": "@kbn/observability-synthetics-test-data",
   "owner": "@elastic/obs-ux-management-team",
   "group": "observability",
-  "visibility": "private"
+  "visibility": "private",
+  "devOnly": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6576,6 +6576,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/observability-synthetics-test-data@link:x-pack/solutions/observability/packages/synthetics_test_data":
+  version "0.0.0"
+  uid ""
+
 "@kbn/observability-utils-browser@link:x-pack/solutions/observability/packages/utils_browser":
   version "0.0.0"
   uid ""

--- a/yarn.lock
+++ b/yarn.lock
@@ -6576,10 +6576,6 @@
   version "0.0.0"
   uid ""
 
-"@kbn/observability-synthetics-test-data@link:x-pack/solutions/observability/packages/synthetics_test_data":
-  version "0.0.0"
-  uid ""
-
 "@kbn/observability-utils-browser@link:x-pack/solutions/observability/packages/utils_browser":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
## Summary

This package relies on devOnly packages, thus it must be devOnly too.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->