### PR TITLE
[8.18] [ Security Solution ] Fix Refetch logic with new timeline batching (#205893)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/containers/index.test.tsx
@@ -8,13 +8,16 @@
 import { DataLoadingState } from '@kbn/unified-data-table';
 import { act, waitFor, renderHook } from '@testing-library/react';
 import type { TimelineArgs, UseTimelineEventsProps } from '.';
-import { initSortDefault, useTimelineEvents } from '.';
+import * as useTimelineEventsModule from '.';
 import { SecurityPageName } from '../../../common/constants';
 import { TimelineId } from '../../../common/types/timeline';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
-import { mockTimelineData } from '../../common/mock';
 import { useRouteSpy } from '../../common/utils/route/use_route_spy';
 import { useFetchNotes } from '../../notes/hooks/use_fetch_notes';
+import { useKibana } from '../../common/lib/kibana';
+import { getMockTimelineSearchSubscription } from '../../common/mock/mock_timeline_search_service';
+
+const { initSortDefault, useTimelineEvents } = useTimelineEventsModule;
 
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => {
@@ -29,10 +32,6 @@ jest.mock('react-redux', () => {
 jest.mock('../../notes/hooks/use_fetch_notes');
 const onLoadMock = jest.fn();
 const useFetchNotesMock = useFetchNotes as jest.Mock;
-
-const mockEvents = mockTimelineData.slice(0, 10);
-
-const mockSearch = jest.fn();
 
 jest.mock('../../common/lib/apm/use_track_http_request');
 jest.mock('../../common/hooks/use_experimental_features');
@@ -49,47 +48,9 @@ jest.mock('../../common/lib/kibana', () => ({
     services: {
       application: {
         capabilities: {
-          siem: {
+          securitySolutionTimeline: {
             crud: true,
           },
-        },
-      },
-      data: {
-        search: {
-          search: jest.fn().mockImplementation((args) => {
-            mockSearch();
-            return {
-              subscribe: jest.fn().mockImplementation(({ next }) => {
-                const timeoutHandler = setTimeout(() => {
-                  next({
-                    isRunning: false,
-                    isPartial: false,
-                    inspect: {
-                      dsl: [],
-                      response: [],
-                    },
-                    edges: mockEvents.map((item) => ({ node: item })),
-                    pageInfo: {
-                      activePage: args.pagination.activePage,
-                      totalPages: 10,
-                    },
-                    rawResponse: {},
-                    totalCount: mockTimelineData.length,
-                  });
-                }, 50);
-                return {
-                  unsubscribe: jest.fn(() => {
-                    clearTimeout(timeoutHandler);
-                  }),
-                };
-              }),
-            };
-          }),
-        },
-      },
-      notifications: {
-        toasts: {
-          addWarning: jest.fn(),
         },
       },
     },
@@ -111,7 +72,40 @@ mockUseRouteSpy.mockReturnValue([
   },
 ]);
 
-describe('useTimelineEvents', () => {
+const startDate: string = '2020-07-07T08:20:18.966Z';
+const endDate: string = '3000-01-01T00:00:00.000Z';
+const props: UseTimelineEventsProps = {
+  dataViewId: 'data-view-id',
+  endDate,
+  id: TimelineId.active,
+  indexNames: ['filebeat-*'],
+  fields: ['@timestamp', 'event.kind'],
+  filterQuery: '*',
+  startDate,
+  limit: 25,
+  runtimeMappings: {},
+  sort: initSortDefault,
+  skip: false,
+};
+
+const { mockTimelineSearchSubscription: mockSearchSubscription, mockSearchWithArgs: mockSearch } =
+  getMockTimelineSearchSubscription();
+
+const loadNextBatch = async (result: { current: [DataLoadingState, TimelineArgs] }) => {
+  act(() => {
+    result.current[1].loadNextBatch();
+  });
+
+  await waitFor(() => {
+    expect(result.current[0]).toBe(DataLoadingState.loadingMore);
+  });
+
+  await waitFor(() => {
+    expect(result.current[0]).toBe(DataLoadingState.loaded);
+  });
+};
+
+describe('useTimelineEventsHandler', () => {
   useIsExperimentalFeatureEnabledMock.mockReturnValue(false);
 
   beforeEach(() => {
@@ -122,25 +116,31 @@ describe('useTimelineEvents', () => {
     useFetchNotesMock.mockReturnValue({
       onLoad: onLoadMock,
     });
+
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        application: {
+          capabilities: {
+            siem: {
+              crud: true,
+            },
+          },
+        },
+        data: {
+          search: {
+            search: mockSearchSubscription,
+          },
+        },
+        notifications: {
+          toasts: {
+            addWarning: jest.fn(),
+          },
+        },
+      },
+    });
   });
 
-  const startDate: string = '2020-07-07T08:20:18.966Z';
-  const endDate: string = '3000-01-01T00:00:00.000Z';
-  const props: UseTimelineEventsProps = {
-    dataViewId: 'data-view-id',
-    endDate,
-    id: TimelineId.active,
-    indexNames: ['filebeat-*'],
-    fields: ['@timestamp', 'event.kind'],
-    filterQuery: '',
-    startDate,
-    limit: 25,
-    runtimeMappings: {},
-    sort: initSortDefault,
-    skip: false,
-  };
-
-  test('init', async () => {
+  test('should init empty response', async () => {
     const { result } = renderHook((args) => useTimelineEvents(args), {
       initialProps: props,
     });
@@ -151,7 +151,7 @@ describe('useTimelineEvents', () => {
         events: [],
         id: TimelineId.active,
         inspect: expect.objectContaining({ dsl: [], response: [] }),
-        loadPage: expect.any(Function),
+        loadNextBatch: expect.any(Function),
         pageInfo: expect.objectContaining({
           activePage: 0,
           querySize: 0,
@@ -163,28 +163,31 @@ describe('useTimelineEvents', () => {
     ]);
   });
 
-  test('happy path query', async () => {
-    const { result, rerender } = renderHook<
-      [DataLoadingState, TimelineArgs],
-      UseTimelineEventsProps
-    >((args) => useTimelineEvents(args), {
-      initialProps: { ...props, startDate: '', endDate: '' },
-    });
-
-    // useEffect on params request
-    await waitFor(() => new Promise((resolve) => resolve(null)));
-    rerender({ ...props, startDate, endDate });
-    // useEffect on params request
+  test('should make events search request correctly', async () => {
+    const { result } = renderHook<[DataLoadingState, TimelineArgs], UseTimelineEventsProps>(
+      (args) => useTimelineEvents(args),
+      {
+        initialProps: props,
+      }
+    );
     await waitFor(() => {
-      expect(mockSearch).toHaveBeenCalledTimes(2);
+      expect(mockSearch).toHaveBeenCalledTimes(1);
+      expect(mockSearch).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+      );
+      expect(result.current[1].events).toHaveLength(25);
       expect(result.current).toEqual([
         DataLoadingState.loaded,
         {
-          events: mockEvents,
+          events: expect.any(Array),
           id: TimelineId.active,
           inspect: result.current[1].inspect,
-          loadPage: result.current[1].loadPage,
-          pageInfo: result.current[1].pageInfo,
+          loadNextBatch: result.current[1].loadNextBatch,
+          pageInfo: {
+            activePage: 0,
+            querySize: 25,
+          },
           refetch: result.current[1].refetch,
           totalCount: 32,
           refreshedAt: result.current[1].refreshedAt,
@@ -193,17 +196,13 @@ describe('useTimelineEvents', () => {
     });
   });
 
-  test('Mock cache for active timeline when switching page', async () => {
+  test('should mock cache for active timeline when switching page', async () => {
     const { result, rerender } = renderHook<
       [DataLoadingState, TimelineArgs],
       UseTimelineEventsProps
     >((args) => useTimelineEvents(args), {
-      initialProps: { ...props, startDate: '', endDate: '' },
+      initialProps: props,
     });
-
-    // useEffect on params request
-    await waitFor(() => new Promise((resolve) => resolve(null)));
-    rerender({ ...props, startDate, endDate });
 
     mockUseRouteSpy.mockReturnValue([
       {
@@ -215,22 +214,29 @@ describe('useTimelineEvents', () => {
       },
     ]);
 
+    rerender({ ...props, startDate, endDate });
+
     await waitFor(() => {
-      expect(mockSearch).toHaveBeenCalledTimes(2);
-      expect(result.current).toEqual([
-        DataLoadingState.loaded,
-        {
-          events: mockEvents,
-          id: TimelineId.active,
-          inspect: result.current[1].inspect,
-          loadPage: result.current[1].loadPage,
-          pageInfo: result.current[1].pageInfo,
-          refetch: result.current[1].refetch,
-          totalCount: 32,
-          refreshedAt: result.current[1].refreshedAt,
-        },
-      ]);
+      expect(result.current[0]).toEqual(DataLoadingState.loaded);
     });
+
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+
+    expect(result.current[1].events).toHaveLength(25);
+
+    expect(result.current).toEqual([
+      DataLoadingState.loaded,
+      {
+        events: expect.any(Array),
+        id: TimelineId.active,
+        inspect: result.current[1].inspect,
+        loadNextBatch: result.current[1].loadNextBatch,
+        pageInfo: result.current[1].pageInfo,
+        refetch: result.current[1].refetch,
+        totalCount: 32,
+        refreshedAt: result.current[1].refreshedAt,
+      },
+    ]);
   });
 
   test('Correlation pagination is calling search strategy when switching page', async () => {
@@ -270,99 +276,521 @@ describe('useTimelineEvents', () => {
     await waitFor(() => new Promise((resolve) => resolve(null)));
     mockSearch.mockReset();
     act(() => {
-      result.current[1].loadPage(4);
+      result.current[1].loadNextBatch();
     });
     await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
   });
 
-  test('should query again when a new field is added', async () => {
-    const { rerender } = renderHook((args) => useTimelineEvents(args), {
-      initialProps: { ...props, startDate: '', endDate: '' },
+  describe('error/invalid states', () => {
+    const uniqueError = 'UNIQUE_ERROR';
+    const onError = jest.fn();
+    const mockSubscribeWithError = jest.fn(({ error }) => {
+      error(uniqueError);
     });
 
-    // useEffect on params request
-    await waitFor(() => new Promise((resolve) => resolve(null)));
-    rerender({ ...props, startDate, endDate });
-    // useEffect on params request
-    await waitFor(() => new Promise((resolve) => resolve(null)));
+    beforeEach(() => {
+      onError.mockClear();
+      mockSubscribeWithError.mockClear();
 
-    expect(mockSearch).toHaveBeenCalledTimes(2);
-    mockSearch.mockClear();
+      (useKibana as jest.Mock).mockReturnValue({
+        services: {
+          data: {
+            search: {
+              search: () => ({
+                subscribe: jest.fn().mockImplementation(({ error }) => {
+                  const requestTimeout = setTimeout(() => {
+                    mockSubscribeWithError({ error });
+                  }, 100);
 
-    rerender({
-      ...props,
-      startDate,
-      endDate,
-      fields: ['@timestamp', 'event.kind', 'event.category'],
+                  return {
+                    unsubscribe: () => {
+                      clearTimeout(requestTimeout);
+                    },
+                  };
+                }),
+              }),
+              showError: onError,
+            },
+          },
+        },
+      });
     });
 
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+    test('should broadcast correct loading state when request throws error', async () => {
+      const { result } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: { ...props },
+      });
+
+      expect(result.current[0]).toBe(DataLoadingState.loading);
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith(uniqueError);
+        expect(result.current[0]).toBe(DataLoadingState.loaded);
+      });
+    });
+    test('should should not fire any request when indexName is empty', async () => {
+      const { result } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: { ...props, indexNames: [] },
+      });
+
+      await waitFor(() => {
+        expect(mockSearch).not.toHaveBeenCalled();
+        expect(result.current[0]).toBe(DataLoadingState.loaded);
+      });
+    });
   });
 
-  test('should not query again when a field is removed', async () => {
-    const { rerender } = renderHook((args) => useTimelineEvents(args), {
-      initialProps: { ...props, startDate: '', endDate: '' },
+  describe('fields', () => {
+    test('should query again when a new field is added', async () => {
+      const { rerender } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: props,
+      });
+
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenCalledTimes(1);
+      });
+
+      mockSearch.mockClear();
+
+      rerender({
+        ...props,
+        startDate,
+        endDate,
+        fields: ['@timestamp', 'event.kind', 'event.category'],
+      });
+
+      await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
     });
 
-    // useEffect on params request
-    await waitFor(() => new Promise((resolve) => resolve(null)));
-    rerender({ ...props, startDate, endDate });
-    // useEffect on params request
-    await waitFor(() => new Promise((resolve) => resolve(null)));
+    test('should not query again when a field is removed', async () => {
+      const { rerender } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: props,
+      });
 
-    expect(mockSearch).toHaveBeenCalledTimes(2);
-    mockSearch.mockClear();
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenCalledTimes(1);
+      });
+      mockSearch.mockClear();
 
-    rerender({ ...props, startDate, endDate, fields: ['@timestamp'] });
+      rerender({ ...props, fields: ['@timestamp'] });
 
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(0));
+      await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(0));
+    });
+    test('should not query again when a removed field is added back', async () => {
+      const { rerender } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: props,
+      });
+
+      expect(mockSearch).toHaveBeenCalledTimes(1);
+      mockSearch.mockClear();
+
+      // remove `event.kind` from default fields
+      rerender({ ...props, fields: ['@timestamp'] });
+
+      await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(0));
+
+      // request default Fields
+      rerender({ ...props });
+
+      await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(0));
+    });
   });
 
-  test('should not query again when a removed field is added back', async () => {
-    const { rerender } = renderHook((args) => useTimelineEvents(args), {
-      initialProps: { ...props, startDate: '', endDate: '' },
+  describe('batching', () => {
+    test('should broadcast correct loading state based on the batch being fetched', async () => {
+      const { result } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: { ...props },
+      });
+
+      await waitFor(() => {
+        expect(result.current[0]).toBe(DataLoadingState.loading);
+      });
+
+      await waitFor(() => {
+        expect(result.current[0]).toBe(DataLoadingState.loaded);
+      });
+
+      act(() => {
+        result.current[1].loadNextBatch();
+      });
+
+      expect(result.current[0]).toBe(DataLoadingState.loadingMore);
+
+      await waitFor(() => {
+        expect(result.current[0]).toBe(DataLoadingState.loaded);
+      });
     });
 
-    // useEffect on params request
-    await waitFor(() => new Promise((resolve) => resolve(null)));
-    rerender({ ...props, startDate, endDate });
-    // useEffect on params request
-    await waitFor(() => new Promise((resolve) => resolve(null)));
+    test('should request incremental batches when next batch has been requested', async () => {
+      const { result } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: { ...props },
+      });
 
-    expect(mockSearch).toHaveBeenCalledTimes(2);
-    mockSearch.mockClear();
+      await waitFor(() => {
+        expect(result.current[0]).toBe(DataLoadingState.loaded);
+        expect(mockSearch).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+        );
+      });
 
-    // remove `event.kind` from default fields
-    rerender({ ...props, startDate, endDate, fields: ['@timestamp'] });
+      expect(mockSearch).toHaveBeenCalledTimes(1);
 
-    await waitFor(() => new Promise((resolve) => resolve(null)));
+      mockSearch.mockClear();
 
-    expect(mockSearch).toHaveBeenCalledTimes(0);
+      await loadNextBatch(result);
 
-    // request default Fields
-    rerender({ ...props, startDate, endDate });
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({ pagination: { activePage: 1, querySize: 25 } })
+        );
+      });
 
-    // since there is no new update in useEffect, it should throw an timeout error
-    // await expect(waitFor(() => null)).rejects.toThrowError();
-    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(0));
-  });
+      mockSearch.mockClear();
 
-  test('should return the combined list of events for all the pages when multiple pages are queried', async () => {
-    const { result } = renderHook((args) => useTimelineEvents(args), {
-      initialProps: { ...props },
+      await loadNextBatch(result);
+
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({ pagination: { activePage: 2, querySize: 25 } })
+        );
+      });
     });
-    await waitFor(() => {
-      expect(result.current[1].events).toHaveLength(10);
+
+    test('should fetch new columns data for the all the batches ', async () => {
+      const { result, rerender } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: { ...props },
+      });
+
+      await waitFor(() => {
+        expect(result.current[0]).toBe(DataLoadingState.loaded);
+      });
+
+      ////////
+      // fetch 2 more batches before requesting new column
+      ////////
+      await loadNextBatch(result);
+
+      await loadNextBatch(result);
+      ///////
+
+      rerender({ ...props, fields: [...props.fields, 'new_column'] });
+
+      await waitFor(() => {
+        expect(result.current[0]).toBe(DataLoadingState.loaded);
+        expect(mockSearch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fields: ['@timestamp', 'event.kind', 'new_column'],
+            pagination: { activePage: 0, querySize: 75 },
+          })
+        );
+      });
     });
 
-    result.current[1].loadPage(1);
+    describe('refetching', () => {
+      /*
+       * Below are some use cases where refetch is triggered :
+       *
+       *  - When user triggers a manual refresh of the data
+       *  - When user updates an event, which triggers a refresh of the data
+       *    - For example, when alert status is updated.
+       *  - When user adds a new column
+       *
+       */
 
-    await waitFor(() => {
-      expect(result.current[0]).toEqual(DataLoadingState.loadingMore);
+      test('should fetch first batch again when refetch is triggered', async () => {
+        const { result } = renderHook((args) => useTimelineEvents(args), {
+          initialProps: { ...props, timerangeKind: 'absolute' } as UseTimelineEventsProps,
+        });
+
+        await waitFor(() => {
+          expect(mockSearch).toHaveBeenCalledWith(
+            expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+          );
+        });
+
+        mockSearch.mockClear();
+
+        act(() => {
+          result.current[1].refetch();
+        });
+
+        await waitFor(() => {
+          expect(mockSearch).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+          );
+        });
+      });
+
+      test('should fetch first batch again when refetch is triggered with relative timerange', async () => {
+        const { result } = renderHook((args) => useTimelineEvents(args), {
+          initialProps: { ...props, timerangeKind: 'relative' } as UseTimelineEventsProps,
+        });
+
+        await waitFor(() => {
+          expect(mockSearch).toHaveBeenCalledWith(
+            expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+          );
+        });
+
+        mockSearch.mockClear();
+
+        act(() => {
+          result.current[1].refetch();
+        });
+
+        await waitFor(() => {
+          expect(mockSearch).toHaveBeenCalledTimes(1);
+          expect(mockSearch).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+          );
+        });
+      });
+
+      test('should fetch first batch again when refetch is triggered when user has already fetched multiple batches', async () => {
+        const { result } = renderHook((args) => useTimelineEvents(args), {
+          initialProps: { ...props },
+        });
+
+        await waitFor(() => {
+          expect(mockSearch).toHaveBeenCalledWith(
+            expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+          );
+        });
+
+        mockSearch.mockClear();
+
+        await loadNextBatch(result);
+
+        await waitFor(() => {
+          expect(mockSearch).toHaveBeenCalledWith(
+            expect.objectContaining({ pagination: { activePage: 1, querySize: 25 } })
+          );
+        });
+
+        mockSearch.mockClear();
+
+        act(() => {
+          result.current[1].refetch();
+        });
+
+        await waitFor(() => {
+          expect(mockSearch).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+          );
+        });
+      });
     });
 
-    await waitFor(() => {
-      expect(result.current[1].events).toHaveLength(20);
+    describe('sort', () => {
+      test('should fetch first batch again when sort is updated', async () => {
+        const { result, rerender } = renderHook((args) => useTimelineEvents(args), {
+          initialProps: { ...props } as UseTimelineEventsProps,
+        });
+
+        await waitFor(() => {
+          expect(mockSearch).toHaveBeenCalledWith(
+            expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+          );
+        });
+
+        act(() => {
+          result.current[1].loadNextBatch();
+        });
+
+        await waitFor(() => {
+          expect(result.current[0]).toBe(DataLoadingState.loaded);
+          expect(mockSearch).toHaveBeenCalledWith(
+            expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+          );
+        });
+
+        mockSearch.mockClear();
+
+        act(() => {
+          rerender({
+            ...props,
+            sort: [...initSortDefault, { ...initSortDefault[0], field: 'event.kind' }],
+          });
+        });
+
+        await waitFor(() => {
+          expect(mockSearch).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+          );
+        });
+      });
+    });
+
+    test('should query all batches when new column is added', async () => {
+      const { result, rerender } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: { ...props },
+      });
+
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenCalledWith(
+          expect.objectContaining({ pagination: { activePage: 0, querySize: 25 } })
+        );
+      });
+      mockSearch.mockClear();
+
+      await loadNextBatch(result);
+
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenCalledWith(
+          expect.objectContaining({ pagination: { activePage: 1, querySize: 25 } })
+        );
+      });
+
+      mockSearch.mockClear();
+
+      rerender({ ...props, fields: [...props.fields, 'new_column'] });
+
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenCalledWith(
+          expect.objectContaining({ pagination: { activePage: 0, querySize: 50 } })
+        );
+      });
+      mockSearch.mockClear();
+
+      await loadNextBatch(result);
+
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenCalledWith(
+          expect.objectContaining({ pagination: { activePage: 2, querySize: 25 } })
+        );
+      });
+    });
+
+    test('should combine batches correctly when new column is added', async () => {
+      const { result, rerender } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: { ...props, limit: 5 },
+      });
+
+      await waitFor(() => {
+        expect(result.current[1].events.length).toBe(5);
+      });
+
+      //////////////////////
+      // Batch 2
+      await loadNextBatch(result);
+      await waitFor(() => {
+        expect(result.current[1].events.length).toBe(10);
+      });
+      //////////////////////
+
+      //////////////////////
+      // Batch 3
+      await loadNextBatch(result);
+      await waitFor(() => {
+        expect(result.current[1].events.length).toBe(15);
+      });
+      //////////////////////
+
+      ///////////////////////////////////////////
+      // add new column
+      // Fetch all 3 batches together
+      rerender({ ...props, limit: 5, fields: [...props.fields, 'new_column'] });
+
+      await waitFor(() => {
+        expect(result.current[0]).toBe(DataLoadingState.loadingMore);
+      });
+
+      // should fetch all the records together
+      await waitFor(() => {
+        expect(result.current[0]).toBe(DataLoadingState.loaded);
+        expect(result.current[1].events.length).toBe(15);
+        expect(result.current[1].pageInfo).toMatchObject({
+          activePage: 0,
+          querySize: 15,
+        });
+      });
+      ///////////////////////////////////////////
+
+      //////////////////////
+      // subsequent batch should be fetched incrementally
+      // Batch 4
+      await loadNextBatch(result);
+
+      await waitFor(() => {
+        expect(result.current[1].events.length).toBe(20);
+        expect(result.current[1].pageInfo).toMatchObject({
+          activePage: 3,
+          querySize: 5,
+        });
+      });
+      //////////////////////
+
+      //////////////////////
+      // Batch 5
+      await loadNextBatch(result);
+
+      await waitFor(() => {
+        expect(result.current[1].events.length).toBe(25);
+        expect(result.current[1].pageInfo).toMatchObject({
+          activePage: 4,
+          querySize: 5,
+        });
+      });
+      //////////////////////
+    });
+
+    test('should request 0th batch when batchSize is changed', async () => {
+      const { result, rerender } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: { ...props, limit: 5 },
+      });
+
+      //////////////////////
+      // Batch 2
+      await loadNextBatch(result);
+
+      //////////////////////
+      // Batch 3
+      await loadNextBatch(result);
+
+      mockSearch.mockClear();
+
+      // change the batch size
+      rerender({ ...props, limit: 10 });
+
+      await waitFor(() => {
+        expect(result.current[0]).toBe(DataLoadingState.loaded);
+        expect(mockSearch).toHaveBeenCalledWith(
+          expect.objectContaining({ pagination: { activePage: 0, querySize: 10 } })
+        );
+      });
+    });
+
+    test('should return correct list of events ( 0th batch ) when batchSize is changed', async () => {
+      const { result, rerender } = renderHook((args) => useTimelineEvents(args), {
+        initialProps: { ...props, limit: 5 },
+      });
+
+      //////////////////////
+      // Batch 2
+      await loadNextBatch(result);
+
+      //////////////////////
+      // Batch 3
+      await loadNextBatch(result);
+
+      // change the batch size
+      rerender({ ...props, limit: 10 });
+
+      await waitFor(() => {
+        expect(result.current[0]).toBe(DataLoadingState.loading);
+      });
+
+      await waitFor(() => {
+        expect(result.current[0]).toBe(DataLoadingState.loaded);
+        expect(result.current[1].events.length).toBe(10);
+      });
     });
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ Security Solution ] Fix Refetch logic with new timeline batching (#205893)](https://github.com/elastic/kibana/pull/205893)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2025-02-05T21:12:38Z","message":"[ Security Solution ] Fix Refetch logic with new timeline batching (#205893)\n\n## Summary\n\nPR : https://github.com/elastic/kibana/pull/204034 fixed some issues\nwith timeline batching. It was not able to fix one of the issue with\n`Refetch` logic which exists in `main` ( resulting in a flaky test ) and\ncausing some tests to fail in `8.16`, `8.17` and `8.x`.\n\n## Issue Description\n\nThere are 2 issues with below video:\n\n1. When user updates a status of an alert, the `Refetch` only happens on\nthe first `batch`. This behaviour is flaky currently. Even if the user\nis on nth batch, table will fetch 0th batch and reset the user's page\nback to 1.\n\n\n\nhttps://github.com/user-attachments/assets/eaf88a82-0e9b-4743-8b2d-60fd327a2443\n     \n\n\n3. When user clicks `Refresh` manually, then also only first (0th)\n`batch` is fetched, which should have rather fetched all the present\nbatches.\n\n\n\n\nhttps://github.com/user-attachments/assets/8d578ce3-4f24-4e70-bc3a-ed6ba99167a0\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"54b4fac705c231b52396d70906f3259f9b129a3b","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","v9.0.0","Team:Threat Hunting:Investigations","v9.1.0"],"title":"[ Security Solution ] Fix Refetch logic with new timeline batching","number":205893,"url":"https://github.com/elastic/kibana/pull/205893","mergeCommit":{"message":"[ Security Solution ] Fix Refetch logic with new timeline batching (#205893)\n\n## Summary\n\nPR : https://github.com/elastic/kibana/pull/204034 fixed some issues\nwith timeline batching. It was not able to fix one of the issue with\n`Refetch` logic which exists in `main` ( resulting in a flaky test ) and\ncausing some tests to fail in `8.16`, `8.17` and `8.x`.\n\n## Issue Description\n\nThere are 2 issues with below video:\n\n1. When user updates a status of an alert, the `Refetch` only happens on\nthe first `batch`. This behaviour is flaky currently. Even if the user\nis on nth batch, table will fetch 0th batch and reset the user's page\nback to 1.\n\n\n\nhttps://github.com/user-attachments/assets/eaf88a82-0e9b-4743-8b2d-60fd327a2443\n     \n\n\n3. When user clicks `Refresh` manually, then also only first (0th)\n`batch` is fetched, which should have rather fetched all the present\nbatches.\n\n\n\n\nhttps://github.com/user-attachments/assets/8d578ce3-4f24-4e70-bc3a-ed6ba99167a0\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"54b4fac705c231b52396d70906f3259f9b129a3b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209916","number":209916,"state":"MERGED","mergeCommit":{"sha":"aeaff4957aded708fecfa0e57f16b3cba5f77485","message":"[9.0] [ Security Solution ] Fix Refetch logic with new timeline batching (#205893) (#209916)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[ Security Solution ] Fix Refetch logic with new timeline batching\n(#205893)](https://github.com/elastic/kibana/pull/205893)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jatin\nKathuria\",\"email\":\"jatin.kathuria@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-02-05T21:12:38Z\",\"message\":\"[\nSecurity Solution ] Fix Refetch logic with new timeline batching\n(#205893)\\n\\n## Summary\\n\\nPR :\nhttps://github.com/elastic/kibana/pull/204034 fixed some issues\\nwith\ntimeline batching. It was not able to fix one of the issue\nwith\\n`Refetch` logic which exists in `main` ( resulting in a flaky test\n) and\\ncausing some tests to fail in `8.16`, `8.17` and `8.x`.\\n\\n##\nIssue Description\\n\\nThere are 2 issues with below video:\\n\\n1. When\nuser updates a status of an alert, the `Refetch` only happens on\\nthe\nfirst `batch`. This behaviour is flaky currently. Even if the user\\nis\non nth batch, table will fetch 0th batch and reset the user's page\\nback\nto\n1.\\n\\n\\n\\nhttps://github.com/user-attachments/assets/eaf88a82-0e9b-4743-8b2d-60fd327a2443\\n\n\\n\\n\\n3. When user clicks `Refresh` manually, then also only first\n(0th)\\n`batch` is fetched, which should have rather fetched all the\npresent\\nbatches.\\n\\n\\n\\n\\nhttps://github.com/user-attachments/assets/8d578ce3-4f24-4e70-bc3a-ed6ba99167a0\\n\\n\\n\\n###\nChecklist\\n\\nCheck the PR satisfies following conditions. \\n\\nReviewers\nshould verify this PR satisfies this list as well.\\n\\n\\n- [x] [Unit or\nfunctional\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"54b4fac705c231b52396d70906f3259f9b129a3b\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"backport\",\"release_note:skip\",\"Team:Threat\nHunting:Investigations\",\"v8.9.1\",\"v9.1.0\"],\"title\":\"[ Security Solution\n] Fix Refetch logic with new timeline\nbatching\",\"number\":205893,\"url\":\"https://github.com/elastic/kibana/pull/205893\",\"mergeCommit\":{\"message\":\"[\nSecurity Solution ] Fix Refetch logic with new timeline batching\n(#205893)\\n\\n## Summary\\n\\nPR :\nhttps://github.com/elastic/kibana/pull/204034 fixed some issues\\nwith\ntimeline batching. It was not able to fix one of the issue\nwith\\n`Refetch` logic which exists in `main` ( resulting in a flaky test\n) and\\ncausing some tests to fail in `8.16`, `8.17` and `8.x`.\\n\\n##\nIssue Description\\n\\nThere are 2 issues with below video:\\n\\n1. When\nuser updates a status of an alert, the `Refetch` only happens on\\nthe\nfirst `batch`. This behaviour is flaky currently. Even if the user\\nis\non nth batch, table will fetch 0th batch and reset the user's page\\nback\nto\n1.\\n\\n\\n\\nhttps://github.com/user-attachments/assets/eaf88a82-0e9b-4743-8b2d-60fd327a2443\\n\n\\n\\n\\n3. When user clicks `Refresh` manually, then also only first\n(0th)\\n`batch` is fetched, which should have rather fetched all the\npresent\\nbatches.\\n\\n\\n\\n\\nhttps://github.com/user-attachments/assets/8d578ce3-4f24-4e70-bc3a-ed6ba99167a0\\n\\n\\n\\n###\nChecklist\\n\\nCheck the PR satisfies following conditions. \\n\\nReviewers\nshould verify this PR satisfies this list as well.\\n\\n\\n- [x] [Unit or\nfunctional\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"54b4fac705c231b52396d70906f3259f9b129a3b\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.9\"],\"targetPullRequestStates\":[{\"branch\":\"8.9\",\"label\":\"v8.9.1\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/205893\",\"number\":205893,\"mergeCommit\":{\"message\":\"[\nSecurity Solution ] Fix Refetch logic with new timeline batching\n(#205893)\\n\\n## Summary\\n\\nPR :\nhttps://github.com/elastic/kibana/pull/204034 fixed some issues\\nwith\ntimeline batching. It was not able to fix one of the issue\nwith\\n`Refetch` logic which exists in `main` ( resulting in a flaky test\n) and\\ncausing some tests to fail in `8.16`, `8.17` and `8.x`.\\n\\n##\nIssue Description\\n\\nThere are 2 issues with below video:\\n\\n1. When\nuser updates a status of an alert, the `Refetch` only happens on\\nthe\nfirst `batch`. This behaviour is flaky currently. Even if the user\\nis\non nth batch, table will fetch 0th batch and reset the user's page\\nback\nto\n1.\\n\\n\\n\\nhttps://github.com/user-attachments/assets/eaf88a82-0e9b-4743-8b2d-60fd327a2443\\n\n\\n\\n\\n3. When user clicks `Refresh` manually, then also only first\n(0th)\\n`batch` is fetched, which should have rather fetched all the\npresent\\nbatches.\\n\\n\\n\\n\\nhttps://github.com/user-attachments/assets/8d578ce3-4f24-4e70-bc3a-ed6ba99167a0\\n\\n\\n\\n###\nChecklist\\n\\nCheck the PR satisfies following conditions. \\n\\nReviewers\nshould verify this PR satisfies this list as well.\\n\\n\\n- [x] [Unit or\nfunctional\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"54b4fac705c231b52396d70906f3259f9b129a3b\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Jatin Kathuria <jatin.kathuria@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205893","number":205893,"mergeCommit":{"message":"[ Security Solution ] Fix Refetch logic with new timeline batching (#205893)\n\n## Summary\n\nPR : https://github.com/elastic/kibana/pull/204034 fixed some issues\nwith timeline batching. It was not able to fix one of the issue with\n`Refetch` logic which exists in `main` ( resulting in a flaky test ) and\ncausing some tests to fail in `8.16`, `8.17` and `8.x`.\n\n## Issue Description\n\nThere are 2 issues with below video:\n\n1. When user updates a status of an alert, the `Refetch` only happens on\nthe first `batch`. This behaviour is flaky currently. Even if the user\nis on nth batch, table will fetch 0th batch and reset the user's page\nback to 1.\n\n\n\nhttps://github.com/user-attachments/assets/eaf88a82-0e9b-4743-8b2d-60fd327a2443\n     \n\n\n3. When user clicks `Refresh` manually, then also only first (0th)\n`batch` is fetched, which should have rather fetched all the present\nbatches.\n\n\n\n\nhttps://github.com/user-attachments/assets/8d578ce3-4f24-4e70-bc3a-ed6ba99167a0\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"54b4fac705c231b52396d70906f3259f9b129a3b"}},{"url":"https://github.com/elastic/kibana/pull/205676","number":205676,"branch":"8.17","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/205702","number":205702,"branch":"8.x","state":"MERGED","mergeCommit":{"sha":"e480de112ae6bc121c4415e2e1726dd551805672","message":"[8.x] [Security Solution] Fix timeline dynamic batching (#204034) (#205702)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Security Solution] Fix timeline dynamic batching\n(#204034)](https://github.com/elastic/kibana/pull/204034)\n - https://github.com/elastic/kibana/pull/205893\n\n<!--- Backport version: 8.9.8 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jatin\nKathuria\",\"email\":\"jatin.kathuria@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-01-07T06:20:30Z\",\"message\":\"[Security\nSolution] Fix timeline dynamic batching (#204034)\\n\\n##\nSummary\\r\\n\\r\\nHandles :\\r\\n\\r\\n\\r\\n### Issue with Batches\\r\\n-\nhttps://github.com/elastic/kibana/issues/201405\\r\\n- Timeline had a bug\nwhere if users fetched multiple batches and then if\\r\\nuser adds a new\ncolumn, the value of this new columns will only be\\r\\nfetched for the\nlatest batch and not old batches.\\r\\n- This PR fixes that ✅ by\ncumulatively fetching the data for old batches\\r\\ntill current batch\n`iff a new column has been added`.\\r\\n- For example, if user has already\nfetched the 3rd batch, data for\\r\\n1st,2nd and 3rd will be fetched\ntogether when a column has been added,\\r\\notherwise, data will be\nfetched incrementally.\\r\\n\\r\\n### Issue with Elastic search\nlimit\\r\\n\\r\\n- Elastic search has a limit of 10K hits at max but we\nthrow error at\\r\\n10K which should be allowed.\\r\\n - Error should be\nthrown at anything `>10K`. 10001 for example.\\r\\n - ✅ This PR fixes that\njust for timeline by allowing 10K hits.\\r\\n\\r\\n### Removal of obsolete\ncode\\r\\n\\r\\nBelow files related to old Timeline code are removed as\nwell:\\r\\n-\\r\\nx-pack/plugins/security_solution/public/timelines/components/timeline/footer/index.test.tsx\\r\\n-\\r\\nx-pack/plugins/security_solution/public/timelines/components/timeline/footer/index.tsx\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nPhilippe Oberti\n<philippe.oberti@elastic.co>\",\"sha\":\"088169f446788f9fa8800d77817881524514943e\",\"branchLabelMapping\":{\"^v9.0.0$\":\"main\",\"^v8.18.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:fix\",\"v9.0.0\",\"Team:Threat\nHunting:Investigations\",\"backport:prev-minor\",\"v8.16.3\"],\"number\":204034,\"url\":\"https://github.com/elastic/kibana/pull/204034\",\"mergeCommit\":{\"message\":\"[Security\nSolution] Fix timeline dynamic batching (#204034)\\n\\n##\nSummary\\r\\n\\r\\nHandles :\\r\\n\\r\\n\\r\\n### Issue with Batches\\r\\n-\nhttps://github.com/elastic/kibana/issues/201405\\r\\n- Timeline had a bug\nwhere if users fetched multiple batches and then if\\r\\nuser adds a new\ncolumn, the value of this new columns will only be\\r\\nfetched for the\nlatest batch and not old batches.\\r\\n- This PR fixes that ✅ by\ncumulatively fetching the data for old batches\\r\\ntill current batch\n`iff a new column has been added`.\\r\\n- For example, if user has already\nfetched the 3rd batch, data for\\r\\n1st,2nd and 3rd will be fetched\ntogether when a column has been added,\\r\\notherwise, data will be\nfetched incrementally.\\r\\n\\r\\n### Issue with Elastic search\nlimit\\r\\n\\r\\n- Elastic search has a limit of 10K hits at max but we\nthrow error at\\r\\n10K which should be allowed.\\r\\n - Error should be\nthrown at anything `>10K`. 10001 for example.\\r\\n - ✅ This PR fixes that\njust for timeline by allowing 10K hits.\\r\\n\\r\\n### Removal of obsolete\ncode\\r\\n\\r\\nBelow files related to old Timeline code are removed as\nwell:\\r\\n-\\r\\nx-pack/plugins/security_solution/public/timelines/components/timeline/footer/index.test.tsx\\r\\n-\\r\\nx-pack/plugins/security_solution/public/timelines/components/timeline/footer/index.tsx\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nPhilippe Oberti\n<philippe.oberti@elastic.co>\",\"sha\":\"088169f446788f9fa8800d77817881524514943e\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.0.0\",\"labelRegex\":\"^v9.0.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/204034\",\"number\":204034,\"mergeCommit\":{\"message\":\"[Security\nSolution] Fix timeline dynamic batching (#204034)\\n\\n##\nSummary\\r\\n\\r\\nHandles :\\r\\n\\r\\n\\r\\n### Issue with Batches\\r\\n-\nhttps://github.com/elastic/kibana/issues/201405\\r\\n- Timeline had a bug\nwhere if users fetched multiple batches and then if\\r\\nuser adds a new\ncolumn, the value of this new columns will only be\\r\\nfetched for the\nlatest batch and not old batches.\\r\\n- This PR fixes that ✅ by\ncumulatively fetching the data for old batches\\r\\ntill current batch\n`iff a new column has been added`.\\r\\n- For example, if user has already\nfetched the 3rd batch, data for\\r\\n1st,2nd and 3rd will be fetched\ntogether when a column has been added,\\r\\notherwise, data will be\nfetched incrementally.\\r\\n\\r\\n### Issue with Elastic search\nlimit\\r\\n\\r\\n- Elastic search has a limit of 10K hits at max but we\nthrow error at\\r\\n10K which should be allowed.\\r\\n - Error should be\nthrown at anything `>10K`. 10001 for example.\\r\\n - ✅ This PR fixes that\njust for timeline by allowing 10K hits.\\r\\n\\r\\n### Removal of obsolete\ncode\\r\\n\\r\\nBelow files related to old Timeline code are removed as\nwell:\\r\\n-\\r\\nx-pack/plugins/security_solution/public/timelines/components/timeline/footer/index.test.tsx\\r\\n-\\r\\nx-pack/plugins/security_solution/public/timelines/components/timeline/footer/index.tsx\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nPhilippe Oberti\n<philippe.oberti@elastic.co>\",\"sha\":\"088169f446788f9fa8800d77817881524514943e\"}},{\"branch\":\"8.16\",\"label\":\"v8.16.3\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"url\":\"https://github.com/elastic/kibana/pull/205674\",\"number\":205674,\"state\":\"OPEN\"},{\"url\":\"https://github.com/elastic/kibana/pull/205676\",\"number\":205676,\"branch\":\"8.17\",\"state\":\"OPEN\"}]}]\nBACKPORT-->\n\n---------\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>"}},{"url":"https://github.com/elastic/kibana/pull/205674","number":205674,"branch":"8.16","state":"OPEN"}]}] BACKPORT-->