### PR TITLE
[Inference Connector][Serverless] Added preconfigured connector for inference Elastic Rainbow Sprinkles LLM

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -276,3 +276,15 @@ uiSettings.experimental.defaultTheme: "amsterdam"
 
 # This feature is disabled in Serverless until Inference Endpoint become enabled within a Serverless environment
 xpack.stack_connectors.enableExperimental: ['inferenceConnectorOff']
+
+# This is the definition introducing pre-configured Kibana Connector for Elastic default LLM
+Elastic-Inference-Rainbow-Sprinkles:
+    name: Elastic-Inference-Rainbow-Sprinkles
+    actionTypeId: .inference
+    exposeConfig: true
+    config:
+      provider: 'elastic'
+      taskType: 'chat_completion'
+      inferenceId: '.rainbow-sprinkles-elastic'
+      providerConfig:
+        model_id: 'rainbow-sprinkles'


### PR DESCRIPTION
This PR is adding the Serverless Kibana preconfigured `.inference` connector for Elastic Rainbow Rainbow Sprinkles LLM.
Instead of adding within kibana-controller