### PR TITLE
[8.x] Add message in ua linking to deprecated debug logs docs (#208806)

### DIFF
--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
@@ -33,6 +33,7 @@ export const getIsAccessApiDeprecation = ({
 export const buildApiAccessDeprecationDetails = ({
   apiUsageStats,
   deprecatedApiDetails,
+  docLinks,
 }: BuildApiDeprecationDetailsParams): DomainDeprecationDetails<ApiDeprecationDetails> => {
   const { apiId, apiTotalCalls, totalMarkedAsResolved } = apiUsageStats;
   const { routeVersion, routePath, routeDeprecationOptions, routeMethod } = deprecatedApiDetails;
@@ -43,7 +44,7 @@ export const buildApiAccessDeprecationDetails = ({
     apiId,
     title: getApiDeprecationTitle(deprecatedApiDetails),
     level: deprecationLevel,
-    message: getApiDeprecationMessage(deprecatedApiDetails, apiUsageStats),
+    message: getApiDeprecationMessage(deprecatedApiDetails, apiUsageStats, docLinks),
     documentationUrl: routeDeprecationOptions?.documentationUrl,
     correctiveActions: {
       manualSteps: getApiDeprecationsManualSteps(),

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/register_api_depercation_info.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/register_api_depercation_info.ts
@@ -15,7 +15,11 @@ import { buildApiDeprecationId } from './api_deprecation_id';
 import type { ApiDeprecationsServiceDeps } from './types';
 
 export const createGetApiDeprecations =
-  ({ http, coreUsageData }: Pick<ApiDeprecationsServiceDeps, 'coreUsageData' | 'http'>) =>
+  ({
+    http,
+    coreUsageData,
+    docLinks,
+  }: Pick<ApiDeprecationsServiceDeps, 'coreUsageData' | 'http' | 'docLinks'>) =>
   async (): Promise<DeprecationsDetails[]> => {
     const usageClient = coreUsageData.getClient();
     const deprecatedApis = http.getRegisteredDeprecatedApis();
@@ -43,6 +47,7 @@ export const createGetApiDeprecations =
             return buildApiRouteDeprecationDetails({
               apiUsageStats,
               deprecatedApiDetails,
+              docLinks,
             });
           }
           // if no access is specified then internal is the default
@@ -51,6 +56,7 @@ export const createGetApiDeprecations =
             return buildApiAccessDeprecationDetails({
               apiUsageStats,
               deprecatedApiDetails,
+              docLinks,
             });
           }
         }
@@ -61,10 +67,11 @@ export const registerApiDeprecationsInfo = ({
   deprecationsFactory,
   http,
   coreUsageData,
+  docLinks,
 }: ApiDeprecationsServiceDeps): void => {
   const deprecationsRegistery = deprecationsFactory.getRegistry('core.api_deprecations');
 
   deprecationsRegistery.registerDeprecations({
-    getDeprecations: createGetApiDeprecations({ http, coreUsageData }),
+    getDeprecations: createGetApiDeprecations({ http, coreUsageData, docLinks }),
   });
 };

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/route_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/route_deprecations.ts
@@ -33,6 +33,7 @@ export const getIsRouteApiDeprecation = ({
 export const buildApiRouteDeprecationDetails = ({
   apiUsageStats,
   deprecatedApiDetails,
+  docLinks,
 }: BuildApiDeprecationDetailsParams): DomainDeprecationDetails<ApiDeprecationDetails> => {
   const { apiId, apiTotalCalls, totalMarkedAsResolved } = apiUsageStats;
   const { routeVersion, routePath, routeDeprecationOptions, routeMethod } = deprecatedApiDetails;
@@ -46,7 +47,7 @@ export const buildApiRouteDeprecationDetails = ({
     apiId,
     title: getApiDeprecationTitle(deprecatedApiDetails),
     level: deprecationLevel,
-    message: getApiDeprecationMessage(deprecatedApiDetails, apiUsageStats),
+    message: getApiDeprecationMessage(deprecatedApiDetails, apiUsageStats, docLinks),
     documentationUrl: routeDeprecationOptions.documentationUrl,
     correctiveActions: {
       manualSteps: getApiDeprecationsManualSteps(deprecatedApiDetails),

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/types.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/types.ts
@@ -11,15 +11,18 @@ import type { InternalHttpServiceSetup } from '@kbn/core-http-server-internal';
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { RouterDeprecatedApiDetails } from '@kbn/core-http-server';
 import type { CoreDeprecatedApiUsageStats } from '@kbn/core-usage-data-server';
+import { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import type { DeprecationsFactory } from '../../deprecations_factory';
 
 export interface ApiDeprecationsServiceDeps {
   deprecationsFactory: DeprecationsFactory;
   http: InternalHttpServiceSetup;
   coreUsageData: InternalCoreUsageDataSetup;
+  docLinks: DocLinksServiceSetup;
 }
 
 export interface BuildApiDeprecationDetailsParams {
   apiUsageStats: CoreDeprecatedApiUsageStats;
   deprecatedApiDetails: RouterDeprecatedApiDetails;
+  docLinks: DocLinksServiceSetup;
 }

--- a/src/core/packages/deprecations/server-internal/src/deprecations_service.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_service.test.ts
@@ -18,6 +18,8 @@ import { coreUsageDataServiceMock } from '@kbn/core-usage-data-server-mocks';
 import { configServiceMock } from '@kbn/config-mocks';
 import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
 import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { docLinksServiceMock } from '@kbn/core-doc-links-server-mocks';
+import type { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import { DeprecationsService, DeprecationsSetupDeps } from './deprecations_service';
 import { firstValueFrom } from 'rxjs';
 
@@ -37,7 +39,8 @@ describe('DeprecationsService', () => {
     coreUsageData = coreUsageDataServiceMock.createSetupContract();
     router = httpServiceMock.createRouter();
     http.createRouter.mockReturnValue(router);
-    deprecationsCoreSetupDeps = { http, coreUsageData, logging: loggingMock };
+    const docLinks: DocLinksServiceSetup = docLinksServiceMock.createSetupContract();
+    deprecationsCoreSetupDeps = { http, coreUsageData, logging: loggingMock, docLinks };
   });
 
   afterEach(() => {

--- a/src/core/packages/deprecations/server-internal/src/deprecations_service.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_service.ts
@@ -22,6 +22,7 @@ import type {
 import { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import { type InternalLoggingServiceSetup } from '@kbn/core-logging-server-internal';
+import { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import { DeprecationsFactory } from './deprecations_factory';
 import { registerRoutes } from './routes';
 import { config as deprecationConfig, DeprecationConfigType } from './deprecation_config';
@@ -51,6 +52,7 @@ export interface DeprecationsSetupDeps {
   http: InternalHttpServiceSetup;
   coreUsageData: InternalCoreUsageDataSetup;
   logging: InternalLoggingServiceSetup;
+  docLinks: DocLinksServiceSetup;
 }
 
 /** @internal */
@@ -70,6 +72,7 @@ export class DeprecationsService
     http,
     coreUsageData,
     logging,
+    docLinks,
   }: DeprecationsSetupDeps): Promise<InternalDeprecationsServiceSetup> {
     this.logger.debug('Setting up Deprecations service');
 
@@ -106,6 +109,7 @@ export class DeprecationsService
       deprecationsFactory: this.deprecationsFactory,
       http,
       coreUsageData,
+      docLinks,
     });
 
     const deprecationsFactory = this.deprecationsFactory;

--- a/src/core/packages/deprecations/server-internal/tsconfig.json
+++ b/src/core/packages/deprecations/server-internal/tsconfig.json
@@ -39,6 +39,8 @@
     "@kbn/core-usage-data-server-mocks",
     "@kbn/core-http-router-server-internal",
     "@kbn/core-logging-server-internal",
+    "@kbn/core-doc-links-server",
+    "@kbn/core-doc-links-server-mocks",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/root/server-internal/src/server.ts
+++ b/src/core/packages/root/server-internal/src/server.ts
@@ -308,6 +308,7 @@ export class Server {
       http: httpSetup,
       coreUsageData: coreUsageDataSetup,
       logging: loggingSetup,
+      docLinks: docLinksSetup,
     });
 
     const savedObjectsSetup = await this.savedObjects.setup({

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -480,6 +480,9 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       ruleApiOverview: `${SECURITY_SOLUTION_DOCS}rule-api-overview.html`,
       configureAlertSuppression: `${SECURITY_SOLUTION_DOCS}alert-suppression.html#_configure_alert_suppression`,
     },
+    logging: {
+      enableDeprecationHttpDebugLogs: `${KIBANA_DOCS}logging-settings.html#enable-http-debug-logs`,
+    },
     securitySolution: {
       artifactControl: `${SECURITY_SOLUTION_DOCS}artifact-control.html`,
       avcResults: `${ELASTIC_WEBSITE_URL}blog/elastic-security-av-comparatives-business-test`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -342,6 +342,9 @@ export interface DocLinks {
     readonly ruleApiOverview: string;
     readonly configureAlertSuppression: string;
   };
+  readonly logging: {
+    readonly enableDeprecationHttpDebugLogs: string;
+  };
   readonly securitySolution: {
     readonly aiAssistant: string;
     readonly artifactControl: string;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add message in ua linking to deprecated debug logs docs (#208806)](https://github.com/elastic/kibana/pull/208806)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jesus Wahrman","email":"41008968+jesuswr@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-31T11:57:25Z","message":"Add message in ua linking to deprecated debug logs docs (#208806)\n\n## Summary\r\n\r\nResolves https://github.com/elastic/kibana/issues/208570\r\n\r\nAdd a message in UA with a link to the new config that enables debug\r\nlogs when a deprecated API is called.\r\n\r\n<img width=\"485\" alt=\"Screenshot 2025-01-29 at 17 16 33\"\r\nsrc=\"https://github.com/user-attachments/assets/ce796b38-c7af-4f0c-bcca-74512c909208\"\r\n/>\r\n\r\nTo try this you can call a deprecated API and look for the warnings in\r\nUA.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: florent-leborgne <florent.leborgne@elastic.co>","sha":"5774e8d402756a040037134c341b94d2dacd56ce","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:http","release_note:skip","deprecation_warnings","v9.0.0","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"Add message in ua linking to deprecated debug logs docs","number":208806,"url":"https://github.com/elastic/kibana/pull/208806","mergeCommit":{"message":"Add message in ua linking to deprecated debug logs docs (#208806)\n\n## Summary\r\n\r\nResolves https://github.com/elastic/kibana/issues/208570\r\n\r\nAdd a message in UA with a link to the new config that enables debug\r\nlogs when a deprecated API is called.\r\n\r\n<img width=\"485\" alt=\"Screenshot 2025-01-29 at 17 16 33\"\r\nsrc=\"https://github.com/user-attachments/assets/ce796b38-c7af-4f0c-bcca-74512c909208\"\r\n/>\r\n\r\nTo try this you can call a deprecated API and look for the warnings in\r\nUA.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: florent-leborgne <florent.leborgne@elastic.co>","sha":"5774e8d402756a040037134c341b94d2dacd56ce"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209094","number":209094,"state":"MERGED","mergeCommit":{"sha":"5ea7caa457d8633fa384b57bb98949d21c525145","message":"[9.0] Add message in ua linking to deprecated debug logs docs (#208806) (#209094)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [Add message in ua linking to deprecated debug logs docs\n(#208806)](https://github.com/elastic/kibana/pull/208806)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jesus\nWahrman\",\"email\":\"41008968+jesuswr@users.noreply.github.com\"},\"sourceCommit\":{\"committedDate\":\"2025-01-31T11:57:25Z\",\"message\":\"Add\nmessage in ua linking to deprecated debug logs docs (#208806)\\n\\n##\nSummary\\r\\n\\r\\nResolves\nhttps://github.com/elastic/kibana/issues/208570\\r\\n\\r\\nAdd a message in\nUA with a link to the new config that enables debug\\r\\nlogs when a\ndeprecated API is called.\\r\\n\\r\\n<img width=\\\"485\\\" alt=\\\"Screenshot\n2025-01-29 at 17 16\n33\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/ce796b38-c7af-4f0c-bcca-74512c909208\\\"\\r\\n/>\\r\\n\\r\\nTo\ntry this you can call a deprecated API and look for the warnings\nin\\r\\nUA.\\r\\n\\r\\n### Checklist\\r\\n\\r\\nCheck the PR satisfies following\nconditions. \\r\\n\\r\\nReviewers should verify this PR satisfies this list\nas well.\\r\\n\\r\\n- [x] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\\r\\n-\n[x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [x] This was\nchecked for breaking HTTP API changes, and any breaking\\r\\nchanges have\nbeen approved by the breaking-change committee.\nThe\\r\\n`release_note:breaking` label should be applied in these\nsituations.\\r\\n- [x] The PR description includes the appropriate Release\nNotes section,\\r\\nand the correct `release_note:*` label is applied per\nthe\\r\\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\\r\\n\\r\\n###\nIdentify risks\\r\\n\\r\\nDoes this PR introduce any risks? For example,\nconsider risks like hard\\r\\nto test bugs, performance regression,\npotential of data loss.\\r\\n\\r\\nDescribe the risk, its severity, and\nmitigation for each identified\\r\\nrisk. Invite stakeholders and evaluate\nhow to proceed before merging.\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\\r\\nCo-authored-by:\nflorent-leborgne\n<florent.leborgne@elastic.co>\",\"sha\":\"5774e8d402756a040037134c341b94d2dacd56ce\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Feature:http\",\"release_note:skip\",\"deprecation_warnings\",\"v9.0.0\",\"backport:version\",\"v8.18.0\",\"v9.1.0\",\"v8.19.0\"],\"title\":\"Add\nmessage in ua linking to deprecated debug logs\ndocs\",\"number\":208806,\"url\":\"https://github.com/elastic/kibana/pull/208806\",\"mergeCommit\":{\"message\":\"Add\nmessage in ua linking to deprecated debug logs docs (#208806)\\n\\n##\nSummary\\r\\n\\r\\nResolves\nhttps://github.com/elastic/kibana/issues/208570\\r\\n\\r\\nAdd a message in\nUA with a link to the new config that enables debug\\r\\nlogs when a\ndeprecated API is called.\\r\\n\\r\\n<img width=\\\"485\\\" alt=\\\"Screenshot\n2025-01-29 at 17 16\n33\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/ce796b38-c7af-4f0c-bcca-74512c909208\\\"\\r\\n/>\\r\\n\\r\\nTo\ntry this you can call a deprecated API and look for the warnings\nin\\r\\nUA.\\r\\n\\r\\n### Checklist\\r\\n\\r\\nCheck the PR satisfies following\nconditions. \\r\\n\\r\\nReviewers should verify this PR satisfies this list\nas well.\\r\\n\\r\\n- [x] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\\r\\n-\n[x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [x] This was\nchecked for breaking HTTP API changes, and any breaking\\r\\nchanges have\nbeen approved by the breaking-change committee.\nThe\\r\\n`release_note:breaking` label should be applied in these\nsituations.\\r\\n- [x] The PR description includes the appropriate Release\nNotes section,\\r\\nand the correct `release_note:*` label is applied per\nthe\\r\\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\\r\\n\\r\\n###\nIdentify risks\\r\\n\\r\\nDoes this PR introduce any risks? For example,\nconsider risks like hard\\r\\nto test bugs, performance regression,\npotential of data loss.\\r\\n\\r\\nDescribe the risk, its severity, and\nmitigation for each identified\\r\\nrisk. Invite stakeholders and evaluate\nhow to proceed before merging.\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\\r\\nCo-authored-by:\nflorent-leborgne\n<florent.leborgne@elastic.co>\",\"sha\":\"5774e8d402756a040037134c341b94d2dacd56ce\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"9.0\",\"8.18\",\"8.x\"],\"targetPullRequestStates\":[{\"branch\":\"9.0\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.18\",\"label\":\"v8.18.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/208806\",\"number\":208806,\"mergeCommit\":{\"message\":\"Add\nmessage in ua linking to deprecated debug logs docs (#208806)\\n\\n##\nSummary\\r\\n\\r\\nResolves\nhttps://github.com/elastic/kibana/issues/208570\\r\\n\\r\\nAdd a message in\nUA with a link to the new config that enables debug\\r\\nlogs when a\ndeprecated API is called.\\r\\n\\r\\n<img width=\\\"485\\\" alt=\\\"Screenshot\n2025-01-29 at 17 16\n33\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/ce796b38-c7af-4f0c-bcca-74512c909208\\\"\\r\\n/>\\r\\n\\r\\nTo\ntry this you can call a deprecated API and look for the warnings\nin\\r\\nUA.\\r\\n\\r\\n### Checklist\\r\\n\\r\\nCheck the PR satisfies following\nconditions. \\r\\n\\r\\nReviewers should verify this PR satisfies this list\nas well.\\r\\n\\r\\n- [x] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\\r\\n-\n[x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [x] This was\nchecked for breaking HTTP API changes, and any breaking\\r\\nchanges have\nbeen approved by the breaking-change committee.\nThe\\r\\n`release_note:breaking` label should be applied in these\nsituations.\\r\\n- [x] The PR description includes the appropriate Release\nNotes section,\\r\\nand the correct `release_note:*` label is applied per\nthe\\r\\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\\r\\n\\r\\n###\nIdentify risks\\r\\n\\r\\nDoes this PR introduce any risks? For example,\nconsider risks like hard\\r\\nto test bugs, performance regression,\npotential of data loss.\\r\\n\\r\\nDescribe the risk, its severity, and\nmitigation for each identified\\r\\nrisk. Invite stakeholders and evaluate\nhow to proceed before merging.\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\\r\\nCo-authored-by:\nflorent-leborgne\n<florent.leborgne@elastic.co>\",\"sha\":\"5774e8d402756a040037134c341b94d2dacd56ce\"}},{\"branch\":\"8.x\",\"label\":\"v8.19.0\",\"branchLabelMappingKey\":\"^v8.19.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Jesus Wahrman <41008968+jesuswr@users.noreply.github.com>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208806","number":208806,"mergeCommit":{"message":"Add message in ua linking to deprecated debug logs docs (#208806)\n\n## Summary\r\n\r\nResolves https://github.com/elastic/kibana/issues/208570\r\n\r\nAdd a message in UA with a link to the new config that enables debug\r\nlogs when a deprecated API is called.\r\n\r\n<img width=\"485\" alt=\"Screenshot 2025-01-29 at 17 16 33\"\r\nsrc=\"https://github.com/user-attachments/assets/ce796b38-c7af-4f0c-bcca-74512c909208\"\r\n/>\r\n\r\nTo try this you can call a deprecated API and look for the warnings in\r\nUA.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: florent-leborgne <florent.leborgne@elastic.co>","sha":"5774e8d402756a040037134c341b94d2dacd56ce"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->