### PR TITLE
[DOCS] Fix hard-coded links

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -1434,7 +1434,7 @@ Before you upgrade to 8.0.0., remove these settings from kibana.yml.
 To start {kib}, you must enable inline scripting in {es}. For more information, refer to {kibana-pull}113068[#113068].
 
 *Impact* +
-Enable link:https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting-security.html[inline scripting].
+Enable link:{ref}/modules-scripting-security.html[inline scripting].
 ====
 
 [discrete]

--- a/docs/developer/plugin-api-changes/plugin-api-changes.asciidoc
+++ b/docs/developer/plugin-api-changes/plugin-api-changes.asciidoc
@@ -18,8 +18,8 @@ initiated a request to the {es} server. To overcome this problem, we introduced
 
 `execution_context` propagates specified metadata from the {kib} browser app
 or {kib} server to the {es} server through the `x-opaque-id` header emitted to the
-{es} https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-slowlog.html[slow logs].
-For details, check the https://www.elastic.co/guide/en/kibana/master/kibana-troubleshooting-trace-query.html[troubleshooting guide].
+{es} {ref}/index-modules-slowlog.html[slow logs].
+For details, check the <<kibana-troubleshooting-trace-query,troubleshooting guide>>.
 
 The `execution_context` has the following interface:
 

--- a/docs/osquery/osquery.asciidoc
+++ b/docs/osquery/osquery.asciidoc
@@ -349,7 +349,7 @@ As an example, the following configuration disables two tables.
 The https://github.com/osquery/osquery/releases[Osquery version] available on an Elastic Agent
 is associated to the version of Osquery Beat on the Agent.
 To get the latest version of Osquery Beat,
-https://www.elastic.co/guide/en/fleet/master/upgrade-elastic-agent.html[upgrade your Elastic Agent].
+{fleet-guide}/upgrade-elastic-agent.html[upgrade your Elastic Agent].
 
 [float]
 === Debug issues


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/docs/pull/3160

This PR addresses the following links that will break when we stop building "master" documentation:

```

INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.1/osquery.html contains broken links to:
--
  | INFO:build_docs:   - en/fleet/master/upgrade-elastic-agent.html
  | INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/8.1/plugin-api-changes.html contains broken links to:
  | INFO:build_docs:   - en/kibana/master/kibana-troubleshooting-trace-query.html
```



