### PR TITLE
[Connectors] depend Sharepoint secret_value on auth_method

### DIFF
--- a/src/platform/packages/shared/kbn-search-connectors/types/native_connectors.ts
+++ b/src/platform/packages/shared/kbn-search-connectors/types/native_connectors.ts
@@ -4283,7 +4283,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
       },
       secret_value: {
         default_value: null,
-        depends_on: [],
+        depends_on: [{"field": "auth_method", "value": "secret"}],
         display: TEXTBOX,
         label: translate(
           'searchConnectors.nativeConnectors.sharepoint_online.configuration.secretValueLabel',

--- a/src/platform/packages/shared/kbn-search-connectors/types/native_connectors.ts
+++ b/src/platform/packages/shared/kbn-search-connectors/types/native_connectors.ts
@@ -4283,7 +4283,7 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
       },
       secret_value: {
         default_value: null,
-        depends_on: [{"field": "auth_method", "value": "secret"}],
+        depends_on: [{ field: 'auth_method', value: 'secret' }],
         display: TEXTBOX,
         label: translate(
           'searchConnectors.nativeConnectors.sharepoint_online.configuration.secretValueLabel',


### PR DESCRIPTION
## Summary

Only have secret_value box when configuring a Sharepoint online connector when auth_method is 'secret'. 

#### Closes https://github.com/elastic/search-team/issues/9196
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.17","8.18","8.x","9.0"]} ONMERGE-->