### PR TITLE
[Security Solution] Remember page index in Rule Updates table

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { CriteriaWithPagination } from '@elastic/eui';
 import {
   EuiInMemoryTable,
   EuiSkeletonLoading,
@@ -14,8 +15,9 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
+import type { RuleResponse } from '../../../../../../common/api/detection_engine/model/rule_schema';
 import { RULES_TABLE_INITIAL_PAGE_SIZE, RULES_TABLE_PAGE_SIZE_OPTIONS } from '../constants';
 import { RulesChangelogLink } from '../rules_changelog_link';
 import { AddPrebuiltRulesTableNoItemsMessage } from './add_prebuilt_rules_no_items_message';
@@ -43,6 +45,14 @@ export const AddPrebuiltRulesTable = React.memo(() => {
   const rulesColumns = useAddPrebuiltRulesTableColumns();
 
   const shouldShowProgress = isUpgradingSecurityPackages || isRefetching;
+
+  const [pageIndex, setPageIndex] = useState(0);
+  const handleTableChange = useCallback(
+    ({ page: { index } }: CriteriaWithPagination<RuleResponse>) => {
+      setPageIndex(index);
+    },
+    [setPageIndex]
+  );
 
   return (
     <>
@@ -82,6 +92,7 @@ export const AddPrebuiltRulesTable = React.memo(() => {
                 pagination={{
                   initialPageSize: RULES_TABLE_INITIAL_PAGE_SIZE,
                   pageSizeOptions: RULES_TABLE_PAGE_SIZE_OPTIONS,
+                  pageIndex,
                 }}
                 selection={{
                   selectable: () => true,
@@ -91,6 +102,7 @@ export const AddPrebuiltRulesTable = React.memo(() => {
                 itemId="rule_id"
                 data-test-subj="add-prebuilt-rules-table"
                 columns={rulesColumns}
+                onTableChange={handleTableChange}
               />
             </>
           )

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
@@ -16,7 +16,7 @@ import {
   EuiSkeletonText,
   EuiSkeletonTitle,
 } from '@elastic/eui';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import type { RuleUpgradeState } from '../../../../rule_management/model/prebuilt_rule_upgrade';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
 import { RULES_TABLE_INITIAL_PAGE_SIZE, RULES_TABLE_PAGE_SIZE_OPTIONS } from '../constants';
@@ -53,9 +53,12 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
   const rulesColumns = useUpgradePrebuiltRulesTableColumns();
   const shouldShowProgress = isUpgradingSecurityPackages || isRefetching;
   const [pageIndex, setPageIndex] = useState(0);
-  const onTableChange = ({ page: { index } }: CriteriaWithPagination<RuleUpgradeState>) => {
-    setPageIndex(index);
-  };
+  const handleTableChange = useCallback(
+    ({ page: { index } }: CriteriaWithPagination<RuleUpgradeState>) => {
+      setPageIndex(index);
+    },
+    [setPageIndex]
+  );
 
   return (
     <>
@@ -117,7 +120,7 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
                 itemId="rule_id"
                 data-test-subj="rules-upgrades-table"
                 columns={rulesColumns}
-                onTableChange={onTableChange}
+                onTableChange={handleTableChange}
               />
             </>
           )

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { CriteriaWithPagination } from '@elastic/eui';
 import {
   EuiEmptyPrompt,
   EuiFlexGroup,
@@ -51,6 +52,10 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
 
   const rulesColumns = useUpgradePrebuiltRulesTableColumns();
   const shouldShowProgress = isUpgradingSecurityPackages || isRefetching;
+  const [pageIndex, setPageIndex] = useState(0);
+  const onTableChange = ({ page: { index } }: CriteriaWithPagination<RuleUpgradeState>) => {
+    setPageIndex(index);
+  };
 
   return (
     <>
@@ -102,6 +107,7 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
                 pagination={{
                   initialPageSize: RULES_TABLE_INITIAL_PAGE_SIZE,
                   pageSizeOptions: RULES_TABLE_PAGE_SIZE_OPTIONS,
+                  pageIndex,
                 }}
                 selection={{
                   selectable: () => true,
@@ -111,6 +117,7 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
                 itemId="rule_id"
                 data-test-subj="rules-upgrades-table"
                 columns={rulesColumns}
+                onTableChange={onTableChange}
               />
             </>
           )


### PR DESCRIPTION
**Resolves: #207245**

## Summary

Pagination mechanism in Rule Updates table was incomplete. When a rule was edited or upgraded, the table was reset to the first page. I am adding a mechanism to preserve the page index.

# BEFORE
## Scenario 1 (Edit and Save)

https://github.com/user-attachments/assets/05927104-28c0-446a-8c14-1a8236854cc0

## Scenario 2 (Update Rule)

https://github.com/user-attachments/assets/9e54c3f9-9823-4a06-af9e-38b8ddc7d887

## Scenario 3 (Update Rule with prebuiltRulesCustomizationEnabled flag disabled)

https://github.com/user-attachments/assets/5dd7929a-1b79-4f7f-b825-23c96fb63131


# AFTER 
## Scenario 1 (Edit and Save)

https://github.com/user-attachments/assets/9d270994-846b-44d0-822d-2dcfba042d9d

## Scenario 2 (Update Rule)

https://github.com/user-attachments/assets/7cf61d8b-55a9-4b5a-ae79-65f95de84fc4

## Scenario 3 (Update Rule with prebuiltRulesCustomizationEnabled flag disabled)

https://github.com/user-attachments/assets/678bb077-b9af-4830-b6cf-0bf5c43648af



<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->