### PR TITLE
[Infra] Change "Inventory" to uppercase in "Infrastructure inventory"

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
@@ -36,7 +36,7 @@ const mainApiRequestsToIntercept = [
 
 const mainAliasNames = mainApiRequestsToIntercept.map(({ aliasName }) => `@${aliasName}`);
 
-describe('Service inventory', () => {
+describe('Service Inventory', () => {
   before(() => {
     const { rangeFrom, rangeTo } = timeRange;
     synthtrace.index(

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/settings/schema/migrated/card_footer_content.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/settings/schema/migrated/card_footer_content.tsx
@@ -36,7 +36,7 @@ export function CardFooterContent() {
                 <LegacyAPMLink path="/services">
                   {i18n.translate(
                     'xpack.apm.settings.schema.success.returnText.serviceInventoryLink',
-                    { defaultMessage: 'Service inventory' }
+                    { defaultMessage: 'Service Inventory' }
                   )}
                 </LegacyAPMLink>
               ),

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/storage_explorer/resources/tips_and_resources.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/storage_explorer/resources/tips_and_resources.tsx
@@ -84,7 +84,7 @@ export function TipsAndResources() {
     },
     {
       label: i18n.translate('xpack.apm.storageExplorer.resources.serviceInventory', {
-        defaultMessage: 'Service inventory',
+        defaultMessage: 'Service Inventory',
       }),
       href: router.link('/services', {
         query: {

--- a/x-pack/solutions/observability/plugins/infra/public/translations.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/translations.ts
@@ -35,7 +35,7 @@ export const metricsTitle = i18n.translate('xpack.infra.header.infrastructureTit
 });
 
 export const inventoryTitle = i18n.translate('xpack.infra.metrics.infrastructureInventoryTitle', {
-  defaultMessage: 'Infrastructure inventory',
+  defaultMessage: 'Infrastructure Inventory',
 });
 
 export const metricsExplorerTitle = i18n.translate('xpack.infra.metrics.metricsExplorerTitle', {

--- a/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
@@ -153,7 +153,7 @@ function createNavTree({ streamsAvailable }: { streamsAvailable?: boolean }) {
                   {
                     link: 'metrics:inventory',
                     title: i18n.translate('xpack.observability.infrastructure.inventory', {
-                      defaultMessage: 'Infrastructure inventory',
+                      defaultMessage: 'Infrastructure Inventory',
                     }),
                     getIsActive: ({ pathNameSerialized, prepend }) => {
                       return pathNameSerialized.startsWith(prepend('/app/metrics/inventory'));

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -87,7 +87,7 @@ export const createNavigationTree = ({
                   {
                     link: 'apm:services',
                     title: i18n.translate('xpack.serverlessObservability.nav.apm.services', {
-                      defaultMessage: 'Service inventory',
+                      defaultMessage: 'Service Inventory',
                     }),
                   },
                   { link: 'apm:traces' },
@@ -141,7 +141,7 @@ export const createNavigationTree = ({
                     title: i18n.translate(
                       'xpack.serverlessObservability.nav.infrastructureInventory',
                       {
-                        defaultMessage: 'Infrastructure inventory',
+                        defaultMessage: 'Infrastructure Inventory',
                       }
                     ),
                   },

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -144,7 +144,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
         const documentTitle = await browser.getTitle();
         expect(documentTitle).to.contain(
-          'Infrastructure inventory - Infrastructure - Observability - Elastic'
+          'Infrastructure Inventory - Infrastructure - Observability - Elastic'
         );
       });
 
@@ -459,7 +459,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await retry.tryForTime(5000, async () => {
             const documentTitle = await browser.getTitle();
             expect(documentTitle).to.contain(
-              'host-5 - Infrastructure inventory - Infrastructure - Observability - Elastic'
+              'host-5 - Infrastructure Inventory - Infrastructure - Observability - Elastic'
             );
           });
 
@@ -476,7 +476,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             await retry.tryForTime(5000, async () => {
               const documentTitle = await browser.getTitle();
               expect(documentTitle).to.contain(
-                'pod-0 - Infrastructure inventory - Infrastructure - Observability - Elastic'
+                'pod-0 - Infrastructure Inventory - Infrastructure - Observability - Elastic'
               );
             });
 
@@ -494,7 +494,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             await retry.tryForTime(5000, async () => {
               const documentTitle = await browser.getTitle();
               expect(documentTitle).to.contain(
-                'container-id-4 - Infrastructure inventory - Infrastructure - Observability - Elastic'
+                'container-id-4 - Infrastructure Inventory - Infrastructure - Observability - Elastic'
               );
             });
 

--- a/x-pack/test/functional_solution_sidenav/tests/observability_sidenav.ts
+++ b/x-pack/test/functional_solution_sidenav/tests/observability_sidenav.ts
@@ -70,7 +70,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         }
         await solutionNavigation.sidenav.clickPanelLink('metrics:inventory');
         await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-          text: 'Infrastructure inventory',
+          text: 'Infrastructure Inventory',
         });
 
         {

--- a/x-pack/test_serverless/functional/test_suites/observability/infra/infra.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/infra/infra.ts
@@ -57,7 +57,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
           const documentTitle = await browser.getTitle();
           expect(documentTitle).to.contain(
-            'Infrastructure inventory - Infrastructure - Observability - Elastic'
+            'Infrastructure Inventory - Infrastructure - Observability - Elastic'
           );
         });
 
@@ -87,7 +87,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             await retry.try(async () => {
               const documentTitle = await browser.getTitle();
               expect(documentTitle).to.contain(
-                'demo-stack-redis-01 - Infrastructure inventory - Infrastructure - Observability - Elastic'
+                'demo-stack-redis-01 - Infrastructure Inventory - Infrastructure - Observability - Elastic'
               );
             });
 
@@ -103,7 +103,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             await retry.try(async () => {
               const documentTitle = await browser.getTitle();
               expect(documentTitle).to.contain(
-                'pod-0 - Infrastructure inventory - Infrastructure - Observability - Elastic'
+                'pod-0 - Infrastructure Inventory - Infrastructure - Observability - Elastic'
               );
             });
 


### PR DESCRIPTION
Closes #210027 

## Summary

This PR changes inventory to start with a capital letter in Infra and APM

| Before | After |
|-------|-------|
| ![image](https://github.com/user-attachments/assets/f0ec7d3c-647a-4da0-94b7-f7a9f57efd47) | <img width="1826" alt="image" src="https://github.com/user-attachments/assets/b91a82ec-effc-45ca-9c82-622e4f631374" /> |

## How to check
- Search for infra
- Search for inventory
- Check the left side nav 
- Check the Infrastructure Inventory page title
- Check the breadcrumbs


https://github.com/user-attachments/assets/030bab66-6f3c-45bc-9b2c-7860ae63ad24




<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->