### PR TITLE
[8.18] [ES|QL] Show common fields source indices and join index (#208681)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/index.ts
@@ -12,6 +12,7 @@ export type {
   ESQLAstItem,
   ESQLAstCommand,
   ESQLAstMetricsCommand,
+  ESQLAstJoinCommand,
   ESQLCommand,
   ESQLCommandOption,
   ESQLCommandMode,

--- a/src/platform/packages/shared/kbn-esql-ast/src/mutate/commands/join/index.test.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/mutate/commands/join/index.test.ts
@@ -162,5 +162,22 @@ describe('commands.where', () => {
         },
       ]);
     });
+
+    it('extracts index of an incomplete query', () => {
+      const src = 'FROM kibana_sample_data_ecommerce | LOOKUP JOIN lookup_index ON ';
+      const query = EsqlQuery.fromSrc(src);
+      const summary = commands.join.summarize(query.ast);
+
+      expect(summary).toMatchObject([
+        {
+          target: {
+            index: {
+              type: 'source',
+              name: 'lookup_index',
+            },
+          },
+        },
+      ]);
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-esql-ast/src/mutate/commands/join/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/mutate/commands/join/index.ts
@@ -55,6 +55,41 @@ const getIdentifier = (node: WalkerAstNode): ESQLIdentifier =>
   }) as ESQLIdentifier;
 
 /**
+ * Summarizes a single JOIN command.
+ *
+ * @param command JOIN command to summarize.
+ * @returns Returns a summary of the JOIN command.
+ */
+export const summarizeCommand = (command: ESQLAstJoinCommand): JoinCommandSummary => {
+  const firstArg = command.args[0];
+  let index: ESQLSource | undefined;
+  let alias: ESQLIdentifier | undefined;
+  const conditions: ESQLAstExpression[] = [];
+
+  if (isAsExpression(firstArg)) {
+    index = getSource(firstArg.args[0]);
+    alias = getIdentifier(firstArg.args[1]);
+  } else {
+    index = getSource(firstArg);
+  }
+
+  const on = generic.commands.options.find(command, ({ name }) => name === 'on');
+
+  conditions.push(...((on?.args || []) as ESQLAstExpression[]));
+
+  const target: JoinCommandTarget = {
+    index: index!,
+    alias,
+  };
+  const summary: JoinCommandSummary = {
+    target,
+    conditions,
+  };
+
+  return summary;
+};
+
+/**
  * Summarizes all JOIN commands in the query.
  *
  * @param query Query to summarize.
@@ -65,30 +100,7 @@ export const summarize = (query: ESQLAstQueryExpression): JoinCommandSummary[] =
   const summaries: JoinCommandSummary[] = [];
 
   for (const command of list(query)) {
-    const firstArg = command.args[0];
-    let index: ESQLSource | undefined;
-    let alias: ESQLIdentifier | undefined;
-    const conditions: ESQLAstExpression[] = [];
-
-    if (isAsExpression(firstArg)) {
-      index = getSource(firstArg.args[0]);
-      alias = getIdentifier(firstArg.args[1]);
-    } else {
-      index = getSource(firstArg);
-    }
-
-    const on = generic.commands.options.find(command, ({ name }) => name === 'on');
-
-    conditions.push(...((on?.args || []) as ESQLAstExpression[]));
-
-    const target: JoinCommandTarget = {
-      index: index!,
-      alias,
-    };
-    const summary: JoinCommandSummary = {
-      target,
-      conditions,
-    };
+    const summary = summarizeCommand(command);
 
     summaries.push(summary);
   }

--- a/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/leaf_printer.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/pretty_print/leaf_printer.ts
@@ -169,8 +169,11 @@ export const LeafPrinter = {
     return text;
   },
 
-  print: (node: ESQLProperNode): string => {
+  print: (node: ESQLProperNode | ESQLAstComment): string => {
     switch (node.type) {
+      case 'source': {
+        return LeafPrinter.source(node);
+      }
       case 'identifier': {
         return LeafPrinter.identifier(node);
       }
@@ -182,6 +185,9 @@ export const LeafPrinter = {
       }
       case 'timeInterval': {
         return LeafPrinter.timeInterval(node);
+      }
+      case 'comment': {
+        return LeafPrinter.comment(node);
       }
     }
     return '';

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.join.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.join.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { setup, getFieldNamesByType } from './helpers';
+import { setup, getFieldNamesByType, lookupIndexFields } from './helpers';
 
 describe('autocomplete.suggest', () => {
   describe('<type> JOIN <index> [ AS <alias> ] ON <condition> [, <condition> [, ...]]', () => {
@@ -103,24 +103,34 @@ describe('autocomplete.suggest', () => {
 
       test('suggests fields after ON keyword', async () => {
         const { suggest } = await setup();
-
         const suggestions = await suggest('FROM index | LOOKUP JOIN join_index ON /');
-        const labels = suggestions.map((s) => s.text).sort();
+        const labels = suggestions.map((s) => s.text.trim()).sort();
         const expected = getFieldNamesByType('any')
           .sort()
-          .map((field) => field + ' ');
+          .map((field) => field.trim());
+
+        for (const { name } of lookupIndexFields) {
+          expected.push(name.trim());
+        }
+
+        expected.sort();
 
         expect(labels).toEqual(expected);
       });
 
       test('more field suggestions after comma', async () => {
         const { suggest } = await setup();
-
         const suggestions = await suggest('FROM index | LOOKUP JOIN join_index ON stringField, /');
-        const labels = suggestions.map((s) => s.text).sort();
+        const labels = suggestions.map((s) => s.text.trim()).sort();
         const expected = getFieldNamesByType('any')
           .sort()
-          .map((field) => field + ' ');
+          .map((field) => field.trim());
+
+        for (const { name } of lookupIndexFields) {
+          expected.push(name.trim());
+        }
+
+        expected.sort();
 
         expect(labels).toEqual(expected);
       });

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
@@ -48,13 +48,21 @@ export const TIME_PICKER_SUGGESTION: PartialSuggestionWithText = {
 
 export const triggerCharacters = [',', '(', '=', ' '];
 
-export const fields: Array<ESQLRealField & { suggestedAs?: string }> = [
+export type TestField = ESQLRealField & { suggestedAs?: string };
+
+export const fields: TestField[] = [
   ...fieldTypes.map((type) => ({
     name: `${camelCase(type)}Field`,
     type,
   })),
   { name: 'any#Char$Field', type: 'double', suggestedAs: '`any#Char$Field`' },
   { name: 'kubernetes.something.something', type: 'double' },
+];
+
+export const lookupIndexFields: TestField[] = [
+  { name: 'booleanField', type: 'boolean' },
+  { name: 'dateField', type: 'date' },
+  { name: 'joinIndexOnlyField', type: 'text' },
 ];
 
 export const indexes = (
@@ -279,7 +287,13 @@ export function createCustomCallbackMocks(
   const finalSources = customSources || indexes;
   const finalPolicies = customPolicies || policies;
   return {
-    getColumnsFor: jest.fn(async () => finalColumnsSinceLastCommand),
+    getColumnsFor: jest.fn(async ({ query }) => {
+      if (query === 'FROM join_index') {
+        return lookupIndexFields;
+      }
+
+      return finalColumnsSinceLastCommand;
+    }),
     getSources: jest.fn(async () => finalSources),
     getPolicies: jest.fn(async () => finalPolicies),
     getJoinIndices: jest.fn(async () => ({ indices: joinIndices })),

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
@@ -8,8 +8,8 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { type ESQLAstItem, ESQLAst } from '@kbn/esql-ast';
-import { ESQLCommand } from '@kbn/esql-ast/src/types';
+import { type ESQLAstItem, ESQLAst, ESQLCommand, mutate, LeafPrinter } from '@kbn/esql-ast';
+import type { ESQLAstJoinCommand } from '@kbn/esql-ast';
 import type { ESQLCallbacks } from '../../../shared/types';
 import {
   CommandBaseDefinition,
@@ -17,8 +17,13 @@ import {
   CommandTypeDefinition,
   type SupportedDataType,
 } from '../../../definitions/types';
-import { getPosition, joinIndicesToSuggestions } from './util';
-import { TRIGGER_SUGGESTION_COMMAND } from '../../factories';
+import {
+  getPosition,
+  joinIndicesToSuggestions,
+  suggestionIntersection,
+  suggestionUnion,
+} from './util';
+import { TRIGGER_SUGGESTION_COMMAND, buildFieldsDefinitionsWithMetadata } from '../../factories';
 import type { GetColumnsByTypeFn, SuggestionRawDefinition } from '../../types';
 import { commaCompleteItem, pipeCompleteItem } from '../../complete_items';
 
@@ -35,6 +40,60 @@ const getFullCommandMnemonics = (
     `${type.name.toUpperCase()} ${definition.name.toUpperCase()}`,
     type.description ?? definition.description,
   ]);
+};
+
+const suggestFields = async (
+  command: ESQLCommand<'join'>,
+  getColumnsByType: GetColumnsByTypeFn,
+  callbacks?: ESQLCallbacks
+) => {
+  const summary = mutate.commands.join.summarizeCommand(command as ESQLAstJoinCommand);
+  const joinIndexPattern = LeafPrinter.print(summary.target.index);
+
+  const [lookupIndexFields, sourceFields] = await Promise.all([
+    callbacks?.getColumnsFor?.({ query: `FROM ${joinIndexPattern}` }),
+    getColumnsByType(['any'], [], {
+      advanceCursor: true,
+      openSuggestions: true,
+    }),
+  ]);
+
+  const supportsControls = callbacks?.canSuggestVariables?.() ?? false;
+  const getVariablesByType = callbacks?.getVariablesByType;
+  const joinFields = buildFieldsDefinitionsWithMetadata(
+    lookupIndexFields!,
+    { supportsControls },
+    getVariablesByType
+  );
+
+  const intersection = suggestionIntersection(joinFields, sourceFields);
+  const union = suggestionUnion(sourceFields, joinFields);
+
+  for (const commonField of intersection) {
+    commonField.sortText = '1';
+    commonField.documentation = {
+      value: i18n.translate('kbn-esql-validation-autocomplete.esql.autocomplete.join.sharedField', {
+        defaultMessage: 'Field shared between the source and the lookup index',
+      }),
+    };
+
+    let detail = commonField.detail || '';
+
+    if (detail) {
+      detail += ' ';
+    }
+
+    detail += i18n.translate(
+      'kbn-esql-validation-autocomplete.esql.autocomplete.join.commonFieldNote',
+      {
+        defaultMessage: '(common field)',
+      }
+    );
+
+    commonField.detail = detail;
+  }
+
+  return [...intersection, ...union];
 };
 
 export const suggest: CommandBaseDefinition<'join'>['suggest'] = async (
@@ -113,10 +172,7 @@ export const suggest: CommandBaseDefinition<'join'>['suggest'] = async (
     }
 
     case 'after_on': {
-      const fields = await getColumnsByType(['any'], [], {
-        advanceCursor: true,
-        openSuggestions: true,
-      });
+      const fields = await suggestFields(command, getColumnsByType, callbacks);
 
       return fields;
     }
@@ -127,10 +183,7 @@ export const suggest: CommandBaseDefinition<'join'>['suggest'] = async (
       const commaIsLastToken = !!match?.groups?.comma;
 
       if (commaIsLastToken) {
-        const fields = await getColumnsByType(['any'], [], {
-          advanceCursor: true,
-          openSuggestions: true,
-        });
+        const fields = await suggestFields(command, getColumnsByType, callbacks);
 
         return fields;
       }

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/util.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/util.test.ts
@@ -8,7 +8,13 @@
  */
 
 import { joinIndices } from '../../../__tests__/helpers';
