### PR TITLE
[8.18] Search: add deprecation warnings for config values removed in 9.0 (#208972)

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
@@ -7,6 +7,7 @@
 
 import { schema, TypeOf } from '@kbn/config-schema';
 import { PluginInitializerContext, PluginConfigDescriptor } from '@kbn/core/server';
+import { i18n } from '@kbn/i18n';
 
 export const plugin = async (initializerContext: PluginInitializerContext) => {
   const { EnterpriseSearchPlugin } = await import('./plugin');
@@ -44,7 +45,42 @@ export const configSchema = schema.object({
 export type ConfigType = TypeOf<typeof configSchema>;
 
 export const config: PluginConfigDescriptor<ConfigType> = {
-  deprecations: ({ unused }) => [unused('canDeployEntSearch', { level: 'warning' })],
+  deprecations: ({ deprecate, unused }) => [
+    unused('canDeployEntSearch', { level: 'warning' }),
+    (deprecationConfig, fromPath, addDeprecation, context) => {
+      [
+        deprecate('ssl', '9.0.0', {
+          documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
+          level: 'critical',
+          title: ENT_SEARCH_NODE_DEPRECATION_TITLE,
+        }),
+        deprecate('accessCheckTimeout', '9.0.0', {
+          documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
+          level: 'critical',
+          title: ENT_SEARCH_NODE_DEPRECATION_TITLE,
+        }),
+        deprecate('accessCheckTimeoutWarning', '9.0.0', {
+          documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
+          level: 'critical',
+          title: ENT_SEARCH_NODE_DEPRECATION_TITLE,
+        }),
+        deprecate('customHeaders', '9.0.0', {
+          documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
+          level: 'critical',
+          title: ENT_SEARCH_NODE_DEPRECATION_TITLE,
+        }),
+        deprecate('isCloud', '9.0.0', {
+          level: 'critical',
+        }),
+        deprecate('ui', '9.0.0', {
+          level: 'critical',
+        }),
+        deprecate('appsDisabled', '9.0.0', {
+          level: 'critical',
+        }),
+      ].forEach((deprecation) => deprecation(deprecationConfig, fromPath, addDeprecation, context));
+    },
+  ],
   exposeToBrowser: {
     host: true,
     ui: true,
@@ -53,3 +89,8 @@ export const config: PluginConfigDescriptor<ConfigType> = {
 };
 
 export const CRAWLERS_INDEX = '.ent-search-actastic-crawler2_configurations_v2';
+
+const ENT_SEARCH_NODE_DEPRECATION_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.deprecations.config.nodeValuesTitle',
+  { defaultMessage: 'Enterprise Search configuration values must be removed' }
+);


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [Search: add deprecation warnings for config values removed in 9.0 (#208972)](https://github.com/elastic/kibana/pull/208972)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Rodney Norris","email":"rodney.norris@elastic.co"},"sourceCommit":{"committedDate":"2025-02-03T19:44:01Z","message":"Search: add deprecation warnings for config values removed in 9.0 (#208972)\n\n## Summary\r\n\r\nAdd `enterpriseSearch` config deprecations for items remove in 9.0.\r\n\r\nThis is paired with #208856 which removes all the listed values from the\r\n`enterprise_search` plugin configuration.\r\n\r\n### Screenshots\r\n\r\n![image](https://github.com/user-attachments/assets/832a9614-ea8f-4c68-839e-b9e26bd95221)","sha":"a2329a376524ac80480b1a3c6e77b0d6dae31381"},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:skip"],"title":"Update dependency chromedriver to ^132.0.2 (8.x)","number":208938,"url":"https://github.com/elastic/kibana/pull/208938"},"sourceBranch":"8.x","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->