### PR TITLE
[Snapshot and restore] Avoid duplicated error messages

### DIFF
--- a/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/validate_schemas.ts
+++ b/x-pack/platform/plugins/private/snapshot_restore/server/routes/api/validate_schemas.ts
@@ -65,30 +65,12 @@ export const policySchema = schema.object({
 // Only validate required settings, everything else is optional
 const fsRepositorySettings = schema.object({ location: schema.string() }, { unknowns: 'allow' });
 
-const fsRepositorySchema = schema.object({
-  name: schema.string({ maxLength: 1000 }),
-  type: schema.string(),
-  settings: fsRepositorySettings,
-});
-
 const readOnlyRepositorySettings = schema.object({
   url: schema.string(),
 });
 
-const readOnlyRepository = schema.object({
-  name: schema.string({ maxLength: 1000 }),
-  type: schema.string(),
-  settings: readOnlyRepositorySettings,
-});
-
 // Only validate required settings, everything else is optional
 const s3RepositorySettings = schema.object({ bucket: schema.string() }, { unknowns: 'allow' });
-
-const s3Repository = schema.object({
-  name: schema.string({ maxLength: 1000 }),
-  type: schema.string(),
-  settings: s3RepositorySettings,
-});
 
 // Only validate required settings, everything else is optional
 const hdsRepositorySettings = schema.object(
@@ -99,30 +81,27 @@ const hdsRepositorySettings = schema.object(
   { unknowns: 'allow' }
 );
 
-const hdsfRepository = schema.object({
-  name: schema.string({ maxLength: 1000 }),
-  type: schema.string(),
-  settings: hdsRepositorySettings,
-});
-
 const azureRepositorySettings = schema.object({}, { unknowns: 'allow' });
-
-const azureRepository = schema.object({
-  name: schema.string({ maxLength: 1000 }),
-  type: schema.string(),
-  settings: azureRepositorySettings,
-});
 
 // Only validate required settings, everything else is optional
 const gcsRepositorySettings = schema.object({ bucket: schema.string() }, { unknowns: 'allow' });
 
-const gcsRepository = schema.object({
-  name: schema.string({ maxLength: 1000 }),
-  type: schema.string(),
-  settings: gcsRepositorySettings,
-});
+const sourceRepositorySettings = schema.oneOf([
+  fsRepositorySettings,
+  readOnlyRepositorySettings,
+  s3RepositorySettings,
+  hdsRepositorySettings,
+  azureRepositorySettings,
+  gcsRepositorySettings,
+  schema.object(
+    {
+      delegateType: schema.string(),
+    },
+    { unknowns: 'allow' }
+  ),
+]);
 
-const sourceRepository = schema.object({
+export const repositorySchema = schema.object({
   name: schema.string({ maxLength: 1000 }),
   type: schema.string(),
   settings: schema.oneOf([
@@ -132,24 +111,9 @@ const sourceRepository = schema.object({
     hdsRepositorySettings,
     azureRepositorySettings,
     gcsRepositorySettings,
-    schema.object(
-      {
-        delegateType: schema.string(),
-      },
-      { unknowns: 'allow' }
-    ),
+    sourceRepositorySettings,
   ]),
 });
-
-export const repositorySchema = schema.oneOf([
-  fsRepositorySchema,
-  readOnlyRepository,
-  sourceRepository,
-  s3Repository,
-  hdsfRepository,
-  azureRepository,
-  gcsRepository,
-]);
 
 export const restoreSettingsSchema = schema.object({
   indices: schema.maybe(schema.oneOf([schema.string(), schema.arrayOf(schema.string())])),


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/187065

## Summary
In the repository creation endpoint, when the validation failed, we were showing duplicated errors. This was caused by how the validation schema was build. This PR refactors the duplication schema so it doesn't duplicate the nama field.

### How to test

* RunES with yarn es snapshot --license=trial -E path.repo=/tmp/es-backups
* Navigate to repos list and try creating a new repo
* Fill the name input with an string longer than 1000 chars.
* Verify the error message when saving the repo is not duplicated

### Screenshot
<img width="1032" alt="Screenshot 2025-02-03 at 15 24 27" src="https://github.com/user-attachments/assets/75231f68-a13e-44bf-8d8a-be488c9f25e5" />





<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->