### PR TITLE
Don't stop Task Manager polling when ES or SO is unavailable

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.test.ts
@@ -6,17 +6,27 @@
  */
 
 import sinon from 'sinon';
-import { Subject } from 'rxjs';
+import { Subject, startWith, distinctUntilChanged, BehaviorSubject, withLatestFrom } from 'rxjs';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import {
-  createManagedConfiguration,
   ADJUST_THROUGHPUT_INTERVAL,
+  calculateStartingCapacity,
+  countErrors,
+  createCapacityScan,
+  createPollIntervalScan,
   INTERVAL_AFTER_BLOCK_EXCEPTION,
 } from './create_managed_configuration';
 import { mockLogger } from '../test_utils';
-import { CLAIM_STRATEGY_UPDATE_BY_QUERY, CLAIM_STRATEGY_MGET, TaskManagerConfig } from '../config';
+import {
+  CLAIM_STRATEGY_UPDATE_BY_QUERY,
+  CLAIM_STRATEGY_MGET,
+  TaskManagerConfig,
+  DEFAULT_CAPACITY,
+  DEFAULT_POLL_INTERVAL,
+} from '../config';
 import { MsearchError } from './msearch_error';
 import { BulkUpdateError } from './bulk_update_error';
+import { createRunningAveragedStat } from '../monitoring/task_run_calculators';
 
 describe('createManagedConfiguration()', () => {
   let clock: sinon.SinonFakeTimers;
@@ -29,123 +39,66 @@ describe('createManagedConfiguration()', () => {
 
   afterEach(() => clock.restore());
 
-  test('returns observables with initialized values', async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      logger,
-      errors$: new Subject<Error>(),
-      config: {
-        capacity: 20,
-        poll_interval: 2,
-      } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 20);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
-  });
-
   test('uses max_workers config as capacity if only max workers is defined', async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      logger,
-      errors$: new Subject<Error>(),
-      config: {
+    const capacity = calculateStartingCapacity(
+      {
         max_workers: 10,
         poll_interval: 2,
       } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 10);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
+      logger,
+      DEFAULT_CAPACITY
+    );
+    expect(capacity).toBe(10);
   });
 
   test('uses max_workers config as capacity but does not exceed MAX_CAPACITY', async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      logger,
-      errors$: new Subject<Error>(),
-      config: {
+    const capacity = calculateStartingCapacity(
+      {
         max_workers: 1000,
         poll_interval: 2,
       } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 50);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
+      logger,
+      DEFAULT_CAPACITY
+    );
+    expect(capacity).toBe(50);
   });
 
   test('uses provided defaultCapacity if neither capacity nor max_workers is defined', async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      defaultCapacity: 500,
-      logger,
-      errors$: new Subject<Error>(),
-      config: {
+    const capacity = calculateStartingCapacity(
+      {
         poll_interval: 2,
       } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 500);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
+      logger,
+      500
+    );
+    expect(capacity).toBe(500);
   });
 
   test('logs warning and uses capacity config if both capacity and max_workers is defined', async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      logger,
-      errors$: new Subject<Error>(),
-      config: {
+    const capacity = calculateStartingCapacity(
+      {
         capacity: 30,
         max_workers: 10,
         poll_interval: 2,
       } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 30);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
+      logger,
+      500
+    );
+    expect(capacity).toBe(30);
     expect(logger.warn).toHaveBeenCalledWith(
       `Both \"xpack.task_manager.capacity\" and \"xpack.task_manager.max_workers\" configs are set, max_workers will be ignored in favor of capacity and the setting should be removed.`
     );
   });
 
   test(`skips errors that aren't about too many requests`, async () => {
-    const capacitySubscription = jest.fn();
-    const pollIntervalSubscription = jest.fn();
+    const errorSubscription = jest.fn();
     const errors$ = new Subject<Error>();
-    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
-      errors$,
-      logger,
-      config: {
-        capacity: 10,
-        poll_interval: 100,
-      } as TaskManagerConfig,
-    });
-    capacityConfiguration$.subscribe(capacitySubscription);
-    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
+    const errorCheck$ = countErrors(errors$, ADJUST_THROUGHPUT_INTERVAL);
+    errorCheck$.subscribe(errorSubscription);
+
     errors$.next(new Error('foo'));
     clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-    expect(capacitySubscription).toHaveBeenCalledTimes(1);