-import { getPosition, joinIndicesToSuggestions } from './util';
+import {
+  getPosition,
+  joinIndicesToSuggestions,
+  suggestionIntersection,
+  suggestionUnion,
+} from './util';
+import { SuggestionRawDefinition } from '../../types';
 
 describe('getPosition()', () => {
   test('returns correct position on complete modifier matches', () => {
@@ -65,6 +71,168 @@ describe('joinIndicesToSuggestions()', () => {
       'join_index_with_alias',
       'join_index_alias_1',
       'join_index_alias_2',
+    ]);
+  });
+});
+
+describe('suggestionIntersection()', () => {
+  test('returns shared fields between two lists', () => {
+    const intersection = suggestionIntersection(
+      [
+        { label: 'id', text: '', kind: 'Field', detail: '' },
+        { label: 'currency', text: '', kind: 'Field', detail: '' },
+        { label: 'value', text: '', kind: 'Field', detail: '' },
+        { label: 'timestamp', text: '', kind: 'Field', detail: '' },
+      ],
+      [
+        { label: 'id', text: '', kind: 'Field', detail: '' },
+        { label: 'currency', text: '', kind: 'Field', detail: '' },
+        { label: 'name', text: '', kind: 'Field', detail: '' },
+      ]
+    );
+
+    expect(intersection).toEqual([
+      {
+        label: 'id',
+        text: '',
+        kind: 'Field',
+        detail: '',
+      },
+      {
+        label: 'currency',
+        text: '',
+        kind: 'Field',
+        detail: '',
+      },
+    ]);
+  });
+
+  test('returns empty list if there are no shared fields', () => {
+    const intersection = suggestionIntersection(
+      [
+        { label: 'id1', text: '', kind: 'Field', detail: '' },
+        { label: 'value', text: '', kind: 'Field', detail: '' },
+        { label: 'timestamp', text: '', kind: 'Field', detail: '' },
+      ],
+      [
+        { label: 'id2', text: '', kind: 'Field', detail: '' },
+        { label: 'currency', text: '', kind: 'Field', detail: '' },
+        { label: 'name', text: '', kind: 'Field', detail: '' },
+      ]
+    );
+
+    expect(intersection).toEqual([]);
+  });
+
+  test('returns all fields, if all intersect', () => {
+    const intersection = suggestionIntersection(
+      [
+        { label: 'id1', text: '', kind: 'Field', detail: '' },
+        { label: 'value', text: '', kind: 'Field', detail: '' },
+        { label: 'timestamp', text: '', kind: 'Field', detail: '' },
+      ],
+      [
+        { label: 'id1', text: '', kind: 'Field', detail: '' },
+        { label: 'value', text: '', kind: 'Field', detail: '' },
+      ]
+    );
+
+    expect(intersection).toEqual([
+      { label: 'id1', text: '', kind: 'Field', detail: '' },
+      { label: 'value', text: '', kind: 'Field', detail: '' },
+    ]);
+  });
+
+  test('creates a clone of suggestions', () => {
+    const suggestion1: SuggestionRawDefinition = {
+      label: 'id1',
+      text: '',
+      kind: 'Field',
+      detail: '',
+    };
+    const suggestion2: SuggestionRawDefinition = {
+      label: 'id1',
+      text: '',
+      kind: 'Field',
+      detail: '',
+    };
+    const intersection = suggestionIntersection([suggestion1], [suggestion2]);
+
+    expect(intersection).toEqual([suggestion1]);
+    expect(intersection[0]).not.toBe(suggestion1);
+    expect(intersection[0]).not.toBe(suggestion2);
+  });
+});
+
+describe('suggestionUnion()', () => {
+  test('combines two sets without duplicates', () => {
+    const intersection = suggestionUnion(
+      [
+        { label: 'id', text: '', kind: 'Field', detail: '' },
+        { label: 'currency', text: '', kind: 'Field', detail: '' },
+        { label: 'value', text: '', kind: 'Field', detail: '' },
+        { label: 'timestamp', text: '', kind: 'Field', detail: '' },
+      ],
+      [
+        { label: 'id', text: '', kind: 'Field', detail: '' },
+        { label: 'currency', text: '', kind: 'Field', detail: '' },
+        { label: 'name', text: '', kind: 'Field', detail: '' },
+      ]
+    );
+
+    expect(intersection).toEqual([
+      {
+        label: 'id',
+        text: '',
+        kind: 'Field',
+        detail: '',
+      },
+      {
+        label: 'currency',
+        text: '',
+        kind: 'Field',
+        detail: '',
+      },
+      {
+        label: 'value',
+        text: '',
+        kind: 'Field',
+        detail: '',
+      },
+      {
+        label: 'timestamp',
+        text: '',
+        kind: 'Field',
+        detail: '',
+      },
+      {
+        label: 'name',
+        text: '',
+        kind: 'Field',
+        detail: '',
+      },
+    ]);
+  });
+
+  test('combines two non-overlapping sets', () => {
+    const intersection = suggestionUnion(
+      [{ label: 'id', text: '', kind: 'Field', detail: '' }],
+      [{ label: 'currency', text: '', kind: 'Field', detail: '' }]
+    );
+
+    expect(intersection).toEqual([
+      {
+        label: 'id',
+        text: '',
+        kind: 'Field',
+        detail: '',
+      },
+      {
+        label: 'currency',
+        text: '',
+        kind: 'Field',
+        detail: '',
+      },
     ]);
   });
 });

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/util.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/util.ts
@@ -10,8 +10,8 @@
 import { ESQLCommand } from '@kbn/esql-ast';
 import { i18n } from '@kbn/i18n';
 import { JoinCommandPosition, JoinPosition, JoinStaticPosition } from './types';
