### PR TITLE
[Infra] Inventory-view saved object schema fix

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/server/saved_objects/inventory_view/inventory_view_saved_object.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/saved_objects/inventory_view/inventory_view_saved_object.ts
@@ -23,9 +23,14 @@ const getInventoryViewTitle = (savedObject: SavedObject<unknown>) =>
   );
 
 const schemaV1 = schema.object({}, { unknowns: 'allow' });
-const schemaV2 = schema.object({
-  legend: schema.object({ steps: schema.number({ max: 18, min: 2 }) }),
-});
+const schemaV2 = schema.object(
+  {
+    legend: schema.maybe(
+      schema.object({ steps: schema.number({ max: 18, min: 2 }) }, { unknowns: 'allow' })
+    ),
+  },
+  { unknowns: 'allow' }
+);
 
 export const inventoryViewSavedObjectType: SavedObjectsType = {
   name: inventoryViewSavedObjectName,
@@ -64,7 +69,7 @@ export const inventoryViewSavedObjectType: SavedObjectsType = {
         },
       ],
       schemas: {
-        forwardCompatibility: schemaV2.extends({}, { unknowns: 'ignore' }),
+        forwardCompatibility: schemaV2,
         create: schemaV2,
       },
     },


### PR DESCRIPTION
fixes [#209996](https://github.com/elastic/kibana/issues/209996) 

## Summary

Fix the `inventory-view` schema. The wrong schema was causing an error when trying to create/update a saved view on Infra Inventory UI

![inventory-saved-view](https://github.com/user-attachments/assets/682533c0-1893-47a6-9f87-99a2390bb19a)

### How to test

- Run on dev tools the request below, it should return a 400 containing the message: `"[attributes.legend.steps]: Value must be equal to or lower than [18].: Bad Request"`
```
POST kbn:/api/saved_objects/inventory-view
{
  "attributes": {
    "metric": {
      "type": "cpuV2"
    },
    "sort": {
      "by": "name",
      "direction": "desc"
    },
    "groupBy": [],
    "nodeType": "host",
    "view": "map",
    "customOptions": [],
    "customMetrics": [],
    "boundsOverride": {
      "max": 1,
      "min": 0
    },
    "autoBounds": true,
    "accountId": "",
    "region": "",
    "time": 1738848614746,
    "autoReload": false,
    "filterQuery": {
      "expression": "",
      "kind": "kuery"
    },
    "legend": {
      "palette": "cool",
      "steps": 20,
      "reverseColors": false
    },
    "timelineOpen": false,
    "name": "sss"
  }
}
```
- Navigate to Infra > Inventory
- Create a new saved view

