### PR TITLE
[8.18] [Logs Explorer] Fix show all logs issue with data source selector (#210158)

### DIFF
--- a/x-pack/solutions/observability/plugins/logs_explorer/public/components/data_source_selector/data_source_selector.tsx
+++ b/x-pack/solutions/observability/plugins/logs_explorer/public/components/data_source_selector/data_source_selector.tsx
@@ -93,7 +93,10 @@ export function DataSourceSelector({
     switchToDataViewsTab,
     togglePopover,
   } = useDataSourceSelector({
-    initialContext: { selection: dataSourceSelection },
+    initialContext: {
+      selection: dataSourceSelection,
+      allSelection,
+    },
     onDataViewsSearch,
     onDataViewsFilter,
     onDataViewsSort,


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[Logs Explorer] Fix show all logs issue with data source selector (#210158)](https://github.com/elastic/kibana/pull/210158)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Achyut Jhunjhunwala","email":"achyut.jhunjhunwala@elastic.co"},"sourceCommit":{"committedDate":"2025-02-07T12:34:22Z","message":"[Logs Explorer] Fix show all logs issue with data source selector (#210158)\n\n## Summary\n\nCloses - https://github.com/elastic/kibana/issues/208557\n\n1 word change\n\n## What was the issue\n\nUser selected `logSources` setting was not respected by Logs Explorer\nData Source Selector\n\n![Feb-07-2025\n16-34-13](https://github.com/user-attachments/assets/1ff6d1a0-994a-4499-ac07-3247f76f6810)\n\n\n## What was done to fix it ?\n\n- We fetch the `logSources` from Kibana Advance Settings. This part\nstill happens.\n- When the page load, we initialize 3 state machines in order\n- Observability Logs Explorer - This state machine does the call to\n`uiSettings` to get the default list of `logSources` which the user has\nset. For example -\n`remote_cluster:filebeat-*,remote_cluster:logs-*,remote_cluster:kibana_sample_data_logs*,filebeat-*,kibana_sample_data_logs*,logs-*`\n- Now the `Observability Logs Explorer` state machine initializes the\n`Logs Explorer` state machine and passes this value of `allSelection`\ninside the `initialState` property to this state machine.\n- Now the `Logs Explorer` state machine initialises the `Data Source\nSelector` state machine where it passes a default `initialState` to this\nmachine but misses to pass the definition of `allSelection`.\n  \nDue to which this state machine uses a default value for `allSelection`\nwhich is set to `logs-*-*` hardcoded in the code.\n  \nHence the value which the user has set in Kibana Advance Settings is not\nrespected any more.\n  \nThe way the state machines are designed, 1st time when page loads, the\nuser selected value is passed as selected value. Where as when user\nmanually changes to different data source and then again clicks on `All\nLogs`, since this `DataSourceSelector` state machine, does not know the\nset value for `allSelection` it uses a hard coded value from the code\nwhich is `logs-*-*` instead of the one retrieved from `logSources`\nsettings","sha":"c43e21254b18acd3b3d0eb9790a00b3d82b93c0c","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-logs","backport:version","v8.18.0","v8.17.3"],"title":"[Logs Explorer] Fix show all logs issue with data source selector","number":210158,"url":"https://github.com/elastic/kibana/pull/210158","mergeCommit":{"message":"[Logs Explorer] Fix show all logs issue with data source selector (#210158)\n\n## Summary\n\nCloses - https://github.com/elastic/kibana/issues/208557\n\n1 word change\n\n## What was the issue\n\nUser selected `logSources` setting was not respected by Logs Explorer\nData Source Selector\n\n![Feb-07-2025\n16-34-13](https://github.com/user-attachments/assets/1ff6d1a0-994a-4499-ac07-3247f76f6810)\n\n\n## What was done to fix it ?\n\n- We fetch the `logSources` from Kibana Advance Settings. This part\nstill happens.\n- When the page load, we initialize 3 state machines in order\n- Observability Logs Explorer - This state machine does the call to\n`uiSettings` to get the default list of `logSources` which the user has\nset. For example -\n`remote_cluster:filebeat-*,remote_cluster:logs-*,remote_cluster:kibana_sample_data_logs*,filebeat-*,kibana_sample_data_logs*,logs-*`\n- Now the `Observability Logs Explorer` state machine initializes the\n`Logs Explorer` state machine and passes this value of `allSelection`\ninside the `initialState` property to this state machine.\n- Now the `Logs Explorer` state machine initialises the `Data Source\nSelector` state machine where it passes a default `initialState` to this\nmachine but misses to pass the definition of `allSelection`.\n  \nDue to which this state machine uses a default value for `allSelection`\nwhich is set to `logs-*-*` hardcoded in the code.\n  \nHence the value which the user has set in Kibana Advance Settings is not\nrespected any more.\n  \nThe way the state machines are designed, 1st time when page loads, the\nuser selected value is passed as selected value. Where as when user\nmanually changes to different data source and then again clicks on `All\nLogs`, since this `DataSourceSelector` state machine, does not know the\nset value for `allSelection` it uses a hard coded value from the code\nwhich is `logs-*-*` instead of the one retrieved from `logSources`\nsettings","sha":"c43e21254b18acd3b3d0eb9790a00b3d82b93c0c"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.18","8.17"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->