### PR TITLE
[Logs Explorer] Fix show all logs issue with data source selector

### DIFF
--- a/x-pack/solutions/observability/plugins/logs_explorer/public/components/data_source_selector/data_source_selector.tsx
+++ b/x-pack/solutions/observability/plugins/logs_explorer/public/components/data_source_selector/data_source_selector.tsx
@@ -93,7 +93,10 @@ export function DataSourceSelector({
     switchToDataViewsTab,
     togglePopover,
   } = useDataSourceSelector({
-    initialContext: { selection: dataSourceSelection },
+    initialContext: {
+      selection: dataSourceSelection,
+      allSelection,
+    },
     onDataViewsSearch,
     onDataViewsFilter,
     onDataViewsSort,


### PR DESCRIPTION
## Summary

Closes - https://github.com/elastic/kibana/issues/208557

1 word change

## What was the issue

User selected `logSources` setting was not respected by Logs Explorer Data Source Selector

![Feb-07-2025 16-34-13](https://github.com/user-attachments/assets/1ff6d1a0-994a-4499-ac07-3247f76f6810)


## What was done to fix it ?

- We fetch the `logSources` from Kibana Advance Settings. This part still happens.
- When the page load, we initialize 3 state machines in order
  - Observability Logs Explorer - This state machine does the call to `uiSettings` to get the default list of `logSources` which the user has set. For example - `remote_cluster:filebeat-*,remote_cluster:logs-*,remote_cluster:kibana_sample_data_logs*,filebeat-*,kibana_sample_data_logs*,logs-*`
  - Now the `Observability Logs Explorer` state machine initializes the `Logs Explorer` state machine and passes this value of `allSelection` inside the `initialState` property to this state machine.
  - Now the `Logs Explorer` state machine initialises the `Data Source Selector` state machine where it passes a default `initialState` to this machine but misses to pass the definition of `allSelection`.
  
  Due to which this state machine uses a default value for `allSelection` which is set to `logs-*-*` hardcoded in the code.
  
  Hence the value which the user has set in Kibana Advance Settings is not respected any more. 
  
  The way the state machines are designed, 1st time when page loads, the user selected value is passed as selected value. Where as when user manually changes to different data source and then again clicks on `All Logs`, since this `DataSourceSelector` state machine, does not know the set value for `allSelection` it uses a hard coded value from the code which is `logs-*-*` instead of the one retrieved from `logSources` settings
 
