### PR TITLE
[Remote clusters] Clean values sent to ES API

### DIFF
--- a/x-pack/platform/plugins/private/remote_clusters/common/lib/cluster_serialization.test.ts
+++ b/x-pack/platform/plugins/private/remote_clusters/common/lib/cluster_serialization.test.ts
@@ -252,8 +252,6 @@ describe('cluster_serialization', () => {
                 skip_unavailable: false,
                 server_name: 'localhost',
                 proxy: null,
-                seeds: null,
-                node_connections: null,
               },
             },
           },
@@ -282,11 +280,8 @@ describe('cluster_serialization', () => {
               test_cluster: {
                 mode: 'sniff',
                 node_connections: null,
-                proxy_address: null,
-                proxy_socket_connections: null,
                 seeds: ['localhost:9300'],
                 skip_unavailable: false,
-                server_name: null,
               },
             },
           },
@@ -307,10 +302,69 @@ describe('cluster_serialization', () => {
               test_cluster: {
                 mode: null,
                 node_connections: null,
-                proxy_address: null,
-                proxy_socket_connections: null,
                 seeds: ['localhost:9300'],
                 skip_unavailable: null,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should serialize a cluster object that will be deleted', () => {
+      expect(
+        serializeCluster(
+          {
+            name: 'test_cluster',
+            seeds: ['localhost:9300'],
+          },
+          undefined,
+          true
+        )
+      ).toEqual({
+        persistent: {
+          cluster: {
+            remote: {
+              test_cluster: {
+                mode: null,
+                node_connections: null,
+                seeds: ['localhost:9300'],
+                skip_unavailable: null,
+                proxy_address: null,
+                proxy_socket_connections: null,
+                server_name: null,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should serialize a cluster object that has modified mode', () => {
+      expect(
+        serializeCluster(
+          {
+            name: 'test_cluster',
+            seeds: ['localhost:9300'],
+            isConnected: true,
+            connectedNodesCount: 1,
+            maxConnectionsPerCluster: 3,
+            mode: 'sniff',
+            nodeConnections: 18,
+          },
+          'proxy'
+        )
+      ).toEqual({
+        persistent: {
+          cluster: {
+            remote: {
+              test_cluster: {
+                mode: 'sniff',
+                node_connections: 18,
+                seeds: ['localhost:9300'],
+                skip_unavailable: null,
+                proxy_address: null,
+                proxy_socket_connections: null,
                 server_name: null,
               },
             },

--- a/x-pack/platform/plugins/private/remote_clusters/common/lib/cluster_serialization.ts
+++ b/x-pack/platform/plugins/private/remote_clusters/common/lib/cluster_serialization.ts
@@ -153,7 +153,9 @@ export function deserializeCluster(
 }
 
 export function serializeCluster(
-  deserializedClusterObject: ClusterPayload
+  deserializedClusterObject: ClusterPayload,
+  previousClusterMode?: 'proxy' | 'sniff',
+  isDelete?: boolean
 ): ClusterSettingsPayloadEs {
   if (!deserializedClusterObject || typeof deserializedClusterObject !== 'object') {
     throw new Error('Unable to serialize cluster');
@@ -174,12 +176,25 @@ export function serializeCluster(
   const clusterData: ClusterPayloadEs = {
     skip_unavailable: typeof skipUnavailable === 'boolean' ? skipUnavailable : null,
     mode: mode || null,
-    proxy_address: proxyAddress || null,
-    proxy_socket_connections: proxySocketConnections || null,
-    server_name: serverName || null,
-    seeds: seeds || null,
-    node_connections: nodeConnections || null,
+    ...(mode === PROXY_MODE
+      ? {
+          proxy_address: proxyAddress || null,
+          proxy_socket_connections: proxySocketConnections || null,
+          server_name: serverName || null,
+        }
+      : {
+          seeds: seeds || null,
+          node_connections: nodeConnections || null,
+        }),
   };
+
+  if (isDelete || (previousClusterMode && previousClusterMode !== mode)) {
+    clusterData.proxy_address = proxyAddress || null;
+    clusterData.proxy_socket_connections = proxySocketConnections || null;
+    clusterData.server_name = serverName || null;
+    clusterData.seeds = seeds || null;
+    clusterData.node_connections = nodeConnections || null;
+  }
 
   // This is only applicable in edit mode
   // In order to "upgrade" an existing remote cluster to use the new proxy mode settings, we need to set the old proxy setting to null

--- a/x-pack/platform/plugins/private/remote_clusters/common/lib/cluster_serialization.ts
+++ b/x-pack/platform/plugins/private/remote_clusters/common/lib/cluster_serialization.ts
@@ -188,6 +188,8 @@ export function serializeCluster(
         }),
   };
 
+  // If the cluster is been deleted, we need to set all values to null
+  // If the cluster is been edited and the mode has changed, we need to set to null the previous mode settings values
   if (isDelete || (previousClusterMode && previousClusterMode !== mode)) {
     clusterData.proxy_address = proxyAddress || null;
     clusterData.proxy_socket_connections = proxySocketConnections || null;

--- a/x-pack/platform/plugins/private/remote_clusters/public/application/sections/components/remote_cluster_config_steps/components/action_buttons.tsx
+++ b/x-pack/platform/plugins/private/remote_clusters/public/application/sections/components/remote_cluster_config_steps/components/action_buttons.tsx
@@ -26,6 +26,7 @@ interface Props {
   cluster?: ClusterPayload;
   nextButtonTestSubj: string;
   backButtonTestSubj?: string;
+  previousClusterMode?: 'proxy' | 'sniff';
 }
 
 export const ActionButtons: React.FC<Props> = ({
@@ -39,6 +40,7 @@ export const ActionButtons: React.FC<Props> = ({
   cluster,
   nextButtonTestSubj,
   backButtonTestSubj,
+  previousClusterMode,
 }) => {
   const [isRequestVisible, setIsRequestVisible] = useState(false);
   const toggleRequest = useCallback(() => {
@@ -92,7 +94,11 @@ export const ActionButtons: React.FC<Props> = ({
         )}
       </EuiFlexItem>
       {isRequestVisible && cluster ? (
-        <RequestFlyout cluster={cluster} close={() => setIsRequestVisible(false)} />
+        <RequestFlyout
+          cluster={cluster}
+          close={() => setIsRequestVisible(false)}
+          previousClusterMode={previousClusterMode}
+        />
       ) : null}
     </EuiFlexGroup>
   );

--- a/x-pack/platform/plugins/private/remote_clusters/public/application/sections/components/remote_cluster_config_steps/components/action_buttons.tsx
+++ b/x-pack/platform/plugins/private/remote_clusters/public/application/sections/components/remote_cluster_config_steps/components/action_buttons.tsx
@@ -6,6 +6,7 @@
  */
 import React, { ReactNode, useCallback, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { PROXY_MODE, SNIFF_MODE } from '../../../../../../common/constants';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -26,7 +27,7 @@ interface Props {
   cluster?: ClusterPayload;
   nextButtonTestSubj: string;
   backButtonTestSubj?: string;
-  previousClusterMode?: 'proxy' | 'sniff';
+  previousClusterMode?: typeof PROXY_MODE | typeof SNIFF_MODE;
 }
 
 export const ActionButtons: React.FC<Props> = ({

--- a/x-pack/platform/plugins/private/remote_clusters/public/application/sections/components/remote_cluster_config_steps/components/request_flyout.tsx
+++ b/x-pack/platform/plugins/private/remote_clusters/public/application/sections/components/remote_cluster_config_steps/components/request_flyout.tsx
@@ -21,11 +21,12 @@ import {
 } from '@elastic/eui';
 
 import { ClusterPayload, serializeCluster } from '../../../../../../common/lib';
+import { SNIFF_MODE, PROXY_MODE } from '../../../../../../common/constants';
 
 interface Props {
   close: () => void;
   cluster: ClusterPayload;
-  previousClusterMode?: 'proxy' | 'sniff';
+  previousClusterMode?: typeof PROXY_MODE | typeof SNIFF_MODE;
 }
 
 export class RequestFlyout extends PureComponent<Props> {

--- a/x-pack/platform/plugins/private/remote_clusters/public/application/sections/components/remote_cluster_config_steps/components/request_flyout.tsx
+++ b/x-pack/platform/plugins/private/remote_clusters/public/application/sections/components/remote_cluster_config_steps/components/request_flyout.tsx
@@ -25,6 +25,7 @@ import { ClusterPayload, serializeCluster } from '../../../../../../common/lib';
 interface Props {
   close: () => void;
   cluster: ClusterPayload;
+  previousClusterMode?: 'proxy' | 'sniff';
 }
 
 export class RequestFlyout extends PureComponent<Props> {
@@ -32,7 +33,11 @@ export class RequestFlyout extends PureComponent<Props> {
     const { close, cluster } = this.props;
     const { name } = cluster;
     const endpoint = 'PUT _cluster/settings';
-    const payload = JSON.stringify(serializeCluster(cluster), null, 2);
+    const payload = JSON.stringify(
+      serializeCluster(cluster, this.props.previousClusterMode),
+      null,
+      2
+    );
     const request = `${endpoint}\n${payload}`;
 
     return (

--- a/x-pack/platform/plugins/private/remote_clusters/public/application/sections/components/remote_cluster_config_steps/remote_cluster_form/remote_cluster_form.tsx
+++ b/x-pack/platform/plugins/private/remote_clusters/public/application/sections/components/remote_cluster_config_steps/remote_cluster_form/remote_cluster_form.tsx
@@ -438,6 +438,7 @@ export const RemoteClusterForm: React.FC<Props> = ({
         cluster={getCluster()}
         nextButtonTestSubj={'remoteClusterFormNextButton'}
         backButtonTestSubj={'remoteClusterFormBackButton'}
+        previousClusterMode={cluster?.mode}
       />
     </>
   );

--- a/x-pack/platform/plugins/private/remote_clusters/server/routes/api/add_route.test.ts
+++ b/x-pack/platform/plugins/private/remote_clusters/server/routes/api/add_route.test.ts
@@ -124,9 +124,6 @@ describe('ADD remote clusters', () => {
                   skip_unavailable: false,
                   mode: 'sniff',
                   node_connections: null,
-                  proxy_address: null,
-                  proxy_socket_connections: null,
-                  server_name: null,
                 },
               },
             },
@@ -181,10 +178,8 @@ describe('ADD remote clusters', () => {
             cluster: {
               remote: {
                 test: {
-                  seeds: null,
                   skip_unavailable: false,
                   mode: 'proxy',
-                  node_connections: null,
                   proxy_address: '127.0.0.1:9300',
                   proxy_socket_connections: null,
                   server_name: 'foobar',
@@ -256,9 +251,6 @@ describe('ADD remote clusters', () => {
                   skip_unavailable: false,
                   mode: 'sniff',
                   node_connections: null,
-                  proxy_address: null,
-                  proxy_socket_connections: null,
-                  server_name: null,
                 },
               },
             },

--- a/x-pack/platform/plugins/private/remote_clusters/server/routes/api/delete_route.ts
+++ b/x-pack/platform/plugins/private/remote_clusters/server/routes/api/delete_route.ts
@@ -72,7 +72,7 @@ export const register = (deps: RouteDependencies): void => {
         hasDeprecatedProxySetting: boolean
       ) => {
         try {
-          const body = serializeCluster({ name, hasDeprecatedProxySetting });
+          const body = serializeCluster({ name, hasDeprecatedProxySetting }, undefined, true);
 
           const updateClusterResponse = await clusterClient.asCurrentUser.cluster.putSettings({
             body,

--- a/x-pack/platform/plugins/private/remote_clusters/server/routes/api/update_route.test.ts
+++ b/x-pack/platform/plugins/private/remote_clusters/server/routes/api/update_route.test.ts
@@ -141,8 +141,83 @@ describe('UPDATE remote clusters', () => {
                   skip_unavailable: true,
                   mode: 'sniff',
                   node_connections: null,
-                  proxy_address: null,
-                  proxy_socket_connections: null,
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    test('updates remote cluster with mode change', async () => {
+      remoteInfoMockFn.mockResponseOnce({
+        test: {
+          connected: true,
+          mode: 'sniff',
+          seeds: ['127.0.0.1:9300'],
+          num_nodes_connected: 1,
+          max_connections_per_cluster: 3,
+          initial_connect_timeout: '30s',
+          skip_unavailable: false,
+        },
+      });
+      putSettingsMockFn.mockResponseOnce({
+        acknowledged: true,
+        persistent: {
+          cluster: {
+            remote: {
+              test: {
+                connected: true,
+                proxy_address: '127.0.0.1:9300',
+                initial_connect_timeout: '30s',
+                skip_unavailable: true,
+                mode: 'proxy',
+                proxy_socket_connections: 18,
+              },
+            },
+          },
+        },
+        transient: {},
+      });
+
+      const mockRequest = createMockRequest({
+        proxyAddress: '127.0.0.1:9300',
+        skipUnavailable: true,
+        mode: 'proxy',
+        proxySocketConnections: 18,
+      });
+
+      const response = await handler(
+        coreMock.createCustomRequestHandlerContext(mockContext),
+        mockRequest,
+        kibanaResponseFactory
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.payload).toEqual({
+        initialConnectTimeout: '30s',
+        isConfiguredByNode: false,
+        isConnected: true,
+        proxyAddress: '127.0.0.1:9300',
+        name: 'test',
+        skipUnavailable: true,
+        mode: 'proxy',
+        securityModel: SECURITY_MODEL.CERTIFICATE,
+      });
+
+      expect(remoteInfoMockFn).toHaveBeenCalledWith();
+      expect(putSettingsMockFn).toHaveBeenCalledWith({
+        body: {
+          persistent: {
+            cluster: {
+              remote: {
+                test: {
+                  proxy_address: '127.0.0.1:9300',
+                  skip_unavailable: true,
+                  mode: 'proxy',
+                  proxy_socket_connections: 18,
+                  node_connections: null,
+                  seeds: null,
                   server_name: null,
                 },
               },
@@ -220,8 +295,6 @@ describe('UPDATE remote clusters', () => {
                   proxy_address: '127.0.0.1:9300',
                   skip_unavailable: true,
                   mode: 'proxy',
-                  node_connections: null,
-                  seeds: null,
                   proxy_socket_connections: 18,
                   server_name: null,
                   proxy: null,
@@ -301,9 +374,6 @@ describe('UPDATE remote clusters', () => {
                   skip_unavailable: false,
                   mode: 'sniff',
                   node_connections: null,
-                  proxy_address: null,
-                  proxy_socket_connections: null,
-                  server_name: null,
                 },
               },
             },


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/156354

## Summary
In the request that the Remote Clusters plugin does to ES to create or update a cluster we are adding some null fields that are not needed. However, those fields must be necessary when deleting the cluster or modifying it with a mode change. This PR modifies the `serializeCluster` method and makes sure that we only add null values when they are needed.

### How to test
Test it in Stateful mode because is where we offer different modes.

1. Go to Remote Clusters and create a new cluster
2. Click `Show request` and verify only the necessary fields are in the request ( for Proxy Mode `proxy_address`, `proxy_socket_connections` and `server_name` and for Sniff mode `seeds` and `node_connections`).
3. Verify that the cluster can be successfully created.
4. Edit the Cluster without change the mode, verify in the request that the fields are correctly updated and there are not fields corresponding the other mode.
5. Change the mode and verify in the request that the fields corresponding to the new mode have been added and the fields corresponding the old mode are set to null.
6. Verify that the cluster can be successfully updated.
7. Verify that the cluster can be successfully deleted.

### Screenshoots

**Create a Cluster with Sniff mode**
<img width="1511" alt="Screenshot 2025-02-04 at 13 40 59" src="https://github.com/user-attachments/assets/62b0a19e-8472-4117-bb48-99674226edb2" />

**Create a Cluster with Proxy mode**
<img width="1495" alt="Screenshot 2025-02-04 at 13 41 37" src="https://github.com/user-attachments/assets/c57404f7-f05c-4bb2-8a07-93b78120edf4" />

**Modify a Cluster with Sniff mode without changing the mode**
<img width="1512" alt="Screenshot 2025-02-04 at 13 43 13" src="https://github.com/user-attachments/assets/308d720f-c691-4837-b253-d84116ac4fd2" />

**Modify a Cluster with Proxy mode without changing the mode**
<img width="1509" alt="Screenshot 2025-02-04 at 13 43 43" src="https://github.com/user-attachments/assets/030e17ad-31c2-40de-84bf-41bf542a1483" />

**Modify a Cluster with Sniff mode changing the mode to Proxy**
<img width="1499" alt="Screenshot 2025-02-04 at 13 42 53" src="https://github.com/user-attachments/assets/be1b0ce9-55c5-481b-9780-93f87557973f" />

**Modify a Cluster with Proxy mode changing the mode to Sniff**
<img width="1497" alt="Screenshot 2025-02-04 at 13 42 09" src="https://github.com/user-attachments/assets/1764af41-e985-41b7-a766-c6ea57bb9f91" />


<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->