### PR TITLE
[8.17] [Synthetics] Fix monitor status rule for empty kql query results !! (#208922)

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/server/alert_rules/status_rule/queries/filter_monitors.test.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/alert_rules/status_rule/queries/filter_monitors.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getFilters } from './filter_monitors';
+
+describe('getFilters', () => {
+  it('returns an empty array when all parameters are empty', () => {
+    const ruleParams = { monitorTypes: [], locations: [], tags: [], projects: [] };
+    expect(getFilters(ruleParams)).toEqual([]);
+  });
+
+  it('creates a terms filter for monitorTypes', () => {
+    const ruleParams = { monitorTypes: ['http', 'tcp'], locations: [], tags: [], projects: [] };
+    expect(getFilters(ruleParams)).toEqual([{ terms: { 'monitor.type': ['http', 'tcp'] } }]);
+  });
+
+  it('creates a terms filter for locations', () => {
+    const ruleParams = {
+      monitorTypes: [],
+      locations: ['us-east', 'us-west'],
+      tags: [],
+      projects: [],
+    };
+    expect(getFilters(ruleParams)).toEqual([
+      { terms: { 'observer.name': ['us-east', 'us-west'] } },
+    ]);
+  });
+
+  it('creates a bool must filter for tags', () => {
+    const ruleParams = { monitorTypes: [], locations: [], tags: ['tag1', 'tag2'], projects: [] };
+    expect(getFilters(ruleParams)).toEqual([
+      {
+        terms: { tags: ['tag1', 'tag2'] },
+      },
+    ]);
+  });
+
+  it('creates a terms filter for projects', () => {
+    const ruleParams = { monitorTypes: [], locations: [], tags: [], projects: ['proj1', 'proj2'] };
+    expect(getFilters(ruleParams)).toEqual([
+      { terms: { 'monitor.project.id': ['proj1', 'proj2'] } },
+    ]);
+  });
+
+  it('handles all filters together', () => {
+    const ruleParams = {
+      monitorTypes: ['http'],
+      locations: ['us-east'],
+      tags: ['tag1', 'tag2'],
+      projects: ['proj1'],
+    };
+    expect(getFilters(ruleParams)).toEqual([
+      { terms: { 'monitor.type': ['http'] } },
+      { terms: { 'observer.name': ['us-east'] } },
+      {
+        terms: { tags: ['tag1', 'tag2'] },
+      },
+      { terms: { 'monitor.project.id': ['proj1'] } },
+    ]);
+  });
+
+  it('ignores undefined fields', () => {
+    const ruleParams = {
+      monitorTypes: undefined,
+      locations: undefined,
+      tags: undefined,
+      projects: undefined,
+    };
+    expect(getFilters(ruleParams)).toEqual([]);
+  });
+
+  it('ignores empty values in an otherwise valid object', () => {
+    const ruleParams = { monitorTypes: [], locations: ['us-east'], tags: [], projects: [] };
+    expect(getFilters(ruleParams)).toEqual([{ terms: { 'observer.name': ['us-east'] } }]);
+  });
+});

