### PR TITLE
[Charts] Fix borealis theme overrides

### DIFF
--- a/src/platform/plugins/shared/charts/public/services/theme/theme.ts
+++ b/src/platform/plugins/shared/charts/public/services/theme/theme.ts
@@ -103,21 +103,8 @@ export class ThemeService {
    */
   public init(theme: CoreSetup['theme']) {
     this.theme$ = theme.theme$;
-    this.theme$.subscribe((newTheme) => {
-      this._chartsBaseTheme$.next(getChartTheme(newTheme));
+    this.theme$.subscribe(({ darkMode }) => {
+      this._chartsBaseTheme$.next(darkMode ? DARK_THEME : LIGHT_THEME);
     });
   }
-}
-
-// TODO: define these overrides in elastic/charts when Borealis becomes default
-function getChartTheme(theme: CoreTheme): Theme {
-  const chartTheme = theme.darkMode ? DARK_THEME : LIGHT_THEME;
-
-  if (theme.name !== 'amsterdam') {
-    const backgroundColor = euiThemeVars.euiColorEmptyShade;
-    chartTheme.background.color = backgroundColor;
-    chartTheme.background.fallbackColor = backgroundColor;
-  }
-
-  return chartTheme;
 }

--- a/src/platform/plugins/shared/charts/public/services/theme/theme.ts
+++ b/src/platform/plugins/shared/charts/public/services/theme/theme.ts
@@ -11,8 +11,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Observable, BehaviorSubject } from 'rxjs';
 
 import { CoreSetup, CoreTheme } from '@kbn/core/public';
-import { DARK_THEME, LIGHT_THEME, PartialTheme, Theme } from '@elastic/charts';
-import { euiThemeVars } from '@kbn/ui-theme';
+import { LIGHT_THEME, PartialTheme, Theme, getChartsTheme } from '@elastic/charts';
 
 export class ThemeService {
   /** Returns default charts theme */
@@ -103,8 +102,8 @@ export class ThemeService {
    */
   public init(theme: CoreSetup['theme']) {
     this.theme$ = theme.theme$;
-    this.theme$.subscribe(({ darkMode }) => {
-      this._chartsBaseTheme$.next(darkMode ? DARK_THEME : LIGHT_THEME);
+    this.theme$.subscribe((newTheme) => {
+      this._chartsBaseTheme$.next(getChartsTheme(newTheme));
     });
   }
 }


### PR DESCRIPTION
## Summary

This removes an override that was applied to the charts theme prior to updating the `Theme` in `@elastic/charts`. This is no longer needed and is now using the wrong color.

Fixes #209596


https://github.com/user-attachments/assets/730b12aa-b0d7-4966-b483-64e5ddb5924a


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release note

Fixes issue with `Amsterdam` theme where charts render with the incorrect background color.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->