### PR TITLE
[8.18] [DataDiscovery] Replace euiThemeVars with euiTheme (#204457)

### DIFF
--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/log_level_badge_cell/log_level_badge_cell.test.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/log_level_badge_cell/log_level_badge_cell.test.tsx
@@ -9,6 +9,7 @@
 
 import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 import { render, screen } from '@testing-library/react';
+import { EuiProvider } from '@elastic/eui';
 import React from 'react';
 import { getLogLevelBadgeCell } from './log_level_badge_cell';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__/data_view';
@@ -17,19 +18,21 @@ import { DataTableRecord, buildDataTableRecord } from '@kbn/discover-utils';
 const renderCell = (logLevelField: string, record: DataTableRecord) => {
   const LogLevelBadgeCell = getLogLevelBadgeCell(logLevelField);
   render(
-    <LogLevelBadgeCell
-      rowIndex={0}
-      colIndex={0}
-      columnId="log.level"
-      isExpandable={false}
-      isExpanded={false}
-      isDetails={false}
-      row={record}
-      dataView={dataViewMock}
-      fieldFormats={fieldFormatsMock}
-      setCellProps={() => {}}
-      closePopover={() => {}}
-    />
+    <EuiProvider>
+      <LogLevelBadgeCell
+        rowIndex={0}
+        colIndex={0}
+        columnId="log.level"
+        isExpandable={false}
+        isExpanded={false}
+        isDetails={false}
+        row={record}
+        dataView={dataViewMock}
+        fieldFormats={fieldFormatsMock}
+        setCellProps={() => {}}
+        closePopover={() => {}}
+      />
+    </EuiProvider>
   );
 };
 

--- a/src/platform/packages/shared/kbn-discover-utils/src/components/custom_control_columns/degraded_docs_control.tsx
+++ b/src/platform/packages/shared/kbn-discover-utils/src/components/custom_control_columns/degraded_docs_control.tsx
@@ -9,9 +9,8 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiCode } from '@elastic/eui';
+import { EuiCode, useEuiTheme } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { euiThemeVars } from '@kbn/ui-theme';
 import {
   RowControlColumn,
   RowControlComponent,
@@ -83,6 +82,8 @@ const DegradedDocs = ({
   Control: RowControlComponent;
   rowProps: RowControlRowProps;
 } & DegradedDocsControlProps) => {
+  const { euiTheme } = useEuiTheme();
+
   const isDegradedDocumentExists = DEGRADED_DOCS_FIELDS.some(
     (field) => field in record.raw && record.raw[field] !== null && record.raw[field] !== undefined
   );
@@ -91,7 +92,7 @@ const DegradedDocs = ({
     if (addIgnoredMetadataToQuery) {
       return (
         <Control
-          css={{ color: euiThemeVars.euiColorDisabledText }} // Give same color as disabled
+          css={{ color: euiTheme.colors.textDisabled }} // Give same color as disabled
           data-test-subj="docTableDegradedDocDisabled"
           iconType="indexClose"
           label={actionsHeaderAriaLabelDegradedAction}

--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/components/log_level_badge.test.tsx
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/components/log_level_badge.test.tsx
@@ -9,14 +9,17 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { EuiProvider } from '@elastic/eui';
 import { LogLevelBadge } from './log_level_badge';
 
 const renderBadge = (logLevel: string) => {
   render(
-    <LogLevelBadge
-      logLevel={logLevel}
-      fallback={<span data-test-subj="logLevelBadge-unknown">{logLevel}</span>}
-    />
+    <EuiProvider>
+      <LogLevelBadge
+        logLevel={logLevel}
+        fallback={<span data-test-subj="logLevelBadge-unknown">{logLevel}</span>}
+      />
+    </EuiProvider>
   );
 };
 

--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/components/log_level_badge.tsx
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/components/log_level_badge.tsx
@@ -8,14 +8,13 @@
  */
 
 import React, { ReactElement } from 'react';
-import { EuiBadge, EuiBadgeProps, mathWithUnits, useEuiTheme } from '@elastic/eui';
-import { CSSObject } from '@emotion/react';
-import { euiThemeVars } from '@kbn/ui-theme';
+import { EuiBadge, EuiBadgeProps, useEuiTheme, UseEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { getLogLevelCoalescedValue, getLogLevelColor } from '../utils';
 
-const badgeCss: CSSObject = {
-  maxWidth: mathWithUnits(euiThemeVars.euiSize, (size) => size * 7.5),
-};
+const badgeCss = ({ euiTheme }: UseEuiTheme) => css`
+  max-width: calc(${euiTheme.size.base} * 7.5);
+`;
 
 export const LogLevelBadge = ({
   logLevel,

--- a/src/platform/packages/shared/kbn-discover-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-discover-utils/tsconfig.json
@@ -6,16 +6,12 @@
       "jest",
       "node",
       "react",
-      "@testing-library/jest-dom"
+      "@testing-library/jest-dom",
+      "../../../../../typings/emotion.d.ts"
     ]
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "target/**/*"
-  ],
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["target/**/*"],
   "kbn_references": [
     "@kbn/data-service",
     "@kbn/data-views-plugin",
@@ -28,7 +24,6 @@
     "@kbn/expressions-plugin",
     "@kbn/logs-data-access-plugin",
     "@kbn/i18n-react",
-    "@kbn/navigation-plugin",
-    "@kbn/ui-theme"
+    "@kbn/navigation-plugin"
   ]
 }

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/column_header_truncate_container.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/column_header_truncate_container.tsx
@@ -8,9 +8,8 @@
  */
 
 import React from 'react';
-import { EuiTextBlockTruncate } from '@elastic/eui';
+import { EuiTextBlockTruncate, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { euiThemeVars } from '@kbn/ui-theme';
 
 const ColumnHeaderTruncateContainer = ({
   headerRowHeight,
@@ -19,11 +18,13 @@ const ColumnHeaderTruncateContainer = ({
   headerRowHeight?: number;
   children: React.ReactNode;
 }) => {
+  const { euiTheme } = useEuiTheme();
+
   const headerCss = css`
     overflow-wrap: anywhere;
     white-space: normal;
     word-break: break-all;
-    line-height: ${euiThemeVars.euiSize};
+    line-height: ${euiTheme.size.base};
     text-align: left;
     .euiDataGridHeaderCell--numeric & {
       float: right;

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_column_header.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table_column_header.tsx
@@ -9,12 +9,11 @@
 
 import React, { useMemo } from 'react';
 import { css, CSSObject } from '@emotion/react';
-import { EuiIconTip } from '@elastic/eui';
+import { EuiIconTip, useEuiTheme } from '@elastic/eui';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import { FieldIcon, getFieldIconProps, getTextBasedColumnIconType } from '@kbn/field-utils';
 import { isNestedFieldParent } from '@kbn/discover-utils';
 import { i18n } from '@kbn/i18n';
-import { euiThemeVars } from '@kbn/ui-theme';
 import type { DataTableColumnsMeta } from '../types';
 import ColumnHeaderTruncateContainer from './column_header_truncate_container';
 
@@ -52,15 +51,14 @@ export const DataTableColumnHeader: React.FC<DataTableColumnHeaderProps> = ({
 const DataTableColumnToken: React.FC<
   Pick<DataTableColumnHeaderProps, 'columnName' | 'columnsMeta' | 'dataView'>
 > = (props) => {
+  const { euiTheme } = useEuiTheme();
   const { columnName, columnsMeta, dataView } = props;
   const columnToken = useMemo(
     () => getRenderedToken({ columnName, columnsMeta, dataView }),
     [columnName, columnsMeta, dataView]
   );
 
-  return columnToken ? (
-    <span css={{ paddingRight: euiThemeVars.euiSizeXS }}>{columnToken}</span>
-  ) : null;
+  return columnToken ? <span css={{ paddingRight: euiTheme.size.xs }}>{columnToken}</span> : null;
 };
 
 const DataTableColumnTitle: React.FC<Pick<DataTableColumnHeaderProps, 'columnDisplayName'>> = ({

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/row_height_settings.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/row_height_settings.tsx
@@ -11,9 +11,9 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiButtonGroup,
-  EuiFormRow,
   EuiFieldNumber,
   EuiFlexGroup,
+  EuiFormRow,
   htmlIdGenerator,
 } from '@elastic/eui';
 

--- a/src/platform/packages/shared/kbn-unified-data-table/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-data-table/tsconfig.json
@@ -3,10 +3,14 @@
   "compilerOptions": {
     "outDir": "target/types"
   },
-  "include": ["*.ts", "**/*.tsx", "src/**/*", "__mocks__/**/*.ts"],
-  "exclude": [
-    "target/**/*"
+  "include": [
+    "*.ts",
+    "**/*.tsx",
+    "src/**/*",
+    "__mocks__/**/*.ts",
+    "../../../../../typings/emotion.d.ts"
   ],
+  "exclude": ["target/**/*"],
   "kbn_references": [
     "@kbn/i18n",
     "@kbn/data-views-plugin",
@@ -16,7 +20,6 @@
     "@kbn/expressions-plugin",
     "@kbn/test-jest-helpers",
     "@kbn/i18n-react",
-    "@kbn/ui-theme",
     "@kbn/field-types",
     "@kbn/kibana-utils-plugin",
     "@kbn/cell-actions",
@@ -40,6 +43,6 @@
     "@kbn/core-notifications-browser",
     "@kbn/core-capabilities-browser-mocks",
     "@kbn/sort-predicates",
-    "@kbn/data-grid-in-table-search",
+    "@kbn/data-grid-in-table-search"
   ]
 }

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover.tsx
@@ -15,8 +15,9 @@ import {
   EuiPopoverProps,
   EuiPopoverTitle,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
+
 import './field_popover.scss';
-import { euiThemeVars } from '@kbn/ui-theme';
 
 export interface FieldPopoverProps extends EuiPopoverProps {
   renderHeader?: () => React.ReactNode;
@@ -80,10 +81,10 @@ export const FieldPopover: React.FC<FieldPopoverProps> = ({
           {content ? (
             <EuiFlexItem
               className="eui-yScrollWithShadows"
-              css={{
-                padding: euiThemeVars.euiSize,
-                margin: `-${euiThemeVars.euiSize}`,
-              }}
+              css={({ euiTheme }) => css`
+                padding: ${euiTheme.size.base};
+                margin: -${euiTheme.size.base};
+              `}
             >
               {content}
             </EuiFlexItem>

--- a/src/platform/packages/shared/kbn-unified-field-list/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-field-list/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "target/types"
   },
-  "include": ["*.ts", "src/**/*", "__mocks__/**/*.ts"],
+  "include": ["*.ts", "src/**/*", "__mocks__/**/*.ts", "../../../../../typings/emotion.d.ts"],
   "kbn_references": [
     "@kbn/i18n",
     "@kbn/data-views-plugin",
@@ -34,8 +34,7 @@
     "@kbn/visualization-utils",
     "@kbn/search-types",
     "@kbn/fields-metadata-plugin",
-    "@kbn/ui-theme",
-    "@kbn/esql-utils",
+    "@kbn/esql-utils"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/discover/public/application/context/context_app_content.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/context/context_app_content.test.tsx
@@ -8,6 +8,7 @@
  */
 
 import React from 'react';
+import { EuiProvider } from '@elastic/eui';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
 import { findTestSubject } from '@elastic/eui/lib/test';
 import { ActionBar } from './components/action_bar/action_bar';
@@ -83,7 +84,9 @@ describe('ContextAppContent test', () => {
 
     const component = mountWithIntl(
       <KibanaContextProvider services={discoverServiceMock}>
-        <ContextAppContent {...props} />
+        <EuiProvider>
+          <ContextAppContent {...props} />
+        </EuiProvider>
       </KibanaContextProvider>
     );
     await act(async () => {

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.test.tsx
@@ -9,6 +9,7 @@
 
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import { EuiProvider } from '@elastic/eui';
 import { BehaviorSubject } from 'rxjs';
 import { findTestSubject } from '@elastic/eui/lib/test';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
@@ -70,7 +71,9 @@ async function mountComponent(fetchStatus: FetchStatus, hits: EsHitRecord[]) {
     <KibanaContextProvider services={services}>
       <DiscoverCustomizationProvider value={customisationService}>
         <DiscoverMainProvider value={stateContainer}>
-          <DiscoverDocuments {...props} />
+          <EuiProvider>
+            <DiscoverDocuments {...props} />
+          </EuiProvider>
         </DiscoverMainProvider>
       </DiscoverCustomizationProvider>
     </KibanaContextProvider>

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_layout.test.tsx
@@ -8,6 +8,7 @@
  */
 
 import React from 'react';
+import { EuiProvider } from '@elastic/eui';
 import { BehaviorSubject, of } from 'rxjs';
 import { EuiPageSidebar } from '@elastic/eui';
 import { mountWithIntl } from '@kbn/test-jest-helpers';
@@ -127,7 +128,9 @@ async function mountComponent(
   const component = mountWithIntl(
     <KibanaContextProvider services={services}>
       <DiscoverMainProvider value={stateContainer}>
-        <DiscoverLayout {...props} />
+        <EuiProvider>
+          <DiscoverLayout {...props} />
+        </EuiProvider>
       </DiscoverMainProvider>
     </KibanaContextProvider>,
     mountOptions

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav_inline.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/discover_topnav_inline.tsx
@@ -8,9 +8,8 @@
  */
 
 import React from 'react';
-import { EuiHeader, EuiHeaderSection, EuiHeaderSectionItem } from '@elastic/eui';
+import { EuiHeader, EuiHeaderSection, EuiHeaderSectionItem, useEuiTheme } from '@elastic/eui';
 import { TopNavMenuBadges, TopNavMenuItems } from '@kbn/navigation-plugin/public';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { LogsExplorerTabs } from '../../../../components/logs_explorer_tabs';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { useDiscoverTopNav } from './use_discover_topnav';
@@ -23,6 +22,7 @@ export const DiscoverTopNavInline = ({
   stateContainer: DiscoverStateContainer;
   hideNavMenuItems?: boolean;
 }) => {
+  const { euiTheme } = useEuiTheme();
   const { customizationContext } = stateContainer;
   const services = useDiscoverServices();
   const { topNavBadges, topNavMenu } = useDiscoverTopNav({ stateContainer });
@@ -36,7 +36,7 @@ export const DiscoverTopNavInline = ({
 
   return (
     <EuiHeader
-      css={{ boxShadow: 'none', backgroundColor: euiThemeVars.euiPageBackgroundColor }}
+      css={{ boxShadow: 'none', backgroundColor: euiTheme.colors.body }}
       data-test-subj="discoverTopNavInline"
     >
       {customizationContext.inlineTopNav.showLogsExplorerTabs && (

--- a/src/platform/plugins/shared/discover/public/components/data_types/logs/service_name_cell.tsx
+++ b/src/platform/plugins/shared/discover/public/components/data_types/logs/service_name_cell.tsx
@@ -8,13 +8,12 @@
  */
 
 import React from 'react';
-import { EuiToolTip } from '@elastic/eui';
+import { EuiToolTip, UseEuiTheme } from '@elastic/eui';
 import type { AgentName } from '@kbn/elastic-agent-utils';
 import { dynamic } from '@kbn/shared-ux-utility';
 import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
 import { css } from '@emotion/react';
 import { getFieldValue } from '@kbn/discover-utils';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { ServiceNameBadgeWithActions } from '@kbn/discover-contextual-components';
 import { useDiscoverServices } from '../../../hooks/use_discover_services';
 import { CellRenderersExtensionParams } from '../../../context_awareness';
@@ -22,8 +21,9 @@ import { AGENT_NAME_FIELD } from '../../../../common/data_types/logs/constants';
 
 const AgentIcon = dynamic(() => import('@kbn/custom-icons/src/components/agent_icon'));
 const dataTestSubj = 'serviceNameCell';
-const agentIconStyle = css`
-  margin-right: ${euiThemeVars.euiSizeXS};
+
+const agentIconStyle = ({ euiTheme }: UseEuiTheme) => css`
+  margin-right: ${euiTheme.size.xs};
 `;
 
 export const getServiceNameCell =

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/example/example_data_source_profile/profile.tsx
@@ -16,7 +16,6 @@ import {
 } from '@kbn/discover-utils';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import { getIndexPatternFromESQLQuery } from '@kbn/esql-utils';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { capitalize } from 'lodash';
 import React from 'react';
 import { DataSourceType, isDataSourceType } from '../../../../../common/data_sources';
@@ -37,7 +36,9 @@ export const createExampleDataSourceProfileProvider = (): DataSourceProfileProvi
         if (!level) {
           return (
             <span
-              css={{ color: euiThemeVars.euiTextSubduedColor }}
+              css={({ euiTheme }) => ({
+                color: euiTheme.colors.textSubdued,
+              })}
               data-test-subj="exampleDataSourceProfileLogLevelEmpty"
             >
               (None)

--- a/src/platform/plugins/shared/discover/tsconfig.json
+++ b/src/platform/plugins/shared/discover/tsconfig.json
@@ -50,7 +50,6 @@
     "@kbn/test-jest-helpers",
     "@kbn/shared-ux-page-analytics-no-data",
     "@kbn/alerting-plugin",
-    "@kbn/ui-theme",
     "@kbn/config-schema",
     "@kbn/storybook",
     "@kbn/shared-ux-router",
@@ -101,7 +100,5 @@
     "@kbn/esql-ast",
     "@kbn/discover-shared-plugin"
   ],
-  "exclude": [
-    "target/**/*"
-  ]
+  "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/discover/tsconfig.json
+++ b/src/platform/plugins/shared/discover/tsconfig.json
@@ -98,7 +98,8 @@
     "@kbn/core-lifecycle-browser",
     "@kbn/discover-contextual-components",
     "@kbn/esql-ast",
-    "@kbn/discover-shared-plugin"
+    "@kbn/discover-shared-plugin",
+    "@kbn/ui-theme"
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_logs_overview/logs_overview.test.tsx
@@ -8,6 +8,7 @@
  */
 
 import React from 'react';
+import { EuiProvider } from '@elastic/eui';
 import { render, screen } from '@testing-library/react';
 import { LogsOverview } from './logs_overview';
 import { DataView } from '@kbn/data-views-plugin/common';
@@ -146,11 +147,17 @@ setUnifiedDocViewerServices(
 
 const renderLogsOverview = (props: Partial<DocViewRenderProps> = {}) => {
   const { rerender: baseRerender, ...tools } = render(
-    <LogsOverview dataView={dataView} hit={fullHit} {...props} />
+    <EuiProvider>
+      <LogsOverview dataView={dataView} hit={fullHit} {...props} />
+    </EuiProvider>
   );
 
   const rerender = (rerenderProps: Partial<DocViewRenderProps>) =>
-    baseRerender(<LogsOverview dataView={dataView} hit={fullHit} {...props} {...rerenderProps} />);
+    baseRerender(
+      <EuiProvider>
+        <LogsOverview dataView={dataView} hit={fullHit} {...props} {...rerenderProps} />
+      </EuiProvider>
+    );
 
   return { rerender, ...tools };
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/test_providers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/test_providers.tsx
@@ -7,6 +7,7 @@
 
 import { euiDarkVars } from '@kbn/ui-theme';
 import { I18nProvider } from '@kbn/i18n-react';
+import { EuiProvider } from '@elastic/eui';
 
 import React from 'react';
 import type { DropResult, ResponderProvided } from '@hello-pangea/dnd';
@@ -87,7 +88,9 @@ export const TestProvidersComponent = ({
                         <CellActionsProvider
                           getTriggerCompatibleActions={() => Promise.resolve(cellActions)}
                         >
-                          <DragDropContext onDragEnd={onDragEnd}>{children}</DragDropContext>
+                          <EuiProvider>
+                            <DragDropContext onDragEnd={onDragEnd}>{children}</DragDropContext>
+                          </EuiProvider>
                         </CellActionsProvider>
                       </ConsoleManager>
                     </ExpandableFlyoutTestProvider>
@@ -146,7 +149,9 @@ const TestProvidersWithPrivilegesComponent: React.FC<Props> = ({
                     <CellActionsProvider
                       getTriggerCompatibleActions={() => Promise.resolve(cellActions)}
                     >
-                      <DragDropContext onDragEnd={onDragEnd}>{children}</DragDropContext>
+                      <EuiProvider>
+                        <DragDropContext onDragEnd={onDragEnd}>{children}</DragDropContext>
+                      </EuiProvider>
                     </CellActionsProvider>
                   </UserPrivilegesProvider>
                 </MockAssistantProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/attach_to_active_timeline.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/attach_to_active_timeline.test.tsx
@@ -49,7 +49,7 @@ describe('AttachToActiveTimeline', () => {
     );
 
     expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toBeInTheDocument();
-    expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toHaveStyle('background-color: #FEC514');
+    expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID).className).toContain('warning');
     expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toHaveTextContent('Save current Timeline');
     expect(queryByTestId(ATTACH_TO_TIMELINE_CHECKBOX_TEST_ID)).not.toBeInTheDocument();
     expect(getByTestId(ATTACH_TO_TIMELINE_CALLOUT_TEST_ID)).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/actions/save_timeline_button.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/actions/save_timeline_button.test.tsx
@@ -58,7 +58,7 @@ describe('SaveTimelineButton', () => {
 
     expect(getByTestId('timeline-modal-save-timeline')).toBeInTheDocument();
     expect(getByText('Save')).toBeInTheDocument();
-    expect(getByTestId('timeline-modal-save-timeline')).toHaveStyle('background-color: #07C');
+    expect(getByTestId('timeline-modal-save-timeline').className).toContain('primary');
 
     expect(queryByTestId('save-timeline-modal')).not.toBeInTheDocument();
   });
@@ -87,7 +87,7 @@ describe('SaveTimelineButton', () => {
 
     expect(queryByText('Save')).not.toBeInTheDocument();
     expect(getByText('TEST')).toBeInTheDocument();
-    expect(getByTestId('TEST_ID')).toHaveStyle('background-color: #FEC514');
+    expect(getByTestId('TEST_ID').className).toContain('warning');
   });
 
   it('should open the timeline save modal', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/notes/save_timeline.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/notes/save_timeline.test.tsx
@@ -41,7 +41,7 @@ describe('SaveTimelineCallout', () => {
     );
 
     expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toBeInTheDocument();
-    expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toHaveStyle('background-color: #BD271E');
+    expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID).className).toContain('danger');
     expect(getByTestId(SAVE_TIMELINE_BUTTON_TEST_ID)).toHaveTextContent('Save Timeline');
     expect(getByTestId(SAVE_TIMELINE_CALLOUT_TEST_ID)).toBeInTheDocument();
     expect(getAllByText('Save Timeline')).toHaveLength(2);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[DataDiscovery] Replace euiThemeVars with euiTheme (#204457)](https://github.com/elastic/kibana/pull/204457)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ania Kowalska","email":"63072419+akowalska622@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-08T10:16:38Z","message":"[DataDiscovery] Replace euiThemeVars with euiTheme (#204457)\n\n## Summary\r\n\r\nCloses #204357 \r\n\r\nThis PR replaces euiThemeVars occurrences with euiTheme.\r\n\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [ ] ~~Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~~\r\n- [ ]\r\n~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials~~\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] ~~If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\r\n- [ ] ~~This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.~~\r\n- [ ] ~~[Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed~~\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"1ef638a2608f3326c47333651b7d481b680f0945","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["technical debt","release_note:skip","Team:DataDiscovery","backport:version","v8.18.0","EUI Visual Refresh","v9.1.0"],"title":"[DataDiscovery] Replace euiThemeVars with euiTheme","number":204457,"url":"https://github.com/elastic/kibana/pull/204457","mergeCommit":{"message":"[DataDiscovery] Replace euiThemeVars with euiTheme (#204457)\n\n## Summary\r\n\r\nCloses #204357 \r\n\r\nThis PR replaces euiThemeVars occurrences with euiTheme.\r\n\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [ ] ~~Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~~\r\n- [ ]\r\n~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials~~\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] ~~If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\r\n- [ ] ~~This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.~~\r\n- [ ] ~~[Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed~~\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"1ef638a2608f3326c47333651b7d481b680f0945"}},"sourceBranch":"main","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.1","label":"v9.1.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->