### PR TITLE
[Security GenAI] Add Telemetry related to the Attack Discovery Alert Filtering feature 

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
@@ -282,7 +282,7 @@ export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<{
     dateRangeDuration: {
       type: 'integer',
       _meta: {
-        description: 'Duration of time period of request in hours',
+        description: 'Duration of time range of request in hours',
         optional: false,
       },
     },

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
@@ -241,8 +241,11 @@ export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<{
   alertsContextCount: number;
   alertsCount: number;
   configuredAlertsCount: number;
+  dateRangeDuration: number;
   discoveriesGenerated: number;
   durationMs: number;
+  hasFilter: boolean;
+  isDefaultDateRange: boolean;
   model?: string;
   provider?: string;
 }> = {
@@ -276,6 +279,13 @@ export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<{
         optional: false,
       },
     },
+    dateRangeDuration: {
+      type: 'integer',
+      _meta: {
+        description: 'Duration of time period of request in hours',
+        optional: false,
+      },
+    },
     discoveriesGenerated: {
       type: 'integer',
       _meta: {
@@ -287,6 +297,20 @@ export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<{
       type: 'integer',
       _meta: {
         description: 'Duration of request in ms',
+        optional: false,
+      },
+    },
+    hasFilter: {
+      type: 'boolean',
+      _meta: {
+        description: 'Whether a filter was applied to the alerts used as context',
+        optional: false,
+      },
+    },
+    isDefaultDateRange: {
+      type: 'boolean',
+      _meta: {
+        description: 'Whether the date range is the default of last 24 hours',
         optional: false,
       },
     },

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/helpers.ts
@@ -21,6 +21,7 @@ import { transformError } from '@kbn/securitysolution-es-utils';
 import moment from 'moment/moment';
 import { uniq } from 'lodash/fp';
 
+import dateMath from '@kbn/datemath';
 import {
   ATTACK_DISCOVERY_ERROR_EVENT,
   ATTACK_DISCOVERY_SUCCESS_EVENT,
@@ -135,9 +136,12 @@ export const updateAttackDiscoveries = async ({
   attackDiscoveryId,
   authenticatedUser,
   dataClient,
+  hasFilter,
+  end,
   latestReplacements,
   logger,
   size,
+  start,
   startTime,
   telemetry,
 }: {
@@ -147,9 +151,14 @@ export const updateAttackDiscoveries = async ({
   attackDiscoveryId: string;
   authenticatedUser: AuthenticatedUser;
   dataClient: AttackDiscoveryDataClient;
+  end?: string;
+  hasFilter: boolean;
   latestReplacements: Replacements;
   logger: Logger;
   size: number;
+  // start of attack discovery time range
+  start?: string;
+  // start time of attack discovery
   startTime: Moment;
   telemetry: AnalyticsServiceSetup;
 }) => {
@@ -185,6 +194,8 @@ export const updateAttackDiscoveries = async ({
       attackDiscoveryUpdateProps: updateProps,
       authenticatedUser,
     });
+    const { dateRangeDuration, isDefaultDateRange } = getTimeRangeDuration({ start, end });
+
     telemetry.reportEvent(ATTACK_DISCOVERY_SUCCESS_EVENT.eventType, {
       actionTypeId: apiConfig.actionTypeId,
       alertsContextCount: updateProps.alertsContextCount,
@@ -195,8 +206,11 @@ export const updateAttackDiscoveries = async ({
           )
         ).length ?? 0,
       configuredAlertsCount: size,
+      dateRangeDuration,
       discoveriesGenerated: updateProps.attackDiscoveries?.length ?? 0,
       durationMs,
+      hasFilter,
+      isDefaultDateRange,
       model: apiConfig.model,
       provider: apiConfig.provider,
     });
@@ -265,4 +279,41 @@ export const getAttackDiscoveryStats = async ({
       connectorId: ad.apiConfig.connectorId,
     };
   });
+};
+
+const getTimeRangeDuration = ({
+  start,
+  end,
+}: {
+  start?: string;
+  end?: string;
+}): {
+  dateRangeDuration: number;
+  isDefaultDateRange: boolean;
+} => {
+  if (start && end) {
+    const forceNow = moment().toDate();
+    const dateStart = dateMath.parse(start, {
+      roundUp: false,
+      momentInstance: moment,
+      forceNow,
+    });
+    const dateEnd = dateMath.parse(end, {
+      roundUp: false,
+      momentInstance: moment,
+      forceNow,
+    });
+    if (dateStart && dateEnd) {
+      const dateRangeDuration = moment.duration(dateEnd.diff(dateStart)).asHours();
+      return {
+        dateRangeDuration,
+        isDefaultDateRange: start === 'now' && end === 'now-24h',
+      };
+    }
+  }
+  return {
+    // start and/or end undefined, return 0 hours
+    dateRangeDuration: 0,
+    isDefaultDateRange: false,
+  };
 };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/helpers.ts
@@ -307,7 +307,7 @@ const getTimeRangeDuration = ({
       const dateRangeDuration = moment.duration(dateEnd.diff(dateStart)).asHours();
       return {
         dateRangeDuration,
-        isDefaultDateRange: start === 'now' && end === 'now-24h',
+        isDefaultDateRange: end === 'now' && start === 'now-24h',
       };
     }
   }

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/post_attack_discovery.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/post_attack_discovery.ts
@@ -157,9 +157,12 @@ export const postAttackDiscoveryRoute = (
                 attackDiscoveryId,
                 authenticatedUser,
                 dataClient,
+                hasFilter: !!(filter && Object.keys(filter).length),
+                end,
                 latestReplacements,
                 logger,
                 size,
+                start,
                 startTime,
                 telemetry,
               })

--- a/x-pack/solutions/security/plugins/elastic_assistant/tsconfig.json
+++ b/x-pack/solutions/security/plugins/elastic_assistant/tsconfig.json
@@ -54,7 +54,8 @@
     "@kbn/llm-tasks-plugin",
     "@kbn/product-doc-base-plugin",
     "@kbn/core-saved-objects-api-server-mocks",
-    "@kbn/security-ai-prompts"
+    "@kbn/security-ai-prompts",
+    "@kbn/datemath"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Adds three new properties to the `ATTACK_DISCOVERY_SUCCESS_EVENT` telemetry event:

- `dateRangeDuration`: Duration of time range of request in hours
- `hasFilter`: Whether a filter was applied to the alerts used as context
- `isDefaultDateRange`: Whether the date range is the default time range of last 24 hours

<img width="390" alt="Screenshot 2025-02-04 at 12 28 32 PM" src="https://github.com/user-attachments/assets/90aba1c8-0b5a-4324-a2fe-2cd222a04ad5" />

## To test

**The fast way**: `console.log` the new `ATTACK_DISCOVERY_SUCCESS_EVENT` fields in `x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/helpers.ts`

**OR**

**The long but thorough way**: add `telemetry.optIn: true` to your dev yml. Run the steps below and wait about 2 hours for data to populate on the staging server. Check for events on telemetry server in the `security-solution-ebt-kibana-server` data view. 

1. Enable feature flag: `xpack.securitySolution.enableExperimental: ['attackDiscoveryAlertFiltering']`
2. Run attack discover with default time range an no filters. You should see `dateRangeDuration = 24`, `isDefaultDateRange = true`, and `hasFilter = false`.
3. Set a filter on the alerts and change the time range to last week. You should see `dateRangeDuration = 168`, `isDefaultDateRange = false`, and `hasFilter = true`.
4. Set the time range to a 24 hour period from a week ago (ex: Jan 30 00:00:00 - Jan 31 00:00:00). You should see `dateRangeDuration = 24` and `isDefaultDateRange = false`

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->