### PR TITLE
[8.17] [OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field name has slashes  (#209263)

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/components/rule_condition_chart/helpers.test.ts
+++ b/x-pack/plugins/observability_solution/observability/public/components/rule_condition_chart/helpers.test.ts
@@ -19,8 +19,8 @@ const useCases = [
     },
     {
       operation: 'sum',
-      operationWithField: 'sum(system.cpu.user.pct)',
-      sourceField: 'system.cpu.user.pct',
+      operationWithField: 'sum("system.cpu.user.pct")',
+      sourceField: '"system.cpu.user.pct"',
     },
   ],
   [
@@ -32,8 +32,8 @@ const useCases = [
     },
     {
       operation: 'max',
-      operationWithField: 'max(system.cpu.user.pct)',
-      sourceField: 'system.cpu.user.pct',
+      operationWithField: 'max("system.cpu.user.pct")',
+      sourceField: '"system.cpu.user.pct"',
     },
   ],
   [
@@ -45,8 +45,8 @@ const useCases = [
     },
     {
       operation: 'min',
-      operationWithField: 'min(system.cpu.user.pct)',
-      sourceField: 'system.cpu.user.pct',
+      operationWithField: 'min("system.cpu.user.pct")',
+      sourceField: '"system.cpu.user.pct"',
     },
   ],
   [
@@ -58,8 +58,8 @@ const useCases = [
     },
     {
       operation: 'average',
-      operationWithField: 'average(system.cpu.user.pct)',
-      sourceField: 'system.cpu.user.pct',
+      operationWithField: 'average("system.cpu.user.pct")',
+      sourceField: '"system.cpu.user.pct"',
     },
   ],
   [
@@ -72,7 +72,33 @@ const useCases = [
     {
       operation: 'count',
       operationWithField: `count(kql='system.cpu.user.pct: *')`,
-      sourceField: '',
+      sourceField: '""',
+    },
+  ],
+  [
+    {
+      aggType: Aggregators.COUNT,
+      field: '',
+      filter: `container.name:container's name-1`,
+      name: '',
+    },
+    {
+      operation: 'count',
+      operationWithField: `count(kql='container.name:container\\'s name-1')`,
+      sourceField: '""',
+    },
+  ],
+  [
+    {
+      aggType: Aggregators.COUNT,
+      field: '',
+      filter: 'host.name: host-*',
+      name: '',
+    },
+    {
+      operation: 'count',
+      operationWithField: `count(kql='host.name: host-*')`,
+      sourceField: '""',
     },
   ],
   [
@@ -84,8 +110,21 @@ const useCases = [
     },
     {
       operation: 'unique_count',
-      operationWithField: 'unique_count(system.cpu.user.pct)',
-      sourceField: 'system.cpu.user.pct',
+      operationWithField: 'unique_count("system.cpu.user.pct")',
+      sourceField: '"system.cpu.user.pct"',
+    },
+  ],
+  [
+    {
+      aggType: Aggregators.CARDINALITY,
+      field: 'field.name/with/slashes',
+      filter: '',
+      name: '',
+    },
+    {
+      operation: 'unique_count',
+      operationWithField: 'unique_count("field.name/with/slashes")',
+      sourceField: '"field.name/with/slashes"',
     },
   ],
   [
@@ -97,8 +136,8 @@ const useCases = [
     },
     {
       operation: 'percentile',
-      operationWithField: 'percentile(system.cpu.user.pct, percentile=95)',
-      sourceField: 'system.cpu.user.pct',
+      operationWithField: 'percentile("system.cpu.user.pct", percentile=95)',
+      sourceField: '"system.cpu.user.pct"',
     },
   ],
   [
@@ -110,8 +149,8 @@ const useCases = [
     },
     {
       operation: 'percentile',
-      operationWithField: 'percentile(system.cpu.user.pct, percentile=99)',
-      sourceField: 'system.cpu.user.pct',
+      operationWithField: 'percentile("system.cpu.user.pct", percentile=99)',
+      sourceField: '"system.cpu.user.pct"',
     },
   ],
   [
@@ -123,8 +162,8 @@ const useCases = [
     },
     {
       operation: 'counter_rate',
-      operationWithField: `counter_rate(max(system.network.in.bytes), kql='')`,
-      sourceField: 'system.network.in.bytes',
+      operationWithField: `counter_rate(max("system.network.in.bytes"), kql='')`,
+      sourceField: '"system.network.in.bytes"',
     },
   ],
   [
@@ -136,8 +175,8 @@ const useCases = [
     },
     {
       operation: 'counter_rate',
-      operationWithField: `counter_rate(max(system.network.in.bytes), kql='host.name : foo')`,
-      sourceField: 'system.network.in.bytes',
+      operationWithField: `counter_rate(max("system.network.in.bytes"), kql='host.name : "foo"')`,
+      sourceField: '"system.network.in.bytes"',
     },
   ],
 ];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field name has slashes  (#209263)](https://github.com/elastic/kibana/pull/209263)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Faisal Kanout","email":"faisal.kanout@elastic.co"},"sourceCommit":{"committedDate":"2025-02-04T12:18:27Z","message":"[OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field name has slashes  (#209263)\n\n## Summary\r\n\r\nIt fixes #201511\r\n\r\n<img width=\"680\" alt=\"Screenshot 2025-02-03 at 12 51 56\"\r\nsrc=\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\"\r\n/>\r\n\r\n### Release notes:\r\nFix the preview chart in the Custom Threshold rule creation form when\r\nthe field name has slashes","sha":"ed333de757b67bfeb1e68ec33b64bb238ecc21eb","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Feature:Alerting","v9.0.0","backport:prev-minor","backport:prev-major","Team:obs-ux-management","v8.18.0","v9.1.0","v8.19.0"],"title":"[OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field name has slashes ","number":209263,"url":"https://github.com/elastic/kibana/pull/209263","mergeCommit":{"message":"[OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field name has slashes  (#209263)\n\n## Summary\r\n\r\nIt fixes #201511\r\n\r\n<img width=\"680\" alt=\"Screenshot 2025-02-03 at 12 51 56\"\r\nsrc=\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\"\r\n/>\r\n\r\n### Release notes:\r\nFix the preview chart in the Custom Threshold rule creation form when\r\nthe field name has slashes","sha":"ed333de757b67bfeb1e68ec33b64bb238ecc21eb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209525","number":209525,"state":"MERGED","mergeCommit":{"sha":"e6c252a45321ff691364c5eb024339622c8e70a9","message":"[9.0] [OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field name has slashes  (#209263) (#209525)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field\nname has slashes\n(#209263)](https://github.com/elastic/kibana/pull/209263)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Faisal\nKanout\",\"email\":\"faisal.kanout@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-02-04T12:18:27Z\",\"message\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n(#209263)\\n\\n## Summary\\r\\n\\r\\nIt fixes #201511\\r\\n\\r\\n<img\nwidth=\\\"680\\\" alt=\\\"Screenshot 2025-02-03 at 12 51\n56\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\\\"\\r\\n/>\\r\\n\\r\\n###\nRelease notes:\\r\\nFix the preview chart in the Custom Threshold rule\ncreation form when\\r\\nthe field name has\nslashes\",\"sha\":\"ed333de757b67bfeb1e68ec33b64bb238ecc21eb\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"release_note:fix\",\"Feature:Alerting\",\"backport:prev-minor\",\"backport:prev-major\",\"Team:obs-ux-management\",\"v9.1.0\"],\"title\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n\",\"number\":209263,\"url\":\"https://github.com/elastic/kibana/pull/209263\",\"mergeCommit\":{\"message\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n(#209263)\\n\\n## Summary\\r\\n\\r\\nIt fixes #201511\\r\\n\\r\\n<img\nwidth=\\\"680\\\" alt=\\\"Screenshot 2025-02-03 at 12 51\n56\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\\\"\\r\\n/>\\r\\n\\r\\n###\nRelease notes:\\r\\nFix the preview chart in the Custom Threshold rule\ncreation form when\\r\\nthe field name has\nslashes\",\"sha\":\"ed333de757b67bfeb1e68ec33b64bb238ecc21eb\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/209263\",\"number\":209263,\"mergeCommit\":{\"message\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n(#209263)\\n\\n## Summary\\r\\n\\r\\nIt fixes #201511\\r\\n\\r\\n<img\nwidth=\\\"680\\\" alt=\\\"Screenshot 2025-02-03 at 12 51\n56\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\\\"\\r\\n/>\\r\\n\\r\\n###\nRelease notes:\\r\\nFix the preview chart in the Custom Threshold rule\ncreation form when\\r\\nthe field name has\nslashes\",\"sha\":\"ed333de757b67bfeb1e68ec33b64bb238ecc21eb\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Faisal Kanout <faisal.kanout@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209523","number":209523,"state":"MERGED","mergeCommit":{"sha":"f6e739b19ec45b8f6eba3e9d4935039f5038f797","message":"[8.18] [OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field name has slashes  (#209263) (#209523)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field\nname has slashes\n(#209263)](https://github.com/elastic/kibana/pull/209263)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Faisal\nKanout\",\"email\":\"faisal.kanout@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-02-04T12:18:27Z\",\"message\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n(#209263)\\n\\n## Summary\\r\\n\\r\\nIt fixes #201511\\r\\n\\r\\n<img\nwidth=\\\"680\\\" alt=\\\"Screenshot 2025-02-03 at 12 51\n56\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\\\"\\r\\n/>\\r\\n\\r\\n###\nRelease notes:\\r\\nFix the preview chart in the Custom Threshold rule\ncreation form when\\r\\nthe field name has\nslashes\",\"sha\":\"ed333de757b67bfeb1e68ec33b64bb238ecc21eb\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"release_note:fix\",\"Feature:Alerting\",\"backport:prev-minor\",\"backport:prev-major\",\"Team:obs-ux-management\",\"v9.1.0\"],\"title\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n\",\"number\":209263,\"url\":\"https://github.com/elastic/kibana/pull/209263\",\"mergeCommit\":{\"message\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n(#209263)\\n\\n## Summary\\r\\n\\r\\nIt fixes #201511\\r\\n\\r\\n<img\nwidth=\\\"680\\\" alt=\\\"Screenshot 2025-02-03 at 12 51\n56\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\\\"\\r\\n/>\\r\\n\\r\\n###\nRelease notes:\\r\\nFix the preview chart in the Custom Threshold rule\ncreation form when\\r\\nthe field name has\nslashes\",\"sha\":\"ed333de757b67bfeb1e68ec33b64bb238ecc21eb\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/209263\",\"number\":209263,\"mergeCommit\":{\"message\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n(#209263)\\n\\n## Summary\\r\\n\\r\\nIt fixes #201511\\r\\n\\r\\n<img\nwidth=\\\"680\\\" alt=\\\"Screenshot 2025-02-03 at 12 51\n56\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\\\"\\r\\n/>\\r\\n\\r\\n###\nRelease notes:\\r\\nFix the preview chart in the Custom Threshold rule\ncreation form when\\r\\nthe field name has\nslashes\",\"sha\":\"ed333de757b67bfeb1e68ec33b64bb238ecc21eb\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Faisal Kanout <faisal.kanout@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209263","number":209263,"mergeCommit":{"message":"[OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field name has slashes  (#209263)\n\n## Summary\r\n\r\nIt fixes #201511\r\n\r\n<img width=\"680\" alt=\"Screenshot 2025-02-03 at 12 51 56\"\r\nsrc=\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\"\r\n/>\r\n\r\n### Release notes:\r\nFix the preview chart in the Custom Threshold rule creation form when\r\nthe field name has slashes","sha":"ed333de757b67bfeb1e68ec33b64bb238ecc21eb"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209524","number":209524,"state":"MERGED","mergeCommit":{"sha":"f228a0643970bb9923f7d5f4361ddf123cc2c94e","message":"[8.x] [OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field name has slashes  (#209263) (#209524)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[OBX-UX-MGMT][BUG] Fix chart in Custom Threshold rule when the field\nname has slashes\n(#209263)](https://github.com/elastic/kibana/pull/209263)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Faisal\nKanout\",\"email\":\"faisal.kanout@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-02-04T12:18:27Z\",\"message\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n(#209263)\\n\\n## Summary\\r\\n\\r\\nIt fixes #201511\\r\\n\\r\\n<img\nwidth=\\\"680\\\" alt=\\\"Screenshot 2025-02-03 at 12 51\n56\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\\\"\\r\\n/>\\r\\n\\r\\n###\nRelease notes:\\r\\nFix the preview chart in the Custom Threshold rule\ncreation form when\\r\\nthe field name has\nslashes\",\"sha\":\"ed333de757b67bfeb1e68ec33b64bb238ecc21eb\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"release_note:fix\",\"Feature:Alerting\",\"backport:prev-minor\",\"backport:prev-major\",\"Team:obs-ux-management\",\"v9.1.0\"],\"title\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n\",\"number\":209263,\"url\":\"https://github.com/elastic/kibana/pull/209263\",\"mergeCommit\":{\"message\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n(#209263)\\n\\n## Summary\\r\\n\\r\\nIt fixes #201511\\r\\n\\r\\n<img\nwidth=\\\"680\\\" alt=\\\"Screenshot 2025-02-03 at 12 51\n56\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\\\"\\r\\n/>\\r\\n\\r\\n###\nRelease notes:\\r\\nFix the preview chart in the Custom Threshold rule\ncreation form when\\r\\nthe field name has\nslashes\",\"sha\":\"ed333de757b67bfeb1e68ec33b64bb238ecc21eb\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/209263\",\"number\":209263,\"mergeCommit\":{\"message\":\"[OBX-UX-MGMT][BUG]\nFix chart in Custom Threshold rule when the field name has slashes\n(#209263)\\n\\n## Summary\\r\\n\\r\\nIt fixes #201511\\r\\n\\r\\n<img\nwidth=\\\"680\\\" alt=\\\"Screenshot 2025-02-03 at 12 51\n56\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/fe3fa780-c50d-4906-8c5b-6758fea5fe9c\\\"\\r\\n/>\\r\\n\\r\\n###\nRelease notes:\\r\\nFix the preview chart in the Custom Threshold rule\ncreation form when\\r\\nthe field name has\nslashes\",\"sha\":\"ed333de757b67bfeb1e68ec33b64bb238ecc21eb\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Faisal Kanout <faisal.kanout@elastic.co>"}}]}] BACKPORT-->