### PR TITLE
[ObsUX] [Profiling] Add date/time to main bar chart tooltip

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/public/components/stacked_bar_chart/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/stacked_bar_chart/index.tsx
@@ -17,6 +17,7 @@ import {
   timeFormatter,
   Tooltip,
   TooltipContainer,
+  TooltipHeader,
 } from '@elastic/charts';
 import { EuiPanel } from '@elastic/eui';
 import { keyBy } from 'lodash';
@@ -57,7 +58,7 @@ export function StackedBarChart({
 
   const { chartsBaseTheme, chartsTheme } = useProfilingChartsTheme();
 
-  function CustomTooltipWithSubChart() {
+  function CustomTooltipWithSubChart({ header }) {
     if (!highlightedSample) {
       return null;
     }
@@ -69,6 +70,7 @@ export function StackedBarChart({
 
     return (
       <TooltipContainer>
+        <TooltipHeader header={header} />
         <EuiPanel>
           <SubChart
             index={highlightedSubchart.Index}

--- a/x-pack/solutions/observability/plugins/profiling/public/components/stacked_bar_chart/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/stacked_bar_chart/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { XYChartElementEvent } from '@elastic/charts';
+import type { CustomTooltip, SeriesIdentifier, XYChartElementEvent } from '@elastic/charts';
 import {
   Axis,
   BrushAxis,
@@ -58,7 +58,7 @@ export function StackedBarChart({
 
   const { chartsBaseTheme, chartsTheme } = useProfilingChartsTheme();
 
-  function CustomTooltipWithSubChart({ header }) {
+  const CustomTooltipWithSubChart: CustomTooltip<{}, SeriesIdentifier> = ({ header }) => {
     if (!highlightedSample) {
       return null;
     }
@@ -90,7 +90,7 @@ export function StackedBarChart({
         </EuiPanel>
       </TooltipContainer>
     );
-  }
+  };
 
   return (
     <Chart size={{ height }}>


### PR DESCRIPTION
Closes https://github.com/elastic/prodfiler/issues/4605

BEFORE

![image](https://github.com/user-attachments/assets/d1315071-9168-4348-94aa-88fc23297a57)

AFTER

![image](https://github.com/user-attachments/assets/21555db6-3337-4a09-bcfe-8e1f8561f0f5)




