### PR TITLE
[8.18] Add refresh for event log, when we fill gap (#209906)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/fill_gap_by_id/fill_gap_by_id.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/fill_gap_by_id/fill_gap_by_id.test.ts
@@ -305,4 +305,16 @@ describe('fillGapById', () => {
     );
     expect(scheduleBackfill).not.toHaveBeenCalled();
   });
+
+  it('should refresh event log after fill gap', async () => {
+    const params = { ruleId: '1', gapId: 'gap1' };
+    const gap = getMockGap();
+
+    (findGapsById as jest.Mock).mockResolvedValue([gap]);
+    (scheduleBackfill as jest.Mock).mockResolvedValue('success');
+
+    await rulesClient.fillGapById(params);
+
+    expect(eventLogClient.refreshIndex).toHaveBeenCalled();
+  });
 });

--- a/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/fill_gap_by_id/fill_gap_by_id.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/rule/methods/fill_gap_by_id/fill_gap_by_id.ts
@@ -81,7 +81,11 @@ export async function fillGapById(context: RulesClientContext, params: FillGapBy
       })
     );
 
-    return scheduleBackfill(context, allGapsToSchedule);
+    const scheduleBackfillResponse = await scheduleBackfill(context, allGapsToSchedule);
+
+    await eventLogClient.refreshIndex();
+
+    return scheduleBackfillResponse;
   } catch (err) {
     const errorMessage = `Failed to find gap and schedule manual rule run for ruleId ${params.ruleId}`;
     context.logger.error(`${errorMessage} - ${err}`);

--- a/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.mock.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.mock.ts
@@ -30,6 +30,7 @@ const createClusterClientMock = () => {
     shutdown: jest.fn(),
     updateDocuments: jest.fn(),
     queryEventsByDocumentIds: jest.fn(),
+    refreshIndex: jest.fn(),
   };
   return mock;
 };

--- a/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.test.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.test.ts
@@ -2595,6 +2595,25 @@ describe('queryEventsByDocumentIds', () => {
   });
 });
 
+describe('refreshIndex', () => {
+  test('should successfully refresh index', async () => {
+    clusterClient.indices.refresh.mockResolvedValue({});
+
+    await clusterClientAdapter.refreshIndex();
+
+    expect(clusterClient.indices.refresh).toHaveBeenCalledWith({
+      index: 'kibana-event-log-ds',
+    });
+  });
+
+  test('should throw error when refresh fails', async () => {
+    clusterClient.indices.refresh.mockRejectedValue(new Error('Failed to refresh index'));
+
+    await expect(clusterClientAdapter.refreshIndex()).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Failed to refresh index"`
+    );
+  });
+});
 type RetryableFunction = () => boolean;
 
 const RETRY_UNTIL_DEFAULT_COUNT = 20;

--- a/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/es/cluster_client_adapter.ts
@@ -664,6 +664,19 @@ export class ClusterClientAdapter<
       throw err;
     }
   }
+
+  public async refreshIndex(): Promise<void> {
+    try {
+      const esClient = await this.elasticsearchClientPromise;
+
+      await esClient.indices.refresh({
+        index: this.esNames.dataStream,
+      });
+    } catch (err) {
+      this.logger.error(`error refreshing index: ${err.message}`);
+      throw err;
+    }
+  }
 }
 
 export function getQueryBodyWithAuthFilter(

--- a/x-pack/platform/plugins/shared/event_log/server/event_log_client.mock.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/event_log_client.mock.ts
@@ -14,6 +14,7 @@ const createEventLogClientMock = () => {
     aggregateEventsBySavedObjectIds: jest.fn(),
     aggregateEventsWithAuthFilter: jest.fn(),
     findEventsByDocumentIds: jest.fn(),
+    refreshIndex: jest.fn(),
   };
   return mock;
 };

--- a/x-pack/platform/plugins/shared/event_log/server/event_log_client.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/event_log_client.ts
@@ -203,6 +203,10 @@ export class EventLogClient implements IEventLogClient {
     });
   }
 
+  public async refreshIndex(): Promise<void> {
+    await this.esContext.esAdapter.refreshIndex();
+  }
+
   private async getNamespace() {
     const space = await this.spacesService?.getActiveSpace(this.request);
     return space && this.spacesService?.spaceIdToNamespace(space.id);

--- a/x-pack/platform/plugins/shared/event_log/server/types.ts
+++ b/x-pack/platform/plugins/shared/event_log/server/types.ts
@@ -84,6 +84,7 @@ export interface IEventLogClient {
   findEventsByDocumentIds(
     docs: Array<{ _id: string; _index: string }>
   ): Promise<Pick<QueryEventsBySavedObjectResult, 'data'>>;
+  refreshIndex(): Promise<void>;
 }
 
 export interface IEventLogger {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Add refresh for event log, when we fill gap (#209906)](https://github.com/elastic/kibana/pull/209906)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Khristinin Nikita","email":"nikita.khristinin@elastic.co"},"sourceCommit":{"committedDate":"2025-02-10T11:31:49Z","message":"Add refresh for event log, when we fill gap (#209906)\n\n## Add refresh for event log, when we fill gap \r\n\r\nAs we update gaps, and don't wait for refresh in UI we can have\r\ninconsistent state:\r\n\r\n- Go to gap table\r\n- Click fill gap, wait for api response\r\n- Then we refetch gaps, but because we don't wait for refresh we get old\r\ngaps and action \"Fill gap\" still remain in the table\r\n\r\nIn this PR we introduce index refresh, which only happens when user make\r\nan action to fill gap\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"fd7c7591daacf68fcc628515687ed1f1f839c589","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","v9.1.0","backport:8.18"],"title":"Add refresh for event log, when we fill gap","number":209906,"url":"https://github.com/elastic/kibana/pull/209906","mergeCommit":{"message":"Add refresh for event log, when we fill gap (#209906)\n\n## Add refresh for event log, when we fill gap \r\n\r\nAs we update gaps, and don't wait for refresh in UI we can have\r\ninconsistent state:\r\n\r\n- Go to gap table\r\n- Click fill gap, wait for api response\r\n- Then we refetch gaps, but because we don't wait for refresh we get old\r\ngaps and action \"Fill gap\" still remain in the table\r\n\r\nIn this PR we introduce index refresh, which only happens when user make\r\nan action to fill gap\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"fd7c7591daacf68fcc628515687ed1f1f839c589"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209906","number":209906,"mergeCommit":{"message":"Add refresh for event log, when we fill gap (#209906)\n\n## Add refresh for event log, when we fill gap \r\n\r\nAs we update gaps, and don't wait for refresh in UI we can have\r\ninconsistent state:\r\n\r\n- Go to gap table\r\n- Click fill gap, wait for api response\r\n- Then we refetch gaps, but because we don't wait for refresh we get old\r\ngaps and action \"Fill gap\" still remain in the table\r\n\r\nIn this PR we introduce index refresh, which only happens when user make\r\nan action to fill gap\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"fd7c7591daacf68fcc628515687ed1f1f839c589"}},{"url":"https://github.com/elastic/kibana/pull/210338","number":210338,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->