### PR TITLE
[8.18] [9.0] [Dashboard] Ensure resize handle does not overlap sticky header (#209937)

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_container/component/grid/use_layout_styles.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_container/component/grid/use_layout_styles.tsx
@@ -50,7 +50,7 @@ export const useLayoutStyles = () => {
       }
 
       .kbnGridPanel--resizeHandle {
-        z-index: ${euiTheme.levels.mask};
+        z-index: 2000; // ensures the drag handle renders below sticky nav but abover panel contents on hover
 
         // applying mask via ::after allows for focus borders to show
         &:after {


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.0` to `8.18`:
 - [[9.0] [Dashboard] Ensure resize handle does not overlap sticky header (#209937)](https://github.com/elastic/kibana/pull/209937)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Mudge","email":"Heenawter@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-06T15:03:28Z","message":"[9.0] [Dashboard] Ensure resize handle does not overlap sticky header (#209937)\n\n## Summary\r\n\r\nSince https://github.com/elastic/kibana/pull/207275 is too large to\r\nbackport to `9.0`/`8.18` and will only be in `9.1`/`8.19`, I wanted to\r\nat least backport **just** the z-index fix for the resize handler as\r\ndescribed\r\n[here](https://github.com/elastic/kibana/pull/207275/files#r1931305375)\r\n. Unfortunately, the z-index used in that PR\r\n(`euiTheme.levels.maskBelowHeader`) only works thanks to other\r\nhover-action style changes, so I've had to set a hardcoded z-index\r\n(`2000`) in this PR instead. This acts as a \"quick fix\" for a pretty\r\nannoying bug while avoiding the risk of backporting the entire\r\npresentation panel refactor PR to `9.0`/`8.18`\r\n\r\n\r\n| Before | After |\r\n|--------|--------|\r\n| ![Screenshot 2025-01-23 at 5 49\r\n13 PM](https://github.com/user-attachments/assets/ea5f2ffe-46bd-4259-920a-8798a1a08775)\r\n|\r\n![image](https://github.com/user-attachments/assets/52a6ac63-5bb3-4cc0-a77d-99cac756aaa4)\r\n|","sha":"7ebe1bf8d020e5b732b22aa2a23adaae8bb5bb48","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","loe:small","release_note:skip","impact:low","backport:version","v8.18.0"],"title":"[9.0] [Dashboard] Ensure resize handle does not overlap sticky header","number":209937,"url":"https://github.com/elastic/kibana/pull/209937","mergeCommit":{"message":"[9.0] [Dashboard] Ensure resize handle does not overlap sticky header (#209937)\n\n## Summary\r\n\r\nSince https://github.com/elastic/kibana/pull/207275 is too large to\r\nbackport to `9.0`/`8.18` and will only be in `9.1`/`8.19`, I wanted to\r\nat least backport **just** the z-index fix for the resize handler as\r\ndescribed\r\n[here](https://github.com/elastic/kibana/pull/207275/files#r1931305375)\r\n. Unfortunately, the z-index used in that PR\r\n(`euiTheme.levels.maskBelowHeader`) only works thanks to other\r\nhover-action style changes, so I've had to set a hardcoded z-index\r\n(`2000`) in this PR instead. This acts as a \"quick fix\" for a pretty\r\nannoying bug while avoiding the risk of backporting the entire\r\npresentation panel refactor PR to `9.0`/`8.18`\r\n\r\n\r\n| Before | After |\r\n|--------|--------|\r\n| ![Screenshot 2025-01-23 at 5 49\r\n13 PM](https://github.com/user-attachments/assets/ea5f2ffe-46bd-4259-920a-8798a1a08775)\r\n|\r\n![image](https://github.com/user-attachments/assets/52a6ac63-5bb3-4cc0-a77d-99cac756aaa4)\r\n|","sha":"7ebe1bf8d020e5b732b22aa2a23adaae8bb5bb48"}},"sourceBranch":"9.0","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->