### PR TITLE
[SLO]: Optional groupings for slo summary

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/common.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/common.ts
@@ -77,12 +77,16 @@ const groupSummarySchema = t.type({
   worst: t.type({
     sliValue: t.number,
     status: t.string,
-    slo: t.type({
-      id: t.string,
-      instanceId: t.string,
-      name: t.string,
-      groupings: t.record(t.string, t.unknown),
-    }),
+    slo: t.intersection([
+      t.type({
+        id: t.string,
+        instanceId: t.string,
+        name: t.string,
+      }),
+      t.partial({
+        groupings: t.record(t.string, t.unknown),
+      }),
+    ]),
   }),
   violated: t.number,
   healthy: t.number,

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/grouped_slos/hooks/use_group_name.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/grouped_slos/hooks/use_group_name.ts
@@ -20,7 +20,7 @@ export function useGroupName(groupBy: GroupByField, group: string, summary?: Gro
     case 'status':
       return groupName;
     case 'slo.instanceId':
-      if (groupName === ALL_VALUE || !summary) {
+      if (groupName === ALL_VALUE || !summary?.worst?.slo?.groupings) {
         return i18n.translate('xpack.slo.group.ungroupedInstanceId', {
           defaultMessage: 'Ungrouped',
         });


### PR DESCRIPTION
## Summary

Resolves #209159

Make groupings property in SLO summary optional to fix schema validation issues with SLOs without groups. 

## Release Notes

Fixed bug that caused issues with loading SLOs by status, SLI type, or instance id. 

## Testing

Create a SLO without an entry in the "group by" field. All SLOs should still be able to be grouped despite this distinction. 




<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->