### PR TITLE
[lens] immediately display loading panel when adding new ES|QL panel

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -382,6 +382,13 @@ export class LensPlugin {
         datasourceMap,
         theme: core.theme,
         uiSettings: core.uiSettings,
+        getEditorFrameService: async () => {
+          if (!this.editorFrameService) {
+            await this.initEditorFrameService();
+          }
+
+          return this.editorFrameService!;
+        },
       };
     };
 
@@ -683,13 +690,7 @@ export class LensPlugin {
     );
 
     // Displays the add ESQL panel in the dashboard add Panel menu
-    const createESQLPanelAction = new CreateESQLPanelAction(startDependencies, core, async () => {
-      if (!this.editorFrameService) {
-        await this.initEditorFrameService();
-      }
-
-      return this.editorFrameService!;
-    });
+    const createESQLPanelAction = new CreateESQLPanelAction(core);
     startDependencies.uiActions.addTriggerAction(ADD_PANEL_TRIGGER, createESQLPanelAction);
 
     const discoverLocator = startDependencies.share?.url.locators.get('DISCOVER_APP_LOCATOR');

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.test.ts
@@ -116,7 +116,7 @@ async function expectRerenderOnDataLoder(
     parentApi,
   };
   const getState = jest.fn(() => runtimeState);
