### PR TITLE
[8.x] [Dataset Quality] Fix flaky tests discover navigation (#208909)

### DIFF
--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_details.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_details.ts
@@ -316,15 +316,15 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
     });
 
     describe('navigation', () => {
-      it('should go to log explorer page when the open in log explorer button is clicked', async () => {
+      it('should go to discover page when the open in discover button is clicked', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
           dataStream: regularDataStreamName,
         });
 
-        const logExplorerButton =
+        const discoverButton =
           await PageObjects.datasetQuality.getDatasetQualityDetailsHeaderButton();
 
-        await logExplorerButton.click();
+        await discoverButton.click();
 
         // Confirm dataset selector text in observability logs explorer
         const datasetSelectorText =
@@ -332,7 +332,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
         expect(datasetSelectorText).to.eql(regularDatasetName);
       });
 
-      it('should go log explorer for degraded docs when the button next to breakdown selector is clicked', async () => {
+      it('should go discover for degraded docs when the button next to breakdown selector is clicked', async () => {
         await PageObjects.datasetQuality.navigateToDetails({
           dataStream: apacheAccessDataStreamName,
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Dataset Quality] Fix flaky tests discover navigation (#208909)](https://github.com/elastic/kibana/pull/208909)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Achyut Jhunjhunwala","email":"achyut.jhunjhunwala@elastic.co"},"sourceCommit":{"committedDate":"2025-02-03T09:46:41Z","message":"[Dataset Quality] Fix flaky tests discover navigation (#208909)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/206734\r\n\r\n- The PR adds a retry logic while getting the Datasource Selector text\r\non the Discover page.\r\n- Also renames the tests as they were missed when migration of links\r\nfrom Log Explorer to Discover were done\r\n\r\n\r\n### Why do we need retry logic\r\n\r\nWe navigate using locators.\r\n\r\n**Without retry** - The link generated has a hash and thus the check for\r\n`dataSelectorId` fails\r\n\r\n```\r\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/r?l=DISCOVER_APP_LOCATOR&v=9.0.0&lz=N4IgLglgtgpgSgQwHYHMYgFygGYCcD2UmIS%2BA7gLQBMALABYgA04%2BxpZIAvs7jHjAGc6ASSRgYuAG4IANplAAHBAFcB6DGFzKYzaTO2YAbAAZTx7iAAmCMAgBqEGGWGXiM%2FCgEUESgMZ0YADoEX19BLwAqJisbe0cyAGUFGF95EAhXDBB3T28%2FAODQ8Ioo5kgwGXVsjy8fEIKQsIFI6MhYADFHGUsAOQRYYgABNsFbKAUuZgBHbVwATzSZZBRlBDRiAGtZhent4gB9CBRSXksMAAIoi198fSgkAUwAbQBdZmwIGXFcR4wn0FgtjSECQlhgAA83DU8vUgo1ilddhIFlgQFAbP59go6LgEGo0tZbPsBJoYP1Akh%2BoI%2FFUFARLMpfJB8EguJxOG90mIJHpiCowKxmAJ8LgwM8niBhtBRv0JswwQJUi8XpwgA%3D%3D%3D\r\n```\r\n\r\n**With retry** - This link then redirects to as Discover Locator\r\nresolves it to\r\n\r\n```\r\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h,to:now))&_a=(columns:!(),dataSource:(dataViewId:%27logs-apache.access-*%27,type:dataView),filters:!((meta:(index:%27logs-apache.access-*%27),query:(match_phrase:(data_stream.namespace:production)))),interval:auto,query:(language:kuery,query:%27_ignored:%20*%27),sort:!(!(%27@timestamp%27,desc)))\r\n```\r\n\r\n**Tested on MKI before and after the fix to confirm the issue is\r\nevidently reproducible and with the fix goes away**","sha":"91ce0ba9e8e4da5c13b55613fcda2de22a4ef98c","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor","Feature:Data Health Quality","Team:obs-ux-logs","v8.18.0","v9.1.0"],"title":"[Dataset Quality] Fix flaky tests discover navigation","number":208909,"url":"https://github.com/elastic/kibana/pull/208909","mergeCommit":{"message":"[Dataset Quality] Fix flaky tests discover navigation (#208909)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/206734\r\n\r\n- The PR adds a retry logic while getting the Datasource Selector text\r\non the Discover page.\r\n- Also renames the tests as they were missed when migration of links\r\nfrom Log Explorer to Discover were done\r\n\r\n\r\n### Why do we need retry logic\r\n\r\nWe navigate using locators.\r\n\r\n**Without retry** - The link generated has a hash and thus the check for\r\n`dataSelectorId` fails\r\n\r\n```\r\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/r?l=DISCOVER_APP_LOCATOR&v=9.0.0&lz=N4IgLglgtgpgSgQwHYHMYgFygGYCcD2UmIS%2BA7gLQBMALABYgA04%2BxpZIAvs7jHjAGc6ASSRgYuAG4IANplAAHBAFcB6DGFzKYzaTO2YAbAAZTx7iAAmCMAgBqEGGWGXiM%2FCgEUESgMZ0YADoEX19BLwAqJisbe0cyAGUFGF95EAhXDBB3T28%2FAODQ8Ioo5kgwGXVsjy8fEIKQsIFI6MhYADFHGUsAOQRYYgABNsFbKAUuZgBHbVwATzSZZBRlBDRiAGtZhent4gB9CBRSXksMAAIoi198fSgkAUwAbQBdZmwIGXFcR4wn0FgtjSECQlhgAA83DU8vUgo1ilddhIFlgQFAbP59go6LgEGo0tZbPsBJoYP1Akh%2BoI%2FFUFARLMpfJB8EguJxOG90mIJHpiCowKxmAJ8LgwM8niBhtBRv0JswwQJUi8XpwgA%3D%3D%3D\r\n```\r\n\r\n**With retry** - This link then redirects to as Discover Locator\r\nresolves it to\r\n\r\n```\r\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h,to:now))&_a=(columns:!(),dataSource:(dataViewId:%27logs-apache.access-*%27,type:dataView),filters:!((meta:(index:%27logs-apache.access-*%27),query:(match_phrase:(data_stream.namespace:production)))),interval:auto,query:(language:kuery,query:%27_ignored:%20*%27),sort:!(!(%27@timestamp%27,desc)))\r\n```\r\n\r\n**Tested on MKI before and after the fix to confirm the issue is\r\nevidently reproducible and with the fix goes away**","sha":"91ce0ba9e8e4da5c13b55613fcda2de22a4ef98c"}},"sourceBranch":"main","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209244","number":209244,"state":"MERGED","mergeCommit":{"sha":"0832e88e861aa8631bb14ef7881a7c6d63b3bf11","message":"[9.0] [Dataset Quality] Fix flaky tests discover navigation (#208909) (#209244)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Dataset Quality] Fix flaky tests discover navigation\n(#208909)](https://github.com/elastic/kibana/pull/208909)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Achyut\nJhunjhunwala\",\"email\":\"achyut.jhunjhunwala@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-02-03T09:46:41Z\",\"message\":\"[Dataset\nQuality] Fix flaky tests discover navigation (#208909)\\n\\n##\nSummary\\r\\n\\r\\nCloses\nhttps://github.com/elastic/kibana/issues/206734\\r\\n\\r\\n- The PR adds a\nretry logic while getting the Datasource Selector text\\r\\non the\nDiscover page.\\r\\n- Also renames the tests as they were missed when\nmigration of links\\r\\nfrom Log Explorer to Discover were\ndone\\r\\n\\r\\n\\r\\n### Why do we need retry logic\\r\\n\\r\\nWe navigate using\nlocators.\\r\\n\\r\\n**Without retry** - The link generated has a hash and\nthus the check for\\r\\n`dataSelectorId`\nfails\\r\\n\\r\\n```\\r\\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/r?l=DISCOVER_APP_LOCATOR&v=9.0.0&lz=N4IgLglgtgpgSgQwHYHMYgFygGYCcD2UmIS%2BA7gLQBMALABYgA04%2BxpZIAvs7jHjAGc6ASSRgYuAG4IANplAAHBAFcB6DGFzKYzaTO2YAbAAZTx7iAAmCMAgBqEGGWGXiM%2FCgEUESgMZ0YADoEX19BLwAqJisbe0cyAGUFGF95EAhXDBB3T28%2FAODQ8Ioo5kgwGXVsjy8fEIKQsIFI6MhYADFHGUsAOQRYYgABNsFbKAUuZgBHbVwATzSZZBRlBDRiAGtZhent4gB9CBRSXksMAAIoi198fSgkAUwAbQBdZmwIGXFcR4wn0FgtjSECQlhgAA83DU8vUgo1ilddhIFlgQFAbP59go6LgEGo0tZbPsBJoYP1Akh%2BoI%2FFUFARLMpfJB8EguJxOG90mIJHpiCowKxmAJ8LgwM8niBhtBRv0JswwQJUi8XpwgA%3D%3D%3D\\r\\n```\\r\\n\\r\\n**With\nretry** - This link then redirects to as Discover Locator\\r\\nresolves it\nto\\r\\n\\r\\n```\\r\\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h,to:now))&_a=(columns:!(),dataSource:(dataViewId:%27logs-apache.access-*%27,type:dataView),filters:!((meta:(index:%27logs-apache.access-*%27),query:(match_phrase:(data_stream.namespace:production)))),interval:auto,query:(language:kuery,query:%27_ignored:%20*%27),sort:!(!(%27@timestamp%27,desc)))\\r\\n```\\r\\n\\r\\n**Tested\non MKI before and after the fix to confirm the issue is\\r\\nevidently\nreproducible and with the fix goes\naway**\",\"sha\":\"91ce0ba9e8e4da5c13b55613fcda2de22a4ef98c\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"backport:prev-minor\",\"Feature:Data\nHealth Quality\",\"Team:obs-ux-logs\",\"v8.18.0\",\"v9.1.0\"],\"title\":\"[Dataset\nQuality] Fix flaky tests discover\nnavigation\",\"number\":208909,\"url\":\"https://github.com/elastic/kibana/pull/208909\",\"mergeCommit\":{\"message\":\"[Dataset\nQuality] Fix flaky tests discover navigation (#208909)\\n\\n##\nSummary\\r\\n\\r\\nCloses\nhttps://github.com/elastic/kibana/issues/206734\\r\\n\\r\\n- The PR adds a\nretry logic while getting the Datasource Selector text\\r\\non the\nDiscover page.\\r\\n- Also renames the tests as they were missed when\nmigration of links\\r\\nfrom Log Explorer to Discover were\ndone\\r\\n\\r\\n\\r\\n### Why do we need retry logic\\r\\n\\r\\nWe navigate using\nlocators.\\r\\n\\r\\n**Without retry** - The link generated has a hash and\nthus the check for\\r\\n`dataSelectorId`\nfails\\r\\n\\r\\n```\\r\\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/r?l=DISCOVER_APP_LOCATOR&v=9.0.0&lz=N4IgLglgtgpgSgQwHYHMYgFygGYCcD2UmIS%2BA7gLQBMALABYgA04%2BxpZIAvs7jHjAGc6ASSRgYuAG4IANplAAHBAFcB6DGFzKYzaTO2YAbAAZTx7iAAmCMAgBqEGGWGXiM%2FCgEUESgMZ0YADoEX19BLwAqJisbe0cyAGUFGF95EAhXDBB3T28%2FAODQ8Ioo5kgwGXVsjy8fEIKQsIFI6MhYADFHGUsAOQRYYgABNsFbKAUuZgBHbVwATzSZZBRlBDRiAGtZhent4gB9CBRSXksMAAIoi198fSgkAUwAbQBdZmwIGXFcR4wn0FgtjSECQlhgAA83DU8vUgo1ilddhIFlgQFAbP59go6LgEGo0tZbPsBJoYP1Akh%2BoI%2FFUFARLMpfJB8EguJxOG90mIJHpiCowKxmAJ8LgwM8niBhtBRv0JswwQJUi8XpwgA%3D%3D%3D\\r\\n```\\r\\n\\r\\n**With\nretry** - This link then redirects to as Discover Locator\\r\\nresolves it\nto\\r\\n\\r\\n```\\r\\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h,to:now))&_a=(columns:!(),dataSource:(dataViewId:%27logs-apache.access-*%27,type:dataView),filters:!((meta:(index:%27logs-apache.access-*%27),query:(match_phrase:(data_stream.namespace:production)))),interval:auto,query:(language:kuery,query:%27_ignored:%20*%27),sort:!(!(%27@timestamp%27,desc)))\\r\\n```\\r\\n\\r\\n**Tested\non MKI before and after the fix to confirm the issue is\\r\\nevidently\nreproducible and with the fix goes\naway**\",\"sha\":\"91ce0ba9e8e4da5c13b55613fcda2de22a4ef98c\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"9.0\",\"8.18\"],\"targetPullRequestStates\":[{\"branch\":\"9.0\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.18\",\"label\":\"v8.18.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/208909\",\"number\":208909,\"mergeCommit\":{\"message\":\"[Dataset\nQuality] Fix flaky tests discover navigation (#208909)\\n\\n##\nSummary\\r\\n\\r\\nCloses\nhttps://github.com/elastic/kibana/issues/206734\\r\\n\\r\\n- The PR adds a\nretry logic while getting the Datasource Selector text\\r\\non the\nDiscover page.\\r\\n- Also renames the tests as they were missed when\nmigration of links\\r\\nfrom Log Explorer to Discover were\ndone\\r\\n\\r\\n\\r\\n### Why do we need retry logic\\r\\n\\r\\nWe navigate using\nlocators.\\r\\n\\r\\n**Without retry** - The link generated has a hash and\nthus the check for\\r\\n`dataSelectorId`\nfails\\r\\n\\r\\n```\\r\\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/r?l=DISCOVER_APP_LOCATOR&v=9.0.0&lz=N4IgLglgtgpgSgQwHYHMYgFygGYCcD2UmIS%2BA7gLQBMALABYgA04%2BxpZIAvs7jHjAGc6ASSRgYuAG4IANplAAHBAFcB6DGFzKYzaTO2YAbAAZTx7iAAmCMAgBqEGGWGXiM%2FCgEUESgMZ0YADoEX19BLwAqJisbe0cyAGUFGF95EAhXDBB3T28%2FAODQ8Ioo5kgwGXVsjy8fEIKQsIFI6MhYADFHGUsAOQRYYgABNsFbKAUuZgBHbVwATzSZZBRlBDRiAGtZhent4gB9CBRSXksMAAIoi198fSgkAUwAbQBdZmwIGXFcR4wn0FgtjSECQlhgAA83DU8vUgo1ilddhIFlgQFAbP59go6LgEGo0tZbPsBJoYP1Akh%2BoI%2FFUFARLMpfJB8EguJxOG90mIJHpiCowKxmAJ8LgwM8niBhtBRv0JswwQJUi8XpwgA%3D%3D%3D\\r\\n```\\r\\n\\r\\n**With\nretry** - This link then redirects to as Discover Locator\\r\\nresolves it\nto\\r\\n\\r\\n```\\r\\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h,to:now))&_a=(columns:!(),dataSource:(dataViewId:%27logs-apache.access-*%27,type:dataView),filters:!((meta:(index:%27logs-apache.access-*%27),query:(match_phrase:(data_stream.namespace:production)))),interval:auto,query:(language:kuery,query:%27_ignored:%20*%27),sort:!(!(%27@timestamp%27,desc)))\\r\\n```\\r\\n\\r\\n**Tested\non MKI before and after the fix to confirm the issue is\\r\\nevidently\nreproducible and with the fix goes\naway**\",\"sha\":\"91ce0ba9e8e4da5c13b55613fcda2de22a4ef98c\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Achyut Jhunjhunwala <achyut.jhunjhunwala@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208909","number":208909,"mergeCommit":{"message":"[Dataset Quality] Fix flaky tests discover navigation (#208909)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/206734\r\n\r\n- The PR adds a retry logic while getting the Datasource Selector text\r\non the Discover page.\r\n- Also renames the tests as they were missed when migration of links\r\nfrom Log Explorer to Discover were done\r\n\r\n\r\n### Why do we need retry logic\r\n\r\nWe navigate using locators.\r\n\r\n**Without retry** - The link generated has a hash and thus the check for\r\n`dataSelectorId` fails\r\n\r\n```\r\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/r?l=DISCOVER_APP_LOCATOR&v=9.0.0&lz=N4IgLglgtgpgSgQwHYHMYgFygGYCcD2UmIS%2BA7gLQBMALABYgA04%2BxpZIAvs7jHjAGc6ASSRgYuAG4IANplAAHBAFcB6DGFzKYzaTO2YAbAAZTx7iAAmCMAgBqEGGWGXiM%2FCgEUESgMZ0YADoEX19BLwAqJisbe0cyAGUFGF95EAhXDBB3T28%2FAODQ8Ioo5kgwGXVsjy8fEIKQsIFI6MhYADFHGUsAOQRYYgABNsFbKAUuZgBHbVwATzSZZBRlBDRiAGtZhent4gB9CBRSXksMAAIoi198fSgkAUwAbQBdZmwIGXFcR4wn0FgtjSECQlhgAA83DU8vUgo1ilddhIFlgQFAbP59go6LgEGo0tZbPsBJoYP1Akh%2BoI%2FFUFARLMpfJB8EguJxOG90mIJHpiCowKxmAJ8LgwM8niBhtBRv0JswwQJUi8XpwgA%3D%3D%3D\r\n```\r\n\r\n**With retry** - This link then redirects to as Discover Locator\r\nresolves it to\r\n\r\n```\r\nhttps://achyut-mki-test-runner-e64297.kb.eu-west-1.aws.qa.elastic.cloud/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h,to:now))&_a=(columns:!(),dataSource:(dataViewId:%27logs-apache.access-*%27,type:dataView),filters:!((meta:(index:%27logs-apache.access-*%27),query:(match_phrase:(data_stream.namespace:production)))),interval:auto,query:(language:kuery,query:%27_ignored:%20*%27),sort:!(!(%27@timestamp%27,desc)))\r\n```\r\n\r\n**Tested on MKI before and after the fix to confirm the issue is\r\nevidently reproducible and with the fix goes away**","sha":"91ce0ba9e8e4da5c13b55613fcda2de22a4ef98c"}}]}] BACKPORT-->