### PR TITLE
🌊 Streams: Define explicit authorization

### DIFF
--- a/x-pack/solutions/observability/plugins/streams/server/routes/esql/route.ts
+++ b/x-pack/solutions/observability/plugins/streams/server/routes/esql/route.ts
@@ -18,6 +18,16 @@ import { createServerRoute } from '../create_server_route';
 
 export const executeEsqlRoute = createServerRoute({
   endpoint: 'POST /internal/streams/esql',
+  options: {
+    access: 'internal',
+  },
+  security: {
+    authz: {
+      enabled: false,
+      reason:
+        'This API delegates security to the currently logged in user and their Elasticsearch permissions.',
+    },
+  },
   params: z.object({
     body: z.object({
       query: z.string(),


### PR DESCRIPTION
Related to https://github.com/elastic/kibana-team/issues/1236

Adds a couple missing explicity authorization opt-outs (since we rely on Elasticsearch everywhere). For some endpoints in the dashboards we didn't check Elasticsearch first, I added those checks.

<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->