### PR TITLE
[8.x] [Security Solution ] Increase test timeouts for EQL Tests to reduce the flakyness. (#206427)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
@@ -146,47 +146,59 @@ describe('EQL Tab', () => {
 
   describe('rendering', () => {
     const fetchNotesMock = jest.spyOn(notesApi, 'fetchNotesByDocumentIds');
-    test('should render the timeline table', async () => {
-      fetchNotesMock.mockImplementation(jest.fn());
-      render(
-        <TestProviders store={createMockStore(mockState)}>
-          <TestComponent />
-        </TestProviders>
-      );
+    test(
+      'should render the timeline table',
+      async () => {
+        fetchNotesMock.mockImplementation(jest.fn());
+        render(
+          <TestProviders store={createMockStore(mockState)}>
+            <TestComponent />
+          </TestProviders>
+        );
 
-      expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
-    });
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
 
-    test('it renders the timeline column headers', async () => {
-      render(
-        <TestProviders store={createMockStore(mockState)}>
-          <TestComponent />
-        </TestProviders>
-      );
+    test(
+      'it renders the timeline column headers',
+      async () => {
+        render(
+          <TestProviders store={createMockStore(mockState)}>
+            <TestComponent />
+          </TestProviders>
+        );
 
-      expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
-    });
+        expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
 
-    test('should render correct placeholder when there are not results', async () => {
-      (useTimelineEvents as jest.Mock).mockReturnValue([
-        false,
-        {
-          events: [],
-          pageInfo: {
-            activePage: 0,
-            totalPages: 10,
+    test(
+      'should render correct placeholder when there are not results',
+      async () => {
+        (useTimelineEvents as jest.Mock).mockReturnValue([
+          false,
+          {
+            events: [],
+            pageInfo: {
+              activePage: 0,
+              totalPages: 10,
+            },
           },
-        },
-      ]);
+        ]);
 
-      render(
-        <TestProviders store={createMockStore(mockState)}>
-          <TestComponent />
-        </TestProviders>
-      );
+        render(
+          <TestProviders store={createMockStore(mockState)}>
+            <TestComponent />
+          </TestProviders>
+        );
 
-      expect(await screen.findByText('No results found')).toBeVisible();
-    });
+        expect(await screen.findByText('No results found')).toBeVisible();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
 
     describe('pagination', () => {
       beforeEach(() => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution ] Increase test timeouts for EQL Tests to reduce the flakyness. (#206427)](https://github.com/elastic/kibana/pull/206427)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2025-01-13T14:43:18Z","message":"[Security Solution ] Increase test timeouts for EQL Tests to reduce the flakyness. (#206427)\n\n## Summary\n\nFailures in build like\n[this](https://buildkite.com/elastic/kibana-on-merge/builds/58925#019451ad-90f1-421d-b09a-0f7893340686)\nare happening for EQL tests because for high rendering content and low\ntest timeout.\n\nThis tests extends that timeout so that tests can run on CI without any\nissues.","sha":"6bffeb749a29c862f454b6e664529ed0a9ed9c70","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","v9.0.0","Team:Threat Hunting:Investigations","v8.18.0","v8.19.0"],"number":206427,"url":"https://github.com/elastic/kibana/pull/206427","mergeCommit":{"message":"[Security Solution ] Increase test timeouts for EQL Tests to reduce the flakyness. (#206427)\n\n## Summary\n\nFailures in build like\n[this](https://buildkite.com/elastic/kibana-on-merge/builds/58925#019451ad-90f1-421d-b09a-0f7893340686)\nare happening for EQL tests because for high rendering content and low\ntest timeout.\n\nThis tests extends that timeout so that tests can run on CI without any\nissues.","sha":"6bffeb749a29c862f454b6e664529ed0a9ed9c70"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","labelRegex":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/206427","number":206427,"mergeCommit":{"message":"[Security Solution ] Increase test timeouts for EQL Tests to reduce the flakyness. (#206427)\n\n## Summary\n\nFailures in build like\n[this](https://buildkite.com/elastic/kibana-on-merge/builds/58925#019451ad-90f1-421d-b09a-0f7893340686)\nare happening for EQL tests because for high rendering content and low\ntest timeout.\n\nThis tests extends that timeout so that tests can run on CI without any\nissues.","sha":"6bffeb749a29c862f454b6e664529ed0a9ed9c70"}},{"branch":"8.x","label":"v8.18.0","labelRegex":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->