### PR TITLE
[DOCS] Fix hard-coded accessibility link

### DIFF
--- a/docs/developer/best-practices/index.asciidoc
+++ b/docs/developer/best-practices/index.asciidoc
@@ -22,7 +22,7 @@ Are you planning with scalability in mind?
 
 Did you know {kib} makes a public statement about our commitment to
 creating an accessible product for people with disabilities?
-https://www.elastic.co/guide/en/kibana/master/accessibility.html[We do]!
+<<accessibility,We do>>!
 It’s very important all of our apps are accessible.
 
 * Learn how https://elastic.github.io/eui/#/guidelines/accessibility[EUI


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/docs/pull/3160

This PR fixes the (final?!) set of broken links in Kibana docs that are hard-coded to use "master":
 
```
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/kibana/7.15/development-best-practices.html contains broken links to:
--
  | INFO:build_docs:   - en/kibana/master/accessibility.html

```