### PR TITLE
[8.17][Fleet] update component templates with deprecated setting (#210200)

### DIFF
--- a/x-pack/plugins/fleet/server/services/setup.test.ts
+++ b/x-pack/plugins/fleet/server/services/setup.test.ts
@@ -28,6 +28,7 @@ jest.mock('./download_source');
 jest.mock('./epm/packages');
 jest.mock('./setup/managed_package_policies');
 jest.mock('./setup/upgrade_package_install_version');
+jest.mock('./setup/update_deprecated_component_templates');
 jest.mock('./epm/elasticsearch/template/install', () => {
   return {
     ...jest.requireActual('./epm/elasticsearch/template/install'),

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -58,6 +58,8 @@ import {
   getPreconfiguredDeleteUnenrolledAgentsSettingFromConfig,
 } from './preconfiguration/delete_unenrolled_agent_setting';
 
+import { updateDeprecatedComponentTemplates } from './setup/update_deprecated_component_templates';
+
 export interface SetupStatus {
   isInitialized: boolean;
   nonFatalErrors: Array<
@@ -299,6 +301,9 @@ async function createSetupSideEffects(
   );
   await ensureAgentPoliciesFleetServerKeysAndPolicies({ soClient, esClient, logger });
   stepSpan?.end();
+
+  logger.debug('Update deprecated _source.mode in component templates');
+  await updateDeprecatedComponentTemplates(esClient);
 
   const nonFatalErrors = [
     ...preconfiguredPackagesNonFatalErrors,

--- a/x-pack/plugins/fleet/server/services/setup/index.ts
+++ b/x-pack/plugins/fleet/server/services/setup/index.ts
@@ -8,3 +8,4 @@
 export { upgradePackageInstallVersion } from './upgrade_package_install_version';
 export { upgradeAgentPolicySchemaVersion } from './upgrade_agent_policy_schema_version';
 export { ensureAgentPoliciesFleetServerKeysAndPolicies } from './fleet_server_policies_enrollment_keys';
+export { updateDeprecatedComponentTemplates } from './update_deprecated_component_templates';

--- a/x-pack/plugins/fleet/server/services/setup/update_deprecated_component_templates.test.ts
+++ b/x-pack/plugins/fleet/server/services/setup/update_deprecated_component_templates.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { updateDeprecatedComponentTemplates } from './update_deprecated_component_templates';
+
+jest.mock('..', () => ({
+  appContextService: {
+    getLogger: () => ({
+      debug: jest.fn(),
+    }),
+  },
+}));
+
+describe('updateDeprecatedComponentTemplates', () => {
+  it('should update deprecated component templates', async () => {
+    const esClientMock: any = {
+      cluster: {
+        getComponentTemplate: jest.fn().mockResolvedValue({
+          component_templates: [
+            {
+              name: 'metrics-apm.app@package',
+              component_template: {
+                template: {
+                  settings: {},
+                  mappings: {
+                    _source: {
+                      mode: 'synthetic',
+                    },
+                    properties: {},
+                  },
+                },
+                _meta: {
+                  managed_by: 'fleet',
+                },
+              },
+            },
+            {
+              name: 'metrics-other',
+              component_template: {
+                template: {
+                  settings: {},
+                  mappings: {
+                    properties: {},
+                  },
+                },
+                _meta: {
+                  managed_by: 'fleet',
+                },
+              },
+            },
+          ],
+        }),
+        putComponentTemplate: jest.fn(),
+      },
+    };
+
+    await updateDeprecatedComponentTemplates(esClientMock);
+
+    expect(esClientMock.cluster.putComponentTemplate).toHaveBeenCalledTimes(1);
+    expect(esClientMock.cluster.putComponentTemplate).toHaveBeenCalledWith({
+      body: {
+        template: {
+          mappings: {
+            _source: {},
+            properties: {},
+          },
+          settings: {
+            index: {
+              mapping: {
+                source: {
+                  mode: 'synthetic',
+                },
+              },
+            },
+          },
+        },
+      },
+      name: 'metrics-apm.app@package',
+    });
+  });
+});

--- a/x-pack/plugins/fleet/server/services/setup/update_deprecated_component_templates.ts
+++ b/x-pack/plugins/fleet/server/services/setup/update_deprecated_component_templates.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import pMap from 'p-map';
+import type { ElasticsearchClient } from '@kbn/core/server';
+
+import { appContextService } from '..';
+
+export async function updateDeprecatedComponentTemplates(esClient: ElasticsearchClient) {
+  const componentTemplates = await esClient.cluster.getComponentTemplate({
+    name: 'metrics-*',
+  });
+
+  const deprecatedTemplates = componentTemplates.component_templates.filter(
+    (componentTemplate) =>
+      componentTemplate.component_template._meta?.managed_by === 'fleet' &&
+      !!componentTemplate.component_template.template.mappings?._source?.mode
+  );
+
+  appContextService
+    .getLogger()
+    .debug(
+      `Updating component templates with deprecated _source.mode config: ${deprecatedTemplates.map(
+        (template) => template.name
+      )}`
+    );
+
+  await pMap(
+    deprecatedTemplates,
+    async (componentTemplate) => {
+      const source = componentTemplate.component_template.template.mappings!._source;
+      const { mode, ...restOfSource } = source!;
+      const settings = componentTemplate.component_template.template.settings;
+      await esClient.cluster.putComponentTemplate({
+        name: componentTemplate.name,
+        body: {
+          template: {
+            settings: {
+              ...settings,
+              index: {
+                ...settings?.index,
+                mapping: {
+                  ...settings?.index?.mapping,
+                  // @ts-expect-error Property 'source' does not exist on type 'IndicesMappingLimitSettings'
+                  source: {
+                    // @ts-expect-error Property 'source.mode' does not exist on type 'IndicesMappingLimitSettings'
+                    ...settings?.index?.mapping?.source,
+                    mode,
+                  },
+                },
+              },
+            },
+            mappings: {
+              ...componentTemplate.component_template.template.mappings,
+              _source: restOfSource,
+            },
+          },
+        },
+      });
+    },
+    {
+      concurrency: 10,
+    }
+  );
+}


### PR DESCRIPTION
Backport https://github.com/elastic/kibana/pull/210200 to 8.17