### PR TITLE
[Obs AI Assistant] Update colors in the AI Assistant icon

### DIFF
--- a/x-pack/platform/packages/shared/ai-assistant/icon/svg/assistant.tsx
+++ b/x-pack/platform/packages/shared/ai-assistant/icon/svg/assistant.tsx
@@ -17,12 +17,12 @@ const AssistantLogo = (props: React.SVGProps<SVGSVGElement>) => (
     {...props}
   >
     <path fill="#F04E98" d="M36 28h24v36H36V28Z" />
-    <path fill="#00BFB3" d="M4 46c0-9.941 8.059-18 18-18h6v36h-6c-9.941 0-18-8.059-18-18Z" />
+    <path fill="#02BCB7" d="M4 46c0-9.941 8.059-18 18-18h6v36h-6c-9.941 0-18-8.059-18-18Z" />
     <path
-      fill="#343741"
+      fill="#0B64DD"
       d="M60 12c0 6.627-5.373 12-12 12s-12-5.373-12-12S41.373 0 48 0s12 5.373 12 12Z"
     />
-    <path fill="#FA744E" d="M6 23C6 10.85 15.85 1 28 1v22H6Z" />
+    <path fill="#FEC514" d="M6 23C6 10.85 15.85 1 28 1v22H6Z" />
   </svg>
 );
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/208816

## Summary

Update the AI Assistant icon colors

### Screenshots

![Screenshot 2025-02-07 at 12 45 00 PM](https://github.com/user-attachments/assets/7eccb0ca-0234-44e1-b11b-eed0ccb761eb)

![Screenshot 2025-02-07 at 12 45 33 PM](https://github.com/user-attachments/assets/b288cdef-8044-43a6-b0c2-0da65b1af5ca)


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->