### PR TITLE
Updates removed params of the Fleet -> Logstash output configurations.

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/logstash_instructions/helpers.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/logstash_instructions/helpers.tsx
@@ -13,11 +13,11 @@ export function getLogstashPipeline(apiKey?: string) {
   return `input {
   elastic_agent {
     port => 5044
-    ssl => true
+    ssl_enabled => true
     ssl_certificate_authorities => ["<ca_path>"]
     ssl_certificate => "<server_cert_path>"
     ssl_key => "<server_cert_key_in_pkcs8>"
-    ssl_verify_mode => "force_peer"
+    ssl_client_authentication => "required"
   }
 }
 
@@ -26,8 +26,8 @@ output {
     hosts => "<es_host>"
     api_key => "<api_key>"
     data_stream => true
-    ssl => true
-    # cacert => "<elasticsearch_ca_path>"
+    ssl_enabled => true
+    # ssl_certificate_authorities => "<elasticsearch_ca_path>"
   }
 }`.replace('<api_key>', apiKey || '<api_key>');
 }


### PR DESCRIPTION
## Summary
The configuration shown on Fleet -> Logstash output isn't up to date that some of them are removed.
This PR updates obsoleted configuration(s) to align with recent Logstash 9.0 configs.

### Author's checklist
- [ ] This needs to be backported to 9.0 Kibana branch
- [ ] and would be good to trigger BC

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks
N.A

- Closes #209976

## Outcome
<img width="1913" alt="image" src="https://github.com/user-attachments/assets/a04596c7-bdbb-4e01-a23e-33a04aaf9071" />



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->