### PR TITLE
[7.17] Update dependency moment-timezone to ^0.5.47 (main) (#208526)

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,7 +296,7 @@
     "minimatch": "^3.1.2",
     "moment": "^2.29.4",
     "moment-duration-format": "^2.3.2",
-    "moment-timezone": "^0.5.46",
+    "moment-timezone": "^0.5.47",
     "monaco-editor": "^0.22.3",
     "mustache": "^2.3.2",
     "ngreact": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19067,10 +19067,10 @@ moment-duration-format@^2.3.2:
   resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-2.3.2.tgz#5fa2b19b941b8d277122ff3f87a12895ec0d6212"
   integrity sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ==
 
-moment-timezone@^0.5.46:
-  version "0.5.46"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.46.tgz#a21aa6392b3c6b3ed916cd5e95858a28d893704a"
-  integrity sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==
+moment-timezone@^0.5.47:
+  version "0.5.47"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.47.tgz#d4d1a21b78372d914d6d69ae285454732a429749"
+  integrity sha512-UbNt/JAWS0m/NJOebR0QMRHBk0hu03r5dx9GK8Cs0AS3I81yDcOc9k+DytPItgVvBP7J6Mf6U2n3BPAacAV9oA==
   dependencies:
     moment "^2.29.4"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Update dependency moment-timezone to ^0.5.47 (main) (#208526)](https://github.com/elastic/kibana/pull/208526)