-    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
+    expect(errorSubscription).toHaveBeenCalledTimes(1);
   });
 
   describe('capacity configuration', () => {
@@ -154,16 +107,21 @@ describe('createManagedConfiguration()', () => {
       claimStrategy: string = CLAIM_STRATEGY_UPDATE_BY_QUERY
     ) {
       const errors$ = new Subject<Error>();
+      const errorCheck$ = countErrors(errors$, ADJUST_THROUGHPUT_INTERVAL);
       const subscription = jest.fn();
-      const { capacityConfiguration$ } = createManagedConfiguration({
-        errors$,
-        logger,
-        config: {
-          capacity: startingCapacity,
-          poll_interval: 1,
-          claim_strategy: claimStrategy,
-        } as TaskManagerConfig,
-      });
+      const capacityConfiguration$ = errorCheck$.pipe(
+        createCapacityScan(
+          {
+            capacity: startingCapacity,
+            poll_interval: 1,
+            claim_strategy: claimStrategy,
+          } as TaskManagerConfig,
+          logger,
+          startingCapacity
+        ),
+        startWith(startingCapacity),
+        distinctUntilChanged()
+      );
       capacityConfiguration$.subscribe(subscription);
       return { subscription, errors$ };
     }
@@ -282,31 +240,9 @@ describe('createManagedConfiguration()', () => {
         expect(subscription).toHaveBeenNthCalledWith(2, 8);
       });
 
-      test('should decrease configuration at the next interval when an msearch 502 error is emitted', async () => {
-        const { subscription, errors$ } = setupScenario(10);
-        errors$.next(new MsearchError(502));
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-        expect(subscription).toHaveBeenCalledTimes(1);
-        expect(subscription).toHaveBeenNthCalledWith(1, 10);
-        clock.tick(1);
-        expect(subscription).toHaveBeenCalledTimes(2);
-        expect(subscription).toHaveBeenNthCalledWith(2, 8);
-      });
-
       test('should decrease configuration at the next interval when an msearch 503 error is emitted', async () => {
         const { subscription, errors$ } = setupScenario(10);
         errors$.next(new MsearchError(503));
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-        expect(subscription).toHaveBeenCalledTimes(1);
-        expect(subscription).toHaveBeenNthCalledWith(1, 10);
-        clock.tick(1);
-        expect(subscription).toHaveBeenCalledTimes(2);
-        expect(subscription).toHaveBeenNthCalledWith(2, 8);
-      });
-
-      test('should decrease configuration at the next interval when an msearch 504 error is emitted', async () => {
-        const { subscription, errors$ } = setupScenario(10);
-        errors$.next(new MsearchError(504));
         clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
         expect(subscription).toHaveBeenCalledTimes(1);
         expect(subscription).toHaveBeenNthCalledWith(1, 10);
@@ -341,11 +277,33 @@ describe('createManagedConfiguration()', () => {
         expect(subscription).toHaveBeenNthCalledWith(2, 8);
       });
 
+      test('should decrease configuration at the next interval when an msearch 502 error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(10);
+        errors$.next(new MsearchError(502));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 10);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 8);
+      });
+
       test('should decrease configuration at the next interval when a bulkPartialUpdate 503 error is emitted', async () => {
         const { subscription, errors$ } = setupScenario(10);
         errors$.next(
           new BulkUpdateError({ statusCode: 503, message: 'test', type: 'unavailable' })
         );
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 10);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 8);
+      });
+
+      test('should decrease configuration at the next interval when an msearch 504 error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(10);
+        errors$.next(new MsearchError(504));
         clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
         expect(subscription).toHaveBeenCalledTimes(1);
         expect(subscription).toHaveBeenNthCalledWith(1, 10);
@@ -402,19 +360,23 @@ describe('createManagedConfiguration()', () => {
   });
 
   describe('pollInterval configuration', () => {
-    function setupScenario(startingPollInterval: number) {
+    function setupScenario(
+      startingPollInterval: number,
+      claimStrategy: string = CLAIM_STRATEGY_UPDATE_BY_QUERY
+    ) {
       const errors$ = new Subject<Error>();
+      const utilization$ = new BehaviorSubject<number>(100);
+      const errorCheck$ = countErrors(errors$, ADJUST_THROUGHPUT_INTERVAL);
       const subscription = jest.fn();
-      const { pollIntervalConfiguration$ } = createManagedConfiguration({
-        logger,
-        errors$,
-        config: {
-          poll_interval: startingPollInterval,
-          capacity: 20,
-        } as TaskManagerConfig,
-      });
+      const queue = createRunningAveragedStat<number>(5);
+      const pollIntervalConfiguration$ = errorCheck$.pipe(
+        withLatestFrom(utilization$),
+        createPollIntervalScan(logger, startingPollInterval, claimStrategy, queue),
+        startWith(startingPollInterval),
+        distinctUntilChanged()
+      );
       pollIntervalConfiguration$.subscribe(subscription);
-      return { subscription, errors$ };
+      return { subscription, errors$, utilization$ };
     }
 
     beforeEach(() => {
@@ -424,139 +386,226 @@ describe('createManagedConfiguration()', () => {
 
     afterEach(() => clock.restore());
 
-    test('should increase configuration at the next interval when an error is emitted', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-      expect(subscription).toHaveBeenCalledTimes(1);
-      clock.tick(1);
-      expect(subscription).toHaveBeenCalledTimes(2);
-      expect(subscription).toHaveBeenNthCalledWith(2, 120);
-    });
+    describe('default claim strategy', () => {
+      test('should increase configuration at the next interval when an error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+      });
 
-    test('should increase configuration at the next interval when a 500 error is emitted', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      errors$.next(SavedObjectsErrorHelpers.decorateGeneralError(new Error('a'), 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-      expect(subscription).toHaveBeenCalledTimes(1);
-      clock.tick(1);
-      expect(subscription).toHaveBeenCalledTimes(2);
-      expect(subscription).toHaveBeenNthCalledWith(2, 120);
-    });
+      test('should increase configuration at the next interval when a 500 error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        errors$.next(SavedObjectsErrorHelpers.decorateGeneralError(new Error('a'), 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+      });
 
-    test('should increase configuration at the next interval when a 503 error is emitted', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      errors$.next(SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError('a', 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-      expect(subscription).toHaveBeenCalledTimes(1);
-      clock.tick(1);
-      expect(subscription).toHaveBeenCalledTimes(2);
-      expect(subscription).toHaveBeenNthCalledWith(2, 120);
-    });
+      test('should increase configuration at the next interval when a 503 error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        errors$.next(SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+      });
 
-    test('should increase configuration at the next interval when an error with cluster_block_exception type is emitted, then decreases back to normal', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      errors$.next(
-        new BulkUpdateError({
-          statusCode: 403,
-          message: 'index is blocked',
-          type: 'cluster_block_exception',
-        })
-      );
-      expect(subscription).toHaveBeenNthCalledWith(1, 100);
-      // It emits the error with cluster_block_exception type immediately
-      expect(subscription).toHaveBeenNthCalledWith(2, INTERVAL_AFTER_BLOCK_EXCEPTION);
-      clock.tick(INTERVAL_AFTER_BLOCK_EXCEPTION);
-      expect(subscription).toHaveBeenCalledTimes(3);
-      expect(subscription).toHaveBeenNthCalledWith(3, 100);
-    });
+      test('should increase configuration at the next interval when an error with cluster_block_exception type is emitted, then decreases back to normal', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        errors$.next(
+          new BulkUpdateError({
+            statusCode: 403,
+            message: 'index is blocked',
+            type: 'cluster_block_exception',
+          })
+        );
+        expect(subscription).toHaveBeenNthCalledWith(1, 100);
+        // It emits the error with cluster_block_exception type immediately
+        expect(subscription).toHaveBeenNthCalledWith(2, INTERVAL_AFTER_BLOCK_EXCEPTION);
+        clock.tick(INTERVAL_AFTER_BLOCK_EXCEPTION);
+        expect(subscription).toHaveBeenCalledTimes(3);
+        expect(subscription).toHaveBeenNthCalledWith(3, 100);
+      });
 
-    test('should log a warning when the configuration changes from the starting value', async () => {
-      const { errors$ } = setupScenario(100);
-      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      expect(logger.warn).toHaveBeenCalledWith(
-        'Poll interval configuration is temporarily increased after Elasticsearch returned 1 "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).'
-      );
-    });
-
-    test('should log a warning when an issue occurred in the calculating of the increased poll interval', async () => {
-      const { errors$ } = setupScenario(NaN);
-      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      expect(logger.error).toHaveBeenCalledWith(
-        'Poll interval configuration had an issue calculating the new poll interval: Math.min(Math.ceil(NaN * 1.2), Math.max(60000, NaN)) = NaN, will keep the poll interval unchanged (NaN)'
-      );
-    });
-
-    test('should log a warning when an issue occurred in the calculating of the decreased poll interval', async () => {
-      setupScenario(NaN);
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      expect(logger.error).toHaveBeenCalledWith(
-        'Poll interval configuration had an issue calculating the new poll interval: Math.max(NaN, Math.floor(NaN * 0.95)) = NaN, will keep the poll interval unchanged (NaN)'
-      );
-    });
-
-    test('should decrease configuration back to normal incrementally after an error is emitted', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-      clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
-      expect(subscription).toHaveBeenNthCalledWith(2, 120);
-      expect(subscription).toHaveBeenNthCalledWith(3, 114);
-      // 108.3 -> 108 from Math.floor
-      expect(subscription).toHaveBeenNthCalledWith(4, 108);
-      expect(subscription).toHaveBeenNthCalledWith(5, 102);
-      // 96.9 -> 100 from Math.max with the starting value
-      expect(subscription).toHaveBeenNthCalledWith(6, 100);
-      // No new calls due to value not changing and usage of distinctUntilChanged()
-      expect(subscription).toHaveBeenCalledTimes(6);
-    });
-
-    test('should increase configuration when errors keep emitting', async () => {
-      const { subscription, errors$ } = setupScenario(100);
-      for (let i = 0; i < 3; i++) {
+      test('should log a warning when the configuration changes from the starting value', async () => {
+        const { errors$ } = setupScenario(100);
         errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
         clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      }
-      expect(subscription).toHaveBeenNthCalledWith(2, 120);
-      expect(subscription).toHaveBeenNthCalledWith(3, 144);
-      // 172.8 -> 173 from Math.ceil
-      expect(subscription).toHaveBeenNthCalledWith(4, 173);
-    });
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Poll interval configuration changing from 100 to 120 after seeing 1 "too many request" and/or "execute [inline] script" error(s) and/or "cluster_block_exception" error(s).'
+        );
+      });
 
-    test('should limit the upper bound to 60s by default', async () => {
-      const { subscription, errors$ } = setupScenario(3000);
-      for (let i = 0; i < 18; i++) {
+      test('should log a warning when an issue occurred in the calculating of the increased poll interval', async () => {
+        const { errors$ } = setupScenario(NaN);
         errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
         clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      }
-      expect(subscription).toHaveBeenNthCalledWith(2, 3600);
-      expect(subscription).toHaveBeenNthCalledWith(3, 4320);
-      expect(subscription).toHaveBeenNthCalledWith(4, 5184);
-      expect(subscription).toHaveBeenNthCalledWith(5, 6221);
-      expect(subscription).toHaveBeenNthCalledWith(6, 7466);
-      expect(subscription).toHaveBeenNthCalledWith(7, 8960);
-      expect(subscription).toHaveBeenNthCalledWith(8, 10752);
-      expect(subscription).toHaveBeenNthCalledWith(9, 12903);
-      expect(subscription).toHaveBeenNthCalledWith(10, 15484);
-      expect(subscription).toHaveBeenNthCalledWith(11, 18581);
-      expect(subscription).toHaveBeenNthCalledWith(12, 22298);
-      expect(subscription).toHaveBeenNthCalledWith(13, 26758);
-      expect(subscription).toHaveBeenNthCalledWith(14, 32110);
-      expect(subscription).toHaveBeenNthCalledWith(15, 38532);
-      expect(subscription).toHaveBeenNthCalledWith(16, 46239);
-      expect(subscription).toHaveBeenNthCalledWith(17, 55487);
-      expect(subscription).toHaveBeenNthCalledWith(18, 60000);
+        expect(logger.error).toHaveBeenCalledWith(
+          'Poll interval configuration had an issue calculating the new poll interval: Math.min(Math.ceil(NaN * 1.2), Math.max(60000, NaN)) = NaN, will keep the poll interval unchanged (NaN)'
+        );
+      });
+
+      test('should log a warning when an issue occurred in the calculating of the decreased poll interval', async () => {
+        setupScenario(NaN);
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        expect(logger.error).toHaveBeenCalledWith(
+          'Poll interval configuration had an issue calculating the new poll interval: Math.max(NaN, Math.floor(NaN * 0.95)) = NaN, will keep the poll interval unchanged (NaN)'
+        );
+      });
+
+      test('should decrease configuration back to normal incrementally after an error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+        expect(subscription).toHaveBeenNthCalledWith(3, 114);
+        // 108.3 -> 108 from Math.floor
+        expect(subscription).toHaveBeenNthCalledWith(4, 108);
+        expect(subscription).toHaveBeenNthCalledWith(5, 102);
+        // 96.9 -> 100 from Math.max with the starting value
+        expect(subscription).toHaveBeenNthCalledWith(6, 100);
+        // No new calls due to value not changing and usage of distinctUntilChanged()
+        expect(subscription).toHaveBeenCalledTimes(6);
+      });
+
+      test('should increase configuration when errors keep emitting', async () => {
+        const { subscription, errors$ } = setupScenario(100);
+        for (let i = 0; i < 3; i++) {
+          errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        }
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+        expect(subscription).toHaveBeenNthCalledWith(3, 144);
+        // 172.8 -> 173 from Math.ceil
+        expect(subscription).toHaveBeenNthCalledWith(4, 173);
+      });
+
+      test('should limit the upper bound to 60s by default', async () => {
+        const { subscription, errors$ } = setupScenario(3000);
+        for (let i = 0; i < 18; i++) {
+          errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        }
+        expect(subscription).toHaveBeenNthCalledWith(2, 3600);
+        expect(subscription).toHaveBeenNthCalledWith(3, 4320);
+        expect(subscription).toHaveBeenNthCalledWith(4, 5184);
+        expect(subscription).toHaveBeenNthCalledWith(5, 6221);
+        expect(subscription).toHaveBeenNthCalledWith(6, 7466);
+        expect(subscription).toHaveBeenNthCalledWith(7, 8960);
+        expect(subscription).toHaveBeenNthCalledWith(8, 10752);
+        expect(subscription).toHaveBeenNthCalledWith(9, 12903);
+        expect(subscription).toHaveBeenNthCalledWith(10, 15484);
+        expect(subscription).toHaveBeenNthCalledWith(11, 18581);
+        expect(subscription).toHaveBeenNthCalledWith(12, 22298);
+        expect(subscription).toHaveBeenNthCalledWith(13, 26758);
+        expect(subscription).toHaveBeenNthCalledWith(14, 32110);
+        expect(subscription).toHaveBeenNthCalledWith(15, 38532);
+        expect(subscription).toHaveBeenNthCalledWith(16, 46239);
+        expect(subscription).toHaveBeenNthCalledWith(17, 55487);
+        expect(subscription).toHaveBeenNthCalledWith(18, 60000);
+      });
+
+      test('should not adjust poll interval dynamically if initial value is > 60s', async () => {
+        const { subscription, errors$ } = setupScenario(65000);
+        for (let i = 0; i < 5; i++) {
+          errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        }
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 65000);
+      });
     });
 
-    test('should not adjust poll interval dynamically if initial value is > 60s', async () => {
-      const { subscription, errors$ } = setupScenario(65000);
-      for (let i = 0; i < 5; i++) {
+    describe('mget claim strategy', () => {
+      test('should increase configuration at the next interval when an error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(100, CLAIM_STRATEGY_MGET);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 120);
+      });
+
+      test('should log a warning when the configuration changes from the starting value', async () => {
+        const { errors$ } = setupScenario(100, CLAIM_STRATEGY_MGET);
         errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
         clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-      }
-      expect(subscription).toHaveBeenCalledTimes(1);
-      expect(subscription).toHaveBeenNthCalledWith(1, 65000);
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Poll interval configuration changing from 100 to 120 after seeing 1 "too many request" and/or "execute [inline] script" error(s) and/or "cluster_block_exception" error(s).'
+        );
+      });
+
+      test('should decrease configuration back to normal incrementally after an error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(DEFAULT_POLL_INTERVAL, CLAIM_STRATEGY_MGET);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
+        expect(subscription).toHaveBeenNthCalledWith(2, 3600);
+        expect(subscription).toHaveBeenNthCalledWith(3, 3420);
+        expect(subscription).toHaveBeenNthCalledWith(4, 3249);
+        expect(subscription).toHaveBeenNthCalledWith(5, 3086);
+        expect(subscription).toHaveBeenNthCalledWith(6, 3000);
+        // No new calls due to value not changing and usage of distinctUntilChanged()
+        expect(subscription).toHaveBeenCalledTimes(6);
+      });
+
+      test('should decrease configuration after error and reset to initial poll interval when poll interval < default and TM utilization > 25%', async () => {
+        const { subscription, errors$ } = setupScenario(2800, CLAIM_STRATEGY_MGET);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
+        expect(subscription).toHaveBeenNthCalledWith(2, 3360);
+        expect(subscription).toHaveBeenNthCalledWith(3, 3192);
+        expect(subscription).toHaveBeenNthCalledWith(4, 3032);
+        expect(subscription).toHaveBeenNthCalledWith(5, 2800);
+        // No new calls due to value not changing and usage of distinctUntilChanged()
+        expect(subscription).toHaveBeenCalledTimes(5);
+      });
+
+      test('should decrease configuration after error and reset to default poll interval when poll interval < default and TM utilization < 25%', async () => {
+        const { subscription, errors$, utilization$ } = setupScenario(2800, CLAIM_STRATEGY_MGET);
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        for (let i = 0; i < 10; i++) {
+          utilization$.next(20);
+          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        }
+        expect(subscription).toHaveBeenNthCalledWith(2, 3360);
+        expect(subscription).toHaveBeenNthCalledWith(3, 3192);
+        expect(subscription).toHaveBeenNthCalledWith(4, 3032);
+        expect(subscription).toHaveBeenNthCalledWith(5, 3000);
+        // No new calls due to value not changing and usage of distinctUntilChanged()
+        expect(subscription).toHaveBeenCalledTimes(5);
+      });
+
+      test('should change configuration based on TM utilization', async () => {
+        const { subscription, utilization$ } = setupScenario(500, CLAIM_STRATEGY_MGET);
+        const u = [15, 35, 5, 48, 0];
+        for (let i = 0; i < u.length; i++) {
+          utilization$.next(u[i]);
+          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        }
+        expect(subscription).toHaveBeenNthCalledWith(2, 3000);
+        expect(subscription).toHaveBeenNthCalledWith(3, 500);
+        expect(subscription).toHaveBeenNthCalledWith(4, 3000);
+        expect(subscription).toHaveBeenNthCalledWith(5, 500);
+        expect(subscription).toHaveBeenNthCalledWith(6, 3000);
+        expect(subscription).toHaveBeenCalledTimes(6);
+      });
+
+      test('should log a warning when the configuration changes from the starting value based on TM utilization', async () => {
+        const { utilization$ } = setupScenario(100, CLAIM_STRATEGY_MGET);
+        utilization$.next(20);
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+        expect(logger.debug).toHaveBeenCalledWith(
+          'Poll interval configuration changing from 100 to 3000 after a change in the average task load: 20.'
+        );
+      });
     });
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.test.ts
@@ -6,27 +6,17 @@
  */
 
 import sinon from 'sinon';
-import { Subject, startWith, distinctUntilChanged, BehaviorSubject, withLatestFrom } from 'rxjs';
+import { Subject } from 'rxjs';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import {
+  createManagedConfiguration,
   ADJUST_THROUGHPUT_INTERVAL,
-  calculateStartingCapacity,
-  countErrors,
-  createCapacityScan,
-  createPollIntervalScan,
   INTERVAL_AFTER_BLOCK_EXCEPTION,
 } from './create_managed_configuration';
 import { mockLogger } from '../test_utils';
-import {
-  CLAIM_STRATEGY_UPDATE_BY_QUERY,
-  CLAIM_STRATEGY_MGET,
-  TaskManagerConfig,
-  DEFAULT_CAPACITY,
-  DEFAULT_POLL_INTERVAL,
-} from '../config';
+import { CLAIM_STRATEGY_UPDATE_BY_QUERY, CLAIM_STRATEGY_MGET, TaskManagerConfig } from '../config';
 import { MsearchError } from './msearch_error';
 import { BulkUpdateError } from './bulk_update_error';
-import { createRunningAveragedStat } from '../monitoring/task_run_calculators';
 
 describe('createManagedConfiguration()', () => {
   let clock: sinon.SinonFakeTimers;
@@ -39,66 +29,123 @@ describe('createManagedConfiguration()', () => {
 
   afterEach(() => clock.restore());
 
+  test('returns observables with initialized values', async () => {
+    const capacitySubscription = jest.fn();
+    const pollIntervalSubscription = jest.fn();
+    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
+      logger,
+      errors$: new Subject<Error>(),
+      config: {
+        capacity: 20,
+        poll_interval: 2,
+      } as TaskManagerConfig,
+    });
+    capacityConfiguration$.subscribe(capacitySubscription);
+    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
+    expect(capacitySubscription).toHaveBeenCalledTimes(1);
+    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 20);
+    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
+    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
+  });
+
   test('uses max_workers config as capacity if only max workers is defined', async () => {
-    const capacity = calculateStartingCapacity(
-      {
+    const capacitySubscription = jest.fn();
+    const pollIntervalSubscription = jest.fn();
+    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
+      logger,
+      errors$: new Subject<Error>(),
+      config: {
         max_workers: 10,
         poll_interval: 2,
       } as TaskManagerConfig,
-      logger,
-      DEFAULT_CAPACITY
-    );
-    expect(capacity).toBe(10);
+    });
+    capacityConfiguration$.subscribe(capacitySubscription);
+    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
+    expect(capacitySubscription).toHaveBeenCalledTimes(1);
+    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 10);
+    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
+    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
   });
 
   test('uses max_workers config as capacity but does not exceed MAX_CAPACITY', async () => {
-    const capacity = calculateStartingCapacity(
-      {
+    const capacitySubscription = jest.fn();
+    const pollIntervalSubscription = jest.fn();
+    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
+      logger,
+      errors$: new Subject<Error>(),
+      config: {
         max_workers: 1000,
         poll_interval: 2,
       } as TaskManagerConfig,
-      logger,
-      DEFAULT_CAPACITY
-    );
-    expect(capacity).toBe(50);
+    });
+    capacityConfiguration$.subscribe(capacitySubscription);
+    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
+    expect(capacitySubscription).toHaveBeenCalledTimes(1);
+    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 50);
+    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
+    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
   });
 
   test('uses provided defaultCapacity if neither capacity nor max_workers is defined', async () => {
-    const capacity = calculateStartingCapacity(
-      {
+    const capacitySubscription = jest.fn();
+    const pollIntervalSubscription = jest.fn();
+    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
+      defaultCapacity: 500,
+      logger,
+      errors$: new Subject<Error>(),
+      config: {
         poll_interval: 2,
       } as TaskManagerConfig,
-      logger,
-      500
-    );
-    expect(capacity).toBe(500);
+    });
+    capacityConfiguration$.subscribe(capacitySubscription);
+    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
+    expect(capacitySubscription).toHaveBeenCalledTimes(1);
+    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 500);
+    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
+    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
   });
 
   test('logs warning and uses capacity config if both capacity and max_workers is defined', async () => {
-    const capacity = calculateStartingCapacity(
-      {
+    const capacitySubscription = jest.fn();
+    const pollIntervalSubscription = jest.fn();
+    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
+      logger,
+      errors$: new Subject<Error>(),
+      config: {
         capacity: 30,
         max_workers: 10,
         poll_interval: 2,
       } as TaskManagerConfig,
-      logger,
-      500
-    );
-    expect(capacity).toBe(30);
+    });
+    capacityConfiguration$.subscribe(capacitySubscription);
+    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
+    expect(capacitySubscription).toHaveBeenCalledTimes(1);
+    expect(capacitySubscription).toHaveBeenNthCalledWith(1, 30);
+    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
+    expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
     expect(logger.warn).toHaveBeenCalledWith(
       `Both \"xpack.task_manager.capacity\" and \"xpack.task_manager.max_workers\" configs are set, max_workers will be ignored in favor of capacity and the setting should be removed.`
     );
   });
 
   test(`skips errors that aren't about too many requests`, async () => {
-    const errorSubscription = jest.fn();
+    const capacitySubscription = jest.fn();
+    const pollIntervalSubscription = jest.fn();
     const errors$ = new Subject<Error>();
-    const errorCheck$ = countErrors(errors$, ADJUST_THROUGHPUT_INTERVAL);
-    errorCheck$.subscribe(errorSubscription);
-
+    const { capacityConfiguration$, pollIntervalConfiguration$ } = createManagedConfiguration({
+      errors$,
+      logger,
+      config: {
+        capacity: 10,
+        poll_interval: 100,
+      } as TaskManagerConfig,
+    });
+    capacityConfiguration$.subscribe(capacitySubscription);
+    pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
     errors$.next(new Error('foo'));
     clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-    expect(errorSubscription).toHaveBeenCalledTimes(1);
+    expect(capacitySubscription).toHaveBeenCalledTimes(1);
+    expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
   });
 
   describe('capacity configuration', () => {
@@ -107,21 +154,16 @@ describe('createManagedConfiguration()', () => {
       claimStrategy: string = CLAIM_STRATEGY_UPDATE_BY_QUERY
     ) {
       const errors$ = new Subject<Error>();
-      const errorCheck$ = countErrors(errors$, ADJUST_THROUGHPUT_INTERVAL);
       const subscription = jest.fn();
-      const capacityConfiguration$ = errorCheck$.pipe(
-        createCapacityScan(
-          {
-            capacity: startingCapacity,
-            poll_interval: 1,
-            claim_strategy: claimStrategy,
-          } as TaskManagerConfig,
-          logger,
-          startingCapacity
-        ),
-        startWith(startingCapacity),
-        distinctUntilChanged()
-      );
+      const { capacityConfiguration$ } = createManagedConfiguration({
+        errors$,
+        logger,
+        config: {
+          capacity: startingCapacity,
+          poll_interval: 1,
+          claim_strategy: claimStrategy,
+        } as TaskManagerConfig,
+      });
       capacityConfiguration$.subscribe(subscription);
       return { subscription, errors$ };
     }
@@ -207,6 +249,17 @@ describe('createManagedConfiguration()', () => {
     });
 
     describe('mget claim strategy', () => {
+      test('should not decrease configuration at the next interval when an error without status code is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(10);
+        errors$.next(new Error());
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 10);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 10);
+      });
+
       test('should decrease configuration at the next interval when an msearch 429 error is emitted', async () => {
         const { subscription, errors$ } = setupScenario(10);
         errors$.next(new MsearchError(429));
@@ -229,9 +282,31 @@ describe('createManagedConfiguration()', () => {
         expect(subscription).toHaveBeenNthCalledWith(2, 8);
       });
 
+      test('should decrease configuration at the next interval when an msearch 502 error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(10);
+        errors$.next(new MsearchError(502));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 10);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 8);
+      });
+
       test('should decrease configuration at the next interval when an msearch 503 error is emitted', async () => {
         const { subscription, errors$ } = setupScenario(10);
         errors$.next(new MsearchError(503));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+        expect(subscription).toHaveBeenCalledTimes(1);
+        expect(subscription).toHaveBeenNthCalledWith(1, 10);
+        clock.tick(1);
+        expect(subscription).toHaveBeenCalledTimes(2);
+        expect(subscription).toHaveBeenNthCalledWith(2, 8);
+      });
+
+      test('should decrease configuration at the next interval when an msearch 504 error is emitted', async () => {
+        const { subscription, errors$ } = setupScenario(10);
+        errors$.next(new MsearchError(504));
         clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
         expect(subscription).toHaveBeenCalledTimes(1);
         expect(subscription).toHaveBeenNthCalledWith(1, 10);
@@ -327,23 +402,19 @@ describe('createManagedConfiguration()', () => {
   });
 
   describe('pollInterval configuration', () => {
-    function setupScenario(
-      startingPollInterval: number,
-      claimStrategy: string = CLAIM_STRATEGY_UPDATE_BY_QUERY
-    ) {
+    function setupScenario(startingPollInterval: number) {
       const errors$ = new Subject<Error>();
-      const utilization$ = new BehaviorSubject<number>(100);
-      const errorCheck$ = countErrors(errors$, ADJUST_THROUGHPUT_INTERVAL);
       const subscription = jest.fn();
-      const queue = createRunningAveragedStat<number>(5);
-      const pollIntervalConfiguration$ = errorCheck$.pipe(
-        withLatestFrom(utilization$),
-        createPollIntervalScan(logger, startingPollInterval, claimStrategy, queue),
-        startWith(startingPollInterval),
-        distinctUntilChanged()
-      );
+      const { pollIntervalConfiguration$ } = createManagedConfiguration({
+        logger,
+        errors$,
+        config: {
+          poll_interval: startingPollInterval,
+          capacity: 20,
+        } as TaskManagerConfig,
+      });
       pollIntervalConfiguration$.subscribe(subscription);
-      return { subscription, errors$, utilization$ };
+      return { subscription, errors$ };
     }
 
     beforeEach(() => {
@@ -353,226 +424,139 @@ describe('createManagedConfiguration()', () => {
 
     afterEach(() => clock.restore());
 
-    describe('default claim strategy', () => {
-      test('should increase configuration at the next interval when an error is emitted', async () => {
-        const { subscription, errors$ } = setupScenario(100);
-        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-        expect(subscription).toHaveBeenCalledTimes(1);
-        clock.tick(1);
-        expect(subscription).toHaveBeenCalledTimes(2);
-        expect(subscription).toHaveBeenNthCalledWith(2, 120);
-      });
-
-      test('should increase configuration at the next interval when a 500 error is emitted', async () => {
-        const { subscription, errors$ } = setupScenario(100);
-        errors$.next(SavedObjectsErrorHelpers.decorateGeneralError(new Error('a'), 'b'));
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-        expect(subscription).toHaveBeenCalledTimes(1);
-        clock.tick(1);
-        expect(subscription).toHaveBeenCalledTimes(2);
-        expect(subscription).toHaveBeenNthCalledWith(2, 120);
-      });
-
-      test('should increase configuration at the next interval when a 503 error is emitted', async () => {
-        const { subscription, errors$ } = setupScenario(100);
-        errors$.next(SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError('a', 'b'));
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-        expect(subscription).toHaveBeenCalledTimes(1);
-        clock.tick(1);
-        expect(subscription).toHaveBeenCalledTimes(2);
-        expect(subscription).toHaveBeenNthCalledWith(2, 120);
-      });
-
-      test('should increase configuration at the next interval when an error with cluster_block_exception type is emitted, then decreases back to normal', async () => {
-        const { subscription, errors$ } = setupScenario(100);
-        errors$.next(
-          new BulkUpdateError({
-            statusCode: 403,
-            message: 'index is blocked',
-            type: 'cluster_block_exception',
-          })
-        );
-        expect(subscription).toHaveBeenNthCalledWith(1, 100);
-        // It emits the error with cluster_block_exception type immediately
-        expect(subscription).toHaveBeenNthCalledWith(2, INTERVAL_AFTER_BLOCK_EXCEPTION);
-        clock.tick(INTERVAL_AFTER_BLOCK_EXCEPTION);
-        expect(subscription).toHaveBeenCalledTimes(3);
-        expect(subscription).toHaveBeenNthCalledWith(3, 100);
-      });
-
-      test('should log a warning when the configuration changes from the starting value', async () => {
-        const { errors$ } = setupScenario(100);
-        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-        expect(logger.warn).toHaveBeenCalledWith(
-          'Poll interval configuration changing from 100 to 120 after seeing 1 "too many request" and/or "execute [inline] script" error(s) and/or "cluster_block_exception" error(s).'
-        );
-      });
-
-      test('should log a warning when an issue occurred in the calculating of the increased poll interval', async () => {
-        const { errors$ } = setupScenario(NaN);
-        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-        expect(logger.error).toHaveBeenCalledWith(
-          'Poll interval configuration had an issue calculating the new poll interval: Math.min(Math.ceil(NaN * 1.2), Math.max(60000, NaN)) = NaN, will keep the poll interval unchanged (NaN)'
-        );
-      });
-
-      test('should log a warning when an issue occurred in the calculating of the decreased poll interval', async () => {
-        setupScenario(NaN);
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-        expect(logger.error).toHaveBeenCalledWith(
-          'Poll interval configuration had an issue calculating the new poll interval: Math.max(NaN, Math.floor(NaN * 0.95)) = NaN, will keep the poll interval unchanged (NaN)'
-        );
-      });
-
-      test('should decrease configuration back to normal incrementally after an error is emitted', async () => {
-        const { subscription, errors$ } = setupScenario(100);
-        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
-        expect(subscription).toHaveBeenNthCalledWith(2, 120);
-        expect(subscription).toHaveBeenNthCalledWith(3, 114);
-        // 108.3 -> 108 from Math.floor
-        expect(subscription).toHaveBeenNthCalledWith(4, 108);
-        expect(subscription).toHaveBeenNthCalledWith(5, 102);
-        // 96.9 -> 100 from Math.max with the starting value
-        expect(subscription).toHaveBeenNthCalledWith(6, 100);
-        // No new calls due to value not changing and usage of distinctUntilChanged()
-        expect(subscription).toHaveBeenCalledTimes(6);
-      });
-
-      test('should increase configuration when errors keep emitting', async () => {
-        const { subscription, errors$ } = setupScenario(100);
-        for (let i = 0; i < 3; i++) {
-          errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-        }
-        expect(subscription).toHaveBeenNthCalledWith(2, 120);
-        expect(subscription).toHaveBeenNthCalledWith(3, 144);
-        // 172.8 -> 173 from Math.ceil
-        expect(subscription).toHaveBeenNthCalledWith(4, 173);
-      });
-
-      test('should limit the upper bound to 60s by default', async () => {
-        const { subscription, errors$ } = setupScenario(3000);
-        for (let i = 0; i < 18; i++) {
-          errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-        }
-        expect(subscription).toHaveBeenNthCalledWith(2, 3600);
-        expect(subscription).toHaveBeenNthCalledWith(3, 4320);
-        expect(subscription).toHaveBeenNthCalledWith(4, 5184);
-        expect(subscription).toHaveBeenNthCalledWith(5, 6221);
-        expect(subscription).toHaveBeenNthCalledWith(6, 7466);
-        expect(subscription).toHaveBeenNthCalledWith(7, 8960);
-        expect(subscription).toHaveBeenNthCalledWith(8, 10752);
-        expect(subscription).toHaveBeenNthCalledWith(9, 12903);
-        expect(subscription).toHaveBeenNthCalledWith(10, 15484);
-        expect(subscription).toHaveBeenNthCalledWith(11, 18581);
-        expect(subscription).toHaveBeenNthCalledWith(12, 22298);
-        expect(subscription).toHaveBeenNthCalledWith(13, 26758);
-        expect(subscription).toHaveBeenNthCalledWith(14, 32110);
-        expect(subscription).toHaveBeenNthCalledWith(15, 38532);
-        expect(subscription).toHaveBeenNthCalledWith(16, 46239);
-        expect(subscription).toHaveBeenNthCalledWith(17, 55487);
-        expect(subscription).toHaveBeenNthCalledWith(18, 60000);
-      });
-
-      test('should not adjust poll interval dynamically if initial value is > 60s', async () => {
-        const { subscription, errors$ } = setupScenario(65000);
-        for (let i = 0; i < 5; i++) {
-          errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-        }
-        expect(subscription).toHaveBeenCalledTimes(1);
-        expect(subscription).toHaveBeenNthCalledWith(1, 65000);
-      });
+    test('should increase configuration at the next interval when an error is emitted', async () => {
+      const { subscription, errors$ } = setupScenario(100);
+      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+      clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+      expect(subscription).toHaveBeenCalledTimes(1);
+      clock.tick(1);
+      expect(subscription).toHaveBeenCalledTimes(2);
+      expect(subscription).toHaveBeenNthCalledWith(2, 120);
     });
 
-    describe('mget claim strategy', () => {
-      test('should increase configuration at the next interval when an error is emitted', async () => {
-        const { subscription, errors$ } = setupScenario(100, CLAIM_STRATEGY_MGET);
-        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
-        expect(subscription).toHaveBeenCalledTimes(1);
-        clock.tick(1);
-        expect(subscription).toHaveBeenCalledTimes(2);
-        expect(subscription).toHaveBeenNthCalledWith(2, 120);
-      });
+    test('should increase configuration at the next interval when a 500 error is emitted', async () => {
+      const { subscription, errors$ } = setupScenario(100);
+      errors$.next(SavedObjectsErrorHelpers.decorateGeneralError(new Error('a'), 'b'));
+      clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+      expect(subscription).toHaveBeenCalledTimes(1);
+      clock.tick(1);
+      expect(subscription).toHaveBeenCalledTimes(2);
+      expect(subscription).toHaveBeenNthCalledWith(2, 120);
+    });
 
-      test('should log a warning when the configuration changes from the starting value', async () => {
-        const { errors$ } = setupScenario(100, CLAIM_STRATEGY_MGET);
+    test('should increase configuration at the next interval when a 503 error is emitted', async () => {
+      const { subscription, errors$ } = setupScenario(100);
+      errors$.next(SavedObjectsErrorHelpers.createGenericNotFoundEsUnavailableError('a', 'b'));
+      clock.tick(ADJUST_THROUGHPUT_INTERVAL - 1);
+      expect(subscription).toHaveBeenCalledTimes(1);
+      clock.tick(1);
+      expect(subscription).toHaveBeenCalledTimes(2);
+      expect(subscription).toHaveBeenNthCalledWith(2, 120);
+    });
+
+    test('should increase configuration at the next interval when an error with cluster_block_exception type is emitted, then decreases back to normal', async () => {
+      const { subscription, errors$ } = setupScenario(100);
+      errors$.next(
+        new BulkUpdateError({
+          statusCode: 403,
+          message: 'index is blocked',
+          type: 'cluster_block_exception',
+        })
+      );
+      expect(subscription).toHaveBeenNthCalledWith(1, 100);
+      // It emits the error with cluster_block_exception type immediately
+      expect(subscription).toHaveBeenNthCalledWith(2, INTERVAL_AFTER_BLOCK_EXCEPTION);
+      clock.tick(INTERVAL_AFTER_BLOCK_EXCEPTION);
+      expect(subscription).toHaveBeenCalledTimes(3);
+      expect(subscription).toHaveBeenNthCalledWith(3, 100);
+    });
+
+    test('should log a warning when the configuration changes from the starting value', async () => {
+      const { errors$ } = setupScenario(100);
+      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Poll interval configuration is temporarily increased after Elasticsearch returned 1 "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).'
+      );
+    });
+
+    test('should log a warning when an issue occurred in the calculating of the increased poll interval', async () => {
+      const { errors$ } = setupScenario(NaN);
+      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+      expect(logger.error).toHaveBeenCalledWith(
+        'Poll interval configuration had an issue calculating the new poll interval: Math.min(Math.ceil(NaN * 1.2), Math.max(60000, NaN)) = NaN, will keep the poll interval unchanged (NaN)'
+      );
+    });
+
+    test('should log a warning when an issue occurred in the calculating of the decreased poll interval', async () => {
+      setupScenario(NaN);
+      clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+      expect(logger.error).toHaveBeenCalledWith(
+        'Poll interval configuration had an issue calculating the new poll interval: Math.max(NaN, Math.floor(NaN * 0.95)) = NaN, will keep the poll interval unchanged (NaN)'
+      );
+    });
+
+    test('should decrease configuration back to normal incrementally after an error is emitted', async () => {
+      const { subscription, errors$ } = setupScenario(100);
+      errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+      clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
+      expect(subscription).toHaveBeenNthCalledWith(2, 120);
+      expect(subscription).toHaveBeenNthCalledWith(3, 114);
+      // 108.3 -> 108 from Math.floor
+      expect(subscription).toHaveBeenNthCalledWith(4, 108);
+      expect(subscription).toHaveBeenNthCalledWith(5, 102);
+      // 96.9 -> 100 from Math.max with the starting value
+      expect(subscription).toHaveBeenNthCalledWith(6, 100);
+      // No new calls due to value not changing and usage of distinctUntilChanged()
+      expect(subscription).toHaveBeenCalledTimes(6);
+    });
+
+    test('should increase configuration when errors keep emitting', async () => {
+      const { subscription, errors$ } = setupScenario(100);
+      for (let i = 0; i < 3; i++) {
         errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
         clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-        expect(logger.warn).toHaveBeenCalledWith(
-          'Poll interval configuration changing from 100 to 120 after seeing 1 "too many request" and/or "execute [inline] script" error(s) and/or "cluster_block_exception" error(s).'
-        );
-      });
+      }
+      expect(subscription).toHaveBeenNthCalledWith(2, 120);
+      expect(subscription).toHaveBeenNthCalledWith(3, 144);
+      // 172.8 -> 173 from Math.ceil
+      expect(subscription).toHaveBeenNthCalledWith(4, 173);
+    });
 
-      test('should decrease configuration back to normal incrementally after an error is emitted', async () => {
-        const { subscription, errors$ } = setupScenario(DEFAULT_POLL_INTERVAL, CLAIM_STRATEGY_MGET);
+    test('should limit the upper bound to 60s by default', async () => {
+      const { subscription, errors$ } = setupScenario(3000);
+      for (let i = 0; i < 18; i++) {
         errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
-        expect(subscription).toHaveBeenNthCalledWith(2, 3600);
-        expect(subscription).toHaveBeenNthCalledWith(3, 3420);
-        expect(subscription).toHaveBeenNthCalledWith(4, 3249);
-        expect(subscription).toHaveBeenNthCalledWith(5, 3086);
-        expect(subscription).toHaveBeenNthCalledWith(6, 3000);
-        // No new calls due to value not changing and usage of distinctUntilChanged()
-        expect(subscription).toHaveBeenCalledTimes(6);
-      });
-
-      test('should decrease configuration after error and reset to initial poll interval when poll interval < default and TM utilization > 25%', async () => {
-        const { subscription, errors$ } = setupScenario(2800, CLAIM_STRATEGY_MGET);
-        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-        clock.tick(ADJUST_THROUGHPUT_INTERVAL * 10);
-        expect(subscription).toHaveBeenNthCalledWith(2, 3360);
-        expect(subscription).toHaveBeenNthCalledWith(3, 3192);
-        expect(subscription).toHaveBeenNthCalledWith(4, 3032);
-        expect(subscription).toHaveBeenNthCalledWith(5, 2800);
-        // No new calls due to value not changing and usage of distinctUntilChanged()
-        expect(subscription).toHaveBeenCalledTimes(5);
-      });
-
-      test('should decrease configuration after error and reset to default poll interval when poll interval < default and TM utilization < 25%', async () => {
-        const { subscription, errors$, utilization$ } = setupScenario(2800, CLAIM_STRATEGY_MGET);
-        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
-        for (let i = 0; i < 10; i++) {
-          utilization$.next(20);
-          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-        }
-        expect(subscription).toHaveBeenNthCalledWith(2, 3360);
-        expect(subscription).toHaveBeenNthCalledWith(3, 3192);
-        expect(subscription).toHaveBeenNthCalledWith(4, 3032);
-        expect(subscription).toHaveBeenNthCalledWith(5, 3000);
-        // No new calls due to value not changing and usage of distinctUntilChanged()
-        expect(subscription).toHaveBeenCalledTimes(5);
-      });
-
-      test('should change configuration based on TM utilization', async () => {
-        const { subscription, utilization$ } = setupScenario(500, CLAIM_STRATEGY_MGET);
-        const u = [15, 35, 5, 48, 0];
-        for (let i = 0; i < u.length; i++) {
-          utilization$.next(u[i]);
-          clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-        }
-        expect(subscription).toHaveBeenNthCalledWith(2, 3000);
-        expect(subscription).toHaveBeenNthCalledWith(3, 500);
-        expect(subscription).toHaveBeenNthCalledWith(4, 3000);
-        expect(subscription).toHaveBeenNthCalledWith(5, 500);
-        expect(subscription).toHaveBeenNthCalledWith(6, 3000);
-        expect(subscription).toHaveBeenCalledTimes(6);
-      });
-
-      test('should log a warning when the configuration changes from the starting value based on TM utilization', async () => {
-        const { utilization$ } = setupScenario(100, CLAIM_STRATEGY_MGET);
-        utilization$.next(20);
         clock.tick(ADJUST_THROUGHPUT_INTERVAL);
-        expect(logger.debug).toHaveBeenCalledWith(
-          'Poll interval configuration changing from 100 to 3000 after a change in the average task load: 20.'
-        );
-      });
+      }
+      expect(subscription).toHaveBeenNthCalledWith(2, 3600);
+      expect(subscription).toHaveBeenNthCalledWith(3, 4320);
+      expect(subscription).toHaveBeenNthCalledWith(4, 5184);
+      expect(subscription).toHaveBeenNthCalledWith(5, 6221);
+      expect(subscription).toHaveBeenNthCalledWith(6, 7466);
+      expect(subscription).toHaveBeenNthCalledWith(7, 8960);
+      expect(subscription).toHaveBeenNthCalledWith(8, 10752);
+      expect(subscription).toHaveBeenNthCalledWith(9, 12903);
+      expect(subscription).toHaveBeenNthCalledWith(10, 15484);
+      expect(subscription).toHaveBeenNthCalledWith(11, 18581);
+      expect(subscription).toHaveBeenNthCalledWith(12, 22298);
+      expect(subscription).toHaveBeenNthCalledWith(13, 26758);
+      expect(subscription).toHaveBeenNthCalledWith(14, 32110);
+      expect(subscription).toHaveBeenNthCalledWith(15, 38532);
+      expect(subscription).toHaveBeenNthCalledWith(16, 46239);
+      expect(subscription).toHaveBeenNthCalledWith(17, 55487);
+      expect(subscription).toHaveBeenNthCalledWith(18, 60000);
+    });
+
+    test('should not adjust poll interval dynamically if initial value is > 60s', async () => {
+      const { subscription, errors$ } = setupScenario(65000);
+      for (let i = 0; i < 5; i++) {
+        errors$.next(SavedObjectsErrorHelpers.createTooManyRequestsError('a', 'b'));
+        clock.tick(ADJUST_THROUGHPUT_INTERVAL);
+      }
+      expect(subscription).toHaveBeenCalledTimes(1);
+      expect(subscription).toHaveBeenNthCalledWith(1, 65000);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts
@@ -5,12 +5,18 @@
  * 2.0.
  */
 
+import stats from 'stats-lite';
 import { interval, merge, of, Observable } from 'rxjs';
-import { filter, mergeScan, map, scan, distinctUntilChanged, startWith } from 'rxjs';
+import { filter, mergeScan, map, scan } from 'rxjs';
 import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { Logger } from '@kbn/core/server';
 import { isEsCannotExecuteScriptError } from './identify_es_error';
-import { CLAIM_STRATEGY_MGET, DEFAULT_CAPACITY, MAX_CAPACITY, TaskManagerConfig } from '../config';
+import {
+  CLAIM_STRATEGY_MGET,
+  DEFAULT_POLL_INTERVAL,
+  MAX_CAPACITY,
+  TaskManagerConfig,
+} from '../config';
 import { TaskCost } from '../task';
 import { getMsearchStatusCode } from './msearch_error';
 import { getBulkUpdateStatusCode, isClusterBlockException } from './bulk_update_error';
@@ -40,49 +46,16 @@ const CAPACITY_INCREASE_PERCENTAGE = 1.05;
 const POLL_INTERVAL_DECREASE_PERCENTAGE = 0.95;
 const POLL_INTERVAL_INCREASE_PERCENTAGE = 1.2;
 
-interface ManagedConfigurationOpts {
-  config: TaskManagerConfig;
-  defaultCapacity?: number;
-  errors$: Observable<Error>;
-  logger: Logger;
-}
-
 interface ErrorScanResult {
   count: number;
   isBlockException: boolean;
 }
 
-export interface ManagedConfiguration {
-  startingCapacity: number;
-  capacityConfiguration$: Observable<number>;
-  pollIntervalConfiguration$: Observable<number>;
-}
-
-export function createManagedConfiguration({
-  config,
-  defaultCapacity = DEFAULT_CAPACITY,
-  logger,
-  errors$,
-}: ManagedConfigurationOpts): ManagedConfiguration {
-  const errorCheck$ = countErrors(errors$, ADJUST_THROUGHPUT_INTERVAL);
-  const startingCapacity = calculateStartingCapacity(config, logger, defaultCapacity);
-  const startingPollInterval = config.poll_interval;
-  return {
-    startingCapacity,
-    capacityConfiguration$: errorCheck$.pipe(
-      createCapacityScan(config, logger, startingCapacity),
-      startWith(startingCapacity),
-      distinctUntilChanged()
-    ),
-    pollIntervalConfiguration$: errorCheck$.pipe(
-      createPollIntervalScan(logger, startingPollInterval),
-      startWith(startingPollInterval),
-      distinctUntilChanged()
-    ),
-  };
-}
-
-function createCapacityScan(config: TaskManagerConfig, logger: Logger, startingCapacity: number) {
+export function createCapacityScan(
+  config: TaskManagerConfig,
+  logger: Logger,
+  startingCapacity: number
+) {
   return scan(
     (previousCapacity: number, { count: errorCount, isBlockException }: ErrorScanResult) => {
       let newCapacity: number;
@@ -124,10 +97,17 @@ function createCapacityScan(config: TaskManagerConfig, logger: Logger, startingC
   );
 }
 
-function createPollIntervalScan(logger: Logger, startingPollInterval: number) {
+export function createPollIntervalScan(
+  logger: Logger,
+  startingPollInterval: number,
+  claimStrategy: string,
+  tmUtilizationQueue: (value?: number | undefined) => number[]
+) {
   return scan(
-    (previousPollInterval: number, { count: errorCount, isBlockException }: ErrorScanResult) => {
+    (previousPollInterval: number, [{ count: errorCount, isBlockException }, tmUtilization]) => {
       let newPollInterval: number;
+      let updatedForCapacity = false;
+      let avgTmUtilization = 0;
       if (isBlockException) {
         newPollInterval = INTERVAL_AFTER_BLOCK_EXCEPTION;
       } else {
@@ -164,19 +144,32 @@ function createPollIntervalScan(logger: Logger, startingPollInterval: number) {
             );
             newPollInterval = previousPollInterval;
           }
+
+          // If the task claim strategy is mget, increase the poll interval if the the avg used capacity over 15s is less than 25%.
+          const queue = tmUtilizationQueue(tmUtilization);
+          avgTmUtilization = stats.mean(queue);
+          if (claimStrategy === CLAIM_STRATEGY_MGET && newPollInterval < DEFAULT_POLL_INTERVAL) {
+            updatedForCapacity = true;
+            if (avgTmUtilization < 25) {
+              newPollInterval = DEFAULT_POLL_INTERVAL;
+            } else {
+              // If the the used capacity is greater than or equal to 25% reset the polling interval.
+              newPollInterval = startingPollInterval;
+            }
+          }
         }
       }
-
       if (newPollInterval !== previousPollInterval) {
         if (previousPollInterval !== INTERVAL_AFTER_BLOCK_EXCEPTION) {
-          logger.debug(
-            `Poll interval configuration changing from ${previousPollInterval} to ${newPollInterval} after seeing ${errorCount} "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).`
-          );
-        }
-        if (previousPollInterval === startingPollInterval) {
-          logger.warn(
-            `Poll interval configuration is temporarily increased after Elasticsearch returned ${errorCount} "too many request" and/or "execute [inline] script" and/or "cluster_block_exception" error(s).`
-          );
+          if (updatedForCapacity) {
+            logger.debug(
+              `Poll interval configuration changing from ${previousPollInterval} to ${newPollInterval} after a change in the average task load: ${avgTmUtilization}.`
+            );
+          } else {
+            logger.warn(
+              `Poll interval configuration changing from ${previousPollInterval} to ${newPollInterval} after seeing ${errorCount} "too many request" and/or "execute [inline] script" error(s) and/or "cluster_block_exception" error(s).`
+            );
+          }
         }
       }
       return newPollInterval;
@@ -185,7 +178,7 @@ function createPollIntervalScan(logger: Logger, startingPollInterval: number) {
   );
 }
 
-function countErrors(
+export function countErrors(
   errors$: Observable<Error>,
   countInterval: number
 ): Observable<ErrorScanResult> {

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
@@ -6,7 +6,7 @@
  */
 
 import sinon from 'sinon';
-import { Subject } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 import { TaskPollingLifecycle, claimAvailableTasks, TaskLifecycleEvent } from './polling_lifecycle';
 import { createInitialMiddleware } from './lib/middleware';
@@ -105,6 +105,8 @@ describe('TaskPollingLifecycle', () => {
     definitions: new TaskTypeDictionary(taskManagerLogger),
     middleware: createInitialMiddleware(),
     startingCapacity: 20,
+    capacityConfiguration$: of(20),
+    pollIntervalConfiguration$: of(100),
     executionContext,
     taskPartitioner: new TaskPartitioner({
       logger: taskManagerLogger,
@@ -152,55 +154,65 @@ describe('TaskPollingLifecycle', () => {
 
     test('provides TaskClaiming with the capacity available when strategy = CLAIM_STRATEGY_UPDATE_BY_QUERY', () => {
       const elasticsearchAndSOAvailability$ = new Subject<boolean>();
+      const capacity$ = new Subject<number>();
 
       new TaskPollingLifecycle({
         ...taskManagerOpts,
         elasticsearchAndSOAvailability$,
-        startingCapacity: 40,
+        capacityConfiguration$: capacity$,
       });
+
       const taskClaimingGetCapacity = (TaskClaiming as jest.Mock<TaskClaimingClass>).mock
         .calls[0][0].getAvailableCapacity;
 
+      capacity$.next(40);
       expect(taskClaimingGetCapacity()).toEqual(40);
       expect(taskClaimingGetCapacity('report')).toEqual(1);
       expect(taskClaimingGetCapacity('quickReport')).toEqual(5);
+
+      capacity$.next(60);
+      expect(taskClaimingGetCapacity()).toEqual(60);
+      expect(taskClaimingGetCapacity('report')).toEqual(1);
+      expect(taskClaimingGetCapacity('quickReport')).toEqual(5);
+
+      capacity$.next(4);
+      expect(taskClaimingGetCapacity()).toEqual(4);
+      expect(taskClaimingGetCapacity('report')).toEqual(1);
+      expect(taskClaimingGetCapacity('quickReport')).toEqual(4);
     });
 
     test('provides TaskClaiming with the capacity available when strategy = CLAIM_STRATEGY_MGET', () => {
       const elasticsearchAndSOAvailability$ = new Subject<boolean>();
+      const capacity$ = new Subject<number>();
+
       new TaskPollingLifecycle({
         ...taskManagerOpts,
         config: { ...taskManagerOpts.config, claim_strategy: CLAIM_STRATEGY_MGET },
         elasticsearchAndSOAvailability$,
-        startingCapacity: 40,
+        capacityConfiguration$: capacity$,
       });
 
       const taskClaimingGetCapacity = (TaskClaiming as jest.Mock<TaskClaimingClass>).mock
         .calls[0][0].getAvailableCapacity;
 
+      capacity$.next(40);
       expect(taskClaimingGetCapacity()).toEqual(80);
       expect(taskClaimingGetCapacity('report')).toEqual(10);
       expect(taskClaimingGetCapacity('quickReport')).toEqual(10);
+
+      capacity$.next(60);
+      expect(taskClaimingGetCapacity()).toEqual(120);
+      expect(taskClaimingGetCapacity('report')).toEqual(10);
+      expect(taskClaimingGetCapacity('quickReport')).toEqual(10);
+
+      capacity$.next(4);
+      expect(taskClaimingGetCapacity()).toEqual(8);
+      expect(taskClaimingGetCapacity('report')).toEqual(8);
+      expect(taskClaimingGetCapacity('quickReport')).toEqual(8);
     });
   });
 
   describe('stop', () => {
-    test('stops polling once the ES and SavedObjects services become unavailable', () => {
-      const elasticsearchAndSOAvailability$ = new Subject<boolean>();
-      new TaskPollingLifecycle({ elasticsearchAndSOAvailability$, ...taskManagerOpts });
-
-      elasticsearchAndSOAvailability$.next(true);
-
-      clock.tick(150);
-      expect(mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable).toHaveBeenCalled();
-
-      elasticsearchAndSOAvailability$.next(false);
-
-      mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable.mockClear();
-      clock.tick(150);
-      expect(mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable).not.toHaveBeenCalled();
-    });
-
     test('stops polling if stop() is called', () => {
       const elasticsearchAndSOAvailability$ = new Subject<boolean>();
       const pollingLifecycle = new TaskPollingLifecycle({
@@ -222,30 +234,6 @@ describe('TaskPollingLifecycle', () => {
 
       clock.tick(100);
       expect(mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable).toHaveBeenCalledTimes(1);
-    });
-
-    test('restarts polling once the ES and SavedObjects services become available again', () => {
-      const elasticsearchAndSOAvailability$ = new Subject<boolean>();
-      new TaskPollingLifecycle({
-        elasticsearchAndSOAvailability$,
-        ...taskManagerOpts,
-      });
-
-      elasticsearchAndSOAvailability$.next(true);
-
-      clock.tick(150);
-      expect(mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable).toHaveBeenCalled();
-
-      elasticsearchAndSOAvailability$.next(false);
-      mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable.mockClear();
-      clock.tick(150);
-
-      expect(mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable).not.toHaveBeenCalled();
-
-      elasticsearchAndSOAvailability$.next(true);
-      clock.tick(150);
-
-      expect(mockTaskClaiming.claimAvailableTasksIfCapacityIsAvailable).toHaveBeenCalled();
     });
   });
 
@@ -561,32 +549,6 @@ describe('TaskPollingLifecycle', () => {
         tag: 'err',
         error: new Error(`Partially failed to poll for work: some tasks could not be claimed.`),
       });
-    });
-  });
-
-  describe('pollingLifecycleEvents capacity and poll interval', () => {
-    test('returns observables with initialized values', async () => {
-      const elasticsearchAndSOAvailability$ = new Subject<boolean>();
-      const taskPollingLifecycle = new TaskPollingLifecycle({
-        ...taskManagerOpts,
-        config: {
-          ...taskManagerOpts.config,
-          poll_interval: 2,
-        },
-        elasticsearchAndSOAvailability$,
-      });
-
-      elasticsearchAndSOAvailability$.next(true);
-
-      const capacitySubscription = jest.fn();
-      const pollIntervalSubscription = jest.fn();
-
-      taskPollingLifecycle.capacityConfiguration$.subscribe(capacitySubscription);
-      taskPollingLifecycle.pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
-      expect(capacitySubscription).toHaveBeenCalledTimes(1);
-      expect(capacitySubscription).toHaveBeenNthCalledWith(1, 20);
-      expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
-      expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
@@ -6,7 +6,7 @@
  */
 
 import sinon from 'sinon';
-import { of, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 
 import { TaskPollingLifecycle, claimAvailableTasks, TaskLifecycleEvent } from './polling_lifecycle';
 import { createInitialMiddleware } from './lib/middleware';
@@ -105,8 +105,6 @@ describe('TaskPollingLifecycle', () => {
     definitions: new TaskTypeDictionary(taskManagerLogger),
     middleware: createInitialMiddleware(),
     startingCapacity: 20,
-    capacityConfiguration$: of(20),
-    pollIntervalConfiguration$: of(100),
     executionContext,
     taskPartitioner: new TaskPartitioner({
       logger: taskManagerLogger,
@@ -154,61 +152,35 @@ describe('TaskPollingLifecycle', () => {
 
     test('provides TaskClaiming with the capacity available when strategy = CLAIM_STRATEGY_UPDATE_BY_QUERY', () => {
       const elasticsearchAndSOAvailability$ = new Subject<boolean>();
-      const capacity$ = new Subject<number>();
 
       new TaskPollingLifecycle({
         ...taskManagerOpts,
         elasticsearchAndSOAvailability$,
-        capacityConfiguration$: capacity$,
+        startingCapacity: 40,
       });
-
       const taskClaimingGetCapacity = (TaskClaiming as jest.Mock<TaskClaimingClass>).mock
         .calls[0][0].getAvailableCapacity;
 
-      capacity$.next(40);
       expect(taskClaimingGetCapacity()).toEqual(40);
       expect(taskClaimingGetCapacity('report')).toEqual(1);
       expect(taskClaimingGetCapacity('quickReport')).toEqual(5);
-
-      capacity$.next(60);
-      expect(taskClaimingGetCapacity()).toEqual(60);
-      expect(taskClaimingGetCapacity('report')).toEqual(1);
-      expect(taskClaimingGetCapacity('quickReport')).toEqual(5);
-
-      capacity$.next(4);
-      expect(taskClaimingGetCapacity()).toEqual(4);
-      expect(taskClaimingGetCapacity('report')).toEqual(1);
-      expect(taskClaimingGetCapacity('quickReport')).toEqual(4);
     });
 
     test('provides TaskClaiming with the capacity available when strategy = CLAIM_STRATEGY_MGET', () => {
       const elasticsearchAndSOAvailability$ = new Subject<boolean>();
-      const capacity$ = new Subject<number>();
-
       new TaskPollingLifecycle({
         ...taskManagerOpts,
         config: { ...taskManagerOpts.config, claim_strategy: CLAIM_STRATEGY_MGET },
         elasticsearchAndSOAvailability$,
-        capacityConfiguration$: capacity$,
+        startingCapacity: 40,
       });
 
       const taskClaimingGetCapacity = (TaskClaiming as jest.Mock<TaskClaimingClass>).mock
         .calls[0][0].getAvailableCapacity;
 
-      capacity$.next(40);
       expect(taskClaimingGetCapacity()).toEqual(80);
       expect(taskClaimingGetCapacity('report')).toEqual(10);
       expect(taskClaimingGetCapacity('quickReport')).toEqual(10);
-
-      capacity$.next(60);
-      expect(taskClaimingGetCapacity()).toEqual(120);
-      expect(taskClaimingGetCapacity('report')).toEqual(10);
-      expect(taskClaimingGetCapacity('quickReport')).toEqual(10);
-
-      capacity$.next(4);
-      expect(taskClaimingGetCapacity()).toEqual(8);
-      expect(taskClaimingGetCapacity('report')).toEqual(8);
-      expect(taskClaimingGetCapacity('quickReport')).toEqual(8);
     });
   });
 
@@ -549,6 +521,32 @@ describe('TaskPollingLifecycle', () => {
         tag: 'err',
         error: new Error(`Partially failed to poll for work: some tasks could not be claimed.`),
       });
+    });
+  });
+
+  describe('pollingLifecycleEvents capacity and poll interval', () => {
+    test('returns observables with initialized values', async () => {
+      const elasticsearchAndSOAvailability$ = new Subject<boolean>();
+      const taskPollingLifecycle = new TaskPollingLifecycle({
+        ...taskManagerOpts,
+        config: {
+          ...taskManagerOpts.config,
+          poll_interval: 2,
+        },
+        elasticsearchAndSOAvailability$,
+      });
+
+      elasticsearchAndSOAvailability$.next(true);
+
+      const capacitySubscription = jest.fn();
+      const pollIntervalSubscription = jest.fn();
+
+      taskPollingLifecycle.capacityConfiguration$.subscribe(capacitySubscription);
+      taskPollingLifecycle.pollIntervalConfiguration$.subscribe(pollIntervalSubscription);
+      expect(capacitySubscription).toHaveBeenCalledTimes(1);
+      expect(capacitySubscription).toHaveBeenNthCalledWith(1, 20);
+      expect(pollIntervalSubscription).toHaveBeenCalledTimes(1);
+      expect(pollIntervalSubscription).toHaveBeenNthCalledWith(1, 2);
     });
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { Subject, Observable } from 'rxjs';
+import { Subject, Observable, withLatestFrom, BehaviorSubject } from 'rxjs';
+import { distinctUntilChanged, startWith } from 'rxjs';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { map as mapOptional, none } from 'fp-ts/lib/Option';
 import { tap } from 'rxjs';
@@ -13,8 +14,11 @@ import { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import type { Logger, ExecutionContextStart } from '@kbn/core/server';
 
 import { Result, asErr, mapErr, asOk, map, mapOk, isOk } from './lib/result_type';
-import { ManagedConfiguration } from './lib/create_managed_configuration';
-import { TaskManagerConfig, CLAIM_STRATEGY_UPDATE_BY_QUERY } from './config';
+import {
+  TaskManagerConfig,
+  CLAIM_STRATEGY_UPDATE_BY_QUERY,
+  WORKER_UTILIZATION_RUNNING_AVERAGE_WINDOW_SIZE_MS,
+} from './config';
 
 import {
   TaskMarkRunning,
@@ -44,6 +48,13 @@ import { TaskClaiming } from './queries/task_claiming';
 import { ClaimOwnershipResult } from './task_claimers';
 import { TaskPartitioner } from './lib/task_partitioner';
 import { TaskPoller } from './polling/task_poller';
+import {
+  createCapacityScan,
+  createPollIntervalScan,
+  countErrors,
+  ADJUST_THROUGHPUT_INTERVAL,
+} from './lib/create_managed_configuration';
+import { createRunningAveragedStat } from './monitoring/task_run_calculators';
 
 const MAX_BUFFER_OPERATIONS = 100;
 
@@ -51,7 +62,7 @@ export interface ITaskEventEmitter<T> {
   get events(): Observable<T>;
 }
 
-export type TaskPollingLifecycleOpts = {
+export interface TaskPollingLifecycleOpts {
   logger: Logger;
   definitions: TaskTypeDictionary;
   taskStore: TaskStore;
@@ -61,7 +72,8 @@ export type TaskPollingLifecycleOpts = {
   executionContext: ExecutionContextStart;
   usageCounter?: UsageCounter;
   taskPartitioner: TaskPartitioner;
-} & ManagedConfiguration;
+  startingCapacity: number;
+}
 
 export type TaskLifecycleEvent =
   | TaskMarkRunning
@@ -85,8 +97,12 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
 
   private logger: Logger;
   private poller: TaskPoller<string, TimedFillPoolResult>;
+  private started = false;
 
   public pool: TaskPool;
+
+  public capacityConfiguration$: Observable<number>;
+  public pollIntervalConfiguration$: Observable<number>;
 
   // all task related events (task claimed, task marked as running, etc.) are emitted through events$
   private events$ = new Subject<TaskLifecycleEvent>();
@@ -96,7 +112,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
   private usageCounter?: UsageCounter;
   private config: TaskManagerConfig;
   private currentPollInterval: number;
-  private started = false;
+  private currentTmUtilization$ = new BehaviorSubject<number>(0);
 
   /**
    * Initializes the task manager, preventing any further addition of middleware,
@@ -106,8 +122,6 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
   constructor({
     logger,
     middleware,
-    capacityConfiguration$,
-    pollIntervalConfiguration$,
     config,
     // Elasticsearch and SavedObjects availability status
     elasticsearchAndSOAvailability$,
@@ -116,6 +130,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     executionContext,
     usageCounter,
     taskPartitioner,
+    startingCapacity,
   }: TaskPollingLifecycleOpts) {
     this.logger = logger;
     this.middleware = middleware;
@@ -124,9 +139,25 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     this.executionContext = executionContext;
     this.usageCounter = usageCounter;
     this.config = config;
-    this.currentPollInterval = config.poll_interval;
-    pollIntervalConfiguration$.subscribe((pollInterval) => {
-      this.currentPollInterval = pollInterval;
+    const { poll_interval: pollInterval, claim_strategy: claimStrategy } = config;
+    this.currentPollInterval = pollInterval;
+
+    const errorCheck$ = countErrors(taskStore.errors$, ADJUST_THROUGHPUT_INTERVAL);
+    const window = WORKER_UTILIZATION_RUNNING_AVERAGE_WINDOW_SIZE_MS / this.currentPollInterval;
+    const tmUtilizationQueue = createRunningAveragedStat<number>(window);
+    this.capacityConfiguration$ = errorCheck$.pipe(
+      createCapacityScan(config, logger, startingCapacity),
+      startWith(startingCapacity),
+      distinctUntilChanged()
+    );
+    this.pollIntervalConfiguration$ = errorCheck$.pipe(
+      withLatestFrom(this.currentTmUtilization$),
+      createPollIntervalScan(logger, this.currentPollInterval, claimStrategy, tmUtilizationQueue),
+      startWith(this.currentPollInterval),
+      distinctUntilChanged()
+    );
+    this.pollIntervalConfiguration$.subscribe((newPollInterval) => {
+      this.currentPollInterval = newPollInterval;
     });
 
     const emitEvent = (event: TaskLifecycleEvent) => this.events$.next(event);
@@ -139,7 +170,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     this.pool = new TaskPool({
       logger,
       strategy: config.claim_strategy,
-      capacity$: capacityConfiguration$,
+      capacity$: this.capacityConfiguration$,
       definitions: this.definitions,
     });
     this.pool.load.subscribe(emitEvent);
@@ -157,13 +188,11 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     // pipe taskClaiming events into the lifecycle event stream
     this.taskClaiming.events.subscribe(emitEvent);
 
-    const { poll_interval: pollInterval, claim_strategy: claimStrategy } = config;
-
     let pollIntervalDelay$: Observable<number> | undefined;
     if (claimStrategy === CLAIM_STRATEGY_UPDATE_BY_QUERY) {
       pollIntervalDelay$ = delayOnClaimConflicts(
-        capacityConfiguration$,
-        pollIntervalConfiguration$,
+        this.capacityConfiguration$,
+        this.pollIntervalConfiguration$,
         this.events$,
         config.version_conflict_threshold,
         config.monitored_stats_running_average_window
@@ -173,7 +202,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     this.poller = createTaskPoller<string, TimedFillPoolResult>({
       logger,
       initialPollInterval: pollInterval,
-      pollInterval$: pollIntervalConfiguration$,
+      pollInterval$: this.pollIntervalConfiguration$,
       pollIntervalDelay$,
       getCapacity: () => {
         const capacity = this.pool.availableCapacity();
@@ -313,6 +342,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
               tmUtilization = 100;
             }
 
+            this.currentTmUtilization$.next(tmUtilization);
             this.emitEvent(asTaskManagerStatEvent('workerUtilization', asOk(tmUtilization)));
           })
         )


### PR DESCRIPTION
Resolves: #203470

This PR removes the codes that stop task polling when Elasticsearch or SO service is unavailable.
So the TM relies only on the back pressure mechanism.
502 and 504 status codes are also added to be sure that all the possible reasons that stops ES or SO are covered by the back pressure.

## To verify:

Force Elasticsearch version check to throw an error:
https://github.com/elastic/kibana/blob/main/src/core/packages/elasticsearch/server-internal/src/version_check/ensure_es_version.ts#L189

Then mock the response of `this.esClientWithoutRetries.msearch` in task store [here](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/task_manager/server/task_store.ts#L584)

Example:

```
    const responses = [
      {
        error: {
          type: 'not found',
        },
        took: 1000,
        timed_out: false,
        hits: { hits: [] },
        _shards: {
          failed: 1,
          successful: 0,
          total: 1,
        },
        status: 503,
      },
    ];
  ```  
  Expect[ back pressure](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/task_manager/server/lib/create_managed_configuration.ts#L182) to return a longer poll interval.




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->