### PR TITLE
[DataDiscovery] Replace useEuiBackgroundColor with color tokens

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/__snapshots__/use_comparison_css.test.ts.snap
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/__snapshots__/use_comparison_css.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`useComparisonCss should render with basic diff mode and diff decorations 1`] = `
 Object {
   "map": undefined,
-  "name": "1qc86qa",
+  "name": "14zju9t",
   "next": undefined,
   "styles": "
     .unifiedDataTable__cellValue {
@@ -15,7 +15,7 @@ Object {
     }
 
     .unifiedDataTable__comparisonBaseDocCell {
-      background-color: rgba(211,218,230,0.2);
+      background-color: #f7f8fc;
     }
 
     
@@ -63,7 +63,7 @@ Object {
 exports[`useComparisonCss should render with basic diff mode and no diff decorations 1`] = `
 Object {
   "map": undefined,
-  "name": "1qc86qa",
+  "name": "14zju9t",
   "next": undefined,
   "styles": "
     .unifiedDataTable__cellValue {
@@ -75,7 +75,7 @@ Object {
     }
 
     .unifiedDataTable__comparisonBaseDocCell {
-      background-color: rgba(211,218,230,0.2);
+      background-color: #f7f8fc;
     }
 
     
@@ -123,7 +123,7 @@ Object {
 exports[`useComparisonCss should render with chars diff mode and diff decorations 1`] = `
 Object {
   "map": undefined,
-  "name": "vd39me",
+  "name": "15v0erc",
   "next": undefined,
   "styles": "
     .unifiedDataTable__cellValue {
@@ -135,7 +135,7 @@ Object {
     }
 
     .unifiedDataTable__comparisonBaseDocCell {
-      background-color: rgba(211,218,230,0.2);
+      background-color: #f7f8fc;
     }
 
     
@@ -173,7 +173,7 @@ Object {
 exports[`useComparisonCss should render with chars diff mode and no diff decorations 1`] = `
 Object {
   "map": undefined,
-  "name": "1ylxgdl",
+  "name": "z8l3vw",
   "next": undefined,
   "styles": "
     .unifiedDataTable__cellValue {
@@ -185,7 +185,7 @@ Object {
     }
 
     .unifiedDataTable__comparisonBaseDocCell {
-      background-color: rgba(211,218,230,0.2);
+      background-color: #f7f8fc;
     }
 
     
@@ -215,7 +215,7 @@ Object {
 exports[`useComparisonCss should render with lines diff mode and diff decorations 1`] = `
 Object {
   "map": undefined,
-  "name": "1nu19hw",
+  "name": "jvfp05",
   "next": undefined,
   "styles": "
     .unifiedDataTable__cellValue {
@@ -227,7 +227,7 @@ Object {
     }
 
     .unifiedDataTable__comparisonBaseDocCell {
-      background-color: rgba(211,218,230,0.2);
+      background-color: #f7f8fc;
     }
 
     
@@ -293,7 +293,7 @@ Object {
 exports[`useComparisonCss should render with lines diff mode and no diff decorations 1`] = `
 Object {
   "map": undefined,
-  "name": "1mthx0u",
+  "name": "trn277",
   "next": undefined,
   "styles": "
     .unifiedDataTable__cellValue {
@@ -305,7 +305,7 @@ Object {
     }
 
     .unifiedDataTable__comparisonBaseDocCell {
-      background-color: rgba(211,218,230,0.2);
+      background-color: #f7f8fc;
     }
 
     
@@ -341,7 +341,7 @@ Object {
 exports[`useComparisonCss should render with no diff mode and no diff decorations 1`] = `
 Object {
   "map": undefined,
-  "name": "1ylxgdl",
+  "name": "z8l3vw",
   "next": undefined,
   "styles": "
     .unifiedDataTable__cellValue {
@@ -353,7 +353,7 @@ Object {
     }
 
     .unifiedDataTable__comparisonBaseDocCell {
-      background-color: rgba(211,218,230,0.2);
+      background-color: #f7f8fc;
     }
 
     
@@ -383,7 +383,7 @@ Object {
 exports[`useComparisonCss should render with words diff mode and diff decorations 1`] = `
 Object {
   "map": undefined,
-  "name": "vd39me",
+  "name": "15v0erc",
   "next": undefined,
   "styles": "
     .unifiedDataTable__cellValue {
@@ -395,7 +395,7 @@ Object {
     }
 
     .unifiedDataTable__comparisonBaseDocCell {
-      background-color: rgba(211,218,230,0.2);
+      background-color: #f7f8fc;
     }
 
     
@@ -433,7 +433,7 @@ Object {
 exports[`useComparisonCss should render with words diff mode and no diff decorations 1`] = `
 Object {
   "map": undefined,
-  "name": "1ylxgdl",
+  "name": "z8l3vw",
   "next": undefined,
   "styles": "
     .unifiedDataTable__cellValue {
@@ -445,7 +445,7 @@ Object {
     }
 
     .unifiedDataTable__comparisonBaseDocCell {
-      background-color: rgba(211,218,230,0.2);
+      background-color: #f7f8fc;
     }
 
     

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_css.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_css.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { useEuiBackgroundColor, useEuiTheme } from '@elastic/eui';
+import { useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { CELL_CLASS } from '../../../utils/get_render_cell_value';
 import { DocumentDiffMode } from '../types';
@@ -28,9 +28,9 @@ export const useComparisonCss = ({
   showDiffDecorations?: boolean;
 }) => {
   const { euiTheme } = useEuiTheme();
-  const baseCellBackgroundColor = useEuiBackgroundColor('subdued', { method: 'transparent' });
-  const matchSegmentBackgroundColor = useEuiBackgroundColor('success');
-  const diffSegmentBackgroundColor = useEuiBackgroundColor('danger');
+  const baseCellBackgroundColor = euiTheme.colors.backgroundBaseSubdued;
+  const matchSegmentBackgroundColor = euiTheme.colors.backgroundBaseSuccess;
+  const diffSegmentBackgroundColor = euiTheme.colors.backgroundBaseDanger;
 
   const indicatorCss = css`
     position: absolute;

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.tsx
@@ -14,8 +14,8 @@ import {
   EuiPageBody,
   EuiPanel,
   EuiProgress,
-  useEuiBackgroundColor,
   EuiDelayRender,
+  useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -77,7 +77,8 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
     ebtManager,
     fieldsMetadata,
   } = useDiscoverServices();
-  const pageBackgroundColor = useEuiBackgroundColor('plain');
+  const { euiTheme } = useEuiTheme();
+  const pageBackgroundColor = euiTheme.colors.backgroundBasePlain;
   const globalQueryState = data.query.getState();
   const { main$ } = stateContainer.dataState.data$;
   const [query, savedQuery, columns, sort, grid] = useAppStateSelector((state) => [

--- a/src/platform/plugins/shared/discover/public/application/main/components/loading_spinner/loading_spinner.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/loading_spinner/loading_spinner.tsx
@@ -8,26 +8,20 @@
  */
 
 import React from 'react';
-import {
-  EuiLoadingSpinner,
-  EuiTitle,
-  EuiSpacer,
-  useEuiPaddingSize,
-  useEuiBackgroundColor,
-} from '@elastic/eui';
+import { EuiLoadingSpinner, EuiTitle, EuiSpacer, UseEuiTheme } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 
 export function LoadingSpinner() {
-  const loadingSpinnerCss = css`
+  const loadingSpinnerCss = ({ euiTheme }: UseEuiTheme) => css`
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
     text-align: center;
-    padding: ${useEuiPaddingSize('l')} 0;
-    background-color: ${useEuiBackgroundColor('plain')};
+    padding: ${euiTheme.size.l} 0;
+    background-color: ${euiTheme.colors.backgroundBasePlain};
     z-index: 3;
   `;
 


### PR DESCRIPTION
## Summary

Closes #208912 
All Data Discovery usages of deprecated useEuiBackgroundColor removed in favor of color tokens


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

~~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~
~~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~
~~- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~~
~~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
~~- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~
~~- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



