### PR TITLE
[Bug] Agent-based deployment selections are not showing on prem for integrations with agentless as a deployment option

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology.ts
@@ -100,13 +100,14 @@ export function useSetupTechnology({
   );
   useEffect(() => {
     const shouldBeDefault =
-      isOnlyAgentlessIntegration(packageInfo, integrationToEnable) ||
-      isAgentlessSetupDefault(packageInfo, integrationToEnable)
+      isAgentlessEnabled &&
+      (isOnlyAgentlessIntegration(packageInfo, integrationToEnable) ||
+        isAgentlessSetupDefault(packageInfo, integrationToEnable))
         ? SetupTechnology.AGENTLESS
         : SetupTechnology.AGENT_BASED;
     setDefaultSetupTechnology(shouldBeDefault);
     setSelectedSetupTechnology(shouldBeDefault);
-  }, [packageInfo, integrationToEnable]);
+  }, [isAgentlessEnabled, packageInfo, integrationToEnable]);
 
   const agentlessPolicyName = getAgentlessAgentPolicyNameFromPackagePolicyName(packagePolicy.name);
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -358,7 +358,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       "'package-policy-create' and 'package-policy-replace-define-step' cannot both be registered as UI extensions"
     );
   }
-  const { isAgentlessIntegration, isAgentlessEnabled } = useAgentless();
+  const { isAgentlessIntegration } = useAgentless();
 
   const replaceStepConfigurePackagePolicy =
     replaceDefineStepView && packageInfo?.name ? (
@@ -471,8 +471,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       children: replaceStepConfigurePackagePolicy || stepConfigurePackagePolicy,
       headingElement: 'h2',
     },
-    ...(!isAgentlessEnabled ||
-    (isAgentlessEnabled && selectedSetupTechnology !== SetupTechnology.AGENTLESS)
+    ...(selectedSetupTechnology !== SetupTechnology.AGENTLESS
       ? [
           {
             title: i18n.translate('xpack.fleet.createPackagePolicy.stepSelectAgentPolicyTitle', {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -358,7 +358,7 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       "'package-policy-create' and 'package-policy-replace-define-step' cannot both be registered as UI extensions"
     );
   }
-  const { isAgentlessIntegration } = useAgentless();
+  const { isAgentlessIntegration, isAgentlessEnabled } = useAgentless();
 
   const replaceStepConfigurePackagePolicy =
     replaceDefineStepView && packageInfo?.name ? (
@@ -471,7 +471,8 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
       children: replaceStepConfigurePackagePolicy || stepConfigurePackagePolicy,
       headingElement: 'h2',
     },
-    ...(selectedSetupTechnology !== SetupTechnology.AGENTLESS
+    ...(!isAgentlessEnabled ||
+    (isAgentlessEnabled && selectedSetupTechnology !== SetupTechnology.AGENTLESS)
       ? [
           {
             title: i18n.translate('xpack.fleet.createPackagePolicy.stepSelectAgentPolicyTitle', {


### PR DESCRIPTION
## Summary

Fixes [[Bug] Agent-based deployment selections are not showing on prem for integrations with agentless option](https://github.com/elastic/security-team/issues/11758)

Before
![image](https://github.com/user-attachments/assets/d65c170a-71ba-468b-a974-6f40df852c9c)

After
![Screenshot 2025-02-03 at 11 01 12 AM](https://github.com/user-attachments/assets/d93d125a-943d-4a25-8b37-37a87643c542)
![Screenshot 2025-02-03 at 11 00 52 AM](https://github.com/user-attachments/assets/d0dfdff1-db2c-4845-91fa-02f354436a6c)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->