--- a/x-pack/plugins/observability_solution/synthetics/server/alert_rules/status_rule/queries/filter_monitors.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/alert_rules/status_rule/queries/filter_monitors.ts
@@ -65,7 +65,7 @@ export async function queryFilterMonitors({
   return result.aggregations?.ids.buckets.map((bucket) => bucket.key as string);
 }
 
-const getFilters = (ruleParams: StatusRuleParams) => {
+export const getFilters = (ruleParams: StatusRuleParams) => {
   const { monitorTypes, locations, tags, projects } = ruleParams;
   const filters: QueryDslQueryContainer[] = [];
   if (monitorTypes?.length) {

--- a/x-pack/plugins/observability_solution/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
@@ -109,6 +109,11 @@ export class StatusRuleExecutor {
       ruleParams: this.params,
     });
 
+    if (this.params.kqlQuery && isEmpty(configIds)) {
+      this.debug(`No monitor found with the given KQL query ${this.params.kqlQuery}`);
+      return processMonitors([]);
+    }
+
     const { filtersStr } = parseArrayFilters({
       configIds,
       filter: baseFilter,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Synthetics] Fix monitor status rule for empty kql query results !! (#208922)](https://github.com/elastic/kibana/pull/208922)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2025-01-31T17:45:41Z","message":"[Synthetics] Fix monitor status rule for empty kql query results !! (#208922)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/208915 !!\n\nFix monitor status rule for empty kql query results !!\n\n1. Made sure if kql filter return no configs ids, rule break early to\nnot cover all monitors\n\n### Testing\n\nCreate a synthetics rule with a kql filter which matches no monitors and\nmake sure rule doesn't trigger for other down monitors in the system\n<img width=\"661\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ed0b3a1f-e8d1-4e22-a77d-1237ce557ac5\"\n/>\n\n\n### Before\n\nCreate a rule and you can observe that rule would get triggered for all\nmonitors down in the system with matching condition criteria","sha":"5c350b4492afaf04cdc103ce237fc579224e652d","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-major","Team:obs-ux-management","v8.18.0","v9.1.0"],"title":"[Synthetics] Fix monitor status rule for empty kql query results !!","number":208922,"url":"https://github.com/elastic/kibana/pull/208922","mergeCommit":{"message":"[Synthetics] Fix monitor status rule for empty kql query results !! (#208922)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/208915 !!\n\nFix monitor status rule for empty kql query results !!\n\n1. Made sure if kql filter return no configs ids, rule break early to\nnot cover all monitors\n\n### Testing\n\nCreate a synthetics rule with a kql filter which matches no monitors and\nmake sure rule doesn't trigger for other down monitors in the system\n<img width=\"661\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ed0b3a1f-e8d1-4e22-a77d-1237ce557ac5\"\n/>\n\n\n### Before\n\nCreate a rule and you can observe that rule would get triggered for all\nmonitors down in the system with matching condition criteria","sha":"5c350b4492afaf04cdc103ce237fc579224e652d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209155","number":209155,"state":"MERGED","mergeCommit":{"sha":"db7d058f44bcb14d5c729a7665c524ea4794cf9b","message":"[8.18] [Synthetics] Fix monitor status rule for empty kql query results !! (#208922) (#209155)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Synthetics] Fix monitor status rule for empty kql query results !!\n(#208922)](https://github.com/elastic/kibana/pull/208922)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT\n[{\"author\":{\"name\":\"Shahzad\",\"email\":\"shahzad31comp@gmail.com\"},\"sourceCommit\":{\"committedDate\":\"2025-01-31T17:45:41Z\",\"message\":\"[Synthetics]\nFix monitor status rule for empty kql query results !! (#208922)\\n\\n##\nSummary\\n\\nFixes https://github.com/elastic/kibana/issues/208915\n!!\\n\\nFix monitor status rule for empty kql query results !!\\n\\n1. Made\nsure if kql filter return no configs ids, rule break early to\\nnot cover\nall monitors\\n\\n### Testing\\n\\nCreate a synthetics rule with a kql\nfilter which matches no monitors and\\nmake sure rule doesn't trigger for\nother down monitors in the system\\n<img width=\\\"661\\\"\nalt=\\\"image\\\"\\nsrc=\\\"https://github.com/user-attachments/assets/ed0b3a1f-e8d1-4e22-a77d-1237ce557ac5\\\"\\n/>\\n\\n\\n###\nBefore\\n\\nCreate a rule and you can observe that rule would get\ntriggered for all\\nmonitors down in the system with matching condition\ncriteria\",\"sha\":\"5c350b4492afaf04cdc103ce237fc579224e652d\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:fix\",\"backport:prev-major\",\"Team:obs-ux-management\",\"v9.1.0\"],\"title\":\"[Synthetics]\nFix monitor status rule for empty kql query results\n!!\",\"number\":208922,\"url\":\"https://github.com/elastic/kibana/pull/208922\",\"mergeCommit\":{\"message\":\"[Synthetics]\nFix monitor status rule for empty kql query results !! (#208922)\\n\\n##\nSummary\\n\\nFixes https://github.com/elastic/kibana/issues/208915\n!!\\n\\nFix monitor status rule for empty kql query results !!\\n\\n1. Made\nsure if kql filter return no configs ids, rule break early to\\nnot cover\nall monitors\\n\\n### Testing\\n\\nCreate a synthetics rule with a kql\nfilter which matches no monitors and\\nmake sure rule doesn't trigger for\nother down monitors in the system\\n<img width=\\\"661\\\"\nalt=\\\"image\\\"\\nsrc=\\\"https://github.com/user-attachments/assets/ed0b3a1f-e8d1-4e22-a77d-1237ce557ac5\\\"\\n/>\\n\\n\\n###\nBefore\\n\\nCreate a rule and you can observe that rule would get\ntriggered for all\\nmonitors down in the system with matching condition\ncriteria\",\"sha\":\"5c350b4492afaf04cdc103ce237fc579224e652d\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/208922\",\"number\":208922,\"mergeCommit\":{\"message\":\"[Synthetics]\nFix monitor status rule for empty kql query results !! (#208922)\\n\\n##\nSummary\\n\\nFixes https://github.com/elastic/kibana/issues/208915\n!!\\n\\nFix monitor status rule for empty kql query results !!\\n\\n1. Made\nsure if kql filter return no configs ids, rule break early to\\nnot cover\nall monitors\\n\\n### Testing\\n\\nCreate a synthetics rule with a kql\nfilter which matches no monitors and\\nmake sure rule doesn't trigger for\nother down monitors in the system\\n<img width=\\\"661\\\"\nalt=\\\"image\\\"\\nsrc=\\\"https://github.com/user-attachments/assets/ed0b3a1f-e8d1-4e22-a77d-1237ce557ac5\\\"\\n/>\\n\\n\\n###\nBefore\\n\\nCreate a rule and you can observe that rule would get\ntriggered for all\\nmonitors down in the system with matching condition\ncriteria\",\"sha\":\"5c350b4492afaf04cdc103ce237fc579224e652d\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208922","number":208922,"mergeCommit":{"message":"[Synthetics] Fix monitor status rule for empty kql query results !! (#208922)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/208915 !!\n\nFix monitor status rule for empty kql query results !!\n\n1. Made sure if kql filter return no configs ids, rule break early to\nnot cover all monitors\n\n### Testing\n\nCreate a synthetics rule with a kql filter which matches no monitors and\nmake sure rule doesn't trigger for other down monitors in the system\n<img width=\"661\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ed0b3a1f-e8d1-4e22-a77d-1237ce557ac5\"\n/>\n\n\n### Before\n\nCreate a rule and you can observe that rule would get triggered for all\nmonitors down in the system with matching condition criteria","sha":"5c350b4492afaf04cdc103ce237fc579224e652d"}},{"url":"https://github.com/elastic/kibana/pull/209156","number":209156,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->