### PR TITLE
[Logs UI] Use the advanced setting in fallback log views

### DIFF
--- a/x-pack/platform/plugins/shared/logs_shared/common/log_views/defaults.ts
+++ b/x-pack/platform/plugins/shared/logs_shared/common/log_views/defaults.ts
@@ -17,8 +17,7 @@ export const defaultLogViewAttributes: LogViewAttributes = {
   name: 'Log View',
   description: 'A default log view',
   logIndices: {
-    type: 'index_name',
-    indexName: 'logs-*,filebeat-*',
+    type: 'kibana_advanced_setting',
   },
   logColumns: [
     {


### PR DESCRIPTION
## :memo: Summary

This fixes the problem that fall-back log views use the deprecated inline log index configuration instead of the advanced setting.

## :female_detective: Review notes

- To test make sure it is a pristine installation with no persistend log view among the saved objects. Then check the embedded usages of the log stream (e.g. in APM or Infrastructure -> Hosts) for the expected absence of the deprecation call-out implemented in https://github.com/elastic/kibana/pull/208242. Since no log view exists it would fall back to the default.
- On serverless the saved object type does not exist. Instead the fall-back is registered as the only possible response when resolving a log view.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->