### PR TITLE
[Security AI] Attack discovery alert filtering telemetry

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/anonymized_alerts_retriever/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/anonymized_alerts_retriever/index.ts
@@ -28,6 +28,7 @@ export class AnonymizedAlertsRetriever extends BaseRetriever {
   #replacements?: Replacements;
   #size?: number;
   #start?: string | null;
+  #unfilteredAlertsCount: number;
 
   constructor({
     alertsIndexPattern,
@@ -54,6 +55,7 @@ export class AnonymizedAlertsRetriever extends BaseRetriever {
   }) {
     super(fields);
 
+    this.#unfilteredAlertsCount = 0;
     this.#alertsIndexPattern = alertsIndexPattern;
     this.#anonymizationFields = anonymizationFields;
     this.#end = end;
@@ -64,12 +66,15 @@ export class AnonymizedAlertsRetriever extends BaseRetriever {
     this.#size = size;
     this.#start = start;
   }
+  public get getUnfilteredAlertsCount() {
+    return this.#unfilteredAlertsCount;
+  }
 
   async _getRelevantDocuments(
     query: string,
     runManager?: CallbackManagerForRetrieverRun
   ): Promise<Document[]> {
-    const anonymizedAlerts = await getAnonymizedAlerts({
+    const { anonymizedAlerts, unfilteredAlertsCount } = await getAnonymizedAlerts({
       alertsIndexPattern: this.#alertsIndexPattern,
       anonymizationFields: this.#anonymizationFields,
       end: this.#end,
@@ -80,6 +85,7 @@ export class AnonymizedAlertsRetriever extends BaseRetriever {
       size: this.#size,
       start: this.#start,
     });
+    this.#unfilteredAlertsCount = unfilteredAlertsCount;
 
     return anonymizedAlerts.map((alert) => ({
       pageContent: alert,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/helpers/get_anonymized_alerts/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/helpers/get_anonymized_alerts/index.test.ts
@@ -66,7 +66,7 @@ describe('getAnonymizedAlerts', () => {
       size,
     });
 
-    expect(result).toEqual([]);
+    expect(result.anonymizedAlerts).toEqual([]);
   });
 
   it('should return an empty array when size is not provided', async () => {
@@ -75,7 +75,7 @@ describe('getAnonymizedAlerts', () => {
       esClient: mockEsClient,
     });
 
-    expect(result).toEqual([]);
+    expect(result.anonymizedAlerts).toEqual([]);
   });
 
   it('should return an empty array when size is out of range', async () => {
@@ -87,7 +87,7 @@ describe('getAnonymizedAlerts', () => {
       size: outOfRange,
     });
 
-    expect(result).toEqual([]);
+    expect(result.anonymizedAlerts).toEqual([]);
   });
 
   it('calls getOpenAndAcknowledgedAlertsQuery with the provided anonymizationFields', async () => {
@@ -174,7 +174,7 @@ describe('getAnonymizedAlerts', () => {
       size,
     });
 
-    expect(result).toEqual([
+    expect(result.anonymizedAlerts).toEqual([
       '_id,b6e883c29b32571aaa667fa13e65bbb4f95172a2b84bdfb85d6f16c72b2d2560\nhost.name,replacement1',
       '_id,0215a6c5cc9499dd0290cd69a4947efb87d3ddd8b6385a766d122c2475be7367\nhost.name,replacement1',
       '_id,600eb9eca925f4c5b544b4e9d3cf95d83b7829f8f74c5bd746369cb4c2968b9a\nhost.name,replacement1',

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/retriever/index.ts
@@ -57,8 +57,10 @@ export const getRetrieveAnonymizedAlertsNode = ({
       .withConfig({ runName: 'runAnonymizedAlertsRetriever' })
       .invoke('');
 
+    const unfilteredAlertsCount = retriever.getUnfilteredAlertsCount;
     return {
       ...state,
+      unfilteredAlertsCount,
       anonymizedAlerts: documents,
       replacements: localReplacements,
     };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/state/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/state/index.ts
@@ -106,6 +106,10 @@ export const getDefaultGraphState = ({
     value: (x?: string | null, y?: string | null) => y ?? x,
     default: () => start,
   },
+  unfilteredAlertsCount: {
+    value: (x: number, y?: number) => y ?? x,
+    default: () => 0,
+  },
   unrefinedResults: {
     value: (x: AttackDiscovery[] | null, y?: AttackDiscovery[] | null) => y ?? x,
     default: () => null,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/types.ts
@@ -29,4 +29,5 @@ export interface GraphState {
   replacements: Replacements;
   start?: string | null;
   unrefinedResults: AttackDiscovery[] | null;
+  unfilteredAlertsCount: number;
 }

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
@@ -316,7 +316,7 @@ export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<{
     unfilteredAlertsCount: {
       type: 'integer',
       _meta: {
-        description: 'Only present when hasAlerts is true, number of alerts without the filter',
+        description: 'Only present when hasFilter is true, number of alerts without the filter',
         optional: true,
       },
     },

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
@@ -243,8 +243,10 @@ export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<{
   configuredAlertsCount: number;
   discoveriesGenerated: number;
   durationMs: number;
+  hasFilter: boolean;
   model?: string;
   provider?: string;
+  unfilteredAlertsCount?: number;
 }> = {
   eventType: 'attack_discovery_success',
   schema: {
@@ -290,6 +292,13 @@ export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<{
         optional: false,
       },
     },
+    hasFilter: {
+      type: 'boolean',
+      _meta: {
+        description: 'Whether a filter was applied to the alerts used as context',
+        optional: false,
+      },
+    },
     model: {
       type: 'keyword',
       _meta: {
@@ -301,6 +310,13 @@ export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<{
       type: 'keyword',
       _meta: {
         description: 'OpenAI provider',
+        optional: true,
+      },
+    },
+    unfilteredAlertsCount: {
+      type: 'integer',
+      _meta: {
+        description: 'Only present when hasAlerts is true, number of alerts without the filter',
         optional: true,
       },
     },

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/helpers.ts
@@ -135,11 +135,13 @@ export const updateAttackDiscoveries = async ({
   attackDiscoveryId,
   authenticatedUser,
   dataClient,
+  hasFilter,
   latestReplacements,
   logger,
   size,
   startTime,
   telemetry,
+  unfilteredAlertsCount,
 }: {
   anonymizedAlerts: Document[];
   apiConfig: ApiConfig;
@@ -147,11 +149,13 @@ export const updateAttackDiscoveries = async ({
   attackDiscoveryId: string;
   authenticatedUser: AuthenticatedUser;
   dataClient: AttackDiscoveryDataClient;
+  hasFilter: boolean;
   latestReplacements: Replacements;
   logger: Logger;
   size: number;
   startTime: Moment;
   telemetry: AnalyticsServiceSetup;
+  unfilteredAlertsCount: number;
 }) => {
   try {
     const currentAd = await dataClient.getAttackDiscovery({
@@ -197,8 +201,10 @@ export const updateAttackDiscoveries = async ({
       configuredAlertsCount: size,
       discoveriesGenerated: updateProps.attackDiscoveries?.length ?? 0,
       durationMs,
+      hasFilter,
       model: apiConfig.model,
       provider: apiConfig.provider,
+      ...(hasFilter ? { unfilteredAlertsCount } : {}),
     });
   } catch (updateErr) {
     logger.error(updateErr);

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/helpers/invoke_attack_discovery_graph/index.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/helpers/invoke_attack_discovery_graph/index.tsx
@@ -62,6 +62,7 @@ export const invokeAttackDiscoveryGraph = async ({
 }): Promise<{
   anonymizedAlerts: Document[];
   attackDiscoveries: AttackDiscovery[] | null;
+  unfilteredAlertsCount: number;
 }> => {
   const llmType = getLlmType(apiConfig.actionTypeId);
   const model = apiConfig.model;
@@ -145,5 +146,9 @@ export const invokeAttackDiscoveryGraph = async ({
     maxHallucinationFailures,
   });
 
-  return { anonymizedAlerts, attackDiscoveries };
+  return {
+    anonymizedAlerts,
+    attackDiscoveries,
+    unfilteredAlertsCount: result.unfilteredAlertsCount,
+  };
 };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/post_attack_discovery.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/post_attack_discovery.ts
@@ -149,7 +149,7 @@ export const postAttackDiscoveryRoute = (
             size,
             start,
           })
-            .then(({ anonymizedAlerts, attackDiscoveries }) =>
+            .then(({ anonymizedAlerts, attackDiscoveries, unfilteredAlertsCount }) =>
               updateAttackDiscoveries({
                 anonymizedAlerts,
                 apiConfig,
@@ -157,11 +157,13 @@ export const postAttackDiscoveryRoute = (
                 attackDiscoveryId,
                 authenticatedUser,
                 dataClient,
+                hasFilter: !!(filter && Object.keys(filter).length),
                 latestReplacements,
                 logger,
                 size,
                 startTime,
                 telemetry,
+                unfilteredAlertsCount,
               })
             )
             .catch((err) =>


### PR DESCRIPTION
## WIP

Adds new properties to the `ATTACK_DISCOVERY_SUCCESS_EVENT` telemetry event object:

1. `hasFilter` - determines whether or not a filter was applied to the alerts used as context
2. `unfilteredAlertsCount` - only present when `hasFilter` is true, gives the count of alerts _without_ using the filter in order to show how many alerts were filtered out

