### PR TITLE
[Security Solution] Show deprecated bulk endpoints in Upgrade Assistant: some clean-up

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -454,7 +454,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       aiAssistant: `${SECURITY_SOLUTION_DOCS}security-assistant.html`,
       signalsMigrationApi: `${SECURITY_SOLUTION_DOCS}signals-migration-api.html`,
       legacyEndpointManagementApiDeprecations: `${KIBANA_DOCS}breaking-changes-summary.html#breaking-199598`,
-      legacyBulkApiDeprecations: `${KIBANA_DOCS}breaking-changes-summary.html#breaking-207091`,
+      legacyRuleManagementBulkApiDeprecations: `${KIBANA_DOCS}breaking-changes-summary.html#breaking-207091`,
     },
     query: {
       eql: `${ELASTICSEARCH_DOCS}eql.html`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -319,7 +319,7 @@ export interface DocLinks {
     readonly detectionEngineOverview: string;
     readonly signalsMigrationApi: string;
     readonly legacyEndpointManagementApiDeprecations: string;
-    readonly legacyBulkApiDeprecations: string;
+    readonly legacyRuleManagementBulkApiDeprecations: string;
   };
   readonly query: {
     readonly eql: string;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
@@ -42,6 +42,8 @@ export const bulkCreateRulesRoute = (
   logger: Logger,
   docLinks: DocLinksServiceSetup
 ) => {
+  const securityDocLinks = docLinks.links.securitySolution;
+
   router.versioned
     .post({
       access: 'public',
@@ -67,7 +69,7 @@ export const bulkCreateRulesRoute = (
         },
         options: {
           deprecated: {
-            documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
+            documentationUrl: securityDocLinks.legacyRuleManagementBulkApiDeprecations,
             severity: 'critical',
             reason: {
               type: 'migrate',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_create_rules/route.ts
@@ -70,7 +70,7 @@ export const bulkCreateRulesRoute = (
         options: {
           deprecated: {
             documentationUrl: securityDocLinks.legacyRuleManagementBulkApiDeprecations,
-            severity: 'critical',
+            severity: 'warning',
             reason: {
               type: 'migrate',
               newApiMethod: 'POST',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
@@ -132,6 +132,9 @@ export const bulkDeleteRulesRoute = (
       authz: { requiredPrivileges: ['securitySolution'] },
     },
   };
+
+  const securityDocLinks = docLinks.links.securitySolution;
+
   router.versioned.delete(routeConfig).addVersion(
     {
       version: '2023-10-31',
@@ -142,7 +145,7 @@ export const bulkDeleteRulesRoute = (
       },
       options: {
         deprecated: {
-          documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
+          documentationUrl: securityDocLinks.legacyRuleManagementBulkApiDeprecations,
           severity: 'critical',
           reason: {
             type: 'migrate',
@@ -154,6 +157,7 @@ export const bulkDeleteRulesRoute = (
     },
     handler
   );
+
   router.versioned.post(routeConfig).addVersion(
     {
       version: '2023-10-31',
@@ -164,7 +168,7 @@ export const bulkDeleteRulesRoute = (
       },
       options: {
         deprecated: {
-          documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
+          documentationUrl: securityDocLinks.legacyRuleManagementBulkApiDeprecations,
           severity: 'critical',
           reason: {
             type: 'migrate',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
@@ -146,7 +146,7 @@ export const bulkDeleteRulesRoute = (
       options: {
         deprecated: {
           documentationUrl: securityDocLinks.legacyRuleManagementBulkApiDeprecations,
-          severity: 'critical',
+          severity: 'warning',
           reason: {
             type: 'migrate',
             newApiMethod: 'POST',
@@ -169,7 +169,7 @@ export const bulkDeleteRulesRoute = (
       options: {
         deprecated: {
           documentationUrl: securityDocLinks.legacyRuleManagementBulkApiDeprecations,
-          severity: 'critical',
+          severity: 'warning',
           reason: {
             type: 'migrate',
             newApiMethod: 'POST',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
@@ -36,6 +36,8 @@ export const bulkPatchRulesRoute = (
   logger: Logger,
   docLinks: DocLinksServiceSetup
 ) => {
+  const securityDocLinks = docLinks.links.securitySolution;
+
   router.versioned
     .patch({
       access: 'public',
@@ -61,7 +63,7 @@ export const bulkPatchRulesRoute = (
         },
         options: {
           deprecated: {
-            documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
+            documentationUrl: securityDocLinks.legacyRuleManagementBulkApiDeprecations,
             severity: 'critical',
             reason: {
               type: 'migrate',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
@@ -64,7 +64,7 @@ export const bulkPatchRulesRoute = (
         options: {
           deprecated: {
             documentationUrl: securityDocLinks.legacyRuleManagementBulkApiDeprecations,
-            severity: 'critical',
+            severity: 'warning',
             reason: {
               type: 'migrate',
               newApiMethod: 'POST',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
@@ -68,7 +68,7 @@ export const bulkUpdateRulesRoute = (
         options: {
           deprecated: {
             documentationUrl: securityDocLinks.legacyRuleManagementBulkApiDeprecations,
-            severity: 'critical',
+            severity: 'warning',
             reason: {
               type: 'migrate',
               newApiMethod: 'POST',

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_update_rules/route.ts
@@ -40,6 +40,8 @@ export const bulkUpdateRulesRoute = (
   logger: Logger,
   docLinks: DocLinksServiceSetup
 ) => {
+  const securityDocLinks = docLinks.links.securitySolution;
+
   router.versioned
     .put({
       access: 'public',
@@ -65,7 +67,7 @@ export const bulkUpdateRulesRoute = (
         },
         options: {
           deprecated: {
-            documentationUrl: docLinks.links.securitySolution.legacyBulkApiDeprecations,
+            documentationUrl: securityDocLinks.legacyRuleManagementBulkApiDeprecations,
             severity: 'critical',
             reason: {
               type: 'migrate',


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/193184
**Is a follow-up to:** https://github.com/elastic/kibana/pull/207091, https://github.com/elastic/kibana/pull/208090, https://github.com/elastic/kibana/pull/207906

## Summary

This PR follows after our recent changes made to the Upgrade Assistant and does some minor cleanup:

- The doc link is renamed to `legacyRuleManagementBulkApiDeprecations` for the sake of being more specific.
- The deprecation level is changed to `warning` in accordance to what we have in `8.x` and `8.18`.


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->