### PR TITLE
[8.18] Fixes Failing test: Jest Integration Tests.x-pack/platform/plugins/shared/task_manager/server/integration_tests - capacity based claiming should claim tasks to full capacity (#201681)

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/integration_tests/lib/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/integration_tests/lib/index.ts
@@ -5,6 +5,6 @@
  * 2.0.
  */
 
-export { injectTask } from './inject_task';
+export { injectTask, injectTaskBulk } from './inject_task';
 export { setupTestServers } from './setup_test_servers';
 export { retry } from './retry';

--- a/x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_manager_capacity_based_claiming.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/integration_tests/task_manager_capacity_based_claiming.test.ts
@@ -12,7 +12,7 @@ import { times } from 'lodash';
 import { TaskCost, TaskStatus } from '../task';
 import type { TaskClaimingOpts } from '../queries/task_claiming';
 import { TaskManagerPlugin, type TaskManagerStartContract } from '../plugin';
-import { injectTask, setupTestServers, retry } from './lib';
+import { injectTaskBulk, setupTestServers, retry } from './lib';
 import { CreateMonitoringStatsOpts } from '../monitoring';
 import { filter, map } from 'rxjs';
 import { isTaskManagerWorkerUtilizationStatEvent } from '../task_events';
@@ -94,8 +94,7 @@ jest.mock('../queries/task_claiming', () => {
 
 const taskManagerStartSpy = jest.spyOn(TaskManagerPlugin.prototype, 'start');
 
-// FLAKY: https://github.com/elastic/kibana/issues/205949
-describe.skip('capacity based claiming', () => {
+describe('capacity based claiming', () => {
   const taskIdsToRemove: string[] = [];
   let esServer: TestElasticsearchUtils;
   let kibanaServer: TestKibanaUtils;
@@ -170,9 +169,10 @@ describe.skip('capacity based claiming', () => {
     times(10, () => ids.push(uuidV4()));
 
     const now = new Date();
-    const runAt = new Date(now.valueOf() + 5000);
+    const runAt = new Date(now.valueOf() + 6000);
+    const tasks = [];
     for (const id of ids) {
-      await injectTask(kibanaServer.coreStart.elasticsearch.client.asInternalUser, {
+      tasks.push({
         id,
         taskType: '_normalCostType',
         params: {},
@@ -189,6 +189,8 @@ describe.skip('capacity based claiming', () => {
       });
       taskIdsToRemove.push(id);
     }
+
+    await injectTaskBulk(kibanaServer.coreStart.elasticsearch.client.asInternalUser, tasks);
 
     await retry(async () => {
       expect(mockTaskTypeNormalCostRunFn).toHaveBeenCalledTimes(10);
@@ -235,8 +237,9 @@ describe.skip('capacity based claiming', () => {
     const ids: string[] = [];
     times(6, () => ids.push(uuidV4()));
     const runAt1 = new Date(now.valueOf() - 5);
+    const tasks = [];
     for (const id of ids) {
-      await injectTask(kibanaServer.coreStart.elasticsearch.client.asInternalUser, {
+      tasks.push({
         id,
         taskType: '_normalCostType',
         params: {},
@@ -257,7 +260,7 @@ describe.skip('capacity based claiming', () => {
     // inject 1 XL cost task that will put us over the max cost capacity of 20
     const xlid = uuidV4();
     const runAt2 = now;
-    await injectTask(kibanaServer.coreStart.elasticsearch.client.asInternalUser, {
+    tasks.push({
       id: xlid,
       taskType: '_xlCostType',
       params: {},
@@ -277,7 +280,7 @@ describe.skip('capacity based claiming', () => {
     // inject one more normal cost task
     const runAt3 = new Date(now.valueOf() + 5);
     const lastid = uuidV4();
-    await injectTask(kibanaServer.coreStart.elasticsearch.client.asInternalUser, {
+    tasks.push({
       id: lastid,
       taskType: '_normalCostType',
       params: {},
@@ -293,6 +296,8 @@ describe.skip('capacity based claiming', () => {
       ownerId: null,
     });
     taskIdsToRemove.push(lastid);
+
+    await injectTaskBulk(kibanaServer.coreStart.elasticsearch.client.asInternalUser, tasks);
 
     // retry until all tasks have been run
     await retry(async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Fixes Failing test: Jest Integration Tests.x-pack/platform/plugins/shared/task_manager/server/integration_tests - capacity based claiming should claim tasks to full capacity (#201681)](https://github.com/elastic/kibana/pull/201681)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-02-05T21:20:38Z","message":"Fixes Failing test: Jest Integration Tests.x-pack/platform/plugins/shared/task_manager/server/integration_tests - capacity based claiming should claim tasks to full capacity (#201681)\n\nResolves https://github.com/elastic/kibana/issues/205949,\r\nhttps://github.com/elastic/kibana/issues/191117\r\n\r\n## Summary\r\n\r\nTrying to fix flaky integration test by performing a bulk create for the\r\ntest tasks instead of creating one by one. After making this change, was\r\nable to run the integration test ~100 times without failure.\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7f28ae63e36d73ec471df7109909b1249f7edafd","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Task Manager","Team:ResponseOps","v9.0.0","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"Fixes Failing test: Jest Integration Tests.x-pack/platform/plugins/shared/task_manager/server/integration_tests - capacity based claiming should claim tasks to full capacity","number":201681,"url":"https://github.com/elastic/kibana/pull/201681","mergeCommit":{"message":"Fixes Failing test: Jest Integration Tests.x-pack/platform/plugins/shared/task_manager/server/integration_tests - capacity based claiming should claim tasks to full capacity (#201681)\n\nResolves https://github.com/elastic/kibana/issues/205949,\r\nhttps://github.com/elastic/kibana/issues/191117\r\n\r\n## Summary\r\n\r\nTrying to fix flaky integration test by performing a bulk create for the\r\ntest tasks instead of creating one by one. After making this change, was\r\nable to run the integration test ~100 times without failure.\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7f28ae63e36d73ec471df7109909b1249f7edafd"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209920","number":209920,"state":"OPEN"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/201681","number":201681,"mergeCommit":{"message":"Fixes Failing test: Jest Integration Tests.x-pack/platform/plugins/shared/task_manager/server/integration_tests - capacity based claiming should claim tasks to full capacity (#201681)\n\nResolves https://github.com/elastic/kibana/issues/205949,\r\nhttps://github.com/elastic/kibana/issues/191117\r\n\r\n## Summary\r\n\r\nTrying to fix flaky integration test by performing a bulk create for the\r\ntest tasks instead of creating one by one. After making this change, was\r\nable to run the integration test ~100 times without failure.\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7f28ae63e36d73ec471df7109909b1249f7edafd"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->