### PR TITLE
[9.0] [Inference Connector] Enable inference connector for ESS by default, disable it for Serverless (#209197)

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -273,3 +273,6 @@ xpack.dataUsage.enableExperimental: ['dataUsageDisabled']
 
 # Ensure Serverless is using the Amsterdam theme
 uiSettings.experimental.defaultTheme: "amsterdam"
+
+# This feature is disabled in Serverless until Inference Endpoint become enabled within a Serverless environment
+xpack.stack_connectors.enableExperimental: ['inferenceConnectorOff']

--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/connector_types.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/connector_types.test.ts
@@ -52,7 +52,7 @@ describe('Connector type config checks', () => {
   });
 
   for (const connectorTypeId of connectorTypes) {
-    const skipConnectorType = ['.gen-ai'];
+    const skipConnectorType = ['.gen-ai', '.inference'];
     if (skipConnectorType.includes(connectorTypeId)) {
       continue;
     }

--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/mocks/connector_types.ts
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/mocks/connector_types.ts
@@ -32,6 +32,7 @@ export const connectorTypes: string[] = [
   '.thehive',
   '.sentinelone',
   '.crowdstrike',
+  '.inference',
   '.microsoft_defender_endpoint',
   '.cases',
   '.observability-ai-assistant',

--- a/x-pack/platform/plugins/shared/stack_connectors/common/experimental_features.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/experimental_features.ts
@@ -15,7 +15,7 @@ export const allowedExperimentalValues = Object.freeze({
   isMustacheAutocompleteOn: false,
   sentinelOneConnectorOn: true,
   crowdstrikeConnectorOn: true,
-  inferenceConnectorOn: false,
+  inferenceConnectorOff: false,
   crowdstrikeConnectorRTROn: true,
   microsoftDefenderEndpointOn: true,
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/index.ts
@@ -82,7 +82,7 @@ export function registerConnectorTypes({
   if (ExperimentalFeaturesService.get().crowdstrikeConnectorOn) {
     connectorTypeRegistry.register(getCrowdStrikeConnectorType());
   }
-  if (ExperimentalFeaturesService.get().inferenceConnectorOn) {
+  if (!ExperimentalFeaturesService.get().inferenceConnectorOff) {
     connectorTypeRegistry.register(getInferenceConnectorType());
   }
   if (ExperimentalFeaturesService.get().microsoftDefenderEndpointOn) {

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference/inference.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/inference/inference.test.tsx
@@ -17,7 +17,7 @@ let actionTypeModel: ActionTypeModel;
 
 beforeAll(() => {
   ExperimentalFeaturesService.init({
-    experimentalFeatures: { ...experimentalFeaturesMock, inferenceConnectorOn: true } as any,
+    experimentalFeatures: { ...experimentalFeaturesMock } as any,
   });
   const connectorTypeRegistry = new TypeRegistry<ActionTypeModel>();
   registerConnectorTypes({ connectorTypeRegistry, services: registrationServicesMock });

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/index.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/index.ts
@@ -121,7 +121,7 @@ export function registerConnectorTypes({
   if (experimentalFeatures.crowdstrikeConnectorOn) {
     actions.registerSubActionConnectorType(getCrowdstrikeConnectorType(experimentalFeatures));
   }
-  if (experimentalFeatures.inferenceConnectorOn) {
+  if (!experimentalFeatures.inferenceConnectorOff) {
     actions.registerSubActionConnectorType(getInferenceConnectorType());
   }
   if (experimentalFeatures.microsoftDefenderEndpointOn) {

--- a/x-pack/platform/plugins/shared/stack_connectors/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/plugin.test.ts
@@ -26,7 +26,6 @@ describe('Stack Connectors Plugin', () => {
       context = coreMock.createPluginInitializerContext();
       mockParseExperimentalConfigValue.mockReturnValue({
         ...experimentalFeaturesMock,
-        inferenceConnectorOn: true,
       });
 
       plugin = new StackConnectorsPlugin(context);

--- a/x-pack/platform/plugins/shared/task_manager/server/integration_tests/__snapshots__/task_cost_check.test.ts.snap
+++ b/x-pack/platform/plugins/shared/task_manager/server/integration_tests/__snapshots__/task_cost_check.test.ts.snap
@@ -40,6 +40,10 @@ Array [
   },
   Object {
     "cost": 1,
+    "taskType": "actions:.inference",
+  },
+  Object {
+    "cost": 1,
     "taskType": "actions:.jira",
   },
   Object {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/check_registered_connector_types.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/check_registered_connector_types.ts
@@ -31,6 +31,7 @@ export default function createRegisteredConnectorTypeTests({ getService }: FtrPr
           '.d3security',
           '.email',
           '.index',
+          '.inference',
           '.pagerduty',
           '.swimlane',
           '.server-log',

--- a/x-pack/test/plugin_api_integration/config.ts
+++ b/x-pack/test/plugin_api_integration/config.ts
@@ -37,7 +37,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         `--xpack.stack_connectors.enableExperimental=${JSON.stringify([
           'crowdstrikeConnectorOn',
           'microsoftDefenderEndpointOn',
-          'inferenceConnectorOn',
         ])}`,
         ...findTestPluginPaths(path.resolve(__dirname, 'plugins')),
       ],

--- a/x-pack/test/task_manager_claimer_update_by_query/config.ts
+++ b/x-pack/test/task_manager_claimer_update_by_query/config.ts
@@ -31,10 +31,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--xpack.task_manager.claim_strategy="update_by_query"',
         '--xpack.task_manager.monitored_aggregated_stats_refresh_rate=5000',
         '--xpack.task_manager.metrics_reset_interval=40000',
-        `--xpack.stack_connectors.enableExperimental=${JSON.stringify([
-          'crowdstrikeConnectorOn',
-          'inferenceConnectorOn',
-        ])}`,
+        `--xpack.stack_connectors.enableExperimental=${JSON.stringify(['crowdstrikeConnectorOn'])}`,
         ...findTestPluginPaths(path.resolve(__dirname, 'plugins')),
       ],
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Inference Connector] Enable inference connector for ESS by default, disable it for Serverless (#209197)](https://github.com/elastic/kibana/pull/209197)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Yuliia Naumenko","email":"jo.naumenko@gmail.com"},"sourceCommit":{"committedDate":"2025-02-05T17:20:58Z","message":"[Inference Connector] Enable inference connector for ESS by default, disable it for Serverless (#209197)\n\n1. ECH/ESS: enable by default for 8.18\r\n2. Serverless: disable by default until PC approval","sha":"ba0b1eca91ab03b98c28d181923bc0e023ca9dc2","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:version","8.18 candidate","v8.18.0","v9.1.0","v8.19.0"],"title":"[Inference Connector] Enable inference connector for ESS by default, disable it for Serverless","number":209197,"url":"https://github.com/elastic/kibana/pull/209197","mergeCommit":{"message":"[Inference Connector] Enable inference connector for ESS by default, disable it for Serverless (#209197)\n\n1. ECH/ESS: enable by default for 8.18\r\n2. Serverless: disable by default until PC approval","sha":"ba0b1eca91ab03b98c28d181923bc0e023ca9dc2"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209850","number":209850,"state":"OPEN"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209197","number":209197,"mergeCommit":{"message":"[Inference Connector] Enable inference connector for ESS by default, disable it for Serverless (#209197)\n\n1. ECH/ESS: enable by default for 8.18\r\n2. Serverless: disable by default until PC approval","sha":"ba0b1eca91ab03b98c28d181923bc0e023ca9dc2"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->