### PR TITLE
[8.x] [Security Solution] Sort rule upgrade flyout fields according to the state (#208553)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/rule_upgrade/rule_upgrade.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/three_way_diff/rule_upgrade/rule_upgrade.tsx
@@ -7,6 +7,7 @@
 
 import React, { memo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
+import type { FieldsUpgradeState } from '../../../../model/prebuilt_rule_upgrade';
 import {
   FieldUpgradeStateEnum,
   type RuleUpgradeState,
@@ -31,9 +32,7 @@ export const RuleUpgrade = memo(function RuleUpgrade({
   const numOfFieldsWithUpdates = calcNumOfFieldsWithUpdates(ruleUpgradeState);
   const numOfSolvableConflicts = calcNumOfSolvableConflicts(ruleUpgradeState);
   const numOfNonSolvableConflicts = calcNumOfNonSolvableConflicts(ruleUpgradeState);
-  const fieldNames = Object.keys(
-    ruleUpgradeState.fieldsUpgradeState
-  ) as UpgradeableDiffableFields[];
+  const fieldNames = extractSortedFieldNames(ruleUpgradeState.fieldsUpgradeState);
 
   return (
     <>
@@ -85,4 +84,31 @@ function calcNumOfNonSolvableConflicts(ruleUpgradeState: RuleUpgradeState): numb
   return Object.values(ruleUpgradeState.fieldsUpgradeState).filter(
     ({ state }) => state === FieldUpgradeStateEnum.NonSolvableConflict
   ).length;
+}
+
+/**
+ * Defines fields sorting order by state.
+ * Lower number corresponds to higher priority.
+ */
+const FIELDS_STATE_ORDER_MAP = {
+  [FieldUpgradeStateEnum.NonSolvableConflict]: 0,
+  [FieldUpgradeStateEnum.SolvableConflict]: 1,
+  [FieldUpgradeStateEnum.SameUpdate]: 2,
+  [FieldUpgradeStateEnum.NoConflict]: 3,
+  [FieldUpgradeStateEnum.Accepted]: 4,
+  [FieldUpgradeStateEnum.NoUpdate]: 5,
+} as const;
+
+function extractSortedFieldNames(
+  fieldsUpgradeState: FieldsUpgradeState
+): UpgradeableDiffableFields[] {
+  const fieldNames = Object.keys(fieldsUpgradeState) as UpgradeableDiffableFields[];
+
+  fieldNames.sort(
+    (a, b) =>
+      FIELDS_STATE_ORDER_MAP[fieldsUpgradeState[a].state] -
+      FIELDS_STATE_ORDER_MAP[fieldsUpgradeState[b].state]
+  );
+
+  return fieldNames;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution] Sort rule upgrade flyout fields according to the state (#208553)](https://github.com/elastic/kibana/pull/208553)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

