### PR TITLE
search: remove test log from indices plugin setup

### DIFF
--- a/x-pack/solutions/search/plugins/search_indices/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/plugin.ts
@@ -27,7 +27,6 @@ export class SearchIndicesPlugin
 
   public setup(core: CoreSetup) {
     this.logger.debug('searchIndices: Setup');
-    this.logger.info('searchIndices test');
     const router = core.http.createRouter();
 
     // Register server side APIs


### PR DESCRIPTION
## Summary

remove test log from indices plugin setup

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->