### PR TITLE
[Connectors] don't display extra 'content-'

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -99,7 +99,7 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
   const [sanitizedName, setSanitizedName] = useState<string>(
     prefixConnectorIndex(formatApiName(connector.name))
   );
-
+  const sanitizedNameWithoutPrefix = formatApiName(connector.name);
   const [selectedIndex, setSelectedIndex] = useState<
     { label: string; shouldCreate?: boolean } | undefined
   >(
@@ -193,7 +193,7 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
 
   useEffect(() => {
     // Suggested name for managed connector should include the content- prefix
-    setSanitizedName(prefixConnectorIndex(formatApiName(connector.name)));
+    setSanitizedName(prefixConnectorIndex(sanitizedNameWithoutPrefix));
   }, [connector.name]);
 
   const { hash } = useLocation();

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -373,7 +373,7 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
                 fill
                 onClick={() => {
                   createIndex({ indexName: sanitizedName, language: null });
-                  setSelectedIndex({ label: sanitizedName });
+                  setSelectedIndex({ label: formatApiName(connector.name)});
                 }}
                 isLoading={isSaveLoading || isExistLoading}
                 disabled={indexExists[sanitizedName]}

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -96,10 +96,10 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
     isFullMatch: boolean;
     searchValue: string;
   }>();
-  const [sanitizedName, setSanitizedName] = useState<string>(
-    prefixConnectorIndex(formatApiName(connector.name))
-  );
   const sanitizedNameWithoutPrefix = formatApiName(connector.name);
+  const [sanitizedName, setSanitizedName] = useState<string>(
+    prefixConnectorIndex(sanitizedNameWithoutPrefix)
+  );
   const [selectedIndex, setSelectedIndex] = useState<
     { label: string; shouldCreate?: boolean } | undefined
   >(
@@ -193,7 +193,7 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
 
   useEffect(() => {
     // Suggested name for managed connector should include the content- prefix
-    setSanitizedName(prefixConnectorIndex(formatApiName(connector.name)));
+    setSanitizedName(prefixConnectorIndex(sanitizedNameWithoutPrefix));
   }, [connector.name]);
 
   const { hash } = useLocation();

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -373,7 +373,7 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
                 fill
                 onClick={() => {
                   createIndex({ indexName: sanitizedName, language: null });
-                  setSelectedIndex({ label: formatApiName(connector.name) });
+                  setSelectedIndex({ label: sanitizedNameWithoutPrefix });
                 }}
                 isLoading={isSaveLoading || isExistLoading}
                 disabled={indexExists[sanitizedName]}

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -193,7 +193,7 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
 
   useEffect(() => {
     // Suggested name for managed connector should include the content- prefix
-    setSanitizedName(prefixConnectorIndex(sanitizedNameWithoutPrefix));
+    setSanitizedName(prefixConnectorIndex(formatApiName(connector.name)));
   }, [connector.name]);
 
   const { hash } = useLocation();

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -373,7 +373,7 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
                 fill
                 onClick={() => {
                   createIndex({ indexName: sanitizedName, language: null });
-                  setSelectedIndex({ label: formatApiName(connector.name)});
+                  setSelectedIndex({ label: formatApiName(connector.name) });
                 }}
                 isLoading={isSaveLoading || isExistLoading}
                 disabled={indexExists[sanitizedName]}


### PR DESCRIPTION
## Summary

There was an extra 'content-' prefix when attaching an automated index name.

Verified e2e that "content-" is still added to the index name without being in the box and it is not added when `is_native` is false. 

<img width="300" alt="Screenshot 2025-02-05 at 9 22 48 AM" src="https://github.com/user-attachments/assets/fc3a0129-8c5e-4182-bc80-9a8ec88b810a" />

<img width="200" alt="Screenshot 2025-02-05 at 9 25 12 AM" src="https://github.com/user-attachments/assets/fa5b8d2f-3ca5-4df3-bfa4-af190e570ae6" />


#### Closes https://github.com/elastic/search-team/issues/9217
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->