### PR TITLE
[ci] Temporarily remove build_plugin_list_docs from Quick Checks

### DIFF
--- a/.buildkite/scripts/steps/checks/quick_checks.txt
+++ b/.buildkite/scripts/steps/checks/quick_checks.txt
@@ -2,7 +2,6 @@
 .buildkite/scripts/steps/checks/packages.sh
 .buildkite/scripts/steps/checks/bazel_packages.sh
 .buildkite/scripts/steps/checks/verify_notice.sh
-.buildkite/scripts/steps/checks/plugin_list_docs.sh
 .buildkite/scripts/steps/checks/event_log.sh
 .buildkite/scripts/steps/checks/telemetry.sh
 .buildkite/scripts/steps/checks/jest_configs.sh


### PR DESCRIPTION
While docs are undergoing migration.  See https://elastic.github.io/docs-builder/migration/freeze/index.html

Follow up tracked at https://github.com/elastic/kibana/issues/209686

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->