### PR TITLE
[8.x] prerequesites part 1 for lens ESQL generation (#203962)

### DIFF
--- a/src/platform/packages/shared/kbn-es-query/src/filters/build_filters/exists_filter.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/filters/build_filters/exists_filter.ts
@@ -57,3 +57,16 @@ export const buildExistsFilter = (field: DataViewFieldBase, indexPattern: DataVi
     },
   } as ExistsFilter;
 };
+
+export const buildSimpleExistFilter = (fieldName: string, dataViewId: string) => {
+  return {
+    meta: {
+      index: dataViewId,
+    },
+    query: {
+      exists: {
+        field: fieldName,
+      },
+    },
+  } as ExistsFilter;
+};

--- a/src/platform/packages/shared/kbn-es-query/src/filters/build_filters/range_filter.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/filters/build_filters/range_filter.ts
@@ -187,6 +187,20 @@ export const buildRangeFilter = (
   }
 };
 
+export const buildSimpleNumberRangeFilter = (
+  fieldName: string,
+  params: RangeFilterParams,
+  value: string,
+  dataViewId: string
+) => {
+  return buildRangeFilter(
+    { name: fieldName, type: 'number' },
+    params,
+    { id: dataViewId, title: dataViewId },
+    value
+  );
+};
+
 /**
  * @internal
  */

--- a/src/platform/packages/shared/kbn-esql-utils/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/index.ts
@@ -35,6 +35,7 @@ export {
   isESQLColumnGroupable,
   isESQLFieldGroupable,
   TextBasedLanguages,
+  sanitazeESQLInput,
   queryCannotBeSampled,
   mapVariableToColumn,
   getValuesFromQueryField,

--- a/src/platform/packages/shared/kbn-esql-utils/src/index.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/index.ts
@@ -45,3 +45,4 @@ export {
   isESQLColumnGroupable,
   isESQLFieldGroupable,
 } from './utils/esql_fields_utils';
+export { sanitazeESQLInput } from './utils/sanitaze_input';

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/append_to_query.ts
@@ -9,6 +9,7 @@
 
 import { getAstAndSyntaxErrors } from '@kbn/esql-ast';
 import { parse, mutate, BasicPrettyPrinter } from '@kbn/esql-ast';
+import { sanitazeESQLInput } from './sanitaze_input';
 
 // Append in a new line the appended text to take care of the case where the user adds a comment at the end of the query
 // in these cases a base query such as "from index // comment" will result in errors or wrong data if we don't append in a new line
@@ -44,7 +45,7 @@ export function appendWhereClauseToESQLQuery(
   let filterValue =
     typeof value === 'string' ? `"${value.replace(/\\/g, '\\\\').replace(/\"/g, '\\"')}"` : value;
   // Adding the backticks here are they are needed for special char fields
-  let fieldName = `\`${field}\``;
+  let fieldName = sanitazeESQLInput(field);
 
   // casting to string
   // there are some field types such as the ip that need

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/sanitaze_input.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/sanitaze_input.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export function sanitazeESQLInput(input: string): string | undefined {
+  return `\`${input.replace(/`/g, '``')}\``;
+}

--- a/src/platform/plugins/shared/data/common/search/aggs/buckets/lib/time_buckets/time_buckets.ts
+++ b/src/platform/plugins/shared/data/common/search/aggs/buckets/lib/time_buckets/time_buckets.ts
@@ -23,7 +23,7 @@ import {
 } from './calc_es_interval';
 import { autoInterval } from '../../_interval_options';
 
-interface TimeBucketsInterval extends moment.Duration {
+export interface TimeBucketsInterval extends moment.Duration {
   // TODO double-check whether all of these are needed
   description: string;
   esValue: EsInterval['value'];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [prerequesites part 1 for lens ESQL generation (#203962)](https://github.com/elastic/kibana/pull/203962)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Peter Pisljar","email":"peter.pisljar@elastic.co"},"sourceCommit":{"committedDate":"2024-12-19T12:56:56Z","message":"prerequesites part 1 for lens ESQL generation (#203962)","sha":"094e4ae2d5e0c87a0adee394c650f1a9d27fb494","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","backport:skip","v9.0.0"],"title":"prerequesites part 1 for lens ESQL generation","number":203962,"url":"https://github.com/elastic/kibana/pull/203962","mergeCommit":{"message":"prerequesites part 1 for lens ESQL generation (#203962)","sha":"094e4ae2d5e0c87a0adee394c650f1a9d27fb494"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/203962","number":203962,"mergeCommit":{"message":"prerequesites part 1 for lens ESQL generation (#203962)","sha":"094e4ae2d5e0c87a0adee394c650f1a9d27fb494"}}]}] BACKPORT-->