### PR TITLE
[Automatic Import] Fix Structured log template to use single quotes

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/server/templates/processors/kv.yml.njk
+++ b/x-pack/platform/plugins/shared/automatic_import/server/templates/processors/kv.yml.njk
@@ -1,7 +1,7 @@
   - kv:
       field: message
-      field_split: "{{ kvInput.field_split }}"
-      value_split: "{{ kvInput.value_split }}"
-      trim_key: "{{ kvInput.trim_key }}"
-      trim_value: "{{ kvInput.trim_value }}"
-      target_field: "{{ packageName }}.{{ dataStreamName }}"
+      field_split: '{{ kvInput.field_split }}'
+      value_split: '{{ kvInput.value_split }}'
+      trim_key: '{{ kvInput.trim_key }}'
+      trim_value: '{{ kvInput.trim_value }}'
+      target_field: '{{ packageName }}.{{ dataStreamName }}'


### PR DESCRIPTION
## Release Note

Fix Structured log template to use single quotes

### Summary

Currently with a single backslash as escape character the template is setting up a double quote surrounding it and it causes YAML Exception
```
 1 |   - kv:
 2 |       field: message
 3 |       field_split: "\|"
--------------------------^

YAMLException: unknown escape sequence (3:22)
```

This PR fixes to use single quotes to not break YAML parsing.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->