### PR TITLE
[Streams 🌊] Fix fields simulation restricted keys

### DIFF
--- a/x-pack/solutions/observability/plugins/streams_app/public/components/schema_editor/flyout/sample_preview_table.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/schema_editor/flyout/sample_preview_table.tsx
@@ -9,13 +9,14 @@ import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { EuiCallOut } from '@elastic/eui';
-import { NamedFieldDefinitionConfig, WiredStreamDefinition } from '@kbn/streams-schema';
+import { WiredStreamDefinition } from '@kbn/streams-schema';
 import { useKibana } from '../../../hooks/use_kibana';
 import { getFormattedError } from '../../../util/errors';
 import { useStreamsAppFetch } from '../../../hooks/use_streams_app_fetch';
 import { PreviewTable } from '../../preview_table';
 import { LoadingPanel } from '../../loading_panel';
-import { SchemaField, isSchemaFieldTyped } from '../types';
+import { MappedSchemaField, SchemaField, isSchemaFieldTyped } from '../types';
+import { convertToFieldDefinitionConfig } from '../utils';
 
 interface SamplePreviewTableProps {
   stream: WiredStreamDefinition;
@@ -36,7 +37,7 @@ const SAMPLE_DOCUMENTS_TO_SHOW = 20;
 const SamplePreviewTableContent = ({
   stream,
   nextField,
-}: SamplePreviewTableProps & { nextField: NamedFieldDefinitionConfig }) => {
+}: SamplePreviewTableProps & { nextField: MappedSchemaField }) => {
   const { streamsRepositoryClient } = useKibana().dependencies.start.streams;
 
   const { value, loading, error } = useStreamsAppFetch(
@@ -48,7 +49,9 @@ const SamplePreviewTableContent = ({
             id: stream.name,
           },
           body: {
-            field_definitions: [nextField],
+            field_definitions: [
+              { ...convertToFieldDefinitionConfig(nextField), name: nextField.name },
+            ],
           },
         },
       });

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/schema_editor/hooks/use_schema_fields.ts
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/schema_editor/hooks/use_schema_fields.ts
@@ -7,16 +7,13 @@
 
 import { i18n } from '@kbn/i18n';
 import { useAbortController } from '@kbn/observability-utils-browser/hooks/use_abort_controller';
-import {
-  FieldDefinitionConfig,
-  NamedFieldDefinitionConfig,
-  WiredStreamGetResponse,
-} from '@kbn/streams-schema';
+import { NamedFieldDefinitionConfig, WiredStreamGetResponse } from '@kbn/streams-schema';
 import { isEqual, omit } from 'lodash';
 import { useMemo, useCallback } from 'react';
 import { useStreamsAppFetch } from '../../../hooks/use_streams_app_fetch';
 import { useKibana } from '../../../hooks/use_kibana';
-import { MappedSchemaField, SchemaField, isSchemaFieldTyped } from '../types';
+import { SchemaField, isSchemaFieldTyped } from '../types';
+import { convertToFieldDefinitionConfig } from '../utils';
 
 export const useSchemaFields = ({
   definition,
@@ -204,11 +201,6 @@ export const useSchemaFields = ({
     updateField,
   };
 };
-
-const convertToFieldDefinitionConfig = (field: MappedSchemaField): FieldDefinitionConfig => ({
-  type: field.type,
-  ...(field.format && field.type === 'date' ? { format: field.format } : {}),
-});
 
 const hasChanges = (
   field: Partial<NamedFieldDefinitionConfig>,

--- a/x-pack/solutions/observability/plugins/streams_app/public/components/schema_editor/utils.ts
+++ b/x-pack/solutions/observability/plugins/streams_app/public/components/schema_editor/utils.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FieldDefinitionConfig } from '@kbn/streams-schema';
+import { MappedSchemaField } from './types';
+
+export const convertToFieldDefinitionConfig = (
+  field: MappedSchemaField
+): FieldDefinitionConfig => ({
+  type: field.type,
+  ...(field.format && field.type === 'date' ? { format: field.format } : {}),
+});


### PR DESCRIPTION
## 📓 Summary

Fix failing fields simulation on the schema editor. This happened because the strict excessive keys check on the zod validation for the API request caught extra parameters used client-side on the Schema Editor, removing those properties fixed the issue.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->