-import type { JoinIndexAutocompleteItem } from '../../../validation/types';
 import { SuggestionRawDefinition } from '../../types';
+import type { JoinIndexAutocompleteItem } from '../../../validation/types';
 
 const REGEX =
   /^(?<type>\w+((?<after_type>\s+((?<mnemonic>(JOIN|JOI|JO|J)((?<after_mnemonic>\s+((?<index>\S+((?<after_index>\s+(?<as>(AS|A))?(?<after_as>\s+(((?<alias>\S+)?(?<after_alias>\s+)?)?))?((?<on>(ON|O)((?<after_on>\s+(?<cond>[^\s])?)?))?))?))?))?))?))?))?/i;
@@ -104,4 +104,52 @@ export const joinIndicesToSuggestions = (
   }
 
   return [...mainSuggestions, ...aliasSuggestions];
+};
+
+export const suggestionIntersection = (
+  suggestions1: SuggestionRawDefinition[],
+  suggestions2: SuggestionRawDefinition[]
+): SuggestionRawDefinition[] => {
+  const labels1 = new Set<string>();
+  const intersection: SuggestionRawDefinition[] = [];
+
+  for (const suggestion1 of suggestions1) {
+    labels1.add(suggestion1.label);
+  }
+
+  for (const suggestion2 of suggestions2) {
+    if (labels1.has(suggestion2.label)) {
+      intersection.push({ ...suggestion2 });
+    }
+  }
+
+  return intersection;
+};
+
+export const suggestionUnion = (
+  suggestions1: SuggestionRawDefinition[],
+  suggestions2: SuggestionRawDefinition[]
+): SuggestionRawDefinition[] => {
+  const labels = new Set<string>();
+  const union: SuggestionRawDefinition[] = [];
+
+  for (const suggestion of suggestions1) {
+    const label = suggestion.label;
+
+    if (!labels.has(label)) {
+      union.push(suggestion);
+      labels.add(label);
+    }
+  }
+
+  for (const suggestion of suggestions2) {
+    const label = suggestion.label;
+
+    if (!labels.has(label)) {
+      union.push(suggestion);
+      labels.add(label);
+    }
+  }
+
+  return union;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ES|QL] Show common fields source indices and join index (#208681)](https://github.com/elastic/kibana/pull/208681)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Vadim Kibana","email":"82822460+vadimkibana@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-03T11:09:12Z","message":"[ES|QL] Show common fields source indices and join index (#208681)\n\n## Summary\r\n\r\nPartially addresses https://github.com/elastic/kibana/issues/206939\r\n\r\nThis PR introduces the following changes in the `JOIN` command\r\nautocomplete.\r\n\r\nShows intersection of source index and join index fields, moves those\r\nfields to the very top of the list. In the below example the `currency`\r\nfield appears in both indices, hence, it is at the very top and with a\r\ndifferent icon:\r\n\r\n<img width=\"786\" alt=\"Screenshot 2025-01-28 at 21 29 52\"\r\nsrc=\"https://github.com/user-attachments/assets/2c1a058f-80a2-4060-a20e-4a0681043dde\"\r\n/>\r\n\r\nAdds join index fields to the total list of all fields. In the below\r\nexample, the `continenet` field is available only in the joined index,\r\nbut it is added to the total list.\r\n\r\n<img width=\"713\" alt=\"Screenshot 2025-01-28 at 21 30 08\"\r\nsrc=\"https://github.com/user-attachments/assets/7cd44ebf-5fe9-4051-a6eb-3feb28801fa5\"\r\n/>\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"5600f2b675c8488578db117eb031f09b2b91ef63","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["review","release_note:skip","backport missing","Feature:ES|QL","Team:ESQL","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[ES|QL] Show common fields source indices and join index","number":208681,"url":"https://github.com/elastic/kibana/pull/208681","mergeCommit":{"message":"[ES|QL] Show common fields source indices and join index (#208681)\n\n## Summary\r\n\r\nPartially addresses https://github.com/elastic/kibana/issues/206939\r\n\r\nThis PR introduces the following changes in the `JOIN` command\r\nautocomplete.\r\n\r\nShows intersection of source index and join index fields, moves those\r\nfields to the very top of the list. In the below example the `currency`\r\nfield appears in both indices, hence, it is at the very top and with a\r\ndifferent icon:\r\n\r\n<img width=\"786\" alt=\"Screenshot 2025-01-28 at 21 29 52\"\r\nsrc=\"https://github.com/user-attachments/assets/2c1a058f-80a2-4060-a20e-4a0681043dde\"\r\n/>\r\n\r\nAdds join index fields to the total list of all fields. In the below\r\nexample, the `continenet` field is available only in the joined index,\r\nbut it is added to the total list.\r\n\r\n<img width=\"713\" alt=\"Screenshot 2025-01-28 at 21 30 08\"\r\nsrc=\"https://github.com/user-attachments/assets/7cd44ebf-5fe9-4051-a6eb-3feb28801fa5\"\r\n/>\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"5600f2b675c8488578db117eb031f09b2b91ef63"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.x"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208681","number":208681,"mergeCommit":{"message":"[ES|QL] Show common fields source indices and join index (#208681)\n\n## Summary\r\n\r\nPartially addresses https://github.com/elastic/kibana/issues/206939\r\n\r\nThis PR introduces the following changes in the `JOIN` command\r\nautocomplete.\r\n\r\nShows intersection of source index and join index fields, moves those\r\nfields to the very top of the list. In the below example the `currency`\r\nfield appears in both indices, hence, it is at the very top and with a\r\ndifferent icon:\r\n\r\n<img width=\"786\" alt=\"Screenshot 2025-01-28 at 21 29 52\"\r\nsrc=\"https://github.com/user-attachments/assets/2c1a058f-80a2-4060-a20e-4a0681043dde\"\r\n/>\r\n\r\nAdds join index fields to the total list of all fields. In the below\r\nexample, the `continenet` field is available only in the joined index,\r\nbut it is added to the total list.\r\n\r\n<img width=\"713\" alt=\"Screenshot 2025-01-28 at 21 30 08\"\r\nsrc=\"https://github.com/user-attachments/assets/7cd44ebf-5fe9-4051-a6eb-3feb28801fa5\"\r\n/>\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"5600f2b675c8488578db117eb031f09b2b91ef63"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->