### PR TITLE
[ci] Allow cancellation of ongoing builds for kibana-vm-images

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-vm-images.yml
@@ -24,6 +24,7 @@ spec:
       default_branch: main
       repository: elastic/ci-agent-images
       pipeline_file: vm-images/.buildkite/pipeline.yml
+      cancel_intermediate_builds: true
       provider_settings:
         trigger_mode: none
       schedules:


### PR DESCRIPTION
## Summary
To keep the caches on the VM image up-to-date, we are now triggering https://buildkite.com/elastic/kibana-vm-images every time a snapshot is updated. This often comes in batches of 3-4, building and publishing 4 separate VMs, and only the last one will be used. It seems a bit wasteful to run all these build jobs, to refresh the same cache. We currently don't have the build separated to base and cache-layer builds, so the images built from the first few runs will probably never be used.

(+) If we enable `cancel_intermediate_builds` we will save CI time on competing builds, and the artifact storage of the VMs we never use
(-) What we'll lose is the cache hits we would have between the expected termination of the first job and the termination of the last job in the batch. Looking at today, the first job started at ~4AM CET, the last job started at ~5AM CET. They would be all interrupting the previous run. 