-  const internalApi = getLensInternalApiMock();
+  const internalApi = await getLensInternalApiMock();
   const services = makeEmbeddableServices(new BehaviorSubject<string>(''), undefined, {
     visOverrides: { id: 'lnsXY' },
     dataOverrides: { id: 'form_based' },

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_actions.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_actions.test.ts
@@ -34,7 +34,7 @@ jest.mock('../../app_plugin/show_underlying_data', () => {
   };
 });
 
-function setupActionsApi(
+async function setupActionsApi(
   stateOverrides?: Partial<LensRuntimeState>,
   contextOverrides?: Omit<VisualizationContext, 'doc'>
 ) {
@@ -46,7 +46,7 @@ function setupActionsApi(
   const runtimeState = getLensRuntimeStateMock(stateOverrides);
   const apiMock = getLensApiMock();
   // create the internal API and customize internal state
-  const internalApi = getLensInternalApiMock();
+  const internalApi = await getLensInternalApiMock();
   internalApi.updateVisualizationContext({
     ...contextOverrides,
     activeAttributes: runtimeState.attributes,
@@ -74,12 +74,12 @@ function setupActionsApi(
 describe('Dashboard actions', () => {
   describe('Drilldowns', () => {
     it('should expose drilldowns for DSL based visualization', async () => {
-      const api = setupActionsApi();
+      const api = await setupActionsApi();
       expect(api.enhancements).toBeDefined();
     });
 
     it('should not expose drilldowns for ES|QL chart types', async () => {
-      const api = setupActionsApi(
+      const api = await setupActionsApi(
         createEmptyLensState('lnsXY', faker.lorem.words(), faker.lorem.text(), {
           esql: 'FROM index',
         })
@@ -120,13 +120,13 @@ describe('Dashboard actions', () => {
       activeData: {},
     };
     it('should expose the "explore in discover" capability for DSL based visualization when compatible', async () => {
-      const api = setupActionsApi(undefined, visualizationContextMockOverrides);
+      const api = await setupActionsApi(undefined, visualizationContextMockOverrides);
       api.loadViewUnderlyingData();
       expect(api.canViewUnderlyingData$.getValue()).toBe(true);
     });
 
     it('should expose the "explore in discover" capability for ES|QL chart types', async () => {
-      const api = setupActionsApi(
+      const api = await setupActionsApi(
         createEmptyLensState('lnsXY', faker.lorem.words(), faker.lorem.text(), {
           esql: 'FROM index',
         }),

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_dashboard_service.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_dashboard_service.test.ts
@@ -13,9 +13,9 @@ import { initializeDashboardServices } from './initialize_dashboard_services';
 import { faker } from '@faker-js/faker';
 import { createEmptyLensState } from '../helper';
 
-function setupDashboardServicesApi(runtimeOverrides?: Partial<LensRuntimeState>) {
+async function setupDashboardServicesApi(runtimeOverrides?: Partial<LensRuntimeState>) {
   const services = makeEmbeddableServices();
-  const internalApiMock = getLensInternalApiMock();
+  const internalApiMock = await getLensInternalApiMock();
   const runtimeState = getLensRuntimeStateMock(runtimeOverrides);
   const stateManagementConfig = initializeStateManagement(runtimeState, internalApiMock);
   const titleManager = initializeTitleManager(runtimeState);
@@ -33,18 +33,18 @@ function setupDashboardServicesApi(runtimeOverrides?: Partial<LensRuntimeState>)
 
 describe('Transformation API', () => {
   it("should not save to library if there's already a saveObjectId", async () => {
-    const api = setupDashboardServicesApi({ savedObjectId: faker.string.uuid() });
+    const api = await setupDashboardServicesApi({ savedObjectId: faker.string.uuid() });
     expect(await api.canLinkToLibrary()).toBe(false);
   });
 
   it("should save to library if there's no saveObjectId declared", async () => {
-    const api = setupDashboardServicesApi();
+    const api = await setupDashboardServicesApi();
     expect(await api.canLinkToLibrary()).toBe(true);
   });
 
   it('should not save to library for ES|QL chart types', async () => {
     // setup a state with an ES|QL query
-    const api = setupDashboardServicesApi(
+    const api = await setupDashboardServicesApi(
       createEmptyLensState('lnsXY', faker.lorem.words(), faker.lorem.text(), {
         esql: 'FROM index',
       })

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_edit.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_edit.test.ts
@@ -17,8 +17,8 @@ import { BehaviorSubject } from 'rxjs';
 import { ApplicationStart } from '@kbn/core/public';
 import { LensEmbeddableStartServices } from '../types';
 
-function createEditApi(servicesOverrides: Partial<LensEmbeddableStartServices> = {}) {
-  const internalApi = getLensInternalApiMock();
+async function createEditApi(servicesOverrides: Partial<LensEmbeddableStartServices> = {}) {
+  const internalApi = await getLensInternalApiMock();
   const runtimeState = getLensRuntimeStateMock();
   const api = getLensApiMock();
   const services = {
@@ -43,13 +43,13 @@ function createEditApi(servicesOverrides: Partial<LensEmbeddableStartServices> =
 }
 
 describe('edit features', () => {
-  it('should be editable if visualize library privileges allow it', () => {
-    const editApi = createEditApi();
+  it('should be editable if visualize library privileges allow it', async () => {
+    const editApi = await createEditApi();
     expect(editApi.api.isEditingEnabled()).toBe(true);
   });
 
-  it('should not be editable if visualize library privileges do not allow it', () => {
-    const editApi = createEditApi({
+  it('should not be editable if visualize library privileges do not allow it', async () => {
+    const editApi = await createEditApi({
       capabilities: {
         visualize_v2: {
           // cannot save

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/setup_inline_editing.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/setup_inline_editing.tsx
@@ -45,6 +45,7 @@ export function prepareInlineEditPanel(
     | 'theme'
     | 'uiSettings'
     | 'attributeService'
+    | 'getEditorFrameService'
   >,
   navigateToLensEditor?: (
     stateTransfer: EmbeddableStateTransfer,

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/lens_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/lens_embeddable.tsx
@@ -61,7 +61,7 @@ export const createLensEmbeddableFactory = (
        * Observables and functions declared here are used internally to store mutating state values
        * This is an internal API not exposed outside of the embeddable.
        */
-      const internalApi = initializeInternalApi(initialState, parentApi, titleManager, services);
+      const internalApi = await initializeInternalApi(initialState, parentApi, titleManager, services);
 
       /**
        * Initialize various configurations required to build all the required

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/lens_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/lens_embeddable.tsx
@@ -61,7 +61,12 @@ export const createLensEmbeddableFactory = (
        * Observables and functions declared here are used internally to store mutating state values
        * This is an internal API not exposed outside of the embeddable.
        */
-      const internalApi = await initializeInternalApi(initialState, parentApi, titleManager, services);
+      const internalApi = await initializeInternalApi(
+        initialState,
+        parentApi,
+        titleManager,
+        services
+      );
 
       /**
        * Initialize various configurations required to build all the required

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/mocks/index.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/mocks/index.tsx
@@ -34,6 +34,7 @@ import {
 import { createMockDatasource, createMockVisualization, makeDefaultServices } from '../../mocks';
 import { Datasource, DatasourceMap, Visualization, VisualizationMap } from '../../types';
 import { initializeInternalApi } from '../initializers/initialize_internal_api';
+import { EditorFrameService } from '../../async_services';
 
 function getDefaultLensApiMock() {
   const LensApiMock: LensApi = {
@@ -206,6 +207,12 @@ export function makeEmbeddableServices(
           } as unknown as ReactEmbeddableDynamicActionsApi)
       ),
     },
+    getEditorFrameService: jest.fn(() =>
+      Promise.resolve({
+        loadVisualizations: jest.fn(),
+        loadDatasources: jest.fn(),
+      } as unknown as EditorFrameService)
+    ),
   };
 }
 
@@ -276,9 +283,9 @@ export function getValidExpressionParams(
   };
 }
 
-function getInternalApiWithFunctionWrappers() {
+async function getInternalApiWithFunctionWrappers() {
   const mockRuntimeState = getLensRuntimeStateMock();
-  const newApi = initializeInternalApi(
+  const newApi = await initializeInternalApi(
     mockRuntimeState,
     {},
     initializeTitleManager(mockRuntimeState),
@@ -295,9 +302,11 @@ function getInternalApiWithFunctionWrappers() {
   return newApi;
 }
 
-export function getLensInternalApiMock(overrides: Partial<LensInternalApi> = {}): LensInternalApi {
+export async function getLensInternalApiMock(
+  overrides: Partial<LensInternalApi> = {}
+): Promise<LensInternalApi> {
   return {
-    ...getInternalApiWithFunctionWrappers(),
+    ...(await getInternalApiWithFunctionWrappers()),
     ...overrides,
   };
 }

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.test.tsx
@@ -21,11 +21,11 @@ jest.mock('../expression_wrapper', () => ({
 
 type GetValueType<Type> = Type extends PublishingSubject<infer X> ? X : never;
 
-function getDefaultProps({
+async function getDefaultProps({
   internalApiOverrides = undefined,
   apiOverrides = undefined,
 }: { internalApiOverrides?: Partial<LensInternalApi>; apiOverrides?: Partial<LensApi> } = {}) {
-  const internalApi = getLensInternalApiMock(internalApiOverrides);
+  const internalApi = await getLensInternalApiMock(internalApiOverrides);
   // provide a valid expression to render
   internalApi.updateExpressionParams(getValidExpressionParams());
   return {
@@ -36,8 +36,8 @@ function getDefaultProps({
 }
 
 describe('Lens Embeddable component', () => {
-  it('should not render the visualization if any error arises', () => {
-    const props = getDefaultProps({
+  it('should not render the visualization if any error arises', async () => {
+    const props = await getDefaultProps({
       internalApiOverrides: {
         expressionParams$: new BehaviorSubject<GetValueType<LensInternalApi['expressionParams$']>>(
           null
@@ -49,9 +49,9 @@ describe('Lens Embeddable component', () => {
     expect(screen.queryByTestId('lens-embeddable')).not.toBeInTheDocument();
   });
 
-  it('shoud not render the title if the visualization forces the title to be hidden', () => {
+  it('shoud not render the title if the visualization forces the title to be hidden', async () => {
     const getDisplayOptions = jest.fn(() => ({ noPanelTitle: true }));
-    const props = getDefaultProps({
+    const props = await getDefaultProps({
       internalApiOverrides: {
         getDisplayOptions,
       },

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/types.ts
@@ -94,6 +94,7 @@ import type { FormBasedPersistedState } from '..';
 import type { TextBasedPersistedState } from '../datasources/text_based/types';
 import type { GaugeVisualizationState } from '../visualizations/gauge/constants';
 import type { MetricVisualizationState } from '../visualizations/metric/types';
+import type { EditorFrameService } from '../editor_frame_service';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface LensApiProps {}
@@ -145,6 +146,7 @@ export type LensEmbeddableStartServices = Simplify<
     theme: ThemeServiceStart;
     uiSettings: IUiSettingsClient;
     attributeService: LensAttributesService;
+    getEditorFrameService: () => Promise<EditorFrameService>;
   }
 >;
 

--- a/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/create_action.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/create_action.test.tsx
@@ -7,31 +7,15 @@
 import type { CoreStart } from '@kbn/core/public';
 import { coreMock } from '@kbn/core/public/mocks';
 import { getMockPresentationContainer } from '@kbn/presentation-containers/mocks';
-import type { LensPluginStartDependencies } from '../../plugin';
-import type { EditorFrameService } from '../../editor_frame_service';
-import { createMockStartDependencies } from '../../editor_frame_service/mocks';
 import { CreateESQLPanelAction } from './create_action';
 
 describe('create Lens panel action', () => {
   const core = coreMock.createStart();
-  const mockStartDependencies =
-    createMockStartDependencies() as unknown as LensPluginStartDependencies;
   const mockPresentationContainer = getMockPresentationContainer();
-
-  const mockEditorFrameService = {
-    loadVisualizations: jest.fn(),
-    loadDatasources: jest.fn(),
-  } as unknown as EditorFrameService;
-
-  const mockGetEditorFrameService = jest.fn(() => Promise.resolve(mockEditorFrameService));
 
   describe('compatibility check', () => {
     it('is incompatible if ui setting for ES|QL is off', async () => {
-      const configurablePanelAction = new CreateESQLPanelAction(
-        mockStartDependencies,
-        core,
-        mockGetEditorFrameService
-      );
+      const configurablePanelAction = new CreateESQLPanelAction(core);
 
       const isCompatible = await configurablePanelAction.isCompatible({
         embeddable: mockPresentationContainer,
@@ -51,11 +35,7 @@ describe('create Lens panel action', () => {
         },
       } as CoreStart;
 
-      const createESQLAction = new CreateESQLPanelAction(
-        mockStartDependencies,
-        updatedCore,
-        mockGetEditorFrameService
-      );
+      const createESQLAction = new CreateESQLPanelAction(updatedCore);
 
       const isCompatible = await createESQLAction.isCompatible({
         embeddable: mockPresentationContainer,

--- a/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/create_action.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/create_action.tsx
@@ -10,9 +10,9 @@ import { Action, IncompatibleActionError } from '@kbn/ui-actions-plugin/public';
 import { EmbeddableApiContext } from '@kbn/presentation-publishing';
 import { apiIsPresentationContainer } from '@kbn/presentation-containers';
 import { ADD_PANEL_VISUALIZATION_GROUP } from '@kbn/embeddable-plugin/public';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 import { generateId } from '../../id_generator';
 import type { LensApi } from '../../react_embeddable/types';
-import { ENABLE_ESQL } from '@kbn/esql-utils';
 
 const ACTION_CREATE_ESQL_CHART = 'ACTION_CREATE_ESQL_CHART';
 

--- a/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/create_action.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/create_action.tsx
@@ -12,10 +12,9 @@ import { apiIsPresentationContainer } from '@kbn/presentation-containers';
 import { ADD_PANEL_VISUALIZATION_GROUP } from '@kbn/embeddable-plugin/public';
 import { generateId } from '../../id_generator';
 import type { LensApi } from '../../react_embeddable/types';
+import { ENABLE_ESQL } from '@kbn/esql-utils';
 
 const ACTION_CREATE_ESQL_CHART = 'ACTION_CREATE_ESQL_CHART';
-
-export const getAsyncHelpers = async () => await import('../../async_services');
 
 export class CreateESQLPanelAction implements Action<EmbeddableApiContext> {
   public type = ACTION_CREATE_ESQL_CHART;
@@ -39,9 +38,7 @@ export class CreateESQLPanelAction implements Action<EmbeddableApiContext> {
 
   public async isCompatible({ embeddable }: EmbeddableApiContext) {
     if (!apiIsPresentationContainer(embeddable)) return false;
-    const { isCreateActionCompatible } = await getAsyncHelpers();
-
-    return isCreateActionCompatible(this.core);
+    return this.core.uiSettings.get(ENABLE_ESQL);
   }
 
   public async execute({ embeddable: parentApi }: EmbeddableApiContext) {

--- a/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/create_action_helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/create_action_helpers.ts
@@ -5,12 +5,10 @@
  * 2.0.
  */
 import { createGetterSetter } from '@kbn/kibana-utils-plugin/common';
-import type { CoreStart } from '@kbn/core/public';
 import { getLensAttributesFromSuggestion } from '@kbn/visualization-utils';
 import {
   getESQLAdHocDataview,
   getIndexForESQLQuery,
-  ENABLE_ESQL,
   getESQLQueryColumns,
   getInitialESQLQuery,
 } from '@kbn/esql-utils';
@@ -27,16 +25,12 @@ export const [getDatasourceMap, setDatasourceMap] = createGetterSetter<
   Record<string, Datasource<unknown, unknown>>
 >('DatasourceMap', false);
 
-export async function isCreateActionCompatible(core: CoreStart) {
-  return core.uiSettings.get(ENABLE_ESQL);
-}
-
 export async function createNewEsqlAttributes(
   services: Pick<LensEmbeddableStartServices, 'data' | 'dataViews' | 'getEditorFrameService'>
 ) {
   const indexName = await getIndexForESQLQuery({ dataViews: services.dataViews });
   if (!indexName) {
-    throw new Error('No data views');
+    return;
   }
   const dataView = await getESQLAdHocDataview(`from ${indexName}`, services.dataViews);
   const editorFrameService = await services.getEditorFrameService();
@@ -51,7 +45,7 @@ export async function createNewEsqlAttributes(
     ]);
 
     if (!visualizationMap && !datasourceMap) {
-      throw new Error('Lens not setup.');
+      return;
     }
 
     // persist for retrieval elsewhere


### PR DESCRIPTION
### Problem
"Add new ES|QL panel" action `awaits` several network requests before showing a new panel. This makes Kibana feel clunky as the UI does not immediately respond to user actions. Follow the test instructions on main to see the problem.

### Solution
"Add new ES|QL panel" action updated to immediately call `parentApi.addNewPanel` when "Add new ES|QL panel" action is executed, thus providing immediate user feedback by displaying a loading panel. Network requests to build default ES|QL lens state are moved into `buildEmbeddable`.

### Test instructions
1. open new dashboard
2. set network speed to "slow 4g".
3. Click "Add panel"
4. Click "ES|QL"
5. Verify user is given immediate feedback by displaying loading panel before any `awaits` occur.

cc @stratoula @dej611 