### PR TITLE
[APM] Skip flaky test (Service map)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_map/service_map.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_map/service_map.cy.ts
@@ -29,6 +29,7 @@ const detailedServiceMap = url.format({
   },
 });
 
+// Flaky: https://github.com/elastic/kibana/issues/207005
 describe.skip('service map', () => {
   before(() => {
     synthtrace.index(
@@ -85,7 +86,6 @@ describe.skip('service map', () => {
       );
     });
 
-    // Flaky: https://github.com/elastic/kibana/issues/207005
     describe('when there is no data', () => {
       it('shows empty state', () => {
         cy.visitKibana(serviceMapHref);

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_map/service_map.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_map/service_map.cy.ts
@@ -29,7 +29,7 @@ const detailedServiceMap = url.format({
   },
 });
 
-describe('service map', () => {
+describe.skip('service map', () => {
   before(() => {
     synthtrace.index(
       opbeans({
@@ -52,7 +52,7 @@ describe('service map', () => {
       cy.intercept('GET', '/internal/apm/service-map?*').as('serviceMap');
     });
 
-    it.skip('shows nodes in service map', () => {
+    it('shows nodes in service map', () => {
       cy.visitKibana(serviceMapHref);
       cy.wait('@serviceMap');
 
@@ -68,7 +68,7 @@ describe('service map', () => {
       );
     });
 
-    it.skip('shows nodes in detailed service map', () => {
+    it('shows nodes in detailed service map', () => {
       cy.visitKibana(detailedServiceMap);
       cy.wait('@serviceMap');
       cy.contains('h1', 'opbeans-java');
@@ -85,6 +85,7 @@ describe('service map', () => {
       );
     });
 
+    // Flaky: https://github.com/elastic/kibana/issues/207005
     describe('when there is no data', () => {
       it('shows empty state', () => {
         cy.visitKibana(serviceMapHref);


### PR DESCRIPTION
Closes #207005 

## Summary

This PR skips flaky tests - 2 of the flaky tests were already skipped so I skipped the test on the top level (as all the tests will be skipped anyway it makes more sense to have the whole test skipped) 
I tried to fix it and managed to reproduce the flaky behavior only once out of many runs (the input was not filled but the next check failed - which was not an expected behavior as it should fail on the previous step or retry it) - It's super hard to reproduce it. I followed the steps locally and it worked as expected so it's not an actual issue: 


https://github.com/user-attachments/assets/d0d33622-c186-4b31-bcf7-b2c27df330ac



As we plan to refactor the test anyway we should not spend more time on it so I skipped it for now.



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->