### PR TITLE
[DOCS] Fix hard-coded master URL

### DIFF
--- a/docs/osquery/manage-integration.asciidoc
+++ b/docs/osquery/manage-integration.asciidoc
@@ -88,7 +88,7 @@ As an example, the following configuration disables two tables.
 The https://github.com/osquery/osquery/releases[Osquery version] available on an Elastic Agent
 is associated to the version of Osquery Beat on the Agent.
 To get the latest version of Osquery Beat,
-https://www.elastic.co/guide/en/fleet/master/upgrade-elastic-agent.html[upgrade your Elastic Agent].
+{fleet-guide}/upgrade-elastic-agent.html[upgrade your Elastic Agent].
 
 [float]
 === Debug issues


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/docs/pull/3160

This PR addresses the following links that will break when we stop building "master" documentation:

```

INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.2/manage-osquery-integration.html contains broken links to:
--
  | INFO:build_docs:   - en/fleet/master/upgrade-elastic-agent.html

```