### PR TITLE
[Security Solution] Fix prebuilt rules exclusion on bulk edit

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/utils/prepare_search_params.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/bulk_actions/utils/prepare_search_params.ts
@@ -40,6 +40,7 @@ export const prepareSearchParams = ({
   dryRunResult?.ruleErrors.forEach(({ errorCode }) => {
     switch (errorCode) {
       case BulkActionsDryRunErrCodeEnum.IMMUTABLE:
+      case BulkActionsDryRunErrCodeEnum.PREBUILT_CUSTOMIZATION_LICENSE:
         modifiedFilterOptions = { ...modifiedFilterOptions, showCustomRules: true };
         break;
       case BulkActionsDryRunErrCodeEnum.MACHINE_LEARNING_INDEX_PATTERN:


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/209888**

## Summary

Resolves an issue when prebuilt rules were not excluded from bulk operations when the license tier is not sufficient to customize prebuilt rules.

See the attached issue for reproduction steps.

**Before**

https://github.com/user-attachments/assets/0f791c4d-f98c-4b97-867d-d8da566eb3a3

**After**

https://github.com/user-attachments/assets/8ed2a1e4-d298-4173-95ca-565e0c280c21



<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->