### PR TITLE
[Connectors][Bugfix] Fix agentless policies created with background task

### DIFF
--- a/x-pack/solutions/search/plugins/search_connectors/server/services/index.ts
+++ b/x-pack/solutions/search/plugins/search_connectors/server/services/index.ts
@@ -167,11 +167,25 @@ export class AgentlessConnectorsInfraService {
     this.logger.debug(`Latest package version for ${pkgName} is ${pkgVersion}`);
 
     const createdPolicy = await this.agentPolicyService.create(this.soClient, this.esClient, {
-      name: `${connector.service_type} connector: ${connector.id}`,
+      name: `Agentless policy for ${connector.service_type} connector: ${connector.id}`,
       description: `Automatically generated on ${new Date(Date.now()).toISOString()}`,
+      global_data_tags: [
+        {
+          name: 'organization',
+          value: 'elastic',
+        },
+        {
+          name: 'division',
+          value: 'engineering',
+        },
+        {
+          name: 'team',
+          value: 'search-extract-and-transform',
+        },
+      ],
       namespace: 'default',
       monitoring_enabled: ['logs', 'metrics'],
-      inactivity_timeout: 1209600,
+      inactivity_timeout: 3600,
       is_protected: false,
       supports_agentless: true,
     });
@@ -203,6 +217,7 @@ export class AgentlessConnectorsInfraService {
           streams: [],
         },
       ],
+      supports_agentless: true,
     });
 
     this.logger.info(


### PR DESCRIPTION
## Summary

Background task that creates agentless policies for connectors was missing some fields in the paylaod, fixing them in this PR

Added unit test

### Verification

Checked against working agentless API calls, example of 2 working calls from Integrations UI. I added missing fields in the background task payload.

<img width="600" alt="Screenshot 2025-02-06 at 11 58 05" src="https://github.com/user-attachments/assets/df35f96b-e60e-4189-8270-c3de92fa9db5" />

<img width="600" alt="Screenshot 2025-02-06 at 11 57 55" src="https://github.com/user-attachments/assets/f88adcff-479e-4af7-b4dc-1cef04757aac" />

Now the generated policies show up correctly (tested locally):

<img width="1633" alt="Screenshot 2025-02-06 at 12 04 23" src="https://github.com/user-attachments/assets/b632b6e0-05dd-4719-8a0d-b5f3879dae53" />



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->