### PR TITLE
[8.x] [streams] basic lifecycle management UI (#208461)

### DIFF
--- a/x-pack/solutions/observability/plugins/streams_app/.storybook/get_mock_streams_app_context.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/.storybook/get_mock_streams_app_context.tsx
@@ -40,5 +40,6 @@ export function getMockStreamsAppContext(): StreamsAppKibanaContext {
     services: {
       query: jest.fn(),
     },
+    isServerless: false,
   };
 }

--- a/x-pack/solutions/observability/plugins/streams_app/public/application.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/application.tsx
@@ -18,10 +18,12 @@ export const renderApp = ({
   pluginsStart,
   services,
   appMountParameters,
+  isServerless,
 }: {
   coreStart: CoreStart;
   pluginsStart: StreamsAppStartDependencies;
   services: StreamsAppServices;
+  isServerless: boolean;
 } & { appMountParameters: AppMountParameters }) => {
   const { element } = appMountParameters;
 
@@ -38,6 +40,7 @@ export const renderApp = ({
         coreStart={coreStart}
         pluginsStart={pluginsStart}
         services={services}
+        isServerless={isServerless}
       />
     </KibanaRenderContextProvider>,
     element

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/app_root/index.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/app_root/index.tsx
@@ -25,10 +25,12 @@ export function AppRoot({
   pluginsStart,
   services,
   appMountParameters,
+  isServerless,
 }: {
   coreStart: CoreStart;
   pluginsStart: StreamsAppStartDependencies;
   services: StreamsAppServices;
+  isServerless: boolean;
 } & { appMountParameters: AppMountParameters }) {
   const { history } = appMountParameters;
 
@@ -39,6 +41,7 @@ export function AppRoot({
       start: pluginsStart,
     },
     services,
+    isServerless,
   };
 
   return (

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_lifecycle/index.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_lifecycle/index.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
+import React, { useMemo, useState } from 'react';
+import {
+  IngestStreamGetResponse,
+  IngestStreamLifecycle,
+  IngestUpsertRequest,
+  isIlmLifecycle,
+  isRoot,
+  isUnwiredStreamGetResponse,
+  isWiredStreamGetResponse,
+} from '@kbn/streams-schema';
+import {
+  ILM_LOCATOR_ID,
+  IlmLocatorParams,
+  PolicyFromES,
+} from '@kbn/index-lifecycle-management-common-shared';
+import { useAbortController } from '@kbn/observability-utils-browser/hooks/use_abort_controller';
+import { i18n } from '@kbn/i18n';
+import { useKibana } from '../../hooks/use_kibana';
+import { EditLifecycleModal, LifecycleEditAction } from './modal';
+import { RetentionSummary } from './summary';
+import { RetentionMetadata } from './metadata';
+
+function useLifecycleState({
+  definition,
+  isServerless,
+}: {
+  definition?: IngestStreamGetResponse;
+  isServerless: boolean;
+}) {
+  const [updateInProgress, setUpdateInProgress] = useState(false);
+  const [openEditModal, setOpenEditModal] = useState<LifecycleEditAction>('none');
+
+  const lifecycleActions = useMemo(() => {
+    if (!definition) return [];
+
+    const actions: Array<{ name: string; action: LifecycleEditAction }> = [];
+    const isWired = isWiredStreamGetResponse(definition);
+    const isUnwired = isUnwiredStreamGetResponse(definition);
+    const isIlm = isIlmLifecycle(definition.effective_lifecycle);
+
+    if (isWired || (isUnwired && !isIlm)) {
+      actions.push({
+        name: i18n.translate('xpack.streams.streamDetailLifecycle.setRetentionDays', {
+          defaultMessage: 'Set specific retention days',
+        }),
+        action: 'dsl',
+      });
+    }
+
+    if (isWired && !isServerless) {
+      actions.push({
+        name: i18n.translate('xpack.streams.streamDetailLifecycle.setLifecyclePolicy', {
+          defaultMessage: 'Use a lifecycle policy',
+        }),
+        action: 'ilm',
+      });
+    }
+
+    if (!isRoot(definition.stream.name) || (isUnwired && !isIlm)) {
+      actions.push({
+        name: i18n.translate('xpack.streams.streamDetailLifecycle.resetToDefault', {
+          defaultMessage: 'Reset to default',
+        }),
+        action: 'inherit',
+      });
+    }
+
+    return actions;
+  }, [definition, isServerless]);
+
+  return {
+    lifecycleActions,
+    openEditModal,
+    setOpenEditModal,
+    updateInProgress,
+    setUpdateInProgress,
+  };
+}
+
+export function StreamDetailLifecycle({
+  definition,
+  refreshDefinition,
+}: {
+  definition?: IngestStreamGetResponse;
+  refreshDefinition: () => void;
+}) {
+  const {
+    core: { http, notifications },
+    dependencies: {
+      start: {
+        share,
+        streams: { streamsRepositoryClient },
+      },
+    },
+    isServerless,
+  } = useKibana();
+
+  const {
+    lifecycleActions,
+    openEditModal,
+    setOpenEditModal,
+    updateInProgress,
+    setUpdateInProgress,
+  } = useLifecycleState({ definition, isServerless });
+
+  const { signal } = useAbortController();
+
+  if (!definition) {
+    return null;
+  }
+
+  const ilmLocator = share.url.locators.get<IlmLocatorParams>(ILM_LOCATOR_ID);
+
+  const getIlmPolicies = () =>
+    http.get<PolicyFromES[]>('/api/index_lifecycle_management/policies', {
+      signal,
+    });
+
+  const updateLifecycle = async (lifecycle: IngestStreamLifecycle) => {
+    try {
+      setUpdateInProgress(true);
+
+      const request = {
+        ingest: {
+          ...definition.stream.ingest,
+          lifecycle,
+        },
+      } as IngestUpsertRequest;
+
+      await streamsRepositoryClient.fetch('PUT /api/streams/{id}/_ingest', {
+        params: {
+          path: { id: definition.stream.name },
+          body: request,
+        },
+        signal,
+      });
+
+      refreshDefinition();
+      setOpenEditModal('none');
+
+      notifications.toasts.addSuccess({
+        title: i18n.translate('xpack.streams.streamDetailLifecycle.updated', {
+          defaultMessage: 'Stream lifecycle updated',
+        }),
+      });
+    } catch (error) {
+      notifications.toasts.addError(error, {
+        title: i18n.translate('xpack.streams.streamDetailLifecycle.failed', {
+          defaultMessage: 'Failed to update lifecycle',
+        }),
+        toastMessage: 'body' in error ? error.body.message : error.message,
+      });
+    } finally {
+      setUpdateInProgress(false);
+    }
+  };
+
+  return (
+    <>
+      <EditLifecycleModal
+        action={openEditModal}
+        definition={definition}
+        closeModal={() => setOpenEditModal('none')}
+        updateLifecycle={updateLifecycle}
+        getIlmPolicies={getIlmPolicies}
+        updateInProgress={updateInProgress}
+        ilmLocator={ilmLocator}
+      />
+
+      <EuiFlexItem grow={false}>
+        <EuiPanel hasShadow={false} hasBorder paddingSize="s">
+          <EuiFlexGroup gutterSize="m">
+            <EuiFlexItem grow={1}>
+              <RetentionSummary definition={definition} />
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={4}>
+              <RetentionMetadata
+                definition={definition}
+                lifecycleActions={lifecycleActions}
+                ilmLocator={ilmLocator}
+                openEditModal={(action) => setOpenEditModal(action)}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPanel>
+      </EuiFlexItem>
+    </>
+  );
+}

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_lifecycle/metadata.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_lifecycle/metadata.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IlmLocatorParams } from '@kbn/index-lifecycle-management-common-shared';
+import { LocatorPublic } from '@kbn/share-plugin/common';
+import {
+  IngestStreamGetResponse,
+  isDisabledLifecycle,
+  isDslLifecycle,
+  isIlmLifecycle,
+  isInheritLifecycle,
+  isWiredStreamGetResponse,
+} from '@kbn/streams-schema';
+import React, { ReactNode } from 'react';
+import { useBoolean } from '@kbn/react-hooks';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiLink,
+  EuiPanel,
+  EuiPopover,
+  EuiText,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { LifecycleEditAction } from './modal';
+import { useStreamsAppRouter } from '../../hooks/use_streams_app_router';
+
+export function RetentionMetadata({
+  definition,
+  ilmLocator,
+  lifecycleActions,
+  openEditModal,
+}: {
+  definition: IngestStreamGetResponse;
+  ilmLocator?: LocatorPublic<IlmLocatorParams>;
+  lifecycleActions: Array<{ name: string; action: LifecycleEditAction }>;
+  openEditModal: (action: LifecycleEditAction) => void;
+}) {
+  const [isMenuOpen, { toggle: toggleMenu, off: closeMenu }] = useBoolean(false);
+  const router = useStreamsAppRouter();
+
+  const lifecycle = definition.effective_lifecycle;
+
+  const contextualMenu =
+    lifecycleActions.length === 0 ? null : (
+      <EuiPopover
+        button={
+          <EuiButton
+            data-test-subj="streamsAppRetentionMetadataEditDataRetentionButton"
+            size="s"
+            fullWidth
+            onClick={toggleMenu}
+          >
+            {i18n.translate('xpack.streams.entityDetailViewWithoutParams.editDataRetention', {
+              defaultMessage: 'Edit data retention',
+            })}
+          </EuiButton>
+        }
+        isOpen={isMenuOpen}
+        closePopover={closeMenu}
+        panelPaddingSize="none"
+        anchorPosition="downLeft"
+      >
+        <EuiContextMenuPanel
+          items={lifecycleActions.map(({ name, action }) => (
+            <EuiContextMenuItem
+              key={action}
+              onClick={() => {
+                closeMenu();
+                openEditModal(action);
+              }}
+            >
+              {name}
+            </EuiContextMenuItem>
+          ))}
+        />
+      </EuiPopover>
+    );
+
+  const ilmLink = isIlmLifecycle(lifecycle) ? (
+    <EuiBadge color="hollow">
+      <EuiLink
+        target="_blank"
+        data-test-subj="streamsAppLifecycleBadgeIlmPolicyNameLink"
+        href={ilmLocator?.getRedirectUrl({
+          page: 'policy_edit',
+          policyName: lifecycle.ilm.policy,
+        })}
+      >
+        {i18n.translate('xpack.streams.entityDetailViewWithoutParams.ilmBadgeLabel', {
+          defaultMessage: 'ILM Policy: {name}',
+          values: { name: lifecycle.ilm.policy },
+        })}
+      </EuiLink>
+    </EuiBadge>
+  ) : null;
+
+  const lifecycleOrigin = isInheritLifecycle(definition.stream.ingest.lifecycle) ? (
+    <EuiText>
+      {i18n.translate('xpack.streams.streamDetailLifecycle.inheritedFrom', {
+        defaultMessage: 'Inherited from',
+      })}{' '}
+      {isWiredStreamGetResponse(definition) ? (
+        <EuiLink
+          data-test-subj="streamsAppRetentionMetadataLink"
+          target="_blank"
+          href={router.link('/{key}/{tab}', {
+            path: {
+              key: definition.effective_lifecycle.from,
+              tab: 'overview',
+            },
+          })}
+        >
+          [{definition.effective_lifecycle.from}]
+        </EuiLink>
+      ) : (
+        i18n.translate('xpack.streams.streamDetailLifecycle.localOverride', {
+          defaultMessage: 'the underlying data stream',
+        })
+      )}
+    </EuiText>
+  ) : (
+    i18n.translate('xpack.streams.streamDetailLifecycle.localOverride', {
+      defaultMessage: 'Local override',
+    })
+  );
+
+  return (
+    <EuiPanel hasBorder={false} hasShadow={false}>
+      <MetadataRow
+        metadata={i18n.translate('xpack.streams.streamDetailLifecycle.retentionPeriodLabel', {
+          defaultMessage: 'Retention period',
+        })}
+        value={
+          <EuiFlexGroup responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color={isDisabledLifecycle(lifecycle) ? 'default' : 'accent'}>
+                {isDslLifecycle(lifecycle)
+                  ? lifecycle.dsl.data_retention ?? '∞'
+                  : isIlmLifecycle(lifecycle)
+                  ? i18n.translate('xpack.streams.streamDetailLifecycle.policyBased', {
+                      defaultMessage: 'Policy-based',
+                    })
+                  : i18n.translate('xpack.streams.streamDetailLifecycle.policyDisabled', {
+                      defaultMessage: 'Disabled',
+                    })}
+              </EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        button={contextualMenu}
+      />
+      <EuiHorizontalRule margin="m" />
+      <MetadataRow
+        metadata={i18n.translate('xpack.streams.streamDetailLifecycle.retentionSourceLabel', {
+          defaultMessage: 'Source',
+        })}
+        value={
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            {ilmLink ? <EuiFlexItem grow={false}>{ilmLink}</EuiFlexItem> : null}
+            <EuiFlexItem grow={false}>{lifecycleOrigin}</EuiFlexItem>
+          </EuiFlexGroup>
+        }
+      />
+    </EuiPanel>
+  );
+}
+
+function MetadataRow({
+  metadata,
+  value,
+  button,
+}: {
+  metadata: string;
+  value: ReactNode;
+  action?: string;
+  button?: ReactNode;
+}) {
+  return (
+    <EuiFlexGroup alignItems="center" gutterSize="xl" responsive={false}>
+      <EuiFlexItem grow={1}>
+        <EuiText>
+          <b>{metadata}</b>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={4}>{value}</EuiFlexItem>
+      <EuiFlexItem grow={1}>{button}</EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_lifecycle/modal.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_lifecycle/modal.tsx
@@ -1,0 +1,452 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  IlmLocatorParams,
+  Phases,
+  PolicyFromES,
+} from '@kbn/index-lifecycle-management-common-shared';
+import { LocatorPublic } from '@kbn/share-plugin/common';
+import {
+  IngestStreamGetResponse,
+  IngestStreamLifecycle,
+  StreamGetResponse,
+  isIlmLifecycle,
+  isWiredStreamGetResponse,
+} from '@kbn/streams-schema';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiFieldNumber,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHighlight,
+  EuiLink,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiPanel,
+  EuiPopover,
+  EuiSelectable,
+  EuiSelectableOption,
+  EuiSpacer,
+  EuiSwitch,
+  EuiText,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useBoolean } from '@kbn/react-hooks';
+import useToggle from 'react-use/lib/useToggle';
+
+export type LifecycleEditAction = 'none' | 'dsl' | 'ilm' | 'inherit';
+
+interface ModalOptions {
+  closeModal: () => void;
+  updateLifecycle: (lifecycle: IngestStreamLifecycle) => void;
+  getIlmPolicies: () => Promise<PolicyFromES[]>;
+  definition: IngestStreamGetResponse;
+  updateInProgress: boolean;
+  ilmLocator?: LocatorPublic<IlmLocatorParams>;
+}
+
+export function EditLifecycleModal({
+  action,
+  ...options
+}: { action: LifecycleEditAction } & ModalOptions) {
+  if (action === 'none') {
+    return null;
+  }
+
+  if (action === 'dsl') {
+    return <DslModal {...options} />;
+  }
+
+  if (action === 'ilm') {
+    return <IlmModal {...options} />;
+  }
+
+  return <InheritModal {...options} />;
+}
+
+function DslModal({ closeModal, definition, updateInProgress, updateLifecycle }: ModalOptions) {
+  const timeUnits = [
+    { name: 'Days', value: 'd' },
+    { name: 'Hours', value: 'h' },
+    { name: 'Minutes', value: 'm' },
+    { name: 'Seconds', value: 's' },
+  ];
+
+  const [selectedUnit, setSelectedUnit] = useState(timeUnits[0]);
+  const [retentionValue, setRetentionValue] = useState(1);
+  const [noRetention, toggleNoRetention] = useToggle(false);
+  const [showUnitMenu, { on: openUnitMenu, off: closeUnitMenu }] = useBoolean(false);
+
+  return (
+    <EuiModal onClose={closeModal}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          {i18n.translate('xpack.streams.streamDetailLifecycle.editRetention', {
+            defaultMessage: 'Edit data retention for stream',
+          })}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        {i18n.translate('xpack.streams.streamDetailLifecycle.setCustomDsl', {
+          defaultMessage: 'Specify a custom data retention period for this stream.',
+        })}
+        <EuiSpacer />
+        <EuiFieldNumber
+          data-test-subj="streamsAppDslModalFieldNumber"
+          value={retentionValue}
+          onChange={(e) => {
+            const valueAsNumber = e.target.valueAsNumber;
+            if (isNaN(valueAsNumber) || valueAsNumber < 1) {
+              setRetentionValue(1);
+            } else {
+              setRetentionValue(valueAsNumber);
+            }
+          }}
+          min={1}
+          disabled={noRetention}
+          fullWidth
+          append={
+            <EuiPopover
+              isOpen={showUnitMenu}
+              panelPaddingSize="none"
+              closePopover={closeUnitMenu}
+              button={
+                <EuiButton
+                  data-test-subj="streamsAppDslModalButton"
+                  disabled={noRetention}
+                  iconType="arrowDown"
+                  iconSide="right"
+                  color="text"
+                  onClick={openUnitMenu}
+                >
+                  {selectedUnit.name}
+                </EuiButton>
+              }
+            >
+              <EuiContextMenuPanel
+                size="s"
+                items={timeUnits.map((unit) => (
+                  <EuiContextMenuItem
+                    key={unit.value}
+                    icon={selectedUnit.value === unit.value ? 'check' : 'empty'}
+                    onClick={() => {
+                      closeUnitMenu();
+                      setSelectedUnit(unit);
+                    }}
+                  >
+                    {unit.name}
+                  </EuiContextMenuItem>
+                ))}
+              />
+            </EuiPopover>
+          }
+        />
+        <EuiSpacer />
+        <EuiSwitch
+          label={i18n.translate('xpack.streams.streamDetailLifecycle.keepDataIndefinitely', {
+            defaultMessage: 'Keep data indefinitely',
+          })}
+          checked={noRetention}
+          onChange={() => toggleNoRetention()}
+        />
+        <EuiSpacer />
+      </EuiModalBody>
+
+      <ModalFooter
+        definition={definition}
+        confirmationLabel="Save"
+        closeModal={closeModal}
+        onConfirm={() => {
+          updateLifecycle({
+            dsl: {
+              data_retention: noRetention ? undefined : `${retentionValue}${selectedUnit.value}`,
+            },
+          });
+        }}
+        updateInProgress={updateInProgress}
+      />
+    </EuiModal>
+  );
+}
+
+interface IlmOptionData {
+  phases?: string;
+}
+
+function IlmModal({
+  closeModal,
+  updateLifecycle,
+  updateInProgress,
+  getIlmPolicies,
+  ilmLocator,
+  definition,
+}: ModalOptions) {
+  const existingLifecycle = definition.stream.ingest.lifecycle;
+  const [selectedPolicy, setSelectedPolicy] = useState(
+    isIlmLifecycle(existingLifecycle) ? existingLifecycle.ilm.policy : undefined
+  );
+  const [policies, setPolicies] = useState<Array<EuiSelectableOption<IlmOptionData>>>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+  useEffect(() => {
+    const phasesDescription = (phases: Phases) => {
+      const desc: string[] = [];
+      if (phases.hot) {
+        const rollover = phases.hot.actions.rollover;
+        const rolloverWhen = [
+          rollover?.max_age && 'max age ' + rollover.max_age,
+          rollover?.max_docs && 'max docs ' + rollover.max_docs,
+          rollover?.max_primary_shard_docs &&
+            'primary shard docs ' + rollover.max_primary_shard_docs,
+          rollover?.max_primary_shard_size &&
+            'primary shard size ' + rollover.max_primary_shard_size,
+          rollover?.max_size && 'index size ' + rollover.max_size,
+        ]
+          .filter(Boolean)
+          .join(' or ');
+        desc.push(`Hot (${rolloverWhen ? 'rollover when ' + rolloverWhen : 'no rollover'})`);
+      }
+      if (phases.warm) {
+        desc.push(`Warm after ${phases.warm.min_age}`);
+      }
+      if (phases.cold) {
+        desc.push(`Cold after ${phases.cold.min_age}`);
+      }
+      if (phases.frozen) {
+        desc.push(`Frozen after ${phases.frozen.min_age}`);
+      }
+      if (phases.delete) {
+        desc.push(`Delete after ${phases.delete.min_age}`);
+      } else {
+        desc.push('Keep data indefinitely');
+      }
+
+      return desc.join(', ');
+    };
+
+    setIsLoading(true);
+    getIlmPolicies()
+      .then((ilmPolicies) => {
+        const policyOptions = ilmPolicies.map(
+          ({ name, policy }): EuiSelectableOption<IlmOptionData> => ({
+            label: `${name}`,
+            searchableLabel: name,
+            checked: selectedPolicy === name ? 'on' : undefined,
+            data: {
+              phases: phasesDescription(policy.phases),
+            },
+          })
+        );
+
+        setPolicies(policyOptions);
+      })
+      .catch((error) => {
+        setErrorMessage('body' in error ? error.body.message : error.message);
+      })
+      .finally(() => setIsLoading(false));
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <EuiModal onClose={closeModal}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          {i18n.translate('xpack.streams.streamDetailLifecycle.attachIlm', {
+            defaultMessage: 'Attach a lifecycle policy to this stream',
+          })}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        {i18n.translate('xpack.streams.streamDetailLifecycle.selectIlmOrVisit1', {
+          defaultMessage: 'Select a pre-defined policy or visit',
+        })}{' '}
+        <EuiLink
+          data-test-subj="streamsAppIlmModalIndexLifecyclePoliciesLink"
+          target="_blank"
+          href={ilmLocator?.getRedirectUrl({ page: 'policies_list' })}
+        >
+          {i18n.translate('xpack.streams.streamDetailLifecycle.selectIlmOrVisit2', {
+            defaultMessage: 'Index Lifecycle Policies',
+          })}
+        </EuiLink>{' '}
+        {i18n.translate('xpack.streams.streamDetailLifecycle.selectIlmOrVisit3', {
+          defaultMessage: 'to create a new one.',
+        })}
+        <EuiSpacer />
+        <EuiPanel hasBorder hasShadow={false} paddingSize="s">
+          <EuiSelectable
+            searchable
+            singleSelection
+            isLoading={isLoading}
+            options={policies}
+            errorMessage={errorMessage}
+            onChange={(options) => {
+              setSelectedPolicy(options.find((option) => option.checked === 'on')?.label);
+              setPolicies(options);
+            }}
+            listProps={{
+              rowHeight: 45,
+            }}
+            renderOption={(option: EuiSelectableOption<IlmOptionData>, searchValue: string) => (
+              <>
+                <EuiHighlight search={searchValue}>{option.label}</EuiHighlight>
+                <EuiText size="xs" color="subdued" className="eui-displayBlock">
+                  <small>
+                    <EuiHighlight search={searchValue}>{option.phases || ''}</EuiHighlight>
+                  </small>
+                </EuiText>
+              </>
+            )}
+          >
+            {(list, search) => (
+              <>
+                {search}
+                {list}
+              </>
+            )}
+          </EuiSelectable>
+        </EuiPanel>
+      </EuiModalBody>
+
+      <ModalFooter
+        definition={definition}
+        confirmationLabel="Attach policy"
+        closeModal={closeModal}
+        onConfirm={() => {
+          if (selectedPolicy) {
+            updateLifecycle({ ilm: { policy: selectedPolicy } });
+          }
+        }}
+        confirmationIsDisabled={!selectedPolicy}
+        updateInProgress={updateInProgress}
+      />
+    </EuiModal>
+  );
+}
+
+function InheritModal({ definition, closeModal, updateInProgress, updateLifecycle }: ModalOptions) {
+  return (
+    <EuiModal onClose={closeModal}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          {i18n.translate('xpack.streams.streamDetailLifecycle.defaultLifecycleTitle', {
+            defaultMessage: 'Set data retention to default',
+          })}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        {isWiredStreamGetResponse(definition)
+          ? i18n.translate('xpack.streams.streamDetailLifecycle.defaultLifecycleWiredDesc', {
+              defaultMessage:
+                'All custom retention settings for this stream will be removed, resetting it to inherit data retention from its nearest parent.',
+            })
+          : i18n.translate('xpack.streams.streamDetailLifecycle.defaultLifecycleUnwiredDesc', {
+              defaultMessage:
+                'All custom retention settings for this stream will be removed, resetting it to use the configuration of the data stream.',
+            })}
+        <EuiSpacer />
+      </EuiModalBody>
+
+      <ModalFooter
+        definition={definition}
+        confirmationLabel="Set to default"
+        closeModal={closeModal}
+        onConfirm={() => updateLifecycle({ inherit: {} })}
+        updateInProgress={updateInProgress}
+      />
+    </EuiModal>
+  );
+}
+
+function ModalFooter({
+  definition,
+  updateInProgress,
+  confirmationLabel,
+  confirmationIsDisabled,
+  onConfirm,
+  closeModal,
+}: {
+  definition: StreamGetResponse;
+  updateInProgress: boolean;
+  confirmationLabel: string;
+  confirmationIsDisabled?: boolean;
+  onConfirm: () => void;
+  closeModal: () => void;
+}) {
+  return (
+    <EuiModalFooter>
+      <EuiFlexGroup direction="column">
+        {isWiredStreamGetResponse(definition) ? (
+          <EuiFlexItem>
+            <EuiCallOut
+              title={i18n.translate(
+                'xpack.streams.streamDetailLifecycle.lifecycleDependentImpactTitle',
+                {
+                  defaultMessage: 'Retention changes for dependent streams',
+                }
+              )}
+              iconType="logstashFilter"
+            >
+              <p>
+                {i18n.translate(
+                  'xpack.streams.streamDetailLifecycle.lifecycleDependentImpactDesc',
+                  {
+                    defaultMessage:
+                      'Data retention changes will apply to dependant streams unless they already have custom retention settings in place.',
+                  }
+                )}
+              </p>
+            </EuiCallOut>
+          </EuiFlexItem>
+        ) : null}
+
+        <EuiFlexItem>
+          <EuiFlexGroup justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                data-test-subj="streamsAppModalFooterCancelButton"
+                disabled={updateInProgress}
+                color="primary"
+                onClick={() => closeModal()}
+              >
+                {i18n.translate('xpack.streams.streamDetailLifecycle.cancelLifecycleUpdate', {
+                  defaultMessage: 'Cancel',
+                })}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                data-test-subj="streamsAppModalFooterButton"
+                fill
+                disabled={confirmationIsDisabled}
+                isLoading={updateInProgress}
+                onClick={() => onConfirm()}
+              >
+                {confirmationLabel}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiModalFooter>
+  );
+}

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_lifecycle/summary.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_lifecycle/summary.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiPanel, EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import {
+  IngestStreamGetResponse,
+  isDslLifecycle,
+  isIlmLifecycle,
+  isInheritLifecycle,
+  isRoot,
+  isUnwiredStreamGetResponse,
+} from '@kbn/streams-schema';
+
+export function RetentionSummary({ definition }: { definition: IngestStreamGetResponse }) {
+  const summary = useMemo(() => summaryText(definition), [definition]);
+
+  return (
+    <EuiPanel hasShadow={false} hasBorder color="subdued" paddingSize="s">
+      <EuiText>
+        <h5>
+          {i18n.translate('xpack.streams.streamDetailLifecycle.retentionSummaryLabel', {
+            defaultMessage: 'Retention summary',
+          })}
+        </h5>
+        <p>{summary}</p>
+      </EuiText>
+    </EuiPanel>
+  );
+}
+
+function summaryText(definition: IngestStreamGetResponse) {
+  const lifecycle = definition.stream.ingest.lifecycle;
+
+  if (isInheritLifecycle(lifecycle)) {
+    return i18n.translate('xpack.streams.streamDetailLifecycle.inheritLifecycleNote', {
+      defaultMessage: 'This data stream is inheriting its lifecycle configuration.',
+    });
+  } else if (isDslLifecycle(lifecycle)) {
+    return isRoot(definition.stream.name) || isUnwiredStreamGetResponse(definition)
+      ? i18n.translate('xpack.streams.streamDetailLifecycle.dslLifecycleRootNote', {
+          defaultMessage: 'This data stream is using a custom data retention.',
+        })
+      : i18n.translate('xpack.streams.streamDetailLifecycle.dslLifecycleNonRootNote', {
+          defaultMessage:
+            'This data stream is using a custom data retention as an override at this level.',
+        });
+  } else if (isIlmLifecycle(lifecycle)) {
+    return isRoot(definition.stream.name) || isUnwiredStreamGetResponse(definition)
+      ? i18n.translate('xpack.streams.streamDetailLifecycle.ilmPolicyRootNote', {
+          defaultMessage: 'This data stream is using an ILM policy.',
+        })
+      : i18n.translate('xpack.streams.streamDetailLifecycle.ilmPolicyNonRootNote', {
+          defaultMessage: 'This data stream is using an ILM policy as an override at this level.',
+        });
+  }
+
+  return i18n.translate('xpack.streams.streamDetailLifecycle.disabledPolicyNote', {
+    defaultMessage: 'The retention for this data stream is disabled.',
+  });
+}

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_management/classic.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_management/classic.tsx
@@ -13,11 +13,12 @@ import { RedirectTo } from '../redirect_to';
 import { StreamDetailEnrichment } from '../stream_detail_enrichment';
 import { useKibana } from '../../hooks/use_kibana';
 import { ManagementTabs, Wrapper } from './wrapper';
+import { StreamDetailLifecycle } from '../stream_detail_lifecycle';
 
-type ManagementSubTabs = 'enrich' | 'overview';
+type ManagementSubTabs = 'enrich' | 'overview' | 'lifecycle';
 
 function isValidManagementSubTab(value: string): value is ManagementSubTabs {
-  return ['enrich', 'overview'].includes(value);
+  return ['enrich', 'overview', 'lifecycle'].includes(value);
 }
 
 export function ClassicStreamDetailManagement({
@@ -47,6 +48,15 @@ export function ClassicStreamDetailManagement({
       ),
       label: i18n.translate('xpack.streams.streamDetailView.enrichmentTab', {
         defaultMessage: 'Extract field',
+      }),
+    };
+
+    tabs.lifecycle = {
+      content: (
+        <StreamDetailLifecycle definition={definition} refreshDefinition={refreshDefinition} />
+      ),
+      label: i18n.translate('xpack.streams.streamDetailView.lifecycleTab', {
+        defaultMessage: 'Data retention',
       }),
     };
   }

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_management/wired.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/stream_detail_management/wired.tsx
@@ -12,12 +12,13 @@ import { RedirectTo } from '../redirect_to';
 import { StreamDetailRouting } from '../stream_detail_routing';
 import { StreamDetailEnrichment } from '../stream_detail_enrichment';
 import { StreamDetailSchemaEditor } from '../stream_detail_schema_editor';
+import { StreamDetailLifecycle } from '../stream_detail_lifecycle';
 import { Wrapper } from './wrapper';
 
-type ManagementSubTabs = 'route' | 'enrich' | 'schemaEditor';
+type ManagementSubTabs = 'route' | 'enrich' | 'schemaEditor' | 'lifecycle';
 
 function isValidManagementSubTab(value: string): value is ManagementSubTabs {
-  return ['route', 'enrich', 'schemaEditor'].includes(value);
+  return ['route', 'enrich', 'schemaEditor', 'lifecycle'].includes(value);
 }
 
 export function WiredStreamDetailManagement({
@@ -60,6 +61,14 @@ export function WiredStreamDetailManagement({
       ),
       label: i18n.translate('xpack.streams.streamDetailView.schemaEditorTab', {
         defaultMessage: 'Schema editor',
+      }),
+    },
+    lifecycle: {
+      content: (
+        <StreamDetailLifecycle definition={definition} refreshDefinition={refreshDefinition} />
+      ),
+      label: i18n.translate('xpack.streams.streamDetailView.lifecycleTab', {
+        defaultMessage: 'Data retention',
       }),
     },
   };

--- a/x-pack/solutions/observability/plugins/streams_app/public/hooks/use_kibana.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/hooks/use_kibana.tsx
@@ -18,19 +18,21 @@ export interface StreamsAppKibanaContext {
     start: StreamsAppStartDependencies;
   };
   services: StreamsAppServices;
+  isServerless: boolean;
 }
 
 const useTypedKibana = (): StreamsAppKibanaContext => {
   const context = useKibana<CoreStart & Omit<StreamsAppKibanaContext, 'core'>>();
 
   return useMemo(() => {
-    const { appParams, dependencies, services, ...core } = context.services;
+    const { appParams, dependencies, services, isServerless, ...core } = context.services;
 
     return {
       appParams,
       core,
       dependencies,
       services,
+      isServerless,
     };
   }, [context.services]);
 };

--- a/x-pack/solutions/observability/plugins/streams_app/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/streams_app/public/plugin.ts
@@ -38,7 +38,7 @@ export class StreamsAppPlugin
 {
   logger: Logger;
 
-  constructor(context: PluginInitializerContext<ConfigSchema>) {
+  constructor(private readonly context: PluginInitializerContext<ConfigSchema>) {
     this.logger = context.logger.get();
   }
   setup(
@@ -126,6 +126,7 @@ export class StreamsAppPlugin
           pluginsStart,
           services,
           appMountParameters,
+          isServerless: this.context.env.packageInfo.buildFlavor === 'serverless',
         });
       },
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[streams] basic lifecycle management UI (#208461)](https://github.com/elastic/kibana/pull/208461)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kevin Lacabane","email":"kevin.lacabane@elastic.co"},"sourceCommit":{"committedDate":"2025-02-06T09:56:42Z","message":"[streams] basic lifecycle management UI (#208461)\n\nImplements an initial UI to manage the data retention of a stream.\n\nThe view displays informations about the lifecycle configuration/origin\nand also allows one to update it to one of the available options.\nOptions depend on the type of stream and the deployment type.\n\nThese are the options that should be currently available (the api also\nhave guards):\n\n|    | stateful | serverless |\n| -------- | ------- | ------ |\n| root stream  | dsl, ilm    | dsl |\n| wired stream | inherit, dsl, ilm     | inherit, dsl |\n| unwired stream*    | inherit, dsl    | inherit, dsl |\n\n*unwired stream's retention cannot be updated if it's currently using\nILM\n\n### Screenshots\n![Screenshot 2025-02-03 at 18 50\n01](https://github.com/user-attachments/assets/68bdd8c1-889c-4e10-8caf-2bb0b8ce5652)\n\n![Screenshot 2025-02-04 at 14 20\n35](https://github.com/user-attachments/assets/835f9b48-09e6-40b8-8a61-8af4b8ea0ee3)\n\n![Screenshot 2025-02-04 at 12 33\n58](https://github.com/user-attachments/assets/bae476d0-1907-44a1-b1d6-0805b6c567bc)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani01@gmail.com>","sha":"cf01af250cdf1e5dbeb81b6495bbad2d79144bf2","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Feature:Streams","v9.1.0","v8.19.0"],"title":"[streams] basic lifecycle management UI","number":208461,"url":"https://github.com/elastic/kibana/pull/208461","mergeCommit":{"message":"[streams] basic lifecycle management UI (#208461)\n\nImplements an initial UI to manage the data retention of a stream.\n\nThe view displays informations about the lifecycle configuration/origin\nand also allows one to update it to one of the available options.\nOptions depend on the type of stream and the deployment type.\n\nThese are the options that should be currently available (the api also\nhave guards):\n\n|    | stateful | serverless |\n| -------- | ------- | ------ |\n| root stream  | dsl, ilm    | dsl |\n| wired stream | inherit, dsl, ilm     | inherit, dsl |\n| unwired stream*    | inherit, dsl    | inherit, dsl |\n\n*unwired stream's retention cannot be updated if it's currently using\nILM\n\n### Screenshots\n![Screenshot 2025-02-03 at 18 50\n01](https://github.com/user-attachments/assets/68bdd8c1-889c-4e10-8caf-2bb0b8ce5652)\n\n![Screenshot 2025-02-04 at 14 20\n35](https://github.com/user-attachments/assets/835f9b48-09e6-40b8-8a61-8af4b8ea0ee3)\n\n![Screenshot 2025-02-04 at 12 33\n58](https://github.com/user-attachments/assets/bae476d0-1907-44a1-b1d6-0805b6c567bc)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani01@gmail.com>","sha":"cf01af250cdf1e5dbeb81b6495bbad2d79144bf2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208461","number":208461,"mergeCommit":{"message":"[streams] basic lifecycle management UI (#208461)\n\nImplements an initial UI to manage the data retention of a stream.\n\nThe view displays informations about the lifecycle configuration/origin\nand also allows one to update it to one of the available options.\nOptions depend on the type of stream and the deployment type.\n\nThese are the options that should be currently available (the api also\nhave guards):\n\n|    | stateful | serverless |\n| -------- | ------- | ------ |\n| root stream  | dsl, ilm    | dsl |\n| wired stream | inherit, dsl, ilm     | inherit, dsl |\n| unwired stream*    | inherit, dsl    | inherit, dsl |\n\n*unwired stream's retention cannot be updated if it's currently using\nILM\n\n### Screenshots\n![Screenshot 2025-02-03 at 18 50\n01](https://github.com/user-attachments/assets/68bdd8c1-889c-4e10-8caf-2bb0b8ce5652)\n\n![Screenshot 2025-02-04 at 14 20\n35](https://github.com/user-attachments/assets/835f9b48-09e6-40b8-8a61-8af4b8ea0ee3)\n\n![Screenshot 2025-02-04 at 12 33\n58](https://github.com/user-attachments/assets/bae476d0-1907-44a1-b1d6-0805b6c567bc)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Marco Antonio Ghiani <marcoantonio.ghiani01@gmail.com>","sha":"cf01af250cdf1e5dbeb81b6495bbad2d79144bf2"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209970","number":209970,"state":"OPEN"}]}] BACKPORT-->