### PR TITLE
[SLO] do not display apm chart without transaction type or svc name

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/apm/embeddable_root.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/custom_panels/apm/embeddable_root.tsx
@@ -79,6 +79,10 @@ export function APMEmbeddableRoot({
     ...groupingsInput.input,
   };
 
+  if (!input.serviceName || !input.transactionType) {
+    return null;
+  }
+
   return (
     <ReactEmbeddableRenderer
       type={embeddableId}


### PR DESCRIPTION
## Summary

Resolves #209172 

### Old
<img width="1724" alt="Screenshot 2025-02-05 at 11 48 59 AM" src="https://github.com/user-attachments/assets/eadf6615-2357-41cd-95bd-1d88425e3d75" />

### New
<img width="1724" alt="Screenshot 2025-02-05 at 11 47 57 AM" src="https://github.com/user-attachments/assets/1adb64c9-4fb8-4a73-a4d8-5d0d3745cfef" />

## Testing
Create an APM availability SLO with any service. Use default settings (`*`) for transaction type and service name. Once SLI drops below objective, you should see an alert. View alert details. On main branch, several alerts appear indicating that Kibana is unable to load APM visualizations, even if for just a second. Now, the errored out charts (alerts) should not appear. 

## Release Notes

Fixes an issue where APM charts were rendered without required transaction type or service name, causing excessive alerts to appear 


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->