### PR TITLE
[7.12] [DOCS] Fix URL in alerting API (#209594)

### DIFF
--- a/docs/api/alerts/create.asciidoc
+++ b/docs/api/alerts/create.asciidoc
@@ -19,7 +19,7 @@ Create {kib} alerts.
 `space_id`::
   (Optional, string) An identifier for the space. If `space_id` is not provided in the URL, the default space is used.
 
-WARNING: As part of the <<sharing-saved-objects,Sharing Saved Objects>> effort, IDs for rules in a custom space will be regenerated in 8.0.0. Rules created prior to 8.0.0 using this API that specify both the `id` and `space_id` path parameters will be re-assigned a randomly generated ID upon upgrading to 8.0.0.
+WARNING: As part of the {kibana-ref-all}/8.0/sharing-saved-objects.html[Sharing Saved Objects] effort, IDs for rules in a custom space will be regenerated in 8.0.0. Rules created prior to 8.0.0 using this API that specify both the `id` and `space_id` path parameters will be re-assigned a randomly generated ID upon upgrading to 8.0.0.
 
 `id`::
   (Optional, string) Specifies a UUID v1 or v4 to use instead of a randomly generated ID.

--- a/docs/api/alerts/create.asciidoc
+++ b/docs/api/alerts/create.asciidoc
@@ -19,7 +19,7 @@ Create {kib} alerts.
 `space_id`::
   (Optional, string) An identifier for the space. If `space_id` is not provided in the URL, the default space is used.
 
-WARNING: As part of the {kibana-ref-all}/master/sharing-saved-objects.html[Sharing Saved Objects] effort, IDs for rules in a custom space will be regenerated in 8.0.0. Rules created prior to 8.0.0 using this API that specify both the `id` and `space_id` path parameters will be re-assigned a randomly generated ID upon upgrading to 8.0.0.
+WARNING: As part of the <<sharing-saved-objects,Sharing Saved Objects>> effort, IDs for rules in a custom space will be regenerated in 8.0.0. Rules created prior to 8.0.0 using this API that specify both the `id` and `space_id` path parameters will be re-assigned a randomly generated ID upon upgrading to 8.0.0.
 
 `id`::
   (Optional, string) Specifies a UUID v1 or v4 to use instead of a randomly generated ID.


### PR DESCRIPTION
# Backport

This will backport the following commits from `7.17` to `7.12`:
 - [[DOCS] Fix URL in alerting API (#209594)](https://github.com/elastic/kibana/pull/209594)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2025-02-04T17:39:12Z","message":"[DOCS] Fix URL in alerting API (#209594)","sha":"8a7cb74f8adc06e00779b66e5ea3212aa182e79a","branchLabelMapping":{"^v8.1.0$":"master","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","v7.12.2","v7.13.5","v7.14.3","skip-ci","v7.15.3","v7.16.4","backport:version"],"title":"[DOCS] Fix URL in alerting API","number":209594,"url":"https://github.com/elastic/kibana/pull/209594","mergeCommit":{"message":"[DOCS] Fix URL in alerting API (#209594)","sha":"8a7cb74f8adc06e00779b66e5ea3212aa182e79a"}},"sourceBranch":"7.17","suggestedTargetBranches":["7.12"],"targetPullRequestStates":[{"branch":"7.12","label":"v7.12.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"7.13","label":"v7.13.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209617","number":209617,"state":"OPEN"},{"branch":"7.14","label":"v7.14.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209616","number":209616,"state":"OPEN"},{"branch":"7.15","label":"v7.15.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209615","number":209615,"state":"OPEN"},{"branch":"7.16","label":"v7.16.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209613","number":209613,"state":"OPEN"}]}] BACKPORT-->