### PR TITLE
[8.17] Remove inference_id field if no inference endpoint is selected (#205660)

### DIFF
--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/mappings_editor.test.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/__jest__/client_integration/mappings_editor.test.tsx
@@ -29,6 +29,14 @@ describe('Mappings editor: core', () => {
   let getMappingsEditorData = getMappingsEditorDataFactory(onChangeHandler);
   let testBed: MappingsEditorTestBed;
   const appDependencies = {
+    core: { application: {} },
+    docLinks: {
+      links: {
+        inferenceManagement: {
+          inferenceAPIDocumentation: 'https://abc.com/inference-api-create',
+        },
+      },
+    },
     plugins: {
       ml: { mlApi: {} },
     },
@@ -470,6 +478,40 @@ describe('Mappings editor: core', () => {
       delete updatedMappings.date_detection;
       delete updatedMappings.dynamic_date_formats;
       delete updatedMappings.numeric_detection;
+
+      expect(data).toEqual(updatedMappings);
+    });
+
+    test('updates mapping without inference id for semantic_text field', async () => {
+      let updatedMappings = { ...defaultMappings };
+
+      const {
+        find,
+        actions: { addField },
+        component,
+      } = testBed;
+
+      /**
+       * Mapped fields
+       */
+      await act(async () => {
+        find('addFieldButton').simulate('click');
+        jest.advanceTimersByTime(0); // advance timers to allow the form to validate
+      });
+      component.update();
+
+      const newField = { name: 'someNewField', type: 'semantic_text' };
+      await addField(newField.name, newField.type);
+
+      updatedMappings = {
+        ...updatedMappings,
+        properties: {
+          ...updatedMappings.properties,
+          [newField.name]: { reference_field: 'address.city', type: 'semantic_text' },
+        },
+      };
+
+      ({ data } = await getMappingsEditorData(component));
 
       expect(data).toEqual(updatedMappings);
     });

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/create_field.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/create_field/create_field.tsx
@@ -106,7 +106,7 @@ export const CreateField = React.memo(function CreateFieldComponent({
     }
   };
 
-  const { createInferenceEndpoint, handleSemanticText } = useSemanticText({
+  const { createInferenceEndpoint } = useSemanticText({
     form,
     setErrorsInTrainedModelDeployment,
     ml,
@@ -130,8 +130,9 @@ export const CreateField = React.memo(function CreateFieldComponent({
     const { isValid, data } = await form.submit();
 
     if (isValid && !clickOutside) {
-      if (isSemanticTextField(data)) {
-        handleSemanticText(data);
+      if (isSemanticTextField(data) && !data.inference_id) {
+        const { inference_id: inferenceId, ...rest } = data;
+        dispatch({ type: 'field.add', value: rest });
       } else {
         dispatch({ type: 'field.add', value: data });
       }

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/fields/fields_list_item.tsx
@@ -293,11 +293,11 @@ function FieldListItemComponent(
               </EuiBadge>
             </EuiFlexItem>
 
-            {isSemanticText && (
+            {isSemanticText && source.inference_id ? (
               <EuiFlexItem grow={false}>
                 <EuiBadge color="hollow">{source.inference_id as string}</EuiBadge>
               </EuiFlexItem>
-            )}
+            ) : null}
 
             {isShadowed && (
               <EuiFlexItem grow={false}>

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/utils.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/utils.ts
@@ -689,7 +689,7 @@ export const getAllFieldTypesFromState = (allFields: Fields): DataType[] => {
 };
 
 export function isSemanticTextField(field: Partial<Field>): field is SemanticTextField {
-  return Boolean(field.inference_id && field.type === 'semantic_text');
+  return field.type === 'semantic_text';
 }
 
 /**

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -235,6 +235,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
               .map((field) => field.inference_id)
               .filter(
                 (inferenceId: string) =>
+                  inferenceId &&
                   inferenceToModelIdMap?.[inferenceId].trainedModelId && // third-party inference models don't have trainedModelId
                   !inferenceToModelIdMap?.[inferenceId].isDeployed &&
                   !isInferencePreconfigured(inferenceId)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Remove inference_id field if no inference endpoint is selected (#205660)](https://github.com/elastic/kibana/pull/205660)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Samiul Monir","email":"150824886+Samiul-TheSoccerFan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-20T12:49:21Z","message":"Remove inference_id field if no inference endpoint is selected (#205660)\n\n## Summary\r\n\r\nCurrently, the `semantic_text` field supports a default `inference_id`,\r\nmeaning users are not required to explicitly select an inference\r\nendpoint during mapping. However, a bug has been identified: if the\r\n`Select inference Id` popover is not opened, the `inference_id` field\r\nproperty remains as an empty string. This causes Elasticsearch (ES) to\r\nthrow an error, as it requires a value to be present if the property is\r\ndefined.\r\n\r\nTo address this issue, the proposed solution is to remove the\r\n`inference_id` property from the `semantic_text` field during field\r\nmapping if its value is empty.\r\n\r\n### Screen Recording\r\n\r\n\r\nhttps://github.com/user-attachments/assets/e8d8d471-7ff2-493e-8872-e42838579d44\r\n\r\n---------\r\n\r\nCo-authored-by: Matthew Kime <matt@mattki.me>","sha":"c8e0408e71e4bdfde59a083833f73b4ef1eb6407","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Kibana Management","release_note:skip","v9.0.0","ci:project-deploy-elasticsearch","backport:version","v8.18.0","v8.17.2"],"title":"Remove inference_id field if no inference endpoint is selected","number":205660,"url":"https://github.com/elastic/kibana/pull/205660","mergeCommit":{"message":"Remove inference_id field if no inference endpoint is selected (#205660)\n\n## Summary\r\n\r\nCurrently, the `semantic_text` field supports a default `inference_id`,\r\nmeaning users are not required to explicitly select an inference\r\nendpoint during mapping. However, a bug has been identified: if the\r\n`Select inference Id` popover is not opened, the `inference_id` field\r\nproperty remains as an empty string. This causes Elasticsearch (ES) to\r\nthrow an error, as it requires a value to be present if the property is\r\ndefined.\r\n\r\nTo address this issue, the proposed solution is to remove the\r\n`inference_id` property from the `semantic_text` field during field\r\nmapping if its value is empty.\r\n\r\n### Screen Recording\r\n\r\n\r\nhttps://github.com/user-attachments/assets/e8d8d471-7ff2-493e-8872-e42838579d44\r\n\r\n---------\r\n\r\nCo-authored-by: Matthew Kime <matt@mattki.me>","sha":"c8e0408e71e4bdfde59a083833f73b4ef1eb6407"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205660","number":205660,"mergeCommit":{"message":"Remove inference_id field if no inference endpoint is selected (#205660)\n\n## Summary\r\n\r\nCurrently, the `semantic_text` field supports a default `inference_id`,\r\nmeaning users are not required to explicitly select an inference\r\nendpoint during mapping. However, a bug has been identified: if the\r\n`Select inference Id` popover is not opened, the `inference_id` field\r\nproperty remains as an empty string. This causes Elasticsearch (ES) to\r\nthrow an error, as it requires a value to be present if the property is\r\ndefined.\r\n\r\nTo address this issue, the proposed solution is to remove the\r\n`inference_id` property from the `semantic_text` field during field\r\nmapping if its value is empty.\r\n\r\n### Screen Recording\r\n\r\n\r\nhttps://github.com/user-attachments/assets/e8d8d471-7ff2-493e-8872-e42838579d44\r\n\r\n---------\r\n\r\nCo-authored-by: Matthew Kime <matt@mattki.me>","sha":"c8e0408e71e4bdfde59a083833f73b4ef1eb6407"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/207189","number":207189,"state":"MERGED","mergeCommit":{"sha":"322cc55dff79a26cfc6b10e2e56cae34c94814f9","message":"[8.x] Remove inference_id field if no inference endpoint is selected (#205660) (#207189)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [Remove inference_id field if no inference endpoint is selected\n(#205660)](https://github.com/elastic/kibana/pull/205660)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Samiul\nMonir\",\"email\":\"150824886+Samiul-TheSoccerFan@users.noreply.github.com\"},\"sourceCommit\":{\"committedDate\":\"2025-01-20T12:49:21Z\",\"message\":\"Remove\ninference_id field if no inference endpoint is selected (#205660)\\n\\n##\nSummary\\r\\n\\r\\nCurrently, the `semantic_text` field supports a default\n`inference_id`,\\r\\nmeaning users are not required to explicitly select\nan inference\\r\\nendpoint during mapping. However, a bug has been\nidentified: if the\\r\\n`Select inference Id` popover is not opened, the\n`inference_id` field\\r\\nproperty remains as an empty string. This causes\nElasticsearch (ES) to\\r\\nthrow an error, as it requires a value to be\npresent if the property is\\r\\ndefined.\\r\\n\\r\\nTo address this issue, the\nproposed solution is to remove the\\r\\n`inference_id` property from the\n`semantic_text` field during field\\r\\nmapping if its value is\nempty.\\r\\n\\r\\n### Screen\nRecording\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/e8d8d471-7ff2-493e-8872-e42838579d44\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nMatthew Kime\n<matt@mattki.me>\",\"sha\":\"c8e0408e71e4bdfde59a083833f73b4ef1eb6407\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"Team:Kibana\nManagement\",\"release_note:skip\",\"v9.0.0\",\"ci:project-deploy-elasticsearch\",\"backport:version\",\"v8.18.0\"],\"title\":\"Remove\ninference_id field if no inference endpoint is\nselected\",\"number\":205660,\"url\":\"https://github.com/elastic/kibana/pull/205660\",\"mergeCommit\":{\"message\":\"Remove\ninference_id field if no inference endpoint is selected (#205660)\\n\\n##\nSummary\\r\\n\\r\\nCurrently, the `semantic_text` field supports a default\n`inference_id`,\\r\\nmeaning users are not required to explicitly select\nan inference\\r\\nendpoint during mapping. However, a bug has been\nidentified: if the\\r\\n`Select inference Id` popover is not opened, the\n`inference_id` field\\r\\nproperty remains as an empty string. This causes\nElasticsearch (ES) to\\r\\nthrow an error, as it requires a value to be\npresent if the property is\\r\\ndefined.\\r\\n\\r\\nTo address this issue, the\nproposed solution is to remove the\\r\\n`inference_id` property from the\n`semantic_text` field during field\\r\\nmapping if its value is\nempty.\\r\\n\\r\\n### Screen\nRecording\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/e8d8d471-7ff2-493e-8872-e42838579d44\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nMatthew Kime\n<matt@mattki.me>\",\"sha\":\"c8e0408e71e4bdfde59a083833f73b4ef1eb6407\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.x\"],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/205660\",\"number\":205660,\"mergeCommit\":{\"message\":\"Remove\ninference_id field if no inference endpoint is selected (#205660)\\n\\n##\nSummary\\r\\n\\r\\nCurrently, the `semantic_text` field supports a default\n`inference_id`,\\r\\nmeaning users are not required to explicitly select\nan inference\\r\\nendpoint during mapping. However, a bug has been\nidentified: if the\\r\\n`Select inference Id` popover is not opened, the\n`inference_id` field\\r\\nproperty remains as an empty string. This causes\nElasticsearch (ES) to\\r\\nthrow an error, as it requires a value to be\npresent if the property is\\r\\ndefined.\\r\\n\\r\\nTo address this issue, the\nproposed solution is to remove the\\r\\n`inference_id` property from the\n`semantic_text` field during field\\r\\nmapping if its value is\nempty.\\r\\n\\r\\n### Screen\nRecording\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/e8d8d471-7ff2-493e-8872-e42838579d44\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nMatthew Kime\n<matt@mattki.me>\",\"sha\":\"c8e0408e71e4bdfde59a083833f73b4ef1eb6407\"}},{\"branch\":\"8.x\",\"label\":\"v8.18.0\",\"branchLabelMappingKey\":\"^v8.18.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Samiul Monir <150824886+Samiul-TheSoccerFan@users.noreply.github.com>"}},{"branch":"8.17","label":"v8.17